### PR TITLE
style(zone.js): fix lint errors after clang update

### DIFF
--- a/packages/zone.js/lib/common/promise.ts
+++ b/packages/zone.js/lib/common/promise.ts
@@ -34,9 +34,9 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
       if (rejection) {
         console.error(
             'Unhandled Promise rejection:',
-            rejection instanceof Error ? rejection.message : rejection, '; Zone:',
-            (<Zone>e.zone).name, '; Task:', e.task && (<Task>e.task).source, '; Value:', rejection,
-            rejection instanceof Error ? rejection.stack : undefined);
+            rejection instanceof Error ? rejection.message : rejection,
+            '; Zone:', (<Zone>e.zone).name, '; Task:', e.task && (<Task>e.task).source,
+            '; Value:', rejection, rejection instanceof Error ? rejection.stack : undefined);
       } else {
         console.error(e);
       }
@@ -45,9 +45,11 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
 
   api.microtaskDrainDone = () => {
     while (_uncaughtPromiseErrors.length) {
-      const uncaughtPromiseError: UncaughtPromiseError = _uncaughtPromiseErrors.shift() !;
+      const uncaughtPromiseError: UncaughtPromiseError = _uncaughtPromiseErrors.shift()!;
       try {
-        uncaughtPromiseError.zone.runGuarded(() => { throw uncaughtPromiseError; });
+        uncaughtPromiseError.zone.runGuarded(() => {
+          throw uncaughtPromiseError;
+        });
       } catch (error) {
         handleUnhandledRejection(error);
       }
@@ -67,11 +69,17 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
     }
   }
 
-  function isThenable(value: any): boolean { return value && value.then; }
+  function isThenable(value: any): boolean {
+    return value && value.then;
+  }
 
-  function forwardResolution(value: any): any { return value; }
+  function forwardResolution(value: any): any {
+    return value;
+  }
 
-  function forwardRejection(rejection: any): any { return ZoneAwarePromise.reject(rejection); }
+  function forwardRejection(rejection: any): any {
+    return ZoneAwarePromise.reject(rejection);
+  }
 
   const symbolState: string = __symbol__('state');
   const symbolValue: string = __symbol__('value');
@@ -127,7 +135,9 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
           then = value && value.then;
         }
       } catch (err) {
-        onceWrapper(() => { resolvePromise(promise, false, err); })();
+        onceWrapper(() => {
+          resolvePromise(promise, false, err);
+        })();
         return promise;
       }
       // if (value instanceof ZoneAwarePromise) {
@@ -142,7 +152,9 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
               value, onceWrapper(makeResolver(promise, state)),
               onceWrapper(makeResolver(promise, false)));
         } catch (err) {
-          onceWrapper(() => { resolvePromise(promise, false, err); })();
+          onceWrapper(() => {
+            resolvePromise(promise, false, err);
+          })();
         }
       } else {
         (promise as any)[symbolState] = state;
@@ -197,7 +209,7 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
           uncaughtPromiseError.rejection = value;
           uncaughtPromiseError.promise = promise;
           uncaughtPromiseError.zone = Zone.current;
-          uncaughtPromiseError.task = Zone.currentTask !;
+          uncaughtPromiseError.task = Zone.currentTask!;
           _uncaughtPromiseErrors.push(uncaughtPromiseError);
           api.scheduleMicroTask();  // to make sure that it is running
         }
