### PR TITLE
refactor(language-service): provide service for attribute binding type

### DIFF
--- a/packages/language-service/src/binding_utils.ts
+++ b/packages/language-service/src/binding_utils.ts
@@ -34,7 +34,7 @@ export enum ATTR {
    * "*"
    * Microsyntax template starts with '*'. See https://angular.io/api/core/TemplateRef
    */
-  KW_TEMPLATE_ATTR = 7,
+  KW_MICROSYNTAX = 7,
   /** The identifier after "bind-", "let-", "ref-/#", "on-", "bindon-", "@", or "*" */
   IDENT_KW = 8,
   /** Identifier inside [()] */
@@ -45,17 +45,25 @@ export enum ATTR {
   IDENT_EVENT = 11,
 }
 
+export interface BindingDescriptor {
+  kind: ATTR;
+  name: string;
+}
 /**
- * Returns an Angular binding kind and name of a given attribute, or undefined if the attribute is
+ * Returns a descriptor for a given Angular attribute, or undefined if the attribute is
  * not an Angular attribute.
  */
-export function getBindingKind(attribute: string): {bindingKind: ATTR, bindingName: string}|
-    undefined {
+export function getBindingDescriptor(attribute: string): BindingDescriptor|undefined {
   const bindParts = attribute.match(BIND_NAME_REGEXP);
-  if (!bindParts) return undefined;
-  const bindingKind = bindParts.findIndex((val, i) => i !== 0 && val !== undefined);
+  if (!bindParts) return;
+  // The first match element is skipped because it matches the entire attribute text, including the
+  // binding part.
+  const kind = bindParts.findIndex((val, i) => i > 0 && val !== undefined);
+  if (!(kind in ATTR)) {
+    throw TypeError(`"${kind}" is not a valid Angular binding kind for "${attribute}"`);
+  }
   return {
-    bindingKind,
-    bindingName: bindParts[ATTR.IDENT_KW],
+    kind,
+    name: bindParts[ATTR.IDENT_KW],
   };
 }

--- a/packages/language-service/src/compiler_utils.ts
+++ b/packages/language-service/src/compiler_utils.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Matches an Angular attribute to a binding type. See `ATTR` for more details.
+ *
+ * This is adapted from packages/compiler/src/render3/r3_template_transform.ts
+ * to allow empty binding names and match template attributes.
+ */
+const BIND_NAME_REGEXP =
+    /^(?:(?:(?:(bind-)|(let-)|(ref-|#)|(on-)|(bindon-)|(@)|(\*))(.*))|\[\(([^\)]*)\)\]|\[([^\]]*)\]|\(([^\)]*)\))$/;
+/**
+ * Represents possible Angular attribute bindings, as indices on a match of `BIND_NAME_REGEXP`.
+ */
+export enum ATTR {
+  /** "bind-" */
+  KW_BIND = 1,
+  /** "let-" */
+  KW_LET = 2,
+  /** "ref-/#" */
+  KW_REF = 3,
+  /** "on-" */
+  KW_ON = 4,
+  /** "bindon-" */
+  KW_BINDON = 5,
+  /** "@" */
+  KW_AT = 6,
+  /**
+   * "*"
+   * Microsyntax template starts with '*'. See https://angular.io/api/core/TemplateRef
+   */
+  KW_TEMPLATE_ATTR = 7,
+  /** The identifier after "bind-", "let-", "ref-/#", "on-", "bindon-", "@", or "*" */
+  IDENT_KW = 8,
+  /** Identifier inside [()] */
+  IDENT_BANANA_BOX = 9,
+  /** Identifier inside [] */
+  IDENT_PROPERTY = 10,
+  /** Identifier inside () */
+  IDENT_EVENT = 11,
+}
+
+/**
+ * Returns an Angular binding kind and name of a given attribute, or undefined if the attribute is
+ * not an Angular attribute.
+ */
+export function getBindingKind(attribute: string): {bindingKind: ATTR, bindingName: string}|
+    undefined {
+  const bindParts = attribute.match(BIND_NAME_REGEXP);
+  if (!bindParts) return undefined;
+  const bindingKind = bindParts.findIndex((val, i) => i !== 0 && val !== undefined);
+  return {
+    bindingKind,
+    bindingName: bindParts[ATTR.IDENT_KW],
+  };
+}


### PR DESCRIPTION
This commit refactors the process for determining the type of an Angular
attribute to be use a function that takes an attribute name and returns
the Angular attribute kind and name, rather than requiring the user to
query match the attribute name with the regex and query the matching
array.

This refactor prepares for a future change that will improve the
experience of completing attributes in `()`, `[]`, or `[()]` contexts.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No