### PR TITLE
docs(forms): clarify the description of `minLength` and `maxLength`

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -262,9 +262,9 @@ export class Validators {
    * @description
    * Validator that requires the length of the control's value to be greater than or equal
    * to the provided minimum length. This validator is also provided by default if you use the
-   * the HTML5 `minlength` attribute. Note that the `minLength` validator only works for types
-   * that have a numeric `length` property, such as strings or arrays. The `minLength` validator
-   * logic is also not invoked for values when their `length` property is 0 (for example in
+   * the HTML5 `minlength` attribute. Note that the `minLength` validator is intended to be used
+   * only for types that have a numeric `length` property, such as strings or arrays. The `minLength`
+   * validator logic is also not invoked for values when their `length` property is 0 (for example in
    * case of an empty string or an empty array), to support optional controls. You can use
    * the standard `required` validator if empty values should not be considered valid.
    *
@@ -304,8 +304,8 @@ export class Validators {
    * @description
    * Validator that requires the length of the control's value to be less than or equal
    * to the provided maximum length. This validator is also provided by default if you use the
-   * the HTML5 `maxlength` attribute. Note that the `maxLength` validator only works for types
-   * that have a numeric `length` property, such as strings or arrays.
+   * the HTML5 `maxlength` attribute. Note that the `maxLength` validator is intended to be used
+   * only for types that have a numeric `length` property, such as strings or arrays.
    *
    * @usageNotes
    *

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -262,7 +262,11 @@ export class Validators {
    * @description
    * Validator that requires the length of the control's value to be greater than or equal
    * to the provided minimum length. This validator is also provided by default if you use the
-   * the HTML5 `minlength` attribute.
+   * the HTML5 `minlength` attribute. Note that the `minLength` validator only works for types
+   * that have a numeric `length` property, such as strings or arrays. The `minLength` validator
+   * logic is also not invoked for values when their `length` property is 0 (for example in
+   * case of an empty string or an empty array), to support optional controls. You can use
+   * the standard `required` validator if empty values should not be considered valid.
    *
    * @usageNotes
    *
@@ -300,7 +304,8 @@ export class Validators {
    * @description
    * Validator that requires the length of the control's value to be less than or equal
    * to the provided maximum length. This validator is also provided by default if you use the
-   * the HTML5 `maxlength` attribute.
+   * the HTML5 `maxlength` attribute. Note that the `maxLength` validator only works for types
+   * that have a numeric `length` property, such as strings or arrays.
    *
    * @usageNotes
    *


### PR DESCRIPTION
Previously, it was not clear that the `minLength` and `maxLength` validators
can only be used with objects that contain a `length` property. This commit
clarifies this.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
