### PR TITLE
feat(common): add extra overload to async pipe

### DIFF
--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -7,6 +7,7 @@ export declare class AsyncPipe implements OnDestroy, PipeTransform {
     transform<T>(obj: undefined): undefined;
     transform<T>(obj: Observable<T> | null | undefined): T | null;
     transform<T>(obj: Promise<T> | null | undefined): T | null;
+    transform<T>(obj: Observable<T> | Promise<T> | null | undefined): T | null;
 }
 
 export declare class CommonModule {

--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -19,17 +19,28 @@ interface SubscriptionStrategy {
 
 class ObservableStrategy implements SubscriptionStrategy {
   createSubscription(async: Observable<any>, updateLatestValue: any): SubscriptionLike {
-    return async.subscribe({next: updateLatestValue, error: (e: any) => { throw e; }});
+    return async.subscribe({
+      next: updateLatestValue,
+      error: (e: any) => {
+        throw e;
+      }
+    });
   }
 
-  dispose(subscription: SubscriptionLike): void { subscription.unsubscribe(); }
+  dispose(subscription: SubscriptionLike): void {
+    subscription.unsubscribe();
+  }
 
-  onDestroy(subscription: SubscriptionLike): void { subscription.unsubscribe(); }
+  onDestroy(subscription: SubscriptionLike): void {
+    subscription.unsubscribe();
+  }
 }
 
 class PromiseStrategy implements SubscriptionStrategy {
   createSubscription(async: Promise<any>, updateLatestValue: (v: any) => any): Promise<any> {
-    return async.then(updateLatestValue, e => { throw e; });
+    return async.then(updateLatestValue, e => {
+      throw e;
+    });
   }
 
   dispose(subscription: Promise<any>): void {}
@@ -74,7 +85,7 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
 
   private _subscription: SubscriptionLike|Promise<any>|null = null;
   private _obj: Observable<any>|Promise<any>|EventEmitter<any>|null = null;
-  private _strategy: SubscriptionStrategy = null !;
+  private _strategy: SubscriptionStrategy = null!;
 
   constructor(private _ref: ChangeDetectorRef) {}
 
@@ -88,6 +99,7 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
   transform<T>(obj: undefined): undefined;
   transform<T>(obj: Observable<T>|null|undefined): T|null;
   transform<T>(obj: Promise<T>|null|undefined): T|null;
+  transform<T>(obj: Observable<T>|Promise<T>|null|undefined): T|null;
   transform(obj: Observable<any>|Promise<any>|null|undefined): any {
     if (!this._obj) {
       if (obj) {
@@ -130,7 +142,7 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
   }
 
   private _dispose(): void {
-    this._strategy.dispose(this._subscription !);
+    this._strategy.dispose(this._subscription!);
     this._latestValue = null;
     this._latestReturnedValue = null;
     this._subscription = null;

--- a/packages/common/test/BUILD.bazel
+++ b/packages/common/test/BUILD.bazel
@@ -32,6 +32,7 @@ ts_library(
         "//packages/platform-browser-dynamic",
         "//packages/platform-browser/testing",
         "//packages/private/testing",
+        "@npm//rxjs",
     ],
 )
 

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -10,12 +10,12 @@ import {AsyncPipe, ɵgetDOM as getDOM} from '@angular/common';
 import {EventEmitter, WrappedValue} from '@angular/core';
 import {AsyncTestCompleter, beforeEach, describe, expect, inject, it} from '@angular/core/testing/src/testing_internal';
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
+import {Observable} from 'rxjs';
 
 import {SpyChangeDetectorRef} from '../spies';
 
 {
   describe('AsyncPipe', () => {
-
     describe('Observable', () => {
       let emitter: EventEmitter<any>;
       let pipe: AsyncPipe;
@@ -29,8 +29,9 @@ import {SpyChangeDetectorRef} from '../spies';
       });
 
       describe('transform', () => {
-        it('should return null when subscribing to an observable',
-           () => { expect(pipe.transform(emitter)).toBe(null); });
+        it('should return null when subscribing to an observable', () => {
+          expect(pipe.transform(emitter)).toBe(null);
+        });
 
         it('should return the latest available value wrapped',
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
@@ -96,8 +97,9 @@ import {SpyChangeDetectorRef} from '../spies';
       });
 
       describe('ngOnDestroy', () => {
-        it('should do nothing when no subscription',
-           () => { expect(() => pipe.ngOnDestroy()).not.toThrow(); });
+        it('should do nothing when no subscription', () => {
+          expect(() => pipe.ngOnDestroy()).not.toThrow();
+        });
 
         it('should dispose of the existing subscription',
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
@@ -133,8 +135,9 @@ import {SpyChangeDetectorRef} from '../spies';
       });
 
       describe('transform', () => {
-        it('should return null when subscribing to a promise',
-           () => { expect(pipe.transform(promise)).toBe(null); });
+        it('should return null when subscribing to a promise', () => {
+          expect(pipe.transform(promise)).toBe(null);
+        });
 
         it('should return the latest available value',
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
@@ -189,8 +192,9 @@ import {SpyChangeDetectorRef} from '../spies';
            }));
 
         describe('ngOnDestroy', () => {
-          it('should do nothing when no source',
-             () => { expect(() => pipe.ngOnDestroy()).not.toThrow(); });
+          it('should do nothing when no source', () => {
+            expect(() => pipe.ngOnDestroy()).not.toThrow();
+          });
 
           it('should dispose of the existing source',
              inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
@@ -221,6 +225,16 @@ import {SpyChangeDetectorRef} from '../spies';
       it('should throw when given an invalid object', () => {
         const pipe = new AsyncPipe(null as any);
         expect(() => pipe.transform(<any>'some bogus object')).toThrowError();
+      });
+    });
+
+    describe('Observable or Promise', () => {
+      it('should allow Observable<T> | Promise<T>', () => {
+        const pipe = new AsyncPipe(null as any);
+        const input: Promise<number>|Observable<number> = Promise.resolve(10) as any;
+        // we're really just ensuring the type is valid here
+        // rather than any runtime value
+        expect(() => pipe.transform(input)).not.toThrowError();
       });
     });
   });


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
- [x] Feature

## What is the current behavior?
Issue Number: #36404

## What is the new behavior?
```
The async pipes supports inputs being
Promise or Observable, this adds an overload
which is a union of both Promise and Observable
```

## Does this PR introduce a breaking change?

- [x] No

## Other information
