### PR TITLE
fix(ngcc): handle entry-points within container folders

### DIFF
--- a/packages/compiler-cli/ngcc/src/entry_point_finder/directory_walker_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/directory_walker_entry_point_finder.ts
@@ -9,7 +9,7 @@ import {AbsoluteFsPath, FileSystem, join, resolve} from '../../../src/ngtsc/file
 import {DependencyResolver, SortedEntryPointsInfo} from '../dependencies/dependency_resolver';
 import {Logger} from '../logging/logger';
 import {NgccConfiguration} from '../packages/configuration';
-import {EntryPoint, INVALID_ENTRY_POINT, NO_ENTRY_POINT, getEntryPointInfo} from '../packages/entry_point';
+import {EntryPoint, INCOMPATIBLE_ENTRY_POINT, NO_ENTRY_POINT, getEntryPointInfo} from '../packages/entry_point';
 import {EntryPointManifest} from '../packages/entry_point_manifest';
 import {PathMappings} from '../utils';
 import {NGCC_DIRECTORY} from '../writing/new_entry_point_file_writer';
@@ -111,7 +111,7 @@ export class DirectoryWalkerEntryPointFinder implements EntryPointFinder {
       return [];
     }
 
-    if (topLevelEntryPoint === INVALID_ENTRY_POINT) {
+    if (topLevelEntryPoint === INCOMPATIBLE_ENTRY_POINT) {
       return null;
     }
 
@@ -126,7 +126,7 @@ export class DirectoryWalkerEntryPointFinder implements EntryPointFinder {
       const possibleEntryPointPath = isDirectory ? path : stripJsExtension(path);
       const subEntryPoint =
           getEntryPointInfo(this.fs, this.config, this.logger, packagePath, possibleEntryPointPath);
-      if (subEntryPoint === NO_ENTRY_POINT || subEntryPoint === INVALID_ENTRY_POINT) {
+      if (subEntryPoint === NO_ENTRY_POINT || subEntryPoint === INCOMPATIBLE_ENTRY_POINT) {
         return false;
       }
       entryPoints.push(subEntryPoint);

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/directory_walker_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/directory_walker_entry_point_finder.ts
@@ -68,8 +68,9 @@ export class DirectoryWalkerEntryPointFinder implements EntryPointFinder {
     const primaryEntryPoint =
         getEntryPointInfo(this.fs, this.config, this.logger, sourceDirectory, sourceDirectory);
 
-    // If there is an entry-point but it is not a TypeScript one then exit
-    // It is unlikely that a non TypeScript entry point has a dependency on an Angular library.
+    // If there is an entry-point but it is not compatible with ngcc (it has a bad package.json or
+    // invalid typings) then exit. It is unlikely that such an entry point has a dependency on an
+    // Angular library.
     if (primaryEntryPoint === INCOMPATIBLE_ENTRY_POINT) {
       return [];
     }
@@ -150,8 +151,7 @@ export class DirectoryWalkerEntryPointFinder implements EntryPointFinder {
       let isEntryPoint = false;
       const subEntryPoint =
           getEntryPointInfo(this.fs, this.config, this.logger, packagePath, possibleEntryPointPath);
-      if (subEntryPoint !== NO_ENTRY_POINT && subEntryPoint !== INCOMPATIBLE_ENTRY_POINT &&
-          subEntryPoint.compiledByAngular) {
+      if (subEntryPoint !== NO_ENTRY_POINT && subEntryPoint !== INCOMPATIBLE_ENTRY_POINT) {
         entryPoints.push(subEntryPoint);
         isEntryPoint = true;
       }

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/directory_walker_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/directory_walker_entry_point_finder.ts
@@ -156,12 +156,18 @@ export class DirectoryWalkerEntryPointFinder implements EntryPointFinder {
         isEntryPoint = true;
       }
 
-      if (!isDirectory || !isEntryPoint) {
-        // This path is not an entry-point directory so we are done
+      if (!isDirectory) {
+        // This path is not a directory so we are done.
         continue;
       }
 
+      // This directory may contain entry-points of its own.
       const childPaths = this.fs.readdir(absolutePath);
+      if (!isEntryPoint && childPaths.some(childPath => childPath.endsWith('.js'))) {
+        // We do not consider non-entry-point directories that contain JS files as they are very
+        // unlikely to be containers for sub-entry-points.
+        continue;
+      }
       this.collectSecondaryEntryPoints(entryPoints, packagePath, absolutePath, childPaths);
     }
   }

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/directory_walker_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/directory_walker_entry_point_finder.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem, join, resolve} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, FileSystem, PathSegment} from '../../../src/ngtsc/file_system';
 import {DependencyResolver, SortedEntryPointsInfo} from '../dependencies/dependency_resolver';
 import {Logger} from '../logging/logger';
 import {NgccConfiguration} from '../packages/configuration';
@@ -14,7 +14,7 @@ import {EntryPointManifest} from '../packages/entry_point_manifest';
 import {PathMappings} from '../utils';
 import {NGCC_DIRECTORY} from '../writing/new_entry_point_file_writer';
 import {EntryPointFinder} from './interface';
-import {getBasePaths} from './utils';
+import {getBasePaths, trackDuration} from './utils';
 
 /**
  * An EntryPointFinder that searches for all entry-points that can be found given a `basePath` and
@@ -33,141 +33,144 @@ export class DirectoryWalkerEntryPointFinder implements EntryPointFinder {
   findEntryPoints(): SortedEntryPointsInfo {
     const unsortedEntryPoints: EntryPoint[] = [];
     for (const basePath of this.basePaths) {
-      let entryPoints = this.entryPointManifest.readEntryPointsUsingManifest(basePath);
-      if (entryPoints === null) {
-        this.logger.debug(
-            `No manifest found for ${basePath} so walking the directories for entry-points.`);
-        const startTime = Date.now();
-        entryPoints = this.walkDirectoryForEntryPoints(basePath);
-        const duration = Math.round((Date.now() - startTime) / 100) / 10;
-        this.logger.debug(`Walking directories took ${duration}s.`);
-
-        this.entryPointManifest.writeEntryPointManifest(basePath, entryPoints);
-      }
+      const entryPoints = this.entryPointManifest.readEntryPointsUsingManifest(basePath) ||
+          this.walkBasePathForPackages(basePath);
       unsortedEntryPoints.push(...entryPoints);
     }
     return this.resolver.sortEntryPointsByDependency(unsortedEntryPoints);
   }
 
   /**
-   * Look for entry points that need to be compiled, starting at the source directory.
-   * The function will recurse into directories that start with `@...`, e.g. `@angular/...`.
-   * @param sourceDirectory An absolute path to the root directory where searching begins.
+   * Search the `basePath` for possible Angular packages and entry-points.
+   *
+   * @param basePath The path at which to start the search
+   * @returns an array of `EntryPoint`s that were found within `basePath`.
    */
-  walkDirectoryForEntryPoints(sourceDirectory: AbsoluteFsPath): EntryPoint[] {
-    const entryPoints = this.getEntryPointsForPackage(sourceDirectory);
-    if (entryPoints === null) {
+  walkBasePathForPackages(basePath: AbsoluteFsPath): EntryPoint[] {
+    this.logger.debug(
+        `No manifest found for ${basePath} so walking the directories for entry-points.`);
+    const entryPoints: EntryPoint[] = trackDuration(
+        () => this.walkDirectoryForPackages(basePath),
+        duration => this.logger.debug(`Walking ${basePath} for entry-points took ${duration}s.`));
+    this.entryPointManifest.writeEntryPointManifest(basePath, entryPoints);
+    return entryPoints;
+  }
+
+  /**
+   * Look for Angular packages that need to be compiled, starting at the source directory.
+   * The function will recurse into directories that start with `@...`, e.g. `@angular/...`.
+   *
+   * @param sourceDirectory An absolute path to the root directory where searching begins.
+   * @returns an array of `EntryPoint`s that were found within `sourceDirectory`.
+   */
+  walkDirectoryForPackages(sourceDirectory: AbsoluteFsPath): EntryPoint[] {
+    // Try to get a primary entry point from this directory
+    const primaryEntryPoint =
+        getEntryPointInfo(this.fs, this.config, this.logger, sourceDirectory, sourceDirectory);
+
+    // If there is an entry-point but it is not a TypeScript one then exit
+    // It is unlikely that a non TypeScript entry point has a dependency on an Angular library.
+    if (primaryEntryPoint === INCOMPATIBLE_ENTRY_POINT) {
       return [];
     }
 
-    if (entryPoints.length > 0) {
-      // The `sourceDirectory` is an entry point itself so no need to search its sub-directories.
-      // Also check for any nested node_modules in this package but only if it was compiled by
-      // Angular.
-      // It is unlikely that a non Angular entry point has a dependency on an Angular library.
+    const entryPoints: EntryPoint[] = [];
+    if (primaryEntryPoint !== NO_ENTRY_POINT) {
+      entryPoints.push(primaryEntryPoint);
+      this.collectSecondaryEntryPoints(
+          entryPoints, sourceDirectory, sourceDirectory, this.fs.readdir(sourceDirectory));
+
+      // Also check for any nested node_modules in this package but only if at least one of the
+      // entry-points was compiled by Angular.
       if (entryPoints.some(e => e.compiledByAngular)) {
         const nestedNodeModulesPath = this.fs.join(sourceDirectory, 'node_modules');
         if (this.fs.exists(nestedNodeModulesPath)) {
-          entryPoints.push(...this.walkDirectoryForEntryPoints(nestedNodeModulesPath));
+          entryPoints.push(...this.walkDirectoryForPackages(nestedNodeModulesPath));
         }
       }
 
       return entryPoints;
     }
 
-    this.fs
-        .readdir(sourceDirectory)
-        // Not interested in hidden files
-        .filter(p => !p.startsWith('.'))
-        // Ignore node_modules
-        .filter(p => p !== 'node_modules' && p !== NGCC_DIRECTORY)
-        // Only interested in directories (and only those that are not symlinks)
-        .filter(p => {
-          const stat = this.fs.lstat(resolve(sourceDirectory, p));
-          return stat.isDirectory() && !stat.isSymbolicLink();
-        })
-        .forEach(p => {
-          // Package is a potential namespace containing packages (e.g `@angular`).
-          const packagePath = join(sourceDirectory, p);
-          entryPoints.push(...this.walkDirectoryForEntryPoints(packagePath));
-        });
+    // The `sourceDirectory` was not a package (i.e. there was no package.json)
+    // So search its sub-directories for Angular packages and entry-points
+    for (const path of this.fs.readdir(sourceDirectory)) {
+      if (isIgnorablePath(path)) {
+        // Ignore hidden files, node_modules and ngcc directory
+        continue;
+      }
+
+      const absolutePath = this.fs.resolve(sourceDirectory, path);
+      const stat = this.fs.lstat(absolutePath);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) {
+        // Ignore symbolic links and non-directories
+        continue;
+      }
+
+      entryPoints.push(...this.walkDirectoryForPackages(this.fs.join(sourceDirectory, path)));
+    }
+
     return entryPoints;
   }
 
   /**
-   * Recurse the folder structure looking for all the entry points
-   * @param packagePath The absolute path to an npm package that may contain entry points
-   * @returns An array of entry points that were discovered or null when it's not a valid entrypoint
+   * Search the `directory` looking for any secondary entry-points for a package, adding any that
+   * are found to the `entryPoints` array.
+   *
+   * @param entryPoints An array where we will add any entry-points found in this directory
+   * @param packagePath The absolute path to the package that may contain entry-points
+   * @param directory The current directory being searched
+   * @param paths The paths contained in the current `directory`.
    */
-  private getEntryPointsForPackage(packagePath: AbsoluteFsPath): EntryPoint[]|null {
-    const entryPoints: EntryPoint[] = [];
-
-    // Try to get an entry point from the top level package directory
-    const topLevelEntryPoint =
-        getEntryPointInfo(this.fs, this.config, this.logger, packagePath, packagePath);
-
-    // If there is no primary entry-point then exit
-    if (topLevelEntryPoint === NO_ENTRY_POINT) {
-      return [];
-    }
-
-    if (topLevelEntryPoint === INCOMPATIBLE_ENTRY_POINT) {
-      return null;
-    }
-
-    // Otherwise store it and search for secondary entry-points
-    entryPoints.push(topLevelEntryPoint);
-    this.walkDirectory(packagePath, packagePath, (path, isDirectory) => {
-      if (!path.endsWith('.js') && !isDirectory) {
-        return false;
+  private collectSecondaryEntryPoints(
+      entryPoints: EntryPoint[], packagePath: AbsoluteFsPath, directory: AbsoluteFsPath,
+      paths: PathSegment[]): void {
+    for (const path of paths) {
+      if (isIgnorablePath(path)) {
+        // Ignore hidden files, node_modules and ngcc directory
+        continue;
       }
 
-      // If the path is a JS file then strip its extension and see if we can match an entry-point.
-      const possibleEntryPointPath = isDirectory ? path : stripJsExtension(path);
+      const absolutePath = this.fs.resolve(directory, path);
+      const stat = this.fs.lstat(absolutePath);
+      if (stat.isSymbolicLink()) {
+        // Ignore symbolic links
+        continue;
+      }
+
+      const isDirectory = stat.isDirectory();
+      if (!path.endsWith('.js') && !isDirectory) {
+        // Ignore files that do not end in `.js`
+        continue;
+      }
+
+      // If the path is a JS file then strip its extension and see if we can match an
+      // entry-point.
+      const possibleEntryPointPath = isDirectory ? absolutePath : stripJsExtension(absolutePath);
+      let isEntryPoint = false;
       const subEntryPoint =
           getEntryPointInfo(this.fs, this.config, this.logger, packagePath, possibleEntryPointPath);
-      if (subEntryPoint === NO_ENTRY_POINT || subEntryPoint === INCOMPATIBLE_ENTRY_POINT) {
-        return false;
+      if (subEntryPoint !== NO_ENTRY_POINT && subEntryPoint !== INCOMPATIBLE_ENTRY_POINT &&
+          subEntryPoint.compiledByAngular) {
+        entryPoints.push(subEntryPoint);
+        isEntryPoint = true;
       }
-      entryPoints.push(subEntryPoint);
-      return true;
-    });
 
-    return entryPoints;
-  }
+      if (!isDirectory || !isEntryPoint) {
+        // This path is not an entry-point directory so we are done
+        continue;
+      }
 
-  /**
-   * Recursively walk a directory and its sub-directories, applying a given
-   * function to each directory.
-   * @param dir the directory to recursively walk.
-   * @param fn the function to apply to each directory.
-   */
-  private walkDirectory(
-      packagePath: AbsoluteFsPath, dir: AbsoluteFsPath,
-      fn: (path: AbsoluteFsPath, isDirectory: boolean) => boolean) {
-    return this.fs
-        .readdir(dir)
-        // Not interested in hidden files
-        .filter(path => !path.startsWith('.'))
-        // Ignore node_modules
-        .filter(path => path !== 'node_modules' && path !== NGCC_DIRECTORY)
-        .forEach(path => {
-          const absolutePath = resolve(dir, path);
-          const stat = this.fs.lstat(absolutePath);
-
-          if (stat.isSymbolicLink()) {
-            // We are not interested in symbolic links
-            return;
-          }
-
-          const containsEntryPoint = fn(absolutePath, stat.isDirectory());
-          if (containsEntryPoint) {
-            this.walkDirectory(packagePath, absolutePath, fn);
-          }
-        });
+      const childPaths = this.fs.readdir(absolutePath);
+      this.collectSecondaryEntryPoints(entryPoints, packagePath, absolutePath, childPaths);
+    }
   }
 }
 
 function stripJsExtension<T extends string>(filePath: T): T {
   return filePath.replace(/\.js$/, '') as T;
+}
+
+function isIgnorablePath(path: PathSegment): boolean {
+  return path.startsWith('.') || path === 'node_modules' || path === NGCC_DIRECTORY;
 }

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/directory_walker_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/directory_walker_entry_point_finder.ts
@@ -163,7 +163,10 @@ export class DirectoryWalkerEntryPointFinder implements EntryPointFinder {
 
       // This directory may contain entry-points of its own.
       const childPaths = this.fs.readdir(absolutePath);
-      if (!isEntryPoint && childPaths.some(childPath => childPath.endsWith('.js'))) {
+      if (!isEntryPoint &&
+          childPaths.some(
+              childPath => childPath.endsWith('.js') &&
+                  this.fs.stat(this.fs.resolve(absolutePath, childPath)).isFile())) {
         // We do not consider non-entry-point directories that contain JS files as they are very
         // unlikely to be containers for sub-entry-points.
         continue;

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
@@ -10,7 +10,7 @@ import {DependencyResolver, SortedEntryPointsInfo} from '../dependencies/depende
 import {Logger} from '../logging/logger';
 import {hasBeenProcessed} from '../packages/build_marker';
 import {NgccConfiguration} from '../packages/configuration';
-import {EntryPoint, EntryPointJsonProperty, INVALID_ENTRY_POINT, NO_ENTRY_POINT, getEntryPointInfo} from '../packages/entry_point';
+import {EntryPoint, EntryPointJsonProperty, INCOMPATIBLE_ENTRY_POINT, NO_ENTRY_POINT, getEntryPointInfo} from '../packages/entry_point';
 import {PathMappings} from '../utils';
 import {EntryPointFinder} from './interface';
 import {getBasePaths} from './utils';
@@ -94,7 +94,7 @@ export class TargetedEntryPointFinder implements EntryPointFinder {
     const packagePath = this.computePackagePath(entryPointPath);
     const entryPoint =
         getEntryPointInfo(this.fs, this.config, this.logger, packagePath, entryPointPath);
-    if (entryPoint === NO_ENTRY_POINT || entryPoint === INVALID_ENTRY_POINT) {
+    if (entryPoint === NO_ENTRY_POINT || entryPoint === INCOMPATIBLE_ENTRY_POINT) {
       return null;
     }
     return entryPoint;

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/utils.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/utils.ts
@@ -78,3 +78,18 @@ function removeContainedPaths(value: AbsoluteFsPath, index: number, array: Absol
   }
   return true;
 }
+
+/**
+ * Run a task and track how long it takes.
+ *
+ * @param task The task whose duration we are tracking
+ * @param log The function to call with the duration of the task
+ * @returns The result of calling `task`.
+ */
+export function trackDuration<T = void>(task: () => T, log: (duration: number) => void): T {
+  const startTime = Date.now();
+  const result = task();
+  const duration = Math.round((Date.now() - startTime) / 100) / 10;
+  log(duration);
+  return result;
+}

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/utils.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/utils.ts
@@ -86,7 +86,8 @@ function removeContainedPaths(value: AbsoluteFsPath, index: number, array: Absol
  * @param log The function to call with the duration of the task
  * @returns The result of calling `task`.
  */
-export function trackDuration<T = void>(task: () => T, log: (duration: number) => void): T {
+export function trackDuration<T = void>(
+    task: () => T extends Promise<unknown>? never : T, log: (duration: number) => void): T {
   const startTime = Date.now();
   const result = task();
   const duration = Math.round((Date.now() - startTime) / 100) / 10;

--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -86,7 +86,7 @@ export const NO_ENTRY_POINT = 'no-entry-point';
 /**
  * The path has a package.json, but it is not a valid entry-point for ngcc processing.
  */
-export const INVALID_ENTRY_POINT = 'invalid-entry-point';
+export const INCOMPATIBLE_ENTRY_POINT = 'incompatible-entry-point';
 
 /**
  * The result of calling `getEntryPointInfo()`.
@@ -94,10 +94,11 @@ export const INVALID_ENTRY_POINT = 'invalid-entry-point';
  * This will be an `EntryPoint` object if an Angular entry-point was identified;
  * Otherwise it will be a flag indicating one of:
  * * NO_ENTRY_POINT - the path is not an entry-point or ngcc is configured to ignore it
- * * INVALID_ENTRY_POINT - the path was a non-processable entry-point that should be searched
+ * * INCOMPATIBLE_ENTRY_POINT - the path was a non-processable entry-point that should be searched
  * for sub-entry-points
  */
-export type GetEntryPointResult = EntryPoint | typeof INVALID_ENTRY_POINT | typeof NO_ENTRY_POINT;
+export type GetEntryPointResult =
+    EntryPoint | typeof INCOMPATIBLE_ENTRY_POINT | typeof NO_ENTRY_POINT;
 
 
 /**
@@ -107,9 +108,10 @@ export type GetEntryPointResult = EntryPoint | typeof INVALID_ENTRY_POINT | type
  * @param entryPointPath the absolute path to the potential entry-point.
  * @returns
  * - An entry-point if it is valid.
- * - `undefined` when there is no package.json at the path and there is no config to force an
+ * - `NO_ENTRY_POINT` when there is no package.json at the path and there is no config to force an
  * entry-point or the entrypoint is `ignored`.
- * - `null` there is a package.json but it is not a valid Angular compiled entry-point.
+ * - `INCOMPATIBLE_ENTRY_POINT` there is a package.json but it is not a valid Angular compiled
+ * entry-point.
  */
 export function getEntryPointInfo(
     fs: FileSystem, config: NgccConfiguration, logger: Logger, packagePath: AbsoluteFsPath,
@@ -138,14 +140,14 @@ export function getEntryPointInfo(
 
   if (entryPointPackageJson === null) {
     // package.json exists but could not be parsed and there was no redeeming config
-    return INVALID_ENTRY_POINT;
+    return INCOMPATIBLE_ENTRY_POINT;
   }
 
   const typings = entryPointPackageJson.typings || entryPointPackageJson.types ||
       guessTypingsFromPackageJson(fs, entryPointPath, entryPointPackageJson);
   if (typeof typings !== 'string') {
     // Missing the required `typings` property
-    return INVALID_ENTRY_POINT;
+    return INCOMPATIBLE_ENTRY_POINT;
   }
 
   // An entry-point is assumed to be compiled by Angular if there is either:

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
@@ -12,7 +12,7 @@ import {Logger} from '../logging/logger';
 
 import {NGCC_VERSION} from './build_marker';
 import {NgccConfiguration} from './configuration';
-import {EntryPoint, INVALID_ENTRY_POINT, NO_ENTRY_POINT, getEntryPointInfo} from './entry_point';
+import {EntryPoint, INCOMPATIBLE_ENTRY_POINT, NO_ENTRY_POINT, getEntryPointInfo} from './entry_point';
 
 /**
  * Manages reading and writing a manifest file that contains a list of all the entry-points that
@@ -71,7 +71,7 @@ export class EntryPointManifest {
       for (const [packagePath, entryPointPath] of entryPointPaths) {
         const result =
             getEntryPointInfo(this.fs, this.config, this.logger, packagePath, entryPointPath);
-        if (result === NO_ENTRY_POINT || result === INVALID_ENTRY_POINT) {
+        if (result === NO_ENTRY_POINT || result === INCOMPATIBLE_ENTRY_POINT) {
           throw new Error(
               `The entry-point manifest at ${manifestPath} contained an invalid pair of package paths: [${packagePath}, ${entryPointPath}]`);
         } else {

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
@@ -230,7 +230,7 @@ runInEachFileSystem(() => {
         const finder = new DirectoryWalkerEntryPointFinder(
             fs, config, logger, resolver, manifest, _Abs('/nested_node_modules/node_modules'),
             undefined);
-        const spy = spyOn(finder, 'walkDirectoryForEntryPoints').and.callThrough();
+        const spy = spyOn(finder, 'walkDirectoryForPackages').and.callThrough();
         const {entryPoints} = finder.findEntryPoints();
         expect(spy.calls.allArgs()).toEqual([
           [_Abs(basePath)],
@@ -252,7 +252,7 @@ runInEachFileSystem(() => {
 
         const finder = new DirectoryWalkerEntryPointFinder(
             fs, config, logger, resolver, manifest, basePath, undefined);
-        const spy = spyOn(finder, 'walkDirectoryForEntryPoints').and.callThrough();
+        const spy = spyOn(finder, 'walkDirectoryForPackages').and.callThrough();
         const {entryPoints} = finder.findEntryPoints();
         expect(spy.calls.allArgs()).toEqual([
           [_Abs(basePath)],
@@ -276,7 +276,7 @@ runInEachFileSystem(() => {
 
         const finder = new DirectoryWalkerEntryPointFinder(
             fs, config, logger, resolver, manifest, basePath, undefined);
-        const spy = spyOn(finder, 'walkDirectoryForEntryPoints').and.callThrough();
+        const spy = spyOn(finder, 'walkDirectoryForPackages').and.callThrough();
         const {entryPoints} = finder.findEntryPoints();
         expect(spy.calls.allArgs()).toEqual([
           [_Abs(basePath)],

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
@@ -287,6 +287,22 @@ runInEachFileSystem(() => {
         expect(entryPoints).toEqual([]);
       });
 
+      it('should process sub-entry-points within a non-entry-point containing folder in a package',
+         () => {
+           const basePath = _Abs('/containing_folders/node_modules');
+           loadTestFiles([
+             ...createPackage(basePath, 'package'),
+             ...createPackage(fs.resolve(basePath, 'package/container'), 'entry-point-1'),
+           ]);
+           const finder = new DirectoryWalkerEntryPointFinder(
+               fs, config, logger, resolver, manifest, basePath, undefined);
+           const {entryPoints} = finder.findEntryPoints();
+           expect(dumpEntryPointPaths(basePath, entryPoints)).toEqual([
+             ['package', 'package'],
+             ['package', 'package/container/entry-point-1'],
+           ]);
+         });
+
       it('should handle dependencies via pathMappings', () => {
         const basePath = _Abs('/path_mapped/node_modules');
         const pathMappings: PathMappings = {

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
@@ -10,7 +10,7 @@ import {AbsoluteFsPath, FileSystem, absoluteFrom, getFileSystem} from '../../../
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadTestFiles} from '../../../test/helpers';
 import {NgccConfiguration} from '../../src/packages/configuration';
-import {EntryPoint, INVALID_ENTRY_POINT, NO_ENTRY_POINT, SUPPORTED_FORMAT_PROPERTIES, getEntryPointFormat, getEntryPointInfo} from '../../src/packages/entry_point';
+import {EntryPoint, INCOMPATIBLE_ENTRY_POINT, NO_ENTRY_POINT, SUPPORTED_FORMAT_PROPERTIES, getEntryPointFormat, getEntryPointInfo} from '../../src/packages/entry_point';
 import {MockLogger} from '../helpers/mock_logger';
 
 runInEachFileSystem(() => {
@@ -165,7 +165,7 @@ runInEachFileSystem(() => {
        });
 
 
-    it('should return `INVALID_ENTRY_POINT` if there is no typings or types field in the package.json',
+    it('should return `INCOMPATIBLE_ENTRY_POINT` if there is no typings or types field in the package.json',
        () => {
          loadTestFiles([
            {
@@ -182,10 +182,10 @@ runInEachFileSystem(() => {
          const entryPoint = getEntryPointInfo(
              fs, config, new MockLogger(), SOME_PACKAGE,
              _('/project/node_modules/some_package/missing_typings'));
-         expect(entryPoint).toBe(INVALID_ENTRY_POINT);
+         expect(entryPoint).toBe(INCOMPATIBLE_ENTRY_POINT);
        });
 
-    it('should return `INVALID_ENTRY_POINT` if the typings or types field is not a string in the package.json',
+    it('should return `INCOMPATIBLE_ENTRY_POINT` if the typings or types field is not a string in the package.json',
        () => {
          loadTestFiles([
            {
@@ -202,7 +202,7 @@ runInEachFileSystem(() => {
          const entryPoint = getEntryPointInfo(
              fs, config, new MockLogger(), SOME_PACKAGE,
              _('/project/node_modules/some_package/typings_array'));
-         expect(entryPoint).toBe(INVALID_ENTRY_POINT);
+         expect(entryPoint).toBe(INCOMPATIBLE_ENTRY_POINT);
        });
 
     for (let prop of SUPPORTED_FORMAT_PROPERTIES) {
@@ -359,7 +359,7 @@ runInEachFileSystem(() => {
       });
     });
 
-    it('should return `INVALID_ENTRY_POINT` if the package.json is not valid JSON', () => {
+    it('should return `INCOMPATIBLE_ENTRY_POINT` if the package.json is not valid JSON', () => {
       loadTestFiles([
         // package.json might not be a valid JSON
         // for example, @schematics/angular contains a package.json blueprint
@@ -373,7 +373,7 @@ runInEachFileSystem(() => {
       const entryPoint = getEntryPointInfo(
           fs, config, new MockLogger(), SOME_PACKAGE,
           _('/project/node_modules/some_package/unexpected_symbols'));
-      expect(entryPoint).toBe(INVALID_ENTRY_POINT);
+      expect(entryPoint).toBe(INCOMPATIBLE_ENTRY_POINT);
     });
   });
 
@@ -395,7 +395,7 @@ runInEachFileSystem(() => {
       const result = getEntryPointInfo(
           fs, config, new MockLogger(), SOME_PACKAGE,
           _('/project/node_modules/some_package/valid_entry_point'));
-      if (result === NO_ENTRY_POINT || result === INVALID_ENTRY_POINT) {
+      if (result === NO_ENTRY_POINT || result === INCOMPATIBLE_ENTRY_POINT) {
         return fail(`Expected an entry point but got ${result}`);
       }
       entryPoint = result;

--- a/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
@@ -9,7 +9,7 @@ import {FileSystem, absoluteFrom, getFileSystem} from '../../../src/ngtsc/file_s
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadTestFiles} from '../../../test/helpers';
 import {NgccConfiguration} from '../../src/packages/configuration';
-import {EntryPoint, EntryPointFormat, EntryPointJsonProperty, INVALID_ENTRY_POINT, NO_ENTRY_POINT, getEntryPointInfo} from '../../src/packages/entry_point';
+import {EntryPoint, EntryPointFormat, EntryPointJsonProperty, INCOMPATIBLE_ENTRY_POINT, NO_ENTRY_POINT, getEntryPointInfo} from '../../src/packages/entry_point';
 import {EntryPointBundle, makeEntryPointBundle} from '../../src/packages/entry_point_bundle';
 import {FileWriter} from '../../src/writing/file_writer';
 import {NewEntryPointFileWriter} from '../../src/writing/new_entry_point_file_writer';
@@ -108,7 +108,7 @@ runInEachFileSystem(() => {
         const config = new NgccConfiguration(fs, _('/'));
         const result = getEntryPointInfo(
             fs, config, logger, _('/node_modules/test'), _('/node_modules/test')) !;
-        if (result === NO_ENTRY_POINT || result === INVALID_ENTRY_POINT) {
+        if (result === NO_ENTRY_POINT || result === INCOMPATIBLE_ENTRY_POINT) {
           return fail(`Expected an entry point but got ${result}`);
         }
         entryPoint = result;
@@ -248,7 +248,7 @@ runInEachFileSystem(() => {
         const config = new NgccConfiguration(fs, _('/'));
         const result = getEntryPointInfo(
             fs, config, logger, _('/node_modules/test'), _('/node_modules/test/a')) !;
-        if (result === NO_ENTRY_POINT || result === INVALID_ENTRY_POINT) {
+        if (result === NO_ENTRY_POINT || result === INCOMPATIBLE_ENTRY_POINT) {
           return fail(`Expected an entry point but got ${result}`);
         }
         entryPoint = result;
@@ -377,7 +377,7 @@ runInEachFileSystem(() => {
         const config = new NgccConfiguration(fs, _('/'));
         const result = getEntryPointInfo(
             fs, config, new MockLogger(), _('/node_modules/test'), _('/node_modules/test/b')) !;
-        if (result === NO_ENTRY_POINT || result === INVALID_ENTRY_POINT) {
+        if (result === NO_ENTRY_POINT || result === INCOMPATIBLE_ENTRY_POINT) {
           return fail(`Expected an entry point but got ${result}`);
         }
         entryPoint = result;


### PR DESCRIPTION
The previous optimizations in #35756 to the
`DirectoryWalkerEntryPointFinder` were over zealous
with regard to packages that have entry-points stored
in "container" directories in the package, where the
container directory was not an entry-point itself.

Now we will also walk such "container" folders as long
as they do not contain `.js` files, which we regard as an
indicator that the directory will not contain entry-points.

Fixes #36216

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
