### PR TITLE
docs: move ng-conf to past events on events page

### DIFF
--- a/aio/content/marketing/events.html
+++ b/aio/content/marketing/events.html
@@ -13,12 +13,7 @@
       </tr>
     </thead>
     <tbody>
-      <!-- ng-conf 2020 -->
-      <tr>
-        <th><a href="https://ng-conf.org/" title="ng-conf">ng-conf</a></th>
-        <td>Salt Lake City, Utah</td>
-        <td>April 1-3, 2020</td>
-      </tr>
+      <!-- ngVikings 2020 -->
       <tr>
         <th><a href="https://ngvikings.org/" title="ngVikings">ngVikings</a></th>
         <td>Oslo, Norway</td>
@@ -37,6 +32,12 @@
       </tr>
     </thead>
     <tbody>
+      <!-- ng-conf 2020 -->
+      <tr>
+        <th><a href="https://ng-conf.org/" title="ng-conf">ng-conf</a></th>
+        <td>Salt Lake City, Utah</td>
+        <td>April 1-3, 2020</td>
+      </tr>
       <!-- ngIndia 2020 -->
       <tr>
         <th><a href="https://www.ng-ind.com/" title="ngIndia">ngIndia</a></th>


### PR DESCRIPTION
ng-conf 2020 was an outdated event removed it from upcoming events on the events page and added to already presented events

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
An outdated event on events page

Issue Number: N/A


## What is the new behavior?
ng-conf 2020 was an outdated event removed it from upcoming events on the events page and added to already presented events

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
