### PR TITLE
feat(dev-infra): standard CLI commands using yargs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,7 @@ jobs:
 
       - run: yarn lint --branch $CI_GIT_BASE_REVISION
       - run: yarn ts-circular-deps:check
-      - run: yarn -s ng-dev pullapprove:verify
+      - run: yarn -s ng-dev pullapprove verify
 
   test:
     executor:

--- a/dev-infra/BUILD.bazel
+++ b/dev-infra/BUILD.bazel
@@ -10,8 +10,11 @@ ts_library(
     deps = [
         "//dev-infra/commit-message",
         "//dev-infra/pullapprove",
+        "//dev-infra/ts-circular-dependencies",
         "//dev-infra/utils:config",
         "@npm//@types/node",
+        "@npm//@types/yargs",
+        "@npm//yargs",
     ],
 )
 

--- a/dev-infra/cli.ts
+++ b/dev-infra/cli.ts
@@ -6,26 +6,17 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {readFileSync} from 'fs';
-import {join} from 'path';
-import {verify} from './pullapprove/verify';
-import {validateCommitMessage} from './commit-message/validate';
-import {getRepoBaseDir} from './utils/config';
+import * as yargs from 'yargs';
+import {tsCircularDependenciesBuilder} from './ts-circular-dependencies/index';
+import {buildPullapproveParser} from './pullapprove/cli';
+import {buildCommitMessageParser} from './commit-message/cli';
 
-const args = process.argv.slice(2);
-
-
-// TODO(josephperrott): Set up proper cli flag/command handling
-switch (args[0]) {
-  case 'pullapprove:verify':
-    verify();
-    break;
-  case 'commit-message:pre-commit-validate':
-    const commitMessage = readFileSync(join(getRepoBaseDir(), '.git/COMMIT_EDITMSG'), 'utf8');
-    if (validateCommitMessage(commitMessage)) {
-      console.info('√  Valid commit message');
-    }
-    break;
-  default:
-    console.info('No commands were matched');
-}
+yargs.scriptName('ng-dev')
+    .demandCommand()
+    .recommendCommands()
+    .command('ts-circular-deps <command>', '', tsCircularDependenciesBuilder)
+    .command('pullapprove <command>', '', buildPullapproveParser)
+    .command('commit-message <command>', '', buildCommitMessageParser)
+    .wrap(120)
+    .strict()
+    .parse();

--- a/dev-infra/commit-message/BUILD.bazel
+++ b/dev-infra/commit-message/BUILD.bazel
@@ -4,15 +4,19 @@ load("@npm_bazel_typescript//:index.bzl", "ts_library")
 ts_library(
     name = "commit-message",
     srcs = [
+        "cli.ts",
         "config.ts",
         "validate.ts",
+        "validate-file.ts",
     ],
     module_name = "@angular/dev-infra-private/commit-message",
     visibility = ["//dev-infra:__subpackages__"],
     deps = [
         "//dev-infra/utils:config",
         "@npm//@types/node",
+        "@npm//@types/yargs",
         "@npm//tslib",
+        "@npm//yargs",
     ],
 )
 

--- a/dev-infra/commit-message/cli.ts
+++ b/dev-infra/commit-message/cli.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as yargs from 'yargs';
+import {validateFile} from './validate-file';
+
+/** Build the parser for the commit-message commands. */
+export function buildCommitMessageParser(localYargs: yargs.Argv) {
+  return localYargs.help().strict().command(
+      'pre-commit-validate', 'Validate the most recent commit message', {},
+      () => { validateFile('.git/COMMIT_EDITMSG'); });
+}
+
+if (require.main == module) {
+  buildCommitMessageParser(yargs).parse();
+}

