### PR TITLE
fix(ngcc): support ignoring deep-imports via package config

### DIFF
--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -241,9 +241,11 @@ export class NgccConfiguration {
     const configFilePath = join(packagePath, NGCC_CONFIG_FILENAME);
     if (this.fs.exists(configFilePath)) {
       try {
+        const packageConfig = this.evalSrcFile(configFilePath);
         return {
+          ...packageConfig,
           versionRange: version || '*',
-          entryPoints: this.processEntryPoints(packagePath, this.evalSrcFile(configFilePath)),
+          entryPoints: this.processEntryPoints(packagePath, packageConfig),
         };
       } catch (e) {
         throw new Error(`Invalid package configuration file at "${configFilePath}": ` + e.message);


### PR DESCRIPTION
Recently we added support for ignoring specified deep-import
warnings by providing sets of regular expressions within the
`ngcc.config.js` file. But this was only working for the project
level configuration.

This commit fixes ngcc so that it will also read these regular
expressions from package level configuration too.

Resolves #35750
