### PR TITLE
[WIP] feat(bazel): add devmode_target, devmode_module, prodmode_target & prodmode_module to ng_module

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,11 +11,6 @@ exports_files([
     "package.json",
 ])
 
-alias(
-    name = "tsconfig.json",
-    actual = "//packages:tsconfig-build.json",
-)
-
 filegroup(
     name = "web_test_bootstrap_scripts",
     # do not sort

--- a/dev-infra/BUILD.bazel
+++ b/dev-infra/BUILD.bazel
@@ -1,12 +1,16 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
 
+exports_files(["tsconfig.json"])
+
 ts_library(
     name = "cli",
     srcs = [
         "cli.ts",
     ],
+    devmode_target = "es5",
     module_name = "@angular/dev-infra-private",
+    tsconfig = ":tsconfig.json",
     deps = [
         "//dev-infra/commit-message",
         "//dev-infra/pullapprove",

--- a/dev-infra/commit-message/BUILD.bazel
+++ b/dev-infra/commit-message/BUILD.bazel
@@ -7,7 +7,9 @@ ts_library(
         "config.ts",
         "validate.ts",
     ],
+    devmode_target = "es5",
     module_name = "@angular/dev-infra-private/commit-message",
+    tsconfig = "//dev-infra:tsconfig.json",
     visibility = ["//dev-infra:__subpackages__"],
     deps = [
         "//dev-infra/utils:config",
@@ -20,6 +22,8 @@ ts_library(
     name = "validate-test",
     testonly = True,
     srcs = ["validate.spec.ts"],
+    devmode_target = "es5",
+    tsconfig = "//dev-infra:tsconfig.json",
     deps = [
         ":commit-message",
         "//dev-infra/utils:config",

--- a/dev-infra/pullapprove/BUILD.bazel
+++ b/dev-infra/pullapprove/BUILD.bazel
@@ -8,7 +8,9 @@ ts_library(
         "parse-yaml.ts",
         "verify.ts",
     ],
+    devmode_target = "es5",
     module_name = "@angular/dev-infra-private/pullapprove",
+    tsconfig = "//dev-infra:tsconfig.json",
     visibility = ["//dev-infra:__subpackages__"],
     deps = [
         "//dev-infra/utils:config",

--- a/dev-infra/ts-circular-dependencies/BUILD.bazel
+++ b/dev-infra/ts-circular-dependencies/BUILD.bazel
@@ -3,7 +3,9 @@ load("@npm_bazel_typescript//:index.bzl", "ts_library")
 ts_library(
     name = "ts-circular-dependencies",
     srcs = glob(["*.ts"]),
+    devmode_target = "es5",
     module_name = "@angular/dev-infra-private/ts-circular-dependencies",
+    tsconfig = "//dev-infra:tsconfig.json",
     visibility = ["//dev-infra:__subpackages__"],
     deps = [
         "//dev-infra/utils:config",

--- a/dev-infra/tsconfig.json
+++ b/dev-infra/tsconfig.json
@@ -1,5 +1,5 @@
 /**
- * Root tsconfig file for use building all Angular packages. Note there is no rootDir
+ * Root tsconfig file for use building all dev-infra-private packages. Note there is no rootDir
  * and therefore any tsconfig in the package directory will need to define its own
  * rootDir.
  */

--- a/dev-infra/utils/BUILD.bazel
+++ b/dev-infra/utils/BUILD.bazel
@@ -5,7 +5,9 @@ ts_library(
     srcs = [
         "config.ts",
     ],
+    devmode_target = "es5",
     module_name = "@angular/dev-infra-private/utils",
+    tsconfig = "//dev-infra:tsconfig.json",
     visibility = ["//dev-infra:__subpackages__"],
     deps = [
         "@npm//@types/json5",

--- a/packages/compiler-cli/integrationtest/bazel/ng_module/BUILD.bazel
+++ b/packages/compiler-cli/integrationtest/bazel/ng_module/BUILD.bazel
@@ -8,6 +8,7 @@ ng_module(
     srcs = glob(["*.ts"]),
     api_extractor = "//packages/bazel/src/api-extractor:api_extractor",
     compiler = "//packages/bazel/src/ngc-wrapped",
+    devmode_target = "es5",
     entry_point = "index.ts",
     flat_module_out_file = "flat_module_filename",
     module_name = "some_npm_module",
@@ -18,6 +19,7 @@ ng_module(
         # the old ngc compiler does. Ivy has no metadata.json files so this test does not apply.
         "no-ivy-aot",
     ],
+    tsconfig = "//packages:tsconfig-build.json",
     deps = [
         "//packages/core",
         "@npm//tslib",

--- a/packages/core/schematics/migrations/dynamic-queries/BUILD.bazel
+++ b/packages/core/schematics/migrations/dynamic-queries/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "dynamic-queries",
     srcs = glob(["**/*.ts"]),
+    devmode_target = "es2015",
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = [
         "//packages/core/schematics:__pkg__",

--- a/packages/core/schematics/migrations/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/google3/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "google3",
     srcs = glob(["**/*.ts"]),
+    devmode_target = "es2015",
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = ["//packages/core/schematics/test/google3:__pkg__"],
     deps = [

--- a/packages/core/schematics/migrations/missing-injectable/BUILD.bazel
+++ b/packages/core/schematics/migrations/missing-injectable/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "missing-injectable",
     srcs = glob(["**/*.ts"]),
+    devmode_target = "es2015",
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = [
         "//packages/core/schematics:__pkg__",

--- a/packages/core/schematics/migrations/missing-injectable/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/missing-injectable/google3/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "google3",
     srcs = glob(["**/*.ts"]),
+    devmode_target = "es2015",
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = ["//packages/core/schematics/migrations/google3:__pkg__"],
     deps = [

--- a/packages/core/schematics/migrations/module-with-providers/BUILD.bazel
+++ b/packages/core/schematics/migrations/module-with-providers/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "module-with-providers",
     srcs = glob(["**/*.ts"]),
+    devmode_target = "es2015",
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = [
         "//packages/core/schematics:__pkg__",

--- a/packages/core/schematics/migrations/move-document/BUILD.bazel
+++ b/packages/core/schematics/migrations/move-document/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "move-document",
     srcs = glob(["**/*.ts"]),
+    devmode_target = "es2015",
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = [
         "//packages/core/schematics:__pkg__",

--- a/packages/core/schematics/migrations/renderer-to-renderer2/BUILD.bazel
+++ b/packages/core/schematics/migrations/renderer-to-renderer2/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "renderer-to-renderer2",
     srcs = glob(["**/*.ts"]),
+    devmode_target = "es2015",
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = [
         "//packages/core/schematics:__pkg__",

--- a/packages/core/schematics/migrations/static-queries/BUILD.bazel
+++ b/packages/core/schematics/migrations/static-queries/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "static-queries",
     srcs = glob(["**/*.ts"]),
+    devmode_target = "es2015",
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = [
         "//packages/core/schematics:__pkg__",

--- a/packages/core/schematics/migrations/template-var-assignment/BUILD.bazel
+++ b/packages/core/schematics/migrations/template-var-assignment/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "template-var-assignment",
     srcs = glob(["**/*.ts"]),
+    devmode_target = "es2015",
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = [
         "//packages/core/schematics:__pkg__",

--- a/packages/core/schematics/migrations/undecorated-classes-with-decorated-fields/BUILD.bazel
+++ b/packages/core/schematics/migrations/undecorated-classes-with-decorated-fields/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "undecorated-classes-with-decorated-fields",
     srcs = glob(["**/*.ts"]),
+    devmode_target = "es2015",
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = [
         "//packages/core/schematics:__pkg__",

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/BUILD.bazel
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "undecorated-classes-with-di",
     srcs = glob(["**/*.ts"]),
+    devmode_target = "es2015",
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = [
         "//packages/core/schematics:__pkg__",

--- a/packages/core/schematics/utils/BUILD.bazel
+++ b/packages/core/schematics/utils/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "utils",
     srcs = glob(["**/*.ts"]),
+    devmode_target = "es2015",
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = ["//packages/core/schematics:__subpackages__"],
     deps = [

--- a/packages/core/schematics/utils/tslint/BUILD.bazel
+++ b/packages/core/schematics/utils/tslint/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "tslint",
     srcs = glob(["**/*.ts"]),
+    devmode_target = "es2015",
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = [
         "//packages/core/schematics/migrations/google3:__pkg__",

--- a/packages/tsconfig-build-no-strict.json
+++ b/packages/tsconfig-build-no-strict.json
@@ -4,7 +4,6 @@
     "strict": false
   },
   "bazelOptions": {
-    "suppressTsconfigOverrideWarnings": true,
-    "devmodeTargetOverride": "es5"
+    "suppressTsconfigOverrideWarnings": true
   }
 }

--- a/packages/tsconfig-test.json
+++ b/packages/tsconfig-test.json
@@ -11,7 +11,6 @@
     }]
   },
   "bazelOptions": {
-    "suppressTsconfigOverrideWarnings": true,
-    "devmodeTargetOverride": "es5"
+    "suppressTsconfigOverrideWarnings": true
   }
 }

--- a/packages/zone.js/lib/BUILD.bazel
+++ b/packages/zone.js/lib/BUILD.bazel
@@ -9,6 +9,8 @@ exports_files(glob([
 ts_library(
     name = "zone_d_ts",
     srcs = [":zone.ts"],
+    devmode_target = "es5",
+    tsconfig = ":tsconfig.json",
     deps = [
         "@npm//@types/node",
     ],
@@ -20,7 +22,9 @@ ts_library(
         ["**/*.ts"],
         exclude = ["zone.ts"],
     ),
+    devmode_target = "es5",
     module_name = "zone.js/lib",
+    tsconfig = ":tsconfig.json",
     deps = [
         ":zone_d_ts",
         "@npm//@types/jasmine",

--- a/packages/zone.js/lib/tsconfig.json
+++ b/packages/zone.js/lib/tsconfig.json
@@ -1,5 +1,5 @@
 /**
- * Root tsconfig file for use building all Angular packages. Note there is no rootDir
+ * Root tsconfig file for use building all zone.js packages. Note there is no rootDir
  * and therefore any tsconfig in the package directory will need to define its own
  * rootDir.
  */

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -15,6 +15,7 @@ load("//tools:ng_benchmark.bzl", _ng_benchmark = "ng_benchmark")
 load("//tools/ts-api-guardian:index.bzl", _ts_api_guardian_test = "ts_api_guardian_test", _ts_api_guardian_test_npm_package = "ts_api_guardian_test_npm_package")
 
 _DEFAULT_TSCONFIG_TEST = "//packages:tsconfig-test"
+_DEFAULT_TSCONFIG_BUILD = "//packages:tsconfig-build.json"
 _INTERNAL_NG_MODULE_API_EXTRACTOR = "//packages/bazel/src/api-extractor:api_extractor"
 _INTERNAL_NG_MODULE_COMPILER = "//packages/bazel/src/ngc-wrapped"
 _INTERNAL_NG_MODULE_XI18N = "//packages/bazel/src/ngc-wrapped:xi18n"
@@ -103,11 +104,16 @@ def ts_library(name, tsconfig = None, testonly = False, deps = [], module_name =
         deps.append("@npm//@types/jasmine")
         deps.append("@npm//@types/node")
         deps.append("@npm//@types/events")
-    if not tsconfig and testonly:
-        tsconfig = _DEFAULT_TSCONFIG_TEST
+    if not tsconfig:
+        tsconfig = _DEFAULT_TSCONFIG_TEST if testonly else _DEFAULT_TSCONFIG_BUILD
+    else:
+        print("//%s:%s using tsconfig %s" % (native.package_name(), name, tsconfig))
 
     if not module_name:
         module_name = _default_module_name(testonly)
+
+    # default to es5 unless otherwise specified
+    devmode_target = kwargs.pop("devmode_target", "es5")
 
     _ts_library(
         name = name,
@@ -115,6 +121,7 @@ def ts_library(name, tsconfig = None, testonly = False, deps = [], module_name =
         testonly = testonly,
         deps = deps,
         module_name = module_name,
+        devmode_target = devmode_target,
         **kwargs
     )
 
@@ -137,13 +144,19 @@ def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps 
         deps.append("@npm//@types/jasmine")
         deps.append("@npm//@types/node")
         deps.append("@npm//@types/events")
-    if not tsconfig and testonly:
-        tsconfig = _DEFAULT_TSCONFIG_TEST
+    if not tsconfig:
+        tsconfig = _DEFAULT_TSCONFIG_TEST if testonly else _DEFAULT_TSCONFIG_BUILD
+    else:
+        print("//%s:%s using tsconfig %s" % (native.package_name(), name, tsconfig))
 
     if not module_name:
         module_name = _default_module_name(testonly)
     if not entry_point:
         entry_point = "public_api.ts"
+
+    # default to es5 unless otherwise specified
+    devmode_target = kwargs.pop("devmode_target", "es5")
+
     _ng_module(
         name = name,
         flat_module_out_file = name,
@@ -156,6 +169,7 @@ def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps 
         api_extractor = _INTERNAL_NG_MODULE_API_EXTRACTOR,
         ng_xi18n = _INTERNAL_NG_MODULE_XI18N,
         module_name = module_name,
+        devmode_target = devmode_target,
         **kwargs
     )
 


### PR DESCRIPTION
These were added to ts_library in rules_nodejs 1.5.0 and this change updates ng_module to use the same pattern. Repo is updated to no longer use deprecated tsconfig bazelOpts devmodeTargetOverride value.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
