### PR TITLE
docs: update ng-conf announcement to remove livestream link

### DIFF
--- a/aio/content/marketing/announcements.json
+++ b/aio/content/marketing/announcements.json
@@ -9,9 +9,9 @@
   {
     "startDate": "2020-04-01",
     "endDate": "2020-04-03",
-    "message": "Watch ng-conf live stream <br/>April 1st-3rd, 2020",
+    "message": "ng-conf: Hardwired is happening! <br/>April 1st-3rd, 2020",
     "imageUrl": "generated/images/marketing/home/ng-conf.png",
-    "linkUrl": "https://www.ng-conf.org/livestream/?utm_source=angular.io&utm_medium=referral"
+    "linkUrl": "https://www.ng-conf.org"
   },
   {
     "startDate": "2019-05-03",


### PR DESCRIPTION
Since the livestream for ng-conf is not public this year,
(and is only available to ng-conf attendees), we are
removing the link from the angular.io homepage.

Instead, we are now pointing to the ng-conf homepage for
more information.
