### PR TITLE
build(docs-infra): fix `autoLinkCode` to ignore docs without a path

### DIFF
--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
@@ -90,6 +90,12 @@ module.exports = function autoLinkCode(getDocFromAlias) {
     }
 
     var doc = docs[0];
+
+    const isInvalidDoc = doc.docType === 'member' && !keyword.includes('.');
+    if (isInvalidDoc) {
+      return false;
+    }
+
     if (doc.path === '') {
       var message = `
       autoLinkCode: Doc path is empty for "${doc.id}" - link will not be generated for "${keyword}".

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
@@ -126,6 +126,15 @@ describe('autoLinkCode post-processor', () => {
     expect(doc.renderedContent).toEqual('<code>MyClass</code>');
   });
 
+  it('should ignore code items that match an API doc but have no path set',
+     () => {
+       aliasMap.addDoc(
+           {docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: ''});
+       const doc = {docType: 'test-doc', renderedContent: '<code>MyClass</code>'};
+       processor.$process([doc]);
+       expect(doc.renderedContent).toEqual('<code>MyClass</code>');
+     });
+
   it('should insert anchors for individual text nodes within a code block', () => {
     aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
     const doc = {

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
@@ -137,12 +137,20 @@ describe('autoLinkCode post-processor', () => {
 
   it('should ignore documents when the `docType` is set to `member` and the keyword doesn\'t include `.`',
      () => {
-       aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
        aliasMap.addDoc(
            {docType: 'member', id: 'MyEnum', aliases: ['MyEnum'], path: 'a/b/c'});
-       const doc = {docType: 'test-doc', renderedContent: '<code>MyClass</code>'};
+       const doc = {docType: 'test-doc', renderedContent: '<code>MyEnum</code>'};
        processor.$process([doc]);
-       expect(doc.renderedContent).toEqual('<code><a href="a/b/myclass" class="code-anchor">MyClass</a></code>');
+       expect(doc.renderedContent).toEqual('<code>MyEnum</code>');
+     });
+
+  it('should insert anchors when the `docType` is set to `member` and the keyword includes `.`',
+     () => {
+       aliasMap.addDoc(
+           {docType: 'member', id: 'MyEnum', aliases: ['MyEnum.Value'], path: 'a/b/c'});
+       const doc = {docType: 'test-doc', renderedContent: '<code>MyEnum.Value</code>'};
+       processor.$process([doc]);
+       expect(doc.renderedContent).toEqual('<code><a href="a/b/c" class="code-anchor">MyEnum.Value</a></code>');
      });
 
   it('should insert anchors for individual text nodes within a code block', () => {

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
@@ -144,15 +144,6 @@ describe('autoLinkCode post-processor', () => {
        expect(doc.renderedContent).toEqual('<code>MyEnum</code>');
      });
 
-  it('should insert anchors when the `docType` is set to `member` and the keyword includes `.`',
-     () => {
-       aliasMap.addDoc(
-           {docType: 'member', id: 'MyEnum', aliases: ['MyEnum.Value'], path: 'a/b/c'});
-       const doc = {docType: 'test-doc', renderedContent: '<code>MyEnum.Value</code>'};
-       processor.$process([doc]);
-       expect(doc.renderedContent).toEqual('<code><a href="a/b/c" class="code-anchor">MyEnum.Value</a></code>');
-     });
-
   it('should insert anchors for individual text nodes within a code block', () => {
     aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
     const doc = {

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
@@ -135,6 +135,16 @@ describe('autoLinkCode post-processor', () => {
        expect(doc.renderedContent).toEqual('<code>MyClass</code>');
      });
 
+  it('should ignore documents when the `docType` is set to `member` and the keyword doesn\'t include `.`',
+     () => {
+       aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
+       aliasMap.addDoc(
+           {docType: 'member', id: 'MyEnum', aliases: ['MyEnum'], path: 'a/b/c'});
+       const doc = {docType: 'test-doc', renderedContent: '<code>MyClass</code>'};
+       processor.$process([doc]);
+       expect(doc.renderedContent).toEqual('<code><a href="a/b/myclass" class="code-anchor">MyClass</a></code>');
+     });
+
   it('should insert anchors for individual text nodes within a code block', () => {
     aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
     const doc = {

--- a/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.js
+++ b/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.js
@@ -5,6 +5,6 @@
  */
 
 module.exports = function ignoreGenericWords() {
-  const ignoredWords = new Set(['a', 'classes', 'create', 'error', 'group', 'request', 'target', 'value']);
+  const ignoredWords = new Set(['a', 'classes', 'create', 'error', 'group', 'request', 'target', 'value', '_']);
   return (docs, words, index) => ignoredWords.has(words[index].toLowerCase()) ? [] : docs;
 };

--- a/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.spec.js
+++ b/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.spec.js
@@ -16,12 +16,6 @@ describe('ignoreGenericWords', () => {
     expect(ignoreGenericWords(docs, words, 1)).toEqual([]);
     expect(ignoreGenericWords(docs, words, 2)).toEqual(docs);
   });
-
-  it('should ignore `_` in all docs', () => {
-    const docs = [{docType: 'package', name: 'create'}, {docType: 'class', name: 'Foo'}];
-    const words = ['_'];
-    expect(ignoreGenericWords(docs, words, 0)).toEqual([]);
-  });
 });
 
 

--- a/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.spec.js
+++ b/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.spec.js
@@ -16,6 +16,12 @@ describe('ignoreGenericWords', () => {
     expect(ignoreGenericWords(docs, words, 1)).toEqual([]);
     expect(ignoreGenericWords(docs, words, 2)).toEqual(docs);
   });
+
+  it('should ignore `_` in all docs', () => {
+    const docs = [{docType: 'package', name: 'create'}, {docType: 'class', name: 'Foo'}];
+    const words = ['_'];
+    expect(ignoreGenericWords(docs, words, 0)).toEqual([]);
+  });
 });
 
 


### PR DESCRIPTION
Closes #36260

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #36260


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
