### PR TITLE
build: update jasmine to 3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/fs-extra": "4.0.2",
     "@types/hammerjs": "2.0.35",
     "@types/inquirer": "^6.5.0",
-    "@types/jasmine": "3.5.10",
+    "@types/jasmine": "^3.5.10",
     "@types/jasminewd2": "^2.0.8",
     "@types/minimist": "^1.2.0",
     "@types/node": "^12.11.1",

--- a/packages/compiler/test/output/value_util_spec.ts
+++ b/packages/compiler/test/output/value_util_spec.ts
@@ -14,7 +14,7 @@ describe('convertValueToOutputAst', () => {
     const ctx = null;
     const value = new Array(3).concat('foo');
     const expr = convertValueToOutputAst(ctx!, value) as o.LiteralArrayExpr;
-    expect(expr instanceof o.LiteralArrayExpr).toBe(true);
+    expect(expr instanceof o.LiteralArrayExpr).toBeTrue();
     expect(expr.entries.length).toBe(4);
     for (let i = 0; i < 4; ++i) {
       expect(expr.entries[i] instanceof o.Expression).toBe(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,7 +1307,7 @@
     "@types/through" "*"
     rxjs "^6.4.0"
 
-"@types/jasmine@*", "@types/jasmine@3.5.10":
+"@types/jasmine@*", "@types/jasmine@^3.5.10":
   version "3.5.10"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.5.10.tgz#a1a41012012b5da9d4b205ba9eba58f6cce2ab7b"
   integrity sha512-3F8qpwBAiVc5+HPJeXJpbrl+XjawGmciN5LgiO7Gv1pl1RHtjoMNqZpqEksaPJW05ViKe8snYInRs6xB25Xdew==


### PR DESCRIPTION
based on PR https://github.com/angular/angular/pull/34625, this one will target `9.1.x` branch.

1. update jasmine to 3.5
2. update @types/jasmine to 3.5
3. update @types/jasminewd2 to 2.0.8

Also fix several cases, the new jasmine 3 will help to create test cases correctly,
such as in the `jasmine 2.x` version, the following case will pass

```
expect(1 == 2);
```

But in jsamine 3, the case will need to be

```
expect(1 == 2).toBeTrue();
```

Some cases will still need to use `spy as any` cast, because `@types/jasmine` have some issues,
1. The issue jasmine doesn't handle optional method properties, https://github.com/DefinitelyTyped/DefinitelyTyped/issues/43486
2. The issue jasmine doesn't handle overload method correctly, https://github.com/DefinitelyTyped/DefinitelyTyped/issues/42455