### PR TITLE
build: remove `fullTemplateTypeCheck` from aio tsconfig

### DIFF
--- a/aio/tsconfig.json
+++ b/aio/tsconfig.json
@@ -37,7 +37,6 @@
   ],
   "angularCompilerOptions": {
     "disableTypeScriptVersionCheck": true,
-    "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
     "strictTemplates": true
   }


### PR DESCRIPTION
`fullTemplateTypeCheck` is no longer required since we now use `strictTemplates` which is a superset of the former option.

---

Follow up on https://github.com/angular/angular/commit/04f61c0c3ee9b3616b1719b4ae9c3eb097698218#r38354112

//cc @IgorMinar 