### PR TITLE
fix(language-service): use the `HtmlAst` to get the span of HTML tag

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -83,11 +83,21 @@ function isIdentifierPart(code: number) {
  * Gets the span of word in a template that surrounds `position`. If there is no word around
  * `position`, nothing is returned.
  */
-function getBoundedWordSpan(templateInfo: AstResult, position: number): ts.TextSpan|undefined {
+function getBoundedWordSpan(
+    templateInfo: AstResult, position: number, ast: HtmlAst|undefined): ts.TextSpan|undefined {
   const {template} = templateInfo;
   const templateSrc = template.source;
 
   if (!templateSrc) return;
+
+  if (ast instanceof Element) {
+    // The HTML tag may include `-` (e.g. `app-root`),
+    // so use the HtmlAst to get the span before ayazhafiz refactor the code.
+    return {
+      start: templateInfo.template.span.start + ast.startSourceSpan!.start.offset + 1,
+      length: ast.name.length
+    };
+  }
 
   // TODO(ayazhafiz): A solution based on word expansion will always be expensive compared to one
   // based on ASTs. Whatever penalty we incur is probably manageable for small-length (i.e. the
@@ -213,7 +223,7 @@ export function getTemplateCompletions(
         null);
   }
 
-  const replacementSpan = getBoundedWordSpan(templateInfo, position);
+  const replacementSpan = getBoundedWordSpan(templateInfo, position, mostSpecific);
   return result.map(entry => {
     return {
       ...entry,

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -670,18 +670,18 @@ describe('completions', () => {
         @Component({
           selector: 'foo-component',
           template: \`
-            <di~{div}></div>
+            <test-comp~{test-comp}></test-comp>
           \`,
         })
         export class FooComponent {}
       `);
-      const location = mockHost.getLocationMarkerFor(fileName, 'div');
+      const location = mockHost.getLocationMarkerFor(fileName, 'test-comp');
       const completions = ngLS.getCompletionsAtPosition(fileName, location.start)!;
       expect(completions).toBeDefined();
-      const completion = completions.entries.find(entry => entry.name === 'div')!;
+      const completion = completions.entries.find(entry => entry.name === 'test-comp')!;
       expect(completion).toBeDefined();
-      expect(completion.kind).toBe('html element');
-      expect(completion.replacementSpan).toEqual({start: location.start - 2, length: 2});
+      expect(completion.kind).toBe('component');
+      expect(completion.replacementSpan).toEqual({start: location.start - 9, length: 9});
     });
 
     it('should work for bindings', () => {


### PR DESCRIPTION
The HTML tag may include `-` (e.g. `app-root`), so use the `HtmlAst` to get the span.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
