### PR TITLE
fix(ngcc): allow ngcc configuration to match pre-release versions of packages

### DIFF
--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -304,5 +304,7 @@ function findSatisfactoryVersion(
     // So just return the first config that matches the package name.
     return configs[0];
   }
-  return configs.find(config => satisfies(version, config.versionRange)) || null;
+  return configs.find(
+             config => satisfies(version, config.versionRange, {includePrerelease: true})) ||
+      null;
 }

--- a/packages/compiler-cli/ngcc/test/packages/configuration_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/configuration_spec.ts
@@ -214,6 +214,34 @@ runInEachFileSystem(() => {
                  .toEqual({versionRange: '*', entryPoints: {}});
            });
 
+        it('should match pre-release versions of a package', () => {
+          loadTestFiles([
+            {
+              name: _Abs('/project-1/ngcc.config.js'),
+              contents: `
+                module.exports = {
+                  packages: {
+                    'package-1': {
+                      entryPoints: {
+                        './entry-point-1': {},
+                      },
+                    },
+                  },
+                };
+              `,
+            },
+          ]);
+
+          const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
+          const config =
+              configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0-beta.2');
+
+          expect(config).toEqual({
+            versionRange: '*',
+            entryPoints: {[_Abs('/project-1/node_modules/package-1/entry-point-1')]: {}},
+          });
+        });
+
         it('should not get confused by the @ in namespaced packages', () => {
           loadTestFiles([{
             name: _Abs('/project-1/ngcc.config.js'),
@@ -359,6 +387,21 @@ runInEachFileSystem(() => {
             versionRange: '*',
             entryPoints:
                 {[_Abs('/project-1/node_modules/package-1/project-level-entry-point')]: {}}
+          });
+        });
+
+        it('should match pre-release versions of a package', () => {
+          DEFAULT_NGCC_CONFIG.packages['package-1'] = {
+            entryPoints: {'./entry-point-1': {}},
+          };
+
+          const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
+          const config =
+              configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0-beta.2');
+
+          expect(config).toEqual({
+            versionRange: '*',
+            entryPoints: {[_Abs('/project-1/node_modules/package-1/entry-point-1')]: {}},
           });
         });
       });


### PR DESCRIPTION
Ngcc supports providing a project-level configuration to affect how certain dependencies are processed and also has a built-in fallback configuration for some unmaintained packages. Each entry in these configurations could be scoped to specific versions of a package by providing a version range. If no version range is provided for a package, it defaults to `*` (with the intention of matching any version).

Previously, the installed version of a package was tested against the version range using the [semver][1] package's `satisfies()` function with the default options. By default, `satisfies()` does not match pre-releases (see [here][2] for more details on reasoning). While this makes sense when determining what version of a dependency to install (trying to avoid unexpected breaking changes), it is not desired in the case of ngcc.

This commit fixes it by explicitly specifying that pre-release versions should be matched normally.

##
This is needed for angular/ngcc-validation#1029.

[1]: https://www.npmjs.com/package/semver
[2]: https://github.com/npm/node-semver#prerelease-tags
