### PR TITLE
fix(common): `locales/global/*.js` are not ES5 compliant

### DIFF
--- a/packages/common/locales/global/af-NA.js
+++ b/packages/common/locales/global/af-NA.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/af.js
+++ b/packages/common/locales/global/af.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/agq.js
+++ b/packages/common/locales/global/agq.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['agq'] = [
     'agq',

--- a/packages/common/locales/global/ak.js
+++ b/packages/common/locales/global/ak.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === Math.floor(n) && n >= 0 && n <= 1) return 1;
     return 5;

--- a/packages/common/locales/global/am.js
+++ b/packages/common/locales/global/am.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || n === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ar-AE.js
+++ b/packages/common/locales/global/ar-AE.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-BH.js
+++ b/packages/common/locales/global/ar-BH.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-DJ.js
+++ b/packages/common/locales/global/ar-DJ.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-DZ.js
+++ b/packages/common/locales/global/ar-DZ.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-EG.js
+++ b/packages/common/locales/global/ar-EG.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-EH.js
+++ b/packages/common/locales/global/ar-EH.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-ER.js
+++ b/packages/common/locales/global/ar-ER.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-IL.js
+++ b/packages/common/locales/global/ar-IL.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-IQ.js
+++ b/packages/common/locales/global/ar-IQ.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 0) return 0;
         if (n === 1) return 1;

--- a/packages/common/locales/global/ar-JO.js
+++ b/packages/common/locales/global/ar-JO.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-KM.js
+++ b/packages/common/locales/global/ar-KM.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-KW.js
+++ b/packages/common/locales/global/ar-KW.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-LB.js
+++ b/packages/common/locales/global/ar-LB.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-LY.js
+++ b/packages/common/locales/global/ar-LY.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-MA.js
+++ b/packages/common/locales/global/ar-MA.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-MR.js
+++ b/packages/common/locales/global/ar-MR.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-OM.js
+++ b/packages/common/locales/global/ar-OM.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-PS.js
+++ b/packages/common/locales/global/ar-PS.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-QA.js
+++ b/packages/common/locales/global/ar-QA.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-SA.js
+++ b/packages/common/locales/global/ar-SA.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-SD.js
+++ b/packages/common/locales/global/ar-SD.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-SO.js
+++ b/packages/common/locales/global/ar-SO.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-SS.js
+++ b/packages/common/locales/global/ar-SS.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-SY.js
+++ b/packages/common/locales/global/ar-SY.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-TD.js
+++ b/packages/common/locales/global/ar-TD.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-TN.js
+++ b/packages/common/locales/global/ar-TN.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar-YE.js
+++ b/packages/common/locales/global/ar-YE.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ar.js
+++ b/packages/common/locales/global/ar.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/as.js
+++ b/packages/common/locales/global/as.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || n === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/asa.js
+++ b/packages/common/locales/global/asa.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ast.js
+++ b/packages/common/locales/global/ast.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/az-Cyrl.js
+++ b/packages/common/locales/global/az-Cyrl.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['az-cyrl'] = [
     'az-Cyrl',

--- a/packages/common/locales/global/az-Latn.js
+++ b/packages/common/locales/global/az-Latn.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/az.js
+++ b/packages/common/locales/global/az.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/bas.js
+++ b/packages/common/locales/global/bas.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['bas'] = [
     'bas',

--- a/packages/common/locales/global/be.js
+++ b/packages/common/locales/global/be.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n % 10 === 1 && !(n % 100 === 11)) return 1;
     if (n % 10 === Math.floor(n % 10) && n % 10 >= 2 && n % 10 <= 4 &&

--- a/packages/common/locales/global/bem.js
+++ b/packages/common/locales/global/bem.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/bez.js
+++ b/packages/common/locales/global/bez.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/bg.js
+++ b/packages/common/locales/global/bg.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/bm.js
+++ b/packages/common/locales/global/bm.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['bm'] = [
     'bm',

--- a/packages/common/locales/global/bn-IN.js
+++ b/packages/common/locales/global/bn-IN.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || n === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/bn.js
+++ b/packages/common/locales/global/bn.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || n === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/bo-IN.js
+++ b/packages/common/locales/global/bo-IN.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['bo-in'] = [
     'bo-IN',

--- a/packages/common/locales/global/bo.js
+++ b/packages/common/locales/global/bo.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['bo'] = [
     'bo',

--- a/packages/common/locales/global/br.js
+++ b/packages/common/locales/global/br.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n % 10 === 1 && !(n % 100 === 11 || n % 100 === 71 || n % 100 === 91)) return 1;
     if (n % 10 === 2 && !(n % 100 === 12 || n % 100 === 72 || n % 100 === 92)) return 2;

--- a/packages/common/locales/global/brx.js
+++ b/packages/common/locales/global/brx.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/bs-Cyrl.js
+++ b/packages/common/locales/global/bs-Cyrl.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['bs-cyrl'] = [
     'bs-Cyrl',

--- a/packages/common/locales/global/bs-Latn.js
+++ b/packages/common/locales/global/bs-Latn.js
@@ -14,9 +14,9 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
-        let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
+        var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
             f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
         if (v === 0 && i % 10 === 1 && !(i % 100 === 11) || f % 10 === 1 && !(f % 100 === 11))
           return 1;

--- a/packages/common/locales/global/bs.js
+++ b/packages/common/locales/global/bs.js
@@ -14,9 +14,9 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
-        let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
+        var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
             f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
         if (v === 0 && i % 10 === 1 && !(i % 100 === 11) || f % 10 === 1 && !(f % 100 === 11))
           return 1;

--- a/packages/common/locales/global/ca-AD.js
+++ b/packages/common/locales/global/ca-AD.js
@@ -14,9 +14,9 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
-        let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+        var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
         if (i === 1 && v === 0) return 1;
         return 5;
       }

--- a/packages/common/locales/global/ca-ES-VALENCIA.js
+++ b/packages/common/locales/global/ca-ES-VALENCIA.js
@@ -14,9 +14,9 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
-        let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+        var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
         if (i === 1 && v === 0) return 1;
         return 5;
       }

--- a/packages/common/locales/global/ca-FR.js
+++ b/packages/common/locales/global/ca-FR.js
@@ -14,9 +14,9 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
-        let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+        var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
         if (i === 1 && v === 0) return 1;
         return 5;
       }

--- a/packages/common/locales/global/ca-IT.js
+++ b/packages/common/locales/global/ca-IT.js
@@ -14,9 +14,9 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
-        let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+        var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
         if (i === 1 && v === 0) return 1;
         return 5;
       }

--- a/packages/common/locales/global/ca.js
+++ b/packages/common/locales/global/ca.js
@@ -14,9 +14,9 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
-        let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+        var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
         if (i === 1 && v === 0) return 1;
         return 5;
       }

--- a/packages/common/locales/global/ccp-IN.js
+++ b/packages/common/locales/global/ccp-IN.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ccp-in'] = [
     'ccp-IN',

--- a/packages/common/locales/global/ccp.js
+++ b/packages/common/locales/global/ccp.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ccp'] = [
     'ccp',

--- a/packages/common/locales/global/ce.js
+++ b/packages/common/locales/global/ce.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ceb.js
+++ b/packages/common/locales/global/ceb.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ceb'] = [
     'ceb',

--- a/packages/common/locales/global/cgg.js
+++ b/packages/common/locales/global/cgg.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/chr.js
+++ b/packages/common/locales/global/chr.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ckb-IR.js
+++ b/packages/common/locales/global/ckb-IR.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ckb.js
+++ b/packages/common/locales/global/ckb.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/cs.js
+++ b/packages/common/locales/global/cs.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     if (i === Math.floor(i) && i >= 2 && i <= 4 && v === 0) return 3;
     if (!(v === 0)) return 4;

