### PR TITLE
fix(core): attempt to recover from user errors during creation 

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -30,7 +30,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 137320,
+        "main-es2015": 137897,
         "polyfills-es2015": 37334
       }
     }
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 226728,
+        "main-es2015": 227258,
         "polyfills-es2015": 36657,
         "5-es2015": 779
       }

--- a/packages/core/src/render3/instructions/lview_debug.ts
+++ b/packages/core/src/render3/instructions/lview_debug.ts
@@ -143,6 +143,7 @@ export const TViewConstructor = class TView implements ITView {
       public firstChild: ITNode|null,                        //
       public schemas: SchemaMetadata[]|null,                 //
       public consts: TConstants|null,                        //
+      public incompleteFirstPass: boolean                    //
   ) {}
 
   get template_(): string {

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -684,6 +684,12 @@ export interface TView {
    * Used for directive matching, attribute bindings, local definitions and more.
    */
   consts: TConstants|null;
+
+  /**
+   * Indicates that there was an error before we managed to complete the first create pass of the
+   * view. This means that the view is likely corrupted and we should try to recover it.
+   */
+  incompleteFirstPass: boolean;
 }
 
 export const enum RootContextFlags {


### PR DESCRIPTION
If there's an error during the first creation pass of a `TView`, the data structure may be corrupted which will cause framework assertion failures downstream which can mask the user's error. These changes add a new flag to the `TView` that indicates whether the first creation pass was successful, and if it wasn't try re-create the `TView`.

Fixes #31221.