### PR TITLE
build: don't use deprecated $(location) pre-declared variable

### DIFF
--- a/dev-infra/BUILD.bazel
+++ b/dev-infra/BUILD.bazel
@@ -23,8 +23,8 @@ genrule(
     ],
     outs = ["package.json"],
     cmd = """
-        $(location //tools:inline-package-json-deps) $(location tmpl-package.json) \
-            $(location //:package.json) $@
+        $(execpath //tools:inline-package-json-deps) $(execpath tmpl-package.json) \
+            $(execpath //:package.json) $@
     """,
     tools = ["//tools:inline-package-json-deps"],
 )

--- a/tools/circular_dependency_test/index.bzl
+++ b/tools/circular_dependency_test/index.bzl
@@ -20,16 +20,16 @@ def circular_dependency_test(name, deps, entry_point, **kwargs):
         templated_args = [
             "--circular",
             "--no-spinner",
-            # NOTE: We cannot use `$(location)` to resolve labels. This is because `ts_library`
+            # NOTE: We cannot use `$(rootpath)` to resolve labels. This is because `ts_library`
             # does not pre-declare outputs in the rule. Hence, the outputs cannot be referenced
             # through labels (i.e. `//packages/core:index.js`). Read more here:
             # https://docs.bazel.build/versions/2.0.0/skylark/rules.html#outputs
             # TODO: revisit once https://github.com/bazelbuild/rules_nodejs/issues/1563 is solved.
-            "$(rlocation %s)" % entry_point,
+            "$$(rlocation %s)" % entry_point,
             # Madge supports custom module resolution, but expects a configuration file
             # similar to a Webpack configuration file setting the `resolve` option.
             "--webpack-config",
-            "$(rlocation $(location %s))" % MADGE_CONFIG_LABEL,
+            "$$(rlocation $(rootpath %s))" % MADGE_CONFIG_LABEL,
         ],
         testonly = 1,
         expected_exit_code = 0,

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -340,7 +340,7 @@ def jasmine_node_test(bootstrap = [], **kwargs):
     templated_args = kwargs.pop("templated_args", [])
     for label in bootstrap:
         deps += [label]
-        templated_args += ["--node_options=--require=$(rlocation $(location %s))" % label]
+        templated_args += ["--node_options=--require=$$(rlocation $(rootpath %s))" % label]
         if label.endswith("_es5"):
             # If this label is a filegroup derived from a ts_library then automatically
             # add the ts_library target (which is the label sans `_es5`) to deps so we pull

--- a/tools/npm_integration_test/npm_integration_test.bzl
+++ b/tools/npm_integration_test/npm_integration_test.bzl
@@ -181,7 +181,7 @@ def npm_integration_test(name, **kwargs):
         name = name,
         data = data + npm_deps + [":%s.config" % name, ":%s.config.js" % name],
         tags = tags,
-        templated_args = ["$(location :%s.config.js)" % name],
+        templated_args = ["$(rootpath :%s.config.js)" % name],
         entry_point = "//tools/npm_integration_test:test_runner.js",
         **kwargs
     )
@@ -192,7 +192,7 @@ def npm_integration_test(name, **kwargs):
         name = name + ".debug",
         data = data + npm_deps + [":%s.debug.config" % name, ":%s.debug.config.js" % name],
         tags = tags + ["manual", "local"],
-        templated_args = ["$(location :%s.debug.config.js)" % name],
+        templated_args = ["$(rootpath :%s.debug.config.js)" % name],
         entry_point = "//tools/npm_integration_test:test_runner.js",
         **kwargs
     )

--- a/tools/npm_integration_test/test_runner.js
+++ b/tools/npm_integration_test/test_runner.js
@@ -340,7 +340,7 @@ class TestRunner {
   }
 }
 
-const config = require(process.argv[2]);
+const config = require(runfiles.resolveWorkspaceRelative(process.argv[2]));
 
 // set env vars passed from --define
 for (const k of Object.keys(config.envVars)) {

--- a/tools/saucelabs/BUILD.bazel
+++ b/tools/saucelabs/BUILD.bazel
@@ -60,5 +60,5 @@ nodejs_binary(
         "@npm//shelljs",
     ],
     entry_point = "karma-saucelabs.js",
-    templated_args = ["$(location sauce-service.sh)"],
+    templated_args = ["$(rootpath sauce-service.sh)"],
 )

--- a/tools/symbol-extractor/cli.ts
+++ b/tools/symbol-extractor/cli.ts
@@ -9,6 +9,8 @@
 import * as fs from 'fs';
 import {SymbolExtractor} from './symbol_extractor';
 
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER'] as string);
+
 if (require.main === module) {
   const args = process.argv.slice(2) as[string, string];
   process.exitCode = main(args) ? 0 : 1;
@@ -22,8 +24,8 @@ if (require.main === module) {
  * ```
  */
 function main(argv: [string, string, string] | [string, string]): boolean {
-  const javascriptFilePath = require.resolve(argv[0]);
-  const goldenFilePath = require.resolve(argv[1]);
+  const javascriptFilePath = runfiles.resolveWorkspaceRelative(argv[0]);
+  const goldenFilePath = runfiles.resolveWorkspaceRelative(argv[1]);
   const doUpdate = argv[2] == '--accept';
 
   const javascriptContent = fs.readFileSync(javascriptFilePath).toString();

--- a/tools/symbol-extractor/index.bzl
+++ b/tools/symbol-extractor/index.bzl
@@ -24,7 +24,7 @@ def js_expected_symbol_test(name, src, golden, data = [], **kwargs):
         name = name,
         data = all_data,
         entry_point = entry_point,
-        templated_args = ["$(location %s)" % src, "$(location %s)" % golden],
+        templated_args = ["$(rootpath %s)" % src, "$(rootpath %s)" % golden],
         configuration_env_vars = ["angular_ivy_enabled"],
         **kwargs
     )
@@ -35,6 +35,6 @@ def js_expected_symbol_test(name, src, golden, data = [], **kwargs):
         data = all_data,
         entry_point = entry_point,
         configuration_env_vars = ["angular_ivy_enabled"],
-        templated_args = ["$(location %s)" % src, "$(location %s)" % golden, "--accept"],
+        templated_args = ["$(rootpath %s)" % src, "$(rootpath %s)" % golden, "--accept"],
         **kwargs
     )


### PR DESCRIPTION
$(location) is not recommended in the bazel docs as depending on context it will either return the value of $(execpath) or $(rootpath). rules_nodejs now supports $(rootpath) and $(execpath) in templated_args of nodejs_binary.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