--- a/packages/common/locales/global/cu.js
+++ b/packages/common/locales/global/cu.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['cu'] = [
     'cu',

--- a/packages/common/locales/global/cy.js
+++ b/packages/common/locales/global/cy.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/da-GL.js
+++ b/packages/common/locales/global/da-GL.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)),
+    var i = Math.floor(Math.abs(n)),
         t = parseInt(n.toString().replace(/^[^.]*\.?|0+$/g, ''), 10) || 0;
     if (n === 1 || !(t === 0) && (i === 0 || i === 1)) return 1;
     return 5;

--- a/packages/common/locales/global/da.js
+++ b/packages/common/locales/global/da.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)),
+    var i = Math.floor(Math.abs(n)),
         t = parseInt(n.toString().replace(/^[^.]*\.?|0+$/g, ''), 10) || 0;
     if (n === 1 || !(t === 0) && (i === 0 || i === 1)) return 1;
     return 5;

--- a/packages/common/locales/global/dav.js
+++ b/packages/common/locales/global/dav.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['dav'] = [
     'dav',

--- a/packages/common/locales/global/de-AT.js
+++ b/packages/common/locales/global/de-AT.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/de-BE.js
+++ b/packages/common/locales/global/de-BE.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/de-CH.js
+++ b/packages/common/locales/global/de-CH.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/de-IT.js
+++ b/packages/common/locales/global/de-IT.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/de-LI.js
+++ b/packages/common/locales/global/de-LI.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/de-LU.js
+++ b/packages/common/locales/global/de-LU.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/de.js
+++ b/packages/common/locales/global/de.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/dje.js
+++ b/packages/common/locales/global/dje.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['dje'] = [
     'dje',

--- a/packages/common/locales/global/dsb.js
+++ b/packages/common/locales/global/dsb.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
         f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
     if (v === 0 && i % 100 === 1 || f % 100 === 1) return 1;
     if (v === 0 && i % 100 === 2 || f % 100 === 2) return 2;

--- a/packages/common/locales/global/dua.js
+++ b/packages/common/locales/global/dua.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['dua'] = [
     'dua',

--- a/packages/common/locales/global/dyo.js
+++ b/packages/common/locales/global/dyo.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['dyo'] = [
     'dyo',

--- a/packages/common/locales/global/dz.js
+++ b/packages/common/locales/global/dz.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['dz'] = [
     'dz',

--- a/packages/common/locales/global/ebu.js
+++ b/packages/common/locales/global/ebu.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ebu'] = [
     'ebu',

--- a/packages/common/locales/global/ee-TG.js
+++ b/packages/common/locales/global/ee-TG.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ee.js
+++ b/packages/common/locales/global/ee.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/el-CY.js
+++ b/packages/common/locales/global/el-CY.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/el.js
+++ b/packages/common/locales/global/el.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/en-001.js
+++ b/packages/common/locales/global/en-001.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-150.js
+++ b/packages/common/locales/global/en-150.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-AE.js
+++ b/packages/common/locales/global/en-AE.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-AG.js
+++ b/packages/common/locales/global/en-AG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-AI.js
+++ b/packages/common/locales/global/en-AI.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-AS.js
+++ b/packages/common/locales/global/en-AS.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-AT.js
+++ b/packages/common/locales/global/en-AT.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-AU.js
+++ b/packages/common/locales/global/en-AU.js
@@ -14,9 +14,9 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
-        let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+        var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
         if (i === 1 && v === 0) return 1;
         return 5;
       }

--- a/packages/common/locales/global/en-BB.js
+++ b/packages/common/locales/global/en-BB.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-BE.js
+++ b/packages/common/locales/global/en-BE.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-BI.js
+++ b/packages/common/locales/global/en-BI.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-BM.js
+++ b/packages/common/locales/global/en-BM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-BS.js
+++ b/packages/common/locales/global/en-BS.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-BW.js
+++ b/packages/common/locales/global/en-BW.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-BZ.js
+++ b/packages/common/locales/global/en-BZ.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-CA.js
+++ b/packages/common/locales/global/en-CA.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-CC.js
+++ b/packages/common/locales/global/en-CC.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-CH.js
+++ b/packages/common/locales/global/en-CH.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-CK.js
+++ b/packages/common/locales/global/en-CK.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-CM.js
+++ b/packages/common/locales/global/en-CM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-CX.js
+++ b/packages/common/locales/global/en-CX.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-CY.js
+++ b/packages/common/locales/global/en-CY.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-DE.js
+++ b/packages/common/locales/global/en-DE.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-DG.js
+++ b/packages/common/locales/global/en-DG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-DK.js
+++ b/packages/common/locales/global/en-DK.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-DM.js
+++ b/packages/common/locales/global/en-DM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-ER.js
+++ b/packages/common/locales/global/en-ER.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-FI.js
+++ b/packages/common/locales/global/en-FI.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-FJ.js
+++ b/packages/common/locales/global/en-FJ.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-FK.js
+++ b/packages/common/locales/global/en-FK.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-FM.js
+++ b/packages/common/locales/global/en-FM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-GB.js
+++ b/packages/common/locales/global/en-GB.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-GD.js
+++ b/packages/common/locales/global/en-GD.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-GG.js
+++ b/packages/common/locales/global/en-GG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-GH.js
+++ b/packages/common/locales/global/en-GH.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-GI.js
+++ b/packages/common/locales/global/en-GI.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-GM.js
+++ b/packages/common/locales/global/en-GM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-GU.js
+++ b/packages/common/locales/global/en-GU.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-GY.js
+++ b/packages/common/locales/global/en-GY.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-HK.js
+++ b/packages/common/locales/global/en-HK.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-IE.js
+++ b/packages/common/locales/global/en-IE.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-IL.js
+++ b/packages/common/locales/global/en-IL.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-IM.js
+++ b/packages/common/locales/global/en-IM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-IN.js
+++ b/packages/common/locales/global/en-IN.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-IO.js
+++ b/packages/common/locales/global/en-IO.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-JE.js
+++ b/packages/common/locales/global/en-JE.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-JM.js
+++ b/packages/common/locales/global/en-JM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-KE.js
+++ b/packages/common/locales/global/en-KE.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-KI.js
+++ b/packages/common/locales/global/en-KI.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-KN.js
+++ b/packages/common/locales/global/en-KN.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-KY.js
+++ b/packages/common/locales/global/en-KY.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-LC.js
+++ b/packages/common/locales/global/en-LC.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-LR.js
+++ b/packages/common/locales/global/en-LR.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-LS.js
+++ b/packages/common/locales/global/en-LS.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-MG.js
+++ b/packages/common/locales/global/en-MG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-MH.js
+++ b/packages/common/locales/global/en-MH.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-MO.js
+++ b/packages/common/locales/global/en-MO.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-MP.js
+++ b/packages/common/locales/global/en-MP.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-MS.js
+++ b/packages/common/locales/global/en-MS.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-MT.js
+++ b/packages/common/locales/global/en-MT.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-MU.js
+++ b/packages/common/locales/global/en-MU.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-MW.js
+++ b/packages/common/locales/global/en-MW.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-MY.js
+++ b/packages/common/locales/global/en-MY.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-NA.js
+++ b/packages/common/locales/global/en-NA.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-NF.js
+++ b/packages/common/locales/global/en-NF.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-NG.js
+++ b/packages/common/locales/global/en-NG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-NL.js
+++ b/packages/common/locales/global/en-NL.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-NR.js
+++ b/packages/common/locales/global/en-NR.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-NU.js
+++ b/packages/common/locales/global/en-NU.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-NZ.js
+++ b/packages/common/locales/global/en-NZ.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-PG.js
+++ b/packages/common/locales/global/en-PG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-PH.js
+++ b/packages/common/locales/global/en-PH.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-PK.js
+++ b/packages/common/locales/global/en-PK.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-PN.js
+++ b/packages/common/locales/global/en-PN.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-PR.js
+++ b/packages/common/locales/global/en-PR.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-PW.js
+++ b/packages/common/locales/global/en-PW.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-RW.js
+++ b/packages/common/locales/global/en-RW.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-SB.js
+++ b/packages/common/locales/global/en-SB.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-SC.js
+++ b/packages/common/locales/global/en-SC.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-SD.js
+++ b/packages/common/locales/global/en-SD.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-SE.js
+++ b/packages/common/locales/global/en-SE.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-SG.js
+++ b/packages/common/locales/global/en-SG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-SH.js
+++ b/packages/common/locales/global/en-SH.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-SI.js
+++ b/packages/common/locales/global/en-SI.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-SL.js
+++ b/packages/common/locales/global/en-SL.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-SS.js
+++ b/packages/common/locales/global/en-SS.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-SX.js
+++ b/packages/common/locales/global/en-SX.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-SZ.js
+++ b/packages/common/locales/global/en-SZ.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-TC.js
+++ b/packages/common/locales/global/en-TC.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-TK.js
+++ b/packages/common/locales/global/en-TK.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-TO.js
+++ b/packages/common/locales/global/en-TO.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-TT.js
+++ b/packages/common/locales/global/en-TT.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-TV.js
+++ b/packages/common/locales/global/en-TV.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-TZ.js
+++ b/packages/common/locales/global/en-TZ.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-UG.js
+++ b/packages/common/locales/global/en-UG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-UM.js
+++ b/packages/common/locales/global/en-UM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-US-POSIX.js
+++ b/packages/common/locales/global/en-US-POSIX.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-VC.js
+++ b/packages/common/locales/global/en-VC.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-VG.js
+++ b/packages/common/locales/global/en-VG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-VI.js
+++ b/packages/common/locales/global/en-VI.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-VU.js
+++ b/packages/common/locales/global/en-VU.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-WS.js
+++ b/packages/common/locales/global/en-WS.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-ZA.js
+++ b/packages/common/locales/global/en-ZA.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-ZM.js
+++ b/packages/common/locales/global/en-ZM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en-ZW.js
+++ b/packages/common/locales/global/en-ZW.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/en.js
+++ b/packages/common/locales/global/en.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/eo.js
+++ b/packages/common/locales/global/eo.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/es-419.js
+++ b/packages/common/locales/global/es-419.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-AR.js
+++ b/packages/common/locales/global/es-AR.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/es-BO.js
+++ b/packages/common/locales/global/es-BO.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-BR.js
+++ b/packages/common/locales/global/es-BR.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-BZ.js
+++ b/packages/common/locales/global/es-BZ.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-CL.js
+++ b/packages/common/locales/global/es-CL.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-CO.js
+++ b/packages/common/locales/global/es-CO.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/es-CR.js
+++ b/packages/common/locales/global/es-CR.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-CU.js
+++ b/packages/common/locales/global/es-CU.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-DO.js
+++ b/packages/common/locales/global/es-DO.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/es-EA.js
+++ b/packages/common/locales/global/es-EA.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/es-EC.js
+++ b/packages/common/locales/global/es-EC.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-GQ.js
+++ b/packages/common/locales/global/es-GQ.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/es-GT.js
+++ b/packages/common/locales/global/es-GT.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-HN.js
+++ b/packages/common/locales/global/es-HN.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-IC.js
+++ b/packages/common/locales/global/es-IC.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/es-MX.js
+++ b/packages/common/locales/global/es-MX.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/es-NI.js
+++ b/packages/common/locales/global/es-NI.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-PA.js
+++ b/packages/common/locales/global/es-PA.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-PE.js
+++ b/packages/common/locales/global/es-PE.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-PH.js
+++ b/packages/common/locales/global/es-PH.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/es-PR.js
+++ b/packages/common/locales/global/es-PR.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-PY.js
+++ b/packages/common/locales/global/es-PY.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/es-SV.js
+++ b/packages/common/locales/global/es-SV.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-US.js
+++ b/packages/common/locales/global/es-US.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/es-UY.js
+++ b/packages/common/locales/global/es-UY.js
@@ -14,7 +14,7 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
         if (n === 1) return 1;
         return 5;

--- a/packages/common/locales/global/es-VE.js
+++ b/packages/common/locales/global/es-VE.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/es.js
+++ b/packages/common/locales/global/es.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/et.js
+++ b/packages/common/locales/global/et.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/eu.js
+++ b/packages/common/locales/global/eu.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ewo.js
+++ b/packages/common/locales/global/ewo.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ewo'] = [
     'ewo',

--- a/packages/common/locales/global/fa-AF.js
+++ b/packages/common/locales/global/fa-AF.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || n === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fa.js
+++ b/packages/common/locales/global/fa.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || n === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ff-Latn-BF.js
+++ b/packages/common/locales/global/ff-Latn-BF.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ff-Latn-CM.js
+++ b/packages/common/locales/global/ff-Latn-CM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ff-Latn-GH.js
+++ b/packages/common/locales/global/ff-Latn-GH.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ff-Latn-GM.js
+++ b/packages/common/locales/global/ff-Latn-GM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ff-Latn-GN.js
+++ b/packages/common/locales/global/ff-Latn-GN.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ff-Latn-GW.js
+++ b/packages/common/locales/global/ff-Latn-GW.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ff-Latn-LR.js
+++ b/packages/common/locales/global/ff-Latn-LR.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ff-Latn-MR.js
+++ b/packages/common/locales/global/ff-Latn-MR.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ff-Latn-NE.js
+++ b/packages/common/locales/global/ff-Latn-NE.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ff-Latn-NG.js
+++ b/packages/common/locales/global/ff-Latn-NG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ff-Latn-SL.js
+++ b/packages/common/locales/global/ff-Latn-SL.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ff-Latn.js
+++ b/packages/common/locales/global/ff-Latn.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ff.js
+++ b/packages/common/locales/global/ff.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fi.js
+++ b/packages/common/locales/global/fi.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fil.js
+++ b/packages/common/locales/global/fil.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
         f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
     if (v === 0 && (i === 1 || i === 2 || i === 3) ||
         v === 0 && !(i % 10 === 4 || i % 10 === 6 || i % 10 === 9) ||

--- a/packages/common/locales/global/fo-DK.js
+++ b/packages/common/locales/global/fo-DK.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/fo.js
+++ b/packages/common/locales/global/fo.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/fr-BE.js
+++ b/packages/common/locales/global/fr-BE.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-BF.js
+++ b/packages/common/locales/global/fr-BF.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-BI.js
+++ b/packages/common/locales/global/fr-BI.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-BJ.js
+++ b/packages/common/locales/global/fr-BJ.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-BL.js
+++ b/packages/common/locales/global/fr-BL.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-CA.js
+++ b/packages/common/locales/global/fr-CA.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-CD.js
+++ b/packages/common/locales/global/fr-CD.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-CF.js
+++ b/packages/common/locales/global/fr-CF.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-CG.js
+++ b/packages/common/locales/global/fr-CG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-CH.js
+++ b/packages/common/locales/global/fr-CH.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-CI.js
+++ b/packages/common/locales/global/fr-CI.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-CM.js
+++ b/packages/common/locales/global/fr-CM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-DJ.js
+++ b/packages/common/locales/global/fr-DJ.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-DZ.js
+++ b/packages/common/locales/global/fr-DZ.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-GA.js
+++ b/packages/common/locales/global/fr-GA.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-GF.js
+++ b/packages/common/locales/global/fr-GF.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-GN.js
+++ b/packages/common/locales/global/fr-GN.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-GP.js
+++ b/packages/common/locales/global/fr-GP.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-GQ.js
+++ b/packages/common/locales/global/fr-GQ.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-HT.js
+++ b/packages/common/locales/global/fr-HT.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-KM.js
+++ b/packages/common/locales/global/fr-KM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-LU.js
+++ b/packages/common/locales/global/fr-LU.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-MA.js
+++ b/packages/common/locales/global/fr-MA.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-MC.js
+++ b/packages/common/locales/global/fr-MC.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-MF.js
+++ b/packages/common/locales/global/fr-MF.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-MG.js
+++ b/packages/common/locales/global/fr-MG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-ML.js
+++ b/packages/common/locales/global/fr-ML.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-MQ.js
+++ b/packages/common/locales/global/fr-MQ.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-MR.js
+++ b/packages/common/locales/global/fr-MR.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-MU.js
+++ b/packages/common/locales/global/fr-MU.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-NC.js
+++ b/packages/common/locales/global/fr-NC.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-NE.js
+++ b/packages/common/locales/global/fr-NE.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-PF.js
+++ b/packages/common/locales/global/fr-PF.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-PM.js
+++ b/packages/common/locales/global/fr-PM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-RE.js
+++ b/packages/common/locales/global/fr-RE.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-RW.js
+++ b/packages/common/locales/global/fr-RW.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-SC.js
+++ b/packages/common/locales/global/fr-SC.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-SN.js
+++ b/packages/common/locales/global/fr-SN.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-SY.js
+++ b/packages/common/locales/global/fr-SY.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-TD.js
+++ b/packages/common/locales/global/fr-TD.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-TG.js
+++ b/packages/common/locales/global/fr-TG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-TN.js
+++ b/packages/common/locales/global/fr-TN.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-VU.js
+++ b/packages/common/locales/global/fr-VU.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-WF.js
+++ b/packages/common/locales/global/fr-WF.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr-YT.js
+++ b/packages/common/locales/global/fr-YT.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fr.js
+++ b/packages/common/locales/global/fr.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/fur.js
+++ b/packages/common/locales/global/fur.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/fy.js
+++ b/packages/common/locales/global/fy.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ga-GB.js
+++ b/packages/common/locales/global/ga-GB.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     if (n === 2) return 2;

--- a/packages/common/locales/global/ga.js
+++ b/packages/common/locales/global/ga.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     if (n === 2) return 2;

--- a/packages/common/locales/global/gd.js
+++ b/packages/common/locales/global/gd.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1 || n === 11) return 1;
     if (n === 2 || n === 12) return 2;

--- a/packages/common/locales/global/gl.js
+++ b/packages/common/locales/global/gl.js
@@ -14,9 +14,9 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
-        let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+        var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
         if (i === 1 && v === 0) return 1;
         return 5;
       }

--- a/packages/common/locales/global/gsw-FR.js
+++ b/packages/common/locales/global/gsw-FR.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/gsw-LI.js
+++ b/packages/common/locales/global/gsw-LI.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/gsw.js
+++ b/packages/common/locales/global/gsw.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/gu.js
+++ b/packages/common/locales/global/gu.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || n === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/guz.js
+++ b/packages/common/locales/global/guz.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['guz'] = [
     'guz',

--- a/packages/common/locales/global/gv.js
+++ b/packages/common/locales/global/gv.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (v === 0 && i % 10 === 1) return 1;
     if (v === 0 && i % 10 === 2) return 2;
     if (v === 0 &&

--- a/packages/common/locales/global/ha-GH.js
+++ b/packages/common/locales/global/ha-GH.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ha-NE.js
+++ b/packages/common/locales/global/ha-NE.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ha.js
+++ b/packages/common/locales/global/ha.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/haw.js
+++ b/packages/common/locales/global/haw.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/he.js
+++ b/packages/common/locales/global/he.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     if (i === 2 && v === 0) return 2;
     if (v === 0 && !(n >= 0 && n <= 10) && n % 10 === 0) return 4;

--- a/packages/common/locales/global/hi.js
+++ b/packages/common/locales/global/hi.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || n === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/hr-BA.js
+++ b/packages/common/locales/global/hr-BA.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
         f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11) || f % 10 === 1 && !(f % 100 === 11)) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&

--- a/packages/common/locales/global/hr.js
+++ b/packages/common/locales/global/hr.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
         f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11) || f % 10 === 1 && !(f % 100 === 11)) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&

--- a/packages/common/locales/global/hsb.js
+++ b/packages/common/locales/global/hsb.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
         f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
     if (v === 0 && i % 100 === 1 || f % 100 === 1) return 1;
     if (v === 0 && i % 100 === 2 || f % 100 === 2) return 2;

--- a/packages/common/locales/global/hu.js
+++ b/packages/common/locales/global/hu.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/hy.js
+++ b/packages/common/locales/global/hy.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ia.js
+++ b/packages/common/locales/global/ia.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ia'] = [
     'ia',

--- a/packages/common/locales/global/id.js
+++ b/packages/common/locales/global/id.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['id'] = [
     'id',

--- a/packages/common/locales/global/ig.js
+++ b/packages/common/locales/global/ig.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ig'] = [
     'ig',

--- a/packages/common/locales/global/ii.js
+++ b/packages/common/locales/global/ii.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ii'] = [
     'ii',

--- a/packages/common/locales/global/is.js
+++ b/packages/common/locales/global/is.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)),
+    var i = Math.floor(Math.abs(n)),
         t = parseInt(n.toString().replace(/^[^.]*\.?|0+$/g, ''), 10) || 0;
     if (t === 0 && i % 10 === 1 && !(i % 100 === 11) || !(t === 0)) return 1;
     return 5;

