### PR TITLE
fix(language-service): infer type of elements of array-like objects

### DIFF
--- a/packages/language-service/src/typescript_symbols.ts
+++ b/packages/language-service/src/typescript_symbols.ts
@@ -127,10 +127,13 @@ class TypeScriptSymbolQuery implements SymbolQuery {
 
   getElementType(type: Symbol): Symbol|undefined {
     if (type instanceof TypeWrapper) {
-      const tSymbol = type.tsType.symbol;
-      const tArgs = type.typeArguments();
-      if (!tSymbol || tSymbol.name !== 'Array' || !tArgs || tArgs.length != 1) return;
-      return tArgs[0];
+      const ty = type.tsType;
+      const tyArgs = type.typeArguments();
+      // The type should be Array-like, like Array<T> or ReadonlyArray<T>.
+      // Since arrays are actually objects in JavaScript (and TypeScript doesn't expose a more
+      // specific type), check if the type is object-like and has one type argument.
+      if (!(ty.flags & ts.TypeFlags.Object) || tyArgs?.length != 1) return;
+      return tyArgs[0];
     }
   }
 

--- a/packages/language-service/src/typescript_symbols.ts
+++ b/packages/language-service/src/typescript_symbols.ts
@@ -129,10 +129,9 @@ class TypeScriptSymbolQuery implements SymbolQuery {
     if (type instanceof TypeWrapper) {
       const ty = type.tsType;
       const tyArgs = type.typeArguments();
-      // The type should be Array-like, like Array<T> or ReadonlyArray<T>.
-      // Since arrays are actually objects in JavaScript (and TypeScript doesn't expose a more
-      // specific type), check if the type is object-like and has one type argument.
-      if (!(ty.flags & ts.TypeFlags.Object) || tyArgs?.length != 1) return;
+      // TODO(ayazhafiz): Track https://github.com/microsoft/TypeScript/issues/37711 to expose
+      // `isArrayLikeType` as a public method.
+      if (!(this.checker as any).isArrayLikeType(ty) || tyArgs?.length !== 1) return;
       return tyArgs[0];
     }
   }

--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -96,15 +96,47 @@ describe('hover', () => {
       expect(documentation).toBe('This is the title of the `TemplateReference` Component.');
     });
 
-    it('should work for property reads', () => {
-      mockHost.override(TEST_TEMPLATE, `<div>{{«title»}}</div>`);
-      const marker = mockHost.getReferenceMarkerFor(TEST_TEMPLATE, 'title');
-      const quickInfo = ngLS.getQuickInfoAtPosition(TEST_TEMPLATE, marker.start);
-      expect(quickInfo).toBeTruthy();
-      const {textSpan, displayParts} = quickInfo !;
-      expect(textSpan).toEqual(marker);
-      expect(textSpan.length).toBe('title'.length);
-      expect(toText(displayParts)).toBe('(property) TemplateReference.title: string');
+    describe('property reads', () => {
+      it('should work for class members', () => {
+        mockHost.override(TEST_TEMPLATE, `<div>{{«title»}}</div>`);
+        const marker = mockHost.getReferenceMarkerFor(TEST_TEMPLATE, 'title');
+        const quickInfo = ngLS.getQuickInfoAtPosition(TEST_TEMPLATE, marker.start);
+        expect(quickInfo).toBeTruthy();
+        const {textSpan, displayParts} = quickInfo !;
+        expect(textSpan).toEqual(marker);
+        expect(toText(displayParts)).toBe('(property) TemplateReference.title: string');
+      });
+
+      it('should work for array members', () => {
+        mockHost.override(TEST_TEMPLATE, `<div *ngFor="let hero of heroes">{{«hero»}}</div>`);
+        const marker = mockHost.getReferenceMarkerFor(TEST_TEMPLATE, 'hero');
+        const quickInfo = ngLS.getQuickInfoAtPosition(TEST_TEMPLATE, marker.start);
+        expect(quickInfo).toBeTruthy();
+        const {textSpan, displayParts} = quickInfo !;
+        expect(textSpan).toEqual(marker);
+        expect(toText(displayParts)).toBe('(variable) hero: Hero');
+      });
+
+      it('should work for ReadonlyArray members (#36191)', () => {
+        mockHost.override(
+            TEST_TEMPLATE, `<div *ngFor="let hero of readonlyHeroes">{{«hero»}}</div>`);
+        const marker = mockHost.getReferenceMarkerFor(TEST_TEMPLATE, 'hero');
+        const quickInfo = ngLS.getQuickInfoAtPosition(TEST_TEMPLATE, marker.start);
+        expect(quickInfo).toBeTruthy();
+        const {textSpan, displayParts} = quickInfo !;
+        expect(textSpan).toEqual(marker);
+        expect(toText(displayParts)).toBe('(variable) hero: Readonly<Hero>');
+      });
+
+      it('should work for const array members (#36191)', () => {
+        mockHost.override(TEST_TEMPLATE, `<div *ngFor="let name of constNames">{{«name»}}</div>`);
+        const marker = mockHost.getReferenceMarkerFor(TEST_TEMPLATE, 'name');
+        const quickInfo = ngLS.getQuickInfoAtPosition(TEST_TEMPLATE, marker.start);
+        expect(quickInfo).toBeTruthy();
+        const {textSpan, displayParts} = quickInfo !;
+        expect(textSpan).toEqual(marker);
+        expect(toText(displayParts)).toBe('(variable) name: { readonly name: "name"; }');
+      });
     });
 
     it('should work for method calls', () => {

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -174,6 +174,8 @@ export class TemplateReference {
   index = null;
   myClick(event: any) {}
   birthday = new Date();
+  readonlyHeroes: ReadonlyArray<Readonly<Hero>> = this.heroes;
+  constNames = [{name: 'name'}] as const ;
 }
 
 @Component({


### PR DESCRIPTION
Currently the language service only provides support for determining the
type of array-like members when the array-like object is an `Array`.
However, there are other kinds of array-like objects, including
`ReadonlyArray`s and `readonly`-property arrays. This commit adds
support for retrieving the element type of arbitrary array-like objects.

Closes #36191

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No