@@ -233,8 +245,8 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
 
   function scheduleResolveOrReject<R, U1, U2>(
       promise: ZoneAwarePromise<any>, zone: Zone, chainPromise: ZoneAwarePromise<any>,
-      onFulfilled?: ((value: R) => U1) | null | undefined,
-      onRejected?: ((error: any) => U2) | null | undefined): void {
+      onFulfilled?: ((value: R) => U1)|null|undefined,
+      onRejected?: ((error: any) => U2)|null|undefined): void {
     clearRejectedNoCatch(promise);
     const promiseState = (promise as any)[symbolState];
     const delegate = promiseState ?
@@ -269,7 +281,9 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
   const noop = function() {};
 
   class ZoneAwarePromise<R> implements Promise<R> {
-    static toString() { return ZONE_AWARE_PROMISE_TO_STRING; }
+    static toString() {
+      return ZONE_AWARE_PROMISE_TO_STRING;
+    }
 
     static resolve<R>(value: R): Promise<R> {
       return resolvePromise(<ZoneAwarePromise<R>>new this(null as any), RESOLVED, value);
@@ -286,8 +300,12 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
         resolve = res;
         reject = rej;
       });
-      function onResolve(value: any) { resolve(value); }
-      function onReject(error: any) { reject(error); }
+      function onResolve(value: any) {
+        resolve(value);
+      }
+      function onReject(error: any) {
+        reject(error);
+      }
 
       for (let value of values) {
         if (!isThenable(value)) {
@@ -298,7 +316,9 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
       return promise;
     }
 
-    static all<R>(values: any): Promise<R> { return ZoneAwarePromise.allWithCallback(values); }
+    static all<R>(values: any): Promise<R> {
+      return ZoneAwarePromise.allWithCallback(values);
+    }
 
     static allSettled<R>(values: any): Promise<R> {
       const P = this && this.prototype instanceof ZoneAwarePromise ? this : ZoneAwarePromise;
@@ -336,22 +356,22 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
                 resolvedValues[curValueIndex] = callback ? callback.thenCallback(value) : value;
                 unresolvedCount--;
                 if (unresolvedCount === 0) {
-                  resolve !(resolvedValues);
+                  resolve!(resolvedValues);
                 }
               },
               (err: any) => {
                 if (!callback) {
-                  reject !(err);
+                  reject!(err);
                 } else {
                   resolvedValues[curValueIndex] = callback.errorCallback(err);
                   unresolvedCount--;
                   if (unresolvedCount === 0) {
-                    resolve !(resolvedValues);
+                    resolve!(resolvedValues);
                   }
                 }
               });
         } catch (thenErr) {
-          reject !(thenErr);
+          reject!(thenErr);
         }
 
         unresolvedCount++;
@@ -362,7 +382,7 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
       unresolvedCount -= 2;
 
       if (unresolvedCount === 0) {
-        resolve !(resolvedValues);
+        resolve!(resolvedValues);
       }
 
       return promise;
@@ -384,9 +404,13 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
       }
     }
 
-    get[Symbol.toStringTag]() { return 'Promise' as any; }
+    get[Symbol.toStringTag]() {
+      return 'Promise' as any;
+    }
 
-    get[Symbol.species]() { return ZoneAwarePromise; }
+    get[Symbol.species]() {
+      return ZoneAwarePromise;
+    }
 
     then<TResult1 = R, TResult2 = never>(
         onFulfilled?: ((value: R) => TResult1 | PromiseLike<TResult1>)|undefined|null,
@@ -492,8 +516,9 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
     proto[symbolThen] = originalThen;
 
     Ctor.prototype.then = function(onResolve: any, onReject: any) {
-      const wrapped =
-          new ZoneAwarePromise((resolve, reject) => { originalThen.call(this, resolve, reject); });
+      const wrapped = new ZoneAwarePromise((resolve, reject) => {
+        originalThen.call(this, resolve, reject);
+      });
       return wrapped.then(onResolve, onReject);
     };
     (Ctor as any)[symbolThenPatched] = true;


### PR DESCRIPTION
Recent ZoneJS-related commit (https://github.com/angular/angular/commit/416c786774dccc20d824737207be4e55cb53c9cc) updated the `promise.ts` file, but it looks like original PR was not rebased after clang update. As a result, the `lint` CircleCI job started to fail in master after merging that PR (https://github.com/angular/angular/pull/36311). This commit updates the format of the `promise.ts` script according to the new clang rules.


## PR Type
What kind of change does this PR introduce?

- [x] Code style update (formatting, local variables)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No