--- a/packages/common/locales/global/it-CH.js
+++ b/packages/common/locales/global/it-CH.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/it-SM.js
+++ b/packages/common/locales/global/it-SM.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/it-VA.js
+++ b/packages/common/locales/global/it-VA.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/it.js
+++ b/packages/common/locales/global/it.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ja.js
+++ b/packages/common/locales/global/ja.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ja'] = [
     'ja',

--- a/packages/common/locales/global/jgo.js
+++ b/packages/common/locales/global/jgo.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/jmc.js
+++ b/packages/common/locales/global/jmc.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/jv.js
+++ b/packages/common/locales/global/jv.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['jv'] = [
     'jv',

--- a/packages/common/locales/global/ka.js
+++ b/packages/common/locales/global/ka.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/kab.js
+++ b/packages/common/locales/global/kab.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || i === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/kam.js
+++ b/packages/common/locales/global/kam.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['kam'] = [
     'kam',

--- a/packages/common/locales/global/kde.js
+++ b/packages/common/locales/global/kde.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['kde'] = [
     'kde',

--- a/packages/common/locales/global/kea.js
+++ b/packages/common/locales/global/kea.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['kea'] = [
     'kea',

--- a/packages/common/locales/global/khq.js
+++ b/packages/common/locales/global/khq.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['khq'] = [
     'khq',

--- a/packages/common/locales/global/ki.js
+++ b/packages/common/locales/global/ki.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ki'] = [
     'ki',

--- a/packages/common/locales/global/kk.js
+++ b/packages/common/locales/global/kk.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/kkj.js
+++ b/packages/common/locales/global/kkj.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/kl.js
+++ b/packages/common/locales/global/kl.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/kln.js
+++ b/packages/common/locales/global/kln.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['kln'] = [
     'kln',

--- a/packages/common/locales/global/km.js
+++ b/packages/common/locales/global/km.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['km'] = [
     'km',

--- a/packages/common/locales/global/kn.js
+++ b/packages/common/locales/global/kn.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || n === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ko-KP.js
+++ b/packages/common/locales/global/ko-KP.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ko-kp'] = [
     'ko-KP',

--- a/packages/common/locales/global/ko.js
+++ b/packages/common/locales/global/ko.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ko'] = [
     'ko',

--- a/packages/common/locales/global/kok.js
+++ b/packages/common/locales/global/kok.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['kok'] = [
     'kok',

--- a/packages/common/locales/global/ks.js
+++ b/packages/common/locales/global/ks.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ksb.js
+++ b/packages/common/locales/global/ksb.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ksf.js
+++ b/packages/common/locales/global/ksf.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ksf'] = [
     'ksf',

--- a/packages/common/locales/global/ksh.js
+++ b/packages/common/locales/global/ksh.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 0) return 0;
     if (n === 1) return 1;

--- a/packages/common/locales/global/ku.js
+++ b/packages/common/locales/global/ku.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/kw.js
+++ b/packages/common/locales/global/kw.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     if (n === 2) return 2;

--- a/packages/common/locales/global/ky.js
+++ b/packages/common/locales/global/ky.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/lag.js
+++ b/packages/common/locales/global/lag.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (n === 0) return 0;
     if ((i === 0 || i === 1) && !(n === 0)) return 1;
     return 5;

--- a/packages/common/locales/global/lb.js
+++ b/packages/common/locales/global/lb.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/lg.js
+++ b/packages/common/locales/global/lg.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/lkt.js
+++ b/packages/common/locales/global/lkt.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['lkt'] = [
     'lkt',

--- a/packages/common/locales/global/ln-AO.js
+++ b/packages/common/locales/global/ln-AO.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === Math.floor(n) && n >= 0 && n <= 1) return 1;
     return 5;

--- a/packages/common/locales/global/ln-CF.js
+++ b/packages/common/locales/global/ln-CF.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === Math.floor(n) && n >= 0 && n <= 1) return 1;
     return 5;

--- a/packages/common/locales/global/ln-CG.js
+++ b/packages/common/locales/global/ln-CG.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === Math.floor(n) && n >= 0 && n <= 1) return 1;
     return 5;

--- a/packages/common/locales/global/ln.js
+++ b/packages/common/locales/global/ln.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === Math.floor(n) && n >= 0 && n <= 1) return 1;
     return 5;

--- a/packages/common/locales/global/lo.js
+++ b/packages/common/locales/global/lo.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['lo'] = [
     'lo',

--- a/packages/common/locales/global/lrc-IQ.js
+++ b/packages/common/locales/global/lrc-IQ.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['lrc-iq'] = [
     'lrc-IQ',

--- a/packages/common/locales/global/lrc.js
+++ b/packages/common/locales/global/lrc.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['lrc'] = [
     'lrc',

--- a/packages/common/locales/global/lt.js
+++ b/packages/common/locales/global/lt.js
@@ -14,9 +14,9 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
-        let f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
+        var f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
         if (n % 10 === 1 && !(n % 100 >= 11 && n % 100 <= 19)) return 1;
         if (n % 10 === Math.floor(n % 10) && n % 10 >= 2 && n % 10 <= 9 &&
             !(n % 100 >= 11 && n % 100 <= 19))

--- a/packages/common/locales/global/lu.js
+++ b/packages/common/locales/global/lu.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['lu'] = [
     'lu',

--- a/packages/common/locales/global/luo.js
+++ b/packages/common/locales/global/luo.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['luo'] = [
     'luo',

--- a/packages/common/locales/global/luy.js
+++ b/packages/common/locales/global/luy.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['luy'] = [
     'luy',

--- a/packages/common/locales/global/lv.js
+++ b/packages/common/locales/global/lv.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let v = n.toString().replace(/^[^.]*\.?/, '').length,
+    var v = n.toString().replace(/^[^.]*\.?/, '').length,
         f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
     if (n % 10 === 0 || n % 100 === Math.floor(n % 100) && n % 100 >= 11 && n % 100 <= 19 ||
         v === 2 && f % 100 === Math.floor(f % 100) && f % 100 >= 11 && f % 100 <= 19)

--- a/packages/common/locales/global/mas-TZ.js
+++ b/packages/common/locales/global/mas-TZ.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/mas.js
+++ b/packages/common/locales/global/mas.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/mer.js
+++ b/packages/common/locales/global/mer.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['mer'] = [
     'mer',

--- a/packages/common/locales/global/mfe.js
+++ b/packages/common/locales/global/mfe.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['mfe'] = [
     'mfe',

--- a/packages/common/locales/global/mg.js
+++ b/packages/common/locales/global/mg.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === Math.floor(n) && n >= 0 && n <= 1) return 1;
     return 5;

--- a/packages/common/locales/global/mgh.js
+++ b/packages/common/locales/global/mgh.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['mgh'] = [
     'mgh',

--- a/packages/common/locales/global/mgo.js
+++ b/packages/common/locales/global/mgo.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/mi.js
+++ b/packages/common/locales/global/mi.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['mi'] = [
     'mi',

--- a/packages/common/locales/global/mk.js
+++ b/packages/common/locales/global/mk.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
         f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11) || f % 10 === 1 && !(f % 100 === 11)) return 1;
     return 5;

--- a/packages/common/locales/global/ml.js
+++ b/packages/common/locales/global/ml.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/mn.js
+++ b/packages/common/locales/global/mn.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/mr.js
+++ b/packages/common/locales/global/mr.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || n === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ms-BN.js
+++ b/packages/common/locales/global/ms-BN.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ms-bn'] = [
     'ms-BN',

--- a/packages/common/locales/global/ms-SG.js
+++ b/packages/common/locales/global/ms-SG.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ms-sg'] = [
     'ms-SG',

--- a/packages/common/locales/global/ms.js
+++ b/packages/common/locales/global/ms.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ms'] = [
     'ms',

--- a/packages/common/locales/global/mt.js
+++ b/packages/common/locales/global/mt.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     if (n === 0 || n % 100 === Math.floor(n % 100) && n % 100 >= 2 && n % 100 <= 10) return 3;

--- a/packages/common/locales/global/mua.js
+++ b/packages/common/locales/global/mua.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['mua'] = [
     'mua',

--- a/packages/common/locales/global/my.js
+++ b/packages/common/locales/global/my.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['my'] = [
     'my',

--- a/packages/common/locales/global/mzn.js
+++ b/packages/common/locales/global/mzn.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['mzn'] = [
     'mzn',

--- a/packages/common/locales/global/naq.js
+++ b/packages/common/locales/global/naq.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     if (n === 2) return 2;

--- a/packages/common/locales/global/nb-SJ.js
+++ b/packages/common/locales/global/nb-SJ.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/nb.js
+++ b/packages/common/locales/global/nb.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/nd.js
+++ b/packages/common/locales/global/nd.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/nds-NL.js
+++ b/packages/common/locales/global/nds-NL.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['nds-nl'] = [
     'nds-NL',

--- a/packages/common/locales/global/nds.js
+++ b/packages/common/locales/global/nds.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['nds'] = [
     'nds',

--- a/packages/common/locales/global/ne-IN.js
+++ b/packages/common/locales/global/ne-IN.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ne.js
+++ b/packages/common/locales/global/ne.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/nl-AW.js
+++ b/packages/common/locales/global/nl-AW.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/nl-BE.js
+++ b/packages/common/locales/global/nl-BE.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/nl-BQ.js
+++ b/packages/common/locales/global/nl-BQ.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/nl-CW.js
+++ b/packages/common/locales/global/nl-CW.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/nl-SR.js
+++ b/packages/common/locales/global/nl-SR.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/nl-SX.js
+++ b/packages/common/locales/global/nl-SX.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/nl.js
+++ b/packages/common/locales/global/nl.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/nmg.js
+++ b/packages/common/locales/global/nmg.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['nmg'] = [
     'nmg',

--- a/packages/common/locales/global/nn.js
+++ b/packages/common/locales/global/nn.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/nnh.js
+++ b/packages/common/locales/global/nnh.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/nus.js
+++ b/packages/common/locales/global/nus.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['nus'] = [
     'nus',

--- a/packages/common/locales/global/nyn.js
+++ b/packages/common/locales/global/nyn.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/om-KE.js
+++ b/packages/common/locales/global/om-KE.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/om.js
+++ b/packages/common/locales/global/om.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/or.js
+++ b/packages/common/locales/global/or.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/os-RU.js
+++ b/packages/common/locales/global/os-RU.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/os.js
+++ b/packages/common/locales/global/os.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/pa-Arab.js
+++ b/packages/common/locales/global/pa-Arab.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['pa-arab'] = [
     'pa-Arab',

--- a/packages/common/locales/global/pa-Guru.js
+++ b/packages/common/locales/global/pa-Guru.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === Math.floor(n) && n >= 0 && n <= 1) return 1;
     return 5;

--- a/packages/common/locales/global/pa.js
+++ b/packages/common/locales/global/pa.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === Math.floor(n) && n >= 0 && n <= 1) return 1;
     return 5;

--- a/packages/common/locales/global/pl.js
+++ b/packages/common/locales/global/pl.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&
         !(i % 100 >= 12 && i % 100 <= 14))

--- a/packages/common/locales/global/prg.js
+++ b/packages/common/locales/global/prg.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let v = n.toString().replace(/^[^.]*\.?/, '').length,
+    var v = n.toString().replace(/^[^.]*\.?/, '').length,
         f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
     if (n % 10 === 0 || n % 100 === Math.floor(n % 100) && n % 100 >= 11 && n % 100 <= 19 ||
         v === 2 && f % 100 === Math.floor(f % 100) && f % 100 >= 11 && f % 100 <= 19)

--- a/packages/common/locales/global/ps-PK.js
+++ b/packages/common/locales/global/ps-PK.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ps.js
+++ b/packages/common/locales/global/ps.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/pt-AO.js
+++ b/packages/common/locales/global/pt-AO.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === Math.floor(i) && i >= 0 && i <= 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/pt-CH.js
+++ b/packages/common/locales/global/pt-CH.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === Math.floor(i) && i >= 0 && i <= 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/pt-CV.js
+++ b/packages/common/locales/global/pt-CV.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === Math.floor(i) && i >= 0 && i <= 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/pt-GQ.js
+++ b/packages/common/locales/global/pt-GQ.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === Math.floor(i) && i >= 0 && i <= 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/pt-GW.js
+++ b/packages/common/locales/global/pt-GW.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === Math.floor(i) && i >= 0 && i <= 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/pt-LU.js
+++ b/packages/common/locales/global/pt-LU.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === Math.floor(i) && i >= 0 && i <= 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/pt-MO.js
+++ b/packages/common/locales/global/pt-MO.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === Math.floor(i) && i >= 0 && i <= 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/pt-MZ.js
+++ b/packages/common/locales/global/pt-MZ.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === Math.floor(i) && i >= 0 && i <= 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/pt-PT.js
+++ b/packages/common/locales/global/pt-PT.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === Math.floor(i) && i >= 0 && i <= 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/pt-ST.js
+++ b/packages/common/locales/global/pt-ST.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === Math.floor(i) && i >= 0 && i <= 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/pt-TL.js
+++ b/packages/common/locales/global/pt-TL.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === Math.floor(i) && i >= 0 && i <= 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/pt.js
+++ b/packages/common/locales/global/pt.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === Math.floor(i) && i >= 0 && i <= 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/qu-BO.js
+++ b/packages/common/locales/global/qu-BO.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['qu-bo'] = [
     'qu-BO',

--- a/packages/common/locales/global/qu-EC.js
+++ b/packages/common/locales/global/qu-EC.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['qu-ec'] = [
     'qu-EC',

--- a/packages/common/locales/global/qu.js
+++ b/packages/common/locales/global/qu.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['qu'] = [
     'qu',

--- a/packages/common/locales/global/rm.js
+++ b/packages/common/locales/global/rm.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/rn.js
+++ b/packages/common/locales/global/rn.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['rn'] = [
     'rn',

--- a/packages/common/locales/global/ro-MD.js
+++ b/packages/common/locales/global/ro-MD.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     if (!(v === 0) || n === 0 ||
         !(n === 1) && n % 100 === Math.floor(n % 100) && n % 100 >= 1 && n % 100 <= 19)

--- a/packages/common/locales/global/ro.js
+++ b/packages/common/locales/global/ro.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     if (!(v === 0) || n === 0 ||
         !(n === 1) && n % 100 === Math.floor(n % 100) && n % 100 >= 1 && n % 100 <= 19)

--- a/packages/common/locales/global/rof.js
+++ b/packages/common/locales/global/rof.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/root.js
+++ b/packages/common/locales/global/root.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['root'] = [
     'root',

--- a/packages/common/locales/global/ru-BY.js
+++ b/packages/common/locales/global/ru-BY.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11)) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&
         !(i % 100 >= 12 && i % 100 <= 14))

--- a/packages/common/locales/global/ru-KG.js
+++ b/packages/common/locales/global/ru-KG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11)) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&
         !(i % 100 >= 12 && i % 100 <= 14))

--- a/packages/common/locales/global/ru-KZ.js
+++ b/packages/common/locales/global/ru-KZ.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11)) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&
         !(i % 100 >= 12 && i % 100 <= 14))

--- a/packages/common/locales/global/ru-MD.js
+++ b/packages/common/locales/global/ru-MD.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11)) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&
         !(i % 100 >= 12 && i % 100 <= 14))

--- a/packages/common/locales/global/ru-UA.js
+++ b/packages/common/locales/global/ru-UA.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11)) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&
         !(i % 100 >= 12 && i % 100 <= 14))

--- a/packages/common/locales/global/ru.js
+++ b/packages/common/locales/global/ru.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11)) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&
         !(i % 100 >= 12 && i % 100 <= 14))

--- a/packages/common/locales/global/rw.js
+++ b/packages/common/locales/global/rw.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['rw'] = [
     'rw',

--- a/packages/common/locales/global/rwk.js
+++ b/packages/common/locales/global/rwk.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/sah.js
+++ b/packages/common/locales/global/sah.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['sah'] = [
     'sah',

--- a/packages/common/locales/global/saq.js
+++ b/packages/common/locales/global/saq.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/sbp.js
+++ b/packages/common/locales/global/sbp.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['sbp'] = [
     'sbp',

--- a/packages/common/locales/global/sd.js
+++ b/packages/common/locales/global/sd.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/se-FI.js
+++ b/packages/common/locales/global/se-FI.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     if (n === 2) return 2;

--- a/packages/common/locales/global/se-SE.js
+++ b/packages/common/locales/global/se-SE.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     if (n === 2) return 2;

--- a/packages/common/locales/global/se.js
+++ b/packages/common/locales/global/se.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     if (n === 2) return 2;

--- a/packages/common/locales/global/seh.js
+++ b/packages/common/locales/global/seh.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ses.js
+++ b/packages/common/locales/global/ses.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['ses'] = [
     'ses',

--- a/packages/common/locales/global/sg.js
+++ b/packages/common/locales/global/sg.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['sg'] = [
     'sg',

--- a/packages/common/locales/global/shi-Latn.js
+++ b/packages/common/locales/global/shi-Latn.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['shi-latn'] = [
     'shi-Latn',

--- a/packages/common/locales/global/shi-Tfng.js
+++ b/packages/common/locales/global/shi-Tfng.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || n === 1) return 1;
     if (n === Math.floor(n) && n >= 2 && n <= 10) return 3;
     return 5;

--- a/packages/common/locales/global/shi.js
+++ b/packages/common/locales/global/shi.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n));
+    var i = Math.floor(Math.abs(n));
     if (i === 0 || n === 1) return 1;
     if (n === Math.floor(n) && n >= 2 && n <= 10) return 3;
     return 5;

--- a/packages/common/locales/global/si.js
+++ b/packages/common/locales/global/si.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
+    var i = Math.floor(Math.abs(n)), f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
     if (n === 0 || n === 1 || i === 0 && f === 1) return 1;
     return 5;
   }

--- a/packages/common/locales/global/sk.js
+++ b/packages/common/locales/global/sk.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     if (i === Math.floor(i) && i >= 2 && i <= 4 && v === 0) return 3;
     if (!(v === 0)) return 4;

--- a/packages/common/locales/global/sl.js
+++ b/packages/common/locales/global/sl.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (v === 0 && i % 100 === 1) return 1;
     if (v === 0 && i % 100 === 2) return 2;
     if (v === 0 && i % 100 === Math.floor(i % 100) && i % 100 >= 3 && i % 100 <= 4 || !(v === 0))

--- a/packages/common/locales/global/smn.js
+++ b/packages/common/locales/global/smn.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     if (n === 2) return 2;

--- a/packages/common/locales/global/sn.js
+++ b/packages/common/locales/global/sn.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/so-DJ.js
+++ b/packages/common/locales/global/so-DJ.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/so-ET.js
+++ b/packages/common/locales/global/so-ET.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/so-KE.js
+++ b/packages/common/locales/global/so-KE.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/so.js
+++ b/packages/common/locales/global/so.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/sq-MK.js
+++ b/packages/common/locales/global/sq-MK.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/sq-XK.js
+++ b/packages/common/locales/global/sq-XK.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/sq.js
+++ b/packages/common/locales/global/sq.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/sr-Cyrl-BA.js
+++ b/packages/common/locales/global/sr-Cyrl-BA.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
         f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11) || f % 10 === 1 && !(f % 100 === 11)) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&

--- a/packages/common/locales/global/sr-Cyrl-ME.js
+++ b/packages/common/locales/global/sr-Cyrl-ME.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
         f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11) || f % 10 === 1 && !(f % 100 === 11)) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&

--- a/packages/common/locales/global/sr-Cyrl-XK.js
+++ b/packages/common/locales/global/sr-Cyrl-XK.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
         f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11) || f % 10 === 1 && !(f % 100 === 11)) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&

