### PR TITLE
fix(core): pipes injecting viewProviders when used on a component host node

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -71,7 +71,7 @@ import {stringifyForError} from './util/misc_utils';
  */
 let includeViewProviders = true;
 
-function setIncludeViewProviders(v: boolean): boolean {
+export function setIncludeViewProviders(v: boolean): boolean {
   const oldValue = includeViewProviders;
   includeViewProviders = v;
   return oldValue;

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -11,6 +11,7 @@ import {PipeTransform} from '../change_detection/pipe_transform';
 import {setInjectImplementation} from '../di/injector_compatibility';
 
 import {getFactoryDef} from './definition';
+import {setIncludeViewProviders} from './di';
 import {store, ɵɵdirectiveInject} from './instructions/all';
 import {PipeDef, PipeDefList} from './interfaces/definition';
 import {HEADER_OFFSET, LView, TVIEW} from './interfaces/view';
@@ -47,7 +48,12 @@ export function ɵɵpipe(index: number, pipeName: string): any {
 
   const pipeFactory = pipeDef.factory || (pipeDef.factory = getFactoryDef(pipeDef.type, true));
   const previousInjectImplementation = setInjectImplementation(ɵɵdirectiveInject);
+
+  // DI for pipes is supposed to behave like directives when placed on a component
+  // host node, which means that we have to disable access to `viewProviders`.
+  const previousIncludeViewProviders = setIncludeViewProviders(false);
   const pipeInstance = pipeFactory();
+  setIncludeViewProviders(previousIncludeViewProviders);
   setInjectImplementation(previousInjectImplementation);
   store(tView, getLView(), index, pipeInstance);
   return pipeInstance;


### PR DESCRIPTION
The flag that determines whether something should be able to inject from `viewProviders` is opt-out and the pipes weren't opted out, resulting in them being able to see the `viewProviders` if they're placed on a component host node.

Fixes #36146.
