### PR TITLE
fix(dev-infra): fix commit message validation in git worktrees

### DIFF
--- a/dev-infra/commit-message/cli.ts
+++ b/dev-infra/commit-message/cli.ts
@@ -14,9 +14,18 @@ export function buildCommitMessageParser(localYargs: yargs.Argv) {
   return localYargs.help()
       .strict()
       .command(
-          'pre-commit-validate', 'Validate the most recent commit message', {},
-          () => {
-            validateFile('.git/COMMIT_EDITMSG');
+          'pre-commit-validate <commit-message-file|commit-message-file-env>',
+          'Validate the most recent commit message',
+          args => {
+            args.positional('commit-message-file|commit-message-file-env', {
+              type: 'string',
+              describe:
+                  'The path to a file containing the commit message to validate or the name of ' +
+                  'an environment variable that holds the path to such a file.',
+            });
+          },
+          args => {
+            validateFile(process.env[args.commitMessageFileEnv] || args.commitMessageFile);
           })
       .command(
           'validate-range', 'Validate a range of commit messages', {

--- a/dev-infra/commit-message/cli.ts
+++ b/dev-infra/commit-message/cli.ts
@@ -14,18 +14,29 @@ export function buildCommitMessageParser(localYargs: yargs.Argv) {
   return localYargs.help()
       .strict()
       .command(
-          'pre-commit-validate <commit-message-file|commit-message-file-env>',
-          'Validate the most recent commit message',
-          args => {
-            args.positional('commit-message-file|commit-message-file-env', {
+          'pre-commit-validate', 'Validate the most recent commit message', {
+            'file': {
               type: 'string',
-              describe:
-                  'The path to a file containing the commit message to validate or the name of ' +
-                  'an environment variable that holds the path to such a file.',
-            });
+              conflicts: ['file-env-variable'],
+              description: 'The path of the commit message file.',
+            },
+            'file-env-variable': {
+              type: 'string',
+              conflicts: ['file'],
+              description:
+                  'The key of the environment variable for the path of the commit message file.',
+              coerce: arg => {
+                const file = process.env[arg];
+                if (!file) {
+                  throw new Error(`Provided environment variable "${arg}" was not found.`);
+                }
+                return file;
+              },
+            }
           },
           args => {
-            validateFile(process.env[args.commitMessageFileEnv] || args.commitMessageFile);
+            const file = args.file || args.fileEnvVariable || '.git/COMMIT_EDITMSG';
+            validateFile(file);
           })
       .command(
           'validate-range', 'Validate a range of commit messages', {

--- a/dev-infra/commit-message/validate-file.ts
+++ b/dev-infra/commit-message/validate-file.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {readFileSync} from 'fs';
-import {join} from 'path';
+import {resolve} from 'path';
 
 import {getRepoBaseDir} from '../utils/config';
 
@@ -14,7 +14,7 @@ import {validateCommitMessage} from './validate';
 
 /** Validate commit message at the provided file path. */
 export function validateFile(filePath: string) {
-  const commitMessage = readFileSync(join(getRepoBaseDir(), filePath), 'utf8');
+  const commitMessage = readFileSync(resolve(getRepoBaseDir(), filePath), 'utf8');
   if (validateCommitMessage(commitMessage)) {
     console.info('√  Valid commit message');
     return;

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
   "cldr-data-coverage": "full",
   "husky": {
     "hooks": {
-      "commit-msg": "yarn -s ng-dev commit-message pre-commit-validate HUSKY_GIT_PARAMS"
+      "commit-msg": "yarn -s ng-dev commit-message pre-commit-validate --file-env-variable HUSKY_GIT_PARAMS"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
   "cldr-data-coverage": "full",
   "husky": {
     "hooks": {
-      "commit-msg": "yarn -s ng-dev commit-message pre-commit-validate"
+      "commit-msg": "yarn -s ng-dev commit-message pre-commit-validate HUSKY_GIT_PARAMS"
     }
   }
 }


### PR DESCRIPTION
Previously, the `pre-commit-validate` command (used in the `commit-msg` git hook) assumed that the commit message was stored in `.git/COMMIT_EDITMSG` file. This is usually true, but not when using [git worktrees](https://git-scm.com/docs/git-worktree), where `.git` is a file containing the path to the actual git directory.

This commit fixes it by taking advantage of the fact that git passes the actual path of the file holding the commit message to the `commit-msg` hook and husky exposes the arguments passed by git as `$HUSKY_GIT_PARAMS`.

NOTE:
We cannot use the environment variable directly in the `commit-msg` hook command, because environment variables need to be referenced differently on Windows (`%VAR_NAME%`) vs macOS/Linux (`$VAR_NAME`). Instead, we pass the name of the environment variable and the validation script reads the variable's value off of `process.env`.

##
This is an alternative to #36497.