--- a/packages/common/locales/global/sr-Cyrl.js
+++ b/packages/common/locales/global/sr-Cyrl.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
         f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11) || f % 10 === 1 && !(f % 100 === 11)) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&

--- a/packages/common/locales/global/sr-Latn-BA.js
+++ b/packages/common/locales/global/sr-Latn-BA.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['sr-latn-ba'] = [
     'sr-Latn-BA',

--- a/packages/common/locales/global/sr-Latn-ME.js
+++ b/packages/common/locales/global/sr-Latn-ME.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['sr-latn-me'] = [
     'sr-Latn-ME',

--- a/packages/common/locales/global/sr-Latn-XK.js
+++ b/packages/common/locales/global/sr-Latn-XK.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['sr-latn-xk'] = [
     'sr-Latn-XK',

--- a/packages/common/locales/global/sr-Latn.js
+++ b/packages/common/locales/global/sr-Latn.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['sr-latn'] = [
     'sr-Latn',

--- a/packages/common/locales/global/sr.js
+++ b/packages/common/locales/global/sr.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length,
         f = parseInt(n.toString().replace(/^[^.]*\.?/, ''), 10) || 0;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11) || f % 10 === 1 && !(f % 100 === 11)) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&

--- a/packages/common/locales/global/sv-AX.js
+++ b/packages/common/locales/global/sv-AX.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/sv-FI.js
+++ b/packages/common/locales/global/sv-FI.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/sv.js
+++ b/packages/common/locales/global/sv.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/sw-CD.js
+++ b/packages/common/locales/global/sw-CD.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/sw-KE.js
+++ b/packages/common/locales/global/sw-KE.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/sw-UG.js
+++ b/packages/common/locales/global/sw-UG.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/sw.js
+++ b/packages/common/locales/global/sw.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ta-LK.js
+++ b/packages/common/locales/global/ta-LK.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ta-MY.js
+++ b/packages/common/locales/global/ta-MY.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ta-SG.js
+++ b/packages/common/locales/global/ta-SG.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/ta.js
+++ b/packages/common/locales/global/ta.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/te.js
+++ b/packages/common/locales/global/te.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/teo-KE.js
+++ b/packages/common/locales/global/teo-KE.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/teo.js
+++ b/packages/common/locales/global/teo.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/tg.js
+++ b/packages/common/locales/global/tg.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['tg'] = [
     'tg',

--- a/packages/common/locales/global/th.js
+++ b/packages/common/locales/global/th.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['th'] = [
     'th',

--- a/packages/common/locales/global/ti-ER.js
+++ b/packages/common/locales/global/ti-ER.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === Math.floor(n) && n >= 0 && n <= 1) return 1;
     return 5;

--- a/packages/common/locales/global/ti.js
+++ b/packages/common/locales/global/ti.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === Math.floor(n) && n >= 0 && n <= 1) return 1;
     return 5;

--- a/packages/common/locales/global/tk.js
+++ b/packages/common/locales/global/tk.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/to.js
+++ b/packages/common/locales/global/to.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['to'] = [
     'to',

--- a/packages/common/locales/global/tr-CY.js
+++ b/packages/common/locales/global/tr-CY.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/tr.js
+++ b/packages/common/locales/global/tr.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/tt.js
+++ b/packages/common/locales/global/tt.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['tt'] = [
     'tt',

--- a/packages/common/locales/global/twq.js
+++ b/packages/common/locales/global/twq.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['twq'] = [
     'twq',

--- a/packages/common/locales/global/tzm.js
+++ b/packages/common/locales/global/tzm.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === Math.floor(n) && n >= 0 && n <= 1 || n === Math.floor(n) && n >= 11 && n <= 99)
       return 1;

--- a/packages/common/locales/global/ug.js
+++ b/packages/common/locales/global/ug.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/uk.js
+++ b/packages/common/locales/global/uk.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (v === 0 && i % 10 === 1 && !(i % 100 === 11)) return 1;
     if (v === 0 && i % 10 === Math.floor(i % 10) && i % 10 >= 2 && i % 10 <= 4 &&
         !(i % 100 >= 12 && i % 100 <= 14))

--- a/packages/common/locales/global/ur-IN.js
+++ b/packages/common/locales/global/ur-IN.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/ur.js
+++ b/packages/common/locales/global/ur.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/uz-Arab.js
+++ b/packages/common/locales/global/uz-Arab.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['uz-arab'] = [
     'uz-Arab',

--- a/packages/common/locales/global/uz-Cyrl.js
+++ b/packages/common/locales/global/uz-Cyrl.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['uz-cyrl'] = [
     'uz-Cyrl',

--- a/packages/common/locales/global/uz-Latn.js
+++ b/packages/common/locales/global/uz-Latn.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/uz.js
+++ b/packages/common/locales/global/uz.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/vai-Latn.js
+++ b/packages/common/locales/global/vai-Latn.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['vai-latn'] = [
     'vai-Latn',

--- a/packages/common/locales/global/vai-Vaii.js
+++ b/packages/common/locales/global/vai-Vaii.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['vai-vaii'] = [
     'vai-Vaii',

--- a/packages/common/locales/global/vai.js
+++ b/packages/common/locales/global/vai.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['vai'] = [
     'vai',

--- a/packages/common/locales/global/vi.js
+++ b/packages/common/locales/global/vi.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['vi'] = [
     'vi',

--- a/packages/common/locales/global/vo.js
+++ b/packages/common/locales/global/vo.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/vun.js
+++ b/packages/common/locales/global/vun.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/wae.js
+++ b/packages/common/locales/global/wae.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/wo.js
+++ b/packages/common/locales/global/wo.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['wo'] = [
     'wo',

--- a/packages/common/locales/global/xh.js
+++ b/packages/common/locales/global/xh.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/xog.js
+++ b/packages/common/locales/global/xog.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
     if (n === 1) return 1;
     return 5;

--- a/packages/common/locales/global/yav.js
+++ b/packages/common/locales/global/yav.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['yav'] = [
     'yav',

--- a/packages/common/locales/global/yi.js
+++ b/packages/common/locales/global/yi.js
@@ -13,9 +13,9 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) {
-    let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+    var i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
     if (i === 1 && v === 0) return 1;
     return 5;
   }

--- a/packages/common/locales/global/yo-BJ.js
+++ b/packages/common/locales/global/yo-BJ.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['yo-bj'] = [
     'yo-BJ',

--- a/packages/common/locales/global/yo.js
+++ b/packages/common/locales/global/yo.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['yo'] = [
     'yo',

--- a/packages/common/locales/global/yue-Hans.js
+++ b/packages/common/locales/global/yue-Hans.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['yue-hans'] = [
     'yue-Hans',

--- a/packages/common/locales/global/yue-Hant.js
+++ b/packages/common/locales/global/yue-Hant.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['yue-hant'] = [
     'yue-Hant',

--- a/packages/common/locales/global/yue.js
+++ b/packages/common/locales/global/yue.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['yue'] = [
     'yue',

--- a/packages/common/locales/global/zgh.js
+++ b/packages/common/locales/global/zgh.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['zgh'] = [
     'zgh',

--- a/packages/common/locales/global/zh-Hans-HK.js
+++ b/packages/common/locales/global/zh-Hans-HK.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['zh-hans-hk'] = [
     'zh-Hans-HK',

--- a/packages/common/locales/global/zh-Hans-MO.js
+++ b/packages/common/locales/global/zh-Hans-MO.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['zh-hans-mo'] = [
     'zh-Hans-MO',

--- a/packages/common/locales/global/zh-Hans-SG.js
+++ b/packages/common/locales/global/zh-Hans-SG.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['zh-hans-sg'] = [
     'zh-Hans-SG',

--- a/packages/common/locales/global/zh-Hans.js
+++ b/packages/common/locales/global/zh-Hans.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['zh-hans'] = [
     'zh-Hans',

--- a/packages/common/locales/global/zh-Hant-HK.js
+++ b/packages/common/locales/global/zh-Hant-HK.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['zh-hant-hk'] = [
     'zh-Hant-HK',

--- a/packages/common/locales/global/zh-Hant-MO.js
+++ b/packages/common/locales/global/zh-Hant-MO.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['zh-hant-mo'] = [
     'zh-Hant-MO',

--- a/packages/common/locales/global/zh-Hant.js
+++ b/packages/common/locales/global/zh-Hant.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['zh-hant'] = [
     'zh-Hant',

--- a/packages/common/locales/global/zh.js
+++ b/packages/common/locales/global/zh.js
@@ -13,7 +13,7 @@
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   function plural(n) { return 5; }
   global.ng.common.locales['zh'] = [
     'zh',

--- a/packages/common/locales/global/zu.js
+++ b/packages/common/locales/global/zu.js
@@ -14,9 +14,9 @@
       global.ng = global.ng || {};
       global.ng.common = global.ng.common || {};
       global.ng.common.locales = global.ng.common.locales || {};
-      const u = undefined;
+      var u = undefined;
       function plural(n) {
-        let i = Math.floor(Math.abs(n));
+        var i = Math.floor(Math.abs(n));
         if (i === 0 || n === 1) return 1;
         return 5;
       }

--- a/tools/gulp-tasks/cldr/extract.js
+++ b/tools/gulp-tasks/cldr/extract.js
@@ -138,7 +138,7 @@ function generateGlobalLocale(locale, localeData, baseCurrencies) {
   global.ng = global.ng || {};
   global.ng.common = global.ng.common || {};
   global.ng.common.locales = global.ng.common.locales || {};
-  const u = undefined;
+  var u = undefined;
   ${getPluralFunction(locale, false)}
   global.ng.common.locales['${normalizeLocale(locale)}'] = ${data};
 })(typeof globalThis !== 'undefined' && globalThis || typeof global !== 'undefined' && global || typeof window !== 'undefined' && window);
@@ -559,18 +559,21 @@ function toRegExp(s) {
  * todo(ocombe): replace "cldr" extractPluralRuleFunction with our own extraction using "CldrJS"
  * because the 2 libs can become out of sync if they use different versions of the cldr database
  */
-function getPluralFunction(locale, withTypes = true) {
+function getPluralFunction(locale, typescript = true) {
   let fn = cldr.extractPluralRuleFunction(locale).toString();
 
   if (fn === EMPTY_RULE) {
     fn = DEFAULT_RULE;
   }
 
-  const numberType = withTypes ? ': number' : '';
+  const numberType = typescript ? ': number' : '';
   fn = fn.replace(/function anonymous\(n[^}]+{/g, `function plural(n${numberType})${numberType} {`)
-           .replace(toRegExp('var'), 'let')
            .replace(toRegExp('if(typeof n==="string")n=parseInt(n,10);'), '')
            .replace(toRegExp('\n}'), ';\n}');
+
+  if (typescript) {
+    fn = fn.replace(toRegExp('var'), 'let');
+  }
 
   // The replacement values must match the `Plural` enum from common.
   // We do not use the enum directly to avoid depending on that package.


### PR DESCRIPTION
Although this code has been part of Angular 9.x I only noticed this error when upgrading to Angular 9.1.x because historically the source locale data was not injected when localizing, but as of angular/angular-cli#16394 (9.1.0) it is now included. This tipped me off that my other bundles were not being built properly, and this change allows me to build a valid ES5 bundle (I have also added a verification step to my build pipeline to alert me if this error appears again in any
of my bundles).

I found the `locales/global/*.js` file paths being referenced by the `I18nOptions` in
@angular-devkit/build-angular/src/utils/i18n-options.ts, and following that it looks like it is actually loaded and used in @angular-devkit/build-angular/src/utils/process-bundle.ts. I saw the function `terserMangle` does appear that it is likely aware of the build being ES5, but I'm not sure why this is not producing a valid ES5 bundle.

This change updates `tools/gulp-tasks/cldr/extract.js` to produce ES5 compliant `locales/global/*.js` and that fixes my issue. However, I am not sure if @angular-devkit/build-angular should be modified to produce a valid ES5 bundle instead or if the files could be TypeScript rather than JavaScript files.

A test that a valid ES5 bundle is produced would be helpful, and I hope this is reproducible and not some issue with my config.


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The code above is injected into the vendor-es5.js bundle, but is not actually valid ES5.

Issue Number: N/A


## What is the new behavior?
vendor-es5.js bundle is once again valid ES5

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
