### PR TITLE
build: enable `strictTemplates` in AIO

### DIFF
--- a/aio/src/app/custom-elements/api/api-list.component.html
+++ b/aio/src/app/custom-elements/api/api-list.component.html
@@ -15,7 +15,7 @@
   </aio-select>
 
   <div class="form-search">
-    <input #filter placeholder="Filter" (input)="setQuery($event.target.value)" aria-label="Filter Search">
+    <input #filter placeholder="Filter" (input)="setQuery($any($event.target).value)" aria-label="Filter Search">
     <i class="material-icons">search</i>
   </div>
 </div>

--- a/aio/tsconfig.json
+++ b/aio/tsconfig.json
@@ -38,6 +38,7 @@
   "angularCompilerOptions": {
     "disableTypeScriptVersionCheck": true,
     "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true
+    "strictInjectionParameters": true,
+    "strictTemplates": true
   }
 }


### PR DESCRIPTION
Related to https://github.com/angular/angular-cli/pull/17372

This is to verify that all examples in AIO are complainant with `strictTemplates` setting.