### PR TITLE
feat(forms) Add `setEnable()` method to AbstractControl

### DIFF
--- a/goldens/public-api/forms/forms.d.ts
+++ b/goldens/public-api/forms/forms.d.ts
@@ -52,6 +52,10 @@ export declare abstract class AbstractControl {
     abstract patchValue(value: any, options?: Object): void;
     abstract reset(value?: any, options?: Object): void;
     setAsyncValidators(newValidator: AsyncValidatorFn | AsyncValidatorFn[] | null): void;
+    setEnable(enabled: boolean, opts?: {
+        onlySelf?: boolean;
+        emitEvent?: boolean;
+    }): void;
     setErrors(errors: ValidationErrors | null, opts?: {
         emitEvent?: boolean;
     }): void;

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -594,6 +594,31 @@ export abstract class AbstractControl {
     this._onDisabledChange.forEach((changeFn) => changeFn(false));
   }
 
+  /**
+   * Enable/disable the control. This means the control is included in validation checks and
+   * the aggregate value of its parent. Its status recalculates based on its value and
+   * its validators.
+   *
+   * By default, if the control has children, all children are enabled.
+   *
+   * @param enabled
+   * @param opts Configure options that control how the control propagates changes and
+   * emits events when marked as untouched
+   * * `onlySelf`: When true, mark only this control. When false or not supplied,
+   * marks all direct ancestors. Default is false..
+   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
+   * `valueChanges`
+   * observables emit events with the latest status and value when the control is enabled.
+   * When false, no events are emitted.
+   */
+  setEnable(enabled: boolean, opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+    if (enabled) {
+      this.enable(opts);
+    } else {
+      this.disable(opts);
+    }
+  }
+
   private _updateAncestors(
       opts: {onlySelf?: boolean, emitEvent?: boolean, skipPristineCheck?: boolean}) {
     if (this._parent && !opts.onlySelf) {

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -1234,6 +1234,49 @@ describe('FormControl', () => {
       });
     });
   });
+  describe('setEnable()', () => {
+    it('should call enable() if enabled is true', () => {
+      const enable = jasmine.createSpy('enable');
+      const c = new FormControl(null);
+      c.enable = enable;
+
+      c.setEnable(true);
+
+      expect(enable).toHaveBeenCalled();
+    });
+
+    it('should call enable() if enabled is true with opts', () => {
+      const enable = jasmine.createSpy('enable');
+      const c = new FormControl(null);
+      const opts = {onlySelf: true, emitEvent: true};
+      c.enable = enable;
+
+      c.setEnable(true, opts);
+
+      expect(enable).toHaveBeenCalledWith(opts);
+    });
+
+    it('should call disable() if enabled is false', () => {
+      const disable = jasmine.createSpy('disable');
+      const c = new FormControl(null);
+      c.disable = disable;
+
+      c.setEnable(false);
+
+      expect(disable).toHaveBeenCalled();
+    });
+
+    it('should call disable() if enabled is false with opts', () => {
+      const disable = jasmine.createSpy('disable');
+      const c = new FormControl(null);
+      const opts = {onlySelf: true, emitEvent: true};
+      c.disable = disable;
+
+      c.setEnable(false, opts);
+
+      expect(disable).toHaveBeenCalledWith(opts);
+    });
+  });
   describe('pending', () => {
     let c: FormControl;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently if someone need to enable/disable a Form Control from a boolean variable, it's necessary to write:

```
if (someBoolean) {
  control.enable();
} else {
  control.disable();
}
```

## What is the new behavior?

With this proposal, we can just do

```
  control.setEnable(someBoolean);
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
