### PR TITLE
build: add commit message scope for migration changes

### DIFF
--- a/.ng-dev/config.ts
+++ b/.ng-dev/config.ts
@@ -32,6 +32,7 @@ const commitMessage = {
     'http',
     'language-service',
     'localize',
+    'migrations',
     'ngcc',
     'packaging',
     'platform-browser',

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,6 +236,7 @@ There are currently a few exceptions to the "use package name" rule:
 * **docs-infra**: used for docs-app (angular.io) related changes within the /aio directory of the
   repo
 * **dev-infra**: used for dev-infra related changes within the directories /scripts, /tools and /dev-infra
+* **migrations**: used for changes to the `ng update` migrations.
 * **ngcc**: used for changes to the [Angular Compatibility Compiler](./packages/compiler-cli/ngcc/README.md)
 * **ve**: used for changes specific to ViewEngine (legacy compiler/renderer).
 * none/empty string: useful for `style`, `test` and `refactor` changes that are done across all


### PR DESCRIPTION
This is a proposal commit that adds a separate scope for migration changes.

The motivation is that migrations aren't necessarily always affecting `@angular/core`
(e.g. the `move-document` migration is affecting platform-browser). Migrations are just
stored in the `@angular/core` package in favor of a canonical location when someone
runs `ng update`. Additionally, it rather seems confusing that migration changes are listed
under `core` in the changelog. Long commit message titles are needed to make clear that
commits do _not_ affect `@angular/core` runtime logic, but just the ng update migrations.