### PR TITLE
fix(ngcc): do not write entry-point manifest outside node_modules

### DIFF
--- a/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
@@ -99,6 +99,10 @@ export class EntryPointManifest {
    * @param entryPoints A collection of entry-points to record in the manifest.
    */
   writeEntryPointManifest(basePath: AbsoluteFsPath, entryPoints: EntryPoint[]): void {
+    if (this.fs.basename(basePath) !== 'node_modules') {
+      return;
+    }
+
     const lockFileHash = this.computeLockFileHash(basePath);
     if (lockFileHash === null) {
       return;

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_manifest_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_manifest_spec.ts
@@ -165,6 +165,12 @@ runInEachFileSystem(() => {
         expect(fs.exists(_Abs('/project/node_modules/__ngcc_entry_points__.json'))).toBe(false);
       });
 
+      it('should do nothing if the basePath is not node_modules', () => {
+        fs.writeFile(_Abs('/project/yarn.lock'), 'LOCK FILE CONTENTS');
+        manifest.writeEntryPointManifest(_Abs('/project/dist'), []);
+        expect(fs.exists(_Abs('/project/dist/__ngcc_entry_points__.json'))).toBe(false);
+      });
+
       it('should write an __ngcc_entry_points__.json file below the base path if there is a yarn.lock file',
          () => {
            fs.writeFile(_Abs('/project/yarn.lock'), 'LOCK FILE CONTENTS');


### PR DESCRIPTION
Fixes #36296
