### PR TITLE
fix(compiler): resolve enum values in binary operations

### DIFF
--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/builtin.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/builtin.ts
@@ -12,7 +12,9 @@ import {DynamicValue} from './dynamic';
 import {KnownFn, ResolvedValue, ResolvedValueArray} from './result';
 
 export class ArraySliceBuiltinFn extends KnownFn {
-  constructor(private lhs: ResolvedValueArray) { super(); }
+  constructor(private lhs: ResolvedValueArray) {
+    super();
+  }
 
   evaluate(node: ts.CallExpression, args: ResolvedValueArray): ResolvedValue {
     if (args.length === 0) {
@@ -24,7 +26,9 @@ export class ArraySliceBuiltinFn extends KnownFn {
 }
 
 export class ArrayConcatBuiltinFn extends KnownFn {
-  constructor(private lhs: ResolvedValueArray) { super(); }
+  constructor(private lhs: ResolvedValueArray) {
+    super();
+  }
 
   evaluate(node: ts.CallExpression, args: ResolvedValueArray): ResolvedValue {
     const result: ResolvedValueArray = [...this.lhs];

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interface.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interface.ts
@@ -17,7 +17,7 @@ import {ResolvedValue} from './result';
 
 export type ForeignFunctionResolver =
     (node: Reference<ts.FunctionDeclaration|ts.MethodDeclaration|ts.FunctionExpression>,
-     args: ReadonlyArray<ts.Expression>) => ts.Expression | null;
+     args: ReadonlyArray<ts.Expression>) => ts.Expression|null;
 
 export class PartialEvaluator {
   constructor(
@@ -31,7 +31,8 @@ export class PartialEvaluator {
       originatingFile: sourceFile,
       absoluteModuleName: null,
       resolutionContext: sourceFile.fileName,
-      scope: new Map<ts.ParameterDeclaration, ResolvedValue>(), foreignFunctionResolver,
+      scope: new Map<ts.ParameterDeclaration, ResolvedValue>(),
+      foreignFunctionResolver,
     });
   }
 }

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -261,7 +261,7 @@ export class StaticInterpreter {
     } else if (ts.isVariableDeclaration(node)) {
       return this.visitVariableDeclaration(node, context);
     } else if (ts.isParameter(node) && context.scope.has(node)) {
-      return context.scope.get(node) !;
+      return context.scope.get(node)!;
     } else if (ts.isExportAssignment(node)) {
       return this.visitExpression(node.expression, context);
     } else if (ts.isEnumDeclaration(node)) {
@@ -337,7 +337,8 @@ export class StaticInterpreter {
       }
 
       const declContext = {
-          ...context, ...joinModuleContext(context, node, decl),
+        ...context,
+        ...joinModuleContext(context, node, decl),
       };
 
       // Visit both concrete and inline declarations.
@@ -354,7 +355,7 @@ export class StaticInterpreter {
     const strIndex = `${rhs}`;
     if (lhs instanceof Map) {
       if (lhs.has(strIndex)) {
-        return lhs.get(strIndex) !;
+        return lhs.get(strIndex)!;
       } else {
         return undefined;
       }
@@ -501,7 +502,7 @@ export class StaticInterpreter {
       return DynamicValue.fromUnsupportedSyntax(node);
     }
 
-    const op = UNARY_OPERATORS.get(operatorKind) !;
+    const op = UNARY_OPERATORS.get(operatorKind)!;
     const value = this.visitExpression(node.operand, context);
     if (value instanceof DynamicValue) {
       return DynamicValue.fromDynamicInput(node, value);
@@ -516,7 +517,7 @@ export class StaticInterpreter {
       return DynamicValue.fromUnsupportedSyntax(node);
     }
 
-    const opRecord = BINARY_OPERATORS.get(tokenKind) !;
+    const opRecord = BINARY_OPERATORS.get(tokenKind)!;
     let lhs: ResolvedValue, rhs: ResolvedValue;
     if (opRecord.literal) {
       lhs = literal(this.visitExpression(node.left, context), node.left);
@@ -621,7 +622,7 @@ function joinModuleContext(existing: Context, node: ts.Node, decl: Declaration):
   }
 }
 
-function owningModule(context: Context, override: OwningModule | null = null): OwningModule|null {
+function owningModule(context: Context, override: OwningModule|null = null): OwningModule|null {
   let specifier = context.absoluteModuleName;
   if (override !== null) {
     specifier = override.specifier;

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -203,19 +203,13 @@ export class StaticInterpreter {
     const pieces: string[] = [node.head.text];
     for (let i = 0; i < node.templateSpans.length; i++) {
       const span = node.templateSpans[i];
-      let value = this.visit(span.expression, context);
-      if (value instanceof EnumValue) {
-        value = value.resolved;
-      }
-      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' ||
-          value == null) {
-        pieces.push(`${value}`);
-      } else if (value instanceof DynamicValue) {
+      const value = literal(
+          this.visit(span.expression, context),
+          () => DynamicValue.fromDynamicString(span.expression));
+      if (value instanceof DynamicValue) {
         return DynamicValue.fromDynamicInput(node, value);
-      } else {
-        return DynamicValue.fromDynamicInput(node, DynamicValue.fromDynamicString(span.expression));
       }
-      pieces.push(span.literal.text);
+      pieces.push(`${value}`, span.literal.text);
     }
     return pieces.join('');
   }
@@ -520,8 +514,12 @@ export class StaticInterpreter {
     const opRecord = BINARY_OPERATORS.get(tokenKind)!;
     let lhs: ResolvedValue, rhs: ResolvedValue;
     if (opRecord.literal) {
-      lhs = literal(this.visitExpression(node.left, context), node.left);
-      rhs = literal(this.visitExpression(node.right, context), node.right);
+      lhs = literal(
+          this.visitExpression(node.left, context),
+          value => DynamicValue.fromInvalidExpressionType(node.left, value));
+      rhs = literal(
+          this.visitExpression(node.right, context),
+          value => DynamicValue.fromInvalidExpressionType(node.right, value));
     } else {
       lhs = this.visitExpression(node.left, context);
       rhs = this.visitExpression(node.right, context);
@@ -585,12 +583,16 @@ function isFunctionOrMethodReference(ref: Reference<ts.Node>):
       ts.isFunctionExpression(ref.node);
 }
 
-function literal(value: ResolvedValue, node: ts.Node): any {
+function literal(
+    value: ResolvedValue, reject: (value: ResolvedValue) => ResolvedValue): ResolvedValue {
+  if (value instanceof EnumValue) {
+    value = value.resolved;
+  }
   if (value instanceof DynamicValue || value === null || value === undefined ||
       typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
     return value;
   }
-  return DynamicValue.fromInvalidExpressionType(node, value);
+  return reject(value);
 }
 
 function isVariableDeclarationDeclared(node: ts.VariableDeclaration): boolean {

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/result.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/result.ts
@@ -21,8 +21,8 @@ import {DynamicValue} from './dynamic';
  * non-primitive value, or a special `DynamicValue` type which indicates the value was not
  * available statically.
  */
-export type ResolvedValue = number | boolean | string | null | undefined | Reference | EnumValue |
-    ResolvedValueArray | ResolvedValueMap | ResolvedModule | KnownFn | DynamicValue<unknown>;
+export type ResolvedValue = number|boolean|string|null|undefined|Reference|EnumValue|
+    ResolvedValueArray|ResolvedValueMap|ResolvedModule|KnownFn|DynamicValue<unknown>;
 
 /**
  * An array of `ResolvedValue`s.
@@ -54,12 +54,14 @@ export class ResolvedModule {
       return undefined;
     }
 
-    return this.evaluate(this.exports.get(name) !);
+    return this.evaluate(this.exports.get(name)!);
   }
 
   getExports(): ResolvedValueMap {
     const map = new Map<string, ResolvedValue>();
-    this.exports.forEach((decl, name) => { map.set(name, this.evaluate(decl)); });
+    this.exports.forEach((decl, name) => {
+      map.set(name, this.evaluate(decl));
+    });
     return map;
   }
 }

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
@@ -42,11 +42,13 @@ runInEachFileSystem(() => {
       expect(value).toEqual('test');
     });
 
-    it('map access works',
-       () => { expect(evaluate('const obj = {a: "test"};', 'obj.a')).toEqual('test'); });
+    it('map access works', () => {
+      expect(evaluate('const obj = {a: "test"};', 'obj.a')).toEqual('test');
+    });
 
-    it('resolves undefined property access',
-       () => { expect(evaluate('const obj: any = {}', 'obj.bar')).toEqual(undefined); });
+    it('resolves undefined property access', () => {
+      expect(evaluate('const obj: any = {}', 'obj.bar')).toEqual(undefined);
+    });
 
     it('function calls work', () => {
       expect(evaluate(`function foo(bar) { return bar; }`, 'foo("test")')).toEqual('test');
@@ -68,7 +70,9 @@ runInEachFileSystem(() => {
       expect(evaluate(`const x = false; const y = x ? 'true' : 'false';`, 'y')).toEqual('false');
     });
 
-    it('addition works', () => { expect(evaluate(`const x = 1 + 2;`, 'x')).toEqual(3); });
+    it('addition works', () => {
+      expect(evaluate(`const x = 1 + 2;`, 'x')).toEqual(3);
+    });
 
     it('static property on class works', () => {
       expect(evaluate(`class Foo { static bar = 'test'; }`, 'Foo.bar')).toEqual('test');
@@ -148,19 +152,22 @@ runInEachFileSystem(() => {
       expect(evaluate('const a: any = 3, b = 3;', 'a !== b')).toEqual(false);
     });
 
-    it('parentheticals work',
-       () => { expect(evaluate(`const a = 3, b = 4;`, 'a * (a + b)')).toEqual(21); });
+    it('parentheticals work', () => {
+      expect(evaluate(`const a = 3, b = 4;`, 'a * (a + b)')).toEqual(21);
+    });
 
-    it('array access works',
-       () => { expect(evaluate(`const a = [1, 2, 3];`, 'a[1] + a[0]')).toEqual(3); });
+    it('array access works', () => {
+      expect(evaluate(`const a = [1, 2, 3];`, 'a[1] + a[0]')).toEqual(3);
+    });
 
     it('array access out of bounds is `undefined`', () => {
       expect(evaluate(`const a = [1, 2, 3];`, 'a[-1]')).toEqual(undefined);
       expect(evaluate(`const a = [1, 2, 3];`, 'a[3]')).toEqual(undefined);
     });
 
-    it('array `length` property access works',
-       () => { expect(evaluate(`const a = [1, 2, 3];`, 'a[\'length\'] + 1')).toEqual(4); });
+    it('array `length` property access works', () => {
+      expect(evaluate(`const a = [1, 2, 3];`, 'a[\'length\'] + 1')).toEqual(4);
+    });
 
     it('array `slice` function works', () => {
       expect(evaluate(`const a = [1, 2, 3];`, 'a[\'slice\']()')).toEqual([1, 2, 3]);
@@ -185,10 +192,13 @@ runInEachFileSystem(() => {
       expect(evaluate('const a = false;', 'a')).toEqual(false);
     });
 
-    it('supports undefined',
-       () => { expect(evaluate('const a = undefined;', 'a')).toEqual(undefined); });
+    it('supports undefined', () => {
+      expect(evaluate('const a = undefined;', 'a')).toEqual(undefined);
+    });
 
-    it('supports null', () => { expect(evaluate('const a = null;', 'a')).toEqual(null); });
+    it('supports null', () => {
+      expect(evaluate('const a = null;', 'a')).toEqual(null);
+    });
 
     it('resolves unknown binary operators as dynamic value', () => {
       const value = evaluate('declare const window: any;', '"location" in window');
@@ -308,7 +318,7 @@ runInEachFileSystem(() => {
       ]);
       const checker = program.getTypeChecker();
       const result = getDeclaration(program, _('/entry.ts'), 'target$', ts.isVariableDeclaration);
-      const expr = result.initializer !;
+      const expr = result.initializer!;
       const evaluator = makeEvaluator(checker);
       const resolved = evaluator.evaluate(expr);
       if (!(resolved instanceof Reference)) {
@@ -338,7 +348,7 @@ runInEachFileSystem(() => {
       ]);
       const checker = program.getTypeChecker();
       const result = getDeclaration(program, _('/entry.ts'), 'target$', ts.isVariableDeclaration);
-      const expr = result.initializer !;
+      const expr = result.initializer!;
       const evaluator = makeEvaluator(checker);
       const resolved = evaluator.evaluate(expr);
       if (!(resolved instanceof Reference)) {
@@ -348,7 +358,7 @@ runInEachFileSystem(() => {
       expect(ts.isFunctionDeclaration(resolved.node)).toBe(true);
       const reference = resolved.getIdentityIn(getSourceFileOrError(program, _('/entry.ts')));
       expect(reference).not.toBeNull();
-      expect(reference !.getSourceFile()).toEqual(getSourceFileOrError(program, _('/entry.ts')));
+      expect(reference!.getSourceFile()).toEqual(getSourceFileOrError(program, _('/entry.ts')));
     });
 
     it('reads values from default exports', () => {
@@ -434,8 +444,9 @@ runInEachFileSystem(() => {
           .toEqual('test');
     });
 
-    it('template expressions work',
-       () => { expect(evaluate('const a = 2, b = 4;', '`1${a}3${b}5`')).toEqual('12345'); });
+    it('template expressions work', () => {
+      expect(evaluate('const a = 2, b = 4;', '`1${a}3${b}5`')).toEqual('12345');
+    });
 
     it('enum resolution works', () => {
       const result = evaluate(
@@ -469,7 +480,7 @@ runInEachFileSystem(() => {
       ]);
       const checker = program.getTypeChecker();
       const result = getDeclaration(program, _('/entry.ts'), 'target$', ts.isVariableDeclaration);
-      const expr = result.initializer !as ts.ObjectLiteralExpression;
+      const expr = result.initializer! as ts.ObjectLiteralExpression;
       const prop = expr.properties[0] as ts.ShorthandPropertyAssignment;
       const evaluator = makeEvaluator(checker);
       const resolved = evaluator.evaluate(prop.name);
@@ -487,13 +498,13 @@ runInEachFileSystem(() => {
       ]);
       const checker = program.getTypeChecker();
       const result = getDeclaration(program, _('/entry.ts'), 'target$', ts.isVariableDeclaration);
-      const expr = result.initializer !as ts.ObjectLiteralExpression;
+      const expr = result.initializer! as ts.ObjectLiteralExpression;
       const evaluator = makeEvaluator(checker);
       const resolved = evaluator.evaluate(expr);
       if (!(resolved instanceof Map)) {
         return fail('Should have resolved to a Map');
       }
-      const value = resolved.get('value') !;
+      const value = resolved.get('value')!;
       if (!(value instanceof DynamicValue)) {
         return fail(`Should have resolved 'value' to a DynamicValue`);
       }

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/utils.ts
@@ -31,7 +31,7 @@ export function makeExpression(code: string, expr: string, supportingFiles: Test
   const decl =
       getDeclaration(program, absoluteFrom('/entry.ts'), 'target$', ts.isVariableDeclaration);
   return {
-    expression: decl.initializer !,
+    expression: decl.initializer!,
     host,
     options,
     checker,


### PR DESCRIPTION
During static evaluation of expressions, the partial evaluator
may come across a binary + operator for which it needs to
evaluate its operands. Any of these operands may be a reference
to an enum member, in which case the enum member's value needs
to be used as literal value, not the enum member reference
itself. This commit fixes the behavior by resolving an
`EnumValue` when used as a literal value.

Fixes #35584
Resolves FW-1951