--- a/dev-infra/commit-message/cli.ts
+++ b/dev-infra/commit-message/cli.ts
@@ -11,8 +11,9 @@ import {validateFile} from './validate-file';
 /** Build the parser for the commit-message commands. */
 export function buildCommitMessageParser(localYargs: yargs.Argv) {
   return localYargs.help().strict().command(
-      'pre-commit-validate', 'Validate the most recent commit message', {},
-      () => { validateFile('.git/COMMIT_EDITMSG'); });
+      'pre-commit-validate', 'Validate the most recent commit message', {}, () => {
+        validateFile('.git/COMMIT_EDITMSG');
+      });
 }
 
 if (require.main == module) {

--- a/dev-infra/commit-message/validate-file.ts
+++ b/dev-infra/commit-message/validate-file.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {readFileSync} from 'fs';
+import {join} from 'path';
+
+import {getRepoBaseDir} from '../utils/config';
+
+import {validateCommitMessage} from './validate';
+
+/** Validate commit message at the provided file path. */
+export function validateFile(filePath: string) {
+  const commitMessage = readFileSync(join(getRepoBaseDir(), filePath), 'utf8');
+  if (validateCommitMessage(commitMessage)) {
+    console.info('√  Valid commit message');
+  }
+}

--- a/dev-infra/ng-dev
+++ b/dev-infra/ng-dev
@@ -1,0 +1,11 @@
+#!/usr/bin/env ts-node
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// Loads the ng-dev cli, automatically executing it.
+require('./cli.ts');

--- a/dev-infra/pullapprove/BUILD.bazel
+++ b/dev-infra/pullapprove/BUILD.bazel
@@ -3,6 +3,7 @@ load("@npm_bazel_typescript//:index.bzl", "ts_library")
 ts_library(
     name = "pullapprove",
     srcs = [
+        "cli.ts",
         "group.ts",
         "logging.ts",
         "parse-yaml.ts",
@@ -16,9 +17,11 @@ ts_library(
         "@npm//@types/node",
         "@npm//@types/shelljs",
         "@npm//@types/yaml",
+        "@npm//@types/yargs",
         "@npm//minimatch",
         "@npm//shelljs",
         "@npm//tslib",
         "@npm//yaml",
+        "@npm//yargs",
     ],
 )

--- a/dev-infra/pullapprove/cli.ts
+++ b/dev-infra/pullapprove/cli.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as yargs from 'yargs';
+import {verify} from './verify';
+
+/** Build the parser for the pullapprove commands. */
+export function buildPullapproveParser(localYargs: yargs.Argv) {
+  return localYargs.help().strict().demandCommand().command(
+      'verify', 'Verify the pullapprove config', {}, () => verify());
+}
+
+if (require.main === module) {
+  buildPullapproveParser(yargs).parse();
+}

--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
   "// 2": "devDependencies are not used under Bazel. Many can be removed after test.sh is deleted.",
   "devDependencies": {
     "@angular/cli": "9.0.3",
-    "@angular/dev-infra-private": "angular/dev-infra-private-builds#3724a71",
     "@bazel/bazelisk": "^1.3.0",
     "@bazel/buildifier": "^0.29.0",
     "@bazel/ibazel": "^0.12.3",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,10 @@
     "tslint": "tsc -p tools/tsconfig.json && tslint -c tslint.json \"+(packages|modules|scripts|tools)/**/*.+(js|ts)\"",
     "public-api:check": "node goldens/public-api/manage.js test",
     "public-api:update": "node goldens/public-api/manage.js accept",
-    "ts-circular-deps": "ts-node dev-infra/ts-circular-dependencies/index.ts --config ./packages/circular-deps-test.conf.js",
+    "ts-circular-deps": "ts-node --transpile-only -- dev-infra/ts-circular-dependencies/index.ts --config ./packages/circular-deps-test.conf.js",
     "ts-circular-deps:check": "yarn -s ts-circular-deps check",
-    "ts-circular-deps:approve": "yarn -s ts-circular-deps approve"
+    "ts-circular-deps:approve": "yarn -s ts-circular-deps approve",
+    "ng-dev": "ts-node --transpile-only -- dev-infra/cli.ts"
   },
   "// 1": "dependencies are used locally and by bazel",
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,10 +153,6 @@
     universal-analytics "^0.4.20"
     uuid "^3.3.2"
 
-"@angular/dev-infra-private@angular/dev-infra-private-builds#3724a71":
-  version "0.0.0"
-  resolved "https://codeload.github.com/angular/dev-infra-private-builds/tar.gz/3724a71047361d85f4131d990f00a5aecdbc3ddc"
-
 "@babel/code-frame@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"


### PR DESCRIPTION
Creates a standard CLI command for `ng-dev`, and switches to executing from local sources rather than @angular/dev-infra-private builds.