### PR TITLE
fix(ngcc): add process title

### DIFF
--- a/packages/compiler-cli/ngcc/main-ngcc.ts
+++ b/packages/compiler-cli/ngcc/main-ngcc.ts
@@ -15,6 +15,8 @@ import {LogLevel} from './src/logging/logger';
 
 // CLI entry point
 if (require.main === module) {
+  process.title = 'ngcc';
+
   const startTime = Date.now();
 
   const args = process.argv.slice(2);


### PR DESCRIPTION
Add process.title, so it's clearly in the task manager when ngcc is running

See: https://github.com/angular/angular/issues/36414#issuecomment-609644282
