### PR TITLE
fix(ngcc): detect non-emitted, non-imported TypeScript helpers

### DIFF
--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -2000,6 +2000,74 @@ exports.ExternalModule = ExternalModule;
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
         });
+
+        it('should recognize undeclared, unimported TypeScript helpers (by name)', () => {
+          const file: TestFile = {
+            name: _('/test.js'),
+            contents: `
+              var a = __assign({foo: 'bar'}, {baz: 'qux'});
+              var b = __spread(['foo', 'bar'], ['baz', 'qux']);
+              var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+            `,
+          };
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host =
+              createHost(bundle, new CommonJsReflectionHost(new MockLogger(), false, bundle));
+
+          const testForHelper =
+              (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+                const node =
+                    getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
+                const helperIdentifier = getIdentifierFromCallExpression(node);
+                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+                expect(helperDeclaration).toEqual({
+                  known: knownAs,
+                  expression: helperIdentifier,
+                  node: null,
+                  viaModule: null,
+                });
+              };
+
+          testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
+          testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
+          testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+        });
+
+        it('should recognize suffixed, undeclared, unimported TypeScript helpers (by name)', () => {
+          const file: TestFile = {
+            name: _('/test.js'),
+            contents: `
+              var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
+              var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
+              var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+            `,
+          };
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host =
+              createHost(bundle, new CommonJsReflectionHost(new MockLogger(), false, bundle));
+
+          const testForHelper =
+              (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+                const node =
+                    getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
+                const helperIdentifier = getIdentifierFromCallExpression(node);
+                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+                expect(helperDeclaration).toEqual({
+                  known: knownAs,
+                  expression: helperIdentifier,
+                  node: null,
+                  viaModule: null,
+                });
+              };
+
+          testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
+          testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
+          testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+        });
       });
 
       describe('getExportsOfModule()', () => {

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -2124,6 +2124,68 @@ runInEachFileSystem(() => {
         testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
         testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
       });
+
+      it('should recognize undeclared, unimported TypeScript helpers (by name)', () => {
+        const file: TestFile = {
+          name: _('/test.js'),
+          contents: `
+            var a = __assign({foo: 'bar'}, {baz: 'qux'});
+            var b = __spread(['foo', 'bar'], ['baz', 'qux']);
+            var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+          `,
+        };
+        loadTestFiles([file]);
+        const bundle = makeTestBundleProgram(file.name);
+        const host = createHost(bundle, new Esm5ReflectionHost(new MockLogger(), false, bundle));
+
+        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+          const node = getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
+          const helperIdentifier = getIdentifierFromCallExpression(node);
+          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+          expect(helperDeclaration).toEqual({
+            known: knownAs,
+            expression: helperIdentifier,
+            node: null,
+            viaModule: null,
+          });
+        };
+
+        testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
+        testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
+        testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+      });
+
+      it('should recognize suffixed, undeclared, unimported TypeScript helpers (by name)', () => {
+        const file: TestFile = {
+          name: _('/test.js'),
+          contents: `
+            var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
+            var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
+            var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+          `,
+        };
+        loadTestFiles([file]);
+        const bundle = makeTestBundleProgram(file.name);
+        const host = createHost(bundle, new Esm5ReflectionHost(new MockLogger(), false, bundle));
+
+        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+          const node = getDeclaration(bundle.program, file.name, varName, ts.isVariableDeclaration);
+          const helperIdentifier = getIdentifierFromCallExpression(node);
+          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+
+          expect(helperDeclaration).toEqual({
+            known: knownAs,
+            expression: helperIdentifier,
+            node: null,
+            viaModule: null,
+          });
+        };
+
+        testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
+        testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
+        testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+      });
     });
 
     describe('getExportsOfModule()', () => {


### PR DESCRIPTION
When TypeScript downlevels ES2015+ code to ES5, it uses some helpers functions to emulated some ES2015+ features, such as spread syntax. The TypeScript compiler can be configured to emit these helpers into the transpiled code (which is controlled by the `noEmitHelpers` option - false by default). It can also be configured to import these helpers from the `tslib` module (which is controlled by the `importHelpers` option - false by default).

While most of the time the helpers will be either emitted or imported, it is possible that one configures their app to neither emit nor import them. In that case, the helpers could, for example, be made available on the global object. This is what `@nativescript/angular` v9.0.0-next-2019-11-12-155500-01 does. See, for example, [common.js][1].

Ngcc must be able to detect and statically evaluate these helpers. Previously, it was only able to detect emitted or imported helpers.

This commit adds support for detecting these helpers if they are neither emitted nor imported . It does this by checking identifiers for which no declaration (either concrete or inline) can be found against a list of known TypeScript helper function names.

##
This is needed for angular/ngcc-validation#1029.

[1]: https://unpkg.com/browse/@nativescript/angular@9.0.0-next-2019-11-12-155500-01/common.js