### PR TITLE
Reformat of the compiler/compiler-cli codebase

### DIFF
--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/dep.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/dep.ts
@@ -20,7 +20,9 @@ export class NormalService {
 })
 export class AppComponent {
   found: boolean;
-  constructor(service: ShakeableService) { this.found = !!service.normal; }
+  constructor(service: ShakeableService) {
+    this.found = !!service.normal;
+  }
 }
 
 @NgModule({

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/hierarchy.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/hierarchy.ts
@@ -29,7 +29,9 @@ export class AppComponent {
 export class ChildComponent {
   found: boolean;
 
-  constructor(@Optional() @Self() service: Service|null) { this.found = !!service; }
+  constructor(@Optional() @Self() service: Service|null) {
+    this.found = !!service;
+  }
 }
 
 @NgModule({

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/self.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/self.ts
@@ -21,7 +21,9 @@ export class NormalService {
 })
 export class AppComponent {
   found: boolean;
-  constructor(service: NormalService) { this.found = !!service.shakeable; }
+  constructor(service: NormalService) {
+    this.found = !!service.shakeable;
+  }
 }
 
 @NgModule({

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/string.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/string.ts
@@ -17,7 +17,9 @@ import {ServerModule} from '@angular/platform-server';
 })
 export class AppComponent {
   data: string;
-  constructor(service: Service) { this.data = service.data; }
+  constructor(service: Service) {
+    this.data = service.data;
+  }
 }
 
 @NgModule({

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/token.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/token.ts
@@ -6,11 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Inject, Injectable, InjectionToken, NgModule, forwardRef, inject} from '@angular/core';
+import {Component, forwardRef, Inject, inject, Injectable, InjectionToken, NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {ServerModule} from '@angular/platform-server';
 
-export interface IService { readonly dep: {readonly data: string;}; }
+export interface IService {
+  readonly dep: {readonly data: string;};
+}
 
 @NgModule({})
 export class TokenModule {
@@ -28,7 +30,9 @@ export const TOKEN = new InjectionToken('test', {
 })
 export class AppComponent {
   data: string;
-  constructor(@Inject(TOKEN) service: IService) { this.data = service.dep.data; }
+  constructor(@Inject(TOKEN) service: IService) {
+    this.data = service.dep.data;
+  }
 }
 
 @NgModule({

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/test/app_spec.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/test/app_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, INJECTOR, Injectable, NgModule} from '@angular/core';
+import {Component, Injectable, INJECTOR, NgModule} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {renderModuleFactory} from '@angular/platform-server';
 import {BasicAppModuleNgFactory} from 'app_built/src/basic.ngfactory';
@@ -104,7 +104,6 @@ describe('ngInjectableDef Bazel Integration', () => {
   });
 
   it('allows provider override in JIT for module-scoped @Injectables', () => {
-
     @NgModule()
     class Module {
     }
@@ -172,7 +171,9 @@ describe('ngInjectableDef Bazel Integration', () => {
 
        // ChildServices exteds ParentService but does not have @Injectable
        class ChildService extends ParentService {
-         constructor(value: string) { super(value); }
+         constructor(value: string) {
+           super(value);
+         }
          static ngInjectableDef = {
            providedIn: 'root',
            factory: () => new ChildService('child'),

--- a/packages/compiler-cli/integrationtest/bazel/injector_def/ivy_build/app/test/module_spec.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injector_def/ivy_build/app/test/module_spec.ts
@@ -6,17 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, InjectionToken, Injector, NgModule, forwardRef, ɵcreateInjector as createInjector} from '@angular/core';
+import {forwardRef, Injectable, InjectionToken, Injector, NgModule, ɵcreateInjector as createInjector} from '@angular/core';
 import {AOT_TOKEN, AotModule, AotService} from 'app_built/src/module';
 
 describe('Ivy NgModule', () => {
   describe('AOT', () => {
     let injector: Injector;
 
-    beforeEach(() => { injector = createInjector(AotModule); });
-    it('works', () => { expect(injector.get(AotService) instanceof AotService).toBeTruthy(); });
+    beforeEach(() => {
+      injector = createInjector(AotModule);
+    });
+    it('works', () => {
+      expect(injector.get(AotService) instanceof AotService).toBeTruthy();
+    });
 
-    it('merges imports and exports', () => { expect(injector.get(AOT_TOKEN)).toEqual('exports'); });
+    it('merges imports and exports', () => {
+      expect(injector.get(AOT_TOKEN)).toEqual('exports');
+    });
   });
 
 
@@ -38,7 +44,9 @@ describe('Ivy NgModule', () => {
     class JitAppModule {
     }
 
-    it('works', () => { createInjector(JitAppModule); });
+    it('works', () => {
+      createInjector(JitAppModule);
+    });
 
     it('throws an error on circular module dependencies', () => {
       @NgModule({

--- a/packages/compiler-cli/integrationtest/ngtools_src/feature/lazy-feature.module.ts
+++ b/packages/compiler-cli/integrationtest/ngtools_src/feature/lazy-feature.module.ts
@@ -16,10 +16,8 @@ export class LazyFeatureComponent {
 @NgModule({
   imports: [RouterModule.forChild([
     {path: '', component: LazyFeatureComponent, pathMatch: 'full'},
-    {path: 'feature', loadChildren: './feature.module#FeatureModule'}, {
-      path: 'nested-feature',
-      loadChildren: './lazy-feature-nested.module#LazyFeatureNestedModule'
-    }
+    {path: 'feature', loadChildren: './feature.module#FeatureModule'},
+    {path: 'nested-feature', loadChildren: './lazy-feature-nested.module#LazyFeatureNestedModule'}
   ])],
   declarations: [LazyFeatureComponent]
 })

--- a/packages/compiler-cli/integrationtest/src/animate.ts
+++ b/packages/compiler-cli/integrationtest/src/animate.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AUTO_STYLE, animate, state, style, transition, trigger} from '@angular/animations';
+import {animate, AUTO_STYLE, state, style, transition, trigger} from '@angular/animations';
 import {Component} from '@angular/core';
 
 @Component({
@@ -30,8 +30,16 @@ import {Component} from '@angular/core';
 })
 export class AnimateCmp {
   stateExpression: string;
-  constructor() { this.setAsClosed(); }
-  setAsSomethingElse() { this.stateExpression = 'something'; }
-  setAsOpen() { this.stateExpression = 'open'; }
-  setAsClosed() { this.stateExpression = 'closed'; }
+  constructor() {
+    this.setAsClosed();
+  }
+  setAsSomethingElse() {
+    this.stateExpression = 'something';
+  }
+  setAsOpen() {
+    this.stateExpression = 'open';
+  }
+  setAsClosed() {
+    this.stateExpression = 'closed';
+  }
 }

--- a/packages/compiler-cli/integrationtest/src/custom_token.ts
+++ b/packages/compiler-cli/integrationtest/src/custom_token.ts
@@ -8,6 +8,8 @@
 
 import {InjectionToken} from '@angular/core';
 
-export interface Named { name: string; }
+export interface Named {
+  name: string;
+}
 
 export const CUSTOM = new InjectionToken<Named>('CUSTOM');

--- a/packages/compiler-cli/integrationtest/src/errors.ts
+++ b/packages/compiler-cli/integrationtest/src/errors.ts
@@ -10,5 +10,7 @@ import {Component} from '@angular/core';
 
 @Component({selector: 'comp-with-error', templateUrl: 'errors.html'})
 export class BindingErrorComp {
-  createError() { throw new Error('Test'); }
+  createError() {
+    throw new Error('Test');
+  }
 }

--- a/packages/compiler-cli/integrationtest/src/features.ts
+++ b/packages/compiler-cli/integrationtest/src/features.ts
@@ -7,7 +7,7 @@
  */
 
 import * as common from '@angular/common';
-import {CUSTOM_ELEMENTS_SCHEMA, Component, Directive, EventEmitter, Inject, InjectionToken, NgModule, Output, forwardRef} from '@angular/core';
+import {Component, CUSTOM_ELEMENTS_SCHEMA, Directive, EventEmitter, forwardRef, Inject, InjectionToken, NgModule, Output} from '@angular/core';
 import {Observable} from 'rxjs';
 
 import {wrapInArray} from './funcs';
@@ -62,7 +62,9 @@ export class CompUsingCustomElements {
 })
 export class CompConsumingEvents {
   handleDomEventVoid(e: any): void {}
-  handleDomEventPreventDefault(e: any): boolean { return false; }
+  handleDomEventPreventDefault(e: any): boolean {
+    return false;
+  }
   handleDirEvent(e: any): void {}
 }
 
@@ -70,8 +72,7 @@ export class CompConsumingEvents {
   selector: '[dirEvent]',
 })
 export class DirPublishingEvents {
-  @Output('dirEvent')
-  dirEvent: Observable<string> = new EventEmitter();
+  @Output('dirEvent') dirEvent: Observable<string> = new EventEmitter();
 }
 
 @NgModule({schemas: [CUSTOM_ELEMENTS_SCHEMA], declarations: wrapInArray(CompUsingCustomElements)})

--- a/packages/compiler-cli/integrationtest/src/jit_summaries.ts
+++ b/packages/compiler-cli/integrationtest/src/jit_summaries.ts
@@ -11,7 +11,7 @@ import {Component, Directive, Injectable, NgModule, Pipe} from '@angular/core';
 const instances = new Map<any, Base>();
 
 export function expectInstanceCreated(type: any) {
-  const instance = instances.get(type) !;
+  const instance = instances.get(type)!;
   expect(instance).toBeDefined();
   expect(instance.dep instanceof SomeDep).toBe(true);
 }
@@ -19,7 +19,9 @@ export function expectInstanceCreated(type: any) {
 export class SomeDep {}
 
 export class Base {
-  constructor(public dep: SomeDep) { instances.set(Object.getPrototypeOf(this).constructor, this); }
+  constructor(public dep: SomeDep) {
+    instances.set(Object.getPrototypeOf(this).constructor, this);
+  }
 }
 
 @Component({templateUrl: './jit_summaries.html'})
@@ -36,7 +38,9 @@ export class SomeDirective extends Base {
 
 @Pipe({name: 'somePipe'})
 export class SomePipe extends Base {
-  transform(value: any) { return value; }
+  transform(value: any) {
+    return value;
+  }
 }
 
 @Injectable()

--- a/packages/compiler-cli/integrationtest/src/module.ts
+++ b/packages/compiler-cli/integrationtest/src/module.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, NgModule, forwardRef} from '@angular/core';
+import {ApplicationRef, forwardRef, NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {ServerModule} from '@angular/platform-server';
 import {FlatModule} from 'flat_module';

--- a/packages/compiler-cli/integrationtest/src/module_fixtures.ts
+++ b/packages/compiler-cli/integrationtest/src/module_fixtures.ts
@@ -19,24 +19,26 @@ export class ServiceUsingLibModule {
 
 @Directive({selector: '[someDir]', host: {'[title]': 'someDir'}})
 export class SomeDirectiveInRootModule {
-  @Input()
-  someDir: string;
+  @Input() someDir: string;
 }
 
 @Directive({selector: '[someDir]', host: {'[title]': 'someDir'}})
 export class SomeDirectiveInLibModule {
-  @Input()
-  someDir: string;
+  @Input() someDir: string;
 }
 
 @Pipe({name: 'somePipe'})
 export class SomePipeInRootModule {
-  transform(value: string): any { return `transformed ${value}`; }
+  transform(value: string): any {
+    return `transformed ${value}`;
+  }
 }
 
 @Pipe({name: 'somePipe'})
 export class SomePipeInLibModule {
-  transform(value: string): any { return `transformed ${value}`; }
+  transform(value: string): any {
+    return `transformed ${value}`;
+  }
 }
 
 @Component({selector: 'comp', template: `<div  [someDir]="'someValue' | somePipe"></div>`})
@@ -66,8 +68,8 @@ export class SomeLibModule {
     return {
       ngModule: SomeLibModule,
       providers: [
-        ServiceUsingLibModule, provideValueWithEntryComponents(
-                                   [{a: 'b', component: CompUsingLibModuleDirectiveAndPipe}])
+        ServiceUsingLibModule,
+        provideValueWithEntryComponents([{a: 'b', component: CompUsingLibModuleDirectiveAndPipe}])
       ]
     };
   }

--- a/packages/compiler-cli/integrationtest/test/jit_summaries_spec.ts
+++ b/packages/compiler-cli/integrationtest/test/jit_summaries_spec.ts
@@ -8,9 +8,9 @@
 
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {ServerTestingModule, platformServerTesting} from '@angular/platform-server/testing';
+import {platformServerTesting, ServerTestingModule} from '@angular/platform-server/testing';
 
-import {SomeDep, SomeDirective, SomeModule, SomePipe, SomePrivateComponent, SomeService, expectInstanceCreated} from '../src/jit_summaries';
+import {expectInstanceCreated, SomeDep, SomeDirective, SomeModule, SomePipe, SomePrivateComponent, SomeService} from '../src/jit_summaries';
 import {SomeModuleNgSummary} from '../src/jit_summaries.ngsummary';
 
 describe('Jit Summaries', () => {
@@ -18,7 +18,9 @@ describe('Jit Summaries', () => {
     TestBed.initTestEnvironment(ServerTestingModule, platformServerTesting(), SomeModuleNgSummary);
   });
 
-  afterEach(() => { TestBed.resetTestEnvironment(); });
+  afterEach(() => {
+    TestBed.resetTestEnvironment();
+  });
 
   it('should use directive metadata from summaries', () => {
     @Component({template: '<div someDir></div>'})

--- a/packages/compiler-cli/integrationtest/test/ng_module_spec.ts
+++ b/packages/compiler-cli/integrationtest/test/ng_module_spec.ts
@@ -10,7 +10,7 @@ import './init';
 import {ComponentUsingThirdParty} from '../src/comp_using_3rdp';
 import {ComponentUsingFlatModule} from '../src/comp_using_flat_module';
 import {MainModule} from '../src/module';
-import {CompUsingLibModuleDirectiveAndPipe, CompUsingRootModuleDirectiveAndPipe, SOME_TOKEN, ServiceUsingLibModule, SomeLibModule, SomeService} from '../src/module_fixtures';
+import {CompUsingLibModuleDirectiveAndPipe, CompUsingRootModuleDirectiveAndPipe, ServiceUsingLibModule, SOME_TOKEN, SomeLibModule, SomeService} from '../src/module_fixtures';
 
 import {createComponent, createModule} from './util';
 

--- a/packages/compiler-cli/integrationtest/test/query_spec.ts
+++ b/packages/compiler-cli/integrationtest/test/query_spec.ts
@@ -19,7 +19,6 @@ describe('child queries', () => {
     debugElement.query(By.directive(CompWithChildQuery));
     expect(childQueryCompFixture.componentInstance.child).toBeDefined();
     expect(childQueryCompFixture.componentInstance.child instanceof CompForChildQuery).toBe(true);
-
   });
 
   it('should support compiling children queries', () => {

--- a/packages/compiler-cli/integrationtest/test/source_map_spec.ts
+++ b/packages/compiler-cli/integrationtest/test/source_map_spec.ts
@@ -31,7 +31,7 @@ function getSourcePositionForStack(stack: string): {source: string, line: number
   const htmlLocations = stack
                             .split('\n')
                             // e.g. at View_MyComp_0 (...html:153:40)
-                            .map(line => /\((.*\.html):(\d+):(\d+)/.exec(line) !)
+                            .map(line => /\((.*\.html):(\d+):(\d+)/.exec(line)!)
                             .filter(match => !!match)
                             .map(match => ({
                                    source: match[1],

--- a/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
+++ b/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
@@ -22,10 +22,15 @@ import {createProgram, readConfiguration} from '@angular/compiler-cli';
  * properly read and wrote.
  */
 function main() {
-  Promise.resolve().then(() => lazyRoutesTest()).then(() => { process.exit(0); }).catch((err) => {
-    console.error(err.stack);
-    process.exit(1);
-  });
+  Promise.resolve()
+      .then(() => lazyRoutesTest())
+      .then(() => {
+        process.exit(0);
+      })
+      .catch((err) => {
+        console.error(err.stack);
+        process.exit(1);
+      });
 }
 
 function lazyRoutesTest() {
@@ -36,7 +41,8 @@ function lazyRoutesTest() {
   const host = ts.createCompilerHost(config.options, true);
   const program = createProgram({
     rootNames: config.rootNames,
-    options: config.options, host,
+    options: config.options,
+    host,
   });
 
   config.options.basePath = basePath;

--- a/packages/compiler-cli/integrationtest/test/util.ts
+++ b/packages/compiler-cli/integrationtest/test/util.ts
@@ -13,7 +13,7 @@ import {platformServerTesting} from '@angular/platform-server/testing';
 import {MainModule} from '../src/module';
 import {MainModuleNgFactory} from '../src/module.ngfactory';
 
-let mainModuleRef: NgModuleRef<MainModule> = null !;
+let mainModuleRef: NgModuleRef<MainModule> = null!;
 beforeEach((done) => {
   platformServerTesting().bootstrapModuleFactory(MainModuleNgFactory).then((moduleRef: any) => {
     mainModuleRef = moduleRef;

--- a/packages/compiler-cli/src/diagnostics/translate_diagnostics.ts
+++ b/packages/compiler-cli/src/diagnostics/translate_diagnostics.ts
@@ -35,7 +35,8 @@ export function translateDiagnostics(
         const fileName = span.start.file.url;
         ng.push({
           messageText: diagnosticMessageToString(diagnostic.messageText),
-          category: diagnostic.category, span,
+          category: diagnostic.category,
+          span,
           source: SOURCE,
           code: DEFAULT_ERROR_CODE
         });
@@ -53,6 +54,6 @@ function sourceSpanOf(host: TypeCheckHost, source: ts.SourceFile, start: number)
   return host.parseSourceSpanOf(source.fileName, line, character);
 }
 
-function diagnosticMessageToString(message: ts.DiagnosticMessageChain | string): string {
+function diagnosticMessageToString(message: ts.DiagnosticMessageChain|string): string {
   return ts.flattenDiagnosticMessageText(message, '\n');
 }

--- a/packages/compiler-cli/src/language_services.ts
+++ b/packages/compiler-cli/src/language_services.ts
@@ -16,4 +16,4 @@ to the language service.
 */
 export {MetadataCollector, ModuleMetadata} from './metadata';
 export {CompilerOptions} from './transformers/api';
-export {MetadataReaderCache, MetadataReaderHost, createMetadataReaderCache, readMetadata} from './transformers/metadata_reader';
+export {createMetadataReaderCache, MetadataReaderCache, MetadataReaderHost, readMetadata} from './transformers/metadata_reader';

--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -24,9 +24,9 @@ import {NodeJSFileSystem, setFileSystem} from './ngtsc/file_system';
 export function main(
     args: string[], consoleError: (s: string) => void = console.error,
     config?: NgcParsedConfiguration, customTransformers?: api.CustomTransformers, programReuse?: {
-      program: api.Program | undefined,
+      program: api.Program|undefined,
     },
-    modifiedResourceFiles?: Set<string>| null): number {
+    modifiedResourceFiles?: Set<string>|null): number {
   let {project, rootNames, options, errors: configErrors, watch, emitFlags} =
       config || readNgcCommandLineAndConfiguration(args);
   if (configErrors.length) {
@@ -47,7 +47,9 @@ export function main(
     options,
     emitFlags,
     oldProgram,
-    emitCallback: createEmitCallback(options), customTransformers, modifiedResourceFiles
+    emitCallback: createEmitCallback(options),
+    customTransformers,
+    modifiedResourceFiles
   });
   if (programReuse !== undefined) {
     programReuse.program = program;
@@ -57,8 +59,8 @@ export function main(
 
 export function mainDiagnosticsForTest(
     args: string[], config?: NgcParsedConfiguration,
-    programReuse?: {program: api.Program | undefined},
-    modifiedResourceFiles?: Set<string>| null): ReadonlyArray<ts.Diagnostic|api.Diagnostic> {
+    programReuse?: {program: api.Program|undefined},
+    modifiedResourceFiles?: Set<string>|null): ReadonlyArray<ts.Diagnostic|api.Diagnostic> {
   let {project, rootNames, options, errors: configErrors, watch, emitFlags} =
       config || readNgcCommandLineAndConfiguration(args);
   if (configErrors.length) {
@@ -100,9 +102,10 @@ function createEmitCallback(options: api.CompilerOptions): api.TsEmitCallback|un
     options.emitDecoratorMetadata = true;
   }
   const tsickleHost: Pick<
-      tsickle.TsickleHost, 'shouldSkipTsickleProcessing'|'pathToModuleName'|
-      'shouldIgnoreWarningsForPath'|'fileNameToModuleId'|'googmodule'|'untyped'|
-      'convertIndexImportShorthand'|'transformDecorators'|'transformTypesToClosure'> = {
+      tsickle.TsickleHost,
+      'shouldSkipTsickleProcessing'|'pathToModuleName'|'shouldIgnoreWarningsForPath'|
+      'fileNameToModuleId'|'googmodule'|'untyped'|'convertIndexImportShorthand'|
+      'transformDecorators'|'transformTypesToClosure'> = {
     shouldSkipTsickleProcessing: (fileName) => /\.d\.ts$/.test(fileName) ||
         // View Engine's generated files were never intended to be processed with tsickle.
         (!options.enableIvy && GENERATED_FILES.test(fileName)),
@@ -111,7 +114,9 @@ function createEmitCallback(options: api.CompilerOptions): api.TsEmitCallback|un
     fileNameToModuleId: (fileName) => fileName,
     googmodule: false,
     untyped: true,
-    convertIndexImportShorthand: false, transformDecorators, transformTypesToClosure,
+    convertIndexImportShorthand: false,
+    transformDecorators,
+    transformTypesToClosure,
   };
 
   if (options.annotateForClosureCompiler || options.annotationsAs === 'static fields') {
@@ -147,7 +152,9 @@ function createEmitCallback(options: api.CompilerOptions): api.TsEmitCallback|un
   }
 }
 
-export interface NgcParsedConfiguration extends ParsedConfiguration { watch?: boolean; }
+export interface NgcParsedConfiguration extends ParsedConfiguration {
+  watch?: boolean;
+}
 
 export function readNgcCommandLineAndConfiguration(args: string[]): NgcParsedConfiguration {
   const options: api.CompilerOptions = {};
@@ -194,7 +201,8 @@ export function readCommandLineAndConfiguration(
   }
   return {
     project,
-    rootNames: config.rootNames, options,
+    rootNames: config.rootNames,
+    options,
     errors: config.errors,
     emitFlags: config.emitFlags
   };
@@ -237,7 +245,7 @@ export function watchMode(
 
 function printDiagnostics(
     diagnostics: ReadonlyArray<ts.Diagnostic|api.Diagnostic>,
-    options: api.CompilerOptions | undefined, consoleError: (s: string) => void): void {
+    options: api.CompilerOptions|undefined, consoleError: (s: string) => void): void {
   if (diagnostics.length === 0) {
     return;
   }

--- a/packages/compiler-cli/src/metadata/bundle_index_host.ts
+++ b/packages/compiler-cli/src/metadata/bundle_index_host.ts
@@ -47,8 +47,7 @@ function createSyntheticIndexHost<H extends ts.CompilerHost>(
 
   newHost.writeFile =
       (fileName: string, data: string, writeByteOrderMark: boolean,
-       onError: ((message: string) => void) | undefined,
-       sourceFiles: Readonly<ts.SourceFile>[]) => {
+       onError: ((message: string) => void)|undefined, sourceFiles: Readonly<ts.SourceFile>[]) => {
         delegate.writeFile(fileName, data, writeByteOrderMark, onError, sourceFiles);
         if (fileName.match(DTS) && sourceFiles && sourceFiles.length == 1 &&
             path.normalize(sourceFiles[0].fileName) === normalSyntheticIndexName) {
@@ -103,7 +102,7 @@ export function createBundleIndexHost<H extends ts.CompilerHost>(
   // contents of the flat module index. The bundle produced during emit does use the metadata cache
   // with associated transforms, so the metadata will have lowered expressions, resource inlining,
   // etc.
-  const getMetadataBundle = (cache: MetadataCache | null) => {
+  const getMetadataBundle = (cache: MetadataCache|null) => {
     const bundler = new MetadataBundler(
         indexModule, ngOptions.flatModuleId, new CompilerHostAdapter(host, cache, ngOptions),
         ngOptions.flatModulePrivateSymbolPrefix);
@@ -113,7 +112,7 @@ export function createBundleIndexHost<H extends ts.CompilerHost>(
   // First, produce the bundle with no MetadataCache.
   const metadataBundle = getMetadataBundle(/* MetadataCache */ null);
   const name =
-      path.join(path.dirname(indexModule), ngOptions.flatModuleOutFile !.replace(JS_EXT, '.ts'));
+      path.join(path.dirname(indexModule), ngOptions.flatModuleOutFile!.replace(JS_EXT, '.ts'));
   const libraryIndex = `./${path.basename(indexModule)}`;
   const content = privateEntriesToIndex(libraryIndex, metadataBundle.privates);
 

--- a/packages/compiler-cli/src/metadata/bundler.ts
+++ b/packages/compiler-cli/src/metadata/bundler.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 import {MetadataCache} from '../transformers/metadata_cache';
 
 import {MetadataCollector} from './collector';
-import {ClassMetadata, ConstructorMetadata, FunctionMetadata, METADATA_VERSION, MemberMetadata, MetadataEntry, MetadataError, MetadataMap, MetadataObject, MetadataSymbolicExpression, MetadataSymbolicReferenceExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isInterfaceMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataImportedSymbolReferenceExpression, isMetadataModuleReferenceExpression, isMetadataSymbolicCallExpression, isMetadataSymbolicExpression, isMethodMetadata} from './schema';
+import {ClassMetadata, ConstructorMetadata, FunctionMetadata, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isInterfaceMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataImportedSymbolReferenceExpression, isMetadataModuleReferenceExpression, isMetadataSymbolicCallExpression, isMetadataSymbolicExpression, isMethodMetadata, MemberMetadata, METADATA_VERSION, MetadataEntry, MetadataError, MetadataMap, MetadataObject, MetadataSymbolicExpression, MetadataSymbolicReferenceExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata} from './schema';
 
 
 
@@ -59,7 +59,9 @@ interface Symbol {
   privateName?: string;
 }
 
-export interface BundleEntries { [name: string]: MetadataEntry; }
+export interface BundleEntries {
+  [name: string]: MetadataEntry;
+}
 
 export interface BundlePrivateEntry {
   privateName: string;
@@ -77,7 +79,7 @@ export interface MetadataBundlerHost {
 }
 
 type StaticsMetadata = {
-  [name: string]: MetadataValue | FunctionMetadata;
+  [name: string]: MetadataValue|FunctionMetadata;
 };
 
 export class MetadataBundler {
@@ -87,7 +89,7 @@ export class MetadataBundler {
   private rootModule: string;
   private privateSymbolPrefix: string;
   // TODO(issue/24571): remove '!'.
-  private exported !: Set<Symbol>;
+  private exported!: Set<Symbol>;
 
   constructor(
       private root: string, private importAs: string|undefined, private host: MetadataBundlerHost,
@@ -106,14 +108,14 @@ export class MetadataBundler {
     const privates = Array.from(this.symbolMap.values())
                          .filter(s => s.referenced && s.isPrivate)
                          .map(s => ({
-                                privateName: s.privateName !,
-                                name: s.declaration !.name,
-                                module: s.declaration !.module
+                                privateName: s.privateName!,
+                                name: s.declaration!.name,
+                                module: s.declaration!.module
                               }));
     const origins = Array.from(this.symbolMap.values())
                         .filter(s => s.referenced && !s.reexport)
                         .reduce<{[name: string]: string}>((p, s) => {
-                          p[s.isPrivate ? s.privateName ! : s.name] = s.declaration !.module;
+                          p[s.isPrivate ? s.privateName! : s.name] = s.declaration!.module;
                           return p;
                         }, {});
     const exports = this.getReExports(exportedSymbols);
@@ -121,8 +123,10 @@ export class MetadataBundler {
       metadata: {
         __symbolic: 'module',
         version: METADATA_VERSION,
-        exports: exports.length ? exports : undefined, metadata, origins,
-        importAs: this.importAs !
+        exports: exports.length ? exports : undefined,
+        metadata,
+        origins,
+        importAs: this.importAs!
       },
       privates
     };
@@ -156,7 +160,7 @@ export class MetadataBundler {
 
     const exportSymbol = (exportedSymbol: Symbol, exportAs: string) => {
       const symbol = this.symbolOf(moduleName, exportAs);
-      result !.push(symbol);
+      result!.push(symbol);
       exportedSymbol.reexportedAs = symbol;
       symbol.exports = exportedSymbol;
     };
@@ -276,18 +280,18 @@ export class MetadataBundler {
     Array.from(this.symbolMap.values()).forEach(symbol => {
       if (symbol.referenced && !symbol.reexport) {
         let name = symbol.name;
-        const identifier = `${symbol.declaration!.module}:${symbol.declaration !.name}`;
+        const identifier = `${symbol.declaration!.module}:${symbol.declaration!.name}`;
         if (symbol.isPrivate && !symbol.privateName) {
           name = newPrivateName(this.privateSymbolPrefix);
           symbol.privateName = name;
         }
         if (symbolsMap.has(identifier)) {
           const names = symbolsMap.get(identifier);
-          names !.push(name);
+          names!.push(name);
         } else {
           symbolsMap.set(identifier, [name]);
         }
-        result[name] = symbol.value !;
+        result[name] = symbol.value!;
       }
     });
 
@@ -320,9 +324,9 @@ export class MetadataBundler {
     for (const symbol of exportedSymbols) {
       if (symbol.reexport) {
         // symbol.declaration is guaranteed to be defined during the phase this method is called.
-        const declaration = symbol.declaration !;
+        const declaration = symbol.declaration!;
         const module = declaration.module;
-        if (declaration !.name == '*') {
+        if (declaration!.name == '*') {
           // Reexport all the symbols.
           exportAlls.add(declaration.module);
         } else {
@@ -346,12 +350,12 @@ export class MetadataBundler {
 
   private convertSymbol(symbol: Symbol) {
     // canonicalSymbol is ensured to be defined before this is called.
-    const canonicalSymbol = symbol.canonicalSymbol !;
+    const canonicalSymbol = symbol.canonicalSymbol!;
 
     if (!canonicalSymbol.referenced) {
       canonicalSymbol.referenced = true;
       // declaration is ensured to be definded before this method is called.
-      const declaration = canonicalSymbol.declaration !;
+      const declaration = canonicalSymbol.declaration!;
       const module = this.getMetadata(declaration.module);
       if (module) {
         const value = module.metadata[declaration.name];
@@ -399,11 +403,11 @@ export class MetadataBundler {
   private convertMember(moduleName: string, member: MemberMetadata) {
     const result: MemberMetadata = {__symbolic: member.__symbolic};
     result.decorators =
-        member.decorators && member.decorators.map(d => this.convertExpression(moduleName, d) !);
+        member.decorators && member.decorators.map(d => this.convertExpression(moduleName, d)!);
     if (isMethodMetadata(member)) {
       (result as MethodMetadata).parameterDecorators = member.parameterDecorators &&
           member.parameterDecorators.map(
-              d => d && d.map(p => this.convertExpression(moduleName, p) !));
+              d => d && d.map(p => this.convertExpression(moduleName, p)!));
       if (isConstructorMetadata(member)) {
         if (member.parameters) {
           (result as ConstructorMetadata).parameters =
@@ -450,7 +454,7 @@ export class MetadataBundler {
       return this.convertError(moduleName, value);
     }
     if (isMetadataSymbolicExpression(value)) {
-      return this.convertExpression(moduleName, value) !;
+      return this.convertExpression(moduleName, value)!;
     }
     if (Array.isArray(value)) {
       return value.map(v => this.convertValue(moduleName, v));
@@ -466,8 +470,8 @@ export class MetadataBundler {
   }
 
   private convertExpression(
-      moduleName: string, value: MetadataSymbolicExpression|MetadataError|null|
-      undefined): MetadataSymbolicExpression|MetadataError|undefined|null {
+      moduleName: string, value: MetadataSymbolicExpression|MetadataError|null|undefined):
+      MetadataSymbolicExpression|MetadataError|undefined|null {
     if (value) {
       switch (value.__symbolic) {
         case 'error':
@@ -487,14 +491,15 @@ export class MetadataBundler {
       message: value.message,
       line: value.line,
       character: value.character,
-      context: value.context, module
+      context: value.context,
+      module
     };
   }
 
   private convertReference(moduleName: string, value: MetadataSymbolicReferenceExpression):
       MetadataSymbolicReferenceExpression|MetadataError|undefined {
     const createReference = (symbol: Symbol): MetadataSymbolicReferenceExpression => {
-      const declaration = symbol.declaration !;
+      const declaration = symbol.declaration!;
       if (declaration.module.startsWith('.')) {
         // Reference to a symbol defined in the module. Ensure it is converted then return a
         // references to the final symbol.
@@ -503,11 +508,11 @@ export class MetadataBundler {
           __symbolic: 'reference',
           get name() {
             // Resolved lazily because private names are assigned late.
-            const canonicalSymbol = symbol.canonicalSymbol !;
+            const canonicalSymbol = symbol.canonicalSymbol!;
             if (canonicalSymbol.isPrivate == null) {
               throw Error('Invalid state: isPrivate was not initialized');
             }
-            return canonicalSymbol.isPrivate ? canonicalSymbol.privateName ! : canonicalSymbol.name;
+            return canonicalSymbol.isPrivate ? canonicalSymbol.privateName! : canonicalSymbol.name;
           }
         };
       } else {
@@ -584,7 +589,7 @@ export class MetadataBundler {
 
   private convertExpressionNode(moduleName: string, value: MetadataSymbolicExpression):
       MetadataSymbolicExpression {
-    const result: MetadataSymbolicExpression = { __symbolic: value.__symbolic } as any;
+    const result: MetadataSymbolicExpression = {__symbolic: value.__symbolic} as any;
     for (const key in value) {
       (result as any)[key] = this.convertValue(moduleName, (value as any)[key]);
     }

--- a/packages/compiler-cli/src/metadata/collector.ts
+++ b/packages/compiler-cli/src/metadata/collector.ts
@@ -8,8 +8,8 @@
 
 import * as ts from 'typescript';
 
-import {Evaluator, errorSymbol, recordMapEntry} from './evaluator';
-import {ClassMetadata, ConstructorMetadata, FunctionMetadata, InterfaceMetadata, METADATA_VERSION, MemberMetadata, MetadataEntry, MetadataError, MetadataMap, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataImportDefaultReference, isMetadataImportedSymbolReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSelectExpression, isMethodMetadata} from './schema';
+import {errorSymbol, Evaluator, recordMapEntry} from './evaluator';
+import {ClassMetadata, ConstructorMetadata, FunctionMetadata, InterfaceMetadata, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataImportDefaultReference, isMetadataImportedSymbolReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSelectExpression, isMethodMetadata, MemberMetadata, METADATA_VERSION, MetadataEntry, MetadataError, MetadataMap, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata} from './schema';
 import {Symbols} from './symbols';
 
 const isStatic = (node: ts.Declaration) =>
@@ -60,12 +60,12 @@ export class MetadataCollector {
         new Map<MetadataValue|ClassMetadata|InterfaceMetadata|FunctionMetadata, ts.Node>();
     const composedSubstituter = substituteExpression && this.options.substituteExpression ?
         (value: MetadataValue, node: ts.Node) =>
-            this.options.substituteExpression !(substituteExpression(value, node), node) :
+            this.options.substituteExpression!(substituteExpression(value, node), node) :
         substituteExpression;
     const evaluatorOptions = substituteExpression ?
         {...this.options, substituteExpression: composedSubstituter} :
         this.options;
-    let metadata: {[name: string]: MetadataValue | ClassMetadata | FunctionMetadata}|undefined;
+    let metadata: {[name: string]: MetadataValue|ClassMetadata|FunctionMetadata}|undefined;
     const evaluator = new Evaluator(locals, nodeMap, evaluatorOptions, (name, value) => {
       if (!metadata) metadata = {};
       metadata[name] = value;
@@ -88,9 +88,9 @@ export class MetadataCollector {
       return errorSymbol(message, node, context, sourceFile);
     }
 
-    function maybeGetSimpleFunction(
-        functionDeclaration: ts.FunctionDeclaration |
-        ts.MethodDeclaration): {func: FunctionMetadata, name: string}|undefined {
+    function maybeGetSimpleFunction(functionDeclaration: ts.FunctionDeclaration|
+                                    ts.MethodDeclaration): {func: FunctionMetadata, name: string}|
+        undefined {
       if (functionDeclaration.name && functionDeclaration.name.kind == ts.SyntaxKind.Identifier) {
         const nameNode = <ts.Identifier>functionDeclaration.name;
         const functionName = nameNode.text;
@@ -119,8 +119,8 @@ export class MetadataCollector {
     function classMetadataOf(classDeclaration: ts.ClassDeclaration): ClassMetadata {
       const result: ClassMetadata = {__symbolic: 'class'};
 
-      function getDecorators(decorators: ReadonlyArray<ts.Decorator>| undefined):
-          MetadataSymbolicExpression[]|undefined {
+      function getDecorators(decorators: ReadonlyArray<ts.Decorator>|
+                             undefined): MetadataSymbolicExpression[]|undefined {
         if (decorators && decorators.length)
           return decorators.map(decorator => objFromDecorator(decorator));
         return undefined;
@@ -167,8 +167,8 @@ export class MetadataCollector {
       }
 
       // static member
-      let statics: {[name: string]: MetadataValue | FunctionMetadata}|null = null;
-      function recordStaticMember(name: string, value: MetadataValue | FunctionMetadata) {
+      let statics: {[name: string]: MetadataValue|FunctionMetadata}|null = null;
+      function recordStaticMember(name: string, value: MetadataValue|FunctionMetadata) {
         if (!statics) statics = {};
         statics[name] = value;
       }
@@ -189,11 +189,10 @@ export class MetadataCollector {
             }
             const methodDecorators = getDecorators(method.decorators);
             const parameters = method.parameters;
-            const parameterDecoratorData:
-                ((MetadataSymbolicExpression | MetadataError)[] | undefined)[] = [];
-            const parametersData:
-                (MetadataSymbolicReferenceExpression | MetadataError |
-                 MetadataSymbolicSelectExpression | null)[] = [];
+            const parameterDecoratorData: ((MetadataSymbolicExpression | MetadataError)[]|
+                                           undefined)[] = [];
+            const parametersData: (MetadataSymbolicReferenceExpression|MetadataError|
+                                   MetadataSymbolicSelectExpression|null)[] = [];
             let hasDecoratorData: boolean = false;
             let hasParameterData: boolean = false;
             for (const parameter of parameters) {
@@ -282,15 +281,14 @@ export class MetadataCollector {
         ts.getCombinedModifierFlags(node as ts.Declaration) & ts.ModifierFlags.Export;
     const isExportedIdentifier = (identifier?: ts.Identifier) =>
         identifier && exportMap.has(identifier.text);
-    const isExported =
-        (node: ts.FunctionDeclaration | ts.ClassDeclaration | ts.TypeAliasDeclaration |
-         ts.InterfaceDeclaration | ts.EnumDeclaration) =>
-            isExport(node) || isExportedIdentifier(node.name);
+    const isExported = (node: ts.FunctionDeclaration|ts.ClassDeclaration|ts.TypeAliasDeclaration|
+                        ts.InterfaceDeclaration|ts.EnumDeclaration) =>
+        isExport(node) || isExportedIdentifier(node.name);
     const exportedIdentifierName = (identifier?: ts.Identifier) =>
         identifier && (exportMap.get(identifier.text) || identifier.text);
-    const exportedName =
-        (node: ts.FunctionDeclaration | ts.ClassDeclaration | ts.InterfaceDeclaration |
-         ts.TypeAliasDeclaration | ts.EnumDeclaration) => exportedIdentifierName(node.name);
+    const exportedName = (node: ts.FunctionDeclaration|ts.ClassDeclaration|
+                          ts.InterfaceDeclaration|ts.TypeAliasDeclaration|ts.EnumDeclaration) =>
+        exportedIdentifierName(node.name);
 
 
     // Pre-declare classes and functions
@@ -419,8 +417,8 @@ export class MetadataCollector {
             if (name) {
               if (!metadata) metadata = {};
               // TODO(alxhub): The literal here is not valid FunctionMetadata.
-              metadata[name] = maybeFunc ? recordEntry(maybeFunc.func, node) :
-                                           ({ __symbolic: 'function' } as any);
+              metadata[name] =
+                  maybeFunc ? recordEntry(maybeFunc.func, node) : ({__symbolic: 'function'} as any);
             }
           }
           break;
@@ -456,7 +454,8 @@ export class MetadataCollector {
                   operator: '+',
                   left: {
                     __symbolic: 'select',
-                    expression: recordEntry({__symbolic: 'reference', name: enumName}, node), name
+                    expression: recordEntry({__symbolic: 'reference', name: enumName}, node),
+                    name
                   },
                 } as any;
               } else {
@@ -555,7 +554,8 @@ export class MetadataCollector {
       }
       const result: ModuleMetadata = {
         __symbolic: 'module',
-        version: this.options.version || METADATA_VERSION, metadata
+        version: this.options.version || METADATA_VERSION,
+        metadata
       };
       if (sourceFile.moduleName) result.importAs = sourceFile.moduleName;
       if (exports) result.exports = exports;
@@ -570,8 +570,7 @@ function validateMetadata(
     metadata: {[name: string]: MetadataEntry}) {
   let locals: Set<string> = new Set(['Array', 'Object', 'Set', 'Map', 'string', 'number', 'any']);
 
-  function validateExpression(
-      expression: MetadataValue | MetadataSymbolicExpression | MetadataError) {
+  function validateExpression(expression: MetadataValue|MetadataSymbolicExpression|MetadataError) {
     if (!expression) {
       return;
     } else if (Array.isArray(expression)) {
@@ -648,11 +647,11 @@ function validateMetadata(
     }
     if (classData.members) {
       Object.getOwnPropertyNames(classData.members)
-          .forEach(name => classData.members ![name].forEach((m) => validateMember(classData, m)));
+          .forEach(name => classData.members![name].forEach((m) => validateMember(classData, m)));
     }
     if (classData.statics) {
       Object.getOwnPropertyNames(classData.statics).forEach(name => {
-        const staticMember = classData.statics ![name];
+        const staticMember = classData.statics![name];
         if (isFunctionMetadata(staticMember)) {
           validateExpression(staticMember.value);
         } else {
@@ -675,7 +674,7 @@ function validateMetadata(
     }
   }
 
-  function shouldReportNode(node: ts.Node | undefined) {
+  function shouldReportNode(node: ts.Node|undefined) {
     if (node) {
       const nodeStart = node.getStart();
       return !(
@@ -688,12 +687,13 @@ function validateMetadata(
   function reportError(error: MetadataError) {
     const node = nodeMap.get(error);
     if (shouldReportNode(node)) {
-      const lineInfo = error.line != undefined ?
-          error.character != undefined ? `:${error.line + 1}:${error.character + 1}` :
-                                         `:${error.line + 1}` :
-          '';
-      throw new Error(
-          `${sourceFile.fileName}${lineInfo}: Metadata collected contains an error that will be reported at runtime: ${expandedMessage(error)}.\n  ${JSON.stringify(error)}`);
+      const lineInfo = error.line != undefined ? error.character != undefined ?
+                                                 `:${error.line + 1}:${error.character + 1}` :
+                                                 `:${error.line + 1}` :
+                                                 '';
+      throw new Error(`${sourceFile.fileName}${
+          lineInfo}: Metadata collected contains an error that will be reported at runtime: ${
+          expandedMessage(error)}.\n  ${JSON.stringify(error)}`);
     }
   }
 
@@ -708,8 +708,9 @@ function validateMetadata(
       if (shouldReportNode(node)) {
         if (node) {
           const {line, character} = sourceFile.getLineAndCharacterOfPosition(node.getStart());
-          throw new Error(
-              `${sourceFile.fileName}:${line + 1}:${character + 1}: Error encountered in metadata generated for exported symbol '${name}': \n ${e.message}`);
+          throw new Error(`${sourceFile.fileName}:${line + 1}:${
+              character + 1}: Error encountered in metadata generated for exported symbol '${
+              name}': \n ${e.message}`);
         }
         throw new Error(
             `Error encountered in metadata generated for exported symbol ${name}: \n ${e.message}`);
@@ -722,7 +723,7 @@ function validateMetadata(
 function namesOf(parameters: ts.NodeArray<ts.ParameterDeclaration>): string[] {
   const result: string[] = [];
 
-  function addNamesOf(name: ts.Identifier | ts.BindingPattern) {
+  function addNamesOf(name: ts.Identifier|ts.BindingPattern) {
     if (name.kind == ts.SyntaxKind.Identifier) {
       const identifier = <ts.Identifier>name;
       result.push(identifier.text);
@@ -752,7 +753,8 @@ function expandedMessage(error: any): string {
   switch (error.message) {
     case 'Reference to non-exported class':
       if (error.context && error.context.className) {
-        return `Reference to a non-exported class ${error.context.className}. Consider exporting the class`;
+        return `Reference to a non-exported class ${
+            error.context.className}. Consider exporting the class`;
       }
       break;
     case 'Variable not initialized':
@@ -771,7 +773,8 @@ function expandedMessage(error: any): string {
           'unction calls are not supported. Consider replacing the function or lambda with a reference to an exported function';
     case 'Reference to a local symbol':
       if (error.context && error.context.name) {
-        return `Reference to a local (non-exported) symbol '${error.context.name}'. Consider exporting the symbol`;
+        return `Reference to a local (non-exported) symbol '${
+            error.context.name}'. Consider exporting the symbol`;
       }
   }
   return error.message;

--- a/packages/compiler-cli/src/metadata/evaluator.ts
+++ b/packages/compiler-cli/src/metadata/evaluator.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 
 import {CollectorOptions} from './collector';
-import {ClassMetadata, FunctionMetadata, InterfaceMetadata, MetadataEntry, MetadataError, MetadataImportedSymbolReferenceExpression, MetadataSourceLocationInfo, MetadataSymbolicCallExpression, MetadataValue, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataImportDefaultReference, isMetadataImportedSymbolReferenceExpression, isMetadataModuleReferenceExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSpreadExpression} from './schema';
+import {ClassMetadata, FunctionMetadata, InterfaceMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataImportDefaultReference, isMetadataImportedSymbolReferenceExpression, isMetadataModuleReferenceExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSpreadExpression, MetadataEntry, MetadataError, MetadataImportedSymbolReferenceExpression, MetadataSourceLocationInfo, MetadataSymbolicCallExpression, MetadataValue} from './schema';
 import {Symbols} from './symbols';
 
 
@@ -46,8 +46,9 @@ export function recordMapEntry<T extends MetadataEntry>(
     sourceFile?: ts.SourceFile) {
   if (!nodeMap.has(entry)) {
     nodeMap.set(entry, node);
-    if (node && (isMetadataImportedSymbolReferenceExpression(entry) ||
-                 isMetadataImportDefaultReference(entry)) &&
+    if (node &&
+        (isMetadataImportedSymbolReferenceExpression(entry) ||
+         isMetadataImportDefaultReference(entry)) &&
         entry.line == null) {
       const info = sourceInfo(node, sourceFile);
       if (info.line != null) entry.line = info.line;
@@ -88,7 +89,7 @@ export interface ImportMetadata {
 }
 
 
-function getSourceFileOfNode(node: ts.Node | undefined): ts.SourceFile {
+function getSourceFileOfNode(node: ts.Node|undefined): ts.SourceFile {
   while (node && node.kind != ts.SyntaxKind.SourceFile) {
     node = node.parent;
   }
@@ -97,7 +98,7 @@ function getSourceFileOfNode(node: ts.Node | undefined): ts.SourceFile {
 
 /* @internal */
 export function sourceInfo(
-    node: ts.Node | undefined, sourceFile: ts.SourceFile | undefined): MetadataSourceLocationInfo {
+    node: ts.Node|undefined, sourceFile: ts.SourceFile|undefined): MetadataSourceLocationInfo {
   if (node) {
     sourceFile = sourceFile || getSourceFileOfNode(node);
     if (sourceFile) {
@@ -435,7 +436,7 @@ export class Evaluator {
       case ts.SyntaxKind.TypeReference:
         const typeReferenceNode = <ts.TypeReferenceNode>node;
         const typeNameNode = typeReferenceNode.typeName;
-        const getReference: (typeNameNode: ts.Identifier | ts.QualifiedName) => MetadataValue =
+        const getReference: (typeNameNode: ts.Identifier|ts.QualifiedName) => MetadataValue =
             node => {
               if (typeNameNode.kind === ts.SyntaxKind.QualifiedName) {
                 const qualifiedName = <ts.QualifiedName>node;
@@ -691,6 +692,6 @@ function isPropertyAssignment(node: ts.Node): node is ts.PropertyAssignment {
 
 const empty = ts.createNodeArray<any>();
 
-function arrayOrEmpty<T extends ts.Node>(v: ts.NodeArray<T>| undefined): ts.NodeArray<T> {
+function arrayOrEmpty<T extends ts.Node>(v: ts.NodeArray<T>|undefined): ts.NodeArray<T> {
   return v || empty;
 }

--- a/packages/compiler-cli/src/metadata/schema.ts
+++ b/packages/compiler-cli/src/metadata/schema.ts
@@ -18,7 +18,7 @@
 
 export const METADATA_VERSION = 4;
 
-export type MetadataEntry = ClassMetadata | InterfaceMetadata | FunctionMetadata | MetadataValue;
+export type MetadataEntry = ClassMetadata|InterfaceMetadata|FunctionMetadata|MetadataValue;
 
 export interface ModuleMetadata {
   __symbolic: 'module';
@@ -43,18 +43,22 @@ export interface ClassMetadata {
   arity?: number;
   decorators?: (MetadataSymbolicExpression|MetadataError)[];
   members?: MetadataMap;
-  statics?: {[name: string]: MetadataValue | FunctionMetadata};
+  statics?: {[name: string]: MetadataValue|FunctionMetadata};
 }
 export function isClassMetadata(value: any): value is ClassMetadata {
   return value && value.__symbolic === 'class';
 }
 
-export interface InterfaceMetadata { __symbolic: 'interface'; }
+export interface InterfaceMetadata {
+  __symbolic: 'interface';
+}
 export function isInterfaceMetadata(value: any): value is InterfaceMetadata {
   return value && value.__symbolic === 'interface';
 }
 
-export interface MetadataMap { [name: string]: MemberMetadata[]; }
+export interface MetadataMap {
+  [name: string]: MemberMetadata[];
+}
 
 export interface MemberMetadata {
   __symbolic: 'constructor'|'method'|'property';
@@ -99,24 +103,26 @@ export function isFunctionMetadata(value: any): value is FunctionMetadata {
   return value && value.__symbolic === 'function';
 }
 
-export type MetadataValue = string | number | boolean | undefined | null | MetadataObject |
-    MetadataArray | MetadataSymbolicExpression | MetadataSymbolicReferenceExpression |
-    MetadataSymbolicBinaryExpression | MetadataSymbolicIndexExpression |
-    MetadataSymbolicCallExpression | MetadataSymbolicPrefixExpression |
-    MetadataSymbolicIfExpression | MetadataSymbolicSpreadExpression |
-    MetadataSymbolicSelectExpression | MetadataError;
+export type MetadataValue = string|number|boolean|undefined|null|MetadataObject|MetadataArray|
+    MetadataSymbolicExpression|MetadataSymbolicReferenceExpression|MetadataSymbolicBinaryExpression|
+    MetadataSymbolicIndexExpression|MetadataSymbolicCallExpression|MetadataSymbolicPrefixExpression|
+    MetadataSymbolicIfExpression|MetadataSymbolicSpreadExpression|MetadataSymbolicSelectExpression|
+    MetadataError;
 
-export interface MetadataObject { [name: string]: MetadataValue; }
+export interface MetadataObject {
+  [name: string]: MetadataValue;
+}
 
-export interface MetadataArray { [name: number]: MetadataValue; }
+export interface MetadataArray {
+  [name: number]: MetadataValue;
+}
 
-export type MetadataSymbolicExpression = MetadataSymbolicBinaryExpression |
-    MetadataSymbolicIndexExpression | MetadataSymbolicIndexExpression |
-    MetadataSymbolicCallExpression | MetadataSymbolicCallExpression |
-    MetadataSymbolicPrefixExpression | MetadataSymbolicIfExpression |
-    MetadataGlobalReferenceExpression | MetadataModuleReferenceExpression |
-    MetadataImportedSymbolReferenceExpression | MetadataImportedDefaultReferenceExpression |
-    MetadataSymbolicSelectExpression | MetadataSymbolicSpreadExpression;
+export type MetadataSymbolicExpression = MetadataSymbolicBinaryExpression|
+    MetadataSymbolicIndexExpression|MetadataSymbolicIndexExpression|MetadataSymbolicCallExpression|
+    MetadataSymbolicCallExpression|MetadataSymbolicPrefixExpression|MetadataSymbolicIfExpression|
+    MetadataGlobalReferenceExpression|MetadataModuleReferenceExpression|
+    MetadataImportedSymbolReferenceExpression|MetadataImportedDefaultReferenceExpression|
+    MetadataSymbolicSelectExpression|MetadataSymbolicSpreadExpression;
 
 export function isMetadataSymbolicExpression(value: any): value is MetadataSymbolicExpression {
   if (value) {
@@ -234,18 +240,17 @@ export function isMetadataImportedSymbolReferenceExpression(value: any):
 export interface MetadataImportedDefaultReferenceExpression extends MetadataSourceLocationInfo {
   __symbolic: 'reference';
   module: string;
-  default:
-    boolean;
-    arguments?: MetadataValue[];
+  default: boolean;
+  arguments?: MetadataValue[];
 }
 export function isMetadataImportDefaultReference(value: any):
     value is MetadataImportedDefaultReferenceExpression {
   return value && value.module && value.default && isMetadataSymbolicReferenceExpression(value);
 }
 
-export type MetadataSymbolicReferenceExpression = MetadataGlobalReferenceExpression |
-    MetadataModuleReferenceExpression | MetadataImportedSymbolReferenceExpression |
-    MetadataImportedDefaultReferenceExpression;
+export type MetadataSymbolicReferenceExpression =
+    MetadataGlobalReferenceExpression|MetadataModuleReferenceExpression|
+    MetadataImportedSymbolReferenceExpression|MetadataImportedDefaultReferenceExpression;
 export function isMetadataSymbolicReferenceExpression(value: any):
     value is MetadataSymbolicReferenceExpression {
   return value && value.__symbolic === 'reference';

--- a/packages/compiler-cli/src/metadata/symbols.ts
+++ b/packages/compiler-cli/src/metadata/symbols.ts
@@ -12,7 +12,7 @@ import {MetadataSymbolicReferenceExpression, MetadataValue} from './schema';
 
 export class Symbols {
   // TODO(issue/24571): remove '!'.
-  private _symbols !: Map<string, MetadataValue>;
+  private _symbols!: Map<string, MetadataValue>;
   private references = new Map<string, MetadataSymbolicReferenceExpression>();
 
   constructor(private sourceFile: ts.SourceFile) {}
@@ -21,12 +21,16 @@ export class Symbols {
     return (preferReference && this.references.get(name)) || this.symbols.get(name);
   }
 
-  define(name: string, value: MetadataValue) { this.symbols.set(name, value); }
+  define(name: string, value: MetadataValue) {
+    this.symbols.set(name, value);
+  }
   defineReference(name: string, value: MetadataSymbolicReferenceExpression) {
     this.references.set(name, value);
   }
 
-  has(name: string): boolean { return this.symbols.has(name); }
+  has(name: string): boolean {
+    return this.symbols.has(name);
+  }
 
   private get symbols(): Map<string, MetadataValue> {
     let result = this._symbols;

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ConstantPool, CssSelector, DEFAULT_INTERPOLATION_CONFIG, DomElementSchemaRegistry, Expression, ExternalExpr, Identifiers, InterpolationConfig, LexerRange, ParseError, ParseSourceFile, ParseTemplateOptions, R3ComponentMetadata, R3FactoryTarget, R3TargetBinder, SchemaMetadata, SelectorMatcher, Statement, TmplAstNode, WrappedNodeExpr, compileComponentFromMetadata, makeBindingParser, parseTemplate} from '@angular/compiler';
+import {compileComponentFromMetadata, ConstantPool, CssSelector, DEFAULT_INTERPOLATION_CONFIG, DomElementSchemaRegistry, Expression, ExternalExpr, Identifiers, InterpolationConfig, LexerRange, makeBindingParser, ParseError, ParseSourceFile, parseTemplate, ParseTemplateOptions, R3ComponentMetadata, R3FactoryTarget, R3TargetBinder, SchemaMetadata, SelectorMatcher, Statement, TmplAstNode, WrappedNodeExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {CycleAnalyzer} from '../../cycles';
@@ -15,7 +15,7 @@ import {absoluteFrom, relative} from '../../file_system';
 import {DefaultImportRecorder, ModuleResolver, Reference, ReferenceEmitter} from '../../imports';
 import {DependencyTracker} from '../../incremental/api';
 import {IndexingContext} from '../../indexer';
-import {DirectiveMeta, InjectableClassRegistry, MetadataReader, MetadataRegistry, extractDirectiveGuards} from '../../metadata';
+import {DirectiveMeta, extractDirectiveGuards, InjectableClassRegistry, MetadataReader, MetadataRegistry} from '../../metadata';
 import {flattenInheritedDirectiveMetadata} from '../../metadata/src/inheritance';
 import {EnumValue, PartialEvaluator} from '../../partial_evaluator';
 import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
@@ -200,7 +200,7 @@ export class ComponentDecoratorHandler implements
       } else {
         return previous;
       }
-    }, undefined) !;
+    }, undefined)!;
 
 
     // Note that we could technically combine the `viewProvidersRequiringFactory` and
@@ -211,7 +211,7 @@ export class ComponentDecoratorHandler implements
     let wrappedViewProviders: Expression|null = null;
 
     if (component.has('viewProviders')) {
-      const viewProviders = component.get('viewProviders') !;
+      const viewProviders = component.get('viewProviders')!;
       viewProvidersRequiringFactory =
           resolveProvidersRequiringFactory(viewProviders, this.reflector, this.evaluator);
       wrappedViewProviders = new WrappedNodeExpr(
@@ -221,7 +221,7 @@ export class ComponentDecoratorHandler implements
 
     if (component.has('providers')) {
       providersRequiringFactory = resolveProvidersRequiringFactory(
-          component.get('providers') !, this.reflector, this.evaluator);
+          component.get('providers')!, this.reflector, this.evaluator);
     }
 
     // Parse the template.
@@ -232,14 +232,14 @@ export class ComponentDecoratorHandler implements
     let template: ParsedTemplateWithSource;
     if (this.preanalyzeTemplateCache.has(node)) {
       // The template was parsed in preanalyze. Use it and delete it to save memory.
-      const preanalyzed = this.preanalyzeTemplateCache.get(node) !;
+      const preanalyzed = this.preanalyzeTemplateCache.get(node)!;
       this.preanalyzeTemplateCache.delete(node);
 
       template = preanalyzed;
     } else {
       // The template was not already parsed. Either there's a templateUrl, or an inline template.
       if (component.has('templateUrl')) {
-        const templateUrlExpr = component.get('templateUrl') !;
+        const templateUrlExpr = component.get('templateUrl')!;
         const templateUrl = this.evaluator.evaluate(templateUrlExpr);
         if (typeof templateUrl !== 'string') {
           throw new FatalDiagnosticError(
@@ -303,7 +303,7 @@ export class ComponentDecoratorHandler implements
 
     let animations: Expression|null = null;
     if (component.has('animations')) {
-      animations = new WrappedNodeExpr(component.get('animations') !);
+      animations = new WrappedNodeExpr(component.get('animations')!);
     }
 
     const output: AnalysisOutput<ComponentAnalysisData> = {
@@ -323,7 +323,8 @@ export class ComponentDecoratorHandler implements
           // analyzed and the full compilation scope for the component can be realized.
           animations,
           viewProviders: wrappedViewProviders,
-          i18nUseExternalIds: this.i18nUseExternalIds, relativeContextFilePath,
+          i18nUseExternalIds: this.i18nUseExternalIds,
+          relativeContextFilePath,
         },
         guards: extractDirectiveGuards(node, this.reflector),
         metadataStmt: generateSetClassMetadataCall(
@@ -335,7 +336,7 @@ export class ComponentDecoratorHandler implements
       },
     };
     if (changeDetection !== null) {
-      output.analysis !.meta.changeDetection = changeDetection;
+      output.analysis!.meta.changeDetection = changeDetection;
     }
     return output;
   }
@@ -353,7 +354,8 @@ export class ComponentDecoratorHandler implements
       outputs: analysis.meta.outputs,
       queries: analysis.meta.queries.map(query => query.propertyName),
       isComponent: true,
-      baseClass: analysis.baseClass, ...analysis.guards,
+      baseClass: analysis.baseClass,
+      ...analysis.guards,
     });
 
     this.injectableRegistry.registerInjectable(node);
@@ -415,8 +417,8 @@ export class ComponentDecoratorHandler implements
       }
       for (const {name, ref} of scope.compilation.pipes) {
         if (!ts.isClassDeclaration(ref.node)) {
-          throw new Error(
-              `Unexpected non-class declaration ${ts.SyntaxKind[ref.node.kind]} for pipe ${ref.debugName}`);
+          throw new Error(`Unexpected non-class declaration ${
+              ts.SyntaxKind[ref.node.kind]} for pipe ${ref.debugName}`);
         }
         pipes.set(name, ref as Reference<ClassDeclaration<ts.ClassDeclaration>>);
       }
@@ -491,7 +493,7 @@ export class ComponentDecoratorHandler implements
 
       // The BoundTarget knows which directives and pipes matched the template.
       const usedDirectives = bound.getUsedDirectives();
-      const usedPipes = bound.getUsedPipes().map(name => pipes.get(name) !);
+      const usedPipes = bound.getUsedPipes().map(name => pipes.get(name)!);
 
       // Scan through the directives/pipes actually used in the template and check whether any
       // import which needs to be generated would create a cycle.
@@ -539,7 +541,7 @@ export class ComponentDecoratorHandler implements
     if (analysis.providersRequiringFactory !== null &&
         analysis.meta.providers instanceof WrappedNodeExpr) {
       const providerDiagnostics = getProviderDiagnostics(
-          analysis.providersRequiringFactory, analysis.meta.providers !.node,
+          analysis.providersRequiringFactory, analysis.meta.providers!.node,
           this.injectableRegistry);
       diagnostics.push(...providerDiagnostics);
     }
@@ -547,7 +549,7 @@ export class ComponentDecoratorHandler implements
     if (analysis.viewProvidersRequiringFactory !== null &&
         analysis.meta.viewProviders instanceof WrappedNodeExpr) {
       const viewProviderDiagnostics = getProviderDiagnostics(
-          analysis.viewProvidersRequiringFactory, analysis.meta.viewProviders !.node,
+          analysis.viewProvidersRequiringFactory, analysis.meta.viewProviders!.node,
           this.injectableRegistry);
       diagnostics.push(...viewProviderDiagnostics);
     }
@@ -587,7 +589,7 @@ export class ComponentDecoratorHandler implements
 
   private _resolveLiteral(decorator: Decorator): ts.ObjectLiteralExpression {
     if (this.literalCache.has(decorator)) {
-      return this.literalCache.get(decorator) !;
+      return this.literalCache.get(decorator)!;
     }
     if (decorator.args === null || decorator.args.length !== 1) {
       throw new FatalDiagnosticError(
@@ -609,7 +611,7 @@ export class ComponentDecoratorHandler implements
       component: Map<string, ts.Expression>, field: string, enumSymbolName: string): number|null {
     let resolved: number|null = null;
     if (component.has(field)) {
-      const expr = component.get(field) !;
+      const expr = component.get(field)!;
       const value = this.evaluator.evaluate(expr) as any;
       if (value instanceof EnumValue && isAngularCoreReference(value.enumRef, enumSymbolName)) {
         resolved = value.resolved as number;
@@ -628,7 +630,7 @@ export class ComponentDecoratorHandler implements
       return extraUrls.length > 0 ? extraUrls : null;
     }
 
-    const styleUrlsExpr = component.get('styleUrls') !;
+    const styleUrlsExpr = component.get('styleUrls')!;
     const styleUrls = this.evaluator.evaluate(styleUrlsExpr);
     if (!Array.isArray(styleUrls) || !styleUrls.every(url => typeof url === 'string')) {
       throw new FatalDiagnosticError(
@@ -643,7 +645,7 @@ export class ComponentDecoratorHandler implements
       containingFile: string): Promise<ParsedTemplate|null> {
     if (component.has('templateUrl')) {
       // Extract the templateUrl and preload it.
-      const templateUrlExpr = component.get('templateUrl') !;
+      const templateUrlExpr = component.get('templateUrl')!;
       const templateUrl = this.evaluator.evaluate(templateUrlExpr);
       if (typeof templateUrl !== 'string') {
         throw new FatalDiagnosticError(
@@ -703,7 +705,7 @@ export class ComponentDecoratorHandler implements
           ErrorCode.COMPONENT_MISSING_TEMPLATE, Decorator.nodeForError(decorator),
           'component is missing a template');
     }
-    const templateExpr = component.get('template') !;
+    const templateExpr = component.get('template')!;
 
     let templateStr: string;
     let templateUrl: string = '';
@@ -721,7 +723,7 @@ export class ComponentDecoratorHandler implements
       escapedString = true;
       sourceMapping = {
         type: 'direct',
-        node: templateExpr as(ts.StringLiteral | ts.NoSubstitutionTemplateLiteral),
+        node: templateExpr as (ts.StringLiteral | ts.NoSubstitutionTemplateLiteral),
       };
     } else {
       const resolvedTemplate = this.evaluator.evaluate(templateExpr);
@@ -749,7 +751,7 @@ export class ComponentDecoratorHandler implements
       templateRange: LexerRange|undefined, escapedString: boolean): ParsedTemplate {
     let preserveWhitespaces: boolean = this.defaultPreserveWhitespaces;
     if (component.has('preserveWhitespaces')) {
-      const expr = component.get('preserveWhitespaces') !;
+      const expr = component.get('preserveWhitespaces')!;
       const value = this.evaluator.evaluate(expr);
       if (typeof value !== 'boolean') {
         throw new FatalDiagnosticError(
@@ -760,7 +762,7 @@ export class ComponentDecoratorHandler implements
 
     let interpolation: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG;
     if (component.has('interpolation')) {
-      const expr = component.get('interpolation') !;
+      const expr = component.get('interpolation')!;
       const value = this.evaluator.evaluate(expr);
       if (!Array.isArray(value) || value.length !== 2 ||
           !value.every(element => typeof element === 'string')) {
@@ -768,14 +770,15 @@ export class ComponentDecoratorHandler implements
             ErrorCode.VALUE_HAS_WRONG_TYPE, expr,
             'interpolation must be an array with 2 elements of string type');
       }
-      interpolation = InterpolationConfig.fromArray(value as[string, string]);
+      interpolation = InterpolationConfig.fromArray(value as [string, string]);
     }
 
     const {errors, nodes: emitNodes, styleUrls, styles, ngContentSelectors} =
         parseTemplate(templateStr, templateUrl, {
           preserveWhitespaces,
           interpolationConfig: interpolation,
-          range: templateRange, escapedString,
+          range: templateRange,
+          escapedString,
           enableI18nLegacyMessageIdFormat: this.enableI18nLegacyMessageIdFormat,
         });
 
@@ -795,7 +798,8 @@ export class ComponentDecoratorHandler implements
     const {nodes: diagNodes} = parseTemplate(templateStr, templateUrl, {
       preserveWhitespaces: true,
       interpolationConfig: interpolation,
-      range: templateRange, escapedString,
+      range: templateRange,
+      escapedString,
       enableI18nLegacyMessageIdFormat: this.enableI18nLegacyMessageIdFormat,
       leadingTriviaChars: [],
     });
@@ -808,7 +812,8 @@ export class ComponentDecoratorHandler implements
       styles,
       ngContentSelectors,
       errors,
-      template: templateStr, templateUrl,
+      template: templateStr,
+      templateUrl,
       isInline: component.has('template'),
       file: new ParseSourceFile(templateStr, templateUrl),
     };
@@ -820,7 +825,7 @@ export class ComponentDecoratorHandler implements
     }
 
     // Figure out what file is being imported.
-    return this.moduleResolver.resolveModule(expr.value.moduleName !, origin.fileName);
+    return this.moduleResolver.resolveModule(expr.value.moduleName!, origin.fileName);
   }
 
   private _isCyclicImport(expr: Expression, origin: ts.SourceFile): boolean {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/diagnostics.ts
@@ -36,9 +36,13 @@ export function getProviderDiagnostics(
     const contextNode = provider.getOriginForDiagnostics(providersDeclaration);
     diagnostics.push(makeDiagnostic(
         ErrorCode.UNDECORATED_PROVIDER, contextNode,
-        `The class '${provider.node.name.text}' cannot be created via dependency injection, as it does not have an Angular decorator. This will result in an error at runtime.
+        `The class '${
+            provider.node.name
+                .text}' cannot be created via dependency injection, as it does not have an Angular decorator. This will result in an error at runtime.
 
-Either add the @Injectable() decorator to '${provider.node.name.text}', or configure a different provider (such as a provider with 'useFactory').
+Either add the @Injectable() decorator to '${
+            provider.node.name
+                .text}', or configure a different provider (such as a provider with 'useFactory').
 `,
         [{node: provider.node, messageText: `'${provider.node.name.text}' is declared here.`}]));
   }
@@ -52,7 +56,7 @@ export function getDirectiveDiagnostics(
     kind: string): ts.Diagnostic[]|null {
   let diagnostics: ts.Diagnostic[]|null = [];
 
-  const addDiagnostics = (more: ts.Diagnostic | ts.Diagnostic[] | null) => {
+  const addDiagnostics = (more: ts.Diagnostic|ts.Diagnostic[]|null) => {
     if (more === null) {
       return;
     } else if (diagnostics === null) {
@@ -121,14 +125,16 @@ export function checkInheritanceOfDirective(
 
 function getInheritedUndecoratedCtorDiagnostic(
     node: ClassDeclaration, baseClass: Reference, reader: MetadataReader) {
-  const subclassMeta = reader.getDirectiveMetadata(new Reference(node)) !;
+  const subclassMeta = reader.getDirectiveMetadata(new Reference(node))!;
   const dirOrComp = subclassMeta.isComponent ? 'Component' : 'Directive';
   const baseClassName = baseClass.debugName;
 
   return makeDiagnostic(
       ErrorCode.DIRECTIVE_INHERITS_UNDECORATED_CTOR, node.name,
-      `The ${dirOrComp.toLowerCase()} ${node.name.text} inherits its constructor from ${baseClassName}, ` +
+      `The ${dirOrComp.toLowerCase()} ${node.name.text} inherits its constructor from ${
+          baseClassName}, ` +
           `but the latter does not have an Angular decorator of its own. Dependency injection will not be able to ` +
-          `resolve the parameters of ${baseClassName}'s constructor. Either add a @Directive decorator ` +
+          `resolve the parameters of ${
+              baseClassName}'s constructor. Either add a @Directive decorator ` +
           `to ${baseClassName}, or add an explicit constructor to ${node.name.text}.`);
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/factory.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/factory.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {R3FactoryMetadata, compileFactoryFunction} from '@angular/compiler';
+import {compileFactoryFunction, R3FactoryMetadata} from '@angular/compiler';
 
 import {CompileResult} from '../../transform';
 

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Expression, Identifiers, LiteralExpr, R3DependencyMetadata, R3FactoryTarget, R3InjectableMetadata, R3ResolvedDependencyType, Statement, WrappedNodeExpr, compileInjectable as compileIvyInjectable} from '@angular/compiler';
+import {compileInjectable as compileIvyInjectable, Expression, Identifiers, LiteralExpr, R3DependencyMetadata, R3FactoryTarget, R3InjectableMetadata, R3ResolvedDependencyType, Statement, WrappedNodeExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
@@ -83,7 +83,9 @@ export class InjectableDecoratorHandler implements
     };
   }
 
-  register(node: ClassDeclaration): void { this.injectableRegistry.registerInjectable(node); }
+  register(node: ClassDeclaration): void {
+    this.injectableRegistry.registerInjectable(node);
+  }
 
   compile(node: ClassDeclaration, analysis: Readonly<InjectableHandlerData>): CompileResult[] {
     const res = compileIvyInjectable(analysis.meta);
@@ -165,12 +167,12 @@ function extractInjectableMetadata(
     const meta = reflectObjectLiteral(metaNode);
     let providedIn: Expression = new LiteralExpr(null);
     if (meta.has('providedIn')) {
-      providedIn = new WrappedNodeExpr(meta.get('providedIn') !);
+      providedIn = new WrappedNodeExpr(meta.get('providedIn')!);
     }
 
     let userDeps: R3DependencyMetadata[]|undefined = undefined;
     if ((meta.has('useClass') || meta.has('useFactory')) && meta.has('deps')) {
-      const depsExpr = meta.get('deps') !;
+      const depsExpr = meta.get('deps')!;
       if (!ts.isArrayLiteralExpression(depsExpr)) {
         throw new FatalDiagnosticError(
             ErrorCode.VALUE_NOT_LITERAL, depsExpr,
@@ -186,7 +188,7 @@ function extractInjectableMetadata(
         typeArgumentCount,
         internalType,
         providedIn,
-        useValue: new WrappedNodeExpr(unwrapForwardRef(meta.get('useValue') !, reflector)),
+        useValue: new WrappedNodeExpr(unwrapForwardRef(meta.get('useValue')!, reflector)),
       };
     } else if (meta.has('useExisting')) {
       return {
@@ -195,7 +197,7 @@ function extractInjectableMetadata(
         typeArgumentCount,
         internalType,
         providedIn,
-        useExisting: new WrappedNodeExpr(unwrapForwardRef(meta.get('useExisting') !, reflector)),
+        useExisting: new WrappedNodeExpr(unwrapForwardRef(meta.get('useExisting')!, reflector)),
       };
     } else if (meta.has('useClass')) {
       return {
@@ -204,19 +206,20 @@ function extractInjectableMetadata(
         typeArgumentCount,
         internalType,
         providedIn,
-        useClass: new WrappedNodeExpr(unwrapForwardRef(meta.get('useClass') !, reflector)),
+        useClass: new WrappedNodeExpr(unwrapForwardRef(meta.get('useClass')!, reflector)),
         userDeps,
       };
     } else if (meta.has('useFactory')) {
       // useFactory is special - the 'deps' property must be analyzed.
-      const factory = new WrappedNodeExpr(meta.get('useFactory') !);
+      const factory = new WrappedNodeExpr(meta.get('useFactory')!);
       return {
         name,
         type,
         typeArgumentCount,
         internalType,
         providedIn,
-        useFactory: factory, userDeps,
+        useFactory: factory,
+        userDeps,
       };
     } else {
       return {name, type, typeArgumentCount, internalType, providedIn};

--- a/packages/compiler-cli/src/ngtsc/annotations/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/metadata.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Expression, ExternalExpr, FunctionExpr, Identifiers, InvokeFunctionExpr, LiteralArrayExpr, LiteralExpr, NONE_TYPE, ReturnStatement, Statement, WrappedNodeExpr, literalMap} from '@angular/compiler';
+import {Expression, ExternalExpr, FunctionExpr, Identifiers, InvokeFunctionExpr, LiteralArrayExpr, LiteralExpr, literalMap, NONE_TYPE, ReturnStatement, Statement, WrappedNodeExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {DefaultImportRecorder} from '../../imports';
@@ -71,7 +71,7 @@ export function generateSetClassMetadataCall(
         duplicateDecoratedMemberNames.join(', '));
   }
   const decoratedMembers =
-      classMembers.map(member => classMemberToMetadata(member.name, member.decorators !, isCore));
+      classMembers.map(member => classMemberToMetadata(member.name, member.decorators!, isCore));
   if (decoratedMembers.length > 0) {
     metaPropDecorators = ts.createObjectLiteral(decoratedMembers);
   }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CUSTOM_ELEMENTS_SCHEMA, Expression, ExternalExpr, InvokeFunctionExpr, LiteralArrayExpr, LiteralExpr, NO_ERRORS_SCHEMA, R3Identifiers, R3InjectorMetadata, R3NgModuleMetadata, R3Reference, STRING_TYPE, SchemaMetadata, Statement, WrappedNodeExpr, compileInjector, compileNgModule} from '@angular/compiler';
+import {compileInjector, compileNgModule, CUSTOM_ELEMENTS_SCHEMA, Expression, ExternalExpr, InvokeFunctionExpr, LiteralArrayExpr, LiteralExpr, NO_ERRORS_SCHEMA, R3Identifiers, R3InjectorMetadata, R3NgModuleMetadata, R3Reference, SchemaMetadata, Statement, STRING_TYPE, WrappedNodeExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError, makeDiagnostic} from '../../diagnostics';
@@ -40,7 +40,9 @@ export interface NgModuleAnalysis {
   providers: ts.Expression|null;
 }
 
-export interface NgModuleResolution { injectorImports: Expression[]; }
+export interface NgModuleResolution {
+  injectorImports: Expression[];
+}
 
 /**
  * Compiles @NgModule annotations to ngModuleDef fields.
@@ -116,7 +118,7 @@ export class NgModuleDecoratorHandler implements
     let declarationRefs: Reference<ClassDeclaration>[] = [];
     let rawDeclarations: ts.Expression|null = null;
     if (ngModule.has('declarations')) {
-      rawDeclarations = ngModule.get('declarations') !;
+      rawDeclarations = ngModule.get('declarations')!;
       const declarationMeta = this.evaluator.evaluate(rawDeclarations, forwardRefResolver);
       declarationRefs =
           this.resolveTypeList(rawDeclarations, declarationMeta, name, 'declarations');
@@ -128,7 +130,9 @@ export class NgModuleDecoratorHandler implements
 
           diagnostics.push(makeDiagnostic(
               ErrorCode.NGMODULE_INVALID_DECLARATION, errorNode,
-              `Cannot declare '${ref.node.name.text}' in an NgModule as it's not a part of the current compilation.`,
+              `Cannot declare '${
+                  ref.node.name
+                      .text}' in an NgModule as it's not a part of the current compilation.`,
               [{
                 node: ref.node.name,
                 messageText: `'${ref.node.name.text}' is declared here.`,
@@ -144,28 +148,28 @@ export class NgModuleDecoratorHandler implements
     let importRefs: Reference<ClassDeclaration>[] = [];
     let rawImports: ts.Expression|null = null;
     if (ngModule.has('imports')) {
-      rawImports = ngModule.get('imports') !;
+      rawImports = ngModule.get('imports')!;
       const importsMeta = this.evaluator.evaluate(rawImports, moduleResolvers);
       importRefs = this.resolveTypeList(rawImports, importsMeta, name, 'imports');
     }
     let exportRefs: Reference<ClassDeclaration>[] = [];
     let rawExports: ts.Expression|null = null;
     if (ngModule.has('exports')) {
-      rawExports = ngModule.get('exports') !;
+      rawExports = ngModule.get('exports')!;
       const exportsMeta = this.evaluator.evaluate(rawExports, moduleResolvers);
       exportRefs = this.resolveTypeList(rawExports, exportsMeta, name, 'exports');
       this.referencesRegistry.add(node, ...exportRefs);
     }
     let bootstrapRefs: Reference<ClassDeclaration>[] = [];
     if (ngModule.has('bootstrap')) {
-      const expr = ngModule.get('bootstrap') !;
+      const expr = ngModule.get('bootstrap')!;
       const bootstrapMeta = this.evaluator.evaluate(expr, forwardRefResolver);
       bootstrapRefs = this.resolveTypeList(expr, bootstrapMeta, name, 'bootstrap');
     }
 
     const schemas: SchemaMetadata[] = [];
     if (ngModule.has('schemas')) {
-      const rawExpr = ngModule.get('schemas') !;
+      const rawExpr = ngModule.get('schemas')!;
       const result = this.evaluator.evaluate(rawExpr);
       if (!Array.isArray(result)) {
         throw new FatalDiagnosticError(
@@ -203,7 +207,7 @@ export class NgModuleDecoratorHandler implements
     }
 
     const id: Expression|null =
-        ngModule.has('id') ? new WrappedNodeExpr(ngModule.get('id') !) : null;
+        ngModule.has('id') ? new WrappedNodeExpr(ngModule.get('id')!) : null;
     const valueContext = node.getSourceFile();
 
     let typeContext = valueContext;
@@ -220,7 +224,7 @@ export class NgModuleDecoratorHandler implements
     const exports = exportRefs.map(exp => this._toR3Reference(exp, valueContext, typeContext));
 
     const isForwardReference = (ref: R3Reference) =>
-        isExpressionForwardReference(ref.value, node.name !, valueContext);
+        isExpressionForwardReference(ref.value, node.name!, valueContext);
     const containsForwardDecls = bootstrap.some(isForwardReference) ||
         declarations.some(isForwardReference) || imports.some(isForwardReference) ||
         exports.some(isForwardReference);
@@ -244,7 +248,7 @@ export class NgModuleDecoratorHandler implements
       schemas: [],
     };
 
-    const rawProviders = ngModule.has('providers') ? ngModule.get('providers') ! : null;
+    const rawProviders = ngModule.has('providers') ? ngModule.get('providers')! : null;
     const wrapperProviders = rawProviders !== null ?
         new WrappedNodeExpr(
             this.annotateForClosureCompiler ? wrapFunctionExpressionsInParens(rawProviders) :
@@ -256,7 +260,7 @@ export class NgModuleDecoratorHandler implements
     // and pipes from the module exports.
     const injectorImports: WrappedNodeExpr<ts.Expression>[] = [];
     if (ngModule.has('imports')) {
-      injectorImports.push(new WrappedNodeExpr(ngModule.get('imports') !));
+      injectorImports.push(new WrappedNodeExpr(ngModule.get('imports')!));
     }
 
     if (this.routeAnalyzer !== null) {
@@ -279,7 +283,8 @@ export class NgModuleDecoratorHandler implements
         schemas: schemas,
         mod: ngModuleDef,
         inj: ngInjectorDef,
-        declarations: declarationRefs, rawDeclarations,
+        declarations: declarationRefs,
+        rawDeclarations,
         imports: importRefs,
         exports: exportRefs,
         providers: rawProviders,
@@ -326,7 +331,7 @@ export class NgModuleDecoratorHandler implements
 
     if (analysis.providersRequiringFactory !== null) {
       const providerDiagnostics = getProviderDiagnostics(
-          analysis.providersRequiringFactory, analysis.providers !, this.injectableRegistry);
+          analysis.providersRequiringFactory, analysis.providers!, this.injectableRegistry);
       diagnostics.push(...providerDiagnostics);
     }
 
@@ -396,7 +401,7 @@ export class NgModuleDecoratorHandler implements
         const pipes = scope.compilation.pipes.map(pipe => this.refEmitter.emit(pipe.ref, context));
         const directiveArray = new LiteralArrayExpr(directives);
         const pipesArray = new LiteralArrayExpr(pipes);
-        const declExpr = this.refEmitter.emit(decl, context) !;
+        const declExpr = this.refEmitter.emit(decl, context)!;
         const setComponentScope = new ExternalExpr(R3Identifiers.setComponentScope);
         const callExpr =
             new InvokeFunctionExpr(setComponentScope, [declExpr, directiveArray, pipesArray]);
@@ -472,8 +477,9 @@ export class NgModuleDecoratorHandler implements
       return null;
     }
 
-    const typeName = type && (ts.isIdentifier(type.typeName) && type.typeName ||
-                              ts.isQualifiedName(type.typeName) && type.typeName.right) ||
+    const typeName = type &&
+            (ts.isIdentifier(type.typeName) && type.typeName ||
+             ts.isQualifiedName(type.typeName) && type.typeName.right) ||
         null;
     if (typeName === null) {
       return null;
@@ -559,7 +565,7 @@ export class NgModuleDecoratorHandler implements
       // Unwrap ModuleWithProviders for modules that are locally declared (and thus static
       // resolution was able to descend into the function and return an object literal, a Map).
       if (entry instanceof Map && entry.has('ngModule')) {
-        entry = entry.get('ngModule') !;
+        entry = entry.get('ngModule')!;
       }
 
       if (Array.isArray(entry)) {
@@ -569,14 +575,16 @@ export class NgModuleDecoratorHandler implements
         if (!this.isClassDeclarationReference(entry)) {
           throw new FatalDiagnosticError(
               ErrorCode.VALUE_HAS_WRONG_TYPE, entry.node,
-              `Value at position ${idx} in the NgModule.${arrayName} of ${className} is not a class`);
+              `Value at position ${idx} in the NgModule.${arrayName} of ${
+                  className} is not a class`);
         }
         refList.push(entry);
       } else {
         // TODO(alxhub): Produce a better diagnostic here - the array index may be an inner array.
         throw new FatalDiagnosticError(
             ErrorCode.VALUE_HAS_WRONG_TYPE, expr,
-            `Value at position ${idx} in the NgModule.${arrayName} of ${className} is not a reference: ${entry}`);
+            `Value at position ${idx} in the NgModule.${arrayName} of ${
+                className} is not a reference: ${entry}`);
       }
     });
 

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Identifiers, R3FactoryTarget, R3PipeMetadata, Statement, WrappedNodeExpr, compilePipeFromMetadata} from '@angular/compiler';
+import {compilePipeFromMetadata, Identifiers, R3FactoryTarget, R3PipeMetadata, Statement, WrappedNodeExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
@@ -79,7 +79,7 @@ export class PipeDecoratorHandler implements DecoratorHandler<Decorator, PipeHan
       throw new FatalDiagnosticError(
           ErrorCode.PIPE_MISSING_NAME, meta, `@Pipe decorator is missing name field`);
     }
-    const pipeNameExpr = pipe.get('name') !;
+    const pipeNameExpr = pipe.get('name')!;
     const pipeName = this.evaluator.evaluate(pipeNameExpr);
     if (typeof pipeName !== 'string') {
       throw new FatalDiagnosticError(
@@ -88,7 +88,7 @@ export class PipeDecoratorHandler implements DecoratorHandler<Decorator, PipeHan
 
     let pure = true;
     if (pipe.has('pure')) {
-      const expr = pipe.get('pure') !;
+      const expr = pipe.get('pure')!;
       const pureValue = this.evaluator.evaluate(expr);
       if (typeof pureValue !== 'boolean') {
         throw new FatalDiagnosticError(
@@ -103,7 +103,8 @@ export class PipeDecoratorHandler implements DecoratorHandler<Decorator, PipeHan
           name,
           type,
           internalType,
-          typeArgumentCount: this.reflector.getGenericArityOfClass(clazz) || 0, pipeName,
+          typeArgumentCount: this.reflector.getGenericArityOfClass(clazz) || 0,
+          pipeName,
           deps: getValidConstructorDependencies(
               clazz, this.reflector, this.defaultImportRecorder, this.isCore),
           pure,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
 import {ErrorCode, FatalDiagnosticError, makeDiagnostic} from '../../diagnostics';
 import {DefaultImportRecorder, ImportFlags, Reference, ReferenceEmitter} from '../../imports';
 import {ForeignFunctionResolver, PartialEvaluator} from '../../partial_evaluator';
-import {ClassDeclaration, CtorParameter, Decorator, Import, ReflectionHost, TypeValueReference, isNamedClassDeclaration} from '../../reflection';
+import {ClassDeclaration, CtorParameter, Decorator, Import, isNamedClassDeclaration, ReflectionHost, TypeValueReference} from '../../reflection';
 import {DeclarationData} from '../../scope';
 
 export enum ConstructorDepErrorKind {
@@ -21,8 +21,7 @@ export enum ConstructorDepErrorKind {
 
 export type ConstructorDeps = {
   deps: R3DependencyMetadata[];
-} |
-{
+}|{
   deps: null;
   errors: ConstructorDepError[];
 };
@@ -53,7 +52,7 @@ export function getConstructorDependencies(
     let resolved = R3ResolvedDependencyType.Token;
 
     (param.decorators || []).filter(dec => isCore || isAngularCore(dec)).forEach(dec => {
-      const name = isCore || dec.import === null ? dec.name : dec.import !.name;
+      const name = isCore || dec.import === null ? dec.name : dec.import!.name;
       if (name === 'Inject') {
         if (dec.args === null || dec.args.length !== 1) {
           throw new FatalDiagnosticError(
@@ -97,7 +96,8 @@ export function getConstructorDependencies(
     if (token === null) {
       errors.push({
         index: idx,
-        kind: ConstructorDepErrorKind.NO_SUITABLE_TOKEN, param,
+        kind: ConstructorDepErrorKind.NO_SUITABLE_TOKEN,
+        param,
       });
     } else {
       deps.push({token, attribute, optional, self, skipSelf, host, resolved});
@@ -122,10 +122,10 @@ export function valueReferenceToExpression(
 export function valueReferenceToExpression(
     valueRef: null, defaultImportRecorder: DefaultImportRecorder): null;
 export function valueReferenceToExpression(
-    valueRef: TypeValueReference | null, defaultImportRecorder: DefaultImportRecorder): Expression|
+    valueRef: TypeValueReference|null, defaultImportRecorder: DefaultImportRecorder): Expression|
     null;
 export function valueReferenceToExpression(
-    valueRef: TypeValueReference | null, defaultImportRecorder: DefaultImportRecorder): Expression|
+    valueRef: TypeValueReference|null, defaultImportRecorder: DefaultImportRecorder): Expression|
     null {
   if (valueRef === null) {
     return null;
@@ -138,7 +138,7 @@ export function valueReferenceToExpression(
     return new WrappedNodeExpr(valueRef.expression);
   } else {
     // TODO(alxhub): this cast is necessary because the g3 typescript version doesn't narrow here.
-    return new ExternalExpr(valueRef as{moduleName: string, name: string});
+    return new ExternalExpr(valueRef as {moduleName: string, name: string});
   }
 }
 
@@ -148,7 +148,7 @@ export function valueReferenceToExpression(
  *
  * This is a companion function to `validateConstructorDependencies` which accepts invalid deps.
  */
-export function unwrapConstructorDependencies(deps: ConstructorDeps | null): R3DependencyMetadata[]|
+export function unwrapConstructorDependencies(deps: ConstructorDeps|null): R3DependencyMetadata[]|
     'invalid'|null {
   if (deps === null) {
     return null;
@@ -176,18 +176,19 @@ export function getValidConstructorDependencies(
  * deps.
  */
 export function validateConstructorDependencies(
-    clazz: ClassDeclaration, deps: ConstructorDeps | null): R3DependencyMetadata[]|null {
+    clazz: ClassDeclaration, deps: ConstructorDeps|null): R3DependencyMetadata[]|null {
   if (deps === null) {
     return null;
   } else if (deps.deps !== null) {
     return deps.deps;
   } else {
     // TODO(alxhub): this cast is necessary because the g3 typescript version doesn't narrow here.
-    const {param, index} = (deps as{errors: ConstructorDepError[]}).errors[0];
+    const {param, index} = (deps as {errors: ConstructorDepError[]}).errors[0];
     // There is at least one error.
     throw new FatalDiagnosticError(
         ErrorCode.PARAM_MISSING_TOKEN, param.nameNode,
-        `No suitable injection token for parameter '${param.name || index}' of class '${clazz.name.text}'.\n` +
+        `No suitable injection token for parameter '${param.name || index}' of class '${
+            clazz.name.text}'.\n` +
             (param.typeNode !== null ? `Found ${param.typeNode.getText()}` :
                                        'no type or decorator'));
   }
@@ -319,8 +320,7 @@ export function forwardRefResolver(
  */
 export function combineResolvers(resolvers: ForeignFunctionResolver[]): ForeignFunctionResolver {
   return (ref: Reference<ts.FunctionDeclaration|ts.MethodDeclaration|ts.FunctionExpression>,
-          args: ReadonlyArray<ts.Expression>): ts.Expression |
-      null => {
+          args: ReadonlyArray<ts.Expression>): ts.Expression|null => {
     for (const resolver of resolvers) {
       const resolved = resolver(ref, args);
       if (resolved !== null) {
@@ -406,8 +406,8 @@ export function makeDuplicateDeclarationError(
     const contextNode = decl.ref.getOriginForDiagnostics(decl.rawDeclarations, decl.ngModule.name);
     context.push({
       node: contextNode,
-      messageText:
-          `'${node.name.text}' is listed in the declarations of the NgModule '${decl.ngModule.name.text}'.`,
+      messageText: `'${node.name.text}' is listed in the declarations of the NgModule '${
+          decl.ngModule.name.text}'.`,
     });
   }
 
@@ -441,7 +441,7 @@ export function resolveProvidersRequiringFactory(
     } else if (provider instanceof Reference) {
       tokenClass = provider;
     } else if (provider instanceof Map && provider.has('useClass') && !provider.has('deps')) {
-      const useExisting = provider.get('useClass') !;
+      const useExisting = provider.get('useClass')!;
       if (useExisting instanceof Reference) {
         tokenClass = useExisting;
       }

--- a/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
@@ -12,17 +12,23 @@ import {runInEachFileSystem} from '../../file_system/testing';
 import {ModuleResolver, NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../imports';
 import {CompoundMetadataReader, DtsMetadataReader, InjectableClassRegistry, LocalMetadataRegistry} from '../../metadata';
 import {PartialEvaluator} from '../../partial_evaluator';
-import {TypeScriptReflectionHost, isNamedClassDeclaration} from '../../reflection';
+import {isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../scope';
 import {getDeclaration, makeProgram} from '../../testing';
 import {ResourceLoader} from '../src/api';
 import {ComponentDecoratorHandler} from '../src/component';
 
 export class NoopResourceLoader implements ResourceLoader {
-  resolve(): string { throw new Error('Not implemented.'); }
+  resolve(): string {
+    throw new Error('Not implemented.');
+  }
   canPreload = false;
-  load(): string { throw new Error('Not implemented'); }
-  preload(): Promise<void>|undefined { throw new Error('Not implemented'); }
+  load(): string {
+    throw new Error('Not implemented');
+  }
+  preload(): Promise<void>|undefined {
+    throw new Error('Not implemented');
+  }
 }
 runInEachFileSystem(() => {
   describe('ComponentDecoratorHandler', () => {
@@ -83,10 +89,12 @@ runInEachFileSystem(() => {
         const diag = err.toDiagnostic();
         expect(diag.code).toEqual(ivyCode(ErrorCode.DECORATOR_ARG_NOT_LITERAL));
         expect(diag.file.fileName.endsWith('entry.ts')).toBe(true);
-        expect(diag.start).toBe(detected.metadata.args ![0].getStart());
+        expect(diag.start).toBe(detected.metadata.args![0].getStart());
       }
     });
   });
 
-  function ivyCode(code: ErrorCode): number { return Number('-99' + code.valueOf()); }
+  function ivyCode(code: ErrorCode): number {
+    return Number('-99' + code.valueOf());
+  }
 });

--- a/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
@@ -6,12 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
+
 import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../imports';
 import {DtsMetadataReader, InjectableClassRegistry, LocalMetadataRegistry} from '../../metadata';
 import {PartialEvaluator} from '../../partial_evaluator';
-import {ClassDeclaration, TypeScriptReflectionHost, isNamedClassDeclaration} from '../../reflection';
+import {ClassDeclaration, isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../scope';
 import {getDeclaration, makeProgram} from '../../testing';
 import {DirectiveDecoratorHandler} from '../src/directive';
@@ -77,9 +78,13 @@ runInEachFileSystem(() => {
   // Helpers
   function analyzeDirective(program: ts.Program, dirName: string, hasBaseClass: boolean = false) {
     class TestReflectionHost extends TypeScriptReflectionHost {
-      constructor(checker: ts.TypeChecker) { super(checker); }
+      constructor(checker: ts.TypeChecker) {
+        super(checker);
+      }
 
-      hasBaseClass(_class: ClassDeclaration): boolean { return hasBaseClass; }
+      hasBaseClass(_class: ClassDeclaration): boolean {
+        return hasBaseClass;
+      }
     }
 
     const checker = program.getTypeChecker();

--- a/packages/compiler-cli/src/ngtsc/annotations/test/injectable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/injectable_spec.ts
@@ -10,7 +10,7 @@ import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {NOOP_DEFAULT_IMPORT_RECORDER} from '../../imports';
 import {InjectableClassRegistry} from '../../metadata';
-import {TypeScriptReflectionHost, isNamedClassDeclaration} from '../../reflection';
+import {isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';
 import {InjectableDecoratorHandler} from '../src/injectable';
 
@@ -31,7 +31,7 @@ runInEachFileSystem(() => {
              const diag = err.toDiagnostic();
              expect(diag.code).toEqual(ngErrorCode(ErrorCode.INJECTABLE_DUPLICATE_PROV));
              expect(diag.file.fileName.endsWith('entry.ts')).toBe(true);
-             expect(diag.start).toBe(ɵprov.nameNode !.getStart());
+             expect(diag.start).toBe(ɵprov.nameNode!.getStart());
            }
          });
 
@@ -43,7 +43,6 @@ runInEachFileSystem(() => {
            expect(res).not.toContain(jasmine.objectContaining({name: 'ɵprov'}));
          });
     });
-
   });
 });
 

--- a/packages/compiler-cli/src/ngtsc/annotations/test/metadata_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/metadata_spec.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
+
 import {absoluteFrom, getSourceFileOrError} from '../../file_system';
-import {TestFile, runInEachFileSystem} from '../../file_system/testing';
+import {runInEachFileSystem, TestFile} from '../../file_system/testing';
 import {NOOP_DEFAULT_IMPORT_RECORDER, NoopImportRewriter} from '../../imports';
 import {TypeScriptReflectionHost} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';

--- a/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
@@ -14,7 +14,7 @@ import {runInEachFileSystem} from '../../file_system/testing';
 import {LocalIdentifierStrategy, NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../imports';
 import {CompoundMetadataReader, DtsMetadataReader, InjectableClassRegistry, LocalMetadataRegistry} from '../../metadata';
 import {PartialEvaluator} from '../../partial_evaluator';
-import {TypeScriptReflectionHost, isNamedClassDeclaration} from '../../reflection';
+import {isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../scope';
 import {getDeclaration, makeProgram} from '../../testing';
 import {NgModuleDecoratorHandler} from '../src/ng_module';
@@ -79,7 +79,7 @@ runInEachFileSystem(() => {
       if (detected === undefined) {
         return fail('Failed to recognize @NgModule');
       }
-      const moduleDef = handler.analyze(TestModule, detected.metadata).analysis !.mod;
+      const moduleDef = handler.analyze(TestModule, detected.metadata).analysis!.mod;
 
       expect(getReferenceIdentifierTexts(moduleDef.declarations)).toEqual(['TestComp']);
       expect(getReferenceIdentifierTexts(moduleDef.exports)).toEqual(['TestComp']);

--- a/packages/compiler-cli/src/ngtsc/annotations/test/util_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/util_spec.ts
@@ -13,8 +13,9 @@ import {unwrapExpression} from '../src/util';
 describe('ngtsc annotation utilities', () => {
   describe('unwrapExpression', () => {
     const obj = ts.createObjectLiteral();
-    it('should pass through an ObjectLiteralExpression',
-       () => { expect(unwrapExpression(obj)).toBe(obj); });
+    it('should pass through an ObjectLiteralExpression', () => {
+      expect(unwrapExpression(obj)).toBe(obj);
+    });
 
     it('should unwrap an ObjectLiteralExpression in parentheses', () => {
       const wrapped = ts.createParen(obj);

--- a/packages/compiler-cli/src/ngtsc/core/api/src/interfaces.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/interfaces.ts
@@ -56,7 +56,7 @@ export interface ResourceHost {
  * core interface.
  */
 export interface ExtendedTsCompilerHost extends ts.CompilerHost, Partial<ResourceHost>,
-    Partial<UnifiedModulesHost> {}
+                                                Partial<UnifiedModulesHost> {}
 
 export interface LazyRoute {
   route: string;

--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -36,7 +36,8 @@ export interface TestOnlyOptions {
    */
   ivyTemplateTypeCheck?: boolean;
 
-  /** An option to enable ngtsc's internal performance tracing.
+  /**
+   * An option to enable ngtsc's internal performance tracing.
    *
    * This should be a path to a JSON file where trace information will be written. An optional 'ts:'
    * prefix will cause the trace to be written via the TS host instead of directly to the filesystem
@@ -54,4 +55,5 @@ export interface TestOnlyOptions {
  * Also includes a few miscellaneous options.
  */
 export interface NgCompilerOptions extends ts.CompilerOptions, LegacyNgcOptions, BazelAndG3Options,
-    NgcCompatibilityOptions, StrictTemplateOptions, TestOnlyOptions, I18nOptions, MiscOptions {}
+                                           NgcCompatibilityOptions, StrictTemplateOptions,
+                                           TestOnlyOptions, I18nOptions, MiscOptions {}

--- a/packages/compiler-cli/src/ngtsc/core/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/host.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 
 import {ErrorCode, ngErrorCode} from '../../diagnostics';
-import {FlatIndexGenerator, findFlatIndexEntryPoint} from '../../entry_point';
+import {findFlatIndexEntryPoint, FlatIndexGenerator} from '../../entry_point';
 import {AbsoluteFsPath, resolve} from '../../file_system';
 import {FactoryGenerator, FactoryTracker, ShimGenerator, SummaryGenerator, TypeCheckShimGenerator} from '../../shims';
 import {typeCheckFilePath} from '../../typecheck';
@@ -88,8 +88,7 @@ export class DelegatingCompilerHost implements
  * `ExtendedTsCompilerHost` methods whenever present.
  */
 export class NgCompilerHost extends DelegatingCompilerHost implements
-    RequiredCompilerHostDelegations,
-    ExtendedTsCompilerHost {
+    RequiredCompilerHostDelegations, ExtendedTsCompilerHost {
   readonly factoryTracker: FactoryTracker|null = null;
   readonly entryPoint: AbsoluteFsPath|null = null;
   readonly diagnostics: ts.Diagnostic[];

--- a/packages/compiler-cli/src/ngtsc/core/test/compiler_test.ts
+++ b/packages/compiler-cli/src/ngtsc/core/test/compiler_test.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {FileSystem, NgtscCompilerHost, absoluteFrom as _, getFileSystem, getSourceFileOrError, setFileSystem} from '../../file_system';
+import {absoluteFrom as _, FileSystem, getFileSystem, getSourceFileOrError, NgtscCompilerHost, setFileSystem} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {NgCompilerOptions} from '../api';
 import {NgCompiler} from '../src/compiler';
@@ -16,7 +16,6 @@ import {NgCompilerHost} from '../src/host';
 
 
 runInEachFileSystem(() => {
-
   describe('NgCompiler', () => {
     let fs: FileSystem;
 

--- a/packages/compiler-cli/src/ngtsc/cycles/src/imports.ts
+++ b/packages/compiler-cli/src/ngtsc/cycles/src/imports.ts
@@ -30,7 +30,7 @@ export class ImportGraph {
     if (!this.map.has(sf)) {
       this.map.set(sf, this.scanImports(sf));
     }
-    return this.map.get(sf) !;
+    return this.map.get(sf)!;
   }
 
   /**
@@ -47,7 +47,9 @@ export class ImportGraph {
       return;
     }
     results.add(sf);
-    this.importsOf(sf).forEach(imported => { this.transitiveImportsOfHelper(imported, results); });
+    this.importsOf(sf).forEach(imported => {
+      this.transitiveImportsOfHelper(imported, results);
+    });
   }
 
   /**

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error.ts
@@ -33,7 +33,8 @@ export function makeDiagnostic(code: ErrorCode, node: ts.Node, messageText: stri
     code: Number('-99' + code.valueOf()),
     file: ts.getOriginalNode(node).getSourceFile(),
     start: node.getStart(undefined, false),
-    length: node.getWidth(), messageText,
+    length: node.getWidth(),
+    messageText,
   };
   if (relatedInfo !== undefined) {
     diag.relatedInformation = relatedInfo.map(info => {

--- a/packages/compiler-cli/src/ngtsc/entry_point/src/generator.ts
+++ b/packages/compiler-cli/src/ngtsc/entry_point/src/generator.ts
@@ -24,7 +24,9 @@ export class FlatIndexGenerator implements ShimGenerator {
         join(dirname(entryPoint), relativeFlatIndexPath).replace(/\.js$/, '') + '.ts';
   }
 
-  recognize(fileName: string): boolean { return fileName === this.flatIndexPath; }
+  recognize(fileName: string): boolean {
+    return fileName === this.flatIndexPath;
+  }
 
   generate(): ts.SourceFile {
     const relativeEntryPoint = relativePathBetween(this.flatIndexPath, this.entryPoint);

--- a/packages/compiler-cli/src/ngtsc/entry_point/src/private_export_checker.ts
+++ b/packages/compiler-cli/src/ngtsc/entry_point/src/private_export_checker.ts
@@ -95,9 +95,11 @@ export function checkForPrivateExports(
         const diagnostic: ts.Diagnostic = {
           category: ts.DiagnosticCategory.Error,
           code: ngErrorCode(ErrorCode.SYMBOL_NOT_EXPORTED),
-          file: transitiveReference.getSourceFile(), ...getPosOfDeclaration(transitiveReference),
-          messageText:
-              `Unsupported private ${descriptor} ${name}. This ${descriptor} is visible to consumers via ${visibleVia}, but is not exported from the top-level library entrypoint.`,
+          file: transitiveReference.getSourceFile(),
+          ...getPosOfDeclaration(transitiveReference),
+          messageText: `Unsupported private ${descriptor} ${name}. This ${
+              descriptor} is visible to consumers via ${
+              visibleVia}, but is not exported from the top-level library entrypoint.`,
         };
 
         diagnostics.push(diagnostic);

--- a/packages/compiler-cli/src/ngtsc/entry_point/src/reference_graph.ts
+++ b/packages/compiler-cli/src/ngtsc/entry_point/src/reference_graph.ts
@@ -15,7 +15,7 @@ export class ReferenceGraph<T = ts.Declaration> {
     if (!this.references.has(from)) {
       this.references.set(from, new Set());
     }
-    this.references.get(from) !.add(to);
+    this.references.get(from)!.add(to);
   }
 
   transitiveReferencesOf(target: T): Set<T> {
@@ -47,7 +47,7 @@ export class ReferenceGraph<T = ts.Declaration> {
       // Look through the outgoing edges of `source`.
       // TODO(alxhub): use proper iteration when the legacy build is removed. (#27762)
       let candidatePath: T[]|null = null;
-      this.references.get(source) !.forEach(edge => {
+      this.references.get(source)!.forEach(edge => {
         // Early exit if a path has already been found.
         if (candidatePath !== null) {
           return;
@@ -67,7 +67,7 @@ export class ReferenceGraph<T = ts.Declaration> {
   private collectTransitiveReferences(set: Set<T>, decl: T): void {
     if (this.references.has(decl)) {
       // TODO(alxhub): use proper iteration when the legacy build is removed. (#27762)
-      this.references.get(decl) !.forEach(ref => {
+      this.references.get(decl)!.forEach(ref => {
         if (!set.has(ref)) {
           set.add(ref);
           this.collectTransitiveReferences(set, ref);

--- a/packages/compiler-cli/src/ngtsc/entry_point/test/entry_point_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/entry_point/test/entry_point_spec.ts
@@ -16,9 +16,9 @@ runInEachFileSystem(() => {
     beforeEach(() => _ = absoluteFrom);
 
     describe('findFlatIndexEntryPoint', () => {
-
-      it('should use the only source file if only a single one is specified',
-         () => { expect(findFlatIndexEntryPoint([_('/src/index.ts')])).toBe(_('/src/index.ts')); });
+      it('should use the only source file if only a single one is specified', () => {
+        expect(findFlatIndexEntryPoint([_('/src/index.ts')])).toBe(_('/src/index.ts'));
+      });
 
       it('should use the shortest source file ending with "index.ts" for multiple files', () => {
         expect(findFlatIndexEntryPoint([

--- a/packages/compiler-cli/src/ngtsc/entry_point/test/reference_graph_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/entry_point/test/reference_graph_spec.ts
@@ -12,8 +12,9 @@ import {ReferenceGraph} from '../src/reference_graph';
 describe('entry_point reference graph', () => {
   let graph: ReferenceGraph<string>;
 
-  const refs =
-      (target: string) => { return Array.from(graph.transitiveReferencesOf(target)).sort(); };
+  const refs = (target: string) => {
+    return Array.from(graph.transitiveReferencesOf(target)).sort();
+  };
 
   beforeEach(() => {
     graph = new ReferenceGraph();
@@ -45,6 +46,7 @@ describe('entry_point reference graph', () => {
     expect(graph.pathFrom('beta', 'alpha')).toEqual(['beta', 'delta', 'alpha']);
   });
 
-  it('should not report a path that doesn\'t exist',
-     () => { expect(graph.pathFrom('gamma', 'beta')).toBeNull(); });
+  it('should not report a path that doesn\'t exist', () => {
+    expect(graph.pathFrom('gamma', 'beta')).toBeNull();
+  });
 });

--- a/packages/compiler-cli/src/ngtsc/file_system/src/cached_file_system.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/cached_file_system.ts
@@ -25,7 +25,7 @@ export class CachedFileSystem implements FileSystem {
     if (!this.existsCache.has(path)) {
       this.existsCache.set(path, this.delegate.exists(path));
     }
-    return this.existsCache.get(path) !;
+    return this.existsCache.get(path)!;
   }
 
   invalidateCaches(path: AbsoluteFsPath) {
@@ -131,15 +131,33 @@ export class CachedFileSystem implements FileSystem {
   }
 
   // The following methods simply call through to the delegate.
-  readdir(path: AbsoluteFsPath): PathSegment[] { return this.delegate.readdir(path); }
-  pwd(): AbsoluteFsPath { return this.delegate.pwd(); }
-  chdir(path: AbsoluteFsPath): void { this.delegate.chdir(path); }
-  extname(path: AbsoluteFsPath|PathSegment): string { return this.delegate.extname(path); }
-  isCaseSensitive(): boolean { return this.delegate.isCaseSensitive(); }
-  isRoot(path: AbsoluteFsPath): boolean { return this.delegate.isRoot(path); }
-  isRooted(path: string): boolean { return this.delegate.isRooted(path); }
-  resolve(...paths: string[]): AbsoluteFsPath { return this.delegate.resolve(...paths); }
-  dirname<T extends PathString>(file: T): T { return this.delegate.dirname(file); }
+  readdir(path: AbsoluteFsPath): PathSegment[] {
+    return this.delegate.readdir(path);
+  }
+  pwd(): AbsoluteFsPath {
+    return this.delegate.pwd();
+  }
+  chdir(path: AbsoluteFsPath): void {
+    this.delegate.chdir(path);
+  }
+  extname(path: AbsoluteFsPath|PathSegment): string {
+    return this.delegate.extname(path);
+  }
+  isCaseSensitive(): boolean {
+    return this.delegate.isCaseSensitive();
+  }
+  isRoot(path: AbsoluteFsPath): boolean {
+    return this.delegate.isRoot(path);
+  }
+  isRooted(path: string): boolean {
+    return this.delegate.isRooted(path);
+  }
+  resolve(...paths: string[]): AbsoluteFsPath {
+    return this.delegate.resolve(...paths);
+  }
+  dirname<T extends PathString>(file: T): T {
+    return this.delegate.dirname(file);
+  }
   join<T extends PathString>(basePath: T, ...paths: string[]): T {
     return this.delegate.join(basePath, ...paths);
   }
@@ -149,7 +167,13 @@ export class CachedFileSystem implements FileSystem {
   basename(filePath: string, extension?: string|undefined): PathSegment {
     return this.delegate.basename(filePath, extension);
   }
-  realpath(filePath: AbsoluteFsPath): AbsoluteFsPath { return this.delegate.realpath(filePath); }
-  getDefaultLibLocation(): AbsoluteFsPath { return this.delegate.getDefaultLibLocation(); }
-  normalize<T extends PathString>(path: T): T { return this.delegate.normalize(path); }
+  realpath(filePath: AbsoluteFsPath): AbsoluteFsPath {
+    return this.delegate.realpath(filePath);
+  }
+  getDefaultLibLocation(): AbsoluteFsPath {
+    return this.delegate.getDefaultLibLocation();
+  }
+  normalize<T extends PathString>(path: T): T {
+    return this.delegate.normalize(path);
+  }
 }

--- a/packages/compiler-cli/src/ngtsc/file_system/src/compiler_host.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/compiler_host.ts
@@ -26,7 +26,9 @@ export class NgtscCompilerHost implements ts.CompilerHost {
     return this.fs.join(this.getDefaultLibLocation(), ts.getDefaultLibFileName(options));
   }
 
-  getDefaultLibLocation(): string { return this.fs.getDefaultLibLocation(); }
+  getDefaultLibLocation(): string {
+    return this.fs.getDefaultLibLocation();
+  }
 
   writeFile(
       fileName: string, data: string, writeByteOrderMark: boolean,
@@ -37,13 +39,17 @@ export class NgtscCompilerHost implements ts.CompilerHost {
     this.fs.writeFile(path, data);
   }
 
-  getCurrentDirectory(): string { return this.fs.pwd(); }
+  getCurrentDirectory(): string {
+    return this.fs.pwd();
+  }
 
   getCanonicalFileName(fileName: string): string {
     return this.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase();
   }
 
-  useCaseSensitiveFileNames(): boolean { return this.fs.isCaseSensitive(); }
+  useCaseSensitiveFileNames(): boolean {
+    return this.fs.isCaseSensitive();
+  }
 
   getNewLine(): string {
     switch (this.options.newLine) {

--- a/packages/compiler-cli/src/ngtsc/file_system/src/invalid_file_system.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/invalid_file_system.ts
@@ -16,32 +16,84 @@ import {AbsoluteFsPath, FileStats, FileSystem, PathSegment, PathString} from './
  * the `FileSystem` under the hood.
  */
 export class InvalidFileSystem implements FileSystem {
-  exists(path: AbsoluteFsPath): boolean { throw makeError(); }
-  readFile(path: AbsoluteFsPath): string { throw makeError(); }
-  writeFile(path: AbsoluteFsPath, data: string, exclusive?: boolean): void { throw makeError(); }
-  removeFile(path: AbsoluteFsPath): void { throw makeError(); }
-  symlink(target: AbsoluteFsPath, path: AbsoluteFsPath): void { throw makeError(); }
-  readdir(path: AbsoluteFsPath): PathSegment[] { throw makeError(); }
-  lstat(path: AbsoluteFsPath): FileStats { throw makeError(); }
-  stat(path: AbsoluteFsPath): FileStats { throw makeError(); }
-  pwd(): AbsoluteFsPath { throw makeError(); }
-  chdir(path: AbsoluteFsPath): void { throw makeError(); }
-  extname(path: AbsoluteFsPath|PathSegment): string { throw makeError(); }
-  copyFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void { throw makeError(); }
-  moveFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void { throw makeError(); }
-  ensureDir(path: AbsoluteFsPath): void { throw makeError(); }
-  removeDeep(path: AbsoluteFsPath): void { throw makeError(); }
-  isCaseSensitive(): boolean { throw makeError(); }
-  resolve(...paths: string[]): AbsoluteFsPath { throw makeError(); }
-  dirname<T extends PathString>(file: T): T { throw makeError(); }
-  join<T extends PathString>(basePath: T, ...paths: string[]): T { throw makeError(); }
-  isRoot(path: AbsoluteFsPath): boolean { throw makeError(); }
-  isRooted(path: string): boolean { throw makeError(); }
-  relative<T extends PathString>(from: T, to: T): PathSegment { throw makeError(); }
-  basename(filePath: string, extension?: string): PathSegment { throw makeError(); }
-  realpath(filePath: AbsoluteFsPath): AbsoluteFsPath { throw makeError(); }
-  getDefaultLibLocation(): AbsoluteFsPath { throw makeError(); }
-  normalize<T extends PathString>(path: T): T { throw makeError(); }
+  exists(path: AbsoluteFsPath): boolean {
+    throw makeError();
+  }
+  readFile(path: AbsoluteFsPath): string {
+    throw makeError();
+  }
+  writeFile(path: AbsoluteFsPath, data: string, exclusive?: boolean): void {
+    throw makeError();
+  }
+  removeFile(path: AbsoluteFsPath): void {
+    throw makeError();
+  }
+  symlink(target: AbsoluteFsPath, path: AbsoluteFsPath): void {
+    throw makeError();
+  }
+  readdir(path: AbsoluteFsPath): PathSegment[] {
+    throw makeError();
+  }
+  lstat(path: AbsoluteFsPath): FileStats {
+    throw makeError();
+  }
+  stat(path: AbsoluteFsPath): FileStats {
+    throw makeError();
+  }
+  pwd(): AbsoluteFsPath {
+    throw makeError();
+  }
+  chdir(path: AbsoluteFsPath): void {
+    throw makeError();
+  }
+  extname(path: AbsoluteFsPath|PathSegment): string {
+    throw makeError();
+  }
+  copyFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void {
+    throw makeError();
+  }
+  moveFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void {
+    throw makeError();
+  }
+  ensureDir(path: AbsoluteFsPath): void {
+    throw makeError();
+  }
+  removeDeep(path: AbsoluteFsPath): void {
+    throw makeError();
+  }
+  isCaseSensitive(): boolean {
+    throw makeError();
+  }
+  resolve(...paths: string[]): AbsoluteFsPath {
+    throw makeError();
+  }
+  dirname<T extends PathString>(file: T): T {
+    throw makeError();
+  }
+  join<T extends PathString>(basePath: T, ...paths: string[]): T {
+    throw makeError();
+  }
+  isRoot(path: AbsoluteFsPath): boolean {
+    throw makeError();
+  }
+  isRooted(path: string): boolean {
+    throw makeError();
+  }
+  relative<T extends PathString>(from: T, to: T): PathSegment {
+    throw makeError();
+  }
+  basename(filePath: string, extension?: string): PathSegment {
+    throw makeError();
+  }
+  realpath(filePath: AbsoluteFsPath): AbsoluteFsPath {
+    throw makeError();
+  }
+  getDefaultLibLocation(): AbsoluteFsPath {
+    throw makeError();
+  }
+  normalize<T extends PathString>(path: T): T {
+    throw makeError();
+  }
 }
 
 function makeError() {

--- a/packages/compiler-cli/src/ngtsc/file_system/src/logical.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/logical.ts
@@ -91,7 +91,7 @@ export class LogicalFileSystem {
       }
       this.cache.set(physicalFile, logicalFile);
     }
-    return this.cache.get(physicalFile) !;
+    return this.cache.get(physicalFile)!;
   }
 
   private createLogicalProjectPath(file: AbsoluteFsPath, rootDir: AbsoluteFsPath):

--- a/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
@@ -17,20 +17,42 @@ import {AbsoluteFsPath, FileStats, FileSystem, PathSegment, PathString} from './
  */
 export class NodeJSFileSystem implements FileSystem {
   private _caseSensitive: boolean|undefined = undefined;
-  exists(path: AbsoluteFsPath): boolean { return fs.existsSync(path); }
-  readFile(path: AbsoluteFsPath): string { return fs.readFileSync(path, 'utf8'); }
+  exists(path: AbsoluteFsPath): boolean {
+    return fs.existsSync(path);
+  }
+  readFile(path: AbsoluteFsPath): string {
+    return fs.readFileSync(path, 'utf8');
+  }
   writeFile(path: AbsoluteFsPath, data: string, exclusive: boolean = false): void {
     fs.writeFileSync(path, data, exclusive ? {flag: 'wx'} : undefined);
   }
-  removeFile(path: AbsoluteFsPath): void { fs.unlinkSync(path); }
-  symlink(target: AbsoluteFsPath, path: AbsoluteFsPath): void { fs.symlinkSync(target, path); }
-  readdir(path: AbsoluteFsPath): PathSegment[] { return fs.readdirSync(path) as PathSegment[]; }
-  lstat(path: AbsoluteFsPath): FileStats { return fs.lstatSync(path); }
-  stat(path: AbsoluteFsPath): FileStats { return fs.statSync(path); }
-  pwd(): AbsoluteFsPath { return this.normalize(process.cwd()) as AbsoluteFsPath; }
-  chdir(dir: AbsoluteFsPath): void { process.chdir(dir); }
-  copyFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void { fs.copyFileSync(from, to); }
-  moveFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void { fs.renameSync(from, to); }
+  removeFile(path: AbsoluteFsPath): void {
+    fs.unlinkSync(path);
+  }
+  symlink(target: AbsoluteFsPath, path: AbsoluteFsPath): void {
+    fs.symlinkSync(target, path);
+  }
+  readdir(path: AbsoluteFsPath): PathSegment[] {
+    return fs.readdirSync(path) as PathSegment[];
+  }
+  lstat(path: AbsoluteFsPath): FileStats {
+    return fs.lstatSync(path);
+  }
+  stat(path: AbsoluteFsPath): FileStats {
+    return fs.statSync(path);
+  }
+  pwd(): AbsoluteFsPath {
+    return this.normalize(process.cwd()) as AbsoluteFsPath;
+  }
+  chdir(dir: AbsoluteFsPath): void {
+    process.chdir(dir);
+  }
+  copyFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void {
+    fs.copyFileSync(from, to);
+  }
+  moveFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void {
+    fs.renameSync(from, to);
+  }
   ensureDir(path: AbsoluteFsPath): void {
     const parents: AbsoluteFsPath[] = [];
     while (!this.isRoot(path) && !this.exists(path)) {
@@ -38,10 +60,12 @@ export class NodeJSFileSystem implements FileSystem {
       path = this.dirname(path);
     }
     while (parents.length) {
-      this.safeMkdir(parents.pop() !);
+      this.safeMkdir(parents.pop()!);
     }
   }
-  removeDeep(path: AbsoluteFsPath): void { fsExtra.removeSync(path); }
+  removeDeep(path: AbsoluteFsPath): void {
+    fsExtra.removeSync(path);
+  }
   isCaseSensitive(): boolean {
     if (this._caseSensitive === undefined) {
       this._caseSensitive = this.exists(togglePathCase(__filename));
@@ -52,20 +76,30 @@ export class NodeJSFileSystem implements FileSystem {
     return this.normalize(p.resolve(...paths)) as AbsoluteFsPath;
   }
 
-  dirname<T extends string>(file: T): T { return this.normalize(p.dirname(file)) as T; }
+  dirname<T extends string>(file: T): T {
+    return this.normalize(p.dirname(file)) as T;
+  }
   join<T extends string>(basePath: T, ...paths: string[]): T {
     return this.normalize(p.join(basePath, ...paths)) as T;
   }
-  isRoot(path: AbsoluteFsPath): boolean { return this.dirname(path) === this.normalize(path); }
-  isRooted(path: string): boolean { return p.isAbsolute(path); }
+  isRoot(path: AbsoluteFsPath): boolean {
+    return this.dirname(path) === this.normalize(path);
+  }
+  isRooted(path: string): boolean {
+    return p.isAbsolute(path);
+  }
   relative<T extends PathString>(from: T, to: T): PathSegment {
     return relativeFrom(this.normalize(p.relative(from, to)));
   }
   basename(filePath: string, extension?: string): PathSegment {
     return p.basename(filePath, extension) as PathSegment;
   }
-  extname(path: AbsoluteFsPath|PathSegment): string { return p.extname(path); }
-  realpath(path: AbsoluteFsPath): AbsoluteFsPath { return this.resolve(fs.realpathSync(path)); }
+  extname(path: AbsoluteFsPath|PathSegment): string {
+    return p.extname(path);
+  }
+  realpath(path: AbsoluteFsPath): AbsoluteFsPath {
+    return this.resolve(fs.realpathSync(path));
+  }
   getDefaultLibLocation(): AbsoluteFsPath {
     return this.resolve(require.resolve('typescript'), '..');
   }

--- a/packages/compiler-cli/src/ngtsc/file_system/src/types.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/types.ts
@@ -12,7 +12,7 @@
  * A `string` is not assignable to a `BrandedPath`, but a `BrandedPath` is assignable to a `string`.
  * Two `BrandedPath`s with different brands are not mutually assignable.
  */
-export type BrandedPath<B extends string> = string & {
+export type BrandedPath<B extends string> = string&{
   _brand: B;
 };
 
@@ -63,7 +63,7 @@ export interface FileSystem {
   normalize<T extends PathString>(path: T): T;
 }
 
-export type PathString = string | AbsoluteFsPath | PathSegment;
+export type PathString = string|AbsoluteFsPath|PathSegment;
 
 /**
  * Information about an object in the FileSystem.

--- a/packages/compiler-cli/src/ngtsc/file_system/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/util.ts
@@ -28,8 +28,8 @@ export function stripExtension(path: string): string {
 export function getSourceFileOrError(program: ts.Program, fileName: AbsoluteFsPath): ts.SourceFile {
   const sf = program.getSourceFile(fileName);
   if (sf === undefined) {
-    throw new Error(
-        `Program does not contain "${fileName}" - available files are ${program.getSourceFiles().map(sf => sf.fileName).join(', ')}`);
+    throw new Error(`Program does not contain "${fileName}" - available files are ${
+        program.getSourceFiles().map(sf => sf.fileName).join(', ')}`);
   }
   return sf;
 }

--- a/packages/compiler-cli/src/ngtsc/file_system/test/helpers_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/test/helpers_spec.ts
@@ -11,37 +11,49 @@ import {absoluteFrom, relativeFrom, setFileSystem} from '../src/helpers';
 import {NodeJSFileSystem} from '../src/node_js_file_system';
 
 describe('path types', () => {
-  beforeEach(() => { setFileSystem(new NodeJSFileSystem()); });
+  beforeEach(() => {
+    setFileSystem(new NodeJSFileSystem());
+  });
 
   describe('absoluteFrom', () => {
-    it('should not throw when creating one from an absolute path',
-       () => { expect(() => absoluteFrom('/test.txt')).not.toThrow(); });
+    it('should not throw when creating one from an absolute path', () => {
+      expect(() => absoluteFrom('/test.txt')).not.toThrow();
+    });
 
     if (os.platform() === 'win32') {
-      it('should not throw when creating one from a windows absolute path',
-         () => { expect(absoluteFrom('C:\\test.txt')).toEqual('C:/test.txt'); });
+      it('should not throw when creating one from a windows absolute path', () => {
+        expect(absoluteFrom('C:\\test.txt')).toEqual('C:/test.txt');
+      });
       it('should not throw when creating one from a windows absolute path with POSIX separators',
-         () => { expect(absoluteFrom('C:/test.txt')).toEqual('C:/test.txt'); });
-      it('should support windows drive letters',
-         () => { expect(absoluteFrom('D:\\foo\\test.txt')).toEqual('D:/foo/test.txt'); });
-      it('should convert Windows path separators to POSIX separators',
-         () => { expect(absoluteFrom('C:\\foo\\test.txt')).toEqual('C:/foo/test.txt'); });
+         () => {
+           expect(absoluteFrom('C:/test.txt')).toEqual('C:/test.txt');
+         });
+      it('should support windows drive letters', () => {
+        expect(absoluteFrom('D:\\foo\\test.txt')).toEqual('D:/foo/test.txt');
+      });
+      it('should convert Windows path separators to POSIX separators', () => {
+        expect(absoluteFrom('C:\\foo\\test.txt')).toEqual('C:/foo/test.txt');
+      });
     }
 
-    it('should throw when creating one from a non-absolute path',
-       () => { expect(() => absoluteFrom('test.txt')).toThrow(); });
+    it('should throw when creating one from a non-absolute path', () => {
+      expect(() => absoluteFrom('test.txt')).toThrow();
+    });
   });
 
   describe('relativeFrom', () => {
-    it('should not throw when creating one from a relative path',
-       () => { expect(() => relativeFrom('a/b/c.txt')).not.toThrow(); });
+    it('should not throw when creating one from a relative path', () => {
+      expect(() => relativeFrom('a/b/c.txt')).not.toThrow();
+    });
 
-    it('should throw when creating one from an absolute path',
-       () => { expect(() => relativeFrom('/a/b/c.txt')).toThrow(); });
+    it('should throw when creating one from an absolute path', () => {
+      expect(() => relativeFrom('/a/b/c.txt')).toThrow();
+    });
 
     if (os.platform() === 'win32') {
-      it('should throw when creating one from a Windows absolute path',
-         () => { expect(() => relativeFrom('C:/a/b/c.txt')).toThrow(); });
+      it('should throw when creating one from a Windows absolute path', () => {
+        expect(() => relativeFrom('C:/a/b/c.txt')).toThrow();
+      });
     }
   });
 });

--- a/packages/compiler-cli/src/ngtsc/file_system/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/testing/index.ts
@@ -10,4 +10,4 @@ export {Folder, MockFileSystem} from './src/mock_file_system';
 export {MockFileSystemNative} from './src/mock_file_system_native';
 export {MockFileSystemPosix} from './src/mock_file_system_posix';
 export {MockFileSystemWindows} from './src/mock_file_system_windows';
-export {TestFile, initMockFileSystem, runInEachFileSystem} from './src/test_helper';
+export {initMockFileSystem, runInEachFileSystem, TestFile} from './src/test_helper';

--- a/packages/compiler-cli/src/ngtsc/file_system/testing/src/mock_file_system.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/testing/src/mock_file_system.ts
@@ -21,9 +21,13 @@ export abstract class MockFileSystem implements FileSystem {
     this._cwd = this.normalize(cwd);
   }
 
-  isCaseSensitive() { return this._isCaseSensitive; }
+  isCaseSensitive() {
+    return this._isCaseSensitive;
+  }
 
-  exists(path: AbsoluteFsPath): boolean { return this.findFromPath(path).entity !== null; }
+  exists(path: AbsoluteFsPath): boolean {
+    return this.findFromPath(path).entity !== null;
+  }
 
   readFile(path: AbsoluteFsPath): string {
     const {entity} = this.findFromPath(path);
@@ -142,7 +146,9 @@ export abstract class MockFileSystem implements FileSystem {
     delete entity[basename];
   }
 
-  isRoot(path: AbsoluteFsPath): boolean { return this.dirname(path) === path; }
+  isRoot(path: AbsoluteFsPath): boolean {
+    return this.dirname(path) === path;
+  }
 
   extname(path: AbsoluteFsPath|PathSegment): string {
     const match = /.+(\.[^.]*)$/.exec(path);
@@ -159,9 +165,13 @@ export abstract class MockFileSystem implements FileSystem {
     }
   }
 
-  pwd(): AbsoluteFsPath { return this._cwd; }
+  pwd(): AbsoluteFsPath {
+    return this._cwd;
+  }
 
-  chdir(path: AbsoluteFsPath): void { this._cwd = this.normalize(path); }
+  chdir(path: AbsoluteFsPath): void {
+    this._cwd = this.normalize(path);
+  }
 
   getDefaultLibLocation(): AbsoluteFsPath {
     // Mimic the node module resolution algorithm and start in the current directory, then look
@@ -201,8 +211,12 @@ export abstract class MockFileSystem implements FileSystem {
   abstract normalize<T extends PathString>(path: T): T;
   protected abstract splitPath<T extends PathString>(path: T): string[];
 
-  dump(): Folder { return cloneFolder(this._fileTree); }
-  init(folder: Folder): void { this._fileTree = cloneFolder(folder); }
+  dump(): Folder {
+    return cloneFolder(this._fileTree);
+  }
+  init(folder: Folder): void {
+    this._fileTree = cloneFolder(folder);
+  }
 
   protected findFromPath(path: AbsoluteFsPath, options?: {followSymLinks: boolean}): FindResult {
     const followSymLinks = !!options && options.followSymLinks;
@@ -215,7 +229,7 @@ export abstract class MockFileSystem implements FileSystem {
     segments[0] = '';
     let current: Entity|null = this._fileTree;
     while (segments.length) {
-      current = current[segments.shift() !];
+      current = current[segments.shift()!];
       if (current === undefined) {
         return {path, entity: null};
       }
@@ -239,7 +253,7 @@ export abstract class MockFileSystem implements FileSystem {
 
   protected splitIntoFolderAndFile(path: AbsoluteFsPath): [AbsoluteFsPath, string] {
     const segments = this.splitPath(path);
-    const file = segments.pop() !;
+    const file = segments.pop()!;
     return [path.substring(0, path.length - file.length - 1) as AbsoluteFsPath, file];
   }
 }
@@ -247,8 +261,10 @@ export interface FindResult {
   path: AbsoluteFsPath;
   entity: Entity|null;
 }
-export type Entity = Folder | File | SymLink;
-export interface Folder { [pathSegments: string]: Entity; }
+export type Entity = Folder|File|SymLink;
+export interface Folder {
+  [pathSegments: string]: Entity;
+}
 export type File = string;
 export class SymLink {
   constructor(public path: AbsoluteFsPath) {}
@@ -256,24 +272,32 @@ export class SymLink {
 
 class MockFileStats implements FileStats {
   constructor(private entity: Entity) {}
-  isFile(): boolean { return isFile(this.entity); }
-  isDirectory(): boolean { return isFolder(this.entity); }
-  isSymbolicLink(): boolean { return isSymLink(this.entity); }
+  isFile(): boolean {
+    return isFile(this.entity);
+  }
+  isDirectory(): boolean {
+    return isFolder(this.entity);
+  }
+  isSymbolicLink(): boolean {
+    return isSymLink(this.entity);
+  }
 }
 
 class MockFileSystemError extends Error {
-  constructor(public code: string, public path: string, message: string) { super(message); }
+  constructor(public code: string, public path: string, message: string) {
+    super(message);
+  }
 }
 
-export function isFile(item: Entity | null): item is File {
+export function isFile(item: Entity|null): item is File {
   return typeof item === 'string';
 }
 
-export function isSymLink(item: Entity | null): item is SymLink {
+export function isSymLink(item: Entity|null): item is SymLink {
   return item instanceof SymLink;
 }
 
-export function isFolder(item: Entity | null): item is Folder {
+export function isFolder(item: Entity|null): item is Folder {
   return item !== null && !isFile(item) && !isSymLink(item);
 }
 

--- a/packages/compiler-cli/src/ngtsc/file_system/testing/src/mock_file_system_native.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/testing/src/mock_file_system_native.ts
@@ -15,7 +15,9 @@ import {MockFileSystem} from './mock_file_system';
 const isWindows = os.platform() === 'win32';
 
 export class MockFileSystemNative extends MockFileSystem {
-  constructor(cwd: AbsoluteFsPath = '/' as AbsoluteFsPath) { super(undefined, cwd); }
+  constructor(cwd: AbsoluteFsPath = '/' as AbsoluteFsPath) {
+    super(undefined, cwd);
+  }
 
   // Delegate to the real NodeJSFileSystem for these path related methods
 
@@ -36,9 +38,13 @@ export class MockFileSystemNative extends MockFileSystem {
     return NodeJSFileSystem.prototype.basename.call(this, filePath, extension);
   }
 
-  isCaseSensitive() { return NodeJSFileSystem.prototype.isCaseSensitive.call(this); }
+  isCaseSensitive() {
+    return NodeJSFileSystem.prototype.isCaseSensitive.call(this);
+  }
 
-  isRooted(path: string): boolean { return NodeJSFileSystem.prototype.isRooted.call(this, path); }
+  isRooted(path: string): boolean {
+    return NodeJSFileSystem.prototype.isRooted.call(this, path);
+  }
 
   isRoot(path: AbsoluteFsPath): boolean {
     return NodeJSFileSystem.prototype.isRoot.call(this, path);
@@ -57,5 +63,7 @@ export class MockFileSystemNative extends MockFileSystem {
     return NodeJSFileSystem.prototype.normalize.call(this, path) as T;
   }
 
-  protected splitPath<T>(path: string): string[] { return path.split(/[\\\/]/); }
+  protected splitPath<T>(path: string): string[] {
+    return path.split(/[\\\/]/);
+  }
 }

--- a/packages/compiler-cli/src/ngtsc/file_system/testing/src/mock_file_system_posix.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/testing/src/mock_file_system_posix.ts
@@ -17,7 +17,9 @@ export class MockFileSystemPosix extends MockFileSystem {
     return this.normalize(resolved) as AbsoluteFsPath;
   }
 
-  dirname<T extends string>(file: T): T { return this.normalize(p.posix.dirname(file)) as T; }
+  dirname<T extends string>(file: T): T {
+    return this.normalize(p.posix.dirname(file)) as T;
+  }
 
   join<T extends string>(basePath: T, ...paths: string[]): T {
     return this.normalize(p.posix.join(basePath, ...paths)) as T;
@@ -31,9 +33,13 @@ export class MockFileSystemPosix extends MockFileSystem {
     return p.posix.basename(filePath, extension) as PathSegment;
   }
 
-  isRooted(path: string): boolean { return path.startsWith('/'); }
+  isRooted(path: string): boolean {
+    return path.startsWith('/');
+  }
 
-  protected splitPath<T extends PathString>(path: T): string[] { return path.split('/'); }
+  protected splitPath<T extends PathString>(path: T): string[] {
+    return path.split('/');
+  }
 
   normalize<T extends PathString>(path: T): T {
     return path.replace(/^[a-z]:\//i, '/').replace(/\\/g, '/') as T;

--- a/packages/compiler-cli/src/ngtsc/file_system/testing/src/mock_file_system_windows.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/testing/src/mock_file_system_windows.ts
@@ -17,7 +17,9 @@ export class MockFileSystemWindows extends MockFileSystem {
     return this.normalize(resolved as AbsoluteFsPath);
   }
 
-  dirname<T extends string>(path: T): T { return this.normalize(p.win32.dirname(path) as T); }
+  dirname<T extends string>(path: T): T {
+    return this.normalize(p.win32.dirname(path) as T);
+  }
 
   join<T extends string>(basePath: T, ...paths: string[]): T {
     return this.normalize(p.win32.join(basePath, ...paths)) as T;
@@ -31,9 +33,13 @@ export class MockFileSystemWindows extends MockFileSystem {
     return p.win32.basename(filePath, extension) as PathSegment;
   }
 
-  isRooted(path: string): boolean { return /^([A-Z]:)?([\\\/]|$)/i.test(path); }
+  isRooted(path: string): boolean {
+    return /^([A-Z]:)?([\\\/]|$)/i.test(path);
+  }
 
-  protected splitPath<T extends PathString>(path: T): string[] { return path.split(/[\\\/]/); }
+  protected splitPath<T extends PathString>(path: T): string[] {
+    return path.split(/[\\\/]/);
+  }
 
   normalize<T extends PathString>(path: T): T {
     return path.replace(/^[\/\\]/i, 'C:/').replace(/\\/g, '/') as T;

--- a/packages/compiler-cli/src/ngtsc/file_system/testing/src/test_helper.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/testing/src/test_helper.ts
@@ -47,7 +47,9 @@ function runInFileSystem(os: string, callback: (os: string) => void, error: bool
     afterEach(() => setFileSystem(new InvalidFileSystem()));
     callback(os);
     if (error) {
-      afterAll(() => { throw new Error(`runInFileSystem limited to ${os}, cannot pass`); });
+      afterAll(() => {
+        throw new Error(`runInFileSystem limited to ${os}, cannot pass`);
+      });
     }
   });
 }
@@ -125,14 +127,16 @@ function monkeyPatchTypeScript(os: string, fs: MockFileSystem) {
     return {files, directories};
   }
 
-  function realPath(path: string): string { return fs.realpath(fs.resolve(path)); }
+  function realPath(path: string): string {
+    return fs.realpath(fs.resolve(path));
+  }
 
   // Rather than completely re-implementing we are using the `ts.matchFiles` function,
   // which is internal to the `ts` namespace.
   const tsMatchFiles: (
-      path: string, extensions: ReadonlyArray<string>| undefined,
-      excludes: ReadonlyArray<string>| undefined, includes: ReadonlyArray<string>| undefined,
-      useCaseSensitiveFileNames: boolean, currentDirectory: string, depth: number | undefined,
+      path: string, extensions: ReadonlyArray<string>|undefined,
+      excludes: ReadonlyArray<string>|undefined, includes: ReadonlyArray<string>|undefined,
+      useCaseSensitiveFileNames: boolean, currentDirectory: string, depth: number|undefined,
       getFileSystemEntries: (path: string) => FileSystemEntries,
       realpath: (path: string) => string) => string[] = (ts as any).matchFiles;
 

--- a/packages/compiler-cli/src/ngtsc/imports/index.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {AliasStrategy, AliasingHost, PrivateExportAliasingHost, UnifiedModulesAliasingHost} from './src/alias';
+export {AliasingHost, AliasStrategy, PrivateExportAliasingHost, UnifiedModulesAliasingHost} from './src/alias';
 export {ImportRewriter, NoopImportRewriter, R3SymbolsImportRewriter, validateAndRewriteCoreSymbol} from './src/core';
 export {DefaultImportRecorder, DefaultImportTracker, NOOP_DEFAULT_IMPORT_RECORDER} from './src/default';
 export {AbsoluteModuleStrategy, ImportFlags, LocalIdentifierStrategy, LogicalProjectStrategy, ReferenceEmitStrategy, ReferenceEmitter, RelativePathStrategy, UnifiedModulesStrategy} from './src/emitter';

--- a/packages/compiler-cli/src/ngtsc/imports/src/alias.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/alias.ts
@@ -10,7 +10,7 @@ import {Expression, ExternalExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {UnifiedModulesHost} from '../../core/api';
-import {ClassDeclaration, ReflectionHost, isNamedClassDeclaration} from '../../reflection';
+import {ClassDeclaration, isNamedClassDeclaration, ReflectionHost} from '../../reflection';
 
 import {ImportFlags, ReferenceEmitStrategy} from './emitter';
 import {Reference} from './references';
@@ -203,7 +203,9 @@ export class PrivateExportAliasingHost implements AliasingHost {
    *
    * Thus, `getAliasIn` always returns `null`.
    */
-  getAliasIn(): null { return null; }
+  getAliasIn(): null {
+    return null;
+  }
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/imports/src/core.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/core.ts
@@ -36,11 +36,17 @@ export interface ImportRewriter {
  * `ImportRewriter` that does no rewriting.
  */
 export class NoopImportRewriter implements ImportRewriter {
-  shouldImportSymbol(symbol: string, specifier: string): boolean { return true; }
+  shouldImportSymbol(symbol: string, specifier: string): boolean {
+    return true;
+  }
 
-  rewriteSymbol(symbol: string, specifier: string): string { return symbol; }
+  rewriteSymbol(symbol: string, specifier: string): string {
+    return symbol;
+  }
 
-  rewriteSpecifier(specifier: string, inContextOfFile: string): string { return specifier; }
+  rewriteSpecifier(specifier: string, inContextOfFile: string): string {
+    return specifier;
+  }
 }
 
 /**
@@ -70,7 +76,9 @@ const CORE_MODULE = '@angular/core';
 export class R3SymbolsImportRewriter implements ImportRewriter {
   constructor(private r3SymbolsPath: string) {}
 
-  shouldImportSymbol(symbol: string, specifier: string): boolean { return true; }
+  shouldImportSymbol(symbol: string, specifier: string): boolean {
+    return true;
+  }
 
   rewriteSymbol(symbol: string, specifier: string): string {
     if (specifier !== CORE_MODULE) {
@@ -89,8 +97,8 @@ export class R3SymbolsImportRewriter implements ImportRewriter {
 
     const relativePathToR3Symbols = relativePathBetween(inContextOfFile, this.r3SymbolsPath);
     if (relativePathToR3Symbols === null) {
-      throw new Error(
-          `Failed to rewrite import inside ${CORE_MODULE}: ${inContextOfFile} -> ${this.r3SymbolsPath}`);
+      throw new Error(`Failed to rewrite import inside ${CORE_MODULE}: ${inContextOfFile} -> ${
+          this.r3SymbolsPath}`);
     }
 
     return relativePathToR3Symbols;
@@ -101,5 +109,5 @@ export function validateAndRewriteCoreSymbol(name: string): string {
   if (!CORE_SUPPORTED_SYMBOLS.has(name)) {
     throw new Error(`Importing unexpected symbol ${name} while compiling ${CORE_MODULE}`);
   }
-  return CORE_SUPPORTED_SYMBOLS.get(name) !;
+  return CORE_SUPPORTED_SYMBOLS.get(name)!;
 }

--- a/packages/compiler-cli/src/ngtsc/imports/src/default.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/default.ts
@@ -1,10 +1,10 @@
 /**
-* @license
-* Copyright Google Inc. All Rights Reserved.
-*
-* Use of this source code is governed by an MIT-style license that can be
-* found in the LICENSE file at https://angular.io/license
-*/
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 
 import * as ts from 'typescript';
 
@@ -96,7 +96,7 @@ export class DefaultImportTracker implements DefaultImportRecorder {
     if (!this.sourceFileToImportMap.has(sf)) {
       this.sourceFileToImportMap.set(sf, new Map<ts.Identifier, ts.ImportDeclaration>());
     }
-    this.sourceFileToImportMap.get(sf) !.set(id, decl);
+    this.sourceFileToImportMap.get(sf)!.set(id, decl);
   }
 
   recordUsedIdentifier(id: ts.Identifier): void {
@@ -105,18 +105,18 @@ export class DefaultImportTracker implements DefaultImportRecorder {
       // The identifier's source file has no registered default imports at all.
       return;
     }
-    const identiferToDeclaration = this.sourceFileToImportMap.get(sf) !;
+    const identiferToDeclaration = this.sourceFileToImportMap.get(sf)!;
     if (!identiferToDeclaration.has(id)) {
       // The identifier isn't from a registered default import.
       return;
     }
-    const decl = identiferToDeclaration.get(id) !;
+    const decl = identiferToDeclaration.get(id)!;
 
     // Add the default import declaration to the set of used import declarations for the file.
     if (!this.sourceFileToUsedImports.has(sf)) {
       this.sourceFileToUsedImports.set(sf, new Set<ts.ImportDeclaration>());
     }
-    this.sourceFileToUsedImports.get(sf) !.add(decl);
+    this.sourceFileToUsedImports.get(sf)!.add(decl);
   }
 
   /**
@@ -127,7 +127,9 @@ export class DefaultImportTracker implements DefaultImportRecorder {
    */
   importPreservingTransformer(): ts.TransformerFactory<ts.SourceFile> {
     return (context: ts.TransformationContext) => {
-      return (sf: ts.SourceFile) => { return this.transformSourceFile(sf); };
+      return (sf: ts.SourceFile) => {
+        return this.transformSourceFile(sf);
+      };
     };
   }
 
@@ -142,7 +144,7 @@ export class DefaultImportTracker implements DefaultImportRecorder {
     }
 
     // There are declarations that need to be preserved.
-    const importsToPreserve = this.sourceFileToUsedImports.get(originalSf) !;
+    const importsToPreserve = this.sourceFileToUsedImports.get(originalSf)!;
 
     // Generate a new statement list which preserves any imports present in `importsToPreserve`.
     const statements = sf.statements.map(stmt => {

--- a/packages/compiler-cli/src/ngtsc/imports/src/emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/emitter.ts
@@ -9,7 +9,7 @@ import {Expression, ExternalExpr, ExternalReference, WrappedNodeExpr} from '@ang
 import * as ts from 'typescript';
 
 import {UnifiedModulesHost} from '../../core/api';
-import {LogicalFileSystem, LogicalProjectPath, PathSegment, absoluteFromSourceFile, dirname, relative} from '../../file_system';
+import {absoluteFromSourceFile, dirname, LogicalFileSystem, LogicalProjectPath, PathSegment, relative} from '../../file_system';
 import {stripExtension} from '../../file_system/src/util';
 import {ReflectionHost} from '../../reflection';
 import {getSourceFile, isDeclaration, isTypeDeclaration, nodeNameForError} from '../../util/src/typescript';
@@ -93,8 +93,8 @@ export class ReferenceEmitter {
         return emitted;
       }
     }
-    throw new Error(
-        `Unable to write a reference to ${nodeNameForError(ref.node)} in ${ref.node.getSourceFile().fileName} from ${context.fileName}`);
+    throw new Error(`Unable to write a reference to ${nodeNameForError(ref.node)} in ${
+        ref.node.getSourceFile().fileName} from ${context.fileName}`);
   }
 }
 
@@ -149,11 +149,11 @@ export class AbsoluteModuleStrategy implements ReferenceEmitStrategy {
       return null;
     } else if (!isDeclaration(ref.node)) {
       // It's not possible to import something which isn't a declaration.
-      throw new Error(
-          `Debug assert: unable to import a Reference to non-declaration of type ${ts.SyntaxKind[ref.node.kind]}.`);
+      throw new Error(`Debug assert: unable to import a Reference to non-declaration of type ${
+          ts.SyntaxKind[ref.node.kind]}.`);
     } else if ((importFlags & ImportFlags.AllowTypeImports) === 0 && isTypeDeclaration(ref.node)) {
-      throw new Error(
-          `Importing a type-only declaration of type ${ts.SyntaxKind[ref.node.kind]} in a value position is not allowed.`);
+      throw new Error(`Importing a type-only declaration of type ${
+          ts.SyntaxKind[ref.node.kind]} in a value position is not allowed.`);
     }
 
     // Try to find the exported name of the declaration, if one is available.
@@ -162,8 +162,9 @@ export class AbsoluteModuleStrategy implements ReferenceEmitStrategy {
     if (symbolName === null) {
       // TODO(alxhub): make this error a ts.Diagnostic pointing at whatever caused this import to be
       // triggered.
-      throw new Error(
-          `Symbol ${ref.debugName} declared in ${getSourceFile(ref.node).fileName} is not exported from ${specifier} (import into ${context.fileName})`);
+      throw new Error(`Symbol ${ref.debugName} declared in ${
+          getSourceFile(ref.node).fileName} is not exported from ${specifier} (import into ${
+          context.fileName})`);
     }
 
     return new ExternalExpr(new ExternalReference(specifier, symbolName));
@@ -173,7 +174,7 @@ export class AbsoluteModuleStrategy implements ReferenceEmitStrategy {
       |null {
     const exports = this.getExportsOfModule(moduleName, fromFile);
     if (exports !== null && exports.has(target)) {
-      return exports.get(target) !;
+      return exports.get(target)!;
     } else {
       return null;
     }
@@ -184,7 +185,7 @@ export class AbsoluteModuleStrategy implements ReferenceEmitStrategy {
     if (!this.moduleExportsCache.has(moduleName)) {
       this.moduleExportsCache.set(moduleName, this.enumerateExportsOfModule(moduleName, fromFile));
     }
-    return this.moduleExportsCache.get(moduleName) !;
+    return this.moduleExportsCache.get(moduleName)!;
   }
 
   protected enumerateExportsOfModule(specifier: string, fromFile: string):

--- a/packages/compiler-cli/src/ngtsc/imports/src/references.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/references.ts
@@ -80,7 +80,9 @@ export class Reference<T extends ts.Node = ts.Node> {
    *
    * See `bestGuessOwningModule`.
    */
-  get hasOwningModuleGuess(): boolean { return this.bestGuessOwningModule !== null; }
+  get hasOwningModuleGuess(): boolean {
+    return this.bestGuessOwningModule !== null;
+  }
 
   /**
    * A name for the node, if one is available.
@@ -93,14 +95,18 @@ export class Reference<T extends ts.Node = ts.Node> {
     return id !== null ? id.text : null;
   }
 
-  get alias(): Expression|null { return this._alias; }
+  get alias(): Expression|null {
+    return this._alias;
+  }
 
 
   /**
    * Record a `ts.Identifier` by which it's valid to refer to this node, within the context of this
    * `Reference`.
    */
-  addIdentifier(identifier: ts.Identifier): void { this.identifiers.push(identifier); }
+  addIdentifier(identifier: ts.Identifier): void {
+    this.identifiers.push(identifier);
+  }
 
   /**
    * Get a `ts.Identifier` within this `Reference` that can be used to refer within the context of a

--- a/packages/compiler-cli/src/ngtsc/imports/test/default_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/test/default_spec.ts
@@ -39,7 +39,7 @@ runInEachFileSystem(() => {
             module: ts.ModuleKind.ES2015,
           });
       const fooClause = getDeclaration(program, _('/test.ts'), 'Foo', ts.isImportClause);
-      const fooId = fooClause.name !;
+      const fooId = fooClause.name!;
       const fooDecl = fooClause.parent;
 
       const tracker = new DefaultImportTracker();
@@ -48,7 +48,7 @@ runInEachFileSystem(() => {
       program.emit(undefined, undefined, undefined, undefined, {
         before: [tracker.importPreservingTransformer()],
       });
-      const testContents = host.readFile('/test.js') !;
+      const testContents = host.readFile('/test.js')!;
       expect(testContents).toContain(`import Foo from './dep';`);
 
       // The control should have the import elided.
@@ -69,7 +69,7 @@ runInEachFileSystem(() => {
             module: ts.ModuleKind.CommonJS,
           });
       const fooClause = getDeclaration(program, _('/test.ts'), 'Foo', ts.isImportClause);
-      const fooId = ts.updateIdentifier(fooClause.name !);
+      const fooId = ts.updateIdentifier(fooClause.name!);
       const fooDecl = fooClause.parent;
 
       const tracker = new DefaultImportTracker();
@@ -81,7 +81,7 @@ runInEachFileSystem(() => {
           tracker.importPreservingTransformer(),
         ],
       });
-      const testContents = host.readFile('/test.js') !;
+      const testContents = host.readFile('/test.js')!;
       expect(testContents).toContain(`var dep_1 = require("./dep");`);
       expect(testContents).toContain(`var ref = dep_1["default"];`);
     });

--- a/packages/compiler-cli/src/ngtsc/imports/test/emitter_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/test/emitter_spec.ts
@@ -8,8 +8,8 @@
 import {ExternalExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {LogicalFileSystem, absoluteFrom as _} from '../../file_system';
-import {TestFile, runInEachFileSystem} from '../../file_system/testing';
+import {absoluteFrom as _, LogicalFileSystem} from '../../file_system';
+import {runInEachFileSystem, TestFile} from '../../file_system/testing';
 import {Declaration, TypeScriptReflectionHost} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';
 import {AbsoluteModuleStrategy, ImportFlags, LogicalProjectStrategy} from '../src/emitter';
@@ -42,7 +42,7 @@ runInEachFileSystem(() => {
       ]);
       const decl =
           getDeclaration(program, _('/node_modules/external.d.ts'), 'Foo', ts.isClassDeclaration);
-      const context = program.getSourceFile(_('/context.ts')) !;
+      const context = program.getSourceFile(_('/context.ts'))!;
 
       const reference = new Reference(decl);
       const emitted = strategy.emit(reference, context, ImportFlags.None);
@@ -65,7 +65,7 @@ runInEachFileSystem(() => {
       ]);
       const decl =
           getDeclaration(program, _('/node_modules/external.d.ts'), 'Foo', ts.isClassDeclaration);
-      const context = program.getSourceFile(_('/context.ts')) !;
+      const context = program.getSourceFile(_('/context.ts'))!;
 
       const reference = new Reference(decl, {
         specifier: 'external',
@@ -92,7 +92,7 @@ runInEachFileSystem(() => {
       ]);
       const decl = getDeclaration(
           program, _('/node_modules/external.d.ts'), 'Foo', ts.isInterfaceDeclaration);
-      const context = program.getSourceFile(_('/context.ts')) !;
+      const context = program.getSourceFile(_('/context.ts'))!;
 
       const reference = new Reference(decl, {
         specifier: 'external',
@@ -116,7 +116,7 @@ runInEachFileSystem(() => {
       ]);
       const decl = getDeclaration(
           program, _('/node_modules/external.d.ts'), 'Foo', ts.isInterfaceDeclaration);
-      const context = program.getSourceFile(_('/context.ts')) !;
+      const context = program.getSourceFile(_('/context.ts'))!;
 
       const reference =
           new Reference(decl, {specifier: 'external', resolutionContext: context.fileName});
@@ -139,7 +139,9 @@ runInEachFileSystem(() => {
             return null;
           }
           const fakeExports = new Map<string, Declaration>();
-          realExports.forEach((decl, name) => { fakeExports.set(`test${name}`, decl); });
+          realExports.forEach((decl, name) => {
+            fakeExports.set(`test${name}`, decl);
+          });
           return fakeExports;
         }
       }
@@ -158,12 +160,12 @@ runInEachFileSystem(() => {
       const logicalFs = new LogicalFileSystem([_('/')]);
       const strategy = new LogicalProjectStrategy(new TestHost(checker), logicalFs);
       const decl = getDeclaration(program, _('/index.ts'), 'Foo', ts.isClassDeclaration);
-      const context = program.getSourceFile(_('/context.ts')) !;
+      const context = program.getSourceFile(_('/context.ts'))!;
       const ref = strategy.emit(new Reference(decl), context);
       expect(ref).not.toBeNull();
 
       // Expect the prefixed name from the TestHost.
-      expect((ref !as ExternalExpr).value.name).toEqual('testFoo');
+      expect((ref! as ExternalExpr).value.name).toEqual('testFoo');
     });
   });
 });

--- a/packages/compiler-cli/src/ngtsc/incremental/api.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/api.ts
@@ -25,7 +25,7 @@ export interface IncrementalBuild<W> {
 /**
  * Tracks dependencies between source files or resources in the application.
  */
-export interface DependencyTracker<T extends{fileName: string} = ts.SourceFile> {
+export interface DependencyTracker<T extends {fileName: string} = ts.SourceFile> {
   /**
    * Record that the file `from` depends on the file `on`.
    */

--- a/packages/compiler-cli/src/ngtsc/incremental/src/dependency_tracking.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/src/dependency_tracking.ts
@@ -23,11 +23,13 @@ import {DependencyTracker} from '../api';
  * 2. One of its dependencies has physically changed.
  * 3. One of its resource dependencies has physically changed.
  */
-export class FileDependencyGraph<T extends{fileName: string} = ts.SourceFile> implements
+export class FileDependencyGraph<T extends {fileName: string} = ts.SourceFile> implements
     DependencyTracker<T> {
   private nodes = new Map<T, FileNode>();
 
-  addDependency(from: T, on: T): void { this.nodeFor(from).dependsOn.add(on.fileName); }
+  addDependency(from: T, on: T): void {
+    this.nodeFor(from).dependsOn.add(on.fileName);
+  }
 
   addResourceDependency(from: T, resource: AbsoluteFsPath): void {
     this.nodeFor(from).usesResources.add(resource);
@@ -103,7 +105,7 @@ export class FileDependencyGraph<T extends{fileName: string} = ts.SourceFile> im
         usesResources: new Set<AbsoluteFsPath>(),
       });
     }
-    return this.nodes.get(sf) !;
+    return this.nodes.get(sf)!;
   }
 }
 
@@ -111,7 +113,7 @@ export class FileDependencyGraph<T extends{fileName: string} = ts.SourceFile> im
  * Determine whether `sf` has logically changed, given its dependencies and the set of physically
  * changed files and resources.
  */
-function isLogicallyChanged<T extends{fileName: string}>(
+function isLogicallyChanged<T extends {fileName: string}>(
     sf: T, node: FileNode, changedTsPaths: ReadonlySet<string>, deletedTsPaths: ReadonlySet<string>,
     changedResources: ReadonlySet<AbsoluteFsPath>): boolean {
   // A file is logically changed if it has physically changed itself (including being deleted).

--- a/packages/compiler-cli/src/ngtsc/incremental/src/state.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/src/state.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {AbsoluteFsPath, absoluteFrom} from '../../file_system';
+import {absoluteFrom, AbsoluteFsPath} from '../../file_system';
 import {ClassRecord, TraitCompiler} from '../../transform';
 import {IncrementalBuild} from '../api';
 
@@ -194,9 +194,13 @@ export class IncrementalDriver implements IncrementalBuild<ClassRecord> {
     };
   }
 
-  recordSuccessfulEmit(sf: ts.SourceFile): void { this.state.pendingEmit.delete(sf.fileName); }
+  recordSuccessfulEmit(sf: ts.SourceFile): void {
+    this.state.pendingEmit.delete(sf.fileName);
+  }
 
-  safeToSkipEmit(sf: ts.SourceFile): boolean { return !this.state.pendingEmit.has(sf.fileName); }
+  safeToSkipEmit(sf: ts.SourceFile): boolean {
+    return !this.state.pendingEmit.has(sf.fileName);
+  }
 
   priorWorkFor(sf: ts.SourceFile): ClassRecord[]|null {
     if (this.state.lastGood === null || this.logicalChanges === null) {
@@ -212,7 +216,7 @@ export class IncrementalDriver implements IncrementalBuild<ClassRecord> {
   }
 }
 
-type BuildState = PendingBuildState | AnalyzedBuildState;
+type BuildState = PendingBuildState|AnalyzedBuildState;
 
 enum BuildStateKind {
   Pending,

--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -43,13 +43,19 @@ interface ExpressionIdentifier extends TemplateIdentifier {
 }
 
 /** Describes a property accessed in a template. */
-export interface PropertyIdentifier extends ExpressionIdentifier { kind: IdentifierKind.Property; }
+export interface PropertyIdentifier extends ExpressionIdentifier {
+  kind: IdentifierKind.Property;
+}
 
 /** Describes a method accessed in a template. */
-export interface MethodIdentifier extends ExpressionIdentifier { kind: IdentifierKind.Method; }
+export interface MethodIdentifier extends ExpressionIdentifier {
+  kind: IdentifierKind.Method;
+}
 
 /** Describes an element attribute in a template. */
-export interface AttributeIdentifier extends TemplateIdentifier { kind: IdentifierKind.Attribute; }
+export interface AttributeIdentifier extends TemplateIdentifier {
+  kind: IdentifierKind.Attribute;
+}
 
 /** A reference to a directive node and its selector. */
 interface DirectiveReference {
@@ -85,7 +91,7 @@ export interface ReferenceIdentifier extends TemplateIdentifier {
   /** The target of this reference. If the target is not known, this is `null`. */
   target: {
     /** The template AST node that the reference targets. */
-    node: ElementIdentifier | TemplateIdentifier;
+    node: ElementIdentifier|TemplateIdentifier;
 
     /**
      * The directive on `node` that the reference targets. If no directive is targeted, this is
@@ -96,14 +102,16 @@ export interface ReferenceIdentifier extends TemplateIdentifier {
 }
 
 /** Describes a template variable like "foo" in `<div *ngFor="let foo of foos"></div>`. */
-export interface VariableIdentifier extends TemplateIdentifier { kind: IdentifierKind.Variable; }
+export interface VariableIdentifier extends TemplateIdentifier {
+  kind: IdentifierKind.Variable;
+}
 
 /**
  * Identifiers recorded at the top level of the template, without any context about the HTML nodes
  * they were discovered in.
  */
-export type TopLevelIdentifier = PropertyIdentifier | MethodIdentifier | ElementIdentifier |
-    TemplateNodeIdentifier | ReferenceIdentifier | VariableIdentifier;
+export type TopLevelIdentifier = PropertyIdentifier|MethodIdentifier|ElementIdentifier|
+    TemplateNodeIdentifier|ReferenceIdentifier|VariableIdentifier;
 
 /**
  * Describes the absolute byte offsets of a text anchor in a source code.

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -56,5 +56,7 @@ export class IndexingContext {
   /**
    * Adds a component to the context.
    */
-  addComponent(info: ComponentInfo) { this.components.add(info); }
+  addComponent(info: ComponentInfo) {
+    this.components.add(info);
+  }
 }

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -18,9 +18,9 @@ interface HTMLNode extends TmplAstNode {
   name?: string;
 }
 
-type ExpressionIdentifier = PropertyIdentifier | MethodIdentifier;
-type TmplTarget = TmplAstReference | TmplAstVariable;
-type TargetIdentifier = ReferenceIdentifier | VariableIdentifier;
+type ExpressionIdentifier = PropertyIdentifier|MethodIdentifier;
+type TmplTarget = TmplAstReference|TmplAstVariable;
+type TargetIdentifier = ReferenceIdentifier|VariableIdentifier;
 type TargetIdentifierMap = Map<TmplTarget, TargetIdentifier>;
 
 /**
@@ -62,7 +62,9 @@ class ExpressionVisitor extends RecursiveAstVisitor {
     return visitor.identifiers;
   }
 
-  visit(ast: AST) { ast.visit(this); }
+  visit(ast: AST) {
+    ast.visit(this);
+  }
 
   visitMethodCall(ast: MethodCall, context: {}) {
     this.visitIdentifier(ast, IdentifierKind.Method);
@@ -144,16 +146,22 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
    *
    * @param boundTemplate bound template target
    */
-  constructor(private boundTemplate: BoundTarget<ComponentMeta>) { super(); }
+  constructor(private boundTemplate: BoundTarget<ComponentMeta>) {
+    super();
+  }
 
   /**
    * Visits a node in the template.
    *
    * @param node node to visit
    */
-  visit(node: HTMLNode) { node.visit(this); }
+  visit(node: HTMLNode) {
+    node.visit(this);
+  }
 
-  visitAll(nodes: TmplAstNode[]) { nodes.forEach(node => this.visit(node)); }
+  visitAll(nodes: TmplAstNode[]) {
+    nodes.forEach(node => this.visit(node));
+  }
 
   /**
    * Add an identifier for an HTML element and visit its children recursively.
@@ -204,8 +212,12 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
         this.targetToIdentifier.bind(this));
     identifiers.forEach(id => this.identifiers.add(id));
   }
-  visitBoundEvent(attribute: TmplAstBoundEvent) { this.visitExpression(attribute.handler); }
-  visitBoundText(text: TmplAstBoundText) { this.visitExpression(text.value); }
+  visitBoundEvent(attribute: TmplAstBoundEvent) {
+    this.visitExpression(attribute.handler);
+  }
+  visitBoundText(text: TmplAstBoundText) {
+    this.visitExpression(text.value);
+  }
   visitReference(reference: TmplAstReference) {
     const referenceIdentifer = this.targetToIdentifier(reference);
 
@@ -222,7 +234,7 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
       |TemplateNodeIdentifier {
     // If this node has already been seen, return the cached result.
     if (this.elementAndTemplateIdentifierCache.has(node)) {
-      return this.elementAndTemplateIdentifierCache.get(node) !;
+      return this.elementAndTemplateIdentifierCache.get(node)!;
     }
 
     let name: string;
@@ -254,7 +266,8 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
 
     const identifier = {
       name,
-      span: absoluteSpan, kind,
+      span: absoluteSpan,
+      kind,
       attributes: new Set(attributes),
       usedDirectives: new Set(usedDirectives.map(dir => {
         return {
@@ -274,7 +287,7 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
   private targetToIdentifier(node: TmplAstReference|TmplAstVariable): TargetIdentifier {
     // If this node has already been seen, return the cached result.
     if (this.targetIdentifierCache.has(node)) {
-      return this.targetIdentifierCache.get(node) !;
+      return this.targetIdentifierCache.get(node)!;
     }
 
     const {name, sourceSpan} = node;
@@ -304,7 +317,8 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
       identifier = {
         name,
         span,
-        kind: IdentifierKind.Reference, target,
+        kind: IdentifierKind.Reference,
+        target,
       };
     } else {
       identifier = {

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -19,7 +19,8 @@ runInEachFileSystem(() => {
 
       context.addComponent({
         declaration,
-        selector: 'c-selector', boundTemplate,
+        selector: 'c-selector',
+        boundTemplate,
         templateMeta: {
           isInline: false,
           file: new ParseSourceFile('<div></div>', util.getTestFilePath()),
@@ -29,7 +30,8 @@ runInEachFileSystem(() => {
       expect(context.components).toEqual(new Set([
         {
           declaration,
-          selector: 'c-selector', boundTemplate,
+          selector: 'c-selector',
+          boundTemplate,
           templateMeta: {
             isInline: false,
             file: new ParseSourceFile('<div></div>', util.getTestFilePath()),

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -219,11 +219,11 @@ runInEachFileSystem(() => {
 
         const refArr = Array.from(refs);
         expect(refArr).toEqual(jasmine.arrayContaining([{
-          name: 'foo',
-          kind: IdentifierKind.Property,
-          span: new AbsoluteSourceSpan(20, 23),
-          target: null,
-        }] as TopLevelIdentifier[]));
+                                                         name: 'foo',
+                                                         kind: IdentifierKind.Property,
+                                                         span: new AbsoluteSourceSpan(20, 23),
+                                                         target: null,
+                                                       }] as TopLevelIdentifier[]));
       });
 
       it('should ignore property writes that are not implicitly received by the template', () => {
@@ -314,12 +314,13 @@ runInEachFileSystem(() => {
       };
 
       const refArray = Array.from(refs);
-      expect(refArray).toEqual(jasmine.arrayContaining([{
-        name: 'foo',
-        kind: IdentifierKind.Reference,
-        span: new AbsoluteSourceSpan(6, 9),
-        target: {node: elementReference, directive: null},
-      }] as TopLevelIdentifier[]));
+      expect(refArray).toEqual(
+          jasmine.arrayContaining([{
+                                    name: 'foo',
+                                    kind: IdentifierKind.Reference,
+                                    span: new AbsoluteSourceSpan(6, 9),
+                                    target: {node: elementReference, directive: null},
+                                  }] as TopLevelIdentifier[]));
     });
 
     it('should discover nested references', () => {
@@ -334,12 +335,13 @@ runInEachFileSystem(() => {
       };
 
       const refArray = Array.from(refs);
-      expect(refArray).toEqual(jasmine.arrayContaining([{
-        name: 'foo',
-        kind: IdentifierKind.Reference,
-        span: new AbsoluteSourceSpan(12, 15),
-        target: {node: elementReference, directive: null},
-      }] as TopLevelIdentifier[]));
+      expect(refArray).toEqual(
+          jasmine.arrayContaining([{
+                                    name: 'foo',
+                                    kind: IdentifierKind.Reference,
+                                    span: new AbsoluteSourceSpan(12, 15),
+                                    target: {node: elementReference, directive: null},
+                                  }] as TopLevelIdentifier[]));
     });
 
     it('should discover references to references', () => {
@@ -409,14 +411,14 @@ runInEachFileSystem(() => {
       const refArr = Array.from(refs);
       let fooRef = refArr.find(id => id.name === 'foo');
       expect(fooRef).toBeDefined();
-      expect(fooRef !.kind).toBe(IdentifierKind.Reference);
+      expect(fooRef!.kind).toBe(IdentifierKind.Reference);
 
       fooRef = fooRef as ReferenceIdentifier;
       expect(fooRef.target).toBeDefined();
-      expect(fooRef.target !.node.kind).toBe(IdentifierKind.Element);
-      expect(fooRef.target !.node.name).toBe('div');
-      expect(fooRef.target !.node.span).toEqual(new AbsoluteSourceSpan(1, 4));
-      expect(fooRef.target !.directive).toEqual(declB);
+      expect(fooRef.target!.node.kind).toBe(IdentifierKind.Element);
+      expect(fooRef.target!.node.name).toBe('div');
+      expect(fooRef.target!.node.span).toEqual(new AbsoluteSourceSpan(1, 4));
+      expect(fooRef.target!.directive).toEqual(declB);
     });
 
     it('should discover references to references', () => {
@@ -455,10 +457,10 @@ runInEachFileSystem(() => {
 
       const refArray = Array.from(refs);
       expect(refArray).toEqual(jasmine.arrayContaining([{
-        name: 'foo',
-        kind: IdentifierKind.Variable,
-        span: new AbsoluteSourceSpan(17, 20),
-      }] as TopLevelIdentifier[]));
+                                                         name: 'foo',
+                                                         kind: IdentifierKind.Variable,
+                                                         span: new AbsoluteSourceSpan(17, 20),
+                                                       }] as TopLevelIdentifier[]));
     });
 
     it('should discover variables with let- syntax', () => {
@@ -467,10 +469,10 @@ runInEachFileSystem(() => {
 
       const refArray = Array.from(refs);
       expect(refArray).toEqual(jasmine.arrayContaining([{
-        name: 'var',
-        kind: IdentifierKind.Variable,
-        span: new AbsoluteSourceSpan(17, 20),
-      }] as TopLevelIdentifier[]));
+                                                         name: 'var',
+                                                         kind: IdentifierKind.Variable,
+                                                         span: new AbsoluteSourceSpan(17, 20),
+                                                       }] as TopLevelIdentifier[]));
     });
 
     it('should discover nested variables', () => {
@@ -479,10 +481,10 @@ runInEachFileSystem(() => {
 
       const refArray = Array.from(refs);
       expect(refArray).toEqual(jasmine.arrayContaining([{
-        name: 'foo',
-        kind: IdentifierKind.Variable,
-        span: new AbsoluteSourceSpan(23, 26),
-      }] as TopLevelIdentifier[]));
+                                                         name: 'foo',
+                                                         kind: IdentifierKind.Variable,
+                                                         span: new AbsoluteSourceSpan(23, 26),
+                                                       }] as TopLevelIdentifier[]));
     });
 
     it('should discover references to variables', () => {

--- a/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
@@ -68,7 +68,7 @@ runInEachFileSystem(() => {
 
       const info = analysis.get(decl);
       expect(info).toBeDefined();
-      expect(info !.template.file)
+      expect(info!.template.file)
           .toEqual(new ParseSourceFile('class C {}', util.getTestFilePath()));
     });
 
@@ -83,7 +83,7 @@ runInEachFileSystem(() => {
 
       const info = analysis.get(decl);
       expect(info).toBeDefined();
-      expect(info !.template.file)
+      expect(info!.template.file)
           .toEqual(new ParseSourceFile('<div>{{foo}}</div>', util.getTestFilePath()));
     });
 
@@ -110,11 +110,11 @@ runInEachFileSystem(() => {
 
       const infoA = analysis.get(declA);
       expect(infoA).toBeDefined();
-      expect(infoA !.template.usedComponents).toEqual(new Set([declB]));
+      expect(infoA!.template.usedComponents).toEqual(new Set([declB]));
 
       const infoB = analysis.get(declB);
       expect(infoB).toBeDefined();
-      expect(infoB !.template.usedComponents).toEqual(new Set([declA]));
+      expect(infoB!.template.usedComponents).toEqual(new Set([declA]));
     });
   });
 });

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BoundTarget, CssSelector, ParseTemplateOptions, R3TargetBinder, SelectorMatcher, parseTemplate} from '@angular/compiler';
+import {BoundTarget, CssSelector, parseTemplate, ParseTemplateOptions, R3TargetBinder, SelectorMatcher} from '@angular/compiler';
 import * as ts from 'typescript';
-import {AbsoluteFsPath, absoluteFrom} from '../../file_system';
+
+import {absoluteFrom, AbsoluteFsPath} from '../../file_system';
 import {Reference} from '../../imports';
 import {ClassDeclaration} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 
 import {Reference} from '../../imports';
-import {ClassDeclaration, ReflectionHost, isNamedClassDeclaration} from '../../reflection';
+import {ClassDeclaration, isNamedClassDeclaration, ReflectionHost} from '../../reflection';
 
 import {DirectiveMeta, MetadataReader, NgModuleMeta, PipeMeta} from './api';
 import {extractDirectiveGuards, extractReferencesFromType, readStringArrayType, readStringMapType, readStringType} from './util';

--- a/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
@@ -25,7 +25,7 @@ export function flattenInheritedDirectiveMetadata(
     throw new Error(`Metadata not found for directive: ${dir.debugName}`);
   }
 
-  let inputs: {[key: string]: string | [string, string]} = {};
+  let inputs: {[key: string]: string|[string, string]} = {};
   let outputs: {[key: string]: string} = {};
   let coercedInputFields = new Set<string>();
   let isDynamic = false;

--- a/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
@@ -22,18 +22,24 @@ export class LocalMetadataRegistry implements MetadataRegistry, MetadataReader {
   private pipes = new Map<ClassDeclaration, PipeMeta>();
 
   getDirectiveMetadata(ref: Reference<ClassDeclaration>): DirectiveMeta|null {
-    return this.directives.has(ref.node) ? this.directives.get(ref.node) ! : null;
+    return this.directives.has(ref.node) ? this.directives.get(ref.node)! : null;
   }
   getNgModuleMetadata(ref: Reference<ClassDeclaration>): NgModuleMeta|null {
-    return this.ngModules.has(ref.node) ? this.ngModules.get(ref.node) ! : null;
+    return this.ngModules.has(ref.node) ? this.ngModules.get(ref.node)! : null;
   }
   getPipeMetadata(ref: Reference<ClassDeclaration>): PipeMeta|null {
-    return this.pipes.has(ref.node) ? this.pipes.get(ref.node) ! : null;
+    return this.pipes.has(ref.node) ? this.pipes.get(ref.node)! : null;
   }
 
-  registerDirectiveMetadata(meta: DirectiveMeta): void { this.directives.set(meta.ref.node, meta); }
-  registerNgModuleMetadata(meta: NgModuleMeta): void { this.ngModules.set(meta.ref.node, meta); }
-  registerPipeMetadata(meta: PipeMeta): void { this.pipes.set(meta.ref.node, meta); }
+  registerDirectiveMetadata(meta: DirectiveMeta): void {
+    this.directives.set(meta.ref.node, meta);
+  }
+  registerNgModuleMetadata(meta: NgModuleMeta): void {
+    this.ngModules.set(meta.ref.node, meta);
+  }
+  registerPipeMetadata(meta: PipeMeta): void {
+    this.pipes.set(meta.ref.node, meta);
+  }
 }
 
 /**
@@ -70,7 +76,9 @@ export class InjectableClassRegistry {
 
   constructor(private host: ReflectionHost) {}
 
-  registerInjectable(declaration: ClassDeclaration): void { this.classes.add(declaration); }
+  registerInjectable(declaration: ClassDeclaration): void {
+    this.classes.add(declaration);
+  }
 
   isInjectable(declaration: ClassDeclaration): boolean {
     // Figure out whether the class is injectable based on the registered classes, otherwise

--- a/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
@@ -9,13 +9,13 @@
 import * as ts from 'typescript';
 
 import {Reference} from '../../imports';
-import {ClassDeclaration, ClassMember, ClassMemberKind, ReflectionHost, isNamedClassDeclaration, reflectTypeEntityToDeclaration} from '../../reflection';
+import {ClassDeclaration, ClassMember, ClassMemberKind, isNamedClassDeclaration, ReflectionHost, reflectTypeEntityToDeclaration} from '../../reflection';
 import {nodeDebugInfo} from '../../util/src/typescript';
 
 import {DirectiveMeta, MetadataReader, NgModuleMeta, PipeMeta, TemplateGuardMeta} from './api';
 
 export function extractReferencesFromType(
-    checker: ts.TypeChecker, def: ts.TypeNode, ngModuleImportedFrom: string | null,
+    checker: ts.TypeChecker, def: ts.TypeNode, ngModuleImportedFrom: string|null,
     resolutionContext: string): Reference<ClassDeclaration>[] {
   if (!ts.isTupleTypeNode(def)) {
     return [];
@@ -122,7 +122,7 @@ function extractTemplateGuard(member: ClassMember): TemplateGuardMeta|null {
 
 function extractCoercedInput(member: ClassMember): string|null {
   if (member.kind !== ClassMemberKind.Property || !member.name.startsWith('ngAcceptInputType_')) {
-    return null !;
+    return null!;
   }
   return afterUnderscore(member.name);
 }

--- a/packages/compiler-cli/src/ngtsc/modulewithproviders/src/scanner.ts
+++ b/packages/compiler-cli/src/ngtsc/modulewithproviders/src/scanner.ts
@@ -13,7 +13,9 @@ import {ImportFlags, Reference, ReferenceEmitter} from '../../imports';
 import {PartialEvaluator, ResolvedValueMap} from '../../partial_evaluator';
 import {ReflectionHost} from '../../reflection';
 
-export interface DtsHandler { addTypeReplacement(node: ts.Declaration, type: Type): void; }
+export interface DtsHandler {
+  addTypeReplacement(node: ts.Declaration, type: Type): void;
+}
 
 export class ModuleWithProvidersScanner {
   constructor(

--- a/packages/compiler-cli/src/ngtsc/perf/src/noop.ts
+++ b/packages/compiler-cli/src/ngtsc/perf/src/noop.ts
@@ -12,9 +12,11 @@ import {PerfRecorder} from './api';
 
 export const NOOP_PERF_RECORDER: PerfRecorder = {
   enabled: false,
-  mark: (name: string, node: ts.SourceFile | ts.Declaration, category?: string, detail?: string):
-            void => {},
-  start: (name: string, node: ts.SourceFile | ts.Declaration, category?: string, detail?: string):
-             number => { return 0;},
-  stop: (span: number | false): void => {},
+  mark: (name: string, node: ts.SourceFile|ts.Declaration, category?: string, detail?: string):
+      void => {},
+  start: (name: string, node: ts.SourceFile|ts.Declaration, category?: string, detail?: string):
+      number => {
+        return 0;
+      },
+  stop: (span: number|false): void => {},
 };

--- a/packages/compiler-cli/src/ngtsc/perf/src/tracking.ts
+++ b/packages/compiler-cli/src/ngtsc/perf/src/tracking.ts
@@ -20,7 +20,9 @@ export class PerfTracker implements PerfRecorder {
 
   private constructor(private zeroTime: HrTime) {}
 
-  static zeroedToNow(): PerfTracker { return new PerfTracker(mark()); }
+  static zeroedToNow(): PerfTracker {
+    return new PerfTracker(mark());
+  }
 
   mark(name: string, node?: ts.SourceFile|ts.Declaration, category?: string, detail?: string):
       void {
@@ -73,7 +75,9 @@ export class PerfTracker implements PerfRecorder {
     return msg;
   }
 
-  asJson(): unknown { return this.log; }
+  asJson(): unknown {
+    return this.log;
+  }
 
   serializeToFile(target: string, host: ts.CompilerHost): void {
     const json = JSON.stringify(this.log, null, 2);

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -77,7 +77,9 @@ export class NgtscProgram implements api.Program {
         new NgCompiler(this.host, options, this.tsProgram, reuseProgram, this.perfRecorder);
   }
 
-  getTsProgram(): ts.Program { return this.tsProgram; }
+  getTsProgram(): ts.Program {
+    return this.tsProgram;
+  }
 
   getTsOptionDiagnostics(cancellationToken?: ts.CancellationToken|
                          undefined): readonly ts.Diagnostic[] {
@@ -137,8 +139,8 @@ export class NgtscProgram implements api.Program {
   }
 
   getNgSemanticDiagnostics(
-      fileName?: string|undefined, cancellationToken?: ts.CancellationToken|
-                                   undefined): readonly(ts.Diagnostic|api.Diagnostic)[] {
+      fileName?: string|undefined, cancellationToken?: ts.CancellationToken|undefined):
+      readonly(ts.Diagnostic|api.Diagnostic)[] {
     let sf: ts.SourceFile|undefined = undefined;
     if (fileName !== undefined) {
       sf = this.tsProgram.getSourceFile(fileName);
@@ -161,14 +163,17 @@ export class NgtscProgram implements api.Program {
    * This is used by the Angular CLI to allow for spawning (async) child compilations for things
    * like SASS files used in `styleUrls`.
    */
-  loadNgStructureAsync(): Promise<void> { return this.compiler.analyzeAsync(); }
+  loadNgStructureAsync(): Promise<void> {
+    return this.compiler.analyzeAsync();
+  }
 
   listLazyRoutes(entryRoute?: string|undefined): api.LazyRoute[] {
     return this.compiler.listLazyRoutes(entryRoute);
   }
 
   emit(opts?: {
-    emitFlags?: api.EmitFlags | undefined; cancellationToken?: ts.CancellationToken | undefined;
+    emitFlags?: api.EmitFlags|undefined;
+    cancellationToken?: ts.CancellationToken | undefined;
     customTransformers?: api.CustomTransformers | undefined;
     emitCallback?: api.TsEmitCallback | undefined;
     mergeEmitResultsCallback?: api.TsMergeEmitResultsCallback | undefined;
@@ -179,8 +184,8 @@ export class NgtscProgram implements api.Program {
 
     const writeFile: ts.WriteFileCallback =
         (fileName: string, data: string, writeByteOrderMark: boolean,
-         onError: ((message: string) => void) | undefined,
-         sourceFiles: ReadonlyArray<ts.SourceFile>| undefined) => {
+         onError: ((message: string) => void)|undefined,
+         sourceFiles: ReadonlyArray<ts.SourceFile>|undefined) => {
           if (sourceFiles !== undefined) {
             // Record successful writes for any `ts.SourceFile` (that's not a declaration file)
             // that's an input to this write.
@@ -221,7 +226,8 @@ export class NgtscProgram implements api.Program {
         program: this.tsProgram,
         host: this.host,
         options: this.options,
-        emitOnlyDtsFiles: false, writeFile,
+        emitOnlyDtsFiles: false,
+        writeFile,
         customTransformers: {
           before: beforeTransforms,
           after: customTransforms && customTransforms.afterTs,
@@ -257,11 +263,16 @@ export class NgtscProgram implements api.Program {
   }
 }
 
-const defaultEmitCallback: api.TsEmitCallback =
-    ({program, targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles,
-      customTransformers}) =>
-        program.emit(
-            targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers);
+const defaultEmitCallback: api.TsEmitCallback = ({
+  program,
+  targetSourceFile,
+  writeFile,
+  cancellationToken,
+  emitOnlyDtsFiles,
+  customTransformers
+}) =>
+    program.emit(
+        targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers);
 
 function mergeEmitResults(emitResults: ts.EmitResult[]): ts.EmitResult {
   const diagnostics: ts.Diagnostic[] = [];

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
  * Metadata extracted from an instance of a decorator on another declaration, or synthesized from
  * other information about a class.
  */
-export type Decorator = ConcreteDecorator | SyntheticDecorator;
+export type Decorator = ConcreteDecorator|SyntheticDecorator;
 
 export interface BaseDecorator {
   /**
@@ -28,11 +28,11 @@ export interface BaseDecorator {
    */
   identifier: DecoratorIdentifier|null;
 
-  /**
-   * `Import` by which the decorator was brought into the module in which it was invoked, or `null`
-   * if the decorator was declared in the same module and not imported.
-   */
-  import : Import | null;
+/**
+ * `Import` by which the decorator was brought into the module in which it was invoked, or `null`
+ * if the decorator was declared in the same module and not imported.
+ */
+import: Import|null;
 
   /**
    * TypeScript reference to the decorator itself, or `null` if the decorator is synthesized (e.g.
@@ -87,8 +87,8 @@ export const Decorator = {
  * A decorator is identified by either a simple identifier (e.g. `Decorator`) or, in some cases,
  * a namespaced property access (e.g. `core.Decorator`).
  */
-export type DecoratorIdentifier = ts.Identifier | NamespacedIdentifier;
-export type NamespacedIdentifier = ts.PropertyAccessExpression & {
+export type DecoratorIdentifier = ts.Identifier|NamespacedIdentifier;
+export type NamespacedIdentifier = ts.PropertyAccessExpression&{
   expression: ts.Identifier;
   name: ts.Identifier
 };
@@ -113,7 +113,7 @@ export function isDecoratorIdentifier(exp: ts.Expression): exp is DecoratorIdent
  * For `ReflectionHost` purposes, a class declaration should always have a `name` identifier,
  * because we need to be able to reference it in other parts of the program.
  */
-export type ClassDeclaration<T extends ts.Declaration = ts.Declaration> = T & {name: ts.Identifier};
+export type ClassDeclaration<T extends ts.Declaration = ts.Declaration> = T&{name: ts.Identifier};
 
 /**
  * An enumeration of possible kinds of class members.
@@ -241,8 +241,7 @@ export interface ClassMember {
  */
 export type TypeValueReference = {
   local: true; expression: ts.Expression; defaultImportStatement: ts.ImportDeclaration | null;
-} |
-{
+}|{
   local: false;
   name: string;
   moduleName: string;
@@ -447,7 +446,7 @@ export interface InlineDeclaration extends BaseDeclaration {
  * downlevelings to a `ts.Expression` instead.
  */
 export type Declaration<T extends ts.Declaration = ts.Declaration> =
-    ConcreteDeclaration<T>| InlineDeclaration;
+    ConcreteDeclaration<T>|InlineDeclaration;
 
 /**
  * Abstracts reflection operations on a TypeScript AST.

--- a/packages/compiler-cli/src/ngtsc/reflection/src/type_to_value.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/type_to_value.ts
@@ -18,7 +18,7 @@ import {TypeValueReference} from './host';
  * declaration, or if it is not possible to statically understand.
  */
 export function typeToValue(
-    typeNode: ts.TypeNode | null, checker: ts.TypeChecker): TypeValueReference|null {
+    typeNode: ts.TypeNode|null, checker: ts.TypeChecker): TypeValueReference|null {
   // It's not possible to get a value expression if the parameter doesn't even have a type.
   if (typeNode === null || !ts.isTypeReferenceNode(typeNode)) {
     return null;
@@ -95,7 +95,7 @@ export function typeNodeToValueExpr(node: ts.TypeNode): ts.Expression|null {
  * give the identifier name within the current file by which the import is known.
  */
 function resolveTypeSymbols(typeRef: ts.TypeReferenceNode, checker: ts.TypeChecker):
-    {local: ts.Symbol, decl: ts.Symbol, importName: string | null}|null {
+    {local: ts.Symbol, decl: ts.Symbol, importName: string|null}|null {
   const typeName = typeRef.typeName;
   // typeRefSymbol is the ts.Symbol of the entire type reference.
   const typeRefSymbol: ts.Symbol|undefined = checker.getSymbolAtLocation(typeName);
@@ -156,8 +156,8 @@ function isImportSource(node: ts.Declaration): node is(ts.ImportSpecifier | ts.N
 }
 
 function extractModuleAndNameFromImport(
-    node: ts.ImportSpecifier | ts.NamespaceImport | ts.ImportClause,
-    localName: string | null): {name: string, moduleName: string} {
+    node: ts.ImportSpecifier|ts.NamespaceImport|ts.ImportClause,
+    localName: string|null): {name: string, moduleName: string} {
   let name: string;
   let moduleSpecifier: ts.Expression;
   switch (node.kind) {

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ClassMember, ClassMemberKind, CtorParameter, Declaration, Decorator, FunctionDefinition, Import, ReflectionHost, isDecoratorIdentifier} from './host';
+import {ClassDeclaration, ClassMember, ClassMemberKind, CtorParameter, Declaration, Decorator, FunctionDefinition, Import, isDecoratorIdentifier, ReflectionHost} from './host';
 import {typeToValue} from './type_to_value';
 
 /**
@@ -76,8 +76,10 @@ export class TypeScriptReflectionHost implements ReflectionHost {
 
       return {
         name,
-        nameNode: node.name, typeValueReference,
-        typeNode: originalTypeNode, decorators,
+        nameNode: node.name,
+        typeValueReference,
+        typeNode: originalTypeNode,
+        decorators,
       };
     });
   }
@@ -183,11 +185,17 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     return declaration.initializer || null;
   }
 
-  getDtsDeclaration(_: ts.Declaration): ts.Declaration|null { return null; }
+  getDtsDeclaration(_: ts.Declaration): ts.Declaration|null {
+    return null;
+  }
 
-  getInternalNameOfClass(clazz: ClassDeclaration): ts.Identifier { return clazz.name; }
+  getInternalNameOfClass(clazz: ClassDeclaration): ts.Identifier {
+    return clazz.name;
+  }
 
-  getAdjacentNameOfClass(clazz: ClassDeclaration): ts.Identifier { return clazz.name; }
+  getAdjacentNameOfClass(clazz: ClassDeclaration): ts.Identifier {
+    return clazz.name;
+  }
 
   protected getDirectImportOfIdentifier(id: ts.Identifier): Import|null {
     const symbol = this.checker.getSymbolAtLocation(id);
@@ -305,12 +313,14 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     if (symbol.valueDeclaration !== undefined) {
       return {
         node: symbol.valueDeclaration,
-        known: null, viaModule,
+        known: null,
+        viaModule,
       };
     } else if (symbol.declarations !== undefined && symbol.declarations.length > 0) {
       return {
         node: symbol.declarations[0],
-        known: null, viaModule,
+        known: null,
+        viaModule,
       };
     } else {
       return null;
@@ -342,7 +352,9 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     return {
       name: decoratorIdentifier.text,
       identifier: decoratorExpr,
-      import: importDecl, node, args,
+      import: importDecl,
+      node,
+      args,
     };
   }
 
@@ -382,8 +394,14 @@ export class TypeScriptReflectionHost implements ReflectionHost {
 
     return {
       node,
-      implementation: node, kind,
-      type: node.type || null, name, nameNode, decorators, value, isStatic,
+      implementation: node,
+      kind,
+      type: node.type || null,
+      name,
+      nameNode,
+      decorators,
+      value,
+      isStatic,
     };
   }
 }
@@ -405,7 +423,7 @@ export function reflectIdentifierOfDeclaration(decl: ts.Declaration): ts.Identif
 }
 
 export function reflectTypeEntityToDeclaration(
-    type: ts.EntityName, checker: ts.TypeChecker): {node: ts.Declaration, from: string | null} {
+    type: ts.EntityName, checker: ts.TypeChecker): {node: ts.Declaration, from: string|null} {
   let realSymbol = checker.getSymbolAtLocation(type);
   if (realSymbol === undefined) {
     throw new Error(`Cannot resolve type entity ${type.getText()} to symbol`);
@@ -434,8 +452,8 @@ export function reflectTypeEntityToDeclaration(
     }
     const decl = symbol.declarations[0];
     if (ts.isNamespaceImport(decl)) {
-      const clause = decl.parent !;
-      const importDecl = clause.parent !;
+      const clause = decl.parent!;
+      const importDecl = clause.parent!;
       if (!ts.isStringLiteral(importDecl.moduleSpecifier)) {
         throw new Error(`Module specifier is not a string`);
       }
@@ -552,7 +570,7 @@ function getFarLeftIdentifier(propertyAccess: ts.PropertyAccessExpression): ts.I
  * `NamespaceImport`. If not return `null`.
  */
 function getContainingImportDeclaration(node: ts.Node): ts.ImportDeclaration|null {
-  return ts.isImportSpecifier(node) ? node.parent !.parent !.parent ! :
+  return ts.isImportSpecifier(node) ? node.parent!.parent!.parent! :
                                       ts.isNamespaceImport(node) ? node.parent.parent : null;
 }
 

--- a/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
@@ -34,7 +34,7 @@ runInEachFileSystem(() => {
         const clazz = getDeclaration(program, _('/entry.ts'), 'Foo', isNamedClassDeclaration);
         const checker = program.getTypeChecker();
         const host = new TypeScriptReflectionHost(checker);
-        const args = host.getConstructorParameters(clazz) !;
+        const args = host.getConstructorParameters(clazz)!;
         expect(args.length).toBe(1);
         expectParameter(args[0], 'bar', 'Bar');
       });
@@ -63,7 +63,7 @@ runInEachFileSystem(() => {
         const clazz = getDeclaration(program, _('/entry.ts'), 'Foo', isNamedClassDeclaration);
         const checker = program.getTypeChecker();
         const host = new TypeScriptReflectionHost(checker);
-        const args = host.getConstructorParameters(clazz) !;
+        const args = host.getConstructorParameters(clazz)!;
         expect(args.length).toBe(1);
         expectParameter(args[0], 'bar', 'Bar', 'dec', './dec');
       });
@@ -92,7 +92,7 @@ runInEachFileSystem(() => {
         const clazz = getDeclaration(program, _('/entry.ts'), 'Foo', isNamedClassDeclaration);
         const checker = program.getTypeChecker();
         const host = new TypeScriptReflectionHost(checker);
-        const args = host.getConstructorParameters(clazz) !;
+        const args = host.getConstructorParameters(clazz)!;
         expect(args.length).toBe(1);
         expectParameter(args[0], 'bar', 'Bar', 'dec', './dec');
       });
@@ -120,7 +120,7 @@ runInEachFileSystem(() => {
         const clazz = getDeclaration(program, _('/entry.ts'), 'Foo', isNamedClassDeclaration);
         const checker = program.getTypeChecker();
         const host = new TypeScriptReflectionHost(checker);
-        const args = host.getConstructorParameters(clazz) !;
+        const args = host.getConstructorParameters(clazz)!;
         expect(args.length).toBe(2);
         expectParameter(args[0], 'bar', {moduleName: './bar', name: 'Bar'});
         expectParameter(args[1], 'otherBar', {moduleName: './bar', name: 'Bar'});
@@ -148,7 +148,7 @@ runInEachFileSystem(() => {
         const clazz = getDeclaration(program, _('/entry.ts'), 'Foo', isNamedClassDeclaration);
         const checker = program.getTypeChecker();
         const host = new TypeScriptReflectionHost(checker);
-        const args = host.getConstructorParameters(clazz) !;
+        const args = host.getConstructorParameters(clazz)!;
         expect(args.length).toBe(1);
         expectParameter(args[0], 'bar', {moduleName: './bar', name: 'Bar'});
       });
@@ -175,7 +175,7 @@ runInEachFileSystem(() => {
         const clazz = getDeclaration(program, _('/entry.ts'), 'Foo', isNamedClassDeclaration);
         const checker = program.getTypeChecker();
         const host = new TypeScriptReflectionHost(checker);
-        const args = host.getConstructorParameters(clazz) !;
+        const args = host.getConstructorParameters(clazz)!;
         expect(args.length).toBe(1);
         const param = args[0].typeValueReference;
         if (param === null || !param.local) {
@@ -207,7 +207,7 @@ runInEachFileSystem(() => {
         const clazz = getDeclaration(program, _('/entry.ts'), 'Foo', isNamedClassDeclaration);
         const checker = program.getTypeChecker();
         const host = new TypeScriptReflectionHost(checker);
-        const args = host.getConstructorParameters(clazz) !;
+        const args = host.getConstructorParameters(clazz)!;
         expect(args.length).toBe(1);
         expectParameter(args[0], 'bar', {moduleName: './bar', name: 'Bar'});
       });
@@ -228,12 +228,11 @@ runInEachFileSystem(() => {
         const clazz = getDeclaration(program, _('/entry.ts'), 'Foo', isNamedClassDeclaration);
         const checker = program.getTypeChecker();
         const host = new TypeScriptReflectionHost(checker);
-        const args = host.getConstructorParameters(clazz) !;
+        const args = host.getConstructorParameters(clazz)!;
         expect(args.length).toBe(2);
         expectParameter(args[0], 'bar', 'Bar');
         expectParameter(args[1], 'baz', 'Baz');
       });
-
     });
 
 
@@ -330,9 +329,9 @@ runInEachFileSystem(() => {
         } else if (directTargetDecl === null) {
           return fail('No declaration found for DirectTarget');
         }
-        expect(targetDecl.node !.getSourceFile().fileName)
+        expect(targetDecl.node!.getSourceFile().fileName)
             .toBe(_('/node_modules/absolute/index.ts'));
-        expect(ts.isClassDeclaration(targetDecl.node !)).toBe(true);
+        expect(ts.isClassDeclaration(targetDecl.node!)).toBe(true);
         expect(directTargetDecl.viaModule).toBe('absolute');
         expect(directTargetDecl.node).toBe(targetDecl.node);
       });
@@ -415,9 +414,9 @@ runInEachFileSystem(() => {
         const checker = program.getTypeChecker();
         const host = new TypeScriptReflectionHost(checker);
         const exportedDeclarations =
-            host.getExportsOfModule(program.getSourceFile(_('/entry.ts')) !);
-        expect(Array.from(exportedDeclarations !.keys())).toEqual(['foo', 'x', 'T', 'I', 'E']);
-        expect(Array.from(exportedDeclarations !.values()).map(v => v.viaModule)).toEqual([
+            host.getExportsOfModule(program.getSourceFile(_('/entry.ts'))!);
+        expect(Array.from(exportedDeclarations!.keys())).toEqual(['foo', 'x', 'T', 'I', 'E']);
+        expect(Array.from(exportedDeclarations!.values()).map(v => v.viaModule)).toEqual([
           null, null, null, null, null
         ]);
       });
@@ -440,11 +439,11 @@ runInEachFileSystem(() => {
         const checker = program.getTypeChecker();
         const host = new TypeScriptReflectionHost(checker);
         const exportedDeclarations =
-            host.getExportsOfModule(program.getSourceFile(_('/entry.ts')) !);
-        expect(Array.from(exportedDeclarations !.keys())).toEqual([
+            host.getExportsOfModule(program.getSourceFile(_('/entry.ts'))!);
+        expect(Array.from(exportedDeclarations!.keys())).toEqual([
           'Target1', 'AliasTarget', 'AliasTarget2', 'Target'
         ]);
-        expect(Array.from(exportedDeclarations !.values()).map(v => v.viaModule)).toEqual([
+        expect(Array.from(exportedDeclarations!.values()).map(v => v.viaModule)).toEqual([
           null, null, null, null
         ]);
       });
@@ -452,9 +451,9 @@ runInEachFileSystem(() => {
   });
 
   function expectParameter(
-      param: CtorParameter, name: string, type?: string | {name: string, moduleName: string},
+      param: CtorParameter, name: string, type?: string|{name: string, moduleName: string},
       decorator?: string, decoratorFrom?: string): void {
-    expect(param.name !).toEqual(name);
+    expect(param.name!).toEqual(name);
     if (type === undefined) {
       expect(param.typeValueReference).toBeNull();
     } else {
@@ -467,21 +466,21 @@ runInEachFileSystem(() => {
         expect(param.typeValueReference.moduleName).toEqual(type.moduleName);
         expect(param.typeValueReference.name).toEqual(type.name);
       } else {
-        return fail(
-            `Mismatch between typeValueReference and expected type: ${param.name} / ${param.typeValueReference.local}`);
+        return fail(`Mismatch between typeValueReference and expected type: ${param.name} / ${
+            param.typeValueReference.local}`);
       }
     }
     if (decorator !== undefined) {
       expect(param.decorators).not.toBeNull();
-      expect(param.decorators !.length).toBeGreaterThan(0);
-      expect(param.decorators !.some(
+      expect(param.decorators!.length).toBeGreaterThan(0);
+      expect(param.decorators!.some(
                  dec => dec.name === decorator && dec.import !== null &&
                      dec.import.from === decoratorFrom))
           .toBe(true);
     }
   }
 
-  function argExpressionToString(name: ts.Node | null): string {
+  function argExpressionToString(name: ts.Node|null): string {
     if (name == null) {
       throw new Error('\'name\' argument can\'t be null');
     }

--- a/packages/compiler-cli/src/ngtsc/resource/src/loader.ts
+++ b/packages/compiler-cli/src/ngtsc/resource/src/loader.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 
 import {ResourceLoader} from '../../annotations';
 import {ExtendedTsCompilerHost} from '../../core/api';
-import {AbsoluteFsPath, PathSegment, join} from '../../file_system';
+import {AbsoluteFsPath, join, PathSegment} from '../../file_system';
 import {getRootDirs} from '../../util/src/typescript';
 
 const CSS_PREPROCESSOR_EXT = /(\.scss|\.sass|\.less|\.styl)$/;
@@ -101,7 +101,7 @@ export class HostResourceLoader implements ResourceLoader {
    */
   load(resolvedUrl: string): string {
     if (this.cache.has(resolvedUrl)) {
-      return this.cache.get(resolvedUrl) !;
+      return this.cache.get(resolvedUrl)!;
     }
 
     const result = this.host.readResource ? this.host.readResource(resolvedUrl) :
@@ -169,14 +169,15 @@ export class HostResourceLoader implements ResourceLoader {
     // but is marked @internal in TypeScript. See
     // https://github.com/Microsoft/TypeScript/issues/28770.
     type ResolvedModuleWithFailedLookupLocations =
-        ts.ResolvedModuleWithFailedLookupLocations & {failedLookupLocations: ReadonlyArray<string>};
+        ts.ResolvedModuleWithFailedLookupLocations&{failedLookupLocations: ReadonlyArray<string>};
 
     // clang-format off
     const failedLookup = ts.resolveModuleName(url + '.$ngresource$', fromFile, this.options, this.host) as ResolvedModuleWithFailedLookupLocations;
     // clang-format on
     if (failedLookup.failedLookupLocations === undefined) {
       throw new Error(
-          `Internal error: expected to find failedLookupLocations during resolution of resource '${url}' in context of ${fromFile}`);
+          `Internal error: expected to find failedLookupLocations during resolution of resource '${
+              url}' in context of ${fromFile}`);
     }
 
     return failedLookup.failedLookupLocations

--- a/packages/compiler-cli/src/ngtsc/routing/src/analyzer.ts
+++ b/packages/compiler-cli/src/ngtsc/routing/src/analyzer.ts
@@ -12,7 +12,7 @@ import {ModuleResolver} from '../../imports';
 import {PartialEvaluator} from '../../partial_evaluator';
 
 import {scanForCandidateTransitiveModules, scanForRouteEntryPoints} from './lazy';
-import {RouterEntryPointManager, entryPointKeyFor} from './route';
+import {entryPointKeyFor, RouterEntryPointManager} from './route';
 
 export interface NgModuleRawRouteData {
   sourceFile: ts.SourceFile;
@@ -42,10 +42,13 @@ export class NgModuleRouteAnalyzer {
     if (this.modules.has(key)) {
       throw new Error(`Double route analyzing for '${key}'.`);
     }
-    this.modules.set(
-        key, {
-                 sourceFile, moduleName, imports, exports, providers,
-             });
+    this.modules.set(key, {
+      sourceFile,
+      moduleName,
+      imports,
+      exports,
+      providers,
+    });
   }
 
   listLazyRoutes(entryModuleKey?: string|undefined): LazyRoute[] {
@@ -63,7 +66,7 @@ export class NgModuleRouteAnalyzer {
     const scanRecursively = entryModuleKey !== undefined;
 
     while (pendingModuleKeys.length > 0) {
-      const key = pendingModuleKeys.pop() !;
+      const key = pendingModuleKeys.pop()!;
 
       if (scannedModuleKeys.has(key)) {
         continue;
@@ -71,7 +74,7 @@ export class NgModuleRouteAnalyzer {
         scannedModuleKeys.add(key);
       }
 
-      const data = this.modules.get(key) !;
+      const data = this.modules.get(key)!;
       const entryPoints = scanForRouteEntryPoints(
           data.sourceFile, data.moduleName, data, this.entryPointManager, this.evaluator);
 

--- a/packages/compiler-cli/src/ngtsc/routing/src/route.ts
+++ b/packages/compiler-cli/src/ngtsc/routing/src/route.ts
@@ -22,10 +22,14 @@ export abstract class RouterEntryPoint {
 class RouterEntryPointImpl implements RouterEntryPoint {
   constructor(readonly filePath: string, readonly moduleName: string) {}
 
-  get name(): string { return this.moduleName; }
+  get name(): string {
+    return this.moduleName;
+  }
 
   // For debugging purposes.
-  toString(): string { return `RouterEntryPoint(name: ${this.name}, filePath: ${this.filePath})`; }
+  toString(): string {
+    return `RouterEntryPoint(name: ${this.name}, filePath: ${this.filePath})`;
+  }
 }
 
 export class RouterEntryPointManager {
@@ -51,7 +55,7 @@ export class RouterEntryPointManager {
     if (!this.map.has(key)) {
       this.map.set(key, new RouterEntryPointImpl(sf.fileName, moduleName));
     }
-    return this.map.get(key) !;
+    return this.map.get(key)!;
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/scope/src/dependency.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/dependency.ts
@@ -47,12 +47,12 @@ export class MetadataDtsModuleScopeResolver implements DtsModuleScopeResolver {
     const clazz = ref.node;
     const sourceFile = clazz.getSourceFile();
     if (!sourceFile.isDeclarationFile) {
-      throw new Error(
-          `Debug error: DtsModuleScopeResolver.read(${ref.debugName} from ${sourceFile.fileName}), but not a .d.ts file`);
+      throw new Error(`Debug error: DtsModuleScopeResolver.read(${ref.debugName} from ${
+          sourceFile.fileName}), but not a .d.ts file`);
     }
 
     if (this.cache.has(clazz)) {
-      return this.cache.get(clazz) !;
+      return this.cache.get(clazz)!;
     }
 
     // Build up the export scope - those directives and pipes made visible by this module.

--- a/packages/compiler-cli/src/ngtsc/scope/src/local.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/local.ts
@@ -143,7 +143,7 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
   getScopeForComponent(clazz: ClassDeclaration): LocalModuleScope|null|'error' {
     const scope = !this.declarationToModule.has(clazz) ?
         null :
-        this.getScopeOfModule(this.declarationToModule.get(clazz) !.ngModule);
+        this.getScopeOfModule(this.declarationToModule.get(clazz)!.ngModule);
     return scope;
   }
 
@@ -159,7 +159,7 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
       return null;
     }
 
-    return Array.from(this.duplicateDeclarations.get(node) !.values());
+    return Array.from(this.duplicateDeclarations.get(node)!.values());
   }
 
   /**
@@ -172,7 +172,7 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
    */
   getScopeOfModule(clazz: ClassDeclaration): LocalModuleScope|'error'|null {
     const scope = this.moduleToRef.has(clazz) ?
-        this.getScopeOfModuleReference(this.moduleToRef.get(clazz) !) :
+        this.getScopeOfModuleReference(this.moduleToRef.get(clazz)!) :
         null;
     // If the NgModule class is marked as tainted, consider it an error.
     if (this.taintedModules.has(clazz)) {
@@ -193,7 +193,7 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
     this.getScopeOfModule(clazz);
 
     if (this.scopeErrors.has(clazz)) {
-      return this.scopeErrors.get(clazz) !;
+      return this.scopeErrors.get(clazz)!;
     } else {
       return null;
     }
@@ -218,21 +218,22 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
       rawDeclarations: ts.Expression|null): void {
     const declData: DeclarationData = {
       ngModule,
-      ref: decl, rawDeclarations,
+      ref: decl,
+      rawDeclarations,
     };
 
     // First, check for duplicate declarations of the same directive/pipe.
     if (this.duplicateDeclarations.has(decl.node)) {
       // This directive/pipe has already been identified as being duplicated. Add this module to the
       // map of modules for which a duplicate declaration exists.
-      this.duplicateDeclarations.get(decl.node) !.set(ngModule, declData);
+      this.duplicateDeclarations.get(decl.node)!.set(ngModule, declData);
     } else if (
         this.declarationToModule.has(decl.node) &&
-        this.declarationToModule.get(decl.node) !.ngModule !== ngModule) {
+        this.declarationToModule.get(decl.node)!.ngModule !== ngModule) {
       // This directive/pipe is already registered as declared in another module. Mark it as a
       // duplicate instead.
       const duplicateDeclMap = new Map<ClassDeclaration, DeclarationData>();
-      const firstDeclData = this.declarationToModule.get(decl.node) !;
+      const firstDeclData = this.declarationToModule.get(decl.node)!;
 
       // Mark both modules as tainted, since their declarations are missing a component.
       this.taintedModules.add(firstDeclData.ngModule);
@@ -341,11 +342,13 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
       } else {
         this.taintedModules.add(ngModule.ref.node);
 
-        const errorNode = decl.getOriginForDiagnostics(ngModule.rawDeclarations !);
+        const errorNode = decl.getOriginForDiagnostics(ngModule.rawDeclarations!);
         diagnostics.push(makeDiagnostic(
             ErrorCode.NGMODULE_INVALID_DECLARATION, errorNode,
             `The class '${decl.node.name.text}' is listed in the declarations ` +
-                `of the NgModule '${ngModule.ref.node.name.text}', but is not a directive, a component, or a pipe. ` +
+                `of the NgModule '${
+                    ngModule.ref.node.name
+                        .text}', but is not a directive, a component, or a pipe. ` +
                 `Either remove it from the NgModule's declarations, or add an appropriate Angular decorator.`,
             [{node: decl.node.name, messageText: `'${decl.node.name.text}' is declared here.`}]));
         continue;
@@ -378,11 +381,11 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
         }
       } else if (compilationDirectives.has(decl.node)) {
         // decl is a directive or component in the compilation scope of this NgModule.
-        const directive = compilationDirectives.get(decl.node) !;
+        const directive = compilationDirectives.get(decl.node)!;
         exportDirectives.set(decl.node, directive);
       } else if (compilationPipes.has(decl.node)) {
         // decl is a pipe in the compilation scope of this NgModule.
-        const pipe = compilationPipes.get(decl.node) !;
+        const pipe = compilationPipes.get(decl.node)!;
         exportPipes.set(decl.node, pipe);
       } else {
         // decl is an unknown export.
@@ -433,7 +436,9 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
   /**
    * Check whether a component requires remote scoping.
    */
-  getRequiresRemoteScope(node: ClassDeclaration): boolean { return this.remoteScoping.has(node); }
+  getRequiresRemoteScope(node: ClassDeclaration): boolean {
+    return this.remoteScoping.has(node);
+  }
 
   /**
    * Set a component as requiring remote scoping.
@@ -466,7 +471,8 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
                                          ErrorCode.NGMODULE_INVALID_EXPORT;
         diagnostics.push(makeDiagnostic(
             code, identifierOfNode(ref.node) || ref.node,
-            `Appears in the NgModule.${type}s of ${nodeNameForError(ownerForErrors)}, but could not be resolved to an NgModule`));
+            `Appears in the NgModule.${type}s of ${
+                nodeNameForError(ownerForErrors)}, but could not be resolved to an NgModule`));
         return undefined;
       }
       return this.dependencyScopeReader.resolve(ref);
@@ -496,16 +502,16 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
         return;
       }
       const isReExport = !declared.has(exportRef.node);
-      const exportName = this.aliasingHost !.maybeAliasSymbolAs(
+      const exportName = this.aliasingHost!.maybeAliasSymbolAs(
           exportRef, sourceFile, ngModule.ref.node.name.text, isReExport);
       if (exportName === null) {
         return;
       }
       if (!reexportMap.has(exportName)) {
         if (exportRef.alias && exportRef.alias instanceof ExternalExpr) {
-          reexports !.push({
-            fromModule: exportRef.alias.value.moduleName !,
-            symbolName: exportRef.alias.value.name !,
+          reexports!.push({
+            fromModule: exportRef.alias.value.moduleName!,
+            symbolName: exportRef.alias.value.name!,
             asAlias: exportName,
           });
         } else {
@@ -514,7 +520,7 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
               expr.value.name === null) {
             throw new Error('Expected ExternalExpr');
           }
-          reexports !.push({
+          reexports!.push({
             fromModule: expr.value.moduleName,
             symbolName: expr.value.name,
             asAlias: exportName,
@@ -523,7 +529,7 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
         reexportMap.set(exportName, exportRef);
       } else {
         // Another re-export already used this name. Produce a diagnostic.
-        const prevRef = reexportMap.get(exportName) !;
+        const prevRef = reexportMap.get(exportName)!;
         diagnostics.push(reexportCollision(ngModuleRef.node, prevRef, exportRef));
       }
     };
@@ -548,12 +554,13 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
  */
 function invalidRef(
     clazz: ts.Declaration, decl: Reference<ts.Declaration>,
-    type: 'import' | 'export'): ts.Diagnostic {
+    type: 'import'|'export'): ts.Diagnostic {
   const code =
       type === 'import' ? ErrorCode.NGMODULE_INVALID_IMPORT : ErrorCode.NGMODULE_INVALID_EXPORT;
   const resolveTarget = type === 'import' ? 'NgModule' : 'NgModule, Component, Directive, or Pipe';
   let message =
-      `Appears in the NgModule.${type}s of ${nodeNameForError(clazz)}, but could not be resolved to an ${resolveTarget} class.` +
+      `Appears in the NgModule.${type}s of ${
+          nodeNameForError(clazz)}, but could not be resolved to an ${resolveTarget} class.` +
       '\n\n';
   const library = decl.ownedByModuleGuess !== null ? ` (${decl.ownedByModuleGuess})` : '';
   const sf = decl.node.getSourceFile();
@@ -573,8 +580,8 @@ function invalidRef(
   } else {
     // This is a monorepo style local dependency. Unfortunately these are too different to really
     // offer much more advice than this.
-    message +=
-        `This likely means that the dependency${library} which declares ${decl.debugName} has not been processed correctly by ngcc.`;
+    message += `This likely means that the dependency${library} which declares ${
+        decl.debugName} has not been processed correctly by ngcc.`;
   }
 
   return makeDiagnostic(code, identifierOfNode(decl.node) || decl.node, message);
@@ -585,7 +592,7 @@ function invalidRef(
  */
 function invalidTransitiveNgModuleRef(
     clazz: ts.Declaration, decl: Reference<ts.Declaration>,
-    type: 'import' | 'export'): ts.Diagnostic {
+    type: 'import'|'export'): ts.Diagnostic {
   const code =
       type === 'import' ? ErrorCode.NGMODULE_INVALID_IMPORT : ErrorCode.NGMODULE_INVALID_EXPORT;
   return makeDiagnostic(
@@ -600,7 +607,8 @@ function invalidTransitiveNgModuleRef(
 function invalidReexport(clazz: ts.Declaration, decl: Reference<ts.Declaration>): ts.Diagnostic {
   return makeDiagnostic(
       ErrorCode.NGMODULE_INVALID_REEXPORT, identifierOfNode(decl.node) || decl.node,
-      `Present in the NgModule.exports of ${nodeNameForError(clazz)} but neither declared nor imported`);
+      `Present in the NgModule.exports of ${
+          nodeNameForError(clazz)} but neither declared nor imported`);
 }
 
 /**
@@ -609,11 +617,13 @@ function invalidReexport(clazz: ts.Declaration, decl: Reference<ts.Declaration>)
 function reexportCollision(
     module: ClassDeclaration, refA: Reference<ClassDeclaration>,
     refB: Reference<ClassDeclaration>): ts.Diagnostic {
-  const childMessageText =
-      `This directive/pipe is part of the exports of '${module.name.text}' and shares the same name as another exported directive/pipe.`;
+  const childMessageText = `This directive/pipe is part of the exports of '${
+      module.name.text}' and shares the same name as another exported directive/pipe.`;
   return makeDiagnostic(
-      ErrorCode.NGMODULE_REEXPORT_NAME_COLLISION, module.name, `
-    There was a name collision between two classes named '${refA.node.name.text}', which are both part of the exports of '${module.name.text}'.
+      ErrorCode.NGMODULE_REEXPORT_NAME_COLLISION, module.name,
+      `
+    There was a name collision between two classes named '${
+          refA.node.name.text}', which are both part of the exports of '${module.name.text}'.
 
     Angular generates re-exports of an NgModule's exported directives/pipes from the module's source file in certain cases, using the declared name of the class. If two classes of the same name are exported, this automatic naming does not work.
 

--- a/packages/compiler-cli/src/ngtsc/scope/test/dependency_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/dependency_spec.ts
@@ -22,7 +22,7 @@ const MODULE_FROM_NODE_MODULES_PATH = /.*node_modules\/(\w+)\/index\.d\.ts$/;
 
 const testHost: UnifiedModulesHost = {
   fileNameToModuleName: function(imported: string): string {
-    const res = MODULE_FROM_NODE_MODULES_PATH.exec(imported) !;
+    const res = MODULE_FROM_NODE_MODULES_PATH.exec(imported)!;
     return 'root/' + res[1];
   }
 };
@@ -44,7 +44,7 @@ export declare type PipeMeta<A, B> = never;
  * destructured to retrieve references to specific declared classes.
  */
 function makeTestEnv(
-    modules: {[module: string]: string}, aliasGenerator: AliasingHost | null = null): {
+    modules: {[module: string]: string}, aliasGenerator: AliasingHost|null = null): {
   refs: {[name: string]: Reference<ClassDeclaration>},
   resolver: MetadataDtsModuleScopeResolver,
 } {
@@ -64,11 +64,11 @@ function makeTestEnv(
   // Resolver for the refs object.
   const get = (target: {}, name: string): Reference<ts.ClassDeclaration> => {
     for (const sf of program.getSourceFiles()) {
-      const symbol = checker.getSymbolAtLocation(sf) !;
-      const exportedSymbol = symbol.exports !.get(name as ts.__String);
+      const symbol = checker.getSymbolAtLocation(sf)!;
+      const exportedSymbol = symbol.exports!.get(name as ts.__String);
       if (exportedSymbol !== undefined) {
         const decl = exportedSymbol.valueDeclaration as ts.ClassDeclaration;
-        const specifier = MODULE_FROM_NODE_MODULES_PATH.exec(sf.fileName) ![1];
+        const specifier = MODULE_FROM_NODE_MODULES_PATH.exec(sf.fileName)![1];
         return new Reference(decl, {specifier, resolutionContext: sf.fileName});
       }
     }
@@ -97,7 +97,7 @@ runInEachFileSystem(() => {
       `
       });
       const {Dir, Module} = refs;
-      const scope = resolver.resolve(Module) !;
+      const scope = resolver.resolve(Module)!;
       expect(scopeToRefs(scope)).toEqual([Dir]);
     });
 
@@ -118,7 +118,7 @@ runInEachFileSystem(() => {
       `
       });
       const {Dir, ModuleB} = refs;
-      const scope = resolver.resolve(ModuleB) !;
+      const scope = resolver.resolve(ModuleB)!;
       expect(scopeToRefs(scope)).toEqual([Dir]);
     });
 
@@ -142,7 +142,7 @@ runInEachFileSystem(() => {
         `
       });
       const {Dir, ModuleB} = refs;
-      const scope = resolver.resolve(ModuleB) !;
+      const scope = resolver.resolve(ModuleB)!;
       expect(scopeToRefs(scope)).toEqual([Dir]);
 
       // Explicitly verify that the directive has the correct owning module.
@@ -186,7 +186,7 @@ runInEachFileSystem(() => {
           },
           new UnifiedModulesAliasingHost(testHost));
       const {ShallowModule} = refs;
-      const scope = resolver.resolve(ShallowModule) !;
+      const scope = resolver.resolve(ShallowModule)!;
       const [DeepDir, MiddleDir, ShallowDir] = scopeToRefs(scope);
       expect(getAlias(DeepDir)).toEqual({
         moduleName: 'root/shallow',
@@ -236,7 +236,7 @@ runInEachFileSystem(() => {
           },
           new UnifiedModulesAliasingHost(testHost));
       const {ShallowModule} = refs;
-      const scope = resolver.resolve(ShallowModule) !;
+      const scope = resolver.resolve(ShallowModule)!;
       const [DeepDir, MiddleDir, ShallowDir] = scopeToRefs(scope);
       expect(getAlias(DeepDir)).toEqual({
         moduleName: 'root/shallow',
@@ -269,7 +269,7 @@ runInEachFileSystem(() => {
              },
              new UnifiedModulesAliasingHost(testHost));
          const {DeepExportModule} = refs;
-         const scope = resolver.resolve(DeepExportModule) !;
+         const scope = resolver.resolve(DeepExportModule)!;
          const [DeepDir] = scopeToRefs(scope);
          expect(getAlias(DeepDir)).toBeNull();
        });
@@ -278,7 +278,7 @@ runInEachFileSystem(() => {
   function scopeToRefs(scope: ExportScope): Reference<ClassDeclaration>[] {
     const directives = scope.exported.directives.map(dir => dir.ref);
     const pipes = scope.exported.pipes.map(pipe => pipe.ref);
-    return [...directives, ...pipes].sort((a, b) => a.debugName !.localeCompare(b.debugName !));
+    return [...directives, ...pipes].sort((a, b) => a.debugName!.localeCompare(b.debugName!));
   }
 
   function getAlias(ref: Reference<ClassDeclaration>): ExternalReference|null {

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -34,8 +34,8 @@ function registerFakeRefs(registry: MetadataRegistry):
 
 describe('LocalModuleScopeRegistry', () => {
   const refEmitter = new ReferenceEmitter([]);
-  let scopeRegistry !: LocalModuleScopeRegistry;
-  let metaRegistry !: MetadataRegistry;
+  let scopeRegistry!: LocalModuleScopeRegistry;
+  let metaRegistry!: MetadataRegistry;
 
   beforeEach(() => {
     const localRegistry = new LocalMetadataRegistry();
@@ -230,7 +230,7 @@ describe('LocalModuleScopeRegistry', () => {
 });
 
 function fakeDirective(ref: Reference<ClassDeclaration>): DirectiveMeta {
-  const name = ref.debugName !;
+  const name = ref.debugName!;
   return {
     ref,
     name,
@@ -248,16 +248,18 @@ function fakeDirective(ref: Reference<ClassDeclaration>): DirectiveMeta {
 }
 
 function fakePipe(ref: Reference<ClassDeclaration>): PipeMeta {
-  const name = ref.debugName !;
+  const name = ref.debugName!;
   return {ref, name};
 }
 
 class MockDtsModuleScopeResolver implements DtsModuleScopeResolver {
-  resolve(ref: Reference<ClassDeclaration>): null { return null; }
+  resolve(ref: Reference<ClassDeclaration>): null {
+    return null;
+  }
 }
 
 function scopeToRefs(scopeData: ScopeData): Reference<ClassDeclaration>[] {
   const directives = scopeData.directives.map(dir => dir.ref);
   const pipes = scopeData.pipes.map(pipe => pipe.ref);
-  return [...directives, ...pipes].sort((a, b) => a.debugName !.localeCompare(b.debugName !));
+  return [...directives, ...pipes].sort((a, b) => a.debugName!.localeCompare(b.debugName!));
 }

--- a/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts
@@ -7,7 +7,7 @@
  */
 import * as ts from 'typescript';
 
-import {AbsoluteFsPath, absoluteFrom, basename} from '../../file_system';
+import {absoluteFrom, AbsoluteFsPath, basename} from '../../file_system';
 import {ImportRewriter} from '../../imports';
 import {isNonDeclarationTsPath} from '../../util/src/typescript';
 
@@ -24,15 +24,21 @@ const STRIP_NG_FACTORY = /(.*)NgFactory$/;
 export class FactoryGenerator implements ShimGenerator {
   private constructor(private map: Map<AbsoluteFsPath, AbsoluteFsPath>) {}
 
-  get factoryFileMap(): Map<AbsoluteFsPath, AbsoluteFsPath> { return this.map; }
+  get factoryFileMap(): Map<AbsoluteFsPath, AbsoluteFsPath> {
+    return this.map;
+  }
 
-  get factoryFileNames(): AbsoluteFsPath[] { return Array.from(this.map.keys()); }
+  get factoryFileNames(): AbsoluteFsPath[] {
+    return Array.from(this.map.keys());
+  }
 
-  recognize(fileName: AbsoluteFsPath): boolean { return this.map.has(fileName); }
+  recognize(fileName: AbsoluteFsPath): boolean {
+    return this.map.has(fileName);
+  }
 
   generate(genFilePath: AbsoluteFsPath, readFile: (fileName: string) => ts.SourceFile | null):
       ts.SourceFile|null {
-    const originalPath = this.map.get(genFilePath) !;
+    const originalPath = this.map.get(genFilePath)!;
     const original = readFile(originalPath);
     if (original === null) {
       return null;
@@ -53,7 +59,7 @@ export class FactoryGenerator implements ShimGenerator {
                                 decl => isExported(decl) && decl.decorators !== undefined &&
                                     decl.name !== undefined)
                             // Grab the symbol name.
-                            .map(decl => decl.name !.text);
+                            .map(decl => decl.name!.text);
 
 
     let sourceText = '';
@@ -71,8 +77,8 @@ export class FactoryGenerator implements ShimGenerator {
       // This will encompass a lot of symbols which don't need factories, but that's okay
       // because it won't miss any that do.
       const varLines = symbolNames.map(
-          name =>
-              `export const ${name}NgFactory: i0.ɵNgModuleFactory<any> = new i0.ɵNgModuleFactory(${name});`);
+          name => `export const ${
+              name}NgFactory: i0.ɵNgModuleFactory<any> = new i0.ɵNgModuleFactory(${name});`);
       sourceText += [
         // This might be incorrect if the current package being compiled is Angular core, but it's
         // okay to leave in at type checking time. TypeScript can handle this reference via its path
@@ -136,7 +142,7 @@ function transformFactorySourceFile(
     return file;
   }
 
-  const {moduleSymbolNames, sourceFilePath} = factoryMap.get(file.fileName) !;
+  const {moduleSymbolNames, sourceFilePath} = factoryMap.get(file.fileName)!;
 
   file = ts.getMutableClone(file);
 

--- a/packages/compiler-cli/src/ngtsc/shims/src/factory_tracker.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/factory_tracker.ts
@@ -32,7 +32,7 @@ export class FactoryTracker {
 
   track(sf: ts.SourceFile, factorySymbolName: string): void {
     if (this.sourceToFactorySymbols.has(sf.fileName)) {
-      this.sourceToFactorySymbols.get(sf.fileName) !.add(factorySymbolName);
+      this.sourceToFactorySymbols.get(sf.fileName)!.add(factorySymbolName);
     }
   }
 }

--- a/packages/compiler-cli/src/ngtsc/shims/src/summary_generator.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/summary_generator.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {AbsoluteFsPath, absoluteFrom} from '../../file_system';
+import {absoluteFrom, AbsoluteFsPath} from '../../file_system';
 import {isNonDeclarationTsPath} from '../../util/src/typescript';
 
 import {ShimGenerator} from './api';
@@ -17,13 +17,17 @@ import {generatedModuleName} from './util';
 export class SummaryGenerator implements ShimGenerator {
   private constructor(private map: Map<AbsoluteFsPath, AbsoluteFsPath>) {}
 
-  getSummaryFileNames(): AbsoluteFsPath[] { return Array.from(this.map.keys()); }
+  getSummaryFileNames(): AbsoluteFsPath[] {
+    return Array.from(this.map.keys());
+  }
 
-  recognize(fileName: AbsoluteFsPath): boolean { return this.map.has(fileName); }
+  recognize(fileName: AbsoluteFsPath): boolean {
+    return this.map.has(fileName);
+  }
 
   generate(genFilePath: AbsoluteFsPath, readFile: (fileName: string) => ts.SourceFile | null):
       ts.SourceFile|null {
-    const originalPath = this.map.get(genFilePath) !;
+    const originalPath = this.map.get(genFilePath)!;
     const original = readFile(originalPath);
     if (original === null) {
       return null;

--- a/packages/compiler-cli/src/ngtsc/shims/src/typecheck_shim.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/typecheck_shim.ts
@@ -22,7 +22,9 @@ import {ShimGenerator} from './api';
 export class TypeCheckShimGenerator implements ShimGenerator {
   constructor(private typeCheckFile: AbsoluteFsPath) {}
 
-  recognize(fileName: AbsoluteFsPath): boolean { return fileName === this.typeCheckFile; }
+  recognize(fileName: AbsoluteFsPath): boolean {
+    return fileName === this.typeCheckFile;
+  }
 
   generate(genFileName: AbsoluteFsPath, readFile: (fileName: string) => ts.SourceFile | null):
       ts.SourceFile|null {

--- a/packages/compiler-cli/src/ngtsc/switch/src/switch.ts
+++ b/packages/compiler-cli/src/ngtsc/switch/src/switch.ts
@@ -107,8 +107,8 @@ function flipIvySwitchesInVariableStatement(
     // reported as a thrown error and not a diagnostic as transformers cannot output diagnostics.
     let newIdentifier = findPostSwitchIdentifier(statements, postSwitchName);
     if (newIdentifier === null) {
-      throw new Error(
-          `Unable to find identifier ${postSwitchName} in ${stmt.getSourceFile().fileName} for the Ivy switch.`);
+      throw new Error(`Unable to find identifier ${postSwitchName} in ${
+          stmt.getSourceFile().fileName} for the Ivy switch.`);
     }
 
     // Copy the identifier with updateIdentifier(). This copies the internal information which

--- a/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
@@ -10,7 +10,7 @@
 
 import * as ts from 'typescript';
 
-import {AbsoluteFsPath, NgtscCompilerHost, dirname, getFileSystem, getSourceFileOrError} from '../../file_system';
+import {AbsoluteFsPath, dirname, getFileSystem, getSourceFileOrError, NgtscCompilerHost} from '../../file_system';
 
 export function makeProgram(
     files: {name: AbsoluteFsPath, contents: string, isRoot?: boolean}[],
@@ -25,7 +25,8 @@ export function makeProgram(
   const compilerOptions = {
     noLib: true,
     experimentalDecorators: true,
-    moduleResolution: ts.ModuleResolutionKind.NodeJs, ...options
+    moduleResolution: ts.ModuleResolutionKind.NodeJs,
+    ...options
   };
   const compilerHost = new NgtscCompilerHost(fs, compilerOptions);
   const rootNames = files.filter(file => file.isRoot !== false)
@@ -38,7 +39,7 @@ export function makeProgram(
         let message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
         if (diagnostic.file) {
           const {line, character} =
-              diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start !);
+              diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!);
           message = `${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`;
         }
         return `Error: ${message}`;

--- a/packages/compiler-cli/src/ngtsc/transform/src/alias.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/alias.ts
@@ -17,7 +17,7 @@ export function aliasTransformFactory(exportStatements: Map<string, Map<string, 
       }
 
       const statements = [...file.statements];
-      exportStatements.get(file.fileName) !.forEach(([moduleName, symbolName], aliasName) => {
+      exportStatements.get(file.fileName)!.forEach(([moduleName, symbolName], aliasName) => {
         const stmt = ts.createExportDeclaration(
             /* decorators */ undefined,
             /* modifiers */ undefined,

--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -94,9 +94,13 @@ export class TraitCompiler {
     }
   }
 
-  analyzeSync(sf: ts.SourceFile): void { this.analyze(sf, false); }
+  analyzeSync(sf: ts.SourceFile): void {
+    this.analyze(sf, false);
+  }
 
-  analyzeAsync(sf: ts.SourceFile): Promise<void>|undefined { return this.analyze(sf, true); }
+  analyzeAsync(sf: ts.SourceFile): Promise<void>|undefined {
+    return this.analyze(sf, true);
+  }
 
   private analyze(sf: ts.SourceFile, preanalyze: false): void;
   private analyze(sf: ts.SourceFile, preanalyze: true): Promise<void>|undefined;
@@ -138,7 +142,7 @@ export class TraitCompiler {
 
   recordFor(clazz: ClassDeclaration): ClassRecord|null {
     if (this.classes.has(clazz)) {
-      return this.classes.get(clazz) !;
+      return this.classes.get(clazz)!;
     } else {
       return null;
     }
@@ -149,8 +153,8 @@ export class TraitCompiler {
       return null;
     }
     const records: ClassRecord[] = [];
-    for (const clazz of this.fileToClasses.get(sf) !) {
-      records.push(this.classes.get(clazz) !);
+    for (const clazz of this.fileToClasses.get(sf)!) {
+      records.push(this.classes.get(clazz)!);
     }
     return records;
   }
@@ -173,7 +177,7 @@ export class TraitCompiler {
     };
 
     for (const priorTrait of priorRecord.traits) {
-      const handler = this.handlersByName.get(priorTrait.handler.name) !;
+      const handler = this.handlersByName.get(priorTrait.handler.name)!;
       let trait: Trait<unknown, unknown, unknown> = Trait.pending(handler, priorTrait.detected);
 
       if (priorTrait.state === TraitState.ANALYZED || priorTrait.state === TraitState.RESOLVED) {
@@ -195,7 +199,7 @@ export class TraitCompiler {
     if (!this.fileToClasses.has(sf)) {
       this.fileToClasses.set(sf, new Set<ClassDeclaration>());
     }
-    this.fileToClasses.get(sf) !.add(record.node);
+    this.fileToClasses.get(sf)!.add(record.node);
   }
 
   private scanClassForTraits(clazz: ClassDeclaration):
@@ -242,7 +246,7 @@ export class TraitCompiler {
         if (!this.fileToClasses.has(sf)) {
           this.fileToClasses.set(sf, new Set<ClassDeclaration>());
         }
-        this.fileToClasses.get(sf) !.add(clazz);
+        this.fileToClasses.get(sf)!.add(clazz);
       } else {
         // This is at least the second handler to match this class. This is a slower path that some
         // classes will go through, which validates that the set of decorators applied to the class
@@ -317,7 +321,7 @@ export class TraitCompiler {
         }
       }
       if (preanalysis !== null) {
-        preanalyzeQueue !.push(preanalysis.then(analyze));
+        preanalyzeQueue!.push(preanalysis.then(analyze));
       } else {
         analyze();
       }
@@ -328,8 +332,8 @@ export class TraitCompiler {
       clazz: ClassDeclaration, trait: Trait<unknown, unknown, unknown>,
       flags?: HandlerFlags): void {
     if (trait.state !== TraitState.PENDING) {
-      throw new Error(
-          `Attempt to analyze trait of ${clazz.name.text} in state ${TraitState[trait.state]} (expected DETECTED)`);
+      throw new Error(`Attempt to analyze trait of ${clazz.name.text} in state ${
+          TraitState[trait.state]} (expected DETECTED)`);
     }
 
     // Attempt analysis. This could fail with a `FatalDiagnosticError`; catch it if it does.
@@ -363,7 +367,7 @@ export class TraitCompiler {
   resolve(): void {
     const classes = Array.from(this.classes.keys());
     for (const clazz of classes) {
-      const record = this.classes.get(clazz) !;
+      const record = this.classes.get(clazz)!;
       for (let trait of record.traits) {
         const handler = trait.handler;
         switch (trait.state) {
@@ -371,8 +375,8 @@ export class TraitCompiler {
           case TraitState.ERRORED:
             continue;
           case TraitState.PENDING:
-            throw new Error(
-                `Resolving a trait that hasn't been analyzed: ${clazz.name.text} / ${Object.getPrototypeOf(trait.handler).constructor.name}`);
+            throw new Error(`Resolving a trait that hasn't been analyzed: ${clazz.name.text} / ${
+                Object.getPrototypeOf(trait.handler).constructor.name}`);
           case TraitState.RESOLVED:
             throw new Error(`Resolving an already resolved trait`);
         }
@@ -410,7 +414,7 @@ export class TraitCompiler {
           if (!this.reexportMap.has(fileName)) {
             this.reexportMap.set(fileName, new Map<string, [string, string]>());
           }
-          const fileReexports = this.reexportMap.get(fileName) !;
+          const fileReexports = this.reexportMap.get(fileName)!;
           for (const reexport of result.reexports) {
             fileReexports.set(reexport.asAlias, [reexport.fromModule, reexport.symbolName]);
           }
@@ -421,7 +425,7 @@ export class TraitCompiler {
 
   typeCheck(ctx: TypeCheckContext): void {
     for (const clazz of this.classes.keys()) {
-      const record = this.classes.get(clazz) !;
+      const record = this.classes.get(clazz)!;
       for (const trait of record.traits) {
         if (trait.state !== TraitState.RESOLVED) {
           continue;
@@ -435,7 +439,7 @@ export class TraitCompiler {
 
   index(ctx: IndexingContext): void {
     for (const clazz of this.classes.keys()) {
-      const record = this.classes.get(clazz) !;
+      const record = this.classes.get(clazz)!;
       for (const trait of record.traits) {
         if (trait.state !== TraitState.RESOLVED) {
           // Skip traits that haven't been resolved successfully.
@@ -457,7 +461,7 @@ export class TraitCompiler {
       return null;
     }
 
-    const record = this.classes.get(original) !;
+    const record = this.classes.get(original)!;
 
     let res: CompileResult[] = [];
 
@@ -496,7 +500,7 @@ export class TraitCompiler {
       return [];
     }
 
-    const record = this.classes.get(original) !;
+    const record = this.classes.get(original)!;
     const decorators: ts.Decorator[] = [];
 
     for (const trait of record.traits) {
@@ -515,7 +519,7 @@ export class TraitCompiler {
   get diagnostics(): ReadonlyArray<ts.Diagnostic> {
     const diagnostics: ts.Diagnostic[] = [];
     for (const clazz of this.classes.keys()) {
-      const record = this.classes.get(clazz) !;
+      const record = this.classes.get(clazz)!;
       if (record.metaDiagnostics !== null) {
         diagnostics.push(...record.metaDiagnostics);
       }
@@ -528,5 +532,7 @@ export class TraitCompiler {
     return diagnostics;
   }
 
-  get exportStatements(): Map<string, Map<string, [string, string]>> { return this.reexportMap; }
+  get exportStatements(): Map<string, Map<string, [string, string]>> {
+    return this.reexportMap;
+  }
 }

--- a/packages/compiler-cli/src/ngtsc/transform/src/declaration.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/declaration.ts
@@ -28,14 +28,14 @@ export class DtsTransformRegistry {
     if (!this.ivyDeclarationTransforms.has(sf)) {
       this.ivyDeclarationTransforms.set(sf, new IvyDeclarationDtsTransform());
     }
-    return this.ivyDeclarationTransforms.get(sf) !;
+    return this.ivyDeclarationTransforms.get(sf)!;
   }
 
   getReturnTypeTransform(sf: ts.SourceFile): ReturnTypeTransform {
     if (!this.returnTypeTransforms.has(sf)) {
       this.returnTypeTransforms.set(sf, new ReturnTypeTransform());
     }
-    return this.returnTypeTransforms.get(sf) !;
+    return this.returnTypeTransforms.get(sf)!;
   }
 
   /**
@@ -55,11 +55,11 @@ export class DtsTransformRegistry {
     let transforms: DtsTransform[]|null = null;
     if (this.ivyDeclarationTransforms.has(originalSf)) {
       transforms = [];
-      transforms.push(this.ivyDeclarationTransforms.get(originalSf) !);
+      transforms.push(this.ivyDeclarationTransforms.get(originalSf)!);
     }
     if (this.returnTypeTransforms.has(originalSf)) {
       transforms = transforms || [];
-      transforms.push(this.returnTypeTransforms.get(originalSf) !);
+      transforms.push(this.returnTypeTransforms.get(originalSf)!);
     }
     return transforms;
   }
@@ -200,7 +200,7 @@ export class IvyDeclarationDtsTransform implements DtsTransform {
     if (!this.declarationFields.has(original)) {
       return clazz;
     }
-    const fields = this.declarationFields.get(original) !;
+    const fields = this.declarationFields.get(original)!;
 
     const newMembers = fields.map(decl => {
       const modifiers = [ts.createModifier(ts.SyntaxKind.StaticKeyword)];
@@ -247,7 +247,7 @@ export class ReturnTypeTransform implements DtsTransform {
     if (!this.typeReplacements.has(original)) {
       return element;
     }
-    const returnType = this.typeReplacements.get(original) !;
+    const returnType = this.typeReplacements.get(original)!;
     const tsReturnType = translateType(returnType, imports);
 
     const methodSignature = ts.updateMethodSignature(
@@ -273,7 +273,7 @@ export class ReturnTypeTransform implements DtsTransform {
     if (!this.typeReplacements.has(original)) {
       return element;
     }
-    const returnType = this.typeReplacements.get(original) !;
+    const returnType = this.typeReplacements.get(original)!;
     const tsReturnType = translateType(returnType, imports);
 
     return ts.updateFunctionDeclaration(

--- a/packages/compiler-cli/src/ngtsc/transform/src/trait.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/trait.ts
@@ -50,8 +50,8 @@ export enum TraitState {
  * This not only simplifies the implementation, but ensures traits are monomorphic objects as
  * they're all just "views" in the type system of the same object (which never changes shape).
  */
-export type Trait<D, A, R> = PendingTrait<D, A, R>| SkippedTrait<D, A, R>| AnalyzedTrait<D, A, R>|
-    ResolvedTrait<D, A, R>| ErroredTrait<D, A, R>;
+export type Trait<D, A, R> = PendingTrait<D, A, R>|SkippedTrait<D, A, R>|AnalyzedTrait<D, A, R>|
+    ResolvedTrait<D, A, R>|ErroredTrait<D, A, R>;
 
 /**
  * The value side of `Trait` exposes a helper to create a `Trait` in a pending state (by delegating
@@ -59,7 +59,7 @@ export type Trait<D, A, R> = PendingTrait<D, A, R>| SkippedTrait<D, A, R>| Analy
  */
 export const Trait = {
   pending: <D, A, R>(handler: DecoratorHandler<D, A, R>, detected: DetectResult<D>):
-               PendingTrait<D, A, R> => TraitImpl.pending(handler, detected),
+      PendingTrait<D, A, R> => TraitImpl.pending(handler, detected),
 };
 
 /**
@@ -137,7 +137,9 @@ export interface ErroredTrait<D, A, R> extends TraitBase<D, A, R> {
  *
  * This is a terminal state.
  */
-export interface SkippedTrait<D, A, R> extends TraitBase<D, A, R> { state: TraitState.SKIPPED; }
+export interface SkippedTrait<D, A, R> extends TraitBase<D, A, R> {
+  state: TraitState.SKIPPED;
+}
 
 /**
  * The part of the `Trait` interface for any trait which has been successfully analyzed.
@@ -251,8 +253,8 @@ class TraitImpl<D, A, R> {
    */
   private assertTransitionLegal(allowedState: TraitState, transitionTo: TraitState): void {
     if (!(this.state & allowedState)) {
-      throw new Error(
-          `Assertion failure: cannot transition from ${TraitState[this.state]} to ${TraitState[transitionTo]}.`);
+      throw new Error(`Assertion failure: cannot transition from ${TraitState[this.state]} to ${
+          TraitState[transitionTo]}.`);
     }
   }
 

--- a/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
 import {DefaultImportRecorder, ImportRewriter} from '../../imports';
 import {Decorator, ReflectionHost} from '../../reflection';
 import {ImportManager, translateExpression, translateStatement} from '../../translator';
-import {VisitListEntryResult, Visitor, visit} from '../../util/src/visitor';
+import {visit, VisitListEntryResult, Visitor} from '../../util/src/visitor';
 
 import {TraitCompiler} from './compilation';
 import {addImports} from './utils';
@@ -285,7 +285,7 @@ function setFileOverviewComment(sf: ts.SourceFile, fileoverview: FileOverviewMet
 }
 
 function maybeFilterDecorator(
-    decorators: ts.NodeArray<ts.Decorator>| undefined,
+    decorators: ts.NodeArray<ts.Decorator>|undefined,
     toRemove: ts.Decorator[]): ts.NodeArray<ts.Decorator>|undefined {
   if (decorators === undefined) {
     return undefined;

--- a/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
@@ -24,11 +24,15 @@ runInEachFileSystem(() => {
         name = 'FakeDecoratorHandler';
         precedence = HandlerPrecedence.PRIMARY;
 
-        detect(): undefined { throw new Error('detect should not have been called'); }
+        detect(): undefined {
+          throw new Error('detect should not have been called');
+        }
         analyze(): AnalysisOutput<unknown> {
           throw new Error('analyze should not have been called');
         }
-        compile(): CompileResult { throw new Error('compile should not have been called'); }
+        compile(): CompileResult {
+          throw new Error('compile should not have been called');
+        }
       }
 
       const {program} = makeProgram([{
@@ -40,7 +44,7 @@ runInEachFileSystem(() => {
       const compiler = new TraitCompiler(
           [new FakeDecoratorHandler()], reflectionHost, NOOP_PERF_RECORDER, NOOP_INCREMENTAL_BUILD,
           true, new DtsTransformRegistry());
-      const sourceFile = program.getSourceFile('lib.d.ts') !;
+      const sourceFile = program.getSourceFile('lib.d.ts')!;
       const analysis = compiler.analyzeSync(sourceFile);
 
       expect(sourceFile.isDeclarationFile).toBe(true);

--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ArrayType, AssertNotNull, BinaryOperator, BinaryOperatorExpr, BuiltinType, BuiltinTypeName, CastExpr, ClassStmt, CommaExpr, CommentStmt, ConditionalExpr, DeclareFunctionStmt, DeclareVarStmt, Expression, ExpressionStatement, ExpressionType, ExpressionVisitor, ExternalExpr, FunctionExpr, IfStmt, InstantiateExpr, InvokeFunctionExpr, InvokeMethodExpr, JSDocCommentStmt, LiteralArrayExpr, LiteralExpr, LiteralMapExpr, MapType, NotExpr, ReadKeyExpr, ReadPropExpr, ReadVarExpr, ReturnStatement, Statement, StatementVisitor, StmtModifier, ThrowStmt, TryCatchStmt, Type, TypeVisitor, TypeofExpr, WrappedNodeExpr, WriteKeyExpr, WritePropExpr, WriteVarExpr} from '@angular/compiler';
+import {ArrayType, AssertNotNull, BinaryOperator, BinaryOperatorExpr, BuiltinType, BuiltinTypeName, CastExpr, ClassStmt, CommaExpr, CommentStmt, ConditionalExpr, DeclareFunctionStmt, DeclareVarStmt, Expression, ExpressionStatement, ExpressionType, ExpressionVisitor, ExternalExpr, FunctionExpr, IfStmt, InstantiateExpr, InvokeFunctionExpr, InvokeMethodExpr, JSDocCommentStmt, LiteralArrayExpr, LiteralExpr, LiteralMapExpr, MapType, NotExpr, ReadKeyExpr, ReadPropExpr, ReadVarExpr, ReturnStatement, Statement, StatementVisitor, StmtModifier, ThrowStmt, TryCatchStmt, Type, TypeofExpr, TypeVisitor, WrappedNodeExpr, WriteKeyExpr, WritePropExpr, WriteVarExpr} from '@angular/compiler';
 import {LocalizedString} from '@angular/compiler/src/output/output_ast';
 import * as ts from 'typescript';
 
@@ -15,9 +15,13 @@ import {DefaultImportRecorder, ImportRewriter, NOOP_DEFAULT_IMPORT_RECORDER, Noo
 export class Context {
   constructor(readonly isStatement: boolean) {}
 
-  get withExpressionMode(): Context { return this.isStatement ? new Context(false) : this; }
+  get withExpressionMode(): Context {
+    return this.isStatement ? new Context(false) : this;
+  }
 
-  get withStatementMode(): Context { return !this.isStatement ? new Context(true) : this; }
+  get withStatementMode(): Context {
+    return !this.isStatement ? new Context(true) : this;
+  }
 }
 
 const BINARY_OPERATORS = new Map<BinaryOperator, ts.BinaryOperator>([
@@ -83,7 +87,7 @@ export class ImportManager {
     if (!this.specifierToIdentifier.has(moduleName)) {
       this.specifierToIdentifier.set(moduleName, `${this.prefix}${this.nextIndex++}`);
     }
-    const moduleImport = this.specifierToIdentifier.get(moduleName) !;
+    const moduleImport = this.specifierToIdentifier.get(moduleName)!;
 
     return {moduleImport, symbol};
   }
@@ -130,19 +134,21 @@ class ExpressionTranslatorVisitor implements ExpressionVisitor, StatementVisitor
         ts.NodeFlags.Const :
         ts.NodeFlags.None;
     return ts.createVariableStatement(
-        undefined, ts.createVariableDeclarationList(
-                       [ts.createVariableDeclaration(
-                           stmt.name, undefined, stmt.value &&
-                               stmt.value.visitExpression(this, context.withExpressionMode))],
-                       nodeFlags));
+        undefined,
+        ts.createVariableDeclarationList(
+            [ts.createVariableDeclaration(
+                stmt.name, undefined,
+                stmt.value && stmt.value.visitExpression(this, context.withExpressionMode))],
+            nodeFlags));
   }
 
   visitDeclareFunctionStmt(stmt: DeclareFunctionStmt, context: Context): ts.FunctionDeclaration {
     return ts.createFunctionDeclaration(
         undefined, undefined, undefined, stmt.name, undefined,
         stmt.params.map(param => ts.createParameter(undefined, undefined, undefined, param.name)),
-        undefined, ts.createBlock(stmt.statements.map(
-                       child => child.visitStatement(this, context.withStatementMode))));
+        undefined,
+        ts.createBlock(
+            stmt.statements.map(child => child.visitStatement(this, context.withStatementMode))));
   }
 
   visitExpressionStmt(stmt: ExpressionStatement, context: Context): ts.ExpressionStatement {
@@ -194,7 +200,7 @@ class ExpressionTranslatorVisitor implements ExpressionVisitor, StatementVisitor
   }
 
   visitReadVarExpr(ast: ReadVarExpr, context: Context): ts.Identifier {
-    const identifier = ts.createIdentifier(ast.name !);
+    const identifier = ts.createIdentifier(ast.name!);
     this.setSourceMapRange(identifier, ast);
     return identifier;
   }
@@ -322,7 +328,7 @@ class ExpressionTranslatorVisitor implements ExpressionVisitor, StatementVisitor
 
     return ts.createConditional(
         cond, ast.trueCase.visitExpression(this, context),
-        ast.falseCase !.visitExpression(this, context));
+        ast.falseCase!.visitExpression(this, context));
   }
 
   visitNotExpr(ast: NotExpr, context: Context): ts.PrefixUnaryExpression {
@@ -352,7 +358,7 @@ class ExpressionTranslatorVisitor implements ExpressionVisitor, StatementVisitor
       throw new Error(`Unknown binary operator: ${BinaryOperator[ast.operator]}`);
     }
     return ts.createBinary(
-        ast.lhs.visitExpression(this, context), BINARY_OPERATORS.get(ast.operator) !,
+        ast.lhs.visitExpression(this, context), BINARY_OPERATORS.get(ast.operator)!,
         ast.rhs.visitExpression(this, context));
   }
 
@@ -537,13 +543,17 @@ export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
     throw new Error('Method not implemented.');
   }
 
-  visitNotExpr(ast: NotExpr, context: Context) { throw new Error('Method not implemented.'); }
+  visitNotExpr(ast: NotExpr, context: Context) {
+    throw new Error('Method not implemented.');
+  }
 
   visitAssertNotNullExpr(ast: AssertNotNull, context: Context) {
     throw new Error('Method not implemented.');
   }
 
-  visitCastExpr(ast: CastExpr, context: Context) { throw new Error('Method not implemented.'); }
+  visitCastExpr(ast: CastExpr, context: Context) {
+    throw new Error('Method not implemented.');
+  }
 
   visitFunctionExpr(ast: FunctionExpr, context: Context) {
     throw new Error('Method not implemented.');
@@ -580,7 +590,9 @@ export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
     return ts.createTypeLiteralNode(entries);
   }
 
-  visitCommaExpr(ast: CommaExpr, context: Context) { throw new Error('Method not implemented.'); }
+  visitCommaExpr(ast: CommaExpr, context: Context) {
+    throw new Error('Method not implemented.');
+  }
 
   visitWrappedNodeExpr(ast: WrappedNodeExpr<any>, context: Context): ts.TypeNode {
     const node: ts.Node = ast.node;

--- a/packages/compiler-cli/src/ngtsc/tsc_plugin.ts
+++ b/packages/compiler-cli/src/ngtsc/tsc_plugin.ts
@@ -71,12 +71,14 @@ export class NgTscPlugin implements TscPlugin {
     return this._compiler;
   }
 
-  constructor(private ngOptions: {}) { setFileSystem(new NodeJSFileSystem()); }
+  constructor(private ngOptions: {}) {
+    setFileSystem(new NodeJSFileSystem());
+  }
 
   wrapHost(
       host: ts.CompilerHost&UnifiedModulesHost, inputFiles: readonly string[],
       options: ts.CompilerOptions): PluginCompilerHost {
-    this.options = {...this.ngOptions, ...options } as NgCompilerOptions;
+    this.options = {...this.ngOptions, ...options} as NgCompilerOptions;
     this.host = NgCompilerHost.wrap(host, inputFiles, this.options);
     return this.host;
   }
@@ -100,9 +102,15 @@ export class NgTscPlugin implements TscPlugin {
     return this.compiler.getDiagnostics(file);
   }
 
-  getOptionDiagnostics(): ts.Diagnostic[] { return this.compiler.getOptionDiagnostics(); }
+  getOptionDiagnostics(): ts.Diagnostic[] {
+    return this.compiler.getOptionDiagnostics();
+  }
 
-  getNextProgram(): ts.Program { return this.compiler.getNextProgram(); }
+  getNextProgram(): ts.Program {
+    return this.compiler.getNextProgram();
+  }
 
-  createTransformers(): ts.CustomTransformers { return this.compiler.prepareEmit().transformers; }
+  createTransformers(): ts.CustomTransformers {
+    return this.compiler.prepareEmit().transformers;
+  }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/api.ts
@@ -25,7 +25,7 @@ export interface TypeCheckableDirectiveMeta extends DirectiveMeta {
   hasNgTemplateContextGuard: boolean;
 }
 
-export type TemplateId = string & {__brand: 'TemplateId'};
+export type TemplateId = string&{__brand: 'TemplateId'};
 
 /**
  * Metadata required in addition to a component class in order to generate a type check block (TCB)
@@ -233,7 +233,7 @@ export interface TypeCheckingConfig {
 
 
 export type TemplateSourceMapping =
-    DirectTemplateSourceMapping | IndirectTemplateSourceMapping | ExternalTemplateSourceMapping;
+    DirectTemplateSourceMapping|IndirectTemplateSourceMapping|ExternalTemplateSourceMapping;
 
 /**
  * A mapping to an inline template in a TS file.

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -14,7 +14,7 @@ import {NoopImportRewriter, Reference, ReferenceEmitter} from '../../imports';
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
 import {ImportManager} from '../../translator';
 
-import {TemplateSourceMapping, TypeCheckBlockMetadata, TypeCheckableDirectiveMeta, TypeCheckingConfig, TypeCtorMetadata} from './api';
+import {TemplateSourceMapping, TypeCheckableDirectiveMeta, TypeCheckBlockMetadata, TypeCheckingConfig, TypeCtorMetadata} from './api';
 import {shouldReportDiagnostic, translateDiagnostic} from './diagnostics';
 import {DomSchemaChecker, RegistryDomSchemaChecker} from './dom';
 import {Environment} from './environment';
@@ -125,7 +125,7 @@ export class TypeCheckContext {
     if (!this.opMap.has(sf)) {
       this.opMap.set(sf, []);
     }
-    const ops = this.opMap.get(sf) !;
+    const ops = this.opMap.get(sf)!;
 
     // Push a `TypeCtorOp` into the operation queue for the source file.
     ops.push(new TypeCtorOp(ref, ctorMeta));
@@ -152,7 +152,7 @@ export class TypeCheckContext {
     // Each Op has a splitPoint index into the text where it needs to be inserted. Split the
     // original source text into chunks at these split points, where code will be inserted between
     // the chunks.
-    const ops = this.opMap.get(sf) !.sort(orderOps);
+    const ops = this.opMap.get(sf)!.sort(orderOps);
     const textParts = splitStringAtPoints(sf.text, ops.map(op => op.splitPoint));
 
     // Use a `ts.Printer` to generate source code.
@@ -238,7 +238,7 @@ export class TypeCheckContext {
     if (!this.opMap.has(sf)) {
       this.opMap.set(sf, []);
     }
-    const ops = this.opMap.get(sf) !;
+    const ops = this.opMap.get(sf)!;
     ops.push(new TcbOp(
         ref, tcbMeta, this.config, this.reflector, this.domSchemaChecker, this.oobRecorder));
   }
@@ -278,7 +278,9 @@ class TcbOp implements Op {
   /**
    * Type check blocks are inserted immediately after the end of the component class.
    */
-  get splitPoint(): number { return this.ref.node.end + 1; }
+  get splitPoint(): number {
+    return this.ref.node.end + 1;
+  }
 
   execute(im: ImportManager, sf: ts.SourceFile, refEmitter: ReferenceEmitter, printer: ts.Printer):
       string {
@@ -301,7 +303,9 @@ class TypeCtorOp implements Op {
   /**
    * Type constructor operations are inserted immediately before the end of the directive class.
    */
-  get splitPoint(): number { return this.ref.node.end - 1; }
+  get splitPoint(): number {
+    return this.ref.node.end - 1;
+  }
 
   execute(im: ImportManager, sf: ts.SourceFile, refEmitter: ReferenceEmitter, printer: ts.Printer):
       string {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/diagnostics.ts
@@ -70,7 +70,7 @@ export function ignoreDiagnostics(node: ts.Node): void {
  * Adds a synthetic comment to the expression that represents the parse span of the provided node.
  * This comment can later be retrieved as trivia of a node to recover original source locations.
  */
-export function addParseSpanInfo(node: ts.Node, span: AbsoluteSourceSpan | ParseSourceSpan): void {
+export function addParseSpanInfo(node: ts.Node, span: AbsoluteSourceSpan|ParseSourceSpan): void {
   let commentText: string;
   if (span instanceof AbsoluteSourceSpan) {
     commentText = `${span.start},${span.end}`;
@@ -145,7 +145,7 @@ export function translateDiagnostic(
  */
 export function makeTemplateDiagnostic(
     mapping: TemplateSourceMapping, span: ParseSourceSpan, category: ts.DiagnosticCategory,
-    code: number, messageText: string | ts.DiagnosticMessageChain, relatedMessage?: {
+    code: number, messageText: string|ts.DiagnosticMessageChain, relatedMessage?: {
       text: string,
       span: ParseSourceSpan,
     }): TemplateDiagnostic {
@@ -172,7 +172,8 @@ export function makeTemplateDiagnostic(
       file: mapping.node.getSourceFile(),
       componentFile: mapping.node.getSourceFile(),
       start: span.start.offset,
-      length: span.end.offset - span.start.offset, relatedInformation,
+      length: span.end.offset - span.start.offset,
+      relatedInformation,
     };
   } else if (mapping.type === 'indirect' || mapping.type === 'external') {
     // For indirect mappings (template was declared inline, but ngtsc couldn't map it directly

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/dom.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/dom.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
 import {ErrorCode, ngErrorCode} from '../../diagnostics';
 
 import {TemplateId} from './api';
-import {TemplateSourceResolver, makeTemplateDiagnostic} from './diagnostics';
+import {makeTemplateDiagnostic, TemplateSourceResolver} from './diagnostics';
 
 const REGISTRY = new DomElementSchemaRegistry();
 const REMOVE_XHTML_REGEX = /^:xhtml:/;
@@ -66,7 +66,9 @@ export interface DomSchemaChecker {
 export class RegistryDomSchemaChecker implements DomSchemaChecker {
   private _diagnostics: ts.Diagnostic[] = [];
 
-  get diagnostics(): ReadonlyArray<ts.Diagnostic> { return this._diagnostics; }
+  get diagnostics(): ReadonlyArray<ts.Diagnostic> {
+    return this._diagnostics;
+  }
 
   constructor(private resolver: TemplateSourceResolver) {}
 
@@ -83,8 +85,8 @@ export class RegistryDomSchemaChecker implements DomSchemaChecker {
       errorMsg +=
           `1. If '${name}' is an Angular component, then verify that it is part of this module.\n`;
       if (name.indexOf('-') > -1) {
-        errorMsg +=
-            `2. If '${name}' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.`;
+        errorMsg += `2. If '${
+            name}' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.`;
       } else {
         errorMsg +=
             `2. To allow any element add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.`;
@@ -107,12 +109,16 @@ export class RegistryDomSchemaChecker implements DomSchemaChecker {
           `Can't bind to '${name}' since it isn't a known property of '${element.name}'.`;
       if (element.name.startsWith('ng-')) {
         errorMsg +=
-            `\n1. If '${name}' is an Angular directive, then add 'CommonModule' to the '@NgModule.imports' of this component.` +
+            `\n1. If '${
+                name}' is an Angular directive, then add 'CommonModule' to the '@NgModule.imports' of this component.` +
             `\n2. To allow any property add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.`;
       } else if (element.name.indexOf('-') > -1) {
         errorMsg +=
-            `\n1. If '${element.name}' is an Angular component and it has '${name}' input, then verify that it is part of this module.` +
-            `\n2. If '${element.name}' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.` +
+            `\n1. If '${element.name}' is an Angular component and it has '${
+                name}' input, then verify that it is part of this module.` +
+            `\n2. If '${
+                element
+                    .name}' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.` +
             `\n3. To allow any property add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.`;
       }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
@@ -59,7 +59,7 @@ export class Environment {
     const dirRef = dir.ref as Reference<ClassDeclaration<ts.ClassDeclaration>>;
     const node = dirRef.node;
     if (this.typeCtors.has(node)) {
-      return this.typeCtors.get(node) !;
+      return this.typeCtors.get(node)!;
     }
 
     if (requiresInlineTypeCtor(node, this.reflector)) {
@@ -101,7 +101,7 @@ export class Environment {
    */
   pipeInst(ref: Reference<ClassDeclaration<ts.ClassDeclaration>>): ts.Expression {
     if (this.pipeInsts.has(ref.node)) {
-      return this.pipeInsts.get(ref.node) !;
+      return this.pipeInsts.get(ref.node)!;
     }
 
     const pipeType = this.referenceType(ref);
@@ -142,7 +142,8 @@ export class Environment {
             /* dotDotDotToken */ undefined,
             /* name */ 'cb',
             /* questionToken */ undefined,
-            /* type */ ts.createFunctionTypeNode(
+            /* type */
+            ts.createFunctionTypeNode(
                 /* typeParameters */ undefined,
                 /* parameters */[ts.createParameter(
                     /* decorators */ undefined,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, ASTWithSource, AstVisitor, Binary, BindingPipe, Chain, Conditional, EmptyExpr, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead} from '@angular/compiler';
+import {AST, AstVisitor, ASTWithSource, Binary, BindingPipe, Chain, Conditional, EmptyExpr, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {TypeCheckingConfig} from './api';
@@ -103,7 +103,7 @@ class AstTranslator implements AstVisitor {
   }
 
   visitFunctionCall(ast: FunctionCall): ts.Expression {
-    const receiver = wrapForDiagnostics(this.translate(ast.target !));
+    const receiver = wrapForDiagnostics(this.translate(ast.target!));
     const args = ast.args.map(expr => this.translate(expr));
     const node = ts.createCall(receiver, undefined, args);
     addParseSpanInfo(node, ast.sourceSpan);
@@ -192,7 +192,9 @@ class AstTranslator implements AstVisitor {
     return node;
   }
 
-  visitPipe(ast: BindingPipe): never { throw new Error('Method not implemented.'); }
+  visitPipe(ast: BindingPipe): never {
+    throw new Error('Method not implemented.');
+  }
 
   visitPrefixNot(ast: PrefixNot): ts.Expression {
     const expression = wrapForDiagnostics(this.translate(ast.expression));
@@ -221,7 +223,9 @@ class AstTranslator implements AstVisitor {
     return node;
   }
 
-  visitQuote(ast: Quote): never { throw new Error('Method not implemented.'); }
+  visitQuote(ast: Quote): never {
+    throw new Error('Method not implemented.');
+  }
 
   visitSafeMethodCall(ast: SafeMethodCall): ts.Expression {
     // See the comments in SafePropertyRead above for an explanation of the cases here.
@@ -296,28 +300,64 @@ class VeSafeLhsInferenceBugDetector implements AstVisitor {
     return ast.receiver.visit(VeSafeLhsInferenceBugDetector.SINGLETON);
   }
 
-  visitBinary(ast: Binary): boolean { return ast.left.visit(this) || ast.right.visit(this); }
-  visitChain(ast: Chain): boolean { return false; }
+  visitBinary(ast: Binary): boolean {
+    return ast.left.visit(this) || ast.right.visit(this);
+  }
+  visitChain(ast: Chain): boolean {
+    return false;
+  }
   visitConditional(ast: Conditional): boolean {
     return ast.condition.visit(this) || ast.trueExp.visit(this) || ast.falseExp.visit(this);
   }
-  visitFunctionCall(ast: FunctionCall): boolean { return true; }
-  visitImplicitReceiver(ast: ImplicitReceiver): boolean { return false; }
+  visitFunctionCall(ast: FunctionCall): boolean {
+    return true;
+  }
+  visitImplicitReceiver(ast: ImplicitReceiver): boolean {
+    return false;
+  }
   visitInterpolation(ast: Interpolation): boolean {
     return ast.expressions.some(exp => exp.visit(this));
   }
-  visitKeyedRead(ast: KeyedRead): boolean { return false; }
-  visitKeyedWrite(ast: KeyedWrite): boolean { return false; }
-  visitLiteralArray(ast: LiteralArray): boolean { return true; }
-  visitLiteralMap(ast: LiteralMap): boolean { return true; }
-  visitLiteralPrimitive(ast: LiteralPrimitive): boolean { return false; }
-  visitMethodCall(ast: MethodCall): boolean { return true; }
-  visitPipe(ast: BindingPipe): boolean { return true; }
-  visitPrefixNot(ast: PrefixNot): boolean { return ast.expression.visit(this); }
-  visitNonNullAssert(ast: PrefixNot): boolean { return ast.expression.visit(this); }
-  visitPropertyRead(ast: PropertyRead): boolean { return false; }
-  visitPropertyWrite(ast: PropertyWrite): boolean { return false; }
-  visitQuote(ast: Quote): boolean { return false; }
-  visitSafeMethodCall(ast: SafeMethodCall): boolean { return true; }
-  visitSafePropertyRead(ast: SafePropertyRead): boolean { return false; }
+  visitKeyedRead(ast: KeyedRead): boolean {
+    return false;
+  }
+  visitKeyedWrite(ast: KeyedWrite): boolean {
+    return false;
+  }
+  visitLiteralArray(ast: LiteralArray): boolean {
+    return true;
+  }
+  visitLiteralMap(ast: LiteralMap): boolean {
+    return true;
+  }
+  visitLiteralPrimitive(ast: LiteralPrimitive): boolean {
+    return false;
+  }
+  visitMethodCall(ast: MethodCall): boolean {
+    return true;
+  }
+  visitPipe(ast: BindingPipe): boolean {
+    return true;
+  }
+  visitPrefixNot(ast: PrefixNot): boolean {
+    return ast.expression.visit(this);
+  }
+  visitNonNullAssert(ast: PrefixNot): boolean {
+    return ast.expression.visit(this);
+  }
+  visitPropertyRead(ast: PropertyRead): boolean {
+    return false;
+  }
+  visitPropertyWrite(ast: PropertyWrite): boolean {
+    return false;
+  }
+  visitQuote(ast: Quote): boolean {
+    return false;
+  }
+  visitSafeMethodCall(ast: SafeMethodCall): boolean {
+    return true;
+  }
+  visitSafePropertyRead(ast: SafePropertyRead): boolean {
+    return false;
+  }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/host.ts
@@ -25,7 +25,7 @@ export class TypeCheckProgramHost implements ts.CompilerHost {
     this.sfMap = sfMap;
 
     if (delegate.getDirectories !== undefined) {
-      this.getDirectories = (path: string) => delegate.getDirectories !(path);
+      this.getDirectories = (path: string) => delegate.getDirectories!(path);
     }
 
     if (delegate.resolveModuleNames !== undefined) {
@@ -69,7 +69,9 @@ export class TypeCheckProgramHost implements ts.CompilerHost {
     throw new Error(`TypeCheckProgramHost should never write files`);
   }
 
-  getCurrentDirectory(): string { return this.delegate.getCurrentDirectory(); }
+  getCurrentDirectory(): string {
+    return this.delegate.getCurrentDirectory();
+  }
 
   getDirectories?: (path: string) => string[];
 
@@ -77,13 +79,19 @@ export class TypeCheckProgramHost implements ts.CompilerHost {
     return this.delegate.getCanonicalFileName(fileName);
   }
 
-  useCaseSensitiveFileNames(): boolean { return this.delegate.useCaseSensitiveFileNames(); }
+  useCaseSensitiveFileNames(): boolean {
+    return this.delegate.useCaseSensitiveFileNames();
+  }
 
-  getNewLine(): string { return this.delegate.getNewLine(); }
+  getNewLine(): string {
+    return this.delegate.getNewLine();
+  }
 
   fileExists(fileName: string): boolean {
     return this.sfMap.has(fileName) || this.delegate.fileExists(fileName);
   }
 
-  readFile(fileName: string): string|undefined { return this.delegate.readFile(fileName); }
+  readFile(fileName: string): string|undefined {
+    return this.delegate.readFile(fileName);
+  }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
 import {ErrorCode, ngErrorCode} from '../../diagnostics';
 
 import {TemplateId} from './api';
-import {TemplateSourceResolver, makeTemplateDiagnostic} from './diagnostics';
+import {makeTemplateDiagnostic, TemplateSourceResolver} from './diagnostics';
 
 
 
@@ -68,7 +68,9 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
 
   constructor(private resolver: TemplateSourceResolver) {}
 
-  get diagnostics(): ReadonlyArray<ts.Diagnostic> { return this._diagnostics; }
+  get diagnostics(): ReadonlyArray<ts.Diagnostic> {
+    return this._diagnostics;
+  }
 
   missingReferenceTarget(templateId: TemplateId, ref: TmplAstReference): void {
     const mapping = this.resolver.getSourceMapping(templateId);
@@ -97,8 +99,9 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
   illegalAssignmentToTemplateVar(
       templateId: TemplateId, assignment: PropertyWrite, target: TmplAstVariable): void {
     const mapping = this.resolver.getSourceMapping(templateId);
-    const errorMsg =
-        `Cannot use variable '${assignment.name}' as the left-hand side of an assignment expression. Template variables are read-only.`;
+    const errorMsg = `Cannot use variable '${
+        assignment
+            .name}' as the left-hand side of an assignment expression. Template variables are read-only.`;
 
     const sourceSpan = this.resolver.toParseSourceSpan(templateId, assignment.sourceSpan);
     if (sourceSpan === null) {
@@ -115,8 +118,8 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
   duplicateTemplateVar(
       templateId: TemplateId, variable: TmplAstVariable, firstDecl: TmplAstVariable): void {
     const mapping = this.resolver.getSourceMapping(templateId);
-    const errorMsg =
-        `Cannot redeclare variable '${variable.name}' as it was previously declared elsewhere for the same template.`;
+    const errorMsg = `Cannot redeclare variable '${
+        variable.name}' as it was previously declared elsewhere for the same template.`;
 
     // The allocation of the error here is pretty useless for variables declared in microsyntax,
     // since the sourceSpan refers to the entire microsyntax property, not a span for the specific

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/source.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/source.ts
@@ -65,14 +65,14 @@ export class TemplateSourceManager implements TemplateSourceResolver {
     if (!this.templateSources.has(id)) {
       throw new Error(`Unexpected unknown template ID: ${id}`);
     }
-    return this.templateSources.get(id) !.mapping;
+    return this.templateSources.get(id)!.mapping;
   }
 
   toParseSourceSpan(id: TemplateId, span: AbsoluteSourceSpan): ParseSourceSpan|null {
     if (!this.templateSources.has(id)) {
       return null;
     }
-    const templateSource = this.templateSources.get(id) !;
+    const templateSource = this.templateSources.get(id)!;
     return templateSource.toParseSourceSpan(span.start, span.end);
   }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -6,17 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, BindingPipe, BindingType, BoundTarget, DYNAMIC_TYPE, ImplicitReceiver, MethodCall, ParseSourceSpan, ParsedEventType, PropertyRead, PropertyWrite, SchemaMetadata, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstElement, TmplAstNode, TmplAstReference, TmplAstTemplate, TmplAstTextAttribute, TmplAstVariable} from '@angular/compiler';
+import {AST, BindingPipe, BindingType, BoundTarget, DYNAMIC_TYPE, ImplicitReceiver, MethodCall, ParsedEventType, ParseSourceSpan, PropertyRead, PropertyWrite, SchemaMetadata, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstElement, TmplAstNode, TmplAstReference, TmplAstTemplate, TmplAstTextAttribute, TmplAstVariable} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {Reference} from '../../imports';
 import {ClassDeclaration} from '../../reflection';
 
-import {TemplateId, TypeCheckBlockMetadata, TypeCheckableDirectiveMeta} from './api';
+import {TemplateId, TypeCheckableDirectiveMeta, TypeCheckBlockMetadata} from './api';
 import {addParseSpanInfo, addTemplateId, ignoreDiagnostics, wrapForDiagnostics} from './diagnostics';
 import {DomSchemaChecker} from './dom';
 import {Environment} from './environment';
-import {NULL_AS_ANY, astToTypescript} from './expression';
+import {astToTypescript, NULL_AS_ANY} from './expression';
 import {OutOfBandDiagnosticRecorder} from './oob';
 import {ExpressionSemanticVisitor} from './template_semantics';
 import {checkIfClassIsExported, checkIfGenericTypesAreUnbound, tsCallMethod, tsCastToAny, tsCreateElement, tsCreateVariable, tsDeclareVariable} from './ts_util';
@@ -109,7 +109,9 @@ abstract class TcbOp {
    * `TcbOp` can be returned in cases where additional code generation is necessary to deal with
    * circular references.
    */
-  circularFallback(): TcbOp|ts.Expression { return INFER_TYPE_FOR_CIRCULAR_OP_EXPR; }
+  circularFallback(): TcbOp|ts.Expression {
+    return INFER_TYPE_FOR_CIRCULAR_OP_EXPR;
+  }
 }
 
 /**
@@ -170,7 +172,9 @@ class TcbVariableOp extends TcbOp {
  * Executing this operation returns a reference to the template's context variable.
  */
 class TcbTemplateContextOp extends TcbOp {
-  constructor(private tcb: Context, private scope: Scope) { super(); }
+  constructor(private tcb: Context, private scope: Scope) {
+    super();
+  }
 
   execute(): ts.Identifier {
     // Allocate a template ctx variable and declare it with an 'any' type. The type of this variable
@@ -219,7 +223,7 @@ class TcbTemplateBodyOp extends TcbOp {
           // For each template guard function on the directive, look for a binding to that input.
           const boundInput = this.template.inputs.find(i => i.name === guard.inputName) ||
               this.template.templateAttrs.find(
-                  (i: TmplAstTextAttribute | TmplAstBoundAttribute): i is TmplAstBoundAttribute =>
+                  (i: TmplAstTextAttribute|TmplAstBoundAttribute): i is TmplAstBoundAttribute =>
                       i instanceof TmplAstBoundAttribute && i.name === guard.inputName);
           if (boundInput !== undefined) {
             // If there is such a binding, generate an expression for it.
@@ -266,7 +270,7 @@ class TcbTemplateBodyOp extends TcbOp {
       guard = directiveGuards.reduce(
           (expr, dirGuard) =>
               ts.createBinary(expr, ts.SyntaxKind.AmpersandAmpersandToken, dirGuard),
-          directiveGuards.pop() !);
+          directiveGuards.pop()!);
     }
 
     // Create a new Scope for the template. This constructs the list of operations for the template
@@ -514,7 +518,7 @@ class TcbDirectiveOutputsOp extends TcbOp {
       if (output.type !== ParsedEventType.Regular || !fieldByEventName.has(output.name)) {
         continue;
       }
-      const field = fieldByEventName.get(output.name) !;
+      const field = fieldByEventName.get(output.name)!;
 
       if (this.tcb.env.config.checkTypeOfOutputEvents) {
         // For strict checking of directive events, generate a call to the `subscribe` method
@@ -644,13 +648,15 @@ export class Context {
    * Currently this uses a monotonically increasing counter, but in the future the variable name
    * might change depending on the type of data being stored.
    */
-  allocateId(): ts.Identifier { return ts.createIdentifier(`_t${this.nextId++}`); }
+  allocateId(): ts.Identifier {
+    return ts.createIdentifier(`_t${this.nextId++}`);
+  }
 
   getPipeByName(name: string): ts.Expression|null {
     if (!this.pipes.has(name)) {
       return null;
     }
-    return this.env.pipeInst(this.pipes.get(name) !);
+    return this.env.pipeInst(this.pipes.get(name)!);
   }
 }
 
@@ -745,7 +751,7 @@ class Scope {
         if (!varMap.has(v.name)) {
           varMap.set(v.name, v);
         } else {
-          const firstDecl = varMap.get(v.name) !;
+          const firstDecl = varMap.get(v.name)!;
           tcb.oobRecorder.duplicateTemplateVar(tcb.id, v, firstDecl);
         }
 
@@ -796,7 +802,9 @@ class Scope {
   /**
    * Add a statement to this scope.
    */
-  addStatement(stmt: ts.Statement): void { this.statements.push(stmt); }
+  addStatement(stmt: ts.Statement): void {
+    this.statements.push(stmt);
+  }
 
   /**
    * Get the statements.
@@ -840,26 +848,26 @@ class Scope {
     if (ref instanceof TmplAstVariable && this.varMap.has(ref)) {
       // Resolving a context variable for this template.
       // Execute the `TcbVariableOp` associated with the `TmplAstVariable`.
-      return this.resolveOp(this.varMap.get(ref) !);
+      return this.resolveOp(this.varMap.get(ref)!);
     } else if (
         ref instanceof TmplAstTemplate && directive === undefined &&
         this.templateCtxOpMap.has(ref)) {
       // Resolving the context of the given sub-template.
       // Execute the `TcbTemplateContextOp` for the template.
-      return this.resolveOp(this.templateCtxOpMap.get(ref) !);
+      return this.resolveOp(this.templateCtxOpMap.get(ref)!);
     } else if (
         (ref instanceof TmplAstElement || ref instanceof TmplAstTemplate) &&
         directive !== undefined && this.directiveOpMap.has(ref)) {
       // Resolving a directive on an element or sub-template.
-      const dirMap = this.directiveOpMap.get(ref) !;
+      const dirMap = this.directiveOpMap.get(ref)!;
       if (dirMap.has(directive)) {
-        return this.resolveOp(dirMap.get(directive) !);
+        return this.resolveOp(dirMap.get(directive)!);
       } else {
         return null;
       }
     } else if (ref instanceof TmplAstElement && this.elementOpMap.has(ref)) {
       // Resolving the DOM node of an element in this template.
-      return this.resolveOp(this.elementOpMap.get(ref) !);
+      return this.resolveOp(this.elementOpMap.get(ref)!);
     } else {
       return null;
     }
@@ -1261,14 +1269,13 @@ function tcbCallTypeCtor(
 
 type TcbDirectiveInput = {
   type: 'binding'; field: string; expression: ts.Expression; sourceSpan: ParseSourceSpan;
-} |
-{
+}|{
   type: 'unset';
   field: string;
 };
 
 function tcbGetDirectiveInputs(
-    el: TmplAstElement | TmplAstTemplate, dir: TypeCheckableDirectiveMeta, tcb: Context,
+    el: TmplAstElement|TmplAstTemplate, dir: TypeCheckableDirectiveMeta, tcb: Context,
     scope: Scope): TcbDirectiveInput[] {
   // Only the first binding to a property is written.
   // TODO(alxhub): produce an error for duplicate bindings to the same property, independently of
@@ -1306,7 +1313,7 @@ function tcbGetDirectiveInputs(
    * Add a binding expression to the map for each input/template attribute of the directive that has
    * a matching binding.
    */
-  function processAttribute(attr: TmplAstBoundAttribute | TmplAstTextAttribute): void {
+  function processAttribute(attr: TmplAstBoundAttribute|TmplAstTextAttribute): void {
     // Skip non-property bindings.
     if (attr instanceof TmplAstBoundAttribute && attr.type !== BindingType.Property) {
       return;
@@ -1321,7 +1328,7 @@ function tcbGetDirectiveInputs(
     if (!propMatch.has(attr.name)) {
       return;
     }
-    const field = propMatch.get(attr.name) !;
+    const field = propMatch.get(attr.name)!;
 
     // Skip the attribute if a previous binding also wrote to it.
     if (directiveInputs.has(field)) {
@@ -1369,7 +1376,7 @@ const enum EventParamType {
  */
 function tcbCreateEventHandler(
     event: TmplAstBoundEvent, tcb: Context, scope: Scope,
-    eventType: EventParamType | ts.TypeNode): ts.Expression {
+    eventType: EventParamType|ts.TypeNode): ts.Expression {
   const handler = tcbEventHandlerExpression(event.handler, tcb, scope);
 
   let eventParamType: ts.TypeNode|undefined;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
@@ -78,7 +78,9 @@ export class TypeCheckFile extends Environment {
         this.fileName, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
   }
 
-  getPreludeStatements(): ts.Statement[] { return []; }
+  getPreludeStatements(): ts.Statement[] {
+    return [];
+  }
 }
 
 export function typeCheckFilePath(rootDirs: AbsoluteFsPath[]): AbsoluteFsPath {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
@@ -15,8 +15,7 @@ import {TypeParameterEmitter} from './type_parameter_emitter';
 
 export function generateTypeCtorDeclarationFn(
     node: ClassDeclaration<ts.ClassDeclaration>, meta: TypeCtorMetadata, nodeTypeRef: ts.EntityName,
-    typeParams: ts.TypeParameterDeclaration[] | undefined,
-    reflector: ReflectionHost): ts.Statement {
+    typeParams: ts.TypeParameterDeclaration[]|undefined, reflector: ReflectionHost): ts.Statement {
   if (requiresInlineTypeCtor(node, reflector)) {
     throw new Error(`${node.name.text} requires an inline type constructor`);
   }
@@ -32,7 +31,8 @@ export function generateTypeCtorDeclarationFn(
     const fnType = ts.createFunctionTypeNode(
         /* typeParameters */ typeParameters,
         /* parameters */[initParam],
-        /* type */ rawType, );
+        /* type */ rawType,
+    );
 
     const decl = ts.createVariableDeclaration(
         /* name */ meta.fnName,
@@ -121,7 +121,8 @@ export function generateInlineTypeCtor(
       /* typeParameters */ typeParametersWithDefaultTypes(node.typeParameters),
       /* parameters */[initParam],
       /* type */ rawType,
-      /* body */ body, );
+      /* body */ body,
+  );
 }
 
 function constructTypeCtorParameter(
@@ -149,7 +150,8 @@ function constructTypeCtorParameter(
           /* modifiers */ undefined,
           /* name */ key,
           /* questionToken */ undefined,
-          /* type */ ts.createTypeQueryNode(
+          /* type */
+          ts.createTypeQueryNode(
               ts.createQualifiedName(rawType.typeName, `ngAcceptInputType_${key}`)),
           /* initializer */ undefined));
     }
@@ -243,9 +245,8 @@ function checkIfGenericTypeBoundsAreContextFree(
  *
  * This correctly infers `T` as `any`, and therefore `_t3` as `NgFor<any>`.
  */
-function typeParametersWithDefaultTypes(
-    params: ReadonlyArray<ts.TypeParameterDeclaration>| undefined): ts.TypeParameterDeclaration[]|
-    undefined {
+function typeParametersWithDefaultTypes(params: ReadonlyArray<ts.TypeParameterDeclaration>|
+                                        undefined): ts.TypeParameterDeclaration[]|undefined {
   if (params === undefined) {
     return undefined;
   }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_emitter.ts
@@ -12,7 +12,7 @@ import {Reference} from '../../imports';
  * A resolved type reference can either be a `Reference`, the original `ts.TypeReferenceNode` itself
  * or null to indicate the no reference could be resolved.
  */
-export type ResolvedTypeReference = Reference | ts.TypeReferenceNode | null;
+export type ResolvedTypeReference = Reference|ts.TypeReferenceNode|null;
 
 /**
  * A type reference resolver function is responsible for finding the declaration of the type
@@ -111,7 +111,9 @@ export class TypeEmitter {
       visitTypeReferenceNode: type => this.emitTypeReference(type),
       visitArrayTypeNode: type => ts.updateArrayTypeNode(type, this.emitType(type.elementType)),
       visitKeywordType: type => type,
-      visitOtherType: () => { throw new Error('Unable to emit a complex type'); },
+      visitOtherType: () => {
+        throw new Error('Unable to emit a complex type');
+      },
     });
   }
 
@@ -137,8 +139,8 @@ export class TypeEmitter {
 
       const emittedType = this.emitReference(reference);
       if (!ts.isTypeReferenceNode(emittedType)) {
-        throw new Error(
-            `Expected TypeReferenceNode for emitted reference, got ${ts.SyntaxKind[emittedType.kind]}`);
+        throw new Error(`Expected TypeReferenceNode for emitted reference, got ${
+            ts.SyntaxKind[emittedType.kind]}`);
       }
 
       typeName = emittedType.typeName;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_parameter_emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_parameter_emitter.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 import {OwningModule, Reference} from '../../imports';
 import {ReflectionHost} from '../../reflection';
 
-import {ResolvedTypeReference, TypeEmitter, canEmitType} from './type_emitter';
+import {canEmitType, ResolvedTypeReference, TypeEmitter} from './type_emitter';
 
 
 /**
@@ -92,6 +92,6 @@ export class TypeParameterEmitter {
   private isLocalTypeParameter(decl: ts.Declaration): boolean {
     // Checking for local type parameters only occurs during resolution of type parameters, so it is
     // guaranteed that type parameters are present.
-    return this.typeParameters !.some(param => param === decl);
+    return this.typeParameters!.some(param => param === decl);
   }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -8,10 +8,10 @@
 
 import * as ts from 'typescript';
 
-import {TestFile, runInEachFileSystem} from '../../file_system/testing';
+import {runInEachFileSystem, TestFile} from '../../file_system/testing';
 import {TypeCheckingConfig} from '../src/api';
 
-import {TestDeclaration, ngForDeclaration, ngForDts, typecheck} from './test_utils';
+import {ngForDeclaration, ngForDts, TestDeclaration, typecheck} from './test_utils';
 
 runInEachFileSystem(() => {
   describe('template diagnostics', () => {
@@ -377,8 +377,8 @@ function diagnose(
   return diagnostics.map(diag => {
     const text =
         typeof diag.messageText === 'string' ? diag.messageText : diag.messageText.messageText;
-    const fileName = diag.file !.fileName;
-    const {line, character} = ts.getLineAndCharacterOfPosition(diag.file !, diag.start !);
+    const fileName = diag.file!.fileName;
+    const {line, character} = ts.getLineAndCharacterOfPosition(diag.file!, diag.start!);
     return `${fileName}(${line + 1}, ${character + 1}): ${text}`;
   });
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {TestDeclaration, tcb} from './test_utils';
+import {tcb, TestDeclaration} from './test_utils';
 
 describe('type check blocks diagnostics', () => {
   describe('parse spans', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CssSelector, ParseSourceFile, ParseSourceSpan, R3TargetBinder, SchemaMetadata, SelectorMatcher, TmplAstElement, TmplAstReference, Type, parseTemplate} from '@angular/compiler';
+import {CssSelector, ParseSourceFile, ParseSourceSpan, parseTemplate, R3TargetBinder, SchemaMetadata, SelectorMatcher, TmplAstElement, TmplAstReference, Type} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {AbsoluteFsPath, LogicalFileSystem, absoluteFrom} from '../../file_system';
+import {absoluteFrom, AbsoluteFsPath, LogicalFileSystem} from '../../file_system';
 import {TestFile} from '../../file_system/testing';
 import {AbsoluteModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, Reference, ReferenceEmitter} from '../../imports';
-import {ClassDeclaration, TypeScriptReflectionHost, isNamedClassDeclaration} from '../../reflection';
+import {ClassDeclaration, isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
 import {makeProgram} from '../../testing';
 import {getRootDirs} from '../../util/src/typescript';
-import {TemplateId, TemplateSourceMapping, TypeCheckBlockMetadata, TypeCheckableDirectiveMeta, TypeCheckingConfig} from '../src/api';
+import {TemplateId, TemplateSourceMapping, TypeCheckableDirectiveMeta, TypeCheckBlockMetadata, TypeCheckingConfig} from '../src/api';
 import {TypeCheckContext} from '../src/context';
 import {DomSchemaChecker} from '../src/dom';
 import {Environment} from '../src/environment';
@@ -168,23 +168,20 @@ export const ALL_ENABLED_CONFIG: TypeCheckingConfig = {
 };
 
 // Remove 'ref' from TypeCheckableDirectiveMeta and add a 'selector' instead.
-export type TestDirective =
-    Partial<Pick<
-        TypeCheckableDirectiveMeta,
-        Exclude<keyof TypeCheckableDirectiveMeta, 'ref'|'coercedInputFields'>>>&
-    {
-      selector: string,
-      name: string, file?: AbsoluteFsPath,
-      type: 'directive', coercedInputFields?: string[],
-    };
+export type TestDirective = Partial<Pick<
+    TypeCheckableDirectiveMeta,
+    Exclude<keyof TypeCheckableDirectiveMeta, 'ref'|'coercedInputFields'>>>&{
+  selector: string,
+  name: string,
+  file?: AbsoluteFsPath, type: 'directive',
+  coercedInputFields?: string[],
+};
 export type TestPipe = {
   name: string,
-  file?: AbsoluteFsPath,
-  pipeName: string,
-  type: 'pipe',
+  file?: AbsoluteFsPath, pipeName: string, type: 'pipe',
 };
 
-export type TestDeclaration = TestDirective | TestPipe;
+export type TestDeclaration = TestDirective|TestPipe;
 
 export function tcb(
     template: string, declarations: TestDeclaration[] = [], config?: TypeCheckingConfig,
@@ -252,7 +249,7 @@ export function typecheck(
   ];
   const {program, host, options} =
       makeProgram(files, {strictNullChecks: true, noImplicitAny: true, ...opts}, undefined, false);
-  const sf = program.getSourceFile(absoluteFrom('/main.ts')) !;
+  const sf = program.getSourceFile(absoluteFrom('/main.ts'))!;
   const checker = program.getTypeChecker();
   const logicalFs = new LogicalFileSystem(getRootDirs(host, options));
   const reflectionHost = new TypeScriptReflectionHost(checker);
@@ -277,7 +274,7 @@ export function typecheck(
   const {matcher, pipes} = prepareDeclarations(declarations, decl => {
     let declFile = sf;
     if (decl.file !== undefined) {
-      declFile = program.getSourceFile(decl.file) !;
+      declFile = program.getSourceFile(decl.file)!;
       if (declFile === undefined) {
         throw new Error(`Unable to locate ${decl.file} for ${decl.type} ${decl.name}`);
       }
@@ -356,7 +353,9 @@ class FakeEnvironment /* implements Environment */ {
     return ts.createParen(ts.createAsExpression(ts.createNull(), this.referenceType(ref)));
   }
 
-  declareOutputHelper(): ts.Expression { return ts.createIdentifier('_outputHelper'); }
+  declareOutputHelper(): ts.Expression {
+    return ts.createIdentifier('_outputHelper');
+  }
 
   reference(ref: Reference<ClassDeclaration<ts.ClassDeclaration>>): ts.Expression {
     return ref.node.name;
@@ -379,7 +378,9 @@ class FakeEnvironment /* implements Environment */ {
     return ts.createTypeReferenceNode(qName, typeArgs.length > 0 ? typeArgs : undefined);
   }
 
-  getPreludeStatements(): ts.Statement[] { return []; }
+  getPreludeStatements(): ts.Statement[] {
+    return [];
+  }
 
   static newFake(config: TypeCheckingConfig): Environment {
     return new FakeEnvironment(config) as Environment;
@@ -387,7 +388,9 @@ class FakeEnvironment /* implements Environment */ {
 }
 
 export class NoopSchemaChecker implements DomSchemaChecker {
-  get diagnostics(): ReadonlyArray<ts.Diagnostic> { return []; }
+  get diagnostics(): ReadonlyArray<ts.Diagnostic> {
+    return [];
+  }
 
   checkElement(id: string, element: TmplAstElement, schemas: SchemaMetadata[]): void {}
   checkProperty(
@@ -396,7 +399,9 @@ export class NoopSchemaChecker implements DomSchemaChecker {
 }
 
 export class NoopOobRecorder implements OutOfBandDiagnosticRecorder {
-  get diagnostics(): ReadonlyArray<ts.Diagnostic> { return []; }
+  get diagnostics(): ReadonlyArray<ts.Diagnostic> {
+    return [];
+  }
   missingReferenceTarget(): void {}
   missingPipe(): void {}
   illegalAssignmentToTemplateVar(): void {}

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -8,12 +8,13 @@
 
 import {TypeCheckingConfig} from '../src/api';
 
-import {ALL_ENABLED_CONFIG, TestDeclaration, TestDirective, tcb} from './test_utils';
+import {ALL_ENABLED_CONFIG, tcb, TestDeclaration, TestDirective} from './test_utils';
 
 
 describe('type check blocks', () => {
-  it('should generate a basic block for a binding',
-     () => { expect(tcb('{{hello}} {{world}}')).toContain('"" + (ctx).hello + (ctx).world;'); });
+  it('should generate a basic block for a binding', () => {
+    expect(tcb('{{hello}} {{world}}')).toContain('"" + (ctx).hello + (ctx).world;');
+  });
 
   it('should generate literal map expressions', () => {
     const TEMPLATE = '{{ method({foo: a, bar: b}) }}';
@@ -264,7 +265,6 @@ describe('type check blocks', () => {
   });
 
   describe('outputs', () => {
-
     it('should emit subscribe calls for directive outputs', () => {
       const DIRECTIVES: TestDeclaration[] = [{
         type: 'directive',
@@ -305,7 +305,6 @@ describe('type check blocks', () => {
       expect(block).toContain(
           '_t3.addEventListener("event", function ($event): any { (_t2 = 3); });');
     });
-
   });
 
   describe('config', () => {
@@ -385,7 +384,6 @@ describe('type check blocks', () => {
     });
 
     describe('config.checkTypeOfBindings', () => {
-
       it('should check types of bindings when enabled', () => {
         const TEMPLATE = `<div dir [dirInput]="a" [nonDirInput]="b"></div>`;
         const block = tcb(TEMPLATE, DIRECTIVES);

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
@@ -6,14 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
-import {LogicalFileSystem, absoluteFrom, getSourceFileOrError} from '../../file_system';
-import {TestFile, runInEachFileSystem} from '../../file_system/testing';
+
+import {absoluteFrom, getSourceFileOrError, LogicalFileSystem} from '../../file_system';
+import {runInEachFileSystem, TestFile} from '../../file_system/testing';
 import {AbsoluteModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, Reference, ReferenceEmitter} from '../../imports';
-import {TypeScriptReflectionHost, isNamedClassDeclaration} from '../../reflection';
+import {isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';
 import {getRootDirs} from '../../util/src/typescript';
 import {TypeCheckContext} from '../src/context';
 import {TypeCheckFile} from '../src/type_check_file';
+
 import {ALL_ENABLED_CONFIG} from './test_utils';
 
 runInEachFileSystem(() => {
@@ -42,7 +44,7 @@ runInEachFileSystem(() => {
     it('should not produce an empty SourceFile when there is nothing to typecheck', () => {
       const file = new TypeCheckFile(
           _('/_typecheck_.ts'), ALL_ENABLED_CONFIG, new ReferenceEmitter([]),
-          /* reflector */ null !);
+          /* reflector */ null!);
       const sf = file.render();
       expect(sf.statements.length).toBe(1);
     });
@@ -126,7 +128,7 @@ TestClass.ngTypeCtor({value: 'test'});
         const res = ctx.calculateTemplateDiagnostics(program, host, options);
         const TestClassWithCtor =
             getDeclaration(res.program, _('/main.ts'), 'TestClass', isNamedClassDeclaration);
-        const typeCtor = TestClassWithCtor.members.find(isTypeCtor) !;
+        const typeCtor = TestClassWithCtor.members.find(isTypeCtor)!;
         expect(typeCtor.getText()).not.toContain('queryField');
       });
     });
@@ -168,7 +170,7 @@ TestClass.ngTypeCtor({value: 'test'});
         const res = ctx.calculateTemplateDiagnostics(program, host, options);
         const TestClassWithCtor =
             getDeclaration(res.program, _('/main.ts'), 'TestClass', isNamedClassDeclaration);
-        const typeCtor = TestClassWithCtor.members.find(isTypeCtor) !;
+        const typeCtor = TestClassWithCtor.members.find(isTypeCtor)!;
         const ctorText = typeCtor.getText().replace(/[ \r\n]+/g, ' ');
         expect(ctorText).toContain(
             'init: Pick<TestClass, "foo"> | { bar: typeof TestClass.ngAcceptInputType_bar; }');

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_parameter_emitter_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_parameter_emitter_spec.ts
@@ -8,16 +8,16 @@
 import * as ts from 'typescript';
 
 import {absoluteFrom} from '../../file_system';
-import {TestFile, runInEachFileSystem} from '../../file_system/testing';
-import {TypeScriptReflectionHost, isNamedClassDeclaration} from '../../reflection';
+import {runInEachFileSystem, TestFile} from '../../file_system/testing';
+import {isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';
 import {TypeParameterEmitter} from '../src/type_parameter_emitter';
+
 import {angularCoreDts} from './test_utils';
 
 
 runInEachFileSystem(() => {
   describe('type parameter emitter', () => {
-
     function createEmitter(source: string, additionalFiles: TestFile[] = []) {
       const files: TestFile[] = [
         angularCoreDts(), {name: absoluteFrom('/main.ts'), contents: source}, ...additionalFiles
@@ -34,7 +34,7 @@ runInEachFileSystem(() => {
 
     function emit(emitter: TypeParameterEmitter) {
       const emitted = emitter.emit(ref => {
-        const typeName = ts.createQualifiedName(ts.createIdentifier('test'), ref.debugName !);
+        const typeName = ts.createQualifiedName(ts.createIdentifier('test'), ref.debugName!);
         return ts.createTypeReferenceNode(typeName, /* typeArguments */ undefined);
       });
 
@@ -209,6 +209,5 @@ runInEachFileSystem(() => {
       expect(emitter.canEmit()).toBe(true);
       expect(emit(emitter)).toEqual('<T extends test.MyType>');
     });
-
   });
 });

--- a/packages/compiler-cli/src/ngtsc/util/src/ts_source_map_bug_29300.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/ts_source_map_bug_29300.ts
@@ -29,16 +29,38 @@ export function tsSourceMapBug29300Fixed() {
     const sourceFile =
         ts.createSourceFile('test.ts', 'a;', ts.ScriptTarget.ES2015, true, ts.ScriptKind.TS);
     const host = {
-      getSourceFile(): ts.SourceFile | undefined{return sourceFile;},
-      fileExists(): boolean{return true;},
-      readFile(): string | undefined{return '';},
-      writeFile(fileName: string, data: string) { writtenFiles[fileName] = data; },
-      getDefaultLibFileName(): string{return '';},
-      getCurrentDirectory(): string{return '';},
-      getDirectories(): string[]{return [];},
-      getCanonicalFileName(): string{return '';},
-      useCaseSensitiveFileNames(): boolean{return true;},
-      getNewLine(): string{return '\n';},
+      getSourceFile(): ts.SourceFile |
+          undefined {
+            return sourceFile;
+          },
+      fileExists(): boolean {
+        return true;
+      },
+      readFile(): string |
+          undefined {
+            return '';
+          },
+      writeFile(fileName: string, data: string) {
+        writtenFiles[fileName] = data;
+      },
+      getDefaultLibFileName(): string {
+        return '';
+      },
+      getCurrentDirectory(): string {
+        return '';
+      },
+      getDirectories(): string[] {
+        return [];
+      },
+      getCanonicalFileName(): string {
+        return '';
+      },
+      useCaseSensitiveFileNames(): boolean {
+        return true;
+      },
+      getNewLine(): string {
+        return '\n';
+      },
     };
 
     const transform = (context: ts.TransformationContext) => {

--- a/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
@@ -28,7 +28,7 @@ export function isFromDtsFile(node: ts.Node): boolean {
   return sf !== undefined && sf.isDeclarationFile;
 }
 
-export function nodeNameForError(node: ts.Node & {name?: ts.Node}): string {
+export function nodeNameForError(node: ts.Node&{name?: ts.Node}): string {
   if (node.name !== undefined && ts.isIdentifier(node.name)) {
     return node.name.text;
   } else {
@@ -58,7 +58,7 @@ export function getTokenAtPosition(sf: ts.SourceFile, pos: number): ts.Node {
   return (ts as any).getTokenAtPosition(sf, pos);
 }
 
-export function identifierOfNode(decl: ts.Node & {name?: ts.Node}): ts.Identifier|null {
+export function identifierOfNode(decl: ts.Node&{name?: ts.Node}): ts.Identifier|null {
   if (decl.name !== undefined && ts.isIdentifier(decl.name)) {
     return decl.name;
   } else {
@@ -123,7 +123,7 @@ export function nodeDebugInfo(node: ts.Node): string {
 export function resolveModuleName(
     moduleName: string, containingFile: string, compilerOptions: ts.CompilerOptions,
     compilerHost: ts.CompilerHost,
-    moduleResolutionCache: ts.ModuleResolutionCache | null): ts.ResolvedModule|undefined {
+    moduleResolutionCache: ts.ModuleResolutionCache|null): ts.ResolvedModule|undefined {
   if (compilerHost.resolveModuleNames) {
     // FIXME: Additional parameters are required in TS3.6, but ignored in 3.5.
     // Remove the any cast once google3 is fully on TS3.6.

--- a/packages/compiler-cli/src/ngtsc/util/src/visitor.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/visitor.ts
@@ -68,7 +68,9 @@ export abstract class Visitor {
   /**
    * Visit types of nodes which don't have their own explicit visitor.
    */
-  visitOtherNode<T extends ts.Node>(node: T): T { return node; }
+  visitOtherNode<T extends ts.Node>(node: T): T {
+    return node;
+  }
 
   /**
    * @internal
@@ -81,8 +83,9 @@ export abstract class Visitor {
     node = ts.visitEachChild(node, child => this._visit(child, context), context) as T;
 
     if (ts.isClassDeclaration(node)) {
-      visitedNode = this._visitListEntryNode(
-          node, (node: ts.ClassDeclaration) => this.visitClassDeclaration(node)) as typeof node;
+      visitedNode =
+          this._visitListEntryNode(
+              node, (node: ts.ClassDeclaration) => this.visitClassDeclaration(node)) as typeof node;
     } else {
       visitedNode = this.visitOtherNode(node);
     }
@@ -111,12 +114,12 @@ export abstract class Visitor {
     const newStatements: ts.Statement[] = [];
     clone.statements.forEach(stmt => {
       if (this._before.has(stmt)) {
-        newStatements.push(...(this._before.get(stmt) !as ts.Statement[]));
+        newStatements.push(...(this._before.get(stmt)! as ts.Statement[]));
         this._before.delete(stmt);
       }
       newStatements.push(stmt);
       if (this._after.has(stmt)) {
-        newStatements.push(...(this._after.get(stmt) !as ts.Statement[]));
+        newStatements.push(...(this._after.get(stmt)! as ts.Statement[]));
         this._after.delete(stmt);
       }
     });
@@ -126,6 +129,6 @@ export abstract class Visitor {
 }
 
 function hasStatements(node: ts.Node): node is ts.Node&{statements: ts.NodeArray<ts.Statement>} {
-  const block = node as{statements?: any};
+  const block = node as {statements?: any};
   return block.statements !== undefined && Array.isArray(block.statements);
 }

--- a/packages/compiler-cli/src/ngtsc/util/test/visitor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/util/test/visitor_spec.ts
@@ -6,22 +6,22 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
+
 import {absoluteFrom, getSourceFileOrError} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {makeProgram} from '../../testing';
-import {VisitListEntryResult, Visitor, visit} from '../src/visitor';
+import {visit, VisitListEntryResult, Visitor} from '../src/visitor';
 
 class TestAstVisitor extends Visitor {
   visitClassDeclaration(node: ts.ClassDeclaration):
       VisitListEntryResult<ts.Statement, ts.ClassDeclaration> {
-    const name = node.name !.text;
-    const statics =
-        node.members.filter(member => (member.modifiers as ReadonlyArray<ts.Modifier>|| [
-                                      ]).some(mod => mod.kind === ts.SyntaxKind.StaticKeyword));
-    const idStatic = statics
-                         .find(
-                             el => ts.isPropertyDeclaration(el) && ts.isIdentifier(el.name) &&
-                                 el.name.text === 'id') as ts.PropertyDeclaration |
+    const name = node.name!.text;
+    const statics = node.members.filter(
+        member => (member.modifiers as ReadonlyArray<ts.Modifier>||
+                   []).some(mod => mod.kind === ts.SyntaxKind.StaticKeyword));
+    const idStatic = statics.find(
+                         el => ts.isPropertyDeclaration(el) && ts.isIdentifier(el.name) &&
+                             el.name.text === 'id') as ts.PropertyDeclaration |
         undefined;
     if (idStatic !== undefined) {
       return {

--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Position, isSyntaxError} from '@angular/compiler';
+import {isSyntaxError, Position} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {AbsoluteFsPath, absoluteFrom, getFileSystem, relative, resolve} from '../src/ngtsc/file_system';
+import {absoluteFrom, AbsoluteFsPath, getFileSystem, relative, resolve} from '../src/ngtsc/file_system';
 
 import {replaceTsWithNgInErrors} from './ngtsc/diagnostics';
 import * as api from './transformers/api';
@@ -35,7 +35,7 @@ function displayFileName(fileName: string, host: ts.FormatDiagnosticsHost): stri
 
 export function formatDiagnosticPosition(
     position: Position, host: ts.FormatDiagnosticsHost = defaultFormatHost): string {
-  return `${displayFileName(position.fileName, host)}(${position.line + 1},${position.column+1})`;
+  return `${displayFileName(position.fileName, host)}(${position.line + 1},${position.column + 1})`;
 }
 
 export function flattenDiagnosticMessageChain(
@@ -73,11 +73,10 @@ export function formatDiagnostic(
   const newLine = host.getNewLine();
   const span = diagnostic.span;
   if (span) {
-    result += `${formatDiagnosticPosition({
-      fileName: span.start.file.url,
-      line: span.start.line,
-      column: span.start.col
-    }, host)}: `;
+    result += `${
+        formatDiagnosticPosition(
+            {fileName: span.start.file.url, line: span.start.line, column: span.start.col},
+            host)}: `;
   } else if (diagnostic.position) {
     result += `${formatDiagnosticPosition(diagnostic.position, host)}: `;
   }
@@ -156,8 +155,10 @@ export function readConfiguration(
           // other options like 'compilerOptions' are merged by TS
           const baseConfig = existingConfig || config;
           if (existingConfig) {
-            baseConfig.angularCompilerOptions = {...config.angularCompilerOptions,
-                                                 ...baseConfig.angularCompilerOptions};
+            baseConfig.angularCompilerOptions = {
+              ...config.angularCompilerOptions,
+              ...baseConfig.angularCompilerOptions
+            };
           }
 
           if (config.extends) {
@@ -223,7 +224,7 @@ export interface PerformCompilationResult {
   emitResult?: ts.EmitResult;
 }
 
-export function exitCodeFromResult(diags: Diagnostics | undefined): number {
+export function exitCodeFromResult(diags: Diagnostics|undefined): number {
   if (!diags || filterErrorsAndWarnings(diags).length === 0) {
     // If we have a result and didn't get any errors, we succeeded.
     return 0;
@@ -233,21 +234,29 @@ export function exitCodeFromResult(diags: Diagnostics | undefined): number {
   return diags.some(d => d.source === 'angular' && d.code === api.UNKNOWN_ERROR_CODE) ? 2 : 1;
 }
 
-export function performCompilation(
-    {rootNames, options, host, oldProgram, emitCallback, mergeEmitResultsCallback,
-     gatherDiagnostics = defaultGatherDiagnostics, customTransformers,
-     emitFlags = api.EmitFlags.Default, modifiedResourceFiles = null}: {
-      rootNames: string[],
-      options: api.CompilerOptions,
-      host?: api.CompilerHost,
-      oldProgram?: api.Program,
-      emitCallback?: api.TsEmitCallback,
-      mergeEmitResultsCallback?: api.TsMergeEmitResultsCallback,
-      gatherDiagnostics?: (program: api.Program) => Diagnostics,
-      customTransformers?: api.CustomTransformers,
-      emitFlags?: api.EmitFlags,
-      modifiedResourceFiles?: Set<string>| null,
-    }): PerformCompilationResult {
+export function performCompilation({
+  rootNames,
+  options,
+  host,
+  oldProgram,
+  emitCallback,
+  mergeEmitResultsCallback,
+  gatherDiagnostics = defaultGatherDiagnostics,
+  customTransformers,
+  emitFlags = api.EmitFlags.Default,
+  modifiedResourceFiles = null
+}: {
+  rootNames: string[],
+  options: api.CompilerOptions,
+  host?: api.CompilerHost,
+  oldProgram?: api.Program,
+  emitCallback?: api.TsEmitCallback,
+  mergeEmitResultsCallback?: api.TsMergeEmitResultsCallback,
+  gatherDiagnostics?: (program: api.Program) => Diagnostics,
+  customTransformers?: api.CustomTransformers,
+  emitFlags?: api.EmitFlags,
+  modifiedResourceFiles?: Set<string>| null,
+}): PerformCompilationResult {
   let program: api.Program|undefined;
   let emitResult: ts.EmitResult|undefined;
   let allDiagnostics: Array<ts.Diagnostic|api.Diagnostic> = [];
@@ -262,7 +271,7 @@ export function performCompilation(
     program = ng.createProgram({rootNames, host, options, oldProgram});
 
     const beforeDiags = Date.now();
-    allDiagnostics.push(...gatherDiagnostics(program !));
+    allDiagnostics.push(...gatherDiagnostics(program!));
     if (options.diagnostics) {
       const afterDiags = Date.now();
       allDiagnostics.push(
@@ -271,7 +280,7 @@ export function performCompilation(
 
     if (!hasErrors(allDiagnostics)) {
       emitResult =
-          program !.emit({emitCallback, mergeEmitResultsCallback, customTransformers, emitFlags});
+          program!.emit({emitCallback, mergeEmitResultsCallback, customTransformers, emitFlags});
       allDiagnostics.push(...emitResult.diagnostics);
       return {diagnostics: allDiagnostics, program, emitResult};
     }
@@ -297,7 +306,7 @@ export function performCompilation(
 export function defaultGatherDiagnostics(program: api.Program): Diagnostics {
   const allDiagnostics: Array<ts.Diagnostic|api.Diagnostic> = [];
 
-  function checkDiagnostics(diags: Diagnostics | undefined) {
+  function checkDiagnostics(diags: Diagnostics|undefined) {
     if (diags) {
       allDiagnostics.push(...diags);
       return !hasErrors(diags);

--- a/packages/compiler-cli/src/perform_watch.ts
+++ b/packages/compiler-cli/src/perform_watch.ts
@@ -10,7 +10,7 @@ import * as chokidar from 'chokidar';
 import * as path from 'path';
 import * as ts from 'typescript';
 
-import {Diagnostics, ParsedConfiguration, PerformCompilationResult, exitCodeFromResult, performCompilation, readConfiguration} from './perform_compile';
+import {Diagnostics, exitCodeFromResult, ParsedConfiguration, performCompilation, PerformCompilationResult, readConfiguration} from './perform_compile';
 import * as api from './transformers/api';
 import {createCompilerHost} from './transformers/entry_points';
 import {createMessageDiagnostic} from './transformers/util';
@@ -50,8 +50,9 @@ export interface PerformWatchHost {
 
 export function createPerformWatchHost(
     configFileName: string, reportDiagnostics: (diagnostics: Diagnostics) => void,
-    existingOptions?: ts.CompilerOptions, createEmitCallback?: (options: api.CompilerOptions) =>
-                                              api.TsEmitCallback | undefined): PerformWatchHost {
+    existingOptions?: ts.CompilerOptions,
+    createEmitCallback?: (options: api.CompilerOptions) =>
+        api.TsEmitCallback | undefined): PerformWatchHost {
   return {
     reportDiagnostics: reportDiagnostics,
     createCompilerHost: options => createCompilerHost({options}),
@@ -130,7 +131,7 @@ export function performWatchCompilation(host: PerformWatchHost):
   // Note: ! is ok as options are filled after the first compilation
   // Note: ! is ok as resolvedReadyPromise is filled by the previous call
   const fileWatcher =
-      host.onFileChange(cachedOptions !.options, watchedFileChanged, resolveReadyPromise !);
+      host.onFileChange(cachedOptions!.options, watchedFileChanged, resolveReadyPromise!);
 
   return {close, ready: cb => readyPromise.then(cb), firstCompileResult};
 
@@ -177,7 +178,7 @@ export function performWatchCompilation(host: PerformWatchHost):
         if (ce.exists == null) {
           ce.exists = originalFileExists.call(this, fileName);
         }
-        return ce.exists !;
+        return ce.exists!;
       };
       const originalGetSourceFile = cachedCompilerHost.getSourceFile;
       cachedCompilerHost.getSourceFile = function(
@@ -186,7 +187,7 @@ export function performWatchCompilation(host: PerformWatchHost):
         if (!ce.sf) {
           ce.sf = originalGetSourceFile.call(this, fileName, languageVersion);
         }
-        return ce.sf !;
+        return ce.sf!;
       };
       const originalReadFile = cachedCompilerHost.readFile;
       cachedCompilerHost.readFile = function(fileName: string) {
@@ -194,7 +195,7 @@ export function performWatchCompilation(host: PerformWatchHost):
         if (ce.content == null) {
           ce.content = originalReadFile.call(this, fileName);
         }
-        return ce.content !;
+        return ce.content!;
       };
       // Provide access to the file paths that triggered this rebuild
       cachedCompilerHost.getModifiedResourceFiles = function() {

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -190,8 +190,12 @@ export interface TsEmitArguments {
   customTransformers?: ts.CustomTransformers;
 }
 
-export interface TsEmitCallback { (args: TsEmitArguments): ts.EmitResult; }
-export interface TsMergeEmitResultsCallback { (results: ts.EmitResult[]): ts.EmitResult; }
+export interface TsEmitCallback {
+  (args: TsEmitArguments): ts.EmitResult;
+}
+export interface TsMergeEmitResultsCallback {
+  (results: ts.EmitResult[]): ts.EmitResult;
+}
 
 export interface LibrarySummary {
   fileName: string;
@@ -283,14 +287,14 @@ export interface Program {
    *
    * Angular structural information is required to emit files.
    */
-  emit({emitFlags, cancellationToken, customTransformers, emitCallback,
-        mergeEmitResultsCallback}?: {
-    emitFlags?: EmitFlags,
-    cancellationToken?: ts.CancellationToken,
-    customTransformers?: CustomTransformers,
-    emitCallback?: TsEmitCallback,
-    mergeEmitResultsCallback?: TsMergeEmitResultsCallback
-  }): ts.EmitResult;
+  emit({emitFlags, cancellationToken, customTransformers, emitCallback, mergeEmitResultsCallback}?:
+           {
+             emitFlags?: EmitFlags,
+             cancellationToken?: ts.CancellationToken,
+             customTransformers?: CustomTransformers,
+             emitCallback?: TsEmitCallback,
+             mergeEmitResultsCallback?: TsMergeEmitResultsCallback
+           }): ts.EmitResult;
 
   /**
    * Returns the .d.ts / .ngsummary.json / .ngfactory.d.ts files of libraries that have been emitted

--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AotCompilerHost, EmitterVisitorContext, GeneratedFile, ParseSourceSpan, TypeScriptEmitter, collectExternalReferences, syntaxError} from '@angular/compiler';
+import {AotCompilerHost, collectExternalReferences, EmitterVisitorContext, GeneratedFile, ParseSourceSpan, syntaxError, TypeScriptEmitter} from '@angular/compiler';
 import * as path from 'path';
 import * as ts from 'typescript';
 
@@ -15,7 +15,7 @@ import {ModuleMetadata} from '../metadata/index';
 import {join} from '../ngtsc/file_system';
 
 import {CompilerHost, CompilerOptions, LibrarySummary} from './api';
-import {MetadataReaderHost, createMetadataReaderCache, readMetadata} from './metadata_reader';
+import {createMetadataReaderCache, MetadataReaderHost, readMetadata} from './metadata_reader';
 import {DTS, GENERATED_FILES, isInRootDir, relativeToRootDirs} from './util';
 
 const NODE_MODULES_PACKAGE_NAME = /node_modules\/((\w|-|\.)+|(@(\w|-|\.)+\/(\w|-|\.)+))/;
@@ -24,8 +24,8 @@ const CSS_PREPROCESSOR_EXT = /(\.scss|\.sass|\.less|\.styl)$/;
 
 let wrapHostForTest: ((host: ts.CompilerHost) => ts.CompilerHost)|null = null;
 
-export function setWrapHostForTest(wrapFn: ((host: ts.CompilerHost) => ts.CompilerHost) | null):
-    void {
+export function setWrapHostForTest(wrapFn: ((host: ts.CompilerHost) => ts.CompilerHost)|
+                                   null): void {
   wrapHostForTest = wrapFn;
 }
 
@@ -53,11 +53,11 @@ export interface CodeGenerator {
   findGeneratedFileNames(fileName: string): string[];
 }
 
-function assert<T>(condition: T | null | undefined) {
+function assert<T>(condition: T|null|undefined) {
   if (!condition) {
     // TODO(chuckjaz): do the right thing
   }
-  return condition !;
+  return condition!;
 }
 
 /**
@@ -67,7 +67,7 @@ function assert<T>(condition: T | null | undefined) {
  * - TypeCheckHost for mapping ts errors to ng errors (via translateDiagnostics)
  */
 export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHost, AotCompilerHost,
-    TypeCheckHost {
+                                                                  TypeCheckHost {
   private metadataReaderCache = createMetadataReaderCache();
   private fileNameToModuleNameCache = new Map<string, string>();
   private flatModuleIndexCache = new Map<string, boolean>();
@@ -83,13 +83,13 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
   private metadataReaderHost: MetadataReaderHost;
 
   // TODO(issue/24571): remove '!'.
-  getCancellationToken !: () => ts.CancellationToken;
+  getCancellationToken!: () => ts.CancellationToken;
   // TODO(issue/24571): remove '!'.
-  getDefaultLibLocation !: () => string;
+  getDefaultLibLocation!: () => string;
   // TODO(issue/24571): remove '!'.
-  trace !: (s: string) => void;
+  trace!: (s: string) => void;
   // TODO(issue/24571): remove '!'.
-  getDirectories !: (path: string) => string[];
+  getDirectories!: (path: string) => string[];
   resolveTypeReferenceDirectives?:
       (names: string[], containingFile: string) => ts.ResolvedTypeReferenceDirective[];
   directoryExists?: (directoryName: string) => boolean;
@@ -100,21 +100,21 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
       private codeGenerator: CodeGenerator,
       private librarySummaries = new Map<string, LibrarySummary>()) {
     this.moduleResolutionCache = ts.createModuleResolutionCache(
-        this.context.getCurrentDirectory !(), this.context.getCanonicalFileName.bind(this.context));
-    const basePath = this.options.basePath !;
+        this.context.getCurrentDirectory!(), this.context.getCanonicalFileName.bind(this.context));
+    const basePath = this.options.basePath!;
     this.rootDirs =
-        (this.options.rootDirs || [this.options.basePath !]).map(p => path.resolve(basePath, p));
+        (this.options.rootDirs || [this.options.basePath!]).map(p => path.resolve(basePath, p));
     if (context.getDirectories) {
-      this.getDirectories = path => context.getDirectories !(path);
+      this.getDirectories = path => context.getDirectories!(path);
     }
     if (context.directoryExists) {
-      this.directoryExists = directoryName => context.directoryExists !(directoryName);
+      this.directoryExists = directoryName => context.directoryExists!(directoryName);
     }
     if (context.getCancellationToken) {
-      this.getCancellationToken = () => context.getCancellationToken !();
+      this.getCancellationToken = () => context.getCancellationToken!();
     }
     if (context.getDefaultLibLocation) {
-      this.getDefaultLibLocation = () => context.getDefaultLibLocation !();
+      this.getDefaultLibLocation = () => context.getDefaultLibLocation!();
     }
     if (context.resolveTypeReferenceDirectives) {
       // Backward compatibility with TypeScript 2.9 and older since return
@@ -123,11 +123,11 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
       type ts3ResolveTypeReferenceDirectives = (names: string[], containingFile: string) =>
           ts.ResolvedTypeReferenceDirective[];
       this.resolveTypeReferenceDirectives = (names: string[], containingFile: string) =>
-          (context.resolveTypeReferenceDirectives as ts3ResolveTypeReferenceDirectives) !(
-              names, containingFile);
+          (context.resolveTypeReferenceDirectives as ts3ResolveTypeReferenceDirectives)!
+          (names, containingFile);
     }
     if (context.trace) {
-      this.trace = s => context.trace !(s);
+      this.trace = s => context.trace!(s);
     }
     if (context.fileNameToModuleName) {
       this.fileNameToModuleName = context.fileNameToModuleName.bind(context);
@@ -265,8 +265,8 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
         }
       }
     } else {
-      throw new Error(
-          `Trying to import a source file from a node_modules package: import ${originalImportedFile} from ${containingFile}`);
+      throw new Error(`Trying to import a source file from a node_modules package: import ${
+          originalImportedFile} from ${containingFile}`);
     }
 
     this.fileNameToModuleNameCache.set(cacheKey, moduleName);
@@ -325,7 +325,7 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
     // Note: we need the explicit check via `has` as we also cache results
     // that were null / undefined.
     if (this.originalSourceFiles.has(filePath)) {
-      return this.originalSourceFiles.get(filePath) !;
+      return this.originalSourceFiles.get(filePath)!;
     }
     if (!languageVersion) {
       languageVersion = this.options.target || ts.ScriptTarget.Latest;
@@ -353,8 +353,8 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
       newRefs.forEach(r => refsAreEqual = refsAreEqual && oldRefs.has(r));
     }
     if (!refsAreEqual) {
-      throw new Error(
-          `Illegal State: external references changed in ${genFile.genFileUrl}.\nOld: ${Array.from(oldRefs)}.\nNew: ${Array.from(newRefs)}`);
+      throw new Error(`Illegal State: external references changed in ${genFile.genFileUrl}.\nOld: ${
+          Array.from(oldRefs)}.\nNew: ${Array.from(newRefs)}`);
     }
     return this.addGeneratedFile(genFile, newRefs);
   }
@@ -381,7 +381,8 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
     }
     this.generatedSourceFiles.set(genFile.genFileUrl, {
       sourceFile: sf,
-      emitCtx: context, externalReferences,
+      emitCtx: context,
+      externalReferences,
     });
     return sf;
   }
@@ -468,7 +469,7 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
     }
     // TODO(tbosch): TypeScript's typings for getSourceFile are incorrect,
     // as it can very well return undefined.
-    return sf !;
+    return sf!;
   }
 
   private getGeneratedFile(fileName: string): ts.SourceFile|null {
@@ -638,7 +639,7 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
 }
 
 function genFileExternalReferences(genFile: GeneratedFile): Set<string> {
-  return new Set(collectExternalReferences(genFile.stmts !).map(er => er.moduleName !));
+  return new Set(collectExternalReferences(genFile.stmts!).map(er => er.moduleName!));
 }
 
 function addReferencesToSourceFile(sf: ts.SourceFile, genFileNames: string[]) {

--- a/packages/compiler-cli/src/transformers/inline_resources.ts
+++ b/packages/compiler-cli/src/transformers/inline_resources.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {MetadataObject, MetadataValue, isClassMetadata, isMetadataImportedSymbolReferenceExpression, isMetadataSymbolicCallExpression} from '../metadata/index';
+import {isClassMetadata, isMetadataImportedSymbolReferenceExpression, isMetadataSymbolicCallExpression, MetadataObject, MetadataValue} from '../metadata/index';
 
 import {MetadataTransformer, ValueTransform} from './metadata_cache';
 
@@ -17,27 +17,29 @@ const PRECONDITIONS_TEXT =
 
 /** A subset of members from AotCompilerHost */
 export type ResourcesHost = {
-  resourceNameToFileName(resourceName: string, containingFileName: string): string | null;
+  resourceNameToFileName(resourceName: string, containingFileName: string): string|null;
   loadResource(path: string): Promise<string>| string;
 };
 
 export type StaticResourceLoader = {
-  get(url: string | MetadataValue): string;
+  get(url: string|MetadataValue): string;
 };
 
 function getResourceLoader(host: ResourcesHost, containingFileName: string): StaticResourceLoader {
   return {
-    get(url: string | MetadataValue): string{
+    get(url: string|MetadataValue): string {
       if (typeof url !== 'string') {
         throw new Error('templateUrl and stylesUrl must be string literals. ' + PRECONDITIONS_TEXT);
-      } const fileName = host.resourceNameToFileName(url, containingFileName);
+      }
+      const fileName = host.resourceNameToFileName(url, containingFileName);
       if (fileName) {
         const content = host.loadResource(fileName);
         if (typeof content !== 'string') {
           throw new Error('Cannot handle async resource. ' + PRECONDITIONS_TEXT);
         }
         return content;
-      } throw new Error(`Failed to resolve ${url} from ${containingFileName}. ${PRECONDITIONS_TEXT}`);
+      }
+      throw new Error(`Failed to resolve ${url} from ${containingFileName}. ${PRECONDITIONS_TEXT}`);
     }
   };
 }
@@ -249,8 +251,7 @@ function isComponentSymbol(identifier: ts.Node, typeChecker: ts.TypeChecker) {
   const name = (declaration.propertyName || declaration.name).text;
   // We know that parent pointers are set because we created the SourceFile ourselves.
   // The number of parent references here match the recursion depth at this point.
-  const moduleId =
-      (declaration.parent !.parent !.parent !.moduleSpecifier as ts.StringLiteral).text;
+  const moduleId = (declaration.parent!.parent!.parent!.moduleSpecifier as ts.StringLiteral).text;
   return moduleId === '@angular/core' && name === 'Component';
 }
 

--- a/packages/compiler-cli/src/transformers/lower_expressions.ts
+++ b/packages/compiler-cli/src/transformers/lower_expressions.ts
@@ -9,7 +9,8 @@
 import {createLoweredSymbol, isLoweredSymbol} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {CollectorOptions, MetadataCollector, MetadataValue, ModuleMetadata, isMetadataGlobalReferenceExpression} from '../metadata/index';
+import {CollectorOptions, isMetadataGlobalReferenceExpression, MetadataCollector, MetadataValue, ModuleMetadata} from '../metadata/index';
+
 import {MetadataCache, MetadataTransformer, ValueTransform} from './metadata_cache';
 
 export interface LoweringRequest {
@@ -21,7 +22,10 @@ export interface LoweringRequest {
 
 export type RequestLocationMap = Map<number, LoweringRequest>;
 
-const enum DeclarationOrder { BeforeStmt, AfterStmt }
+const enum DeclarationOrder {
+  BeforeStmt,
+  AfterStmt
+}
 
 interface Declaration {
   name: string;
@@ -201,14 +205,16 @@ export function getExpressionLoweringTransformFactory(
   };
 }
 
-export interface RequestsMap { getRequests(sourceFile: ts.SourceFile): RequestLocationMap; }
+export interface RequestsMap {
+  getRequests(sourceFile: ts.SourceFile): RequestLocationMap;
+}
 
 interface MetadataAndLoweringRequests {
   metadata: ModuleMetadata|undefined;
   requests: RequestLocationMap;
 }
 
-function isEligibleForLowering(node: ts.Node | undefined): boolean {
+function isEligibleForLowering(node: ts.Node|undefined): boolean {
   if (node) {
     switch (node.kind) {
       case ts.SyntaxKind.SourceFile:
@@ -232,10 +238,11 @@ function isEligibleForLowering(node: ts.Node | undefined): boolean {
         // example) might also require lowering even if the top-level declaration is already
         // properly exported.
         const varNode = node as ts.VariableDeclaration;
-        return isExported || (varNode.initializer !== undefined &&
-                              (ts.isObjectLiteralExpression(varNode.initializer) ||
-                               ts.isArrayLiteralExpression(varNode.initializer) ||
-                               ts.isCallExpression(varNode.initializer)));
+        return isExported ||
+            (varNode.initializer !== undefined &&
+             (ts.isObjectLiteralExpression(varNode.initializer) ||
+              ts.isArrayLiteralExpression(varNode.initializer) ||
+              ts.isCallExpression(varNode.initializer)));
     }
     return isEligibleForLowering(node.parent);
   }
@@ -264,7 +271,7 @@ function isLiteralFieldNamed(node: ts.Node, names: Set<string>): boolean {
 
 export class LowerMetadataTransform implements RequestsMap, MetadataTransformer {
   // TODO(issue/24571): remove '!'.
-  private cache !: MetadataCache;
+  private cache!: MetadataCache;
   private requests = new Map<string, RequestLocationMap>();
   private lowerableFieldNames: Set<string>;
 
@@ -288,7 +295,9 @@ export class LowerMetadataTransform implements RequestsMap, MetadataTransformer 
   }
 
   // MetadataTransformer
-  connect(cache: MetadataCache): void { this.cache = cache; }
+  connect(cache: MetadataCache): void {
+    this.cache = cache;
+  }
 
   start(sourceFile: ts.SourceFile): ValueTransform|undefined {
     let identNumber = 0;
@@ -329,7 +338,7 @@ export class LowerMetadataTransform implements RequestsMap, MetadataTransformer 
 
     const hasLowerableParentCache = new Map<ts.Node, boolean>();
 
-    const shouldBeLowered = (node: ts.Node | undefined): boolean => {
+    const shouldBeLowered = (node: ts.Node|undefined): boolean => {
       if (node === undefined) {
         return false;
       }
@@ -346,7 +355,7 @@ export class LowerMetadataTransform implements RequestsMap, MetadataTransformer 
       return lowerable;
     };
 
-    const hasLowerableParent = (node: ts.Node | undefined): boolean => {
+    const hasLowerableParent = (node: ts.Node|undefined): boolean => {
       if (node === undefined) {
         return false;
       }
@@ -354,10 +363,10 @@ export class LowerMetadataTransform implements RequestsMap, MetadataTransformer 
         hasLowerableParentCache.set(
             node, shouldBeLowered(node.parent) || hasLowerableParent(node.parent));
       }
-      return hasLowerableParentCache.get(node) !;
+      return hasLowerableParentCache.get(node)!;
     };
 
-    const isLowerable = (node: ts.Node | undefined): boolean => {
+    const isLowerable = (node: ts.Node|undefined): boolean => {
       if (node === undefined) {
         return false;
       }
@@ -383,7 +392,7 @@ function createExportTableFor(sourceFile: ts.SourceFile): Set<string> {
       case ts.SyntaxKind.InterfaceDeclaration:
         if ((ts.getCombinedModifierFlags(node as ts.Declaration) & ts.ModifierFlags.Export) != 0) {
           const classDeclaration =
-              node as(ts.ClassDeclaration | ts.FunctionDeclaration | ts.InterfaceDeclaration);
+              node as (ts.ClassDeclaration | ts.FunctionDeclaration | ts.InterfaceDeclaration);
           const name = classDeclaration.name;
           if (name) exportTable.add(name.text);
         }
@@ -406,7 +415,9 @@ function createExportTableFor(sourceFile: ts.SourceFile): Set<string> {
         const exportDeclaration = node as ts.ExportDeclaration;
         const {moduleSpecifier, exportClause} = exportDeclaration;
         if (!moduleSpecifier && exportClause && ts.isNamedExports(exportClause)) {
-          exportClause.elements.forEach(spec => { exportTable.add(spec.name.text); });
+          exportClause.elements.forEach(spec => {
+            exportTable.add(spec.name.text);
+          });
         }
     }
   });

--- a/packages/compiler-cli/src/transformers/node_emitter.ts
+++ b/packages/compiler-cli/src/transformers/node_emitter.ts
@@ -12,7 +12,9 @@ import * as ts from 'typescript';
 
 import {error} from './util';
 
-export interface Node { sourceSpan: ParseSourceSpan|null; }
+export interface Node {
+  sourceSpan: ParseSourceSpan|null;
+}
 
 const METHOD_THIS_NAME = 'this';
 const CATCH_ERROR_NAME = 'error';
@@ -110,15 +112,16 @@ export function updateSourceFile(
 
   // Validate that all the classes have been generated
   classNames.size == 0 ||
-      error(
-          `${classNames.size == 1 ? 'Class' : 'Classes'} "${Array.from(classNames.keys()).join(', ')}" not generated`);
+      error(`${classNames.size == 1 ? 'Class' : 'Classes'} "${
+          Array.from(classNames.keys()).join(', ')}" not generated`);
 
   // Add imports to the module required by the new methods
   const imports = converter.getImports();
   if (imports && imports.length) {
     // Find where the new imports should go
     const index = firstAfter(
-        newStatements, statement => statement.kind === ts.SyntaxKind.ImportDeclaration ||
+        newStatements,
+        statement => statement.kind === ts.SyntaxKind.ImportDeclaration ||
             statement.kind === ts.SyntaxKind.ImportEqualsDeclaration);
     newStatements =
         [...newStatements.slice(0, index), ...imports, ...prefix, ...newStatements.slice(index)];
@@ -152,7 +155,9 @@ function firstAfter<T>(a: T[], predicate: (value: T) => boolean) {
 // A recorded node is a subtype of the node that is marked as being recorded. This is used
 // to ensure that NodeEmitterVisitor.record has been called on all nodes returned by the
 // NodeEmitterVisitor
-export type RecordedNode<T extends ts.Node = ts.Node> = (T & { __recorded: any;}) | null;
+export type RecordedNode<T extends ts.Node = ts.Node> = (T&{
+  __recorded: any;
+})|null;
 
 function escapeLiteral(value: string): string {
   return value.replace(/(\"|\\)/g, '\\$1').replace(/(\n)|(\r)/g, function(v, n, r) {
@@ -220,8 +225,9 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
         .map(
             ([exportedFilePath, reexports]) => ts.createExportDeclaration(
                 /* decorators */ undefined,
-                /* modifiers */ undefined, ts.createNamedExports(reexports.map(
-                                               ({name, as}) => ts.createExportSpecifier(name, as))),
+                /* modifiers */ undefined,
+                ts.createNamedExports(
+                    reexports.map(({name, as}) => ts.createExportSpecifier(name, as))),
                 /* moduleSpecifier */ createLiteral(exportedFilePath)));
   }
 
@@ -231,13 +237,16 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
             ([namespace, prefix]) => ts.createImportDeclaration(
                 /* decorators */ undefined,
                 /* modifiers */ undefined,
-                /* importClause */ ts.createImportClause(
+                /* importClause */
+                ts.createImportClause(
                     /* name */<ts.Identifier>(undefined as any),
                     ts.createNamespaceImport(ts.createIdentifier(prefix))),
                 /* moduleSpecifier */ createLiteral(namespace)));
   }
 
-  getNodeMap() { return this._nodeMap; }
+  getNodeMap() {
+    return this._nodeMap;
+  }
 
   updateSourceMap(statements: ts.Statement[]) {
     let lastRangeStartNode: ts.Node|undefined = undefined;
@@ -324,7 +333,7 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
           reexports = [];
           this._reexports.set(moduleName, reexports);
         }
-        reexports.push({name: name !, as: stmt.name});
+        reexports.push({name: name!, as: stmt.name});
         return null;
       }
     }
@@ -340,9 +349,10 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
       const tsVarStmt =
           this.record(stmt, ts.createVariableStatement(/* modifiers */[], varDeclList));
       const exportStmt = this.record(
-          stmt, ts.createExportDeclaration(
-                    /*decorators*/ undefined, /*modifiers*/ undefined,
-                    ts.createNamedExports([ts.createExportSpecifier(stmt.name, stmt.name)])));
+          stmt,
+          ts.createExportDeclaration(
+              /*decorators*/ undefined, /*modifiers*/ undefined,
+              ts.createNamedExports([ts.createExportSpecifier(stmt.name, stmt.name)])));
       return [tsVarStmt, exportStmt];
     }
     return this.record(stmt, ts.createVariableStatement(this.getModifiers(stmt), varDeclList));
@@ -350,14 +360,15 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
 
   visitDeclareFunctionStmt(stmt: DeclareFunctionStmt) {
     return this.record(
-        stmt, ts.createFunctionDeclaration(
-                  /* decorators */ undefined, this.getModifiers(stmt),
-                  /* asteriskToken */ undefined, stmt.name, /* typeParameters */ undefined,
-                  stmt.params.map(
-                      p => ts.createParameter(
-                          /* decorators */ undefined, /* modifiers */ undefined,
-                          /* dotDotDotToken */ undefined, p.name)),
-                  /* type */ undefined, this._visitStatements(stmt.statements)));
+        stmt,
+        ts.createFunctionDeclaration(
+            /* decorators */ undefined, this.getModifiers(stmt),
+            /* asteriskToken */ undefined, stmt.name, /* typeParameters */ undefined,
+            stmt.params.map(
+                p => ts.createParameter(
+                    /* decorators */ undefined, /* modifiers */ undefined,
+                    /* dotDotDotToken */ undefined, p.name)),
+            /* type */ undefined, this._visitStatements(stmt.statements)));
   }
 
   visitExpressionStmt(stmt: ExpressionStatement) {
@@ -401,7 +412,8 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
         (stmt.constructorMethod && [ts.createConstructor(
                                        /* decorators */ undefined,
                                        /* modifiers */ undefined,
-                                       /* parameters */ stmt.constructorMethod.params.map(
+                                       /* parameters */
+                                       stmt.constructorMethod.params.map(
                                            p => ts.createParameter(
                                                /* decorators */ undefined,
                                                /* modifiers */ undefined,
@@ -415,7 +427,7 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
                             method => ts.createMethod(
                                 /* decorators */ undefined,
                                 /* modifiers */ translateModifiers(method.modifiers),
-                                /* astriskToken */ undefined, method.name !/* guarded by filter */,
+                                /* astriskToken */ undefined, method.name!/* guarded by filter */,
                                 /* questionToken */ undefined, /* typeParameters */ undefined,
                                 method.params.map(
                                     p => ts.createParameter(
@@ -423,13 +435,14 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
                                         /* dotDotDotToken */ undefined, p.name)),
                                 /* type */ undefined, this._visitStatements(method.body)));
     return this.record(
-        stmt, ts.createClassDeclaration(
-                  /* decorators */ undefined, modifiers, stmt.name, /* typeParameters*/ undefined,
-                  stmt.parent && [ts.createHeritageClause(
-                                     ts.SyntaxKind.ExtendsKeyword,
-                                     [stmt.parent.visitExpression(this, null)])] ||
-                      [],
-                  [...fields, ...getters, ...constructor, ...methods]));
+        stmt,
+        ts.createClassDeclaration(
+            /* decorators */ undefined, modifiers, stmt.name, /* typeParameters*/ undefined,
+            stmt.parent &&
+                    [ts.createHeritageClause(
+                        ts.SyntaxKind.ExtendsKeyword, [stmt.parent.visitExpression(this, null)])] ||
+                [],
+            [...fields, ...getters, ...constructor, ...methods]));
   }
 
   visitIfStmt(stmt: IfStmt) {
@@ -443,19 +456,21 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
 
   visitTryCatchStmt(stmt: TryCatchStmt): RecordedNode<ts.TryStatement> {
     return this.record(
-        stmt, ts.createTry(
-                  this._visitStatements(stmt.bodyStmts),
-                  ts.createCatchClause(
-                      CATCH_ERROR_NAME, this._visitStatementsPrefix(
-                                            [ts.createVariableStatement(
-                                                /* modifiers */ undefined,
-                                                [ts.createVariableDeclaration(
-                                                    CATCH_STACK_NAME, /* type */ undefined,
-                                                    ts.createPropertyAccess(
-                                                        ts.createIdentifier(CATCH_ERROR_NAME),
-                                                        ts.createIdentifier(CATCH_STACK_NAME)))])],
-                                            stmt.catchStmts)),
-                  /* finallyBlock */ undefined));
+        stmt,
+        ts.createTry(
+            this._visitStatements(stmt.bodyStmts),
+            ts.createCatchClause(
+                CATCH_ERROR_NAME,
+                this._visitStatementsPrefix(
+                    [ts.createVariableStatement(
+                        /* modifiers */ undefined,
+                        [ts.createVariableDeclaration(
+                            CATCH_STACK_NAME, /* type */ undefined,
+                            ts.createPropertyAccess(
+                                ts.createIdentifier(CATCH_ERROR_NAME),
+                                ts.createIdentifier(CATCH_STACK_NAME)))])],
+                    stmt.catchStmts)),
+            /* finallyBlock */ undefined));
   }
 
   visitThrowStmt(stmt: ThrowStmt) {
@@ -481,7 +496,9 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
   }
 
   // ExpressionVisitor
-  visitWrappedNodeExpr(expr: WrappedNodeExpr<any>) { return this.record(expr, expr.node); }
+  visitWrappedNodeExpr(expr: WrappedNodeExpr<any>) {
+    return this.record(expr, expr.node);
+  }
 
   visitTypeofExpr(expr: TypeofExpr) {
     const typeOf = ts.createTypeOf(expr.expr.visitExpression(this, null));
@@ -508,8 +525,9 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
 
   visitWriteVarExpr(expr: WriteVarExpr): RecordedNode<ts.BinaryExpression> {
     return this.record(
-        expr, ts.createAssignment(
-                  ts.createIdentifier(expr.name), expr.value.visitExpression(this, null)));
+        expr,
+        ts.createAssignment(
+            ts.createIdentifier(expr.name), expr.value.visitExpression(this, null)));
   }
 
   visitWriteKeyExpr(expr: WriteKeyExpr): RecordedNode<ts.BinaryExpression> {
@@ -523,9 +541,10 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
 
   visitWritePropExpr(expr: WritePropExpr): RecordedNode<ts.BinaryExpression> {
     return this.record(
-        expr, ts.createAssignment(
-                  ts.createPropertyAccess(expr.receiver.visitExpression(this, null), expr.name),
-                  expr.value.visitExpression(this, null)));
+        expr,
+        ts.createAssignment(
+            ts.createPropertyAccess(expr.receiver.visitExpression(this, null), expr.name),
+            expr.value.visitExpression(this, null)));
   }
 
   visitInvokeMethodExpr(expr: InvokeMethodExpr): RecordedNode<ts.CallExpression> {
@@ -539,19 +558,23 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
 
   visitInvokeFunctionExpr(expr: InvokeFunctionExpr): RecordedNode<ts.CallExpression> {
     return this.record(
-        expr, ts.createCall(
-                  expr.fn.visitExpression(this, null), /* typeArguments */ undefined,
-                  expr.args.map(arg => arg.visitExpression(this, null))));
+        expr,
+        ts.createCall(
+            expr.fn.visitExpression(this, null), /* typeArguments */ undefined,
+            expr.args.map(arg => arg.visitExpression(this, null))));
   }
 
   visitInstantiateExpr(expr: InstantiateExpr): RecordedNode<ts.NewExpression> {
     return this.record(
-        expr, ts.createNew(
-                  expr.classExpr.visitExpression(this, null), /* typeArguments */ undefined,
-                  expr.args.map(arg => arg.visitExpression(this, null))));
+        expr,
+        ts.createNew(
+            expr.classExpr.visitExpression(this, null), /* typeArguments */ undefined,
+            expr.args.map(arg => arg.visitExpression(this, null))));
   }
 
-  visitLiteralExpr(expr: LiteralExpr) { return this.record(expr, createLiteral(expr.value)); }
+  visitLiteralExpr(expr: LiteralExpr) {
+    return this.record(expr, createLiteral(expr.value));
+  }
 
   visitLocalizedString(expr: LocalizedString, context: any) {
     throw new Error('localized strings are not supported in pre-ivy mode.');
@@ -567,13 +590,14 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
         expr,
         ts.createParen(ts.createConditional(
             expr.condition.visitExpression(this, null), expr.trueCase.visitExpression(this, null),
-            expr.falseCase !.visitExpression(this, null))));
+            expr.falseCase!.visitExpression(this, null))));
   }
 
   visitNotExpr(expr: NotExpr): RecordedNode<ts.PrefixUnaryExpression> {
     return this.record(
-        expr, ts.createPrefix(
-                  ts.SyntaxKind.ExclamationToken, expr.condition.visitExpression(this, null)));
+        expr,
+        ts.createPrefix(
+            ts.SyntaxKind.ExclamationToken, expr.condition.visitExpression(this, null)));
   }
 
   visitAssertNotNullExpr(expr: AssertNotNull): RecordedNode<ts.Expression> {
@@ -586,15 +610,16 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
 
   visitFunctionExpr(expr: FunctionExpr) {
     return this.record(
-        expr, ts.createFunctionExpression(
-                  /* modifiers */ undefined, /* astriskToken */ undefined,
-                  /* name */ expr.name || undefined,
-                  /* typeParameters */ undefined,
-                  expr.params.map(
-                      p => ts.createParameter(
-                          /* decorators */ undefined, /* modifiers */ undefined,
-                          /* dotDotDotToken */ undefined, p.name)),
-                  /* type */ undefined, this._visitStatements(expr.statements)));
+        expr,
+        ts.createFunctionExpression(
+            /* modifiers */ undefined, /* astriskToken */ undefined,
+            /* name */ expr.name || undefined,
+            /* typeParameters */ undefined,
+            expr.params.map(
+                p => ts.createParameter(
+                    /* decorators */ undefined, /* modifiers */ undefined,
+                    /* dotDotDotToken */ undefined, p.name)),
+            /* type */ undefined, this._visitStatements(expr.statements)));
   }
 
   visitBinaryOperatorExpr(expr: BinaryOperatorExpr):
@@ -676,21 +701,23 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
 
   visitLiteralMapExpr(expr: LiteralMapExpr): RecordedNode<ts.ObjectLiteralExpression> {
     return this.record(
-        expr, ts.createObjectLiteral(expr.entries.map(
-                  entry => ts.createPropertyAssignment(
-                      entry.quoted || !_VALID_IDENTIFIER_RE.test(entry.key) ?
-                          ts.createLiteral(entry.key) :
-                          entry.key,
-                      entry.value.visitExpression(this, null)))));
+        expr,
+        ts.createObjectLiteral(expr.entries.map(
+            entry => ts.createPropertyAssignment(
+                entry.quoted || !_VALID_IDENTIFIER_RE.test(entry.key) ?
+                    ts.createLiteral(entry.key) :
+                    entry.key,
+                entry.value.visitExpression(this, null)))));
   }
 
   visitCommaExpr(expr: CommaExpr): RecordedNode<ts.Expression> {
     return this.record(
-        expr, expr.parts.map(e => e.visitExpression(this, null))
-                  .reduce<ts.Expression|null>(
-                      (left, right) =>
-                          left ? ts.createBinary(left, ts.SyntaxKind.CommaToken, right) : right,
-                      null));
+        expr,
+        expr.parts.map(e => e.visitExpression(this, null))
+            .reduce<ts.Expression|null>(
+                (left, right) =>
+                    left ? ts.createBinary(left, ts.SyntaxKind.CommaToken, right) : right,
+                null));
   }
 
   private _visitStatements(statements: Statement[]): ts.Block {
@@ -705,7 +732,7 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
 
   private _visitIdentifier(value: ExternalReference): ts.Expression {
     // name can only be null during JIT which never executes this code.
-    const moduleName = value.moduleName, name = value.name !;
+    const moduleName = value.moduleName, name = value.name!;
     let prefixIdent: ts.Identifier|null = null;
     if (moduleName) {
       let prefix = this._importsWithPrefixes.get(moduleName);
@@ -730,7 +757,7 @@ export class NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
 }
 
 
-function getMethodName(methodRef: {name: string | null; builtin: BuiltinMethod | null}): string {
+function getMethodName(methodRef: {name: string|null; builtin: BuiltinMethod | null}): string {
   if (methodRef.name) {
     return methodRef.name;
   } else {
@@ -760,6 +787,6 @@ function modifierFromModifier(modifier: StmtModifier): ts.Modifier {
   return error(`unknown statement modifier`);
 }
 
-function translateModifiers(modifiers: StmtModifier[] | null): ts.Modifier[]|undefined {
-  return modifiers == null ? undefined : modifiers !.map(modifierFromModifier);
+function translateModifiers(modifiers: StmtModifier[]|null): ts.Modifier[]|undefined {
+  return modifiers == null ? undefined : modifiers!.map(modifierFromModifier);
 }

--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -7,26 +7,26 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AotCompiler, AotCompilerHost, AotCompilerOptions, EmitterVisitorContext, FormattedMessageChain, GeneratedFile, MessageBundle, NgAnalyzedFile, NgAnalyzedFileWithInjectables, NgAnalyzedModules, ParseSourceSpan, PartialModule, Position, Serializer, StaticSymbol, TypeScriptEmitter, Xliff, Xliff2, Xmb, core, createAotCompiler, getParseErrors, isFormattedError, isSyntaxError} from '@angular/compiler';
+import {AotCompiler, AotCompilerHost, AotCompilerOptions, core, createAotCompiler, EmitterVisitorContext, FormattedMessageChain, GeneratedFile, getParseErrors, isFormattedError, isSyntaxError, MessageBundle, NgAnalyzedFile, NgAnalyzedFileWithInjectables, NgAnalyzedModules, ParseSourceSpan, PartialModule, Position, Serializer, StaticSymbol, TypeScriptEmitter, Xliff, Xliff2, Xmb} from '@angular/compiler';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
-import {TypeCheckHost, translateDiagnostics} from '../diagnostics/translate_diagnostics';
-import {MetadataCollector, ModuleMetadata, createBundleIndexHost} from '../metadata';
+import {translateDiagnostics, TypeCheckHost} from '../diagnostics/translate_diagnostics';
+import {createBundleIndexHost, MetadataCollector, ModuleMetadata} from '../metadata';
 import {NgtscProgram} from '../ngtsc/program';
 import {verifySupportedTypeScriptVersion} from '../typescript_support';
 
 import {CompilerHost, CompilerOptions, CustomTransformers, DEFAULT_ERROR_CODE, Diagnostic, DiagnosticMessageChain, EmitFlags, LazyRoute, LibrarySummary, Program, SOURCE, TsEmitArguments, TsEmitCallback, TsMergeEmitResultsCallback} from './api';
-import {CodeGenerator, TsCompilerAotCompilerTypeCheckHostAdapter, getOriginalReferences} from './compiler_host';
-import {InlineResourcesMetadataTransformer, getInlineResourcesTransformFactory} from './inline_resources';
-import {LowerMetadataTransform, getExpressionLoweringTransformFactory} from './lower_expressions';
+import {CodeGenerator, getOriginalReferences, TsCompilerAotCompilerTypeCheckHostAdapter} from './compiler_host';
+import {getInlineResourcesTransformFactory, InlineResourcesMetadataTransformer} from './inline_resources';
+import {getExpressionLoweringTransformFactory, LowerMetadataTransform} from './lower_expressions';
 import {MetadataCache, MetadataTransformer} from './metadata_cache';
 import {getAngularEmitterTransformFactory} from './node_emitter_transform';
 import {PartialModuleMetadataTransformer} from './r3_metadata_transform';
-import {StripDecoratorsMetadataTransformer, getDecoratorStripTransformerFactory} from './r3_strip_decorators';
+import {getDecoratorStripTransformerFactory, StripDecoratorsMetadataTransformer} from './r3_strip_decorators';
 import {getAngularClassTransformerFactory} from './r3_transform';
-import {DTS, GENERATED_FILES, StructureIsReused, TS, createMessageDiagnostic, isInRootDir, ngToTsDiagnostic, tsStructureIsReused, userError} from './util';
+import {createMessageDiagnostic, DTS, GENERATED_FILES, isInRootDir, ngToTsDiagnostic, StructureIsReused, TS, tsStructureIsReused, userError} from './util';
 
 
 /**
@@ -60,18 +60,23 @@ const emptyModules: NgAnalyzedModules = {
   files: []
 };
 
-const defaultEmitCallback: TsEmitCallback =
-    ({program, targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles,
-      customTransformers}) =>
-        program.emit(
-            targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers);
+const defaultEmitCallback: TsEmitCallback = ({
+  program,
+  targetSourceFile,
+  writeFile,
+  cancellationToken,
+  emitOnlyDtsFiles,
+  customTransformers
+}) =>
+    program.emit(
+        targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers);
 
 class AngularCompilerProgram implements Program {
   private rootNames: string[];
   private metadataCache: MetadataCache;
   // Metadata cache used exclusively for the flat module index
   // TODO(issue/24571): remove '!'.
-  private flatModuleMetadataCache !: MetadataCache;
+  private flatModuleMetadataCache!: MetadataCache;
   private loweringMetadataTransform: LowerMetadataTransform;
   private oldProgramLibrarySummaries: Map<string, LibrarySummary>|undefined;
   private oldProgramEmittedGeneratedFiles: Map<string, GeneratedFile>|undefined;
@@ -84,18 +89,18 @@ class AngularCompilerProgram implements Program {
 
   // Lazily initialized fields
   // TODO(issue/24571): remove '!'.
-  private _compiler !: AotCompiler;
+  private _compiler!: AotCompiler;
   // TODO(issue/24571): remove '!'.
-  private _hostAdapter !: TsCompilerAotCompilerTypeCheckHostAdapter;
+  private _hostAdapter!: TsCompilerAotCompilerTypeCheckHostAdapter;
   // TODO(issue/24571): remove '!'.
-  private _tsProgram !: ts.Program;
+  private _tsProgram!: ts.Program;
   private _analyzedModules: NgAnalyzedModules|undefined;
   private _analyzedInjectables: NgAnalyzedFileWithInjectables[]|undefined;
   private _structuralDiagnostics: Diagnostic[]|undefined;
   private _programWithStubs: ts.Program|undefined;
   private _optionsDiagnostics: Diagnostic[] = [];
   // TODO(issue/24571): remove '!'.
-  private _reifiedDecorators !: Set<StaticSymbol>;
+  private _reifiedDecorators!: Set<StaticSymbol>;
 
   constructor(
       rootNames: ReadonlyArray<string>, private options: CompilerOptions,
@@ -124,7 +129,7 @@ class AngularCompilerProgram implements Program {
                                                       code: DEFAULT_ERROR_CODE
                                                     })));
       } else {
-        this.rootNames.push(indexName !);
+        this.rootNames.push(indexName!);
         this.host = bundleHost;
       }
     }
@@ -175,7 +180,9 @@ class AngularCompilerProgram implements Program {
     return result;
   }
 
-  getTsProgram(): ts.Program { return this.tsProgram; }
+  getTsProgram(): ts.Program {
+    return this.tsProgram;
+  }
 
   getTsOptionDiagnostics(cancellationToken?: ts.CancellationToken) {
     return this.tsProgram.getOptionsDiagnostics(cancellationToken);
@@ -256,17 +263,19 @@ class AngularCompilerProgram implements Program {
     return this._emitRender2(parameters);
   }
 
-  private _emitRender3(
-      {
-          emitFlags = EmitFlags.Default, cancellationToken, customTransformers,
-          emitCallback = defaultEmitCallback, mergeEmitResultsCallback = mergeEmitResults,
-      }: {
-        emitFlags?: EmitFlags,
-        cancellationToken?: ts.CancellationToken,
-        customTransformers?: CustomTransformers,
-        emitCallback?: TsEmitCallback,
-        mergeEmitResultsCallback?: TsMergeEmitResultsCallback,
-      } = {}): ts.EmitResult {
+  private _emitRender3({
+    emitFlags = EmitFlags.Default,
+    cancellationToken,
+    customTransformers,
+    emitCallback = defaultEmitCallback,
+    mergeEmitResultsCallback = mergeEmitResults,
+  }: {
+    emitFlags?: EmitFlags,
+    cancellationToken?: ts.CancellationToken,
+    customTransformers?: CustomTransformers,
+    emitCallback?: TsEmitCallback,
+    mergeEmitResultsCallback?: TsMergeEmitResultsCallback,
+  } = {}): ts.EmitResult {
     const emitStart = Date.now();
     if ((emitFlags & (EmitFlags.JS | EmitFlags.DTS | EmitFlags.Metadata | EmitFlags.Codegen)) ===
         0) {
@@ -276,7 +285,7 @@ class AngularCompilerProgram implements Program {
     // analyzedModules and analyzedInjectables are created together. If one exists, so does the
     // other.
     const modules =
-        this.compiler.emitAllPartialModules(this.analyzedModules, this._analyzedInjectables !);
+        this.compiler.emitAllPartialModules(this.analyzedModules, this._analyzedInjectables!);
 
     const writeTsFile: ts.WriteFileCallback =
         (outFileName, outData, writeByteOrderMark, onError?, sourceFiles?) => {
@@ -306,7 +315,8 @@ class AngularCompilerProgram implements Program {
         program: this.tsProgram,
         host: this.host,
         options: this.options,
-        writeFile: writeTsFile, emitOnlyDtsFiles,
+        writeFile: writeTsFile,
+        emitOnlyDtsFiles,
         customTransformers: tsCustomTransformers
       });
     } finally {
@@ -319,17 +329,19 @@ class AngularCompilerProgram implements Program {
     }
   }
 
-  private _emitRender2(
-      {
-          emitFlags = EmitFlags.Default, cancellationToken, customTransformers,
-          emitCallback = defaultEmitCallback, mergeEmitResultsCallback = mergeEmitResults,
-      }: {
-        emitFlags?: EmitFlags,
-        cancellationToken?: ts.CancellationToken,
-        customTransformers?: CustomTransformers,
-        emitCallback?: TsEmitCallback,
-        mergeEmitResultsCallback?: TsMergeEmitResultsCallback,
-      } = {}): ts.EmitResult {
+  private _emitRender2({
+    emitFlags = EmitFlags.Default,
+    cancellationToken,
+    customTransformers,
+    emitCallback = defaultEmitCallback,
+    mergeEmitResultsCallback = mergeEmitResults,
+  }: {
+    emitFlags?: EmitFlags,
+    cancellationToken?: ts.CancellationToken,
+    customTransformers?: CustomTransformers,
+    emitCallback?: TsEmitCallback,
+    mergeEmitResultsCallback?: TsMergeEmitResultsCallback,
+  } = {}): ts.EmitResult {
     const emitStart = Date.now();
     if (emitFlags & EmitFlags.I18nBundle) {
       const locale = this.options.i18nOutLocale || null;
@@ -413,7 +425,8 @@ class AngularCompilerProgram implements Program {
                                   program: this.tsProgram,
                                   host: this.host,
                                   options: this.options,
-                                  writeFile: writeTsFile, emitOnlyDtsFiles,
+                                  writeFile: writeTsFile,
+                                  emitOnlyDtsFiles,
                                   customTransformers: tsCustomTransformers,
                                   targetSourceFile: this.tsProgram.getSourceFile(fileName),
                                 })));
@@ -423,7 +436,8 @@ class AngularCompilerProgram implements Program {
           program: this.tsProgram,
           host: this.host,
           options: this.options,
-          writeFile: writeTsFile, emitOnlyDtsFiles,
+          writeFile: writeTsFile,
+          emitOnlyDtsFiles,
           customTransformers: tsCustomTransformers
         });
         emittedUserTsCount = this.tsProgram.getSourceFiles().length - genTsFiles.length;
@@ -466,7 +480,7 @@ class AngularCompilerProgram implements Program {
     if (emitFlags & EmitFlags.Codegen) {
       genJsonFiles.forEach(gf => {
         const outFileName = srcToOutPath(gf.genFileUrl);
-        this.writeFile(outFileName, gf.source !, false, undefined, gf);
+        this.writeFile(outFileName, gf.source!, false, undefined, gf);
       });
     }
     let metadataJsonCount = 0;
@@ -501,21 +515,21 @@ class AngularCompilerProgram implements Program {
     if (!this._compiler) {
       this._createCompiler();
     }
-    return this._compiler !;
+    return this._compiler!;
   }
 
   private get hostAdapter(): TsCompilerAotCompilerTypeCheckHostAdapter {
     if (!this._hostAdapter) {
       this._createCompiler();
     }
-    return this._hostAdapter !;
+    return this._hostAdapter!;
   }
 
   private get analyzedModules(): NgAnalyzedModules {
     if (!this._analyzedModules) {
       this.initSync();
     }
-    return this._analyzedModules !;
+    return this._analyzedModules!;
   }
 
   private get structuralDiagnostics(): ReadonlyArray<Diagnostic> {
@@ -531,7 +545,7 @@ class AngularCompilerProgram implements Program {
     if (!this._tsProgram) {
       this.initSync();
     }
-    return this._tsProgram !;
+    return this._tsProgram!;
   }
 
   private get reifiedDecorators(): Set<StaticSymbol> {
@@ -617,7 +631,7 @@ class AngularCompilerProgram implements Program {
   private _createCompiler() {
     const codegen: CodeGenerator = {
       generateFile: (genFileName, baseFileName) =>
-                        this._compiler.emitBasicStub(genFileName, baseFileName),
+          this._compiler.emitBasicStub(genFileName, baseFileName),
       findGeneratedFileNames: (fileName) => this._compiler.findGeneratedFileNames(fileName),
     };
 
@@ -646,7 +660,7 @@ class AngularCompilerProgram implements Program {
 
     const codegen: CodeGenerator = {
       generateFile: (genFileName, baseFileName) =>
-                        this.compiler.emitBasicStub(genFileName, baseFileName),
+          this.compiler.emitBasicStub(genFileName, baseFileName),
       findGeneratedFileNames: (fileName) => this.compiler.findGeneratedFileNames(fileName),
     };
 
@@ -692,7 +706,7 @@ class AngularCompilerProgram implements Program {
         if (generate) {
           // Note: ! is ok as hostAdapter.shouldGenerateFile will always return a baseFileName
           // for .ngfactory.ts files.
-          const genFile = this.compiler.emitTypeCheckStub(sf.fileName, baseFileName !);
+          const genFile = this.compiler.emitTypeCheckStub(sf.fileName, baseFileName!);
           if (genFile) {
             this.hostAdapter.updateGeneratedFile(genFile);
           }
@@ -782,11 +796,12 @@ class AngularCompilerProgram implements Program {
   private getSourceFilesForEmit(): ts.SourceFile[]|undefined {
     // TODO(tbosch): if one of the files contains a `const enum`
     // always emit all files -> return undefined!
-    let sourceFilesToEmit = this.tsProgram.getSourceFiles().filter(
-        sf => { return !sf.isDeclarationFile && !GENERATED_FILES.test(sf.fileName); });
+    let sourceFilesToEmit = this.tsProgram.getSourceFiles().filter(sf => {
+      return !sf.isDeclarationFile && !GENERATED_FILES.test(sf.fileName);
+    });
     if (this.oldProgramEmittedSourceFiles) {
       sourceFilesToEmit = sourceFilesToEmit.filter(sf => {
-        const oldFile = this.oldProgramEmittedSourceFiles !.get(sf.fileName);
+        const oldFile = this.oldProgramEmittedSourceFiles!.get(sf.fileName);
         return sf !== oldFile;
       });
     }
@@ -849,7 +864,8 @@ class AngularCompilerProgram implements Program {
 export function createProgram({rootNames, options, host, oldProgram}: {
   rootNames: ReadonlyArray<string>,
   options: CompilerOptions,
-  host: CompilerHost, oldProgram?: Program
+  host: CompilerHost,
+  oldProgram?: Program
 }): Program {
   if (options.enableIvy !== false) {
     return new NgtscProgram(rootNames, options, host, oldProgram as NgtscProgram | undefined);
@@ -887,7 +903,9 @@ function getAotCompilerOptions(options: CompilerOptions): AotCompilerOptions {
   return {
     locale: options.i18nInLocale,
     i18nFormat: options.i18nInFormat || options.i18nOutFormat,
-    i18nUseExternalIds: options.i18nUseExternalIds, translations, missingTranslation,
+    i18nUseExternalIds: options.i18nUseExternalIds,
+    translations,
+    missingTranslation,
     enableSummariesForJit: options.enableSummariesForJit,
     preserveWhitespaces: options.preserveWhitespaces,
     fullTemplateTypeCheck: options.fullTemplateTypeCheck,
@@ -931,8 +949,8 @@ function normalizeSeparators(path: string): string {
  * POSIX normalized paths for output paths.
  */
 export function createSrcToOutPathMapper(
-    outDir: string | undefined, sampleSrcFileName: string | undefined,
-    sampleOutFileName: string | undefined, host: {
+    outDir: string|undefined, sampleSrcFileName: string|undefined,
+    sampleOutFileName: string|undefined, host: {
       dirname: typeof path.dirname,
       resolve: typeof path.resolve,
       relative: typeof path.relative
@@ -971,14 +989,14 @@ export function createSrcToOutPathMapper(
 }
 
 export function i18nExtract(
-    formatName: string | null, outFile: string | null, host: ts.CompilerHost,
-    options: CompilerOptions, bundle: MessageBundle): string[] {
+    formatName: string|null, outFile: string|null, host: ts.CompilerHost, options: CompilerOptions,
+    bundle: MessageBundle): string[] {
   formatName = formatName || 'xlf';
   // Checks the format and returns the extension
   const ext = i18nGetExtension(formatName);
   const content = i18nSerialize(bundle, formatName, options);
   const dstFile = outFile || `messages.${ext}`;
-  const dstPath = path.resolve(options.outDir || options.basePath !, dstFile);
+  const dstPath = path.resolve(options.outDir || options.basePath!, dstFile);
   host.writeFile(dstPath, content, false, undefined, []);
   return [dstPath];
 }
@@ -1045,7 +1063,7 @@ function mergeEmitResults(emitResults: ts.EmitResult[]): ts.EmitResult {
 function diagnosticSourceOfSpan(span: ParseSourceSpan): ts.SourceFile {
   // For diagnostics, TypeScript only uses the fileName and text properties.
   // The redundant '()' are here is to avoid having clang-format breaking the line incorrectly.
-  return ({ fileName: span.start.file.url, text: span.start.file.content } as any);
+  return ({fileName: span.start.file.url, text: span.start.file.content} as any);
 }
 
 function diagnosticSourceOfFileName(fileName: string, program: ts.Program): ts.SourceFile {
@@ -1055,7 +1073,7 @@ function diagnosticSourceOfFileName(fileName: string, program: ts.Program): ts.S
   // If we are reporting diagnostics for a source file that is not in the project then we need
   // to fake a source file so the diagnostic formatting routines can emit the file name.
   // The redundant '()' are here is to avoid having clang-format breaking the line incorrectly.
-  return ({ fileName, text: '' } as any);
+  return ({fileName, text: ''} as any);
 }
 
 

--- a/packages/compiler-cli/src/transformers/r3_metadata_transform.ts
+++ b/packages/compiler-cli/src/transformers/r3_metadata_transform.ts
@@ -9,7 +9,7 @@
 import {ClassStmt, PartialModule, Statement, StmtModifier} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {MetadataCollector, MetadataValue, ModuleMetadata, isClassMetadata} from '../metadata/index';
+import {isClassMetadata, MetadataCollector, MetadataValue, ModuleMetadata} from '../metadata/index';
 
 import {MetadataTransformer, ValueTransform} from './metadata_cache';
 

--- a/packages/compiler-cli/src/transformers/r3_strip_decorators.ts
+++ b/packages/compiler-cli/src/transformers/r3_strip_decorators.ts
@@ -9,7 +9,7 @@
 import {StaticReflector, StaticSymbol} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {MetadataValue, isClassMetadata, isMetadataImportedSymbolReferenceExpression, isMetadataSymbolicCallExpression} from '../metadata';
+import {isClassMetadata, isMetadataImportedSymbolReferenceExpression, isMetadataSymbolicCallExpression, MetadataValue} from '../metadata';
 
 import {MetadataTransformer, ValueTransform} from './metadata_cache';
 
@@ -39,8 +39,14 @@ export function getDecoratorStripTransformerFactory(
             });
             if (decorators.length !== node.decorators.length) {
               return ts.updateClassDeclaration(
-                  node, decorators, node.modifiers, node.name, node.typeParameters,
-                  node.heritageClauses || [], node.members, );
+                  node,
+                  decorators,
+                  node.modifiers,
+                  node.name,
+                  node.typeParameters,
+                  node.heritageClauses || [],
+                  node.members,
+              );
             }
             return node;
           };
@@ -130,7 +136,7 @@ function resolveToStaticSymbol(
   if (!ts.isImportSpecifier(decl)) {
     return null;
   }
-  const moduleSpecifier = decl.parent !.parent !.parent !.moduleSpecifier;
+  const moduleSpecifier = decl.parent!.parent!.parent!.moduleSpecifier;
   if (!ts.isStringLiteral(moduleSpecifier)) {
     return null;
   }

--- a/packages/compiler-cli/src/transformers/util.ts
+++ b/packages/compiler-cli/src/transformers/util.ts
@@ -16,7 +16,11 @@ export const GENERATED_FILES = /(.*?)\.(ngfactory|shim\.ngstyle|ngstyle|ngsummar
 export const DTS = /\.d\.ts$/;
 export const TS = /^(?!.*\.d\.ts$).*\.ts$/;
 
-export const enum StructureIsReused {Not = 0, SafeModules = 1, Completely = 2}
+export const enum StructureIsReused {
+  Not = 0,
+  SafeModules = 1,
+  Completely = 2
+}
 
 // Note: This is an internal property in TypeScript. Use it only for assertions and tests.
 export function tsStructureIsReused(program: ts.Program): StructureIsReused {
@@ -36,7 +40,8 @@ export function createMessageDiagnostic(messageText: string): ts.Diagnostic&Diag
     file: undefined,
     start: undefined,
     length: undefined,
-    category: ts.DiagnosticCategory.Message, messageText,
+    category: ts.DiagnosticCategory.Message,
+    messageText,
     code: DEFAULT_ERROR_CODE,
     source: SOURCE,
   };
@@ -76,7 +81,7 @@ export function ngToTsDiagnostic(ng: Diagnostic): ts.Diagnostic {
     // Note: We can't use a real ts.SourceFile,
     // but we can at least mirror the properties `fileName` and `text`, which
     // are mostly used for error reporting.
-    file = { fileName: ng.span.start.file.url, text: ng.span.start.file.content } as ts.SourceFile;
+    file = {fileName: ng.span.start.file.url, text: ng.span.start.file.content} as ts.SourceFile;
     start = ng.span.start.offset;
     length = ng.span.end.offset - start;
   }
@@ -84,6 +89,8 @@ export function ngToTsDiagnostic(ng: Diagnostic): ts.Diagnostic {
     file,
     messageText: ng.messageText,
     category: ng.category,
-    code: ng.code, start, length,
+    code: ng.code,
+    start,
+    length,
   };
 }

--- a/packages/compiler-cli/src/typescript_support.ts
+++ b/packages/compiler-cli/src/typescript_support.ts
@@ -49,8 +49,8 @@ export function restoreTypeScriptVersionForTesting(): void {
  */
 export function checkVersion(version: string, minVersion: string, maxVersion: string) {
   if ((compareVersions(version, minVersion) < 0 || compareVersions(version, maxVersion) >= 0)) {
-    throw new Error(
-        `The Angular Compiler requires TypeScript >=${minVersion} and <${maxVersion} but ${version} was found instead.`);
+    throw new Error(`The Angular Compiler requires TypeScript >=${minVersion} and <${
+        maxVersion} but ${version} was found instead.`);
   }
 }
 

--- a/packages/compiler-cli/test/compliance/mock_compile.ts
+++ b/packages/compiler-cli/test/compliance/mock_compile.ts
@@ -7,8 +7,9 @@
  */
 import {AotCompilerOptions} from '@angular/compiler';
 import {escapeRegExp} from '@angular/compiler/src/util';
-import {MockCompilerHost, MockData, MockDirectory, arrayToMockDir, toMockFileArray} from '@angular/compiler/test/aot/test_util';
+import {arrayToMockDir, MockCompilerHost, MockData, MockDirectory, toMockFileArray} from '@angular/compiler/test/aot/test_util';
 import * as ts from 'typescript';
+
 import {NodeJSFileSystem, setFileSystem} from '../../src/ngtsc/file_system';
 import {NgtscProgram} from '../../src/ngtsc/program';
 
@@ -22,10 +23,11 @@ const NUMBER = /\d+/;
 
 const ELLIPSIS = '…';
 const TOKEN = new RegExp(
-    `\\s*((${IDENTIFIER.source})|(${BACKTICK_STRING.source})|(${OPERATOR.source})|(${STRING.source})|${NUMBER.source}|${ELLIPSIS})\\s*`,
+    `\\s*((${IDENTIFIER.source})|(${BACKTICK_STRING.source})|(${OPERATOR.source})|(${
+        STRING.source})|${NUMBER.source}|${ELLIPSIS})\\s*`,
     'y');
 
-type Piece = string | RegExp;
+type Piece = string|RegExp;
 
 const SKIP = /(?:.|\n|\r)*/;
 
@@ -116,15 +118,16 @@ export function expectEmit(
         const context = fullContext.length > contextLength ?
             `...${fullContext.substr(-contextLength)}` :
             fullContext;
-        fail(
-            `${description}: Failed to find "${expectedPiece}" after "${context}" in:\n'${source.substr(0,last)}[<---HERE expected "${expectedPiece}"]${source.substr(last)}'`);
+        fail(`${description}: Failed to find "${expectedPiece}" after "${context}" in:\n'${
+            source.substr(0, last)}[<---HERE expected "${expectedPiece}"]${source.substr(last)}'`);
         return;
       } else {
         last = (m.index || 0) + m[0].length;
       }
     }
     fail(
-        `Test helper failure: Expected expression failed but the reporting logic could not find where it failed in: ${source}`);
+        `Test helper failure: Expected expression failed but the reporting logic could not find where it failed in: ${
+            source}`);
   } else {
     if (assertIdentifiers) {
       // It might be possible to add the constraints in the original regexp (see `buildMatcher`)
@@ -141,8 +144,8 @@ export function expectEmit(
           const name = matches[groups.get(id) as number];
           const regexp = assertIdentifiers[id];
           if (!regexp.test(name)) {
-            throw Error(
-                `${description}: The matching identifier "${id}" is "${name}" which doesn't match ${regexp}`);
+            throw Error(`${description}: The matching identifier "${id}" is "${
+                name}" which doesn't match ${regexp}`);
           }
         }
       }
@@ -160,7 +163,7 @@ const MATCHING_IDENT = /^\$.*\$$/;
  * - the `regexp` to be used to match the generated code,
  * - the `groups` which maps `$...$` identifier to their position in the regexp matches.
  */
-function buildMatcher(pieces: (string | RegExp)[]): {regexp: RegExp, groups: Map<string, number>} {
+function buildMatcher(pieces: (string|RegExp)[]): {regexp: RegExp, groups: Map<string, number>} {
   const results: string[] = [];
   let first = true;
   let group = 0;
@@ -196,7 +199,9 @@ function buildMatcher(pieces: (string | RegExp)[]): {regexp: RegExp, groups: Map
 
 export function compile(
     data: MockDirectory, angularFiles: MockData, options: AotCompilerOptions = {},
-    errorCollector: (error: any, fileName?: string) => void = error => { throw error;}): {
+    errorCollector: (error: any, fileName?: string) => void = error => {
+      throw error;
+    }): {
   source: string,
 } {
   setFileSystem(new NodeJSFileSystem());
@@ -211,7 +216,8 @@ export function compile(
         target: ts.ScriptTarget.ES2015,
         module: ts.ModuleKind.ES2015,
         moduleResolution: ts.ModuleResolutionKind.NodeJs,
-        enableI18nLegacyMessageIdFormat: false, ...options,
+        enableI18nLegacyMessageIdFormat: false,
+        ...options,
       },
       mockCompilerHost);
   program.emit();

--- a/packages/compiler-cli/test/compliance/mock_compiler_spec.ts
+++ b/packages/compiler-cli/test/compliance/mock_compiler_spec.ts
@@ -100,14 +100,14 @@ describe('mock_compiler', () => {
     it('should be able to properly handle string literals with escaped quote', () => {
       const files = {
         app: {
-          'test.ts': String.raw `const identifier = "\"quoted\"";`,
+          'test.ts': String.raw`const identifier = "\"quoted\"";`,
         }
       };
 
       const result = compile(files, angularFiles);
 
       expect(() => {
-        expectEmit(result.source, String.raw `const $a$ = "\"quoted\"";`, 'Output does not match.');
+        expectEmit(result.source, String.raw`const $a$ = "\"quoted\"";`, 'Output does not match.');
       }).not.toThrow();
     });
   });

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -16,7 +16,6 @@ import {compile, expectEmit} from './mock_compile';
  * test in compiler_canonical_spec.ts should have a corresponding test here.
  */
 describe('compiler compliance', () => {
-
   const angularFiles = setup({
     compileAngular: false,
     compileAnimations: false,
@@ -49,7 +48,8 @@ describe('compiler compliance', () => {
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
         …
-        consts: [["title", "Hello", ${AttributeMarker.Classes}, "my-app"], ["cx", "20", "cy", "30", "r", "50"]],
+        consts: [["title", "Hello", ${
+          AttributeMarker.Classes}, "my-app"], ["cx", "20", "cy", "30", "r", "50"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
@@ -536,7 +536,6 @@ describe('compiler compliance', () => {
       const result = compile(files, angularFiles);
       expectEmit(result.source, template, 'Incorrect template');
     });
-
   });
 
   describe('components & directives', () => {
@@ -867,7 +866,6 @@ describe('compiler compliance', () => {
     });
 
     describe('value composition', () => {
-
       it('should support array literals', () => {
         const files = {
           app: {
@@ -1143,7 +1141,6 @@ describe('compiler compliance', () => {
     });
 
     describe('content projection', () => {
-
       it('should support content projection in root template', () => {
         const files = {
           app: {
@@ -1319,7 +1316,8 @@ describe('compiler compliance', () => {
           }
           const $_c4$ = [[["span", "title", "tofirst"]], "*"];
           …
-          consts: [["id", "second", ${AttributeMarker.Template}, "ngIf"], ["id", "third", ${AttributeMarker.Template}, "ngIf"], ["id", "second"], ["id", "third"]],
+          consts: [["id", "second", ${AttributeMarker.Template}, "ngIf"], ["id", "third", ${
+            AttributeMarker.Template}, "ngIf"], ["id", "second"], ["id", "third"]],
           template: function Cmp_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵprojectionDef($_c4$);
@@ -1534,7 +1532,8 @@ describe('compiler compliance', () => {
             decls: 1,
             vars: 1,
             consts: [
-                ["ngProjectAs", ".someclass", ${AttributeMarker.ProjectAs}, ["", 8, "someclass"], ${AttributeMarker.Template}, "ngIf"],
+                ["ngProjectAs", ".someclass", ${AttributeMarker.ProjectAs}, ["", 8, "someclass"], ${
+            AttributeMarker.Template}, "ngIf"],
                 ["ngProjectAs", ".someclass", ${AttributeMarker.ProjectAs}, ["", 8, "someclass"]]
             ],
             template: function MyApp_Template(rf, ctx) {
@@ -1552,7 +1551,6 @@ describe('compiler compliance', () => {
         const result = compile(files, angularFiles);
         expectEmit(result.source, SimpleComponentDefinition, 'Incorrect MyApp definition');
       });
-
     });
 
     describe('queries', () => {
@@ -2044,9 +2042,7 @@ describe('compiler compliance', () => {
     });
 
     describe('pipes', () => {
-
       it('should render pipes', () => {
-
         const files = {
           app: {
             'spec.ts': `
@@ -2217,7 +2213,6 @@ describe('compiler compliance', () => {
 
       it('should generate the proper instruction when injecting ChangeDetectorRef into a pipe',
          () => {
-
            const files = {
              app: {
                'spec.ts': `
@@ -2282,7 +2277,6 @@ describe('compiler compliance', () => {
            expectEmit(source, MyOtherPipeDefinition, 'Invalid alternate pipe definition');
            expectEmit(source, MyOtherPipeFactory, 'Invalid alternate pipe factory function');
          });
-
     });
 
     it('local reference', () => {
@@ -2477,7 +2471,8 @@ describe('compiler compliance', () => {
       }
 
       // ...
-      consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], ["foo", ""], [${AttributeMarker.Template}, "ngIf"]],
+      consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], ["foo", ""], [${
+          AttributeMarker.Template}, "ngIf"]],
       template:function MyComponent_Template(rf, ctx){
         if (rf & 1) {
           $i0$.ɵɵtemplate(0, MyComponent_div_0_Template, 4, 1, "div", 0);
@@ -3280,7 +3275,6 @@ describe('compiler compliance', () => {
       const result = compile(files, angularFiles);
       expectEmit(result.source, MyAppDeclaration, 'Invalid component definition');
     });
-
   });
 
   describe('inherited base classes', () => {
@@ -3849,7 +3843,7 @@ describe('compiler compliance', () => {
         }
       };
       const result = compile(files, angularFiles);
-      expect(result.source.match(/ɵdir/g) !.length).toBe(1);
+      expect(result.source.match(/ɵdir/g)!.length).toBe(1);
     });
   });
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -405,7 +405,6 @@ describe('compiler compliance: bindings', () => {
 
       expectEmit(result.source, template, 'Incorrect template');
     });
-
   });
 
   describe('attribute bindings', () => {
@@ -640,13 +639,13 @@ describe('compiler compliance: bindings', () => {
       };
 
       const template = `
-        consts: [["target", "_blank", "aria-label", "link", ${AttributeMarker.Bindings}, "title", "id", "customEvent"]],
+        consts: [["target", "_blank", "aria-label", "link", ${
+          AttributeMarker.Bindings}, "title", "id", "customEvent"]],
         …
       `;
       const result = compile(files, angularFiles);
       expectEmit(result.source, template, 'Incorrect attribute array');
     });
-
   });
 
   describe('host bindings', () => {
@@ -850,12 +849,15 @@ describe('compiler compliance: bindings', () => {
         HostAttributeComp.ɵcmp = $r3$.ɵɵdefineComponent({
           type: HostAttributeComp,
           selectors: [["my-host-attribute-component"]],
-          hostAttrs: ["title", "hello there from component", ${AttributeMarker.Styles}, "opacity", "1"],
+          hostAttrs: ["title", "hello there from component", ${
+          AttributeMarker.Styles}, "opacity", "1"],
         …
         HostAttributeDir.ɵdir = $r3$.ɵɵdefineDirective({
           type: HostAttributeDir,
           selectors: [["", "hostAttributeDir", ""]],
-          hostAttrs: ["title", "hello there from directive", ${AttributeMarker.Classes}, "one", "two", ${AttributeMarker.Styles}, "width", "200px", "height", "500px"],
+          hostAttrs: ["title", "hello there from directive", ${
+          AttributeMarker.Classes}, "one", "two", ${
+          AttributeMarker.Styles}, "width", "200px", "height", "500px"],
           hostVars: 4,
           hostBindings: function HostAttributeDir_HostBindings(rf, ctx) {
             …
@@ -1216,7 +1218,6 @@ describe('compiler compliance: bindings', () => {
       `;
       expectEmit(result.source, template, 'Incorrect template');
     });
-
   });
 
   describe('non bindable behavior', () => {
@@ -1420,7 +1421,5 @@ describe('compiler compliance: bindings', () => {
       const result = compile(files, angularFiles);
       expectEmit(result.source, template, 'Incorrect handling of elements with no children');
     });
-
   });
-
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
@@ -386,8 +386,7 @@ describe('compiler compliance: dependency injection', () => {
 
        expectEmit(source, MyPipeDefs, 'Invalid pipe factory function');
        expectEmit(source, MyOtherPipeDefs, 'Invalid pipe factory function');
-       expect(source.match(/MyPipe\.ɵfac =/g) !.length).toBe(1);
-       expect(source.match(/MyOtherPipe\.ɵfac =/g) !.length).toBe(1);
+       expect(source.match(/MyPipe\.ɵfac =/g)!.length).toBe(1);
+       expect(source.match(/MyOtherPipe\.ɵfac =/g)!.length).toBe(1);
      });
-
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
@@ -10,7 +10,6 @@ import {setup} from '@angular/compiler/test/aot/test_util';
 import {compile, expectEmit} from './mock_compile';
 
 describe('compiler compliance: directives', () => {
-
   const angularFiles = setup({
     compileAngular: false,
     compileAnimations: false,
@@ -18,7 +17,6 @@ describe('compiler compliance: directives', () => {
   });
 
   describe('matching', () => {
-
     it('should not match directives on i18n attribute', () => {
       const files = {
         app: {
@@ -114,7 +112,6 @@ describe('compiler compliance: directives', () => {
     });
 
     it('should match directives on element bindings', () => {
-
       const files = {
         app: {
           'spec.ts': `
@@ -273,7 +270,6 @@ describe('compiler compliance: directives', () => {
     });
 
     it('should match directives on ng-template bindings', () => {
-
       const files = {
         app: {
           'spec.ts': `
@@ -321,7 +317,6 @@ describe('compiler compliance: directives', () => {
     });
 
     it('should match structural directives', () => {
-
       const files = {
         app: {
           'spec.ts': `
@@ -362,11 +357,9 @@ describe('compiler compliance: directives', () => {
       const source = result.source;
 
       expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
-
     });
 
     it('should match directives on element outputs', () => {
-
       const files = {
         app: {
           'spec.ts': `
@@ -413,6 +406,5 @@ describe('compiler compliance: directives', () => {
 
       expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
     });
-
   });
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -58,7 +58,9 @@ const verifyTranslationIds =
       });
       const regexp = /const\s*MSG_EXTERNAL_(.+?)\s*=\s*goog\.getMsg/g;
       const ids = extract(output, regexp, v => v[1]);
-      ids.forEach(id => { generatedIds.add(id.split('$$')[0]); });
+      ids.forEach(id => {
+        generatedIds.add(id.split('$$')[0]);
+      });
       const delta = diff(extractedIds, generatedIds);
       if (delta.size) {
         // check if we have ids in exception list
@@ -179,7 +181,6 @@ const verify = (input: string, output: string, extra: any = {}): void => {
 };
 
 describe('i18n support in the template compiler', () => {
-
   describe('element attributes', () => {
     it('should add the meaning and description as JsDoc comments and metadata blocks', () => {
       const input = `
@@ -193,7 +194,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n="Some text \\' [BACKUP_MESSAGE_ID: xxx]">Content H</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             /**
@@ -269,8 +270,8 @@ describe('i18n support in the template compiler', () => {
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             /**
              * @desc [BACKUP_$` +
-          String.raw `{MESSAGE}_ID:idH]` +
-          '`' + String.raw `desc
+          String.raw`{MESSAGE}_ID:idH]` +
+          '`' + String.raw`desc
              */
             const $MSG_EXTERNAL_idG$$APP_SPEC_TS_24$ = goog.getMsg("Title G");
             $I18N_23$ = $MSG_EXTERNAL_idG$$APP_SPEC_TS_24$;
@@ -338,7 +339,7 @@ describe('i18n support in the template compiler', () => {
 
       // TODO (FW-1942): update the code to avoid adding `title` attribute in plain form
       // into the `consts` array on Component def.
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_6616505470450179563$$APP_SPEC_TS_1$ = goog.getMsg("Hello");
@@ -368,7 +369,7 @@ describe('i18n support in the template compiler', () => {
 
          // TODO (FW-1942): update the code to avoid adding `title` attribute in plain form
          // into the `consts` array on Component def.
-         const output = String.raw `
+         const output = String.raw`
             var $I18N_0$;
             if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
                 const $MSG_EXTERNAL_6616505470450179563$$APP_SPEC_TS_1$ = goog.getMsg("Hello");
@@ -409,7 +410,7 @@ describe('i18n support in the template compiler', () => {
            <ng-template i18n-title title="Hello {{ name }}"></ng-template>
          `;
 
-         const output = String.raw `
+         const output = String.raw`
            var $I18N_0$;
            if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
              const $MSG_EXTERNAL_3771704108176831903$$APP_SPEC_TS_1$ = goog.getMsg("Hello {$interpolation}", {
@@ -419,7 +420,7 @@ describe('i18n support in the template compiler', () => {
            }
            else {
              $I18N_0$ = $localize \`Hello $` +
-             String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+             String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
            }
            const $_c2$ = ["title", $I18N_0$];
            …
@@ -444,7 +445,7 @@ describe('i18n support in the template compiler', () => {
             <ng-template *ngIf="true" i18n-title title="Hello {{ name }}"></ng-template>
           `;
 
-         const output = String.raw `
+         const output = String.raw`
             var $I18N_0$;
             if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
               const $MSG_EXTERNAL_3771704108176831903$$APP_SPEC_TS__1$ = goog.getMsg("Hello {$interpolation}", {
@@ -454,7 +455,7 @@ describe('i18n support in the template compiler', () => {
             }
             else {
               $I18N_0$ = $localize \`Hello $` +
-             String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+             String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
             }
             const $_c2$ = ["title", $I18N_0$];
             …
@@ -531,7 +532,7 @@ describe('i18n support in the template compiler', () => {
         <div id="static" i18n-title="m|d" title="introduction"></div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           /**
@@ -572,7 +573,7 @@ describe('i18n support in the template compiler', () => {
         ></div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           const $MSG_EXTERNAL_5526535577705876535$$APP_SPEC_TS_1$ = goog.getMsg("static text");
@@ -594,7 +595,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_2$ = $localize \`:m|d:intro $` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         var $I18N_3$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
@@ -609,7 +610,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_3$ = $localize \`:m1|d1:$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c1$ = [
           "aria-roledescription", $I18N_1$,
@@ -629,9 +630,9 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_6$ = $localize \`:m2|d2:$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: and $` +
-          String.raw `{"\uFFFD1\uFFFD"}:INTERPOLATION_1: and again $` +
-          String.raw `{"\uFFFD2\uFFFD"}:INTERPOLATION_2:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: and $` +
+          String.raw`{"\uFFFD1\uFFFD"}:INTERPOLATION_1: and again $` +
+          String.raw`{"\uFFFD2\uFFFD"}:INTERPOLATION_2:\`;
         }
         var $I18N_7$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
@@ -642,7 +643,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_7$ = $localize \`$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c3$ = [
           "title", $I18N_6$,
@@ -651,7 +652,10 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 5,
         vars: 8,
-        consts: [["id", "dynamic-1", ${AttributeMarker.I18n}, "aria-roledescription", "title", "aria-label"], ["id", "dynamic-2", ${AttributeMarker.I18n}, "title", "aria-roledescription"]],
+        consts: [["id", "dynamic-1", ${
+              AttributeMarker
+                  .I18n}, "aria-roledescription", "title", "aria-label"], ["id", "dynamic-2", ${
+              AttributeMarker.I18n}, "title", "aria-roledescription"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
@@ -680,7 +684,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n-title="m|d" title="intro {% valueA | uppercase %}"></div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             /**
@@ -694,7 +698,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_1$ = $localize \`:m|d:intro $` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c3$ = ["title", $I18N_1$];
         …
@@ -722,7 +726,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             /**
@@ -736,7 +740,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_1$ = $localize \`:m|d:different scope $` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c2$ = ["title", $I18N_1$];
         function MyComponent_div_0_Template(rf, ctx) {
@@ -758,7 +762,8 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 1,
         vars: 1,
-        consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${AttributeMarker.I18n}, "title"]],
+        consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${
+              AttributeMarker.I18n}, "title"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 4, 3, "div", 0);
@@ -777,7 +782,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n-title title="{{valueA.getRawValue()?.getTitle()}} title"></div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_3462388422673575127$$APP_SPEC_TS_2$ = goog.getMsg("{$interpolation} title", {
@@ -787,7 +792,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_1$ = $localize \`$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: title\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: title\`;
         }
         const $_c3$ = ["title", $I18N_1$];
         …
@@ -825,7 +830,7 @@ describe('i18n support in the template compiler', () => {
         ></div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_5526535577705876535$$APP_SPEC_TS_1$ = goog.getMsg("static text");
@@ -847,7 +852,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_2$ = $localize \`:m|d:intro $` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         var $I18N_3$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
@@ -862,7 +867,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_3$ = $localize \`:m1|d1:$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c1$ = [
           "aria-roledescription", $I18N_1$,
@@ -882,9 +887,9 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_6$ = $localize \`:m2|d2:$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: and $` +
-          String.raw `{"\uFFFD1\uFFFD"}:INTERPOLATION_1: and again $` +
-          String.raw `{"\uFFFD2\uFFFD"}:INTERPOLATION_2:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: and $` +
+          String.raw`{"\uFFFD1\uFFFD"}:INTERPOLATION_1: and again $` +
+          String.raw`{"\uFFFD2\uFFFD"}:INTERPOLATION_2:\`;
         }
         var $I18N_7$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
@@ -895,7 +900,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_7$ = $localize \`$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c3$ = [
           "title", $I18N_6$,
@@ -938,7 +943,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_2$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             /**
@@ -952,7 +957,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_2$ = $localize \`:m|d:different scope $` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c4$ = ["title", $I18N_2$];
         function MyComponent_div_0_Template(rf, ctx) {
@@ -974,7 +979,8 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 1,
         vars: 1,
-        consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${AttributeMarker.I18n}, "title"]],
+        consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${
+              AttributeMarker.I18n}, "title"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 4, 3, "div", 0);
@@ -993,7 +999,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n i18n-title="m|d" title="Element title">Some content</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             /**
@@ -1036,7 +1042,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_ID_WITH_INVALID_CHARS$$APP_SPEC_TS_1$ = goog.getMsg("Element title");
@@ -1075,7 +1081,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelement(0, "div");
@@ -1097,7 +1103,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n>Some <!-- comments --> text</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
       var $I18N_0$;
       if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           const $MSG_APP_SPEC_TS_1$ = goog.getMsg("Some  text");
@@ -1115,11 +1121,11 @@ describe('i18n support in the template compiler', () => {
         <div i18n>Some text 'with single quotes', "with double quotes", \`with backticks\` and without quotes.</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_4924931801512133405$$APP_SPEC_TS_0$ = goog.getMsg("Some text 'with single quotes', \"with double quotes\", ` +
-          '`with backticks`' + String.raw ` and without quotes.");
+          '`with backticks`' + String.raw` and without quotes.");
             $I18N_0$ = $MSG_EXTERNAL_4924931801512133405$$APP_SPEC_TS_0$;
         }
         else {
@@ -1132,16 +1138,16 @@ describe('i18n support in the template compiler', () => {
 
     it('should handle interpolations wrapped in backticks', () => {
       const input = '<div i18n>`{{ count }}`</div>';
-      const output = String.raw `
+      const output = String.raw`
       var $I18N_0$;
       if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           const $MSG_APP_SPEC_TS_1$ = goog.getMsg("` +
-          '`{$interpolation}`' + String.raw `", { "interpolation": "\uFFFD0\uFFFD" });
+          '`{$interpolation}`' + String.raw`", { "interpolation": "\uFFFD0\uFFFD" });
           $I18N_0$ = $MSG_APP_SPEC_TS_1$;
       }
       else {
           $I18N_0$ = $localize \`\\\`$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\\\`\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\\\`\`;
       }`;
       verify(input, output);
     });
@@ -1155,7 +1161,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n>My i18n block #3</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_4890179241114413722$$APP_SPEC_TS_0$ = goog.getMsg("My i18n block #1");
@@ -1213,7 +1219,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_7597881511811528589$$APP_SPEC_TS_0$ = goog.getMsg(" Named interpolation: {$phA} Named interpolation with spaces: {$phB} ", {
@@ -1224,8 +1230,8 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` Named interpolation: $` +
-          String.raw `{"\uFFFD0\uFFFD"}:PH_A: Named interpolation with spaces: $` +
-          String.raw `{"\uFFFD1\uFFFD"}:PH_B: \`;
+          String.raw`{"\uFFFD0\uFFFD"}:PH_A: Named interpolation with spaces: $` +
+          String.raw`{"\uFFFD1\uFFFD"}:PH_B: \`;
         }
         …
         decls: 2,
@@ -1252,7 +1258,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n>{% valueA %}</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_6749967533321674787$$APP_SPEC_TS_0$ = goog.getMsg("{$interpolation}", {
@@ -1262,7 +1268,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \`$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         …
         template: function MyComponent_Template(rf, ctx) {
@@ -1290,7 +1296,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_APP_SPEC_TS_1$$APP_SPEC_TS_1$ = goog.getMsg(" {$interpolation} {$interpolation_1} {$interpolation_2} ", {
@@ -1302,9 +1308,9 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` $` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
-          String.raw `{"\uFFFD1\uFFFD"}:INTERPOLATION_1: $` +
-          String.raw `{"\uFFFD2\uFFFD"}:INTERPOLATION_2: \`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
+          String.raw`{"\uFFFD1\uFFFD"}:INTERPOLATION_1: $` +
+          String.raw`{"\uFFFD2\uFFFD"}:INTERPOLATION_2: \`;
         }
         …
         template: function MyComponent_Template(rf, ctx) {
@@ -1333,7 +1339,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n>My i18n block #{{ three + four + five }}</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_572579892698764378$$APP_SPEC_TS_0$ = goog.getMsg("My i18n block #{$interpolation}", {
@@ -1343,7 +1349,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \`My i18n block #$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
@@ -1354,7 +1360,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_1$ = $localize \`My i18n block #$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         var $I18N_2$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
@@ -1365,7 +1371,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_2$ = $localize \`My i18n block #$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         …
         decls: 7,
@@ -1418,7 +1424,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_7905233330103651696$$APP_SPEC_TS_0$ = goog.getMsg(" My i18n block #{$interpolation} {$startTagSpan}Plain text in nested element{$closeTagSpan}", {
@@ -1430,9 +1436,9 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` My i18n block #$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
-          String.raw `{"\uFFFD#2\uFFFD"}:START_TAG_SPAN:Plain text in nested element$` +
-          String.raw `{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_SPAN:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
+          String.raw`{"\uFFFD#2\uFFFD"}:START_TAG_SPAN:Plain text in nested element$` +
+          String.raw`{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_SPAN:\`;
         }
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
@@ -1448,14 +1454,14 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_1$ = $localize \` My i18n block #$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
-          String.raw `{"[\uFFFD#6\uFFFD|\uFFFD#7\uFFFD]"}:START_TAG_DIV:$` +
-          String.raw `{"[\uFFFD#6\uFFFD|\uFFFD#7\uFFFD]"}:START_TAG_DIV:$` + String.raw
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
+          String.raw`{"[\uFFFD#6\uFFFD|\uFFFD#7\uFFFD]"}:START_TAG_DIV:$` +
+          String.raw`{"[\uFFFD#6\uFFFD|\uFFFD#7\uFFFD]"}:START_TAG_DIV:$` + String.raw
       `{"\uFFFD#8\uFFFD"}:START_TAG_SPAN: More bindings in more nested element: $` +
-          String.raw `{"\uFFFD1\uFFFD"}:INTERPOLATION_1: $` +
-          String.raw `{"\uFFFD/#8\uFFFD"}:CLOSE_TAG_SPAN:$` +
-          String.raw `{"[\uFFFD/#7\uFFFD|\uFFFD/#6\uFFFD]"}:CLOSE_TAG_DIV:$` +
-          String.raw `{"[\uFFFD/#7\uFFFD|\uFFFD/#6\uFFFD]"}:CLOSE_TAG_DIV:\`;
+          String.raw`{"\uFFFD1\uFFFD"}:INTERPOLATION_1: $` +
+          String.raw`{"\uFFFD/#8\uFFFD"}:CLOSE_TAG_SPAN:$` +
+          String.raw`{"[\uFFFD/#7\uFFFD|\uFFFD/#6\uFFFD]"}:CLOSE_TAG_DIV:$` +
+          String.raw`{"[\uFFFD/#7\uFFFD|\uFFFD/#6\uFFFD]"}:CLOSE_TAG_DIV:\`;
         }
         $I18N_1$ = $r3$.ɵɵi18nPostprocess($I18N_1$);
         …
@@ -1509,7 +1515,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_2$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_4782264005467235841$$APP_SPEC_TS_3$ = goog.getMsg("Span title {$interpolation} and {$interpolation_1}", {
@@ -1520,8 +1526,8 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_2$ = $localize \`Span title $` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: and $` +
-          String.raw `{"\uFFFD1\uFFFD"}:INTERPOLATION_1:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: and $` +
+          String.raw`{"\uFFFD1\uFFFD"}:INTERPOLATION_1:\`;
         }
         const $_c4$ = ["title", $I18N_2$];
         var $I18N_0$;
@@ -1535,9 +1541,9 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` My i18n block #1 with value: $` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: $` + String.raw
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: $` + String.raw
       `{"\uFFFD#2\uFFFD"}:START_TAG_SPAN: Plain text in nested element (block #1) $` +
-          String.raw `{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_SPAN:\`;
+          String.raw`{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_SPAN:\`;
         }
         var $I18N_7$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
@@ -1548,7 +1554,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_7$ = $localize \`Span title $` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c9$ = ["title", $I18N_7$];
         var $I18N_6$;
@@ -1562,9 +1568,9 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_6$ = $localize \` My i18n block #2 with value $` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: $` + String.raw
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: $` + String.raw
       `{"\uFFFD#7\uFFFD"}:START_TAG_SPAN: Plain text in nested element (block #2) $` +
-          String.raw `{"\uFFFD/#7\uFFFD"}:CLOSE_TAG_SPAN:\`;
+          String.raw`{"\uFFFD/#7\uFFFD"}:CLOSE_TAG_SPAN:\`;
         }
         …
         decls: 9,
@@ -1623,7 +1629,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_7679414751795588050$$APP_SPEC_TS__1$ = goog.getMsg(" Some other content {$interpolation} {$startTagDiv} More nested levels with bindings {$interpolation_1} {$closeTagDiv}", {
@@ -1636,10 +1642,10 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_1$ = $localize \` Some other content $` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
-          String.raw `{"\uFFFD#3\uFFFD"}:START_TAG_DIV: More nested levels with bindings $` +
-          String.raw `{"\uFFFD1\uFFFD"}:INTERPOLATION_1: $` +
-          String.raw `{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_DIV:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
+          String.raw`{"\uFFFD#3\uFFFD"}:START_TAG_DIV: More nested levels with bindings $` +
+          String.raw`{"\uFFFD1\uFFFD"}:INTERPOLATION_1: $` +
+          String.raw`{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_DIV:\`;
         }
         …
         function MyComponent_div_2_Template(rf, ctx) {
@@ -1688,7 +1694,7 @@ describe('i18n support in the template compiler', () => {
         <img src="logo.png" i18n *ngIf="visible" i18n-title title="App logo #{{ id }}" />
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         function MyComponent_img_1_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelement(0, "img", 0);
@@ -1703,7 +1709,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_2$ = $localize \`App logo #$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         const $_c4$ = ["title", $I18N_2$];
         function MyComponent_img_2_Template(rf, ctx) {
@@ -1721,7 +1727,11 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 3,
         vars: 2,
-        consts: [["src", "logo.png"], ["src", "logo.png", ${AttributeMarker.Template}, "ngIf"], ["src", "logo.png", ${AttributeMarker.Bindings}, "title", ${AttributeMarker.Template}, "ngIf"], ["src", "logo.png", ${AttributeMarker.I18n}, "title"]],
+        consts: [["src", "logo.png"], ["src", "logo.png", ${
+              AttributeMarker.Template}, "ngIf"], ["src", "logo.png", ${
+              AttributeMarker.Bindings}, "title", ${
+              AttributeMarker.Template}, "ngIf"], ["src", "logo.png", ${
+              AttributeMarker.I18n}, "title"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelement(0, "img", 0);
@@ -1765,7 +1775,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         function MyComponent_div_2_div_4_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵi18nStart(0, $I18N_0$, 2);
@@ -1821,13 +1831,13 @@ describe('i18n support in the template compiler', () => {
             $I18N_0$ = $localize \` Some content $` +
           String.raw
       `{"\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_DIV_2: Some other content $` +
-          String.raw `{"\uFFFD0:1\uFFFD"}:INTERPOLATION: $` + String.raw
+          String.raw`{"\uFFFD0:1\uFFFD"}:INTERPOLATION: $` + String.raw
       `{"[\uFFFD#2:1\uFFFD|\uFFFD#2:2\uFFFD|\uFFFD#2:3\uFFFD]"}:START_TAG_DIV: More nested levels with bindings $` +
-          String.raw `{"\uFFFD1:1\uFFFD"}:INTERPOLATION_1: $` + String.raw
+          String.raw`{"\uFFFD1:1\uFFFD"}:INTERPOLATION_1: $` + String.raw
       `{"\uFFFD*4:2\uFFFD\uFFFD#1:2\uFFFD"}:START_TAG_DIV_1: Content inside sub-template $` +
-          String.raw `{"\uFFFD0:2\uFFFD"}:INTERPOLATION_2: $` + String.raw
+          String.raw`{"\uFFFD0:2\uFFFD"}:INTERPOLATION_2: $` + String.raw
       `{"[\uFFFD#2:1\uFFFD|\uFFFD#2:2\uFFFD|\uFFFD#2:3\uFFFD]"}:START_TAG_DIV: Bottom level element $` +
-          String.raw `{"\uFFFD1:2\uFFFD"}:INTERPOLATION_3: $` + String.raw
+          String.raw`{"\uFFFD1:2\uFFFD"}:INTERPOLATION_3: $` + String.raw
       `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:$` +
           String.raw
       `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:$` +
@@ -1837,9 +1847,9 @@ describe('i18n support in the template compiler', () => {
       `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:$` +
           String.raw
       `{"\uFFFD*3:3\uFFFD\uFFFD#1:3\uFFFD"}:START_TAG_DIV_3: Some other content $` +
-          String.raw `{"\uFFFD0:3\uFFFD"}:INTERPOLATION_4: $` + String.raw
+          String.raw`{"\uFFFD0:3\uFFFD"}:INTERPOLATION_4: $` + String.raw
       `{"[\uFFFD#2:1\uFFFD|\uFFFD#2:2\uFFFD|\uFFFD#2:3\uFFFD]"}:START_TAG_DIV: More nested levels with bindings $` +
-          String.raw `{"\uFFFD1:3\uFFFD"}:INTERPOLATION_5: $` + String.raw
+          String.raw`{"\uFFFD1:3\uFFFD"}:INTERPOLATION_5: $` + String.raw
       `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:$` +
           String.raw
       `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:\`;
@@ -1891,7 +1901,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n *ngIf="visible">Some other content <span>{{ valueA }}</span></div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_119975189388320493$$APP_SPEC_TS__1$ = goog.getMsg("Some other content {$startTagSpan}{$interpolation}{$closeTagSpan}", {
@@ -1903,9 +1913,9 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_1$ = $localize \`Some other content $` +
-          String.raw `{"\uFFFD#2\uFFFD"}:START_TAG_SPAN:$` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:$` +
-          String.raw `{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_SPAN:\`;
+          String.raw`{"\uFFFD#2\uFFFD"}:START_TAG_SPAN:$` +
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:$` +
+          String.raw`{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_SPAN:\`;
         }
         …
         function MyComponent_div_0_Template(rf, ctx) {
@@ -1945,7 +1955,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n (click)="onClick()">Hello</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_APP_SPEC_TS_2$ = goog.getMsg("Hello");
@@ -1976,7 +1986,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n>My i18n block #1</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_4890179241114413722$$APP_SPEC_TS_0$ = goog.getMsg("My i18n block #1");
@@ -2003,7 +2013,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n>{age, select, 10 {ten} 20 {twenty} other {other}}</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_8806993169187953163$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}");
@@ -2041,7 +2051,7 @@ describe('i18n support in the template compiler', () => {
         <ng-container i18n>My i18n block #2</ng-container>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_2413150872298537152$$APP_SPEC_TS_0$ = goog.getMsg("My i18n block #2");
@@ -2083,7 +2093,7 @@ describe('i18n support in the template compiler', () => {
         <span i18n style="padding: 10px;">Text #2</span>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_5295701706185791735$$APP_SPEC_TS_1$ = goog.getMsg("Text #1");
@@ -2103,7 +2113,8 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 4,
         vars: 0,
-        consts: [[${AttributeMarker.Classes}, "myClass"], [${AttributeMarker.Styles}, "padding", "10px"]],
+        consts: [[${AttributeMarker.Classes}, "myClass"], [${
+          AttributeMarker.Styles}, "padding", "10px"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "span", 0);
@@ -2126,7 +2137,7 @@ describe('i18n support in the template compiler', () => {
         <ng-container i18n>Some content: {{ valueA | uppercase }}</ng-container>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           const $MSG_EXTERNAL_355394464191978948$$APP_SPEC_TS_0$ = goog.getMsg("Some content: {$interpolation}", {
@@ -2136,7 +2147,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_0$ = $localize \`Some content: $` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         …
         decls: 3,
@@ -2164,7 +2175,7 @@ describe('i18n support in the template compiler', () => {
         <ng-template i18n>Some content: {{ valueA | uppercase }}</ng-template>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_355394464191978948$$APP_SPEC_TS__0$ = goog.getMsg("Some content: {$interpolation}", {
@@ -2174,7 +2185,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \`Some content: $` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
         }
         function MyComponent_ng_template_0_Template(rf, ctx) {
           if (rf & 1) {
@@ -2208,7 +2219,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           const $MSG_EXTERNAL_702706566400598764$$APP_SPEC_TS_0$ = goog.getMsg("{$startTagNgTemplate}Template content: {$interpolation}{$closeTagNgTemplate}{$startTagNgContainer}Container content: {$interpolation_1}{$closeTagNgContainer}", {
@@ -2223,12 +2234,12 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_0$ = $localize \`$` +
-          String.raw `{"\uFFFD*2:1\uFFFD"}:START_TAG_NG_TEMPLATE:Template content: $` +
-          String.raw `{"\uFFFD0:1\uFFFD"}:INTERPOLATION:$` +
-          String.raw `{"\uFFFD/*2:1\uFFFD"}:CLOSE_TAG_NG_TEMPLATE:$` +
-          String.raw `{"\uFFFD#3\uFFFD"}:START_TAG_NG_CONTAINER:Container content: $` +
-          String.raw `{"\uFFFD0\uFFFD"}:INTERPOLATION_1:$` +
-          String.raw `{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
+          String.raw`{"\uFFFD*2:1\uFFFD"}:START_TAG_NG_TEMPLATE:Template content: $` +
+          String.raw`{"\uFFFD0:1\uFFFD"}:INTERPOLATION:$` +
+          String.raw`{"\uFFFD/*2:1\uFFFD"}:CLOSE_TAG_NG_TEMPLATE:$` +
+          String.raw`{"\uFFFD#3\uFFFD"}:START_TAG_NG_CONTAINER:Container content: $` +
+          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION_1:$` +
+          String.raw`{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
         }
         function MyComponent_ng_template_2_Template(rf, ctx) {
           if (rf & 1) {
@@ -2272,7 +2283,7 @@ describe('i18n support in the template compiler', () => {
         <ng-container>{age, select, 10 {ten} 20 {twenty} other {other}}</ng-container>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_8806993169187953163$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}");
@@ -2341,7 +2352,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         function MyComponent_ng_template_2_ng_template_2_ng_template_1_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵi18n(0, $I18N_0$, 3);
@@ -2380,11 +2391,11 @@ describe('i18n support in the template compiler', () => {
             $I18N_0$ = $localize \`$` +
           String.raw
       `{"[\uFFFD*2:1\uFFFD|\uFFFD*2:2\uFFFD|\uFFFD*1:3\uFFFD]"}:START_TAG_NG_TEMPLATE: Template A: $` +
-          String.raw `{"\uFFFD0:1\uFFFD"}:INTERPOLATION: $` + String.raw
+          String.raw`{"\uFFFD0:1\uFFFD"}:INTERPOLATION: $` + String.raw
       `{"[\uFFFD*2:1\uFFFD|\uFFFD*2:2\uFFFD|\uFFFD*1:3\uFFFD]"}:START_TAG_NG_TEMPLATE: Template B: $` +
-          String.raw `{"\uFFFD0:2\uFFFD"}:INTERPOLATION_1: $` + String.raw
+          String.raw`{"\uFFFD0:2\uFFFD"}:INTERPOLATION_1: $` + String.raw
       `{"[\uFFFD*2:1\uFFFD|\uFFFD*2:2\uFFFD|\uFFFD*1:3\uFFFD]"}:START_TAG_NG_TEMPLATE: Template C: $` +
-          String.raw `{"\uFFFD0:3\uFFFD"}:INTERPOLATION_2: $` + String.raw
+          String.raw`{"\uFFFD0:3\uFFFD"}:INTERPOLATION_2: $` + String.raw
       `{"[\uFFFD/*1:3\uFFFD|\uFFFD/*2:2\uFFFD|\uFFFD/*2:1\uFFFD]"}:CLOSE_TAG_NG_TEMPLATE:$` +
           String.raw
       `{"[\uFFFD/*1:3\uFFFD|\uFFFD/*2:2\uFFFD|\uFFFD/*2:1\uFFFD]"}:CLOSE_TAG_NG_TEMPLATE:$` +
@@ -2429,7 +2440,7 @@ describe('i18n support in the template compiler', () => {
         <ng-template i18n>{age, select, 10 {ten} 20 {twenty} other {other}}</ng-template>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
@@ -2493,7 +2504,7 @@ describe('i18n support in the template compiler', () => {
         </ng-template>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_4891196282781544695$$APP_SPEC_TS_0$ = goog.getMsg("{$tagImg} is my logo #1 ", {
@@ -2503,7 +2514,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \`$` +
-          String.raw `{"\uFFFD#2\uFFFD\uFFFD/#2\uFFFD"}:TAG_IMG: is my logo #1 \`;
+          String.raw`{"\uFFFD#2\uFFFD\uFFFD/#2\uFFFD"}:TAG_IMG: is my logo #1 \`;
         }
         var $I18N_2$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
@@ -2514,7 +2525,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_2$ = $localize \`$` +
-          String.raw `{"\uFFFD#1\uFFFD\uFFFD/#1\uFFFD"}:TAG_IMG: is my logo #2 \`;
+          String.raw`{"\uFFFD#1\uFFFD\uFFFD/#1\uFFFD"}:TAG_IMG: is my logo #2 \`;
         }
         function MyComponent_ng_template_3_Template(rf, ctx) {
           if (rf & 1) {
@@ -2550,7 +2561,7 @@ describe('i18n support in the template compiler', () => {
         </ng-template>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_8537814667662432133$$APP_SPEC_TS__0$ = goog.getMsg(" Root content {$startTagNgContainer} Nested content {$closeTagNgContainer}", {
@@ -2563,7 +2574,7 @@ describe('i18n support in the template compiler', () => {
             $I18N_0$ = $localize \` Root content $` +
           String.raw
       `{"\uFFFD*1:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_NG_CONTAINER: Nested content $` +
-          String.raw `{"\uFFFD/#1:1\uFFFD\uFFFD/*1:1\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
+          String.raw`{"\uFFFD/#1:1\uFFFD\uFFFD/*1:1\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
         }
         …
       `;
@@ -2580,7 +2591,7 @@ describe('i18n support in the template compiler', () => {
       // TODO(FW-635): currently we generate unique consts for each i18n block even though it
       // might contain the same content. This should be optimized by translation statements caching,
       // that can be implemented in the future within FW-635.
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_6563391987554512024$$APP_SPEC_TS_0$ = goog.getMsg("Test");
@@ -2610,7 +2621,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           const $MSG_APP_SPEC_TS_1$ = goog.getMsg(" Hello {$startTagNgContainer}there{$closeTagNgContainer}", { "startTagNgContainer": "\uFFFD#2\uFFFD", "closeTagNgContainer": "\uFFFD/#2\uFFFD" });
@@ -2618,8 +2629,8 @@ describe('i18n support in the template compiler', () => {
         }
         else {
           $I18N_0$ = $localize \` Hello $` +
-          String.raw `{"\uFFFD#2\uFFFD"}:START_TAG_NG_CONTAINER:there$` +
-          String.raw `{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
+          String.raw`{"\uFFFD#2\uFFFD"}:START_TAG_NG_CONTAINER:there$` +
+          String.raw`{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
         }
         …
         decls: 3,
@@ -2646,7 +2657,7 @@ describe('i18n support in the template compiler', () => {
           </div>
         `;
 
-         const output = String.raw `
+         const output = String.raw`
           var $I18N_0$;
           if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_APP_SPEC_TS_1$ = goog.getMsg(" Hello {$startTagNgContainer}there {$startTagStrong}!{$closeTagStrong}{$closeTagNgContainer}", { "startTagNgContainer": "\uFFFD#2\uFFFD", "startTagStrong": "\uFFFD#3\uFFFD", "closeTagStrong": "\uFFFD/#3\uFFFD", "closeTagNgContainer": "\uFFFD/#2\uFFFD" });
@@ -2654,10 +2665,10 @@ describe('i18n support in the template compiler', () => {
           }
           else {
             $I18N_0$ = $localize \` Hello $` +
-             String.raw `{"\uFFFD#2\uFFFD"}:START_TAG_NG_CONTAINER:there $` +
-             String.raw `{"\uFFFD#3\uFFFD"}:START_TAG_STRONG:!$` +
-             String.raw `{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_STRONG:$` +
-             String.raw `{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
+             String.raw`{"\uFFFD#2\uFFFD"}:START_TAG_NG_CONTAINER:there $` +
+             String.raw`{"\uFFFD#3\uFFFD"}:START_TAG_STRONG:!$` +
+             String.raw`{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_STRONG:$` +
+             String.raw`{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
           }
           …
           decls: 4,
@@ -2686,7 +2697,7 @@ describe('i18n support in the template compiler', () => {
         <ng-container *ngIf="someFlag" i18n>Content B</ng-container>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_3308216566145348998$$APP_SPEC_TS___2$ = goog.getMsg("Content A");
@@ -2747,7 +2758,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_963542717423364282$$APP_SPEC_TS_0$ = goog.getMsg("\n          Some text\n          {$startTagSpan}Text inside span{$closeTagSpan}\n        ", {
@@ -2760,8 +2771,8 @@ describe('i18n support in the template compiler', () => {
             $I18N_0$ = $localize \`
           Some text
           $` +
-          String.raw `{"\uFFFD#3\uFFFD"}:START_TAG_SPAN:Text inside span$` +
-          String.raw `{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_SPAN:
+          String.raw`{"\uFFFD#3\uFFFD"}:START_TAG_SPAN:Text inside span$` +
+          String.raw`{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_SPAN:
         \`;
         }
         …
@@ -2788,7 +2799,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n>{gender, select, male {male} female {female} other {other}}</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
@@ -2825,7 +2836,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n>{gender, select, single {'single quotes'} double {"double quotes"} other {other}}</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_4166854826696768832$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, single {'single quotes'} double {\"double quotes\"} other {other}}");
@@ -2847,7 +2858,7 @@ describe('i18n support in the template compiler', () => {
         {age, select, 10 {ten} 20 {twenty} other {other}}
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_8806993169187953163$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}");
@@ -2887,7 +2898,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
@@ -2955,7 +2966,9 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 4,
         vars: 3,
-        consts: [["title", "icu only", ${AttributeMarker.Template}, "ngIf"], ["title", "icu and text", ${AttributeMarker.Template}, "ngIf"], ["title", "icu only"], ["title", "icu and text"]],
+        consts: [["title", "icu only", ${
+          AttributeMarker.Template}, "ngIf"], ["title", "icu and text", ${
+          AttributeMarker.Template}, "ngIf"], ["title", "icu only"], ["title", "icu and text"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
@@ -2984,7 +2997,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n>{age, select, 10 {ten} 20 {twenty} other {{% other %}}}</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_2949673783721159566$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} other {{INTERPOLATION}}}");
@@ -3024,7 +3037,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_2417296354340576868$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male - {START_BOLD_TEXT}male{CLOSE_BOLD_TEXT}} female {female {START_BOLD_TEXT}female{CLOSE_BOLD_TEXT}} other {{START_TAG_DIV}{START_ITALIC_TEXT}other{CLOSE_ITALIC_TEXT}{CLOSE_TAG_DIV}}}");
@@ -3057,13 +3070,13 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` $` +
-          String.raw `{$I18N_1$}:ICU: $` +
-          String.raw `{"\uFFFD#2\uFFFD"}:START_BOLD_TEXT:Other content$` +
-          String.raw `{"\uFFFD/#2\uFFFD"}:CLOSE_BOLD_TEXT:$` +
-          String.raw `{"\uFFFD#3\uFFFD"}:START_TAG_DIV:$` +
-          String.raw `{"\uFFFD#4\uFFFD"}:START_ITALIC_TEXT:Another content$` +
-          String.raw `{"\uFFFD/#4\uFFFD"}:CLOSE_ITALIC_TEXT:$` +
-          String.raw `{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_DIV:\`;
+          String.raw`{$I18N_1$}:ICU: $` +
+          String.raw`{"\uFFFD#2\uFFFD"}:START_BOLD_TEXT:Other content$` +
+          String.raw`{"\uFFFD/#2\uFFFD"}:CLOSE_BOLD_TEXT:$` +
+          String.raw`{"\uFFFD#3\uFFFD"}:START_TAG_DIV:$` +
+          String.raw`{"\uFFFD#4\uFFFD"}:START_ITALIC_TEXT:Another content$` +
+          String.raw`{"\uFFFD/#4\uFFFD"}:CLOSE_ITALIC_TEXT:$` +
+          String.raw`{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_DIV:\`;
         }
         …
         decls: 5,
@@ -3096,7 +3109,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n>{gender, select, male {male of age: {{ ageA + ageB + ageC }}} female {female} other {other}}</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_6879461626778511059$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male of age: {INTERPOLATION}} female {female} other {other}}");
@@ -3137,7 +3150,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
@@ -3170,7 +3183,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` $` +
-          String.raw `{$I18N_1$}:ICU: $` + String.raw `{$I18N_2$}:ICU_1: \`;
+          String.raw`{$I18N_1$}:ICU: $` + String.raw`{$I18N_2$}:ICU_1: \`;
         }
         …
         decls: 2,
@@ -3205,7 +3218,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
@@ -3251,12 +3264,12 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` $` +
-          String.raw `{"\uFFFDI18N_EXP_ICU\uFFFD"}:ICU: $` +
-          String.raw `{"\uFFFD#2\uFFFD"}:START_TAG_DIV: $` +
-          String.raw `{"\uFFFDI18N_EXP_ICU\uFFFD"}:ICU: $` + String.raw
+          String.raw`{"\uFFFDI18N_EXP_ICU\uFFFD"}:ICU: $` +
+          String.raw`{"\uFFFD#2\uFFFD"}:START_TAG_DIV: $` +
+          String.raw`{"\uFFFDI18N_EXP_ICU\uFFFD"}:ICU: $` + String.raw
       `{"[\uFFFD/#2\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*3:1\uFFFD]"}:CLOSE_TAG_DIV:$` +
-          String.raw `{"\uFFFD*3:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_DIV_1: $` +
-          String.raw `{"\uFFFDI18N_EXP_ICU\uFFFD"}:ICU: $` + String.raw
+          String.raw`{"\uFFFD*3:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_DIV_1: $` +
+          String.raw`{"\uFFFDI18N_EXP_ICU\uFFFD"}:ICU: $` + String.raw
       `{"[\uFFFD/#2\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*3:1\uFFFD]"}:CLOSE_TAG_DIV:\`;
         }
         $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
@@ -3314,7 +3327,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_343563413083115114$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT_1, select, male {male of age: {VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other}}} female {female} other {other}}");
@@ -3334,7 +3347,7 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` $` +
-          String.raw `{$I18N_1$}:ICU: \`;
+          String.raw`{$I18N_1$}:ICU: \`;
         }        …
         decls: 2,
         vars: 2,
@@ -3370,7 +3383,7 @@ describe('i18n support in the template compiler', () => {
         }</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_6870293071705078389$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_PLURAL, plural, =0 {zero} =2 {{INTERPOLATION} {VAR_SELECT, select, cat {cats} dog {dogs} other {animals}} !} other {other - {INTERPOLATION}}}");
@@ -3414,7 +3427,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
@@ -3449,10 +3462,10 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` $` +
-          String.raw `{$I18N_1$}:ICU: $` +
-          String.raw `{"\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_SPAN: $` +
-          String.raw `{$I18N_3$}:ICU_1: $` +
-          String.raw `{"\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD"}:CLOSE_TAG_SPAN:\`;
+          String.raw`{$I18N_1$}:ICU: $` +
+          String.raw`{"\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_SPAN: $` +
+          String.raw`{$I18N_3$}:ICU_1: $` +
+          String.raw`{"\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD"}:CLOSE_TAG_SPAN:\`;
         }
         function MyComponent_span_2_Template(rf, ctx) {
           if (rf & 1) {
@@ -3501,7 +3514,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_7825031864601787094$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male {INTERPOLATION}} female {female {INTERPOLATION_1}} other {other}}");
@@ -3539,10 +3552,10 @@ describe('i18n support in the template compiler', () => {
         }
         else {
             $I18N_0$ = $localize \` $` +
-          String.raw `{I18N_1}:ICU: $` +
-          String.raw `{"\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_SPAN: $` +
-          String.raw `{I18N_3}:ICU_1: $` +
-          String.raw `{"\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD"}:CLOSE_TAG_SPAN:\`;
+          String.raw`{I18N_1}:ICU: $` +
+          String.raw`{"\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_SPAN: $` +
+          String.raw`{I18N_3}:ICU_1: $` +
+          String.raw`{"\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD"}:CLOSE_TAG_SPAN:\`;
         }
         function MyComponent_span_2_Template(rf, ctx) {
           if (rf & 1) {
@@ -3592,7 +3605,7 @@ describe('i18n support in the template compiler', () => {
         }</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_6318060397235942326$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male {PH_A}} female {female {PH_B}} other {other {PH_WITH_SPACES}}}");
@@ -3632,7 +3645,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n="meaningA|descA@@idA">{count, select, 1 {one} other {more than one}}</div>
       `;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             /**
@@ -3656,7 +3669,7 @@ describe('i18n support in the template compiler', () => {
     it('should add legacy message ids if `enableI18nLegacyMessageIdFormat` is true', () => {
       const input = `<div i18n>Some Message</div>`;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) { … }
         else {
@@ -3671,7 +3684,7 @@ describe('i18n support in the template compiler', () => {
     it('should add legacy message ids if `enableI18nLegacyMessageIdFormat` is undefined', () => {
       const input = `<div i18n>Some Message</div>`;
 
-      const output = String.raw `
+      const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) { … }
         else {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_input_outputs_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_input_outputs_spec.ts
@@ -85,5 +85,4 @@ describe('compiler compliance: listen()', () => {
     expectEmit(result.source, componentDef, 'Incorrect component definition');
     expectEmit(result.source, directiveDef, 'Incorrect directive definition');
   });
-
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -10,8 +10,8 @@ import {setup} from '@angular/compiler/test/aot/test_util';
 import {compile, expectEmit} from './mock_compile';
 
 /* These tests are codified version of the tests in compiler_canonical_spec.ts. Every
-  * test in compiler_canonical_spec.ts should have a corresponding test here.
-  */
+ * test in compiler_canonical_spec.ts should have a corresponding test here.
+ */
 describe('compiler compliance: listen()', () => {
   const angularFiles = setup({
     compileAngular: false,
@@ -292,7 +292,8 @@ describe('compiler compliance: listen()', () => {
 
     const template = `
         …
-        consts: [[${AttributeMarker.Bindings}, "click", "change"], [${AttributeMarker.Bindings}, "update", "delete"]],
+        consts: [[${AttributeMarker.Bindings}, "click", "change"], [${
+        AttributeMarker.Bindings}, "update", "delete"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
@@ -446,5 +447,4 @@ describe('compiler compliance: listen()', () => {
     const result = compile(files, angularFiles);
     expectEmit(result.source, template, 'Incorrect host bindings');
   });
-
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -622,7 +622,6 @@ describe('compiler compliance: styling', () => {
       const result = compile(files, angularFiles);
       expect(result.source).not.toContain('styling');
     });
-
   });
 
   describe('[class]', () => {
@@ -743,7 +742,8 @@ describe('compiler compliance: styling', () => {
               selectors:[["my-component"]],
               decls: 1,
               vars: 2,
-              consts: [[${AttributeMarker.Classes}, "foo", ${AttributeMarker.Styles}, "width", "100px"]],
+              consts: [[${AttributeMarker.Classes}, "foo", ${
+             AttributeMarker.Styles}, "width", "100px"]],
               template:  function MyComponent_Template(rf, $ctx$) {
                 if (rf & 1) {
                   $r3$.ɵɵelement(0, "div", 0);
@@ -782,7 +782,6 @@ describe('compiler compliance: styling', () => {
       const result = compile(files, angularFiles);
       expect(result.source).not.toContain('styling');
     });
-
   });
 
   describe('[style] mixed with [class]', () => {
@@ -1005,7 +1004,8 @@ describe('compiler compliance: styling', () => {
       };
 
       const template = `
-          hostAttrs: [${AttributeMarker.Classes}, "foo", "baz", ${AttributeMarker.Styles}, "width", "200px", "height", "500px"],
+          hostAttrs: [${AttributeMarker.Classes}, "foo", "baz", ${
+          AttributeMarker.Styles}, "width", "200px", "height", "500px"],
           hostVars: 8,
           hostBindings: function MyComponent_HostBindings(rf, ctx) {
             if (rf & 2) {
@@ -1594,7 +1594,6 @@ describe('compiler compliance: styling', () => {
 
          expectEmit(result.source, template, 'Incorrect handling of interpolated style properties');
        });
-
   });
 
   describe('instruction chaining', () => {
@@ -1981,7 +1980,8 @@ describe('compiler compliance: styling', () => {
     };
 
     const template = `
-      hostAttrs: ["title", "foo title", ${AttributeMarker.Classes}, "foo", "baz", ${AttributeMarker.Styles}, "width", "200px", "height", "500px"],
+      hostAttrs: ["title", "foo title", ${AttributeMarker.Classes}, "foo", "baz", ${
+        AttributeMarker.Styles}, "width", "200px", "height", "500px"],
       hostVars: 6,
       hostBindings: function MyComponent_HostBindings(rf, ctx) {
         if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -103,7 +103,10 @@ describe('compiler compliance: template', () => {
         }
       }
       // ...
-      consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${AttributeMarker.Bindings}, "title", "click", ${AttributeMarker.Template}, "ngFor", "ngForOf"], [${AttributeMarker.Bindings}, "title", "click"]],
+      consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${
+        AttributeMarker.Bindings}, "title", "click", ${
+        AttributeMarker.Template}, "ngFor", "ngForOf"], [${
+        AttributeMarker.Bindings}, "title", "click"]],
       template:function MyComponent_Template(rf, ctx){
         if (rf & 1) {
           $i0$.ɵɵtemplate(0, MyComponent_ul_0_Template, 2, 1, "ul", 0);
@@ -157,7 +160,8 @@ describe('compiler compliance: template', () => {
           }
         }
         // ...
-        consts: [[${AttributeMarker.Bindings}, "click", ${AttributeMarker.Template}, "ngFor", "ngForOf"], [${AttributeMarker.Bindings}, "click"]],
+        consts: [[${AttributeMarker.Bindings}, "click", ${
+        AttributeMarker.Template}, "ngFor", "ngForOf"], [${AttributeMarker.Bindings}, "click"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 1, 0, "div", 0);
@@ -329,7 +333,8 @@ describe('compiler compliance: template', () => {
       }
 
       // ...
-      consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${AttributeMarker.Template}, "ngIf"]],
+      consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${
+        AttributeMarker.Template}, "ngIf"]],
       template:function MyComponent_Template(rf, ctx){
         if (rf & 1) {
           $i0$.ɵɵtemplate(0, MyComponent_div_0_Template, 2, 1, "div", 0);
@@ -472,7 +477,6 @@ describe('compiler compliance: template', () => {
   });
 
   it('should support local refs on <ng-template>', () => {
-
     const files = {
       app: {
         'spec.ts': `
@@ -511,7 +515,6 @@ describe('compiler compliance: template', () => {
   });
 
   it('should support directive outputs on <ng-template>', () => {
-
     const files = {
       app: {
         'spec.ts': `
@@ -545,7 +548,6 @@ describe('compiler compliance: template', () => {
     const result = compile(files, angularFiles);
 
     expectEmit(result.source, template, 'Incorrect template');
-
   });
 
   it('should allow directive inputs as an interpolated prop on <ng-template>', () => {

--- a/packages/compiler-cli/test/diagnostics/check_types_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/check_types_spec.ts
@@ -11,7 +11,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as ts from 'typescript';
-import {TestSupport, expectNoDiagnostics, setup} from '../test_support';
+
+import {expectNoDiagnostics, setup, TestSupport} from '../test_support';
 
 type MockFiles = {
   [fileName: string]: string
@@ -47,19 +48,19 @@ describe('ng type checker', () => {
   }
 
   function reject(
-      message: string | RegExp, location: RegExp | null, files: MockFiles,
+      message: string|RegExp, location: RegExp|null, files: MockFiles,
       overrideOptions: ng.CompilerOptions = {}) {
     const diagnostics = compileAndCheck([QUICKSTART, files], overrideOptions);
     if (!diagnostics || !diagnostics.length) {
       throw new Error('Expected a diagnostic error message');
     } else {
-      const matches: (d: ng.Diagnostic | ts.Diagnostic) => boolean = typeof message === 'string' ?
+      const matches: (d: ng.Diagnostic|ts.Diagnostic) => boolean = typeof message === 'string' ?
           d => ng.isNgDiagnostic(d)&& d.messageText == message :
           d => ng.isNgDiagnostic(d) && message.test(d.messageText);
       const matchingDiagnostics = diagnostics.filter(matches) as ng.Diagnostic[];
       if (!matchingDiagnostics || !matchingDiagnostics.length) {
-        throw new Error(
-            `Expected a diagnostics matching ${message}, received\n  ${diagnostics.map(d => d.messageText).join('\n  ')}`);
+        throw new Error(`Expected a diagnostics matching ${message}, received\n  ${
+            diagnostics.map(d => d.messageText).join('\n  ')}`);
       }
 
       if (location) {
@@ -72,7 +73,9 @@ describe('ng type checker', () => {
     }
   }
 
-  it('should accept unmodified QuickStart', () => { accept(); });
+  it('should accept unmodified QuickStart', () => {
+    accept();
+  });
 
   it('should accept unmodified QuickStart with tests for unused variables', () => {
     accept({}, {
@@ -523,7 +526,7 @@ describe('ng type checker', () => {
     };
 
     const r =
-        (message: string | RegExp, location: RegExp | null, files: MockFiles,
+        (message: string|RegExp, location: RegExp|null, files: MockFiles,
          options: ng.AngularCompilerOptions = {}) => {
           reject(
               message, location, {'src/app.component.ts': '', 'src/lib.ts': '', ...files},
@@ -712,16 +715,18 @@ describe('ng type checker', () => {
   });
 
   function addTests(config: {fullTemplateTypeCheck: boolean}) {
-    function a(template: string) { accept({'src/app.component.html': template}, config); }
+    function a(template: string) {
+      accept({'src/app.component.html': template}, config);
+    }
 
-    function r(template: string, message: string | RegExp, location: string) {
+    function r(template: string, message: string|RegExp, location: string) {
       reject(
           message, new RegExp(`app\.component\.html\@${location}$`),
           {'src/app.component.html': template}, config);
     }
 
     function rejectOnlyWithFullTemplateTypeCheck(
-        template: string, message: string | RegExp, location: string) {
+        template: string, message: string|RegExp, location: string) {
       if (config.fullTemplateTypeCheck) {
         r(template, message, location);
       } else {
@@ -732,23 +737,33 @@ describe('ng type checker', () => {
     it('should report an invalid field access', () => {
       r('<div>{{fame}}<div>', `Property 'fame' does not exist on type 'AppComponent'.`, '0:5');
     });
-    it('should reject a reference to a field of a nullable',
-       () => { r('<div>{{maybePerson.name}}</div>', `Object is possibly 'undefined'.`, '0:5'); });
-    it('should accept a reference to a field of a nullable using using non-null-assert',
-       () => { a('{{maybePerson!.name}}'); });
-    it('should accept a safe property access of a nullable person',
-       () => { a('{{maybePerson?.name}}'); });
+    it('should reject a reference to a field of a nullable', () => {
+      r('<div>{{maybePerson.name}}</div>', `Object is possibly 'undefined'.`, '0:5');
+    });
+    it('should accept a reference to a field of a nullable using using non-null-assert', () => {
+      a('{{maybePerson!.name}}');
+    });
+    it('should accept a safe property access of a nullable person', () => {
+      a('{{maybePerson?.name}}');
+    });
 
-    it('should accept using a library pipe', () => { a('{{1 | libPipe}}'); });
-    it('should accept using a library directive',
-       () => { a('<div libDir #libDir="libDir">{{libDir.name}}</div>'); });
+    it('should accept using a library pipe', () => {
+      a('{{1 | libPipe}}');
+    });
+    it('should accept using a library directive', () => {
+      a('<div libDir #libDir="libDir">{{libDir.name}}</div>');
+    });
 
-    it('should accept a function call', () => { a('{{getName()}}'); });
+    it('should accept a function call', () => {
+      a('{{getName()}}');
+    });
     it('should reject an invalid method', () => {
       r('<div>{{getFame()}}</div>',
         `Property 'getFame' does not exist on type 'AppComponent'. Did you mean 'getName'?`, '0:5');
     });
-    it('should accept a field access of a method result', () => { a('{{getPerson().name}}'); });
+    it('should accept a field access of a method result', () => {
+      a('{{getPerson().name}}');
+    });
     it('should reject an invalid field reference of a method result', () => {
       r('<div>{{getPerson().fame}}</div>', `Property 'fame' does not exist on type 'Person'.`,
         '0:5');
@@ -756,10 +771,13 @@ describe('ng type checker', () => {
     it('should reject an access to a nullable field of a method result', () => {
       r('<div>{{getMaybePerson().name}}</div>', `Object is possibly 'undefined'.`, '0:5');
     });
-    it('should accept a nullable assert of a nullable field references of a method result',
-       () => { a('{{getMaybePerson()!.name}}'); });
+    it('should accept a nullable assert of a nullable field references of a method result', () => {
+      a('{{getMaybePerson()!.name}}');
+    });
     it('should accept a safe property access of a nullable field reference of a method result',
-       () => { a('{{getMaybePerson()?.name}}'); });
+       () => {
+         a('{{getMaybePerson()?.name}}');
+       });
 
     it('should report an invalid field access inside of an ng-template', () => {
       rejectOnlyWithFullTemplateTypeCheck(
@@ -779,8 +797,9 @@ describe('ng type checker', () => {
   }
 
   describe('with lowered expressions', () => {
-    it('should not report lowered expressions as errors',
-       () => { expectNoDiagnostics({}, compileAndCheck([LOWERING_QUICKSTART])); });
+    it('should not report lowered expressions as errors', () => {
+      expectNoDiagnostics({}, compileAndCheck([LOWERING_QUICKSTART]));
+    });
   });
 });
 

--- a/packages/compiler-cli/test/diagnostics/typescript_version_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/typescript_version_spec.ts
@@ -18,8 +18,9 @@ describe('toNumbers', () => {
 });
 
 describe('compareNumbers', () => {
-
-  it('should handle empty arrays', () => { expect(compareNumbers([], [])).toEqual(0); });
+  it('should handle empty arrays', () => {
+    expect(compareNumbers([], [])).toEqual(0);
+  });
 
   it('should handle arrays of same length', () => {
     expect(compareNumbers([1], [3])).toEqual(-1);

--- a/packages/compiler-cli/test/extract_i18n_spec.ts
+++ b/packages/compiler-cli/test/extract_i18n_spec.ts
@@ -207,7 +207,9 @@ describe('extract_i18n command line', () => {
   beforeEach(() => {
     errorSpy = jasmine.createSpy('consoleError').and.callFake(console.error);
     const support = setup();
-    write = (fileName: string, content: string) => { support.write(fileName, content); };
+    write = (fileName: string, content: string) => {
+      support.write(fileName, content);
+    };
     basePath = support.basePath;
     outDir = path.join(basePath, 'built');
     write('tsconfig-base.json', `{

--- a/packages/compiler-cli/test/helpers/src/mock_file_loading.ts
+++ b/packages/compiler-cli/test/helpers/src/mock_file_loading.ts
@@ -7,7 +7,7 @@
  */
 
 /// <reference types="node" />
-import {readFileSync, readdirSync, statSync} from 'fs';
+import {readdirSync, readFileSync, statSync} from 'fs';
 import {resolve} from 'path';
 
 import {getAngularPackagesFromRunfiles, resolveNpmTreeArtifact} from '..';

--- a/packages/compiler-cli/test/helpers/src/runfile_helpers.ts
+++ b/packages/compiler-cli/test/helpers/src/runfile_helpers.ts
@@ -22,7 +22,7 @@ export function getAngularPackagesFromRunfiles() {
   const runfilesManifestPath = process.env.RUNFILES_MANIFEST_FILE;
 
   if (!runfilesManifestPath) {
-    const packageRunfilesDir = path.join(process.env.RUNFILES !, 'angular/packages');
+    const packageRunfilesDir = path.join(process.env.RUNFILES!, 'angular/packages');
 
     return fs.readdirSync(packageRunfilesDir)
         .map(name => ({name, pkgPath: path.join(packageRunfilesDir, name, 'npm_package/')}))

--- a/packages/compiler-cli/test/metadata/bundler_spec.ts
+++ b/packages/compiler-cli/test/metadata/bundler_spec.ts
@@ -15,7 +15,6 @@ import {ClassMetadata, MetadataEntry, MetadataGlobalReferenceExpression, ModuleM
 import {Directory, MockAotContext, MockCompilerHost} from '../mocks';
 
 describe('compiler host adapter', () => {
-
   it('should retrieve metadata for an explicit index relative path reference', () => {
     const context = new MockAotContext('.', SIMPLE_LIBRARY);
     const host = new MockCompilerHost(context);
@@ -28,7 +27,7 @@ describe('compiler host adapter', () => {
     const metadata = adapter.getMetadataFor('./lib/src/two/index', '.');
 
     expect(metadata).toBeDefined();
-    expect(Object.keys(metadata !.metadata).sort()).toEqual([
+    expect(Object.keys(metadata!.metadata).sort()).toEqual([
       'PrivateTwo',
       'TWO_CLASSES',
       'Two',
@@ -48,7 +47,7 @@ describe('compiler host adapter', () => {
     const metadata = adapter.getMetadataFor('./lib/src/two', '.');
 
     expect(metadata).toBeDefined();
-    expect(Object.keys(metadata !.metadata).sort()).toEqual([
+    expect(Object.keys(metadata!.metadata).sort()).toEqual([
       'PrivateTwo',
       'TWO_CLASSES',
       'Two',
@@ -82,7 +81,7 @@ describe('compiler host adapter', () => {
     const metadata = adapter.getMetadataFor('./lib/src/index', '.');
 
     expect(metadata).toBeDefined();
-    expect(metadata !.exports !.map(e => e.export !)
+    expect(metadata!.exports!.map(e => e.export !)
                .reduce((prev, next) => prev.concat(next), [])
                .sort())
         .toEqual([
@@ -127,13 +126,13 @@ describe('compiler host adapter', () => {
     const metadata = adapter.getMetadataFor('./lib', '.');
 
     expect(metadata).toBeDefined();
-    expect(Object.keys(metadata !.metadata).sort()).toEqual([
+    expect(Object.keys(metadata!.metadata).sort()).toEqual([
       'ONE_CLASSES',
       'One',
       'OneMore',
       'PrivateOne',
     ]);
-    expect(Array.isArray(metadata !.metadata !['ONE_CLASSES'])).toBeTruthy();
+    expect(Array.isArray(metadata!.metadata!['ONE_CLASSES'])).toBeTruthy();
   });
 
   it('should look for non-declaration file when resolving metadata via a package.json "types" entry',
@@ -180,19 +179,17 @@ describe('compiler host adapter', () => {
        const metadata = adapter.getMetadataFor('./lib', '.');
 
        expect(metadata).toBeDefined();
-       expect(Object.keys(metadata !.metadata).sort()).toEqual([
+       expect(Object.keys(metadata!.metadata).sort()).toEqual([
          'ONE_CLASSES',
          'One',
          'OneMore',
          'PrivateOne',
        ]);
-       expect(Array.isArray(metadata !.metadata !['ONE_CLASSES'])).toBeTruthy();
-
+       expect(Array.isArray(metadata!.metadata!['ONE_CLASSES'])).toBeTruthy();
      });
 });
 
 describe('metadata bundler', () => {
-
   it('should be able to bundle a simple library', () => {
     const host = new MockStringBundlerHost('/', SIMPLE_LIBRARY);
     const bundler = new MetadataBundler('/lib/index', undefined, host, 'prfx_');
@@ -203,9 +200,9 @@ describe('metadata bundler', () => {
 
     const originalOne = './src/one';
     const originalTwo = './src/two/index';
-    expect(Object.keys(result.metadata.origins !)
+    expect(Object.keys(result.metadata.origins!)
                .sort()
-               .map(name => ({name, value: result.metadata.origins ![name]})))
+               .map(name => ({name, value: result.metadata.origins![name]})))
         .toEqual([
           {name: 'ONE_CLASSES', value: originalOne}, {name: 'One', value: originalOne},
           {name: 'OneMore', value: originalOne}, {name: 'TWO_CLASSES', value: originalTwo},
@@ -239,7 +236,7 @@ describe('metadata bundler', () => {
     });
     const bundler = new MetadataBundler('/lib/index', undefined, host);
     const bundledMetadata = bundler.getMetadataBundle().metadata;
-    const deepIndexMetadata = host.getMetadataFor('/lib/deep/index') !;
+    const deepIndexMetadata = host.getMetadataFor('/lib/deep/index')!;
 
     // The unbundled metadata should reference symbols using the relative module path.
     expect(deepIndexMetadata.metadata['MyClass']).toEqual(jasmine.objectContaining<MetadataEntry>({
@@ -419,7 +416,7 @@ describe('metadata bundler', () => {
         from: 'external_one'
       }
     ]);
-    expect(result.metadata.origins !['E']).toBeUndefined();
+    expect(result.metadata.origins!['E']).toBeUndefined();
   });
 
   it('should be able to bundle a library with multiple unnamed re-exports', () => {
@@ -456,7 +453,7 @@ describe('metadata bundler', () => {
 
     const bundler = new MetadataBundler('/public-api', undefined, host);
     const result = bundler.getMetadataBundle();
-    const {A, A2, A3, B1, B2} = result.metadata.metadata as{
+    const {A, A2, A3, B1, B2} = result.metadata.metadata as {
       A: ClassMetadata,
       A2: MetadataGlobalReferenceExpression,
       A3: ClassMetadata,

--- a/packages/compiler-cli/test/metadata/evaluator_spec.ts
+++ b/packages/compiler-cli/test/metadata/evaluator_spec.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 import {Evaluator} from '../../src/metadata/evaluator';
 import {Symbols} from '../../src/metadata/symbols';
 
-import {Directory, Host, expectNoDiagnostics, findVar, findVarInitializer} from './typescript.mocks';
+import {Directory, expectNoDiagnostics, findVar, findVarInitializer, Host} from './typescript.mocks';
 
 describe('Evaluator', () => {
   const documentRegistry = ts.createDocumentRegistry();
@@ -27,7 +27,7 @@ describe('Evaluator', () => {
       'newExpression.ts', 'errors.ts', 'declared.ts'
     ]);
     service = ts.createLanguageService(host, documentRegistry);
-    program = service.getProgram() !;
+    program = service.getProgram()!;
     typeChecker = program.getTypeChecker();
     symbols = new Symbols(null as any as ts.SourceFile);
     evaluator = new Evaluator(symbols, new Map());
@@ -45,7 +45,7 @@ describe('Evaluator', () => {
   });
 
   it('should be able to fold literal expressions', () => {
-    const consts = program.getSourceFile('consts.ts') !;
+    const consts = program.getSourceFile('consts.ts')!;
     expect(evaluator.isFoldable(findVarInitializer(consts, 'someName'))).toBeTruthy();
     expect(evaluator.isFoldable(findVarInitializer(consts, 'someBool'))).toBeTruthy();
     expect(evaluator.isFoldable(findVarInitializer(consts, 'one'))).toBeTruthy();
@@ -53,7 +53,7 @@ describe('Evaluator', () => {
   });
 
   it('should be able to fold expressions with foldable references', () => {
-    const expressions = program.getSourceFile('expressions.ts') !;
+    const expressions = program.getSourceFile('expressions.ts')!;
     symbols.define('someName', 'some-name');
     symbols.define('someBool', true);
     symbols.define('one', 1);
@@ -67,7 +67,7 @@ describe('Evaluator', () => {
   });
 
   it('should be able to evaluate literal expressions', () => {
-    const consts = program.getSourceFile('consts.ts') !;
+    const consts = program.getSourceFile('consts.ts')!;
     expect(evaluator.evaluateNode(findVarInitializer(consts, 'someName'))).toBe('some-name');
     expect(evaluator.evaluateNode(findVarInitializer(consts, 'someBool'))).toBe(true);
     expect(evaluator.evaluateNode(findVarInitializer(consts, 'one'))).toBe(1);
@@ -75,7 +75,7 @@ describe('Evaluator', () => {
   });
 
   it('should be able to evaluate expressions', () => {
-    const expressions = program.getSourceFile('expressions.ts') !;
+    const expressions = program.getSourceFile('expressions.ts')!;
     symbols.define('someName', 'some-name');
     symbols.define('someBool', true);
     symbols.define('one', 1);
@@ -118,11 +118,10 @@ describe('Evaluator', () => {
     expect(evaluator.evaluateNode(findVarInitializer(expressions, 'bShiftRight'))).toEqual(-1 >> 2);
     expect(evaluator.evaluateNode(findVarInitializer(expressions, 'bShiftRightU')))
         .toEqual(-1 >>> 2);
-
   });
 
   it('should report recursive references as symbolic', () => {
-    const expressions = program.getSourceFile('expressions.ts') !;
+    const expressions = program.getSourceFile('expressions.ts')!;
     expect(evaluator.evaluateNode(findVarInitializer(expressions, 'recursiveA')))
         .toEqual({__symbolic: 'reference', name: 'recursiveB'});
     expect(evaluator.evaluateNode(findVarInitializer(expressions, 'recursiveB')))
@@ -130,13 +129,13 @@ describe('Evaluator', () => {
   });
 
   it('should correctly handle special cases for CONST_EXPR', () => {
-    const const_expr = program.getSourceFile('const_expr.ts') !;
+    const const_expr = program.getSourceFile('const_expr.ts')!;
     expect(evaluator.evaluateNode(findVarInitializer(const_expr, 'bTrue'))).toEqual(true);
     expect(evaluator.evaluateNode(findVarInitializer(const_expr, 'bFalse'))).toEqual(false);
   });
 
   it('should resolve a forwardRef', () => {
-    const forwardRef = program.getSourceFile('forwardRef.ts') !;
+    const forwardRef = program.getSourceFile('forwardRef.ts')!;
     expect(evaluator.evaluateNode(findVarInitializer(forwardRef, 'bTrue'))).toEqual(true);
     expect(evaluator.evaluateNode(findVarInitializer(forwardRef, 'bFalse'))).toEqual(false);
   });
@@ -144,7 +143,7 @@ describe('Evaluator', () => {
   it('should return new expressions', () => {
     symbols.define('Value', {__symbolic: 'reference', module: './classes', name: 'Value'});
     evaluator = new Evaluator(symbols, new Map());
-    const newExpression = program.getSourceFile('newExpression.ts') !;
+    const newExpression = program.getSourceFile('newExpression.ts')!;
     expect(evaluator.evaluateNode(findVarInitializer(newExpression, 'someValue'))).toEqual({
       __symbolic: 'new',
       expression:
@@ -160,9 +159,9 @@ describe('Evaluator', () => {
   });
 
   it('should support reference to a declared module type', () => {
-    const declared = program.getSourceFile('declared.ts') !;
-    const aDecl = findVar(declared, 'a') !;
-    expect(evaluator.evaluateNode(aDecl.type !)).toEqual({
+    const declared = program.getSourceFile('declared.ts')!;
+    const aDecl = findVar(declared, 'a')!;
+    expect(evaluator.evaluateNode(aDecl.type!)).toEqual({
       __symbolic: 'select',
       expression: {__symbolic: 'reference', name: 'Foo'},
       member: 'A'
@@ -170,28 +169,28 @@ describe('Evaluator', () => {
   });
 
   it('should return errors for unsupported expressions', () => {
-    const errors = program.getSourceFile('errors.ts') !;
-    const fDecl = findVar(errors, 'f') !;
-    expect(evaluator.evaluateNode(fDecl.initializer !))
+    const errors = program.getSourceFile('errors.ts')!;
+    const fDecl = findVar(errors, 'f')!;
+    expect(evaluator.evaluateNode(fDecl.initializer!))
         .toEqual({__symbolic: 'error', message: 'Lambda not supported', line: 1, character: 12});
-    const eDecl = findVar(errors, 'e') !;
-    expect(evaluator.evaluateNode(eDecl.type !)).toEqual({
+    const eDecl = findVar(errors, 'e')!;
+    expect(evaluator.evaluateNode(eDecl.type!)).toEqual({
       __symbolic: 'error',
       message: 'Could not resolve type',
       line: 2,
       character: 11,
       context: {typeName: 'NotFound'}
     });
-    const sDecl = findVar(errors, 's') !;
-    expect(evaluator.evaluateNode(sDecl.initializer !)).toEqual({
+    const sDecl = findVar(errors, 's')!;
+    expect(evaluator.evaluateNode(sDecl.initializer!)).toEqual({
       __symbolic: 'error',
       message: 'Name expected',
       line: 3,
       character: 14,
       context: {received: '1'}
     });
-    const tDecl = findVar(errors, 't') !;
-    expect(evaluator.evaluateNode(tDecl.initializer !)).toEqual({
+    const tDecl = findVar(errors, 't')!;
+    expect(evaluator.evaluateNode(tDecl.initializer!)).toEqual({
       __symbolic: 'error',
       message: 'Expression form not supported',
       line: 4,
@@ -200,16 +199,16 @@ describe('Evaluator', () => {
   });
 
   it('should be able to fold an array spread', () => {
-    const expressions = program.getSourceFile('expressions.ts') !;
+    const expressions = program.getSourceFile('expressions.ts')!;
     symbols.define('arr', [1, 2, 3, 4]);
-    const arrSpread = findVar(expressions, 'arrSpread') !;
-    expect(evaluator.evaluateNode(arrSpread.initializer !)).toEqual([0, 1, 2, 3, 4, 5]);
+    const arrSpread = findVar(expressions, 'arrSpread')!;
+    expect(evaluator.evaluateNode(arrSpread.initializer!)).toEqual([0, 1, 2, 3, 4, 5]);
   });
 
   it('should be able to produce a spread expression', () => {
-    const expressions = program.getSourceFile('expressions.ts') !;
-    const arrSpreadRef = findVar(expressions, 'arrSpreadRef') !;
-    expect(evaluator.evaluateNode(arrSpreadRef.initializer !)).toEqual([
+    const expressions = program.getSourceFile('expressions.ts')!;
+    const arrSpreadRef = findVar(expressions, 'arrSpreadRef')!;
+    expect(evaluator.evaluateNode(arrSpreadRef.initializer!)).toEqual([
       0, {__symbolic: 'spread', expression: {__symbolic: 'reference', name: 'arrImport'}}, 5
     ]);
   });
@@ -218,8 +217,8 @@ describe('Evaluator', () => {
     const source = sourceFileOf(`
       export var a = new f;
     `);
-    const expr = findVar(source, 'a') !;
-    expect(evaluator.evaluateNode(expr.initializer !))
+    const expr = findVar(source, 'a')!;
+    expect(evaluator.evaluateNode(expr.initializer!))
         .toEqual({__symbolic: 'new', expression: {__symbolic: 'reference', name: 'f'}});
   });
 
@@ -244,7 +243,7 @@ describe('Evaluator', () => {
         export var a = () => b;
       `);
       const expr = findVar(source, 'a');
-      expect(evaluator.evaluateNode(expr !.initializer !))
+      expect(evaluator.evaluateNode(expr!.initializer!))
           .toEqual({__symbolic: 'reference', name: lambdaTemp});
     });
 
@@ -256,7 +255,7 @@ describe('Evaluator', () => {
         ];
       `);
       const expr = findVar(source, 'a');
-      expect(evaluator.evaluateNode(expr !.initializer !)).toEqual([
+      expect(evaluator.evaluateNode(expr!.initializer!)).toEqual([
         {provide: 'someValue', useFactory: {__symbolic: 'reference', name: lambdaTemp}}
       ]);
     });

--- a/packages/compiler-cli/test/metadata/symbols_spec.ts
+++ b/packages/compiler-cli/test/metadata/symbols_spec.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 import {isMetadataGlobalReferenceExpression} from '../../src/metadata/schema';
 import {Symbols} from '../../src/metadata/symbols';
 
-import {Directory, Host, expectNoDiagnostics} from './typescript.mocks';
+import {Directory, expectNoDiagnostics, Host} from './typescript.mocks';
 
 describe('Symbols', () => {
   let symbols: Symbols;
@@ -42,9 +42,9 @@ describe('Symbols', () => {
   beforeEach(() => {
     host = new Host(FILES, ['consts.ts', 'expressions.ts', 'imports.ts']);
     service = ts.createLanguageService(host);
-    program = service.getProgram() !;
-    expressions = program.getSourceFile('expressions.ts') !;
-    imports = program.getSourceFile('imports.ts') !;
+    program = service.getProgram()!;
+    expressions = program.getSourceFile('expressions.ts')!;
+    imports = program.getSourceFile('imports.ts')!;
   });
 
   it('should not have syntax errors in the test sources', () => {
@@ -111,7 +111,7 @@ describe('Symbols', () => {
       }
       return false;
     };
-    ts.forEachChild(core !, visit);
+    ts.forEachChild(core!, visit);
   });
 });
 

--- a/packages/compiler-cli/test/metadata/typescript.mocks.ts
+++ b/packages/compiler-cli/test/metadata/typescript.mocks.ts
@@ -10,7 +10,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
-export interface Directory { [name: string]: (Directory|string); }
+export interface Directory {
+  [name: string]: (Directory|string);
+}
 
 export class Host implements ts.LanguageServiceHost {
   private overrides = new Map<string, string>();
@@ -26,20 +28,30 @@ export class Host implements ts.LanguageServiceHost {
     };
   }
 
-  getScriptFileNames(): string[] { return this.scripts; }
+  getScriptFileNames(): string[] {
+    return this.scripts;
+  }
 
-  getScriptVersion(fileName: string): string { return this.version.toString(); }
+  getScriptVersion(fileName: string): string {
+    return this.version.toString();
+  }
 
   getScriptSnapshot(fileName: string): ts.IScriptSnapshot|undefined {
     const content = this.getFileContent(fileName);
     if (content) return ts.ScriptSnapshot.fromString(content);
   }
 
-  fileExists(fileName: string): boolean { return this.getFileContent(fileName) != null; }
+  fileExists(fileName: string): boolean {
+    return this.getFileContent(fileName) != null;
+  }
 
-  getCurrentDirectory(): string { return '/'; }
+  getCurrentDirectory(): string {
+    return '/';
+  }
 
-  getDefaultLibFileName(options: ts.CompilerOptions): string { return 'lib.d.ts'; }
+  getDefaultLibFileName(options: ts.CompilerOptions): string {
+    return 'lib.d.ts';
+  }
 
   overrideFile(fileName: string, content: string) {
     this.overrides.set(fileName, content);
@@ -81,24 +93,52 @@ export function open(directory: Directory, fileName: string): Directory|string|u
 export class MockNode implements ts.Node {
   decorators?: ts.NodeArray<ts.Decorator>;
   modifiers?: ts.NodeArray<ts.Modifier>;
-  parent !: ts.Node;
+  parent!: ts.Node;
   constructor(
       public kind: ts.SyntaxKind = ts.SyntaxKind.Identifier, public flags: ts.NodeFlags = 0,
       public pos: number = 0, public end: number = 0) {}
-  getSourceFile(): ts.SourceFile { return null as any as ts.SourceFile; }
-  getChildCount(sourceFile?: ts.SourceFile): number { return 0; }
-  getChildAt(index: number, sourceFile?: ts.SourceFile): ts.Node { return null as any as ts.Node; }
-  getChildren(sourceFile?: ts.SourceFile): ts.Node[] { return []; }
-  getStart(sourceFile?: ts.SourceFile): number { return 0; }
-  getFullStart(): number { return 0; }
-  getEnd(): number { return 0; }
-  getWidth(sourceFile?: ts.SourceFile): number { return 0; }
-  getFullWidth(): number { return 0; }
-  getLeadingTriviaWidth(sourceFile?: ts.SourceFile): number { return 0; }
-  getFullText(sourceFile?: ts.SourceFile): string { return ''; }
-  getText(sourceFile?: ts.SourceFile): string { return ''; }
-  getFirstToken(sourceFile?: ts.SourceFile): ts.Node { return null as any as ts.Node; }
-  getLastToken(sourceFile?: ts.SourceFile): ts.Node { return null as any as ts.Node; }
+  getSourceFile(): ts.SourceFile {
+    return null as any as ts.SourceFile;
+  }
+  getChildCount(sourceFile?: ts.SourceFile): number {
+    return 0;
+  }
+  getChildAt(index: number, sourceFile?: ts.SourceFile): ts.Node {
+    return null as any as ts.Node;
+  }
+  getChildren(sourceFile?: ts.SourceFile): ts.Node[] {
+    return [];
+  }
+  getStart(sourceFile?: ts.SourceFile): number {
+    return 0;
+  }
+  getFullStart(): number {
+    return 0;
+  }
+  getEnd(): number {
+    return 0;
+  }
+  getWidth(sourceFile?: ts.SourceFile): number {
+    return 0;
+  }
+  getFullWidth(): number {
+    return 0;
+  }
+  getLeadingTriviaWidth(sourceFile?: ts.SourceFile): number {
+    return 0;
+  }
+  getFullText(sourceFile?: ts.SourceFile): string {
+    return '';
+  }
+  getText(sourceFile?: ts.SourceFile): string {
+    return '';
+  }
+  getFirstToken(sourceFile?: ts.SourceFile): ts.Node {
+    return null as any as ts.Node;
+  }
+  getLastToken(sourceFile?: ts.SourceFile): ts.Node {
+    return null as any as ts.Node;
+  }
   forEachChild<T>(
       cbNode: (node: ts.Node) => T | undefined,
       cbNodeArray?: (nodes: ts.NodeArray<ts.Node>) => T | undefined): T|undefined {
@@ -111,10 +151,10 @@ export class MockIdentifier extends MockNode implements ts.Identifier {
   isInJSDocNamespace?: boolean;
   decorators?: ts.NodeArray<ts.Decorator>;
   modifiers?: ts.NodeArray<ts.Modifier>;
-  parent !: ts.Node;
+  parent!: ts.Node;
   public text: string;
   // TODO(issue/24571): remove '!'.
-  public escapedText !: ts.__String;
+  public escapedText!: ts.__String;
   // tslint:disable
   public _declarationBrand: any;
   public _primaryExpressionBrand: any;
@@ -135,7 +175,7 @@ export class MockIdentifier extends MockNode implements ts.Identifier {
 }
 
 export class MockVariableDeclaration extends MockNode implements ts.VariableDeclaration {
-  parent !: ts.VariableDeclarationList | ts.CatchClause;
+  parent!: ts.VariableDeclarationList|ts.CatchClause;
   exclamationToken?: ts.Token<ts.SyntaxKind.ExclamationToken>;
   type?: ts.TypeNode;
   initializer?: ts.Expression;
@@ -151,32 +191,46 @@ export class MockVariableDeclaration extends MockNode implements ts.VariableDecl
     super(kind, flags, pos, end);
   }
 
-  static of (name: string): MockVariableDeclaration {
+  static of(name: string): MockVariableDeclaration {
     return new MockVariableDeclaration(new MockIdentifier(name));
   }
 }
 
 export class MockSymbol implements ts.Symbol {
-  declarations !: ts.Declaration[];
-  valueDeclaration !: ts.Declaration;
+  declarations!: ts.Declaration[];
+  valueDeclaration!: ts.Declaration;
   members?: ts.UnderscoreEscapedMap<ts.Symbol>;
   exports?: ts.UnderscoreEscapedMap<ts.Symbol>;
   globalExports?: ts.UnderscoreEscapedMap<ts.Symbol>;
   // TODO(issue/24571): remove '!'.
-  public escapedName !: ts.__String;
+  public escapedName!: ts.__String;
   constructor(
       public name: string, private node: ts.Declaration = MockVariableDeclaration.of(name),
       public flags: ts.SymbolFlags = 0) {}
 
-  getFlags(): ts.SymbolFlags { return this.flags; }
-  getName(): string { return this.name; }
-  getEscapedName(): ts.__String { return this.escapedName; }
-  getDeclarations(): ts.Declaration[] { return [this.node]; }
-  getDocumentationComment(): ts.SymbolDisplayPart[] { return []; }
+  getFlags(): ts.SymbolFlags {
+    return this.flags;
+  }
+  getName(): string {
+    return this.name;
+  }
+  getEscapedName(): ts.__String {
+    return this.escapedName;
+  }
+  getDeclarations(): ts.Declaration[] {
+    return [this.node];
+  }
+  getDocumentationComment(): ts.SymbolDisplayPart[] {
+    return [];
+  }
   // TODO(vicb): removed in TS 2.2
-  getJsDocTags(): any[] { return []; }
+  getJsDocTags(): any[] {
+    return [];
+  }
 
-  static of (name: string): MockSymbol { return new MockSymbol(name); }
+  static of(name: string): MockSymbol {
+    return new MockSymbol(name);
+  }
 }
 
 export function expectNoDiagnostics(diagnostics: ts.Diagnostic[]) {
@@ -219,14 +273,14 @@ export function findVar(sourceFile: ts.SourceFile, name: string): ts.VariableDec
 export function findVarInitializer(sourceFile: ts.SourceFile, name: string): ts.Expression {
   const v = findVar(sourceFile, name);
   expect(v && v.initializer).toBeDefined();
-  return v !.initializer !;
+  return v!.initializer!;
 }
 
 export function isClass(node: ts.Node): node is ts.ClassDeclaration {
   return node.kind === ts.SyntaxKind.ClassDeclaration;
 }
 
-export function isNamed(node: ts.Node | undefined, name: string): node is ts.Identifier {
+export function isNamed(node: ts.Node|undefined, name: string): node is ts.Identifier {
   return !!node && node.kind === ts.SyntaxKind.Identifier && (<ts.Identifier>node).text === name;
 }
 

--- a/packages/compiler-cli/test/mocks.ts
+++ b/packages/compiler-cli/test/mocks.ts
@@ -8,16 +8,22 @@
 
 import * as ts from 'typescript';
 
-export type Entry = string | Directory;
+export type Entry = string|Directory;
 
-export interface Directory { [name: string]: Entry; }
+export interface Directory {
+  [name: string]: Entry;
+}
 
 export class MockAotContext {
   private files: Entry[];
 
-  constructor(public currentDirectory: string, ...files: Entry[]) { this.files = files; }
+  constructor(public currentDirectory: string, ...files: Entry[]) {
+    this.files = files;
+  }
 
-  fileExists(fileName: string): boolean { return typeof this.getEntry(fileName) === 'string'; }
+  fileExists(fileName: string): boolean {
+    return typeof this.getEntry(fileName) === 'string';
+  }
 
   directoryExists(path: string): boolean {
     return path === this.currentDirectory || typeof this.getEntry(path) === 'object';
@@ -28,7 +34,7 @@ export class MockAotContext {
     if (typeof data === 'string') {
       return data;
     }
-    return undefined !;
+    return undefined!;
   }
 
   readResource(fileName: string): Promise<string> {
@@ -41,14 +47,16 @@ export class MockAotContext {
 
   writeFile(fileName: string, data: string): void {
     const parts = fileName.split('/');
-    const name = parts.pop() !;
+    const name = parts.pop()!;
     const entry = this.getEntry(parts);
     if (entry && typeof entry !== 'string') {
       entry[name] = data;
     }
   }
 
-  assumeFileExists(fileName: string): void { this.writeFile(fileName, ''); }
+  assumeFileExists(fileName: string): void {
+    this.writeFile(fileName, '');
+  }
 
   getEntry(fileName: string|string[]): Entry|undefined {
     let parts = typeof fileName === 'string' ? fileName.split('/') : fileName;
@@ -69,7 +77,9 @@ export class MockAotContext {
     }
   }
 
-  override(files: Entry) { return new MockAotContext(this.currentDirectory, files, ...this.files); }
+  override(files: Entry) {
+    return new MockAotContext(this.currentDirectory, files, ...this.files);
+  }
 }
 
 function first<T>(a: T[], cb: (value: T) => T | undefined): T|undefined {
@@ -82,7 +92,7 @@ function first<T>(a: T[], cb: (value: T) => T | undefined): T|undefined {
 function getEntryFromFiles(parts: string[], files: Entry) {
   let current = files;
   while (parts.length) {
-    const part = parts.shift() !;
+    const part = parts.shift()!;
     if (typeof current === 'string') {
       return undefined;
     }
@@ -98,7 +108,7 @@ function getEntryFromFiles(parts: string[], files: Entry) {
 function normalize(parts: string[]): string[] {
   const result: string[] = [];
   while (parts.length) {
-    const part = parts.shift() !;
+    const part = parts.shift()!;
     switch (part) {
       case '.':
         break;
@@ -115,9 +125,13 @@ function normalize(parts: string[]): string[] {
 export class MockCompilerHost implements ts.CompilerHost {
   constructor(private context: MockAotContext) {}
 
-  fileExists(fileName: string): boolean { return this.context.fileExists(fileName); }
+  fileExists(fileName: string): boolean {
+    return this.context.fileExists(fileName);
+  }
 
-  readFile(fileName: string): string { return this.context.readFile(fileName); }
+  readFile(fileName: string): string {
+    return this.context.readFile(fileName);
+  }
 
   directoryExists(directoryName: string): boolean {
     return this.context.directoryExists(directoryName);
@@ -130,7 +144,7 @@ export class MockCompilerHost implements ts.CompilerHost {
     if (sourceText != null) {
       return ts.createSourceFile(fileName, sourceText, languageVersion);
     } else {
-      return undefined !;
+      return undefined!;
     }
   }
 
@@ -138,15 +152,28 @@ export class MockCompilerHost implements ts.CompilerHost {
     return ts.getDefaultLibFileName(options);
   }
 
-  writeFile: ts.WriteFileCallback = (fileName, text) => { this.context.writeFile(fileName, text); };
+  writeFile: ts.WriteFileCallback =
+      (fileName, text) => {
+        this.context.writeFile(fileName, text);
+      }
 
-  getCurrentDirectory(): string { return this.context.currentDirectory; }
+  getCurrentDirectory(): string {
+    return this.context.currentDirectory;
+  }
 
-  getCanonicalFileName(fileName: string): string { return fileName; }
+  getCanonicalFileName(fileName: string): string {
+    return fileName;
+  }
 
-  useCaseSensitiveFileNames(): boolean { return false; }
+  useCaseSensitiveFileNames(): boolean {
+    return false;
+  }
 
-  getNewLine(): string { return '\n'; }
+  getNewLine(): string {
+    return '\n';
+  }
 
-  getDirectories(path: string): string[] { return this.context.getDirectories(path); }
+  getDirectories(path: string): string[] {
+    return this.context.getDirectories(path);
+  }
 }

--- a/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
@@ -14,7 +14,7 @@ import {NgtscTestEnvironment} from './env';
 
 runInEachFileSystem(() => {
   describe('ngtsc component indexing', () => {
-    let env !: NgtscTestEnvironment;
+    let env!: NgtscTestEnvironment;
     let testSourceFile: AbsoluteFsPath;
     let testTemplateFile: AbsoluteFsPath;
 
@@ -177,10 +177,10 @@ runInEachFileSystem(() => {
         expect(testComp).toBeDefined();
         expect(testImportComp).toBeDefined();
 
-        expect(testComp !.template.usedComponents.size).toBe(0);
-        expect(testImportComp !.template.usedComponents.size).toBe(1);
+        expect(testComp!.template.usedComponents.size).toBe(0);
+        expect(testImportComp!.template.usedComponents.size).toBe(1);
 
-        const [usedComp] = Array.from(testImportComp !.template.usedComponents);
+        const [usedComp] = Array.from(testImportComp!.template.usedComponents);
         expect(indexed.get(usedComp)).toEqual(testComp);
       });
     });

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CustomTransformers, Program, defaultGatherDiagnostics} from '@angular/compiler-cli';
+import {CustomTransformers, defaultGatherDiagnostics, Program} from '@angular/compiler-cli';
 import * as api from '@angular/compiler-cli/src/transformers/api';
 import * as ts from 'typescript';
 
 import {createCompilerHost, createProgram} from '../../index';
 import {main, mainDiagnosticsForTest, readNgcCommandLineAndConfiguration} from '../../src/main';
-import {AbsoluteFsPath, FileSystem, NgtscCompilerHost, absoluteFrom, getFileSystem} from '../../src/ngtsc/file_system';
+import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, NgtscCompilerHost} from '../../src/ngtsc/file_system';
 import {Folder, MockFileSystem} from '../../src/ngtsc/file_system/testing';
 import {IndexedComponent} from '../../src/ngtsc/indexer';
 import {NgtscProgram} from '../../src/ngtsc/program';
@@ -115,7 +115,7 @@ export class NgtscTestEnvironment {
     if (this.multiCompileHostExt === null) {
       throw new Error(`Not tracking written files - call enableMultipleCompilations()`);
     }
-    this.changedResources !.clear();
+    this.changedResources!.clear();
     this.multiCompileHostExt.flushWrittenFileTracking();
   }
 
@@ -123,7 +123,9 @@ export class NgtscTestEnvironment {
    * Older versions of the CLI do not provide the `CompilerHost.getModifiedResourceFiles()` method.
    * This results in the `changedResources` set being `null`.
    */
-  simulateLegacyCLICompilerHost() { this.changedResources = null; }
+  simulateLegacyCLICompilerHost() {
+    this.changedResources = null;
+  }
 
   getFilesWrittenSinceLastFlush(): Set<string> {
     if (this.multiCompileHostExt === null) {
@@ -142,7 +144,7 @@ export class NgtscTestEnvironment {
     const absFilePath = this.fs.resolve(this.basePath, fileName);
     if (this.multiCompileHostExt !== null) {
       this.multiCompileHostExt.invalidate(absFilePath);
-      this.changedResources !.add(absFilePath);
+      this.changedResources!.add(absFilePath);
     }
     this.fs.ensureDir(this.fs.dirname(absFilePath));
     this.fs.writeFile(absFilePath, content);
@@ -156,8 +158,7 @@ export class NgtscTestEnvironment {
     this.multiCompileHostExt.invalidate(absFilePath);
   }
 
-  tsconfig(extraOpts: {[key: string]: string | boolean | null} = {}, extraRootDirs?: string[]):
-      void {
+  tsconfig(extraOpts: {[key: string]: string|boolean|null} = {}, extraRootDirs?: string[]): void {
     const tsconfig: {[key: string]: any} = {
       extends: './tsconfig-base.json',
       angularCompilerOptions: {...extraOpts, enableIvy: true},
@@ -179,7 +180,7 @@ export class NgtscTestEnvironment {
    */
   driveMain(customTransformers?: CustomTransformers): void {
     const errorSpy = jasmine.createSpy('consoleError').and.callFake(console.error);
-    let reuseProgram: {program: Program | undefined}|undefined = undefined;
+    let reuseProgram: {program: Program|undefined}|undefined = undefined;
     if (this.multiCompileHostExt !== null) {
       reuseProgram = {
         program: this.oldProgram || undefined,
@@ -191,7 +192,7 @@ export class NgtscTestEnvironment {
     expect(errorSpy).not.toHaveBeenCalled();
     expect(exitCode).toBe(0);
     if (this.multiCompileHostExt !== null) {
-      this.oldProgram = reuseProgram !.program !;
+      this.oldProgram = reuseProgram!.program!;
     }
   }
 
@@ -200,7 +201,7 @@ export class NgtscTestEnvironment {
    */
   driveDiagnostics(): ReadonlyArray<ts.Diagnostic> {
     // ngtsc only produces ts.Diagnostic messages.
-    let reuseProgram: {program: Program | undefined}|undefined = undefined;
+    let reuseProgram: {program: Program|undefined}|undefined = undefined;
     if (this.multiCompileHostExt !== null) {
       reuseProgram = {
         program: this.oldProgram || undefined,
@@ -212,7 +213,7 @@ export class NgtscTestEnvironment {
 
 
     if (this.multiCompileHostExt !== null) {
-      this.oldProgram = reuseProgram !.program !;
+      this.oldProgram = reuseProgram!.program!;
     }
 
     // In ngtsc, only `ts.Diagnostic`s are produced.
@@ -245,7 +246,7 @@ export class NgtscTestEnvironment {
 }
 
 class AugmentedCompilerHost extends NgtscCompilerHost {
-  delegate !: ts.CompilerHost;
+  delegate!: ts.CompilerHost;
 }
 
 const ROOT_PREFIX = 'root/';
@@ -283,7 +284,7 @@ class MultiCompileHostExt extends AugmentedCompilerHost implements Partial<ts.Co
       fileName: string, languageVersion: ts.ScriptTarget, onError?: (message: string) => void,
       shouldCreateNewSourceFile?: boolean): ts.SourceFile|undefined {
     if (this.cache.has(fileName)) {
-      return this.cache.get(fileName) !;
+      return this.cache.get(fileName)!;
     }
     const sf = super.getSourceFile(fileName, languageVersion);
     if (sf !== undefined) {
@@ -292,7 +293,9 @@ class MultiCompileHostExt extends AugmentedCompilerHost implements Partial<ts.Co
     return sf;
   }
 
-  flushWrittenFileTracking(): void { this.writtenFiles.clear(); }
+  flushWrittenFileTracking(): void {
+    this.writtenFiles.clear();
+  }
 
   writeFile(
       fileName: string, data: string, writeByteOrderMark: boolean,
@@ -302,9 +305,13 @@ class MultiCompileHostExt extends AugmentedCompilerHost implements Partial<ts.Co
     this.writtenFiles.add(fileName);
   }
 
-  getFilesWrittenSinceLastFlush(): Set<string> { return this.writtenFiles; }
+  getFilesWrittenSinceLastFlush(): Set<string> {
+    return this.writtenFiles;
+  }
 
-  invalidate(fileName: string): void { this.cache.delete(fileName); }
+  invalidate(fileName: string): void {
+    this.cache.delete(fileName);
+  }
 }
 
 class ResourceLoadingCompileHost extends AugmentedCompilerHost implements api.CompilerHost {
@@ -323,7 +330,7 @@ function makeWrapHost(wrapped: AugmentedCompilerHost): (host: ts.CompilerHost) =
     return new Proxy(delegate, {
       get: (target: ts.CompilerHost, name: string): any => {
         if ((wrapped as any)[name] !== undefined) {
-          return (wrapped as any)[name] !.bind(wrapped);
+          return (wrapped as any)[name]!.bind(wrapped);
         }
         return (target as any)[name];
       }

--- a/packages/compiler-cli/test/ngtsc/fake_core/index.ts
+++ b/packages/compiler-cli/test/ngtsc/fake_core/index.ts
@@ -8,19 +8,19 @@
 
 interface FnWithArg<T> {
   (...args: any[]): T;
-  new (...args: any[]): T;
+  new(...args: any[]): T;
 }
 
 function callableClassDecorator(): FnWithArg<(clazz: any) => any> {
-  return null !;
+  return null!;
 }
 
 function callableParamDecorator(): FnWithArg<(a: any, b: any, c: any) => void> {
-  return null !;
+  return null!;
 }
 
 function callablePropDecorator(): FnWithArg<(a: any, b: any) => any> {
-  return null !;
+  return null!;
 }
 
 export const Component = callableClassDecorator();
@@ -66,7 +66,9 @@ export function forwardRef<T>(fn: () => T): T {
   return fn();
 }
 
-export interface SimpleChanges { [propName: string]: any; }
+export interface SimpleChanges {
+  [propName: string]: any;
+}
 
 export type ɵɵNgModuleDefWithMeta<ModuleT, DeclarationsT, ImportsT, ExportsT> = any;
 export type ɵɵDirectiveDefWithMeta<
@@ -89,11 +91,15 @@ export const CUSTOM_ELEMENTS_SCHEMA: any = false;
 export const NO_ERRORS_SCHEMA: any = false;
 
 export class EventEmitter<T> {
-  subscribe(generatorOrNext?: any, error?: any, complete?: any): unknown { return null; }
+  subscribe(generatorOrNext?: any, error?: any, complete?: any): unknown {
+    return null;
+  }
 }
 
-export interface QueryList<T>/* implements Iterable<T> */ { [Symbol.iterator]: () => Iterator<T>; }
+export interface QueryList<T>/* implements Iterable<T> */ {
+  [Symbol.iterator]: () => Iterator<T>;
+}
 
-export type NgIterable<T> = Array<T>| Iterable<T>;
+export type NgIterable<T> = Array<T>|Iterable<T>;
 
 export class NgZone {}

--- a/packages/compiler-cli/test/ngtsc/incremental_error_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/incremental_error_spec.ts
@@ -16,7 +16,7 @@ const testFiles = loadStandardTestFiles();
 
 runInEachFileSystem(() => {
   describe('ngtsc incremental compilation with errors', () => {
-    let env !: NgtscTestEnvironment;
+    let env!: NgtscTestEnvironment;
 
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);
@@ -66,7 +66,7 @@ runInEachFileSystem(() => {
       `);
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].file !.fileName).toBe(_('/other.ts'));
+      expect(diags[0].file!.fileName).toBe(_('/other.ts'));
       expectToHaveWritten([]);
 
       // Remove the error. /other.js should now be emitted again.
@@ -92,7 +92,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].file !.fileName).toBe(_('/other.ts'));
+      expect(diags[0].file!.fileName).toBe(_('/other.ts'));
       expectToHaveWritten([]);
 
       // Remove the error. All files should be emitted.
@@ -128,7 +128,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].file !.fileName).toBe(_('/other.ts'));
+      expect(diags[0].file!.fileName).toBe(_('/other.ts'));
       expectToHaveWritten([]);
 
       // Remove the error. All files should be emitted.
@@ -175,7 +175,7 @@ runInEachFileSystem(() => {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].file !.fileName).toBe(_('/other.ts'));
+      expect(diags[0].file!.fileName).toBe(_('/other.ts'));
       expectToHaveWritten([]);
 
       // Remove the error. All files should be emitted.

--- a/packages/compiler-cli/test/ngtsc/incremental_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/incremental_spec.ts
@@ -15,7 +15,7 @@ const testFiles = loadStandardTestFiles();
 
 runInEachFileSystem(() => {
   describe('ngtsc incremental compilation', () => {
-    let env !: NgtscTestEnvironment;
+    let env!: NgtscTestEnvironment;
 
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);

--- a/packages/compiler-cli/test/ngtsc/modulewithproviders_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/modulewithproviders_spec.ts
@@ -17,7 +17,7 @@ const testFiles = loadStandardTestFiles();
 
 runInEachFileSystem(() => {
   describe('ModuleWithProviders generic type transform', () => {
-    let env !: NgtscTestEnvironment;
+    let env!: NgtscTestEnvironment;
 
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);

--- a/packages/compiler-cli/test/ngtsc/monorepo_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/monorepo_spec.ts
@@ -16,7 +16,7 @@ const testFiles = loadStandardTestFiles();
 
 runInEachFileSystem(() => {
   describe('monorepos', () => {
-    let env !: NgtscTestEnvironment;
+    let env!: NgtscTestEnvironment;
 
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles, absoluteFrom('/app'));

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -38,12 +38,12 @@ const setClassMetadataRegExp = (expectedType: string): RegExp =>
 const testFiles = loadStandardTestFiles();
 
 function getDiagnosticSourceCode(diag: ts.Diagnostic): string {
-  return diag.file !.text.substr(diag.start !, diag.length !);
+  return diag.file!.text.substr(diag.start!, diag.length!);
 }
 
 runInEachFileSystem(os => {
   describe('ngtsc behavioral tests', () => {
-    let env !: NgtscTestEnvironment;
+    let env!: NgtscTestEnvironment;
 
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);
@@ -369,7 +369,6 @@ runInEachFileSystem(os => {
     // that start with `C:`.
     if (os !== 'Windows' || platform() === 'win32') {
       describe('when closure annotations are requested', () => {
-
         it('should add @nocollapse to static fields', () => {
           env.tsconfig({
             'annotateForClosureCompiler': true,
@@ -531,7 +530,6 @@ runInEachFileSystem(os => {
             verifyOutput(env.getContents('test.js'));
           });
         });
-
       });
     }
 
@@ -1714,7 +1712,8 @@ runInEachFileSystem(os => {
       });
 
       ['ContentChild', 'ContentChildren'].forEach(decorator => {
-        it(`should throw if \`descendants\` field of @${decorator}'s options argument has wrong type`,
+        it(`should throw if \`descendants\` field of @${
+               decorator}'s options argument has wrong type`,
            () => {
              env.tsconfig({});
              env.write('test.ts', `
@@ -2148,7 +2147,6 @@ runInEachFileSystem(os => {
              expect(jsContents)
                  .toContain('Test.ɵfac = function Test_Factory(t) { i0.ɵɵinvalidFactory()');
            });
-
       });
     });
 
@@ -3466,7 +3464,9 @@ runInEachFileSystem(os => {
     });
 
     describe('ngfactory shims', () => {
-      beforeEach(() => { env.tsconfig({'generateNgFactoryShims': true}); });
+      beforeEach(() => {
+        env.tsconfig({'generateNgFactoryShims': true});
+      });
 
       it('should generate correct type annotation for NgModuleFactory calls in ngfactories', () => {
         env.write('test.ts', `
@@ -3568,7 +3568,9 @@ runInEachFileSystem(os => {
 
 
     describe('ngsummary shim generation', () => {
-      beforeEach(() => { env.tsconfig({'generateNgSummaryShims': true}); });
+      beforeEach(() => {
+        env.tsconfig({'generateNgSummaryShims': true});
+      });
 
       it('should generate a summary stub for decorated classes in the input file only', () => {
         env.write('test.ts', `
@@ -3792,7 +3794,6 @@ runInEachFileSystem(os => {
     });
 
     it('should use imported types in setClassMetadata if they can be represented as values', () => {
-
       env.write(`types.ts`, `
       export class MyTypeA {}
       export class MyTypeB {}
@@ -3824,7 +3825,6 @@ runInEachFileSystem(os => {
 
     it('should use imported types in setClassMetadata if they can be represented as values and imported as `* as foo`',
        () => {
-
          env.write(`types.ts`, `
          export class MyTypeA {}
          export class MyTypeB {}
@@ -3855,7 +3855,6 @@ runInEachFileSystem(os => {
        });
 
     it('should use default-imported types if they can be represented as values', () => {
-
       env.write(`types.ts`, `
             export default class Default {}
             export class Other {}
@@ -3883,7 +3882,6 @@ runInEachFileSystem(os => {
 
     it('should use `undefined` in setClassMetadata if types can\'t be represented as values',
        () => {
-
          env.write(`types.ts`, `
       export type MyType = Map<any, any>;
     `);
@@ -4059,7 +4057,6 @@ runInEachFileSystem(os => {
       it('should not generate an error when a local ref is unresolved' +
              ' (outside of template type-checking)',
          () => {
-
            env.write('test.ts', `
           import {Component} from '@angular/core';
 
@@ -4347,7 +4344,7 @@ runInEachFileSystem(os => {
           }
         });
 
-        it('should throw if @Component is missing a template', async() => {
+        it('should throw if @Component is missing a template', async () => {
           env.write('test.ts', `
             import {Component} from '@angular/core';
 
@@ -4359,10 +4356,10 @@ runInEachFileSystem(os => {
 
           const diags = await driveDiagnostics();
           expect(diags[0].messageText).toBe('component is missing a template');
-          expect(diags[0].file !.fileName).toBe(absoluteFrom('/test.ts'));
+          expect(diags[0].file!.fileName).toBe(absoluteFrom('/test.ts'));
         });
 
-        it('should throw if `styleUrls` is defined incorrectly in @Component', async() => {
+        it('should throw if `styleUrls` is defined incorrectly in @Component', async () => {
           env.write('test.ts', `
             import {Component} from '@angular/core';
 
@@ -4376,7 +4373,7 @@ runInEachFileSystem(os => {
 
           const diags = await driveDiagnostics();
           expect(diags[0].messageText).toBe('styleUrls must be an array of strings');
-          expect(diags[0].file !.fileName).toBe(absoluteFrom('/test.ts'));
+          expect(diags[0].file!.fileName).toBe(absoluteFrom('/test.ts'));
         });
       });
     });
@@ -4497,7 +4494,7 @@ runInEachFileSystem(os => {
 
         // Verify that the error is for the correct class.
         const error = errors[0] as ts.Diagnostic;
-        const id = expectTokenAtPosition(error.file !, error.start !, ts.isIdentifier);
+        const id = expectTokenAtPosition(error.file!, error.start!, ts.isIdentifier);
         expect(id.text).toBe('Dir');
         expect(ts.isClassDeclaration(id.parent)).toBe(true);
       });
@@ -4804,7 +4801,7 @@ runInEachFileSystem(os => {
 
            const diag = env.driveDiagnostics();
            expect(diag.length).toBe(1);
-           expect(diag[0] !.code).toEqual(ngErrorCode(ErrorCode.NGMODULE_REEXPORT_NAME_COLLISION));
+           expect(diag[0]!.code).toEqual(ngErrorCode(ErrorCode.NGMODULE_REEXPORT_NAME_COLLISION));
          });
 
       it('should not error when two directives with the same declared name are exported from the same NgModule, but one is exported from the file directly',
@@ -6701,9 +6698,7 @@ export const Foo = Foo__PRE_R3__;
            const diags = env.driveDiagnostics();
            expect(diags.length).toBe(0);
          });
-
     });
-
   });
 
   function expectTokenAtPosition<T extends ts.Node>(
@@ -6714,5 +6709,7 @@ export const Foo = Foo__PRE_R3__;
     return node as T;
   }
 
-  function normalize(input: string): string { return input.replace(/\s+/g, ' ').trim(); }
+  function normalize(input: string): string {
+    return input.replace(/\s+/g, ' ').trim();
+  }
 });

--- a/packages/compiler-cli/test/ngtsc/scope_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/scope_spec.ts
@@ -20,7 +20,7 @@ const testFiles = loadStandardTestFiles();
 
 runInEachFileSystem(() => {
   describe('ngtsc module scopes', () => {
-    let env !: NgtscTestEnvironment;
+    let env!: NgtscTestEnvironment;
 
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);
@@ -92,11 +92,11 @@ runInEachFileSystem(() => {
           const diags = env.driveDiagnostics();
           expect(diags.length).toBe(1);
           const node = findContainingClass(diagnosticToNode(diags[0], ts.isIdentifier));
-          expect(node.name !.text).toEqual('TestDir');
+          expect(node.name!.text).toEqual('TestDir');
 
-          const relatedNodes = new Set(diags[0].relatedInformation !.map(
+          const relatedNodes = new Set(diags[0].relatedInformation!.map(
               related =>
-                  findContainingClass(diagnosticToNode(related, ts.isIdentifier)).name !.text));
+                  findContainingClass(diagnosticToNode(related, ts.isIdentifier)).name!.text));
           expect(relatedNodes).toContain('ModuleA');
           expect(relatedNodes).toContain('ModuleB');
           expect(relatedNodes.size).toBe(2);
@@ -141,11 +141,11 @@ runInEachFileSystem(() => {
              const diags = env.driveDiagnostics();
              expect(diags.length).toBe(1);
              const node = findContainingClass(diagnosticToNode(diags[0], ts.isIdentifier));
-             expect(node.name !.text).toEqual('TestDir');
+             expect(node.name!.text).toEqual('TestDir');
 
-             const relatedNodes = new Set(diags[0].relatedInformation !.map(
+             const relatedNodes = new Set(diags[0].relatedInformation!.map(
                  related =>
-                     findContainingClass(diagnosticToNode(related, ts.isIdentifier)).name !.text));
+                     findContainingClass(diagnosticToNode(related, ts.isIdentifier)).name!.text));
              expect(relatedNodes).toContain('ModuleA');
              expect(relatedNodes).toContain('ModuleB');
              expect(relatedNodes.size).toBe(2);
@@ -386,13 +386,13 @@ runInEachFileSystem(() => {
   });
 
   function diagnosticToNode<T extends ts.Node>(
-      diagnostic: ts.Diagnostic | Diagnostic | ts.DiagnosticRelatedInformation,
+      diagnostic: ts.Diagnostic|Diagnostic|ts.DiagnosticRelatedInformation,
       guard: (node: ts.Node) => node is T): T {
     const diag = diagnostic as ts.Diagnostic | ts.DiagnosticRelatedInformation;
     if (diag.file === undefined) {
       throw new Error(`Expected ts.Diagnostic to have a file source`);
     }
-    const node = getTokenAtPosition(diag.file, diag.start !);
+    const node = getTokenAtPosition(diag.file, diag.start!);
     expect(guard(node)).toBe(true);
     return node as T;
   }

--- a/packages/compiler-cli/test/ngtsc/sourcemap_utils.ts
+++ b/packages/compiler-cli/test/ngtsc/sourcemap_utils.ts
@@ -85,7 +85,7 @@ export function getMappedSegments(
   while (currentMapping) {
     const nextMapping = mappings.shift();
     if (nextMapping) {
-      const source = sources.get(currentMapping.source) !;
+      const source = sources.get(currentMapping.source)!;
       const segment = {
         generated: generated.getSegment('generated', currentMapping, nextMapping),
         source: source.getSegment('original', currentMapping, nextMapping),

--- a/packages/compiler-cli/test/ngtsc/template_mapping_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_mapping_spec.ts
@@ -14,13 +14,13 @@ import {tsSourceMapBug29300Fixed} from '../../src/ngtsc/util/src/ts_source_map_b
 import {loadStandardTestFiles} from '../helpers/src/mock_file_loading';
 
 import {NgtscTestEnvironment} from './env';
-import {SegmentMapping, getMappedSegments} from './sourcemap_utils';
+import {getMappedSegments, SegmentMapping} from './sourcemap_utils';
 
 const testFiles = loadStandardTestFiles();
 
 runInEachFileSystem((os) => {
   describe('template source-mapping', () => {
-    let env !: NgtscTestEnvironment;
+    let env!: NgtscTestEnvironment;
 
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);
@@ -323,7 +323,6 @@ runInEachFileSystem((os) => {
 
           expect(mappings).toContain(
               {source: '</div>', generated: 'i0.ɵɵelementEnd()', sourceUrl: '../test.ts'});
-
         });
 
         it('should map ng-template [ngFor] scenario', () => {
@@ -518,7 +517,7 @@ runInEachFileSystem((os) => {
       });
     }
 
-    function compileAndMap(template: string, templateUrl: string | null = null) {
+    function compileAndMap(template: string, templateUrl: string|null = null) {
       const templateConfig = templateUrl ? `templateUrl: '${templateUrl}'` :
                                            ('template: `' + template.replace(/`/g, '\\`') + '`');
       env.tsconfig({sourceMap: true});

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -19,7 +19,7 @@ const testFiles = loadStandardTestFiles();
 
 runInEachFileSystem(() => {
   describe('ngtsc type checking', () => {
-    let env !: NgtscTestEnvironment;
+    let env!: NgtscTestEnvironment;
 
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);
@@ -1502,8 +1502,9 @@ export declare class AnimationEvent {
     });
 
     describe('legacy schema checking with the DOM schema', () => {
-      beforeEach(
-          () => { env.tsconfig({ivyTemplateTypeCheck: true, fullTemplateTypeCheck: false}); });
+      beforeEach(() => {
+        env.tsconfig({ivyTemplateTypeCheck: true, fullTemplateTypeCheck: false});
+      });
 
       it('should check for unknown elements', () => {
         env.write('test.ts', `
@@ -1734,7 +1735,7 @@ export declare class AnimationEvent {
           }
         });
 
-        it('should be correct for direct templates', async() => {
+        it('should be correct for direct templates', async () => {
           env.write('test.ts', `
           import {Component, NgModule} from '@angular/core';
 
@@ -1750,11 +1751,11 @@ export declare class AnimationEvent {
 
           const diags = await driveDiagnostics();
           expect(diags.length).toBe(1);
-          expect(diags[0].file !.fileName).toBe(_('/test.ts'));
+          expect(diags[0].file!.fileName).toBe(_('/test.ts'));
           expect(getSourceCodeForDiagnostic(diags[0])).toBe('user.does_not_exist');
         });
 
-        it('should be correct for indirect templates', async() => {
+        it('should be correct for indirect templates', async () => {
           env.write('test.ts', `
           import {Component, NgModule} from '@angular/core';
 
@@ -1772,12 +1773,12 @@ export declare class AnimationEvent {
 
           const diags = await driveDiagnostics();
           expect(diags.length).toBe(1);
-          expect(diags[0].file !.fileName).toBe(_('/test.ts') + ' (TestCmp template)');
+          expect(diags[0].file!.fileName).toBe(_('/test.ts') + ' (TestCmp template)');
           expect(getSourceCodeForDiagnostic(diags[0])).toBe('user.does_not_exist');
-          expect(getSourceCodeForDiagnostic(diags[0].relatedInformation ![0])).toBe('TEMPLATE');
+          expect(getSourceCodeForDiagnostic(diags[0].relatedInformation![0])).toBe('TEMPLATE');
         });
 
-        it('should be correct for external templates', async() => {
+        it('should be correct for external templates', async () => {
           env.write('template.html', `<p>
           {{user.does_not_exist}}
         </p>`);
@@ -1795,9 +1796,9 @@ export declare class AnimationEvent {
 
           const diags = await driveDiagnostics();
           expect(diags.length).toBe(1);
-          expect(diags[0].file !.fileName).toBe(_('/template.html'));
+          expect(diags[0].file!.fileName).toBe(_('/template.html'));
           expect(getSourceCodeForDiagnostic(diags[0])).toBe('user.does_not_exist');
-          expect(getSourceCodeForDiagnostic(diags[0].relatedInformation ![0]))
+          expect(getSourceCodeForDiagnostic(diags[0].relatedInformation![0]))
               .toBe(`'./template.html'`);
         });
       });
@@ -1841,6 +1842,6 @@ export declare class AnimationEvent {
 });
 
 function getSourceCodeForDiagnostic(diag: ts.Diagnostic): string {
-  const text = diag.file !.text;
-  return text.substr(diag.start !, diag.length !);
+  const text = diag.file!.text;
+  return text.substr(diag.start!, diag.length!);
 }

--- a/packages/compiler-cli/test/perform_compile_spec.ts
+++ b/packages/compiler-cli/test/perform_compile_spec.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 
 import {readConfiguration} from '../src/perform_compile';
 
-import {TestSupport, setup} from './test_support';
+import {setup, TestSupport} from './test_support';
 
 describe('perform_compile', () => {
   let support: TestSupport;

--- a/packages/compiler-cli/test/perform_watch_spec.ts
+++ b/packages/compiler-cli/test/perform_watch_spec.ts
@@ -14,7 +14,7 @@ import * as ts from 'typescript';
 import * as ng from '../index';
 import {FileChangeEvent, performWatchCompilation} from '../src/perform_watch';
 
-import {TestSupport, expectNoDiagnostics, setup} from './test_support';
+import {expectNoDiagnostics, setup, TestSupport} from './test_support';
 
 describe('perform watch', () => {
   let testSupport: TestSupport;
@@ -105,23 +105,23 @@ describe('perform watch', () => {
 
     performWatchCompilation(host);
     expect(fs.existsSync(mainNgFactory)).toBe(true);
-    expect(fileExistsSpy !).toHaveBeenCalledWith(mainTsPath);
-    expect(fileExistsSpy !).toHaveBeenCalledWith(utilTsPath);
-    expect(getSourceFileSpy !).toHaveBeenCalledWith(mainTsPath, ts.ScriptTarget.ES5);
-    expect(getSourceFileSpy !).toHaveBeenCalledWith(utilTsPath, ts.ScriptTarget.ES5);
+    expect(fileExistsSpy!).toHaveBeenCalledWith(mainTsPath);
+    expect(fileExistsSpy!).toHaveBeenCalledWith(utilTsPath);
+    expect(getSourceFileSpy!).toHaveBeenCalledWith(mainTsPath, ts.ScriptTarget.ES5);
+    expect(getSourceFileSpy!).toHaveBeenCalledWith(utilTsPath, ts.ScriptTarget.ES5);
 
-    fileExistsSpy !.calls.reset();
-    getSourceFileSpy !.calls.reset();
+    fileExistsSpy!.calls.reset();
+    getSourceFileSpy!.calls.reset();
 
     // trigger a single file change
     // -> all other files should be cached
     host.triggerFileChange(FileChangeEvent.Change, utilTsPath);
     expectNoDiagnostics(config.options, host.diagnostics);
 
-    expect(fileExistsSpy !).not.toHaveBeenCalledWith(mainTsPath);
-    expect(fileExistsSpy !).toHaveBeenCalledWith(utilTsPath);
-    expect(getSourceFileSpy !).not.toHaveBeenCalledWith(mainTsPath, ts.ScriptTarget.ES5);
-    expect(getSourceFileSpy !).toHaveBeenCalledWith(utilTsPath, ts.ScriptTarget.ES5);
+    expect(fileExistsSpy!).not.toHaveBeenCalledWith(mainTsPath);
+    expect(fileExistsSpy!).toHaveBeenCalledWith(utilTsPath);
+    expect(getSourceFileSpy!).not.toHaveBeenCalledWith(mainTsPath, ts.ScriptTarget.ES5);
+    expect(getSourceFileSpy!).toHaveBeenCalledWith(utilTsPath, ts.ScriptTarget.ES5);
 
     // trigger a folder change
     // -> nothing should be cached
@@ -129,10 +129,10 @@ describe('perform watch', () => {
         FileChangeEvent.CreateDeleteDir, path.resolve(testSupport.basePath, 'src'));
     expectNoDiagnostics(config.options, host.diagnostics);
 
-    expect(fileExistsSpy !).toHaveBeenCalledWith(mainTsPath);
-    expect(fileExistsSpy !).toHaveBeenCalledWith(utilTsPath);
-    expect(getSourceFileSpy !).toHaveBeenCalledWith(mainTsPath, ts.ScriptTarget.ES5);
-    expect(getSourceFileSpy !).toHaveBeenCalledWith(utilTsPath, ts.ScriptTarget.ES5);
+    expect(fileExistsSpy!).toHaveBeenCalledWith(mainTsPath);
+    expect(fileExistsSpy!).toHaveBeenCalledWith(utilTsPath);
+    expect(getSourceFileSpy!).toHaveBeenCalledWith(mainTsPath, ts.ScriptTarget.ES5);
+    expect(getSourceFileSpy!).toHaveBeenCalledWith(utilTsPath, ts.ScriptTarget.ES5);
   });
 
   // https://github.com/angular/angular/pull/26036
@@ -239,10 +239,18 @@ class MockWatchHost {
   diagnostics: ng.Diagnostic[] = [];
   constructor(public config: ng.ParsedConfiguration) {}
 
-  reportDiagnostics(diags: ng.Diagnostics) { this.diagnostics.push(...(diags as ng.Diagnostic[])); }
-  readConfiguration() { return this.config; }
-  createCompilerHost(options: ng.CompilerOptions) { return ng.createCompilerHost({options}); }
-  createEmitCallback() { return undefined; }
+  reportDiagnostics(diags: ng.Diagnostics) {
+    this.diagnostics.push(...(diags as ng.Diagnostic[]));
+  }
+  readConfiguration() {
+    return this.config;
+  }
+  createCompilerHost(options: ng.CompilerOptions) {
+    return ng.createCompilerHost({options});
+  }
+  createEmitCallback() {
+    return undefined;
+  }
   onFileChange(
       options: ng.CompilerOptions, listener: (event: FileChangeEvent, fileName: string) => void,
       ready: () => void) {
@@ -258,7 +266,9 @@ class MockWatchHost {
     this.timeoutListeners[id] = callback;
     return id;
   }
-  clearTimeout(timeoutId: any): void { delete this.timeoutListeners[timeoutId]; }
+  clearTimeout(timeoutId: any): void {
+    delete this.timeoutListeners[timeoutId];
+  }
   flushTimeouts() {
     const listeners = this.timeoutListeners;
     this.timeoutListeners = {};

--- a/packages/compiler-cli/test/test_support.ts
+++ b/packages/compiler-cli/test/test_support.ts
@@ -15,7 +15,7 @@ import {NodeJSFileSystem, setFileSystem} from '../src/ngtsc/file_system';
 import {getAngularPackagesFromRunfiles, resolveNpmTreeArtifact} from '../test/helpers';
 
 // TEST_TMPDIR is always set by Bazel.
-const tmpdir = process.env.TEST_TMPDIR !;
+const tmpdir = process.env.TEST_TMPDIR!;
 
 export function makeTempDir(): string {
   let dir: string;
@@ -97,8 +97,11 @@ function createTestSupportFor(basePath: string) {
   }
 
   function writeFiles(...mockDirs: {[fileName: string]: string}[]) {
-    mockDirs.forEach(
-        (dir) => { Object.keys(dir).forEach((fileName) => { write(fileName, dir[fileName]); }); });
+    mockDirs.forEach((dir) => {
+      Object.keys(dir).forEach((fileName) => {
+        write(fileName, dir[fileName]);
+      });
+    });
   }
 
   function createCompilerOptions(overrideOptions: ng.CompilerOptions = {}): ng.CompilerOptions {

--- a/packages/compiler-cli/test/transformers/compiler_host_spec.ts
+++ b/packages/compiler-cli/test/transformers/compiler_host_spec.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 
 import {MetadataCollector} from '../../src/metadata/collector';
 import {CompilerHost, CompilerOptions, LibrarySummary} from '../../src/transformers/api';
-import {TsCompilerAotCompilerTypeCheckHostAdapter, createCompilerHost} from '../../src/transformers/compiler_host';
+import {createCompilerHost, TsCompilerAotCompilerTypeCheckHostAdapter} from '../../src/transformers/compiler_host';
 import {Directory, Entry, MockAotContext, MockCompilerHost} from '../mocks';
 
 const dummyModule = 'export let foo: any[];';
@@ -53,12 +53,15 @@ describe('NgCompilerHost', () => {
   } = {}) {
     return new TsCompilerAotCompilerTypeCheckHostAdapter(
         rootNames, options, ngHost, new MetadataCollector(), codeGenerator,
-        new Map(librarySummaries.map(entry => [entry.fileName, entry] as[string, LibrarySummary])));
+        new Map(
+            librarySummaries.map(entry => [entry.fileName, entry] as [string, LibrarySummary])));
   }
 
   describe('fileNameToModuleName', () => {
     let host: TsCompilerAotCompilerTypeCheckHostAdapter;
-    beforeEach(() => { host = createHost(); });
+    beforeEach(() => {
+      host = createHost();
+    });
 
     it('should use a package import when accessing a package from a source file', () => {
       expect(host.fileNameToModuleName('/tmp/node_modules/@angular/core.d.ts', '/tmp/main.ts'))
@@ -239,9 +242,8 @@ describe('NgCompilerHost', () => {
 
     it('should not get tripped on nested node_modules', () => {
       const genSf = generate('/tmp/node_modules/lib1/node_modules/lib2/thing', {
-        'tmp': {
-          'node_modules': {'lib1': {'node_modules': {'lib2': {'thing.ts': `// some content`}}}}
-        }
+        'tmp':
+            {'node_modules': {'lib1': {'node_modules': {'lib2': {'thing.ts': `// some content`}}}}}
       });
       expect(genSf.moduleName).toBe('lib2/thing.ngfactory');
     });
@@ -387,8 +389,9 @@ describe('NgCompilerHost', () => {
           () => host.updateGeneratedFile(new compiler.GeneratedFile(
               '/tmp/src/index.ts', '/tmp/src/index.ngfactory.ts',
               [new compiler.DeclareVarStmt(
-                  'x', new compiler.ExternalExpr(
-                           new compiler.ExternalReference('otherModule', 'aName')))])))
+                  'x',
+                  new compiler.ExternalExpr(
+                      new compiler.ExternalReference('otherModule', 'aName')))])))
           .toThrowError([
             `Illegal State: external references changed in /tmp/src/index.ngfactory.ts.`,
             `Old: aModule.`, `New: otherModule`

--- a/packages/compiler-cli/test/transformers/inline_resources_spec.ts
+++ b/packages/compiler-cli/test/transformers/inline_resources_spec.ts
@@ -8,8 +8,8 @@
 
 import * as ts from 'typescript';
 
-import {MetadataCollector, isClassMetadata} from '../../src/metadata/index';
-import {InlineResourcesMetadataTransformer, getInlineResourcesTransformFactory} from '../../src/transformers/inline_resources';
+import {isClassMetadata, MetadataCollector} from '../../src/metadata/index';
+import {getInlineResourcesTransformFactory, InlineResourcesMetadataTransformer} from '../../src/transformers/inline_resources';
 import {MetadataCache} from '../../src/transformers/metadata_cache';
 import {MockAotContext, MockCompilerHost} from '../mocks';
 

--- a/packages/compiler-cli/test/transformers/lower_expressions_spec.ts
+++ b/packages/compiler-cli/test/transformers/lower_expressions_spec.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 
 import {MetadataCollector, ModuleMetadata} from '../../src/metadata/index';
-import {LowerMetadataTransform, LoweringRequest, RequestLocationMap, getExpressionLoweringTransformFactory} from '../../src/transformers/lower_expressions';
+import {getExpressionLoweringTransformFactory, LoweringRequest, LowerMetadataTransform, RequestLocationMap} from '../../src/transformers/lower_expressions';
 import {MetadataCache} from '../../src/transformers/metadata_cache';
 import {Directory, MockAotContext, MockCompilerHost} from '../mocks';
 
@@ -196,14 +196,16 @@ function convert(annotatedSource: string) {
 
   const program = ts.createProgram(
       [fileName], {module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2017}, host);
-  const moduleSourceFile = program.getSourceFile(fileName) !;
+  const moduleSourceFile = program.getSourceFile(fileName)!;
   const transformers: ts.CustomTransformers = {
     before: [getExpressionLoweringTransformFactory(
         {
-          getRequests(sourceFile: ts.SourceFile): RequestLocationMap{
+          getRequests(sourceFile: ts.SourceFile): RequestLocationMap {
             if (sourceFile.fileName == moduleSourceFile.fileName) {
               return requests;
-            } else {return new Map();}
+            } else {
+              return new Map();
+            }
           }
         },
         program)]
@@ -254,6 +256,7 @@ function collect(annotatedSource: string) {
       'someName.ts', unannotatedSource, ts.ScriptTarget.Latest, /* setParentNodes */ true);
   return {
     metadata: cache.getMetadata(sourceFile),
-    requests: transformer.getRequests(sourceFile), annotations
+    requests: transformer.getRequests(sourceFile),
+    annotations
   };
 }

--- a/packages/compiler-cli/test/transformers/metadata_reader_spec.ts
+++ b/packages/compiler-cli/test/transformers/metadata_reader_spec.ts
@@ -23,10 +23,9 @@ describe('metadata reader', () => {
       readFile: (fileName) => context.readFile(fileName),
       getSourceFileMetadata: (fileName) => {
         const sourceText = context.readFile(fileName);
-        return sourceText != null ?
-            metadataCollector.getMetadata(
-                ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest)) :
-            undefined;
+        return sourceText != null ? metadataCollector.getMetadata(ts.createSourceFile(
+                                        fileName, sourceText, ts.ScriptTarget.Latest)) :
+                                    undefined;
       },
     };
   });
@@ -42,11 +41,13 @@ describe('metadata reader', () => {
     expect(readMetadata('node_modules/@angular/unused.d.ts', host)).toEqual([dummyMetadata]);
   });
 
-  it('should be able to read empty metadata ',
-     () => { expect(readMetadata('node_modules/@angular/empty.d.ts', host)).toEqual([]); });
+  it('should be able to read empty metadata ', () => {
+    expect(readMetadata('node_modules/@angular/empty.d.ts', host)).toEqual([]);
+  });
 
-  it('should return undefined for missing modules',
-     () => { expect(readMetadata('node_modules/@angular/missing.d.ts', host)).toBeUndefined(); });
+  it('should return undefined for missing modules', () => {
+    expect(readMetadata('node_modules/@angular/missing.d.ts', host)).toBeUndefined();
+  });
 
   it(`should add missing v${METADATA_VERSION} metadata from v1 metadata and .d.ts files`, () => {
     expect(readMetadata('metadata_versions/v1.d.ts', host)).toEqual([
@@ -117,8 +118,8 @@ const FILES: Entry = {
       'node_modules': {
         '@angular': {
           'core.d.ts': dummyModule,
-          'core.metadata.json':
-              `{"__symbolic":"module", "version": ${METADATA_VERSION}, "metadata": {"foo": {"__symbolic": "class"}}}`,
+          'core.metadata.json': `{"__symbolic":"module", "version": ${
+              METADATA_VERSION}, "metadata": {"foo": {"__symbolic": "class"}}}`,
           'router': {'index.d.ts': dummyModule, 'src': {'providers.d.ts': dummyModule}},
           'unused.d.ts': dummyModule,
           'empty.d.ts': 'export declare var a: string;',

--- a/packages/compiler-cli/test/transformers/program_spec.ts
+++ b/packages/compiler-cli/test/transformers/program_spec.ts
@@ -10,11 +10,12 @@ import * as ng from '@angular/compiler-cli';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
+
 import {formatDiagnostics} from '../../src/perform_compile';
 import {CompilerHost, EmitFlags, LazyRoute} from '../../src/transformers/api';
 import {createSrcToOutPathMapper} from '../../src/transformers/program';
 import {StructureIsReused, tsStructureIsReused} from '../../src/transformers/util';
-import {TestSupport, expectNoDiagnosticsInProgram, setup, stripAnsi} from '../test_support';
+import {expectNoDiagnosticsInProgram, setup, stripAnsi, TestSupport} from '../test_support';
 
 describe('ng program', () => {
   let testSupport: TestSupport;
@@ -83,21 +84,21 @@ describe('ng program', () => {
 
     const originalGetSourceFile = host.getSourceFile;
     const cache = new Map<string, ts.SourceFile>();
-    host.getSourceFile = function(
-                             fileName: string, languageVersion: ts.ScriptTarget): ts.SourceFile |
-        undefined {
-          const sf = originalGetSourceFile.call(host, fileName, languageVersion);
-          if (sf) {
-            if (cache.has(sf.fileName)) {
-              const oldSf = cache.get(sf.fileName) !;
-              if (oldSf.getFullText() === sf.getFullText()) {
-                return oldSf;
-              }
-            }
-            cache.set(sf.fileName, sf);
-          }
-          return sf;
-        };
+    host.getSourceFile = function(fileName: string, languageVersion: ts.ScriptTarget):
+                             ts.SourceFile|
+                         undefined {
+                           const sf = originalGetSourceFile.call(host, fileName, languageVersion);
+                           if (sf) {
+                             if (cache.has(sf.fileName)) {
+                               const oldSf = cache.get(sf.fileName)!;
+                               if (oldSf.getFullText() === sf.getFullText()) {
+                                 return oldSf;
+                               }
+                             }
+                             cache.set(sf.fileName, sf);
+                           }
+                           return sf;
+                         };
     return host;
   }
 
@@ -248,7 +249,8 @@ describe('ng program', () => {
       fileCache.delete(path.posix.join(testSupport.basePath, 'src/index.ts'));
       const p6 = ng.createProgram({
         rootNames: [path.posix.join(testSupport.basePath, 'src/index.ts')],
-        options: testSupport.createCompilerOptions(options), host,
+        options: testSupport.createCompilerOptions(options),
+        host,
         oldProgram: p5
       });
       const p7 = compile(p6, options, undefined, host).program;
@@ -295,7 +297,6 @@ describe('ng program', () => {
     describe(
         'verify that program structure is reused within tsc in order to speed up incremental compilation',
         () => {
-
           it('should reuse the old ts program completely if nothing changed', () => {
             testSupport.writeFiles({'src/index.ts': createModuleAndCompSource('main')});
             const host = createWatchModeHost();
@@ -351,7 +352,6 @@ describe('ng program', () => {
             expect(tsStructureIsReused(p2.getTsProgram())).toBe(StructureIsReused.SafeModules);
           });
         });
-
   });
 
   it('should not typecheck templates if skipTemplateCodegen is set but fullTemplateTypeCheck is not',
@@ -473,7 +473,7 @@ describe('ng program', () => {
 
     host.writeFile =
         (fileName: string, data: string, writeByteOrderMark: boolean,
-         onError: ((message: string) => void) | undefined,
+         onError: ((message: string) => void)|undefined,
          sourceFiles?: ReadonlyArray<ts.SourceFile>) => {
           written.set(fileName, {original: sourceFiles, data});
         };
@@ -487,19 +487,19 @@ describe('ng program', () => {
       const writeData = written.get(path.posix.join(testSupport.basePath, fileName));
       expect(writeData).toBeTruthy();
       expect(
-          writeData !.original !.some(
+          writeData!.original!.some(
               sf => sf.fileName === path.posix.join(testSupport.basePath, checks.originalFileName)))
           .toBe(true);
       switch (checks.shouldBe) {
         case ShouldBe.Empty:
-          expect(writeData !.data).toMatch(/^(\s*\/\*([^*]|\*[^/])*\*\/\s*)?$/);
+          expect(writeData!.data).toMatch(/^(\s*\/\*([^*]|\*[^/])*\*\/\s*)?$/);
           break;
         case ShouldBe.EmptyExport:
-          expect(writeData !.data)
+          expect(writeData!.data)
               .toMatch(/^((\s*\/\*([^*]|\*[^/])*\*\/\s*)|(\s*export\s*{\s*}\s*;\s*)|())$/);
           break;
         case ShouldBe.NoneEmpty:
-          expect(writeData !.data).not.toBe('');
+          expect(writeData!.data).not.toBe('');
           break;
       }
     }
@@ -1099,15 +1099,15 @@ describe('ng program', () => {
          });
          const host = ng.createCompilerHost({options});
          const originalGetSourceFile = host.getSourceFile;
-         host.getSourceFile = (fileName: string, languageVersion: ts.ScriptTarget,
-                               onError?: ((message: string) => void) | undefined): ts.SourceFile |
-             undefined => {
-           // We should never try to load .ngfactory.ts files
-           if (fileName.match(/\.ngfactory\.ts$/)) {
-             throw new Error(`Non existent ngfactory file: ` + fileName);
-           }
-           return originalGetSourceFile.call(host, fileName, languageVersion, onError);
-         };
+         host.getSourceFile =
+             (fileName: string, languageVersion: ts.ScriptTarget,
+              onError?: ((message: string) => void)|undefined): ts.SourceFile|undefined => {
+               // We should never try to load .ngfactory.ts files
+               if (fileName.match(/\.ngfactory\.ts$/)) {
+                 throw new Error(`Non existent ngfactory file: ` + fileName);
+               }
+               return originalGetSourceFile.call(host, fileName, languageVersion, onError);
+             };
          const program = ng.createProgram({rootNames: allRootNames, options, host});
          const structuralErrors = program.getNgStructuralDiagnostics();
          expect(structuralErrors.length).toBe(1);
@@ -1115,5 +1115,4 @@ describe('ng program', () => {
              .toContain('Function expressions are not supported');
        });
   });
-
 });

--- a/packages/compiler-cli/test/transformers/r3_metadata_transform_spec.ts
+++ b/packages/compiler-cli/test/transformers/r3_metadata_transform_spec.ts
@@ -9,12 +9,11 @@
 import {ClassField, ClassMethod, ClassStmt, PartialModule, Statement, StmtModifier} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {MetadataCollector, isClassMetadata} from '../../src/metadata/index';
+import {isClassMetadata, MetadataCollector} from '../../src/metadata/index';
 import {MetadataCache} from '../../src/transformers/metadata_cache';
 import {PartialModuleMetadataTransformer} from '../../src/transformers/r3_metadata_transform';
 
 describe('r3_transform_spec', () => {
-
   it('should add a static method to collected metadata', () => {
     const fileName = '/some/directory/someFileName.ts';
     const className = 'SomeClass';

--- a/packages/compiler-cli/test/transformers/r3_transform_spec.ts
+++ b/packages/compiler-cli/test/transformers/r3_transform_spec.ts
@@ -30,8 +30,9 @@ describe('r3_transform_spec', () => {
         .toContain('static someMethod(v) { return v; }');
   });
 
-  it('should be able to generate a static field declaration',
-     () => { expect(emitStaticField(o.literal(10))).toContain('SomeClass.someField = 10'); });
+  it('should be able to generate a static field declaration', () => {
+    expect(emitStaticField(o.literal(10))).toContain('SomeClass.someField = 10');
+  });
 
   it('should be able to import a symbol', () => {
     expect(emitStaticMethod(new o.ReturnStatement(
@@ -90,8 +91,8 @@ describe('r3_transform_spec', () => {
   }
 
   function emitStaticMethod(
-      stmt: o.Statement | o.Statement[], parameters: string[] = [],
-      methodName: string = 'someMethod', className: string = 'SomeClass'): string {
+      stmt: o.Statement|o.Statement[], parameters: string[] = [], methodName: string = 'someMethod',
+      className: string = 'SomeClass'): string {
     const module: PartialModule = {
       fileName: someGenFileName,
       statements: [classMethod(stmt, parameters, methodName, className)]
@@ -122,7 +123,7 @@ const FILES: Directory = {
 };
 
 function classMethod(
-    stmt: o.Statement | o.Statement[], parameters: string[] = [], methodName: string = 'someMethod',
+    stmt: o.Statement|o.Statement[], parameters: string[] = [], methodName: string = 'someMethod',
     className: string = 'SomeClass'): o.ClassStmt {
   const statements = Array.isArray(stmt) ? stmt : [stmt];
   return new o.ClassStmt(

--- a/packages/compiler-cli/test/typescript_support_spec.ts
+++ b/packages/compiler-cli/test/typescript_support_spec.ts
@@ -11,8 +11,8 @@ describe('checkVersion', () => {
   const MIN_TS_VERSION = '2.7.2';
   const MAX_TS_VERSION = '2.8.0';
 
-  const versionError = (version: string) =>
-      `The Angular Compiler requires TypeScript >=${MIN_TS_VERSION} and <${MAX_TS_VERSION} but ${version} was found instead.`;
+  const versionError = (version: string) => `The Angular Compiler requires TypeScript >=${
+      MIN_TS_VERSION} and <${MAX_TS_VERSION} but ${version} was found instead.`;
 
   it('should not throw when a supported TypeScript version is used', () => {
     expect(() => checkVersion('2.7.2', MIN_TS_VERSION, MAX_TS_VERSION)).not.toThrow();

--- a/packages/compiler/src/aot/compiler.ts
+++ b/packages/compiler/src/aot/compiler.ts
@@ -11,7 +11,7 @@ import {CompilerConfig} from '../config';
 import {ConstantPool} from '../constant_pool';
 import {ViewEncapsulation} from '../core';
 import {MessageBundle} from '../i18n/message_bundle';
-import {Identifiers, createTokenForExternalReference} from '../identifiers';
+import {createTokenForExternalReference, Identifiers} from '../identifiers';
 import {InjectableCompiler} from '../injectable_compiler';
 import {CompileMetadataResolver} from '../metadata_resolver';
 import {HtmlParser} from '../ml_parser/html_parser';
@@ -31,9 +31,9 @@ import {SummaryResolver} from '../summary_resolver';
 import {BindingParser} from '../template_parser/binding_parser';
 import {TemplateAst} from '../template_parser/template_ast';
 import {TemplateParser} from '../template_parser/template_parser';
-import {OutputContext, ValueVisitor, error, newArray, syntaxError, visitValue} from '../util';
+import {error, newArray, OutputContext, syntaxError, ValueVisitor, visitValue} from '../util';
 import {TypeCheckCompiler} from '../view_compiler/type_check_compiler';
-import {ViewCompileResult, ViewCompiler} from '../view_compiler/view_compiler';
+import {ViewCompiler, ViewCompileResult} from '../view_compiler/view_compiler';
 
 import {AotCompilerHost} from './compiler_host';
 import {AotCompilerOptions} from './compiler_options';
@@ -46,7 +46,11 @@ import {StaticSymbolResolver} from './static_symbol_resolver';
 import {createForJitStub, serializeSummaries} from './summary_serializer';
 import {ngfactoryFilePath, normalizeGenFileSuffix, splitTypescriptSuffix, summaryFileName, summaryForJitFileName} from './util';
 
-const enum StubEmitFlags { Basic = 1 << 0, TypeCheck = 1 << 1, All = TypeCheck | Basic }
+const enum StubEmitFlags {
+  Basic = 1 << 0,
+  TypeCheck = 1 << 1,
+  All = TypeCheck | Basic
+}
 
 export class AotCompiler {
   private _templateAstCache =
@@ -64,7 +68,9 @@ export class AotCompiler {
       private _summaryResolver: SummaryResolver<StaticSymbol>,
       private _symbolResolver: StaticSymbolResolver) {}
 
-  clearCache() { this._metadataResolver.clearCache(); }
+  clearCache() {
+    this._metadataResolver.clearCache();
+  }
 
   analyzeModulesSync(rootFiles: string[]): NgAnalyzedModules {
     const analyzeResult = analyzeAndValidateNgModules(
@@ -123,7 +129,7 @@ export class AotCompiler {
     const fileSuffix = normalizeGenFileSuffix(splitTypescriptSuffix(file.fileName, true)[1]);
     file.directives.forEach((dirSymbol) => {
       const compMeta =
-          this._metadataResolver.getNonNormalizedDirectiveMetadata(dirSymbol) !.metadata;
+          this._metadataResolver.getNonNormalizedDirectiveMetadata(dirSymbol)!.metadata;
       if (!compMeta.isComponent) {
         return;
       }
@@ -149,7 +155,8 @@ export class AotCompiler {
     if (genFileName.endsWith('.ngfactory.ts')) {
       if (!originalFileName) {
         throw new Error(
-            `Assertion error: require the original file for .ngfactory.ts stubs. File: ${genFileName}`);
+            `Assertion error: require the original file for .ngfactory.ts stubs. File: ${
+                genFileName}`);
       }
       const originalFile = this._analyzeFile(originalFileName);
       this._createNgFactoryStub(outputCtx, originalFile, StubEmitFlags.Basic);
@@ -157,7 +164,8 @@ export class AotCompiler {
       if (this._options.enableSummariesForJit) {
         if (!originalFileName) {
           throw new Error(
-              `Assertion error: require the original file for .ngsummary.ts stubs. File: ${genFileName}`);
+              `Assertion error: require the original file for .ngsummary.ts stubs. File: ${
+                  genFileName}`);
         }
         const originalFile = this._analyzeFile(originalFileName);
         _createEmptyStub(outputCtx);
@@ -319,10 +327,10 @@ export class AotCompiler {
         const html = compMeta.template !.template !;
         // Template URL points to either an HTML or TS file depending on whether
         // the file is used with `templateUrl:` or `template:`, respectively.
-        const templateUrl = compMeta.template !.templateUrl !;
+        const templateUrl = compMeta.template !.templateUrl!;
         const interpolationConfig =
             InterpolationConfig.fromArray(compMeta.template !.interpolation);
-        errors.push(...messageBundle.updateFromTemplate(html, templateUrl, interpolationConfig) !);
+        errors.push(...messageBundle.updateFromTemplate(html, templateUrl, interpolationConfig)!);
       });
     });
 
@@ -342,7 +350,7 @@ export class AotCompiler {
       if (!contextMap.has(fileName)) {
         contextMap.set(fileName, this._createOutputContext(fileName));
       }
-      return contextMap.get(fileName) !;
+      return contextMap.get(fileName)!;
     };
 
     files.forEach(
@@ -381,13 +389,13 @@ export class AotCompiler {
     directives.forEach(directiveType => {
       const directiveMetadata = this._metadataResolver.getDirectiveMetadata(directiveType);
       if (directiveMetadata.isComponent) {
-        const module = ngModuleByPipeOrDirective.get(directiveType) !;
+        const module = ngModuleByPipeOrDirective.get(directiveType)!;
         module ||
-            error(
-                `Cannot determine the module for component '${identifierName(directiveMetadata.type)}'`);
+            error(`Cannot determine the module for component '${
+                identifierName(directiveMetadata.type)}'`);
 
-        let htmlAst = directiveMetadata.template !.htmlAst !;
-        const preserveWhitespaces = directiveMetadata !.template !.preserveWhitespaces;
+        let htmlAst = directiveMetadata.template !.htmlAst!;
+        const preserveWhitespaces = directiveMetadata!.template !.preserveWhitespaces;
 
         if (!preserveWhitespaces) {
           htmlAst = removeWhitespaces(htmlAst);
@@ -412,7 +420,9 @@ export class AotCompiler {
         const pipes = module.transitiveModule.pipes.map(
             pipe => this._metadataResolver.getPipeSummary(pipe.reference));
 
-        pipes.forEach(pipe => { pipeTypeByName.set(pipe.name, pipe.type.reference); });
+        pipes.forEach(pipe => {
+          pipeTypeByName.set(pipe.name, pipe.type.reference);
+        });
 
         compileR3Component(
             context, directiveMetadata, render3Ast, this.reflector, hostBindingParser,
@@ -484,8 +494,8 @@ export class AotCompiler {
       }
       const ngModule = ngModuleByPipeOrDirective.get(dirType);
       if (!ngModule) {
-        throw new Error(
-            `Internal Error: cannot determine the module for component ${identifierName(compMeta.type)}!`);
+        throw new Error(`Internal Error: cannot determine the module for component ${
+            identifierName(compMeta.type)}!`);
       }
 
       // compile styles
@@ -524,27 +534,27 @@ export class AotCompiler {
                                 .map(symbol => this._symbolResolver.resolveSymbol(symbol));
     const typeData: {
       summary: CompileTypeSummary,
-      metadata: CompileNgModuleMetadata | CompileDirectiveMetadata | CompilePipeMetadata |
-          CompileTypeMetadata
+      metadata: CompileNgModuleMetadata|CompileDirectiveMetadata|CompilePipeMetadata|
+      CompileTypeMetadata
     }[] =
         [
           ...ngModules.map(
               meta => ({
-                summary: this._metadataResolver.getNgModuleSummary(meta.type.reference) !,
-                metadata: this._metadataResolver.getNgModuleMetadata(meta.type.reference) !
+                summary: this._metadataResolver.getNgModuleSummary(meta.type.reference)!,
+                metadata: this._metadataResolver.getNgModuleMetadata(meta.type.reference)!
               })),
           ...directives.map(ref => ({
-                              summary: this._metadataResolver.getDirectiveSummary(ref) !,
-                              metadata: this._metadataResolver.getDirectiveMetadata(ref) !
+                              summary: this._metadataResolver.getDirectiveSummary(ref)!,
+                              metadata: this._metadataResolver.getDirectiveMetadata(ref)!
                             })),
           ...pipes.map(ref => ({
-                         summary: this._metadataResolver.getPipeSummary(ref) !,
-                         metadata: this._metadataResolver.getPipeMetadata(ref) !
+                         summary: this._metadataResolver.getPipeSummary(ref)!,
+                         metadata: this._metadataResolver.getPipeMetadata(ref)!
                        })),
           ...injectables.map(
               ref => ({
-                summary: this._metadataResolver.getInjectableSummary(ref.symbol) !,
-                metadata: this._metadataResolver.getInjectableSummary(ref.symbol) !.type
+                summary: this._metadataResolver.getInjectableSummary(ref.symbol)!,
+                metadata: this._metadataResolver.getInjectableSummary(ref.symbol)!.type
               }))
         ];
     const forJitOutputCtx = this._options.enableSummariesForJit ?
@@ -621,7 +631,7 @@ export class AotCompiler {
             .toDeclStmt(
                 o.importType(
                     Identifiers.ComponentFactory,
-                    [o.expressionType(outputCtx.importExpr(compMeta.type.reference)) !],
+                    [o.expressionType(outputCtx.importExpr(compMeta.type.reference))!],
                     [o.TypeModifier.Const]),
                 [o.StmtModifier.Final, o.StmtModifier.Exported]));
   }
@@ -648,15 +658,15 @@ export class AotCompiler {
       directiveIdentifiers: CompileIdentifierMetadata[]):
       {template: TemplateAst[], pipes: CompilePipeSummary[]} {
     if (this._templateAstCache.has(compMeta.type.reference)) {
-      return this._templateAstCache.get(compMeta.type.reference) !;
+      return this._templateAstCache.get(compMeta.type.reference)!;
     }
-    const preserveWhitespaces = compMeta !.template !.preserveWhitespaces;
+    const preserveWhitespaces = compMeta!.template !.preserveWhitespaces;
     const directives =
         directiveIdentifiers.map(dir => this._metadataResolver.getDirectiveSummary(dir.reference));
     const pipes = ngModule.transitiveModule.pipes.map(
         pipe => this._metadataResolver.getPipeSummary(pipe.reference));
     const result = this._templateParser.parse(
-        compMeta, compMeta.template !.htmlAst !, directives, pipes, ngModule.schemas,
+        compMeta, compMeta.template !.htmlAst!, directives, pipes, ngModule.schemas,
         templateSourceUrl(ngModule.type, compMeta, compMeta.template !), preserveWhitespaces);
     this._templateAstCache.set(compMeta.type.reference, result);
     return result;
@@ -664,8 +674,7 @@ export class AotCompiler {
 
   private _createOutputContext(genFilePath: string): OutputContext {
     const importExpr =
-        (symbol: StaticSymbol, typeParams: o.Type[] | null = null,
-         useSummaries: boolean = true) => {
+        (symbol: StaticSymbol, typeParams: o.Type[]|null = null, useSummaries: boolean = true) => {
           if (!(symbol instanceof StaticSymbol)) {
             throw new Error(`Internal error: unknown identifier ${JSON.stringify(symbol)}`);
           }
@@ -710,7 +719,7 @@ export class AotCompiler {
       stylesheetMetadata: CompileStylesheetMetadata, isShimmed: boolean,
       fileSuffix: string): GeneratedFile {
     const outputCtx = this._createOutputContext(
-        _stylesModuleUrl(stylesheetMetadata.moduleUrl !, isShimmed, fileSuffix));
+        _stylesModuleUrl(stylesheetMetadata.moduleUrl!, isShimmed, fileSuffix));
     const compiledStylesheet =
         this._styleCompiler.compileStyles(outputCtx, compMeta, stylesheetMetadata, isShimmed);
     _resolveStyleStatements(this._symbolResolver, compiledStylesheet, isShimmed, fileSuffix);
@@ -748,8 +757,8 @@ export class AotCompiler {
         return allLazyRoutes;
       }
       seenRoutes.add(symbol);
-      const lazyRoutes = listLazyRoutes(
-          self._metadataResolver.getNgModuleMetadata(symbol, true) !, self.reflector);
+      const lazyRoutes =
+          listLazyRoutes(self._metadataResolver.getNgModuleMetadata(symbol, true)!, self.reflector);
       for (const lazyRoute of lazyRoutes) {
         allLazyRoutes.push(lazyRoute);
         visitLazyRoute(lazyRoute.referencedModule, seenRoutes, allLazyRoutes);
@@ -803,7 +812,9 @@ export interface NgAnalyzedFile {
   exportsNonSourceFiles: boolean;
 }
 
-export interface NgAnalyzeModulesHost { isSourceFile(filePath: string): boolean; }
+export interface NgAnalyzeModulesHost {
+  isSourceFile(filePath: string): boolean;
+}
 
 export function analyzeNgModules(
     fileNames: string[], host: NgAnalyzeModulesHost, staticSymbolResolver: StaticSymbolResolver,
@@ -823,8 +834,8 @@ export function analyzeAndValidateNgModules(
 function validateAnalyzedModules(analyzedModules: NgAnalyzedModules): NgAnalyzedModules {
   if (analyzedModules.symbolsMissingModule && analyzedModules.symbolsMissingModule.length) {
     const messages = analyzedModules.symbolsMissingModule.map(
-        s =>
-            `Cannot determine the module for class ${s.name} in ${s.filePath}! Add ${s.name} to the NgModule to fix it.`);
+        s => `Cannot determine the module for class ${s.name} in ${s.filePath}! Add ${
+            s.name} to the NgModule to fix it.`);
     throw syntaxError(messages.join('\n'));
   }
   return analyzedModules;
@@ -918,8 +929,13 @@ export function analyzeFile(
     });
   }
   return {
-      fileName,  directives,  abstractDirectives,    pipes,
-      ngModules, injectables, exportsNonSourceFiles,
+    fileName,
+    directives,
+    abstractDirectives,
+    pipes,
+    ngModules,
+    injectables,
+    exportsNonSourceFiles,
   };
 }
 
@@ -957,7 +973,9 @@ function isValueExportingNonSourceFile(host: NgAnalyzeModulesHost, metadata: any
   let exportsNonSourceFiles = false;
 
   class Visitor implements ValueVisitor {
-    visitArray(arr: any[], context: any): any { arr.forEach(v => visitValue(v, this, context)); }
+    visitArray(arr: any[], context: any): any {
+      arr.forEach(v => visitValue(v, this, context));
+    }
     visitStringMap(map: {[key: string]: any}, context: any): any {
       Object.keys(map).forEach((key) => visitValue(map[key], this, context));
     }

--- a/packages/compiler/src/aot/compiler_factory.ts
+++ b/packages/compiler/src/aot/compiler_factory.ts
@@ -36,9 +36,9 @@ import {StaticSymbol, StaticSymbolCache} from './static_symbol';
 import {StaticSymbolResolver} from './static_symbol_resolver';
 import {AotSummaryResolver} from './summary_resolver';
 
-export function createAotUrlResolver(host: {
-  resourceNameToFileName(resourceName: string, containingFileName: string): string | null;
-}): UrlResolver {
+export function createAotUrlResolver(
+    host: {resourceNameToFileName(resourceName: string, containingFileName: string): string|null;}):
+    UrlResolver {
   return {
     resolve: (basePath: string, url: string) => {
       const filePath = host.resourceNameToFileName(url, basePath);

--- a/packages/compiler/src/aot/formatted_error.ts
+++ b/packages/compiler/src/aot/formatted_error.ts
@@ -20,7 +20,7 @@ export interface FormattedMessageChain {
   next?: FormattedMessageChain[];
 }
 
-export type FormattedError = Error & {
+export type FormattedError = Error&{
   chain: FormattedMessageChain;
   position?: Position;
 };
@@ -34,10 +34,10 @@ function indentStr(level: number): string {
   return half + half + (level % 2 === 1 ? ' ' : '');
 }
 
-function formatChain(chain: FormattedMessageChain | undefined, indent: number = 0): string {
+function formatChain(chain: FormattedMessageChain|undefined, indent: number = 0): string {
   if (!chain) return '';
   const position = chain.position ?
-      `${chain.position.fileName}(${chain.position.line+1},${chain.position.column+1})` :
+      `${chain.position.fileName}(${chain.position.line + 1},${chain.position.column + 1})` :
       '';
   const prefix = position && indent === 0 ? `${position}: ` : '';
   const postfix = position && indent !== 0 ? ` at ${position}` : '';

--- a/packages/compiler/src/aot/generated_file.ts
+++ b/packages/compiler/src/aot/generated_file.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Statement, areAllEquivalent} from '../output/output_ast';
+import {areAllEquivalent, Statement} from '../output/output_ast';
 import {TypeScriptEmitter} from '../output/ts_emitter';
 
 export class GeneratedFile {
@@ -36,7 +36,7 @@ export class GeneratedFile {
     }
     // Note: the constructor guarantees that if this.source is not filled,
     // then this.stmts is.
-    return areAllEquivalent(this.stmts !, other.stmts !);
+    return areAllEquivalent(this.stmts!, other.stmts!);
   }
 }
 

--- a/packages/compiler/src/aot/lazy_routes.ts
+++ b/packages/compiler/src/aot/lazy_routes.ts
@@ -34,7 +34,7 @@ export function listLazyRoutes(
   return allLazyRoutes;
 }
 
-function _collectLoadChildren(routes: string | Route | Route[], target: string[] = []): string[] {
+function _collectLoadChildren(routes: string|Route|Route[], target: string[] = []): string[] {
   if (typeof routes === 'string') {
     target.push(routes);
   } else if (Array.isArray(routes)) {

--- a/packages/compiler/src/aot/static_reflector.ts
+++ b/packages/compiler/src/aot/static_reflector.ts
@@ -8,12 +8,12 @@
 
 import {CompileSummaryKind} from '../compile_metadata';
 import {CompileReflector} from '../compile_reflector';
-import {MetadataFactory, createAttribute, createComponent, createContentChild, createContentChildren, createDirective, createHost, createHostBinding, createHostListener, createInject, createInjectable, createInput, createNgModule, createOptional, createOutput, createPipe, createSelf, createSkipSelf, createViewChild, createViewChildren} from '../core';
+import {createAttribute, createComponent, createContentChild, createContentChildren, createDirective, createHost, createHostBinding, createHostListener, createInject, createInjectable, createInput, createNgModule, createOptional, createOutput, createPipe, createSelf, createSkipSelf, createViewChild, createViewChildren, MetadataFactory} from '../core';
 import * as o from '../output/output_ast';
 import {SummaryResolver} from '../summary_resolver';
 import {syntaxError} from '../util';
 
-import {FormattedMessageChain, formattedError} from './formatted_error';
+import {formattedError, FormattedMessageChain} from './formatted_error';
 import {StaticSymbol} from './static_symbol';
 import {StaticSymbolResolver} from './static_symbol_resolver';
 
@@ -50,13 +50,13 @@ export class StaticReflector implements CompileReflector {
   private conversionMap = new Map<StaticSymbol, (context: StaticSymbol, args: any[]) => any>();
   private resolvedExternalReferences = new Map<string, StaticSymbol>();
   // TODO(issue/24571): remove '!'.
-  private injectionToken !: StaticSymbol;
+  private injectionToken!: StaticSymbol;
   // TODO(issue/24571): remove '!'.
-  private opaqueToken !: StaticSymbol;
+  private opaqueToken!: StaticSymbol;
   // TODO(issue/24571): remove '!'.
-  ROUTES !: StaticSymbol;
+  ROUTES!: StaticSymbol;
   // TODO(issue/24571): remove '!'.
-  private ANALYZE_FOR_ENTRY_COMPONENTS !: StaticSymbol;
+  private ANALYZE_FOR_ENTRY_COMPONENTS!: StaticSymbol;
   private annotationForParentClassWithSummaryKind =
       new Map<CompileSummaryKind, MetadataFactory<any>[]>();
 
@@ -110,10 +110,10 @@ export class StaticReflector implements CompileReflector {
       if (declarationSymbol) return declarationSymbol;
     }
     const refSymbol =
-        this.symbolResolver.getSymbolByModule(ref.moduleName !, ref.name !, containingFile);
+        this.symbolResolver.getSymbolByModule(ref.moduleName!, ref.name!, containingFile);
     const declarationSymbol = this.findSymbolDeclaration(refSymbol);
     if (!containingFile) {
-      this.symbolResolver.recordModuleNameForFileName(refSymbol.filePath, ref.moduleName !);
+      this.symbolResolver.recordModuleNameForFileName(refSymbol.filePath, ref.moduleName!);
       this.symbolResolver.recordImportAs(declarationSymbol, refSymbol);
     }
     if (key) {
@@ -192,16 +192,20 @@ export class StaticReflector implements CompileReflector {
         const summary = this.summaryResolver.resolveSummary(parentType);
         if (summary && summary.type) {
           const requiredAnnotationTypes =
-              this.annotationForParentClassWithSummaryKind.get(summary.type.summaryKind !) !;
+              this.annotationForParentClassWithSummaryKind.get(summary.type.summaryKind!)!;
           const typeHasRequiredAnnotation = requiredAnnotationTypes.some(
               (requiredType) => ownAnnotations.some(ann => requiredType.isTypeOf(ann)));
           if (!typeHasRequiredAnnotation) {
             this.reportError(
                 formatMetadataError(
                     metadataError(
-                        `Class ${type.name} in ${type.filePath} extends from a ${CompileSummaryKind[summary.type.summaryKind!]} in another compilation unit without duplicating the decorator`,
+                        `Class ${type.name} in ${type.filePath} extends from a ${
+                            CompileSummaryKind[summary.type.summaryKind!
+            ]} in another compilation unit without duplicating the decorator`,
                         /* summary */ undefined,
-                        `Please add a ${requiredAnnotationTypes.map((type) => type.ngMetadataName).join(' or ')} decorator to the class`),
+                        `Please add a ${
+                            requiredAnnotationTypes.map((type) => type.ngMetadataName)
+                                .join(' or ')} decorator to the class`),
                     type),
                 type);
           }
@@ -221,7 +225,7 @@ export class StaticReflector implements CompileReflector {
       if (parentType) {
         const parentPropMetadata = this.propMetadata(parentType);
         Object.keys(parentPropMetadata).forEach((parentProp) => {
-          propMetadata ![parentProp] = parentPropMetadata[parentProp];
+          propMetadata![parentProp] = parentPropMetadata[parentProp];
         });
       }
 
@@ -231,10 +235,10 @@ export class StaticReflector implements CompileReflector {
         const prop = (<any[]>propData)
                          .find(a => a['__symbolic'] == 'property' || a['__symbolic'] == 'method');
         const decorators: any[] = [];
-        if (propMetadata ![propName]) {
-          decorators.push(...propMetadata ![propName]);
+        if (propMetadata![propName]) {
+          decorators.push(...propMetadata![propName]);
         }
-        propMetadata ![propName] = decorators;
+        propMetadata![propName] = decorators;
         if (prop && prop['decorators']) {
           decorators.push(...this.simplify(type, prop['decorators']));
         }
@@ -271,7 +275,7 @@ export class StaticReflector implements CompileReflector {
             if (decorators) {
               nestedResult.push(...decorators);
             }
-            parameters !.push(nestedResult);
+            parameters!.push(nestedResult);
           });
         } else if (parentType) {
           parameters = this.parameters(parentType);
@@ -297,7 +301,7 @@ export class StaticReflector implements CompileReflector {
       if (parentType) {
         const parentMethodNames = this._methodNames(parentType);
         Object.keys(parentMethodNames).forEach((parentProp) => {
-          methodNames ![parentProp] = parentMethodNames[parentProp];
+          methodNames![parentProp] = parentMethodNames[parentProp];
         });
       }
 
@@ -305,7 +309,7 @@ export class StaticReflector implements CompileReflector {
       Object.keys(members).forEach((propName) => {
         const propData = members[propName];
         const isMethod = (<any[]>propData).some(a => a['__symbolic'] == 'method');
-        methodNames ![propName] = methodNames ![propName] || isMethod;
+        methodNames![propName] = methodNames![propName] || isMethod;
       });
       this.methodCache.set(type, methodNames);
     }
@@ -485,7 +489,7 @@ export class StaticReflector implements CompileReflector {
             // Propagate the message text up but add a message to the chain that explains how we got
             // here.
             // e.chain implies e.symbol
-            const summaryMsg = e.chain ? 'references \'' + e.symbol !.name + '\'' : errorSummary(e);
+            const summaryMsg = e.chain ? 'references \'' + e.symbol!.name + '\'' : errorSummary(e);
             const summary = `'${nestedContext.name}' ${summaryMsg}`;
             const chain = {message: summary, position: e.position, next: e.chain};
             // TODO(chuckj): retrieve the position information indirectly from the collectors node
@@ -494,7 +498,8 @@ export class StaticReflector implements CompileReflector {
                 {
                   message: e.message,
                   advise: e.advise,
-                  context: e.context, chain,
+                  context: e.context,
+                  chain,
                   symbol: nestedContext
                 },
                 context);
@@ -566,7 +571,8 @@ export class StaticReflector implements CompileReflector {
             {
               message: FUNCTION_CALL_NOT_SUPPORTED,
               context: functionSymbol,
-              value: targetFunction, position
+              value: targetFunction,
+              position
             },
             context);
       }
@@ -875,7 +881,7 @@ interface MetadataMessageChain {
   next?: MetadataMessageChain;
 }
 
-type MetadataError = Error & {
+type MetadataError = Error&{
   position?: Position;
   advise?: string;
   summary?: string;
@@ -916,7 +922,8 @@ function expandedMessage(message: string, context: any): string {
   switch (message) {
     case REFERENCE_TO_NONEXPORTED_CLASS:
       if (context && context.className) {
-        return `References to a non-exported class are not supported in decorators but ${context.className} was referenced.`;
+        return `References to a non-exported class are not supported in decorators but ${
+            context.className} was referenced.`;
       }
       break;
     case VARIABLE_NOT_INITIALIZED:
@@ -935,7 +942,8 @@ function expandedMessage(message: string, context: any): string {
       return 'Function calls are not supported in decorators';
     case REFERENCE_TO_LOCAL_SYMBOL:
       if (context && context.name) {
-        return `Reference to a local (non-exported) symbols are not supported in decorators but '${context.name}' was referenced`;
+        return `Reference to a local (non-exported) symbols are not supported in decorators but '${
+            context.name}' was referenced`;
       }
       break;
     case LAMBDA_NOT_SUPPORTED:
@@ -1040,7 +1048,9 @@ abstract class BindingScope {
 }
 
 class PopulatedScope extends BindingScope {
-  constructor(private bindings: Map<string, any>) { super(); }
+  constructor(private bindings: Map<string, any>) {
+    super();
+  }
 
   resolve(name: string): any {
     return this.bindings.has(name) ? this.bindings.get(name) : BindingScope.missing;
@@ -1048,7 +1058,7 @@ class PopulatedScope extends BindingScope {
 }
 
 function formatMetadataMessageChain(
-    chain: MetadataMessageChain, advise: string | undefined): FormattedMessageChain {
+    chain: MetadataMessageChain, advise: string|undefined): FormattedMessageChain {
   const expanded = expandedMessage(chain.message, chain.context);
   const nesting = chain.symbol ? ` in '${chain.symbol.name}'` : '';
   const message = `${expanded}${nesting}`;

--- a/packages/compiler/src/aot/static_symbol.ts
+++ b/packages/compiler/src/aot/static_symbol.ts
@@ -31,7 +31,7 @@ export class StaticSymbolCache {
 
   get(declarationFile: string, name: string, members?: string[]): StaticSymbol {
     members = members || [];
-    const memberSuffix = members.length ? `.${ members.join('.')}` : '';
+    const memberSuffix = members.length ? `.${members.join('.')}` : '';
     const key = `"${declarationFile}".${name}${memberSuffix}`;
     let result = this.cache.get(key);
     if (!result) {

--- a/packages/compiler/src/aot/static_symbol_resolver.ts
+++ b/packages/compiler/src/aot/static_symbol_resolver.ts
@@ -76,12 +76,12 @@ export class StaticSymbolResolver {
 
   resolveSymbol(staticSymbol: StaticSymbol): ResolvedStaticSymbol {
     if (staticSymbol.members.length > 0) {
-      return this._resolveSymbolMembers(staticSymbol) !;
+      return this._resolveSymbolMembers(staticSymbol)!;
     }
     // Note: always ask for a summary first,
     // as we might have read shallow metadata via a .d.ts file
     // for the symbol.
-    const resultFromSummary = this._resolveSymbolFromSummary(staticSymbol) !;
+    const resultFromSummary = this._resolveSymbolFromSummary(staticSymbol)!;
     if (resultFromSummary) {
       return resultFromSummary;
     }
@@ -93,7 +93,7 @@ export class StaticSymbolResolver {
     // have summaries, only .d.ts files. So we always need to check both, the summary
     // and metadata.
     this._createSymbolsOf(staticSymbol.filePath);
-    return this.resolvedSymbols.get(staticSymbol) !;
+    return this.resolvedSymbols.get(staticSymbol)!;
   }
 
   /**
@@ -119,15 +119,14 @@ export class StaticSymbolResolver {
       const baseSymbol =
           this.getStaticSymbol(summarizedFileName, summarizedName, staticSymbol.members);
       const baseImportAs = this.getImportAs(baseSymbol, useSummaries);
-      return baseImportAs ?
-          this.getStaticSymbol(
-              summaryForJitFileName(baseImportAs.filePath), summaryForJitName(baseImportAs.name),
-              baseSymbol.members) :
-          null;
+      return baseImportAs ? this.getStaticSymbol(
+                                summaryForJitFileName(baseImportAs.filePath),
+                                summaryForJitName(baseImportAs.name), baseSymbol.members) :
+                            null;
     }
     let result = (useSummaries && this.summaryResolver.getImportAs(staticSymbol)) || null;
     if (!result) {
-      result = this.importAs.get(staticSymbol) !;
+      result = this.importAs.get(staticSymbol)!;
     }
     return result;
   }
@@ -347,8 +346,8 @@ export class StaticSymbolResolver {
           // correctly.
           const originFilePath = this.resolveModule(origin, filePath);
           if (!originFilePath) {
-            this.reportError(new Error(
-                `Couldn't resolve original symbol for ${origin} from ${this.host.getOutputName(filePath)}`));
+            this.reportError(new Error(`Couldn't resolve original symbol for ${origin} from ${
+                this.host.getOutputName(filePath)}`));
           } else {
             this.symbolResourcePaths.set(symbol, originFilePath);
           }
@@ -413,7 +412,7 @@ export class StaticSymbolResolver {
           }
           let filePath: string;
           if (module) {
-            filePath = self.resolveModule(module, sourceSymbol.filePath) !;
+            filePath = self.resolveModule(module, sourceSymbol.filePath)!;
             if (!filePath) {
               return {
                 __symbolic: 'error',
@@ -501,8 +500,11 @@ export class StaticSymbolResolver {
       }
       if (moduleMetadata['version'] != SUPPORTED_SCHEMA_VERSION) {
         const errorMessage = moduleMetadata['version'] == 2 ?
-            `Unsupported metadata version ${moduleMetadata['version']} for module ${module}. This module should be compiled with a newer version of ngc` :
-            `Metadata version mismatch for module ${this.host.getOutputName(module)}, found version ${moduleMetadata['version']}, expected ${SUPPORTED_SCHEMA_VERSION}`;
+            `Unsupported metadata version ${moduleMetadata['version']} for module ${
+                module}. This module should be compiled with a newer version of ngc` :
+            `Metadata version mismatch for module ${
+                this.host.getOutputName(module)}, found version ${
+                moduleMetadata['version']}, expected ${SUPPORTED_SCHEMA_VERSION}`;
         this.reportError(new Error(errorMessage));
       }
       this.metadataCache.set(module, moduleMetadata);
@@ -514,9 +516,8 @@ export class StaticSymbolResolver {
   getSymbolByModule(module: string, symbolName: string, containingFile?: string): StaticSymbol {
     const filePath = this.resolveModule(module, containingFile);
     if (!filePath) {
-      this.reportError(
-          new Error(`Could not resolve module ${module}${containingFile ? ' relative to ' +
-            this.host.getOutputName(containingFile) : ''}`));
+      this.reportError(new Error(`Could not resolve module ${module}${
+          containingFile ? ' relative to ' + this.host.getOutputName(containingFile) : ''}`));
       return this.getStaticSymbol(`ERROR:${module}`, symbolName);
     }
     return this.getStaticSymbol(filePath, symbolName);

--- a/packages/compiler/src/aot/summary_resolver.ts
+++ b/packages/compiler/src/aot/summary_resolver.ts
@@ -71,7 +71,7 @@ export class AotSummaryResolver implements SummaryResolver<StaticSymbol> {
     let summary = this.summaryCache.get(rootSymbol);
     if (!summary) {
       this._loadSummaryFile(staticSymbol.filePath);
-      summary = this.summaryCache.get(staticSymbol) !;
+      summary = this.summaryCache.get(staticSymbol)!;
     }
     return (rootSymbol === staticSymbol && summary) || null;
   }
@@ -85,7 +85,7 @@ export class AotSummaryResolver implements SummaryResolver<StaticSymbol> {
 
   getImportAs(staticSymbol: StaticSymbol): StaticSymbol {
     staticSymbol.assertNoMembers();
-    return this.importAs.get(staticSymbol) !;
+    return this.importAs.get(staticSymbol)!;
   }
 
   /**
@@ -95,7 +95,9 @@ export class AotSummaryResolver implements SummaryResolver<StaticSymbol> {
     return this.knownFileNameToModuleNames.get(importedFilePath) || null;
   }
 
-  addSummary(summary: Summary<StaticSymbol>) { this.summaryCache.set(summary.symbol, summary); }
+  addSummary(summary: Summary<StaticSymbol>) {
+    this.summaryCache.set(summary.symbol, summary);
+  }
 
   private _loadSummaryFile(filePath: string): boolean {
     let hasSummary = this.loadedFilePaths.get(filePath);
@@ -121,7 +123,9 @@ export class AotSummaryResolver implements SummaryResolver<StaticSymbol> {
       if (moduleName) {
         this.knownFileNameToModuleNames.set(filePath, moduleName);
       }
-      importAs.forEach((importAs) => { this.importAs.set(importAs.symbol, importAs.importAs); });
+      importAs.forEach((importAs) => {
+        this.importAs.set(importAs.symbol, importAs.importAs);
+      });
     }
     return hasSummary;
   }

--- a/packages/compiler/src/ast_path.ts
+++ b/packages/compiler/src/ast_path.ts
@@ -26,23 +26,35 @@
 export class AstPath<T> {
   constructor(private path: T[], public position: number = -1) {}
 
-  get empty(): boolean { return !this.path || !this.path.length; }
-  get head(): T|undefined { return this.path[0]; }
-  get tail(): T|undefined { return this.path[this.path.length - 1]; }
+  get empty(): boolean {
+    return !this.path || !this.path.length;
+  }
+  get head(): T|undefined {
+    return this.path[0];
+  }
+  get tail(): T|undefined {
+    return this.path[this.path.length - 1];
+  }
 
   parentOf(node: T|undefined): T|undefined {
     return node && this.path[this.path.indexOf(node) - 1];
   }
-  childOf(node: T): T|undefined { return this.path[this.path.indexOf(node) + 1]; }
+  childOf(node: T): T|undefined {
+    return this.path[this.path.indexOf(node) + 1];
+  }
 
-  first<N extends T>(ctor: {new (...args: any[]): N}): N|undefined {
+  first<N extends T>(ctor: {new(...args: any[]): N}): N|undefined {
     for (let i = this.path.length - 1; i >= 0; i--) {
       let item = this.path[i];
       if (item instanceof ctor) return <N>item;
     }
   }
 
-  push(node: T) { this.path.push(node); }
+  push(node: T) {
+    this.path.push(node);
+  }
 
-  pop(): T { return this.path.pop() !; }
+  pop(): T {
+    return this.path.pop()!;
+  }
 }

--- a/packages/compiler/src/compile_metadata.ts
+++ b/packages/compiler/src/compile_metadata.ts
@@ -24,8 +24,8 @@ export function sanitizeIdentifier(name: string): string {
 
 let _anonymousTypeIndex = 0;
 
-export function identifierName(compileIdentifier: CompileIdentifierMetadata | null | undefined):
-    string|null {
+export function identifierName(compileIdentifier: CompileIdentifierMetadata|null|undefined): string|
+    null {
   if (!compileIdentifier || !compileIdentifier.reference) {
     return null;
   }
@@ -72,9 +72,13 @@ export function componentFactoryName(compType: any): string {
   return `${identifierName({reference: compType})}NgFactory`;
 }
 
-export interface ProxyClass { setDelegate(delegate: any): void; }
+export interface ProxyClass {
+  setDelegate(delegate: any): void;
+}
 
-export interface CompileIdentifierMetadata { reference: any; }
+export interface CompileIdentifierMetadata {
+  reference: any;
+}
 
 export enum CompileSummaryKind {
   Pipe,
@@ -175,8 +179,8 @@ export class CompileStylesheetMetadata {
   styles: string[];
   styleUrls: string[];
   constructor(
-      {moduleUrl, styles,
-       styleUrls}: {moduleUrl?: string, styles?: string[], styleUrls?: string[]} = {}) {
+      {moduleUrl, styles, styleUrls}:
+          {moduleUrl?: string, styles?: string[], styleUrls?: string[]} = {}) {
     this.moduleUrl = moduleUrl || null;
     this.styles = _normalizeArray(styles);
     this.styleUrls = _normalizeArray(styleUrls);
@@ -209,10 +213,21 @@ export class CompileTemplateMetadata {
   ngContentSelectors: string[];
   interpolation: [string, string]|null;
   preserveWhitespaces: boolean;
-  constructor({encapsulation, template, templateUrl, htmlAst, styles, styleUrls,
-               externalStylesheets, animations, ngContentSelectors, interpolation, isInline,
-               preserveWhitespaces}: {
-    encapsulation: ViewEncapsulation | null,
+  constructor({
+    encapsulation,
+    template,
+    templateUrl,
+    htmlAst,
+    styles,
+    styleUrls,
+    externalStylesheets,
+    animations,
+    ngContentSelectors,
+    interpolation,
+    isInline,
+    preserveWhitespaces
+  }: {
+    encapsulation: ViewEncapsulation|null,
     template: string|null,
     templateUrl: string|null,
     htmlAst: HtmlParseTreeResult|null,
@@ -286,9 +301,27 @@ export interface CompileDirectiveSummary extends CompileTypeSummary {
  * Metadata regarding compilation of a directive.
  */
 export class CompileDirectiveMetadata {
-  static create({isHost, type, isComponent, selector, exportAs, changeDetection, inputs, outputs,
-                 host, providers, viewProviders, queries, guards, viewQueries, entryComponents,
-                 template, componentViewType, rendererType, componentFactory}: {
+  static create({
+    isHost,
+    type,
+    isComponent,
+    selector,
+    exportAs,
+    changeDetection,
+    inputs,
+    outputs,
+    host,
+    providers,
+    viewProviders,
+    queries,
+    guards,
+    viewQueries,
+    entryComponents,
+    template,
+    componentViewType,
+    rendererType,
+    componentFactory
+  }: {
     isHost: boolean,
     type: CompileTypeMetadata,
     isComponent: boolean,
@@ -347,7 +380,10 @@ export class CompileDirectiveMetadata {
     return new CompileDirectiveMetadata({
       isHost,
       type,
-      isComponent: !!isComponent, selector, exportAs, changeDetection,
+      isComponent: !!isComponent,
+      selector,
+      exportAs,
+      changeDetection,
       inputs: inputsMap,
       outputs: outputsMap,
       hostListeners,
@@ -389,27 +425,29 @@ export class CompileDirectiveMetadata {
   rendererType: StaticSymbol|object|null;
   componentFactory: StaticSymbol|object|null;
 
-  constructor({isHost,
-               type,
-               isComponent,
-               selector,
-               exportAs,
-               changeDetection,
-               inputs,
-               outputs,
-               hostListeners,
-               hostProperties,
-               hostAttributes,
-               providers,
-               viewProviders,
-               queries,
-               guards,
-               viewQueries,
-               entryComponents,
-               template,
-               componentViewType,
-               rendererType,
-               componentFactory}: {
+  constructor({
+    isHost,
+    type,
+    isComponent,
+    selector,
+    exportAs,
+    changeDetection,
+    inputs,
+    outputs,
+    hostListeners,
+    hostProperties,
+    hostAttributes,
+    providers,
+    viewProviders,
+    queries,
+    guards,
+    viewQueries,
+    entryComponents,
+    template,
+    componentViewType,
+    rendererType,
+    componentFactory
+  }: {
     isHost: boolean,
     type: CompileTypeMetadata,
     isComponent: boolean,
@@ -534,7 +572,7 @@ export interface CompileNgModuleSummary extends CompileTypeSummary {
 
 export class CompileShallowModuleMetadata {
   // TODO(issue/24571): remove '!'.
-  type !: CompileTypeMetadata;
+  type!: CompileTypeMetadata;
 
   rawExports: any;
   rawImports: any;
@@ -562,9 +600,21 @@ export class CompileNgModuleMetadata {
 
   transitiveModule: TransitiveCompileNgModuleMetadata;
 
-  constructor({type, providers, declaredDirectives, exportedDirectives, declaredPipes,
-               exportedPipes, entryComponents, bootstrapComponents, importedModules,
-               exportedModules, schemas, transitiveModule, id}: {
+  constructor({
+    type,
+    providers,
+    declaredDirectives,
+    exportedDirectives,
+    declaredPipes,
+    exportedPipes,
+    entryComponents,
+    bootstrapComponents,
+    importedModules,
+    exportedModules,
+    schemas,
+    transitiveModule,
+    id
+  }: {
     type: CompileTypeMetadata,
     providers: CompileProviderMetadata[],
     declaredDirectives: CompileIdentifierMetadata[],
@@ -595,7 +645,7 @@ export class CompileNgModuleMetadata {
   }
 
   toSummary(): CompileNgModuleSummary {
-    const module = this.transitiveModule !;
+    const module = this.transitiveModule!;
     return {
       summaryKind: CompileSummaryKind.NgModule,
       type: this.type,
@@ -666,7 +716,7 @@ export class TransitiveCompileNgModuleMetadata {
   }
 }
 
-function _normalizeArray(obj: any[] | undefined | null): any[] {
+function _normalizeArray(obj: any[]|undefined|null): any[] {
   return obj || [];
 }
 
@@ -698,7 +748,7 @@ export class ProviderMeta {
 }
 
 export function flatten<T>(list: Array<T|T[]>): T[] {
-  return list.reduce((flat: any[], item: T | T[]): T[] => {
+  return list.reduce((flat: any[], item: T|T[]): T[] => {
     const flatItem = Array.isArray(item) ? flatten(item) : item;
     return (<T[]>flat).concat(flatItem);
   }, []);
@@ -712,7 +762,7 @@ function jitSourceUrl(url: string) {
 
 export function templateSourceUrl(
     ngModuleType: CompileIdentifierMetadata, compMeta: {type: CompileIdentifierMetadata},
-    templateMeta: {isInline: boolean, templateUrl: string | null}) {
+    templateMeta: {isInline: boolean, templateUrl: string|null}) {
   let url: string;
   if (templateMeta.isInline) {
     if (compMeta.type.reference instanceof StaticSymbol) {
@@ -723,13 +773,13 @@ export function templateSourceUrl(
       url = `${identifierName(ngModuleType)}/${identifierName(compMeta.type)}.html`;
     }
   } else {
-    url = templateMeta.templateUrl !;
+    url = templateMeta.templateUrl!;
   }
   return compMeta.type.reference instanceof StaticSymbol ? url : jitSourceUrl(url);
 }
 
 export function sharedStylesheetJitUrl(meta: CompileStylesheetMetadata, id: number) {
-  const pathParts = meta.moduleUrl !.split(/\/\\/g);
+  const pathParts = meta.moduleUrl!.split(/\/\\/g);
   const baseName = pathParts[pathParts.length - 1];
   return jitSourceUrl(`css/${id}${baseName}.ngstyle.js`);
 }

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -22,7 +22,9 @@
  * ```
  */
 
-export interface ExportedCompilerFacade { ɵcompilerFacade: CompilerFacade; }
+export interface ExportedCompilerFacade {
+  ɵcompilerFacade: CompilerFacade;
+}
 
 export interface CompilerFacade {
   compilePipe(angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3PipeMetadataFacade):
@@ -44,13 +46,15 @@ export interface CompilerFacade {
 
   R3ResolvedDependencyType: typeof R3ResolvedDependencyType;
   R3FactoryTarget: typeof R3FactoryTarget;
-  ResourceLoader: {new (): ResourceLoader};
+  ResourceLoader: {new(): ResourceLoader};
 }
 
-export interface CoreEnvironment { [name: string]: Function; }
+export interface CoreEnvironment {
+  [name: string]: Function;
+}
 
 export type ResourceLoader = {
-  get(url: string): Promise<string>| string;
+  get(url: string): Promise<string>|string;
 };
 
 export type StringMap = {
@@ -58,7 +62,7 @@ export type StringMap = {
 };
 
 export type StringMapWithRename = {
-  [key: string]: string | [string, string];
+  [key: string]: string|[string, string];
 };
 
 export type Provider = any;

--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -11,7 +11,9 @@ import {Identifiers} from '../identifiers';
 import * as o from '../output/output_ast';
 import {ParseSourceSpan} from '../parse_util';
 
-export class EventHandlerVars { static event = o.variable('$event'); }
+export class EventHandlerVars {
+  static event = o.variable('$event');
+}
 
 export interface LocalResolver {
   getLocal(name: string): o.Expression|null;
@@ -68,7 +70,7 @@ export type InterpolationFunction = (args: o.Expression[]) => o.Expression;
  * used in an action binding (e.g. an event handler).
  */
 export function convertActionBinding(
-    localResolver: LocalResolver | null, implicitReceiver: o.Expression, action: cdAst.AST,
+    localResolver: LocalResolver|null, implicitReceiver: o.Expression, action: cdAst.AST,
     bindingId: string, interpolationFunction?: InterpolationFunction,
     baseSourceSpan?: ParseSourceSpan,
     implicitReceiverAccesses?: Set<string>): ConvertActionBindingResult {
@@ -110,7 +112,7 @@ export function convertActionBinding(
   }
 
   const lastIndex = actionStmts.length - 1;
-  let preventDefaultVar: o.ReadVarExpr = null !;
+  let preventDefaultVar: o.ReadVarExpr = null!;
   if (lastIndex >= 0) {
     const lastStatement = actionStmts[lastIndex];
     const returnExpr = convertStmtIntoExpression(lastStatement);
@@ -126,7 +128,9 @@ export function convertActionBinding(
   return new ConvertActionBindingResult(actionStmts, preventDefaultVar);
 }
 
-export interface BuiltinConverter { (args: o.Expression[]): o.Expression; }
+export interface BuiltinConverter {
+  (args: o.Expression[]): o.Expression;
+}
 
 export interface BuiltinConverterFactory {
   createLiteralArrayConverter(argCount: number): BuiltinConverter;
@@ -158,7 +162,7 @@ export enum BindingForm {
  * `convertPropertyBindingBuiltins`.
  */
 export function convertPropertyBinding(
-    localResolver: LocalResolver | null, implicitReceiver: o.Expression,
+    localResolver: LocalResolver|null, implicitReceiver: o.Expression,
     expressionWithoutBuiltins: cdAst.AST, bindingId: string, form: BindingForm,
     interpolationFunction?: InterpolationFunction): ConvertPropertyBindingResult {
   if (!localResolver) {
@@ -284,7 +288,9 @@ function convertToStatementIfNeeded(mode: _Mode, expr: o.Expression): o.Expressi
 }
 
 class _BuiltinAstConverter extends cdAst.AstTransformer {
-  constructor(private _converterFactory: BuiltinConverterFactory) { super(); }
+  constructor(private _converterFactory: BuiltinConverterFactory) {
+    super();
+  }
   visitPipe(ast: cdAst.BindingPipe, context: any): any {
     const args = [ast.exp, ...ast.args].map(ast => ast.visit(this, context));
     return new BuiltinFunctionCall(
@@ -384,9 +390,10 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
   visitConditional(ast: cdAst.Conditional, mode: _Mode): any {
     const value: o.Expression = this._visit(ast.condition, _Mode.Expression);
     return convertToStatementIfNeeded(
-        mode, value.conditional(
-                  this._visit(ast.trueExp, _Mode.Expression),
-                  this._visit(ast.falseExp, _Mode.Expression), this.convertSourceSpan(ast.span)));
+        mode,
+        value.conditional(
+            this._visit(ast.trueExp, _Mode.Expression), this._visit(ast.falseExp, _Mode.Expression),
+            this.convertSourceSpan(ast.span)));
   }
 
   visitPipe(ast: cdAst.BindingPipe, mode: _Mode): any {
@@ -400,7 +407,7 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
     if (ast instanceof BuiltinFunctionCall) {
       fnResult = ast.converter(convertedArgs);
     } else {
-      fnResult = this._visit(ast.target !, _Mode.Expression)
+      fnResult = this._visit(ast.target!, _Mode.Expression)
                      .callFn(convertedArgs, this.convertSourceSpan(ast.span));
     }
     return convertToStatementIfNeeded(mode, fnResult);
@@ -467,7 +474,9 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
         mode, o.literal(ast.value, type, this.convertSourceSpan(ast.span)));
   }
 
-  private _getLocal(name: string): o.Expression|null { return this._localResolver.getLocal(name); }
+  private _getLocal(name: string): o.Expression|null {
+    return this._localResolver.getLocal(name);
+  }
 
   visitMethodCall(ast: cdAst.MethodCall, mode: _Mode): any {
     if (ast.receiver instanceof cdAst.ImplicitReceiver && ast.name == '$any') {
@@ -558,8 +567,8 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
           // Otherwise it's an error.
           const receiver = ast.name;
           const value = (ast.value instanceof cdAst.PropertyRead) ? ast.value.name : undefined;
-          throw new Error(
-              `Cannot assign value "${value}" to template variable "${receiver}". Template variables are read-only.`);
+          throw new Error(`Cannot assign value "${value}" to template variable "${
+              receiver}". Template variables are read-only.`);
         }
       }
     }
@@ -579,7 +588,9 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
     return this.convertSafeAccess(ast, this.leftMostSafeNode(ast), mode);
   }
 
-  visitAll(asts: cdAst.AST[], mode: _Mode): any { return asts.map(ast => this._visit(ast, mode)); }
+  visitAll(asts: cdAst.AST[], mode: _Mode): any {
+    return asts.map(ast => this._visit(ast, mode));
+  }
 
   visitQuote(ast: cdAst.Quote, mode: _Mode): any {
     throw new Error(`Quotes are not supported for evaluation!
@@ -634,7 +645,7 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
     // which comes in as leftMostSafe to this routine.
 
     let guardedExpression = this._visit(leftMostSafe.receiver, _Mode.Expression);
-    let temporary: o.ReadVarExpr = undefined !;
+    let temporary: o.ReadVarExpr = undefined!;
     if (this.needsTemporary(leftMostSafe.receiver)) {
       // If the expression has method calls or pipes then we need to save the result into a
       // temporary variable to avoid calling stateful or impure code more than once.
@@ -652,14 +663,16 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
     // leftMostNode with its unguarded version in the call to `this.visit()`.
     if (leftMostSafe instanceof cdAst.SafeMethodCall) {
       this._nodeMap.set(
-          leftMostSafe, new cdAst.MethodCall(
-                            leftMostSafe.span, leftMostSafe.sourceSpan, leftMostSafe.receiver,
-                            leftMostSafe.name, leftMostSafe.args));
+          leftMostSafe,
+          new cdAst.MethodCall(
+              leftMostSafe.span, leftMostSafe.sourceSpan, leftMostSafe.receiver, leftMostSafe.name,
+              leftMostSafe.args));
     } else {
       this._nodeMap.set(
-          leftMostSafe, new cdAst.PropertyRead(
-                            leftMostSafe.span, leftMostSafe.sourceSpan, leftMostSafe.receiver,
-                            leftMostSafe.name));
+          leftMostSafe,
+          new cdAst.PropertyRead(
+              leftMostSafe.span, leftMostSafe.sourceSpan, leftMostSafe.receiver,
+              leftMostSafe.name));
     }
 
     // Recursively convert the node now without the guarded member access.
@@ -690,25 +703,63 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
       return (this._nodeMap.get(ast) || ast).visit(visitor);
     };
     return ast.visit({
-      visitBinary(ast: cdAst.Binary) { return null; },
-      visitChain(ast: cdAst.Chain) { return null; },
-      visitConditional(ast: cdAst.Conditional) { return null; },
-      visitFunctionCall(ast: cdAst.FunctionCall) { return null; },
-      visitImplicitReceiver(ast: cdAst.ImplicitReceiver) { return null; },
-      visitInterpolation(ast: cdAst.Interpolation) { return null; },
-      visitKeyedRead(ast: cdAst.KeyedRead) { return visit(this, ast.obj); },
-      visitKeyedWrite(ast: cdAst.KeyedWrite) { return null; },
-      visitLiteralArray(ast: cdAst.LiteralArray) { return null; },
-      visitLiteralMap(ast: cdAst.LiteralMap) { return null; },
-      visitLiteralPrimitive(ast: cdAst.LiteralPrimitive) { return null; },
-      visitMethodCall(ast: cdAst.MethodCall) { return visit(this, ast.receiver); },
-      visitPipe(ast: cdAst.BindingPipe) { return null; },
-      visitPrefixNot(ast: cdAst.PrefixNot) { return null; },
-      visitNonNullAssert(ast: cdAst.NonNullAssert) { return null; },
-      visitPropertyRead(ast: cdAst.PropertyRead) { return visit(this, ast.receiver); },
-      visitPropertyWrite(ast: cdAst.PropertyWrite) { return null; },
-      visitQuote(ast: cdAst.Quote) { return null; },
-      visitSafeMethodCall(ast: cdAst.SafeMethodCall) { return visit(this, ast.receiver) || ast; },
+      visitBinary(ast: cdAst.Binary) {
+        return null;
+      },
+      visitChain(ast: cdAst.Chain) {
+        return null;
+      },
+      visitConditional(ast: cdAst.Conditional) {
+        return null;
+      },
+      visitFunctionCall(ast: cdAst.FunctionCall) {
+        return null;
+      },
+      visitImplicitReceiver(ast: cdAst.ImplicitReceiver) {
+        return null;
+      },
+      visitInterpolation(ast: cdAst.Interpolation) {
+        return null;
+      },
+      visitKeyedRead(ast: cdAst.KeyedRead) {
+        return visit(this, ast.obj);
+      },
+      visitKeyedWrite(ast: cdAst.KeyedWrite) {
+        return null;
+      },
+      visitLiteralArray(ast: cdAst.LiteralArray) {
+        return null;
+      },
+      visitLiteralMap(ast: cdAst.LiteralMap) {
+        return null;
+      },
+      visitLiteralPrimitive(ast: cdAst.LiteralPrimitive) {
+        return null;
+      },
+      visitMethodCall(ast: cdAst.MethodCall) {
+        return visit(this, ast.receiver);
+      },
+      visitPipe(ast: cdAst.BindingPipe) {
+        return null;
+      },
+      visitPrefixNot(ast: cdAst.PrefixNot) {
+        return null;
+      },
+      visitNonNullAssert(ast: cdAst.NonNullAssert) {
+        return null;
+      },
+      visitPropertyRead(ast: cdAst.PropertyRead) {
+        return visit(this, ast.receiver);
+      },
+      visitPropertyWrite(ast: cdAst.PropertyWrite) {
+        return null;
+      },
+      visitQuote(ast: cdAst.Quote) {
+        return null;
+      },
+      visitSafeMethodCall(ast: cdAst.SafeMethodCall) {
+        return visit(this, ast.receiver) || ast;
+      },
       visitSafePropertyRead(ast: cdAst.SafePropertyRead) {
         return visit(this, ast.receiver) || ast;
       }
@@ -726,29 +777,66 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
       return ast.some(ast => visit(visitor, ast));
     };
     return ast.visit({
-      visitBinary(ast: cdAst.Binary):
-          boolean{return visit(this, ast.left) || visit(this, ast.right);},
-      visitChain(ast: cdAst.Chain) { return false; },
-      visitConditional(ast: cdAst.Conditional):
-          boolean{return visit(this, ast.condition) || visit(this, ast.trueExp) ||
-                      visit(this, ast.falseExp);},
-      visitFunctionCall(ast: cdAst.FunctionCall) { return true; },
-      visitImplicitReceiver(ast: cdAst.ImplicitReceiver) { return false; },
-      visitInterpolation(ast: cdAst.Interpolation) { return visitSome(this, ast.expressions); },
-      visitKeyedRead(ast: cdAst.KeyedRead) { return false; },
-      visitKeyedWrite(ast: cdAst.KeyedWrite) { return false; },
-      visitLiteralArray(ast: cdAst.LiteralArray) { return true; },
-      visitLiteralMap(ast: cdAst.LiteralMap) { return true; },
-      visitLiteralPrimitive(ast: cdAst.LiteralPrimitive) { return false; },
-      visitMethodCall(ast: cdAst.MethodCall) { return true; },
-      visitPipe(ast: cdAst.BindingPipe) { return true; },
-      visitPrefixNot(ast: cdAst.PrefixNot) { return visit(this, ast.expression); },
-      visitNonNullAssert(ast: cdAst.PrefixNot) { return visit(this, ast.expression); },
-      visitPropertyRead(ast: cdAst.PropertyRead) { return false; },
-      visitPropertyWrite(ast: cdAst.PropertyWrite) { return false; },
-      visitQuote(ast: cdAst.Quote) { return false; },
-      visitSafeMethodCall(ast: cdAst.SafeMethodCall) { return true; },
-      visitSafePropertyRead(ast: cdAst.SafePropertyRead) { return false; }
+      visitBinary(ast: cdAst.Binary): boolean {
+        return visit(this, ast.left) || visit(this, ast.right);
+      },
+      visitChain(ast: cdAst.Chain) {
+        return false;
+      },
+      visitConditional(ast: cdAst.Conditional): boolean {
+        return visit(this, ast.condition) || visit(this, ast.trueExp) || visit(this, ast.falseExp);
+      },
+      visitFunctionCall(ast: cdAst.FunctionCall) {
+        return true;
+      },
+      visitImplicitReceiver(ast: cdAst.ImplicitReceiver) {
+        return false;
+      },
+      visitInterpolation(ast: cdAst.Interpolation) {
+        return visitSome(this, ast.expressions);
+      },
+      visitKeyedRead(ast: cdAst.KeyedRead) {
+        return false;
+      },
+      visitKeyedWrite(ast: cdAst.KeyedWrite) {
+        return false;
+      },
+      visitLiteralArray(ast: cdAst.LiteralArray) {
+        return true;
+      },
+      visitLiteralMap(ast: cdAst.LiteralMap) {
+        return true;
+      },
+      visitLiteralPrimitive(ast: cdAst.LiteralPrimitive) {
+        return false;
+      },
+      visitMethodCall(ast: cdAst.MethodCall) {
+        return true;
+      },
+      visitPipe(ast: cdAst.BindingPipe) {
+        return true;
+      },
+      visitPrefixNot(ast: cdAst.PrefixNot) {
+        return visit(this, ast.expression);
+      },
+      visitNonNullAssert(ast: cdAst.PrefixNot) {
+        return visit(this, ast.expression);
+      },
+      visitPropertyRead(ast: cdAst.PropertyRead) {
+        return false;
+      },
+      visitPropertyWrite(ast: cdAst.PropertyWrite) {
+        return false;
+      },
+      visitQuote(ast: cdAst.Quote) {
+        return false;
+      },
+      visitSafeMethodCall(ast: cdAst.SafeMethodCall) {
+        return true;
+      },
+      visitSafePropertyRead(ast: cdAst.SafePropertyRead) {
+        return false;
+      }
     });
   }
 

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -20,16 +20,21 @@ export class CompilerConfig {
   public preserveWhitespaces: boolean;
   public strictInjectionParameters: boolean;
 
-  constructor(
-      {defaultEncapsulation = ViewEncapsulation.Emulated, useJit = true, jitDevMode = false,
-       missingTranslation = null, preserveWhitespaces, strictInjectionParameters}: {
-        defaultEncapsulation?: ViewEncapsulation,
-        useJit?: boolean,
-        jitDevMode?: boolean,
-        missingTranslation?: MissingTranslationStrategy|null,
-        preserveWhitespaces?: boolean,
-        strictInjectionParameters?: boolean,
-      } = {}) {
+  constructor({
+    defaultEncapsulation = ViewEncapsulation.Emulated,
+    useJit = true,
+    jitDevMode = false,
+    missingTranslation = null,
+    preserveWhitespaces,
+    strictInjectionParameters
+  }: {
+    defaultEncapsulation?: ViewEncapsulation,
+    useJit?: boolean,
+    jitDevMode?: boolean,
+    missingTranslation?: MissingTranslationStrategy|null,
+    preserveWhitespaces?: boolean,
+    strictInjectionParameters?: boolean,
+  } = {}) {
     this.defaultEncapsulation = defaultEncapsulation;
     this.useJit = !!useJit;
     this.jitDevMode = !!jitDevMode;
@@ -40,6 +45,6 @@ export class CompilerConfig {
 }
 
 export function preserveWhitespacesDefault(
-    preserveWhitespacesOption: boolean | null, defaultSetting = false): boolean {
+    preserveWhitespacesOption: boolean|null, defaultSetting = false): boolean {
   return preserveWhitespacesOption === null ? defaultSetting : preserveWhitespacesOption;
 }

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -7,7 +7,7 @@
  */
 
 import * as o from './output/output_ast';
-import {OutputContext, error} from './util';
+import {error, OutputContext} from './util';
 
 const CONSTANT_PREFIX = '_c';
 
@@ -21,7 +21,12 @@ const CONSTANT_PREFIX = '_c';
  */
 const UNKNOWN_VALUE_KEY = o.variable('<unknown>');
 
-export const enum DefinitionKind {Injector, Directive, Component, Pipe}
+export const enum DefinitionKind {
+  Injector,
+  Directive,
+  Component,
+  Pipe
+}
 
 /**
  * Context to use when producing a key.
@@ -43,7 +48,7 @@ class FixupExpression extends o.Expression {
   private original: o.Expression;
 
   // TODO(issue/24571): remove '!'.
-  shared !: boolean;
+  shared!: boolean;
 
   constructor(public resolved: o.Expression) {
     super(resolved.type);
@@ -64,7 +69,9 @@ class FixupExpression extends o.Expression {
     return e instanceof FixupExpression && this.resolved.isEquivalent(e.resolved);
   }
 
-  isConstant() { return true; }
+  isConstant() {
+    return true;
+  }
 
   fixup(expression: o.Expression) {
     this.resolved = expression;
@@ -169,7 +176,7 @@ export class ConstantPool {
       const resultExpressions = values.map(
           (e, index) => e.isConstant() ? this.getConstLiteral(e, true) : o.variable(`a${index}`));
       const parameters =
-          resultExpressions.filter(isVariable).map(e => new o.FnParam(e.name !, o.DYNAMIC_TYPE));
+          resultExpressions.filter(isVariable).map(e => new o.FnParam(e.name!, o.DYNAMIC_TYPE));
       const pureFunctionDeclaration =
           o.fn(parameters, [new o.ReturnStatement(resultMap(resultExpressions))], o.INFERRED_TYPE);
       const name = this.freshName();
@@ -190,7 +197,9 @@ export class ConstantPool {
    * a digit so the prefix should be a constant string (not based on user input) and
    * must not end in a digit.
    */
-  uniqueName(prefix: string): string { return `${prefix}${this.nextNameIndex++}`; }
+  uniqueName(prefix: string): string {
+    return `${prefix}${this.nextNameIndex++}`;
+  }
 
   private definitionsOf(kind: DefinitionKind): Map<any, FixupExpression> {
     switch (kind) {
@@ -222,7 +231,9 @@ export class ConstantPool {
     return '<unknown>';
   }
 
-  private freshName(): string { return this.uniqueName(CONSTANT_PREFIX); }
+  private freshName(): string {
+    return this.uniqueName(CONSTANT_PREFIX);
+  }
 
   private keyOf(expression: o.Expression) {
     return expression.visitExpression(new KeyVisitor(), KEY_CONTEXT);
@@ -259,7 +270,9 @@ class KeyVisitor implements o.ExpressionVisitor {
                                   `EX:${ast.value.runtime.name}`;
   }
 
-  visitReadVarExpr(node: o.ReadVarExpr) { return `VAR:${node.name}`; }
+  visitReadVarExpr(node: o.ReadVarExpr) {
+    return `VAR:${node.name}`;
+  }
 
   visitTypeofExpr(node: o.TypeofExpr, context: any): string {
     return `TYPEOF:${node.expr.visitExpression(this, context)}`;
@@ -284,7 +297,7 @@ class KeyVisitor implements o.ExpressionVisitor {
   visitLocalizedString = invalid;
 }
 
-function invalid<T>(this: o.ExpressionVisitor, arg: o.Expression | o.Statement): never {
+function invalid<T>(this: o.ExpressionVisitor, arg: o.Expression|o.Statement): never {
   throw new Error(
       `Invalid state: Visitor ${this.constructor.name} doesn't handle ${arg.constructor.name}`);
 }

--- a/packages/compiler/src/core.ts
+++ b/packages/compiler/src/core.ts
@@ -14,12 +14,16 @@
 
 import {CssSelector} from './selector';
 
-export interface Inject { token: any; }
+export interface Inject {
+  token: any;
+}
 export const createInject = makeMetadataFactory<Inject>('Inject', (token: any) => ({token}));
 export const createInjectionToken = makeMetadataFactory<object>(
     'InjectionToken', (desc: string) => ({_desc: desc, ɵprov: undefined}));
 
-export interface Attribute { attributeName?: string; }
+export interface Attribute {
+  attributeName?: string;
+}
 export const createAttribute =
     makeMetadataFactory<Attribute>('Attribute', (attributeName?: string) => ({attributeName}));
 
@@ -37,14 +41,17 @@ export const createContentChildren = makeMetadataFactory<Query>(
     (selector?: any, data: any = {}) =>
         ({selector, first: false, isViewQuery: false, descendants: false, ...data}));
 export const createContentChild = makeMetadataFactory<Query>(
-    'ContentChild', (selector?: any, data: any = {}) =>
-                        ({selector, first: true, isViewQuery: false, descendants: true, ...data}));
+    'ContentChild',
+    (selector?: any, data: any = {}) =>
+        ({selector, first: true, isViewQuery: false, descendants: true, ...data}));
 export const createViewChildren = makeMetadataFactory<Query>(
-    'ViewChildren', (selector?: any, data: any = {}) =>
-                        ({selector, first: false, isViewQuery: true, descendants: true, ...data}));
+    'ViewChildren',
+    (selector?: any, data: any = {}) =>
+        ({selector, first: false, isViewQuery: true, descendants: true, ...data}));
 export const createViewChild = makeMetadataFactory<Query>(
-    'ViewChild', (selector: any, data: any) =>
-                     ({selector, first: true, isViewQuery: true, descendants: true, ...data}));
+    'ViewChild',
+    (selector: any, data: any) =>
+        ({selector, first: true, isViewQuery: true, descendants: true, ...data}));
 
 export interface Directive {
   selector?: string;
@@ -94,15 +101,21 @@ export interface Pipe {
 }
 export const createPipe = makeMetadataFactory<Pipe>('Pipe', (p: Pipe) => ({pure: true, ...p}));
 
-export interface Input { bindingPropertyName?: string; }
+export interface Input {
+  bindingPropertyName?: string;
+}
 export const createInput =
     makeMetadataFactory<Input>('Input', (bindingPropertyName?: string) => ({bindingPropertyName}));
 
-export interface Output { bindingPropertyName?: string; }
+export interface Output {
+  bindingPropertyName?: string;
+}
 export const createOutput = makeMetadataFactory<Output>(
     'Output', (bindingPropertyName?: string) => ({bindingPropertyName}));
 
-export interface HostBinding { hostPropertyName?: string; }
+export interface HostBinding {
+  hostPropertyName?: string;
+}
 export const createHostBinding = makeMetadataFactory<HostBinding>(
     'HostBinding', (hostPropertyName?: string) => ({hostPropertyName}));
 
@@ -140,7 +153,9 @@ export interface Injectable {
 }
 export const createInjectable =
     makeMetadataFactory('Injectable', (injectable: Injectable = {}) => injectable);
-export interface SchemaMetadata { name: string; }
+export interface SchemaMetadata {
+  name: string;
+}
 
 export const CUSTOM_ELEMENTS_SCHEMA: SchemaMetadata = {
   name: 'custom-elements'
@@ -155,7 +170,9 @@ export const createSelf = makeMetadataFactory('Self');
 export const createSkipSelf = makeMetadataFactory('SkipSelf');
 export const createHost = makeMetadataFactory('Host');
 
-export interface Type extends Function { new (...args: any[]): any; }
+export interface Type extends Function {
+  new(...args: any[]): any;
+}
 export const Type = Function;
 
 export enum SecurityContext {
@@ -240,7 +257,10 @@ export const enum InjectFlags {
   Optional = 1 << 3,
 }
 
-export const enum ArgumentType {Inline = 0, Dynamic = 1}
+export const enum ArgumentType {
+  Inline = 0,
+  Dynamic = 1
+}
 
 export const enum BindingFlags {
   TypeElementAttribute = 1 << 0,
@@ -255,7 +275,10 @@ export const enum BindingFlags {
   Types = TypeElementAttribute | TypeElementClass | TypeElementStyle | TypeProperty
 }
 
-export const enum QueryBindingType {First = 0, All = 1}
+export const enum QueryBindingType {
+  First = 0,
+  All = 1
+}
 
 export const enum QueryValueType {
   ElementRef = 0,
@@ -324,7 +347,7 @@ export const enum SelectorFlags {
 
 // These are a copy the CSS types from core/src/render3/interfaces/projection.ts
 // They are duplicated here as they cannot be directly referenced from core.
-export type R3CssSelector = (string | SelectorFlags)[];
+export type R3CssSelector = (string|SelectorFlags)[];
 export type R3CssSelectorList = R3CssSelector[];
 
 function parserSelectorToSimpleSelector(selector: CssSelector): R3CssSelector {
@@ -363,7 +386,7 @@ function parserSelectorToR3Selector(selector: CssSelector): R3CssSelector {
   return positive.concat(...negative);
 }
 
-export function parseSelectorToR3Selector(selector: string | null): R3CssSelectorList {
+export function parseSelectorToR3Selector(selector: string|null): R3CssSelectorList {
   return selector ? CssSelector.parse(selector).map(parserSelectorToR3Selector) : [];
 }
 

--- a/packages/compiler/src/css_parser/css_ast.ts
+++ b/packages/compiler/src/css_parser/css_ast.ts
@@ -46,8 +46,12 @@ export interface CssAstVisitor {
 
 export abstract class CssAst {
   constructor(public location: ParseSourceSpan) {}
-  get start(): ParseLocation { return this.location.start; }
-  get end(): ParseLocation { return this.location.end; }
+  get start(): ParseLocation {
+    return this.location.start;
+  }
+  get end(): ParseLocation {
+    return this.location.end;
+  }
   abstract visit(visitor: CssAstVisitor, context?: any): any;
 }
 
@@ -55,11 +59,15 @@ export class CssStyleValueAst extends CssAst {
   constructor(location: ParseSourceSpan, public tokens: CssToken[], public strValue: string) {
     super(location);
   }
-  visit(visitor: CssAstVisitor, context?: any): any { return visitor.visitCssValue(this); }
+  visit(visitor: CssAstVisitor, context?: any): any {
+    return visitor.visitCssValue(this);
+  }
 }
 
 export abstract class CssRuleAst extends CssAst {
-  constructor(location: ParseSourceSpan) { super(location); }
+  constructor(location: ParseSourceSpan) {
+    super(location);
+  }
 }
 
 export class CssBlockRuleAst extends CssRuleAst {
@@ -158,7 +166,9 @@ export class CssDefinitionAst extends CssAst {
 }
 
 export abstract class CssSelectorPartAst extends CssAst {
-  constructor(location: ParseSourceSpan) { super(location); }
+  constructor(location: ParseSourceSpan) {
+    super(location);
+  }
 }
 
 export class CssSelectorAst extends CssSelectorPartAst {
@@ -195,8 +205,12 @@ export class CssPseudoSelectorAst extends CssSelectorPartAst {
 }
 
 export class CssBlockAst extends CssAst {
-  constructor(location: ParseSourceSpan, public entries: CssAst[]) { super(location); }
-  visit(visitor: CssAstVisitor, context?: any): any { return visitor.visitCssBlock(this, context); }
+  constructor(location: ParseSourceSpan, public entries: CssAst[]) {
+    super(location);
+  }
+  visit(visitor: CssAstVisitor, context?: any): any {
+    return visitor.visitCssBlock(this, context);
+  }
 }
 
 /*
@@ -213,7 +227,9 @@ export class CssStylesBlockAst extends CssBlockAst {
 }
 
 export class CssStyleSheetAst extends CssAst {
-  constructor(location: ParseSourceSpan, public rules: CssAst[]) { super(location); }
+  constructor(location: ParseSourceSpan, public rules: CssAst[]) {
+    super(location);
+  }
   visit(visitor: CssAstVisitor, context?: any): any {
     return visitor.visitCssStyleSheet(this, context);
   }

--- a/packages/compiler/src/css_parser/css_lexer.ts
+++ b/packages/compiler/src/css_parser/css_lexer.ts
@@ -117,7 +117,7 @@ function _trackWhitespace(mode: CssLexerMode) {
 
 export class CssScanner {
   // TODO(issue/24571): remove '!'.
-  peek !: number;
+  peek!: number;
   peekPeek: number;
   length: number = 0;
   index: number = -1;
@@ -135,7 +135,9 @@ export class CssScanner {
     this.advance();
   }
 
-  getMode(): CssLexerMode { return this._currentMode; }
+  getMode(): CssLexerMode {
+    return this._currentMode;
+  }
 
   setMode(mode: CssLexerMode) {
     if (this._currentMode != mode) {
@@ -198,7 +200,7 @@ export class CssScanner {
     const previousLine = this.line;
     const previousColumn = this.column;
 
-    let next: CssToken = undefined !;
+    let next: CssToken = undefined!;
     const output = this.scan();
     if (output != null) {
       // just incase the inner scan method returned an error
@@ -236,9 +238,10 @@ export class CssScanner {
       }
 
       error = cssScannerError(
-          next, generateErrorMessage(
-                    this.input, errorMessage, next.strValue, previousIndex, previousLine,
-                    previousColumn));
+          next,
+          generateErrorMessage(
+              this.input, errorMessage, next.strValue, previousIndex, previousLine,
+              previousColumn));
     }
 
     return new LexedCssResult(error, next);
@@ -254,7 +257,7 @@ export class CssScanner {
     const token = this._scan();
     if (token == null) return null;
 
-    const error = this._currentError !;
+    const error = this._currentError!;
     this._currentError = null;
 
     if (!trackWS) {
@@ -461,7 +464,7 @@ export class CssScanner {
     const startingColumn = this.column;
     this.advance();
     if (isIdentifierStart(this.peek, this.peekPeek)) {
-      const ident = this.scanIdentifier() !;
+      const ident = this.scanIdentifier()!;
       const strValue = '@' + ident.strValue;
       return new CssToken(start, startingColumn, this.line, CssTokenType.AtKeyword, strValue);
     } else {

--- a/packages/compiler/src/css_parser/css_parser.ts
+++ b/packages/compiler/src/css_parser/css_parser.ts
@@ -9,7 +9,7 @@
 import * as chars from '../chars';
 import {ParseError, ParseLocation, ParseSourceFile, ParseSourceSpan} from '../parse_util';
 
-import {BlockType, CssAst, CssAtRulePredicateAst, CssBlockAst, CssBlockDefinitionRuleAst, CssBlockRuleAst, CssDefinitionAst, CssInlineRuleAst, CssKeyframeDefinitionAst, CssKeyframeRuleAst, CssMediaQueryRuleAst, CssPseudoSelectorAst, CssRuleAst, CssSelectorAst, CssSelectorRuleAst, CssSimpleSelectorAst, CssStyleSheetAst, CssStyleValueAst, CssStylesBlockAst, CssUnknownRuleAst, CssUnknownTokenListAst, mergeTokens} from './css_ast';
+import {BlockType, CssAst, CssAtRulePredicateAst, CssBlockAst, CssBlockDefinitionRuleAst, CssBlockRuleAst, CssDefinitionAst, CssInlineRuleAst, CssKeyframeDefinitionAst, CssKeyframeRuleAst, CssMediaQueryRuleAst, CssPseudoSelectorAst, CssRuleAst, CssSelectorAst, CssSelectorRuleAst, CssSimpleSelectorAst, CssStylesBlockAst, CssStyleSheetAst, CssStyleValueAst, CssUnknownRuleAst, CssUnknownTokenListAst, mergeTokens} from './css_ast';
 import {CssLexer, CssLexerMode, CssScanner, CssToken, CssTokenType, generateErrorMessage, getRawMessage, isNewline} from './css_lexer';
 
 const SPACE_OPERATOR = ' ';
@@ -84,11 +84,11 @@ export class ParsedCssResult {
 export class CssParser {
   private _errors: CssParseError[] = [];
   // TODO(issue/24571): remove '!'.
-  private _file !: ParseSourceFile;
+  private _file!: ParseSourceFile;
   // TODO(issue/24571): remove '!'.
-  private _scanner !: CssScanner;
+  private _scanner!: CssScanner;
   // TODO(issue/24571): remove '!'.
-  private _lastToken !: CssToken;
+  private _lastToken!: CssToken;
 
   /**
    * @param css the CSS code that will be parsed
@@ -125,11 +125,13 @@ export class CssParser {
       // EOF token that was emitted sometime during the lexing
       span = this._generateSourceSpan(firstRule, this._lastToken);
     }
-    return new CssStyleSheetAst(span !, results);
+    return new CssStyleSheetAst(span!, results);
   }
 
   /** @internal */
-  _getSourceContent(): string { return this._scanner != null ? this._scanner.input : ''; }
+  _getSourceContent(): string {
+    return this._scanner != null ? this._scanner.input : '';
+  }
 
   /** @internal */
   _extractSourceContent(start: number, end: number): string {
@@ -159,9 +161,9 @@ export class CssParser {
     let endColumn: number = -1;
     let endIndex: number = -1;
     if (end instanceof CssAst) {
-      endLine = end.location.end.line !;
-      endColumn = end.location.end.col !;
-      endIndex = end.location.end.offset !;
+      endLine = end.location.end.line!;
+      endColumn = end.location.end.col!;
+      endIndex = end.location.end.offset!;
     } else if (end instanceof CssToken) {
       endLine = end.line;
       endColumn = end.column;
@@ -253,7 +255,7 @@ export class CssParser {
 
       case BlockType.Viewport:
       case BlockType.FontFace:
-        block = this._parseStyleBlock(delimiters) !;
+        block = this._parseStyleBlock(delimiters)!;
         span = this._generateSourceSpan(startToken, block);
         return new CssBlockRuleAst(span, type, block);
 
@@ -293,7 +295,7 @@ export class CssParser {
         span = this._generateSourceSpan(startToken, tokens[tokens.length - 1]);
         query = new CssAtRulePredicateAst(span, strValue, tokens);
         block = this._parseBlock(delimiters);
-        strValue = this._extractSourceContent(start, block.end.offset !);
+        strValue = this._extractSourceContent(start, block.end.offset!);
         span = this._generateSourceSpan(startToken, block);
         return new CssBlockDefinitionRuleAst(span, strValue, type, query, block);
 
@@ -310,11 +312,15 @@ export class CssParser {
             token);
 
         this._collectUntilDelim(delimiters | LBRACE_DELIM_FLAG | SEMICOLON_DELIM_FLAG)
-            .forEach((token) => { listOfTokens.push(token); });
+            .forEach((token) => {
+              listOfTokens.push(token);
+            });
         if (this._scanner.peek == chars.$LBRACE) {
           listOfTokens.push(this._consume(CssTokenType.Character, '{'));
           this._collectUntilDelim(delimiters | RBRACE_DELIM_FLAG | LBRACE_DELIM_FLAG)
-              .forEach((token) => { listOfTokens.push(token); });
+              .forEach((token) => {
+                listOfTokens.push(token);
+              });
           listOfTokens.push(this._consume(CssTokenType.Character, '}'));
         }
         endToken = listOfTokens[listOfTokens.length - 1];
@@ -339,7 +345,9 @@ export class CssParser {
       const innerTokens: CssToken[] = [];
       selectors.forEach((selector: CssSelectorAst) => {
         selector.selectorParts.forEach((part: CssSimpleSelectorAst) => {
-          part.tokens.forEach((token: CssToken) => { innerTokens.push(token); });
+          part.tokens.forEach((token: CssToken) => {
+            innerTokens.push(token);
+          });
         });
       });
       const endToken = innerTokens[innerTokens.length - 1];
@@ -376,7 +384,7 @@ export class CssParser {
 
   /** @internal */
   _scan(): CssToken {
-    const output = this._scanner.scan() !;
+    const output = this._scanner.scan()!;
     const token = output.token;
     const error = output.error;
     if (error != null) {
@@ -387,7 +395,9 @@ export class CssParser {
   }
 
   /** @internal */
-  _getScannerIndex(): number { return this._scanner.index; }
+  _getScannerIndex(): number {
+    return this._scanner.index;
+  }
 
   /** @internal */
   _consume(type: CssTokenType, value: string|null = null): CssToken {
@@ -432,7 +442,7 @@ export class CssParser {
     }
     const stylesBlock = this._parseStyleBlock(delimiters | RBRACE_DELIM_FLAG);
     const span = this._generateSourceSpan(stepTokens[0], stylesBlock);
-    const ast = new CssKeyframeDefinitionAst(span, stepTokens, stylesBlock !);
+    const ast = new CssKeyframeDefinitionAst(span, stepTokens, stylesBlock!);
 
     this._scanner.setMode(CssLexerMode.BLOCK);
     return ast;
@@ -523,7 +533,7 @@ export class CssParser {
     const selectorCssTokens: CssToken[] = [];
     const pseudoSelectors: CssPseudoSelectorAst[] = [];
 
-    let previousToken: CssToken = undefined !;
+    let previousToken: CssToken = undefined!;
 
     const selectorPartDelimiters = delimiters | SPACE_DELIM_FLAG;
     let loopOverSelector = !characterContainsDelimiter(this._scanner.peek, selectorPartDelimiters);
@@ -576,7 +586,8 @@ export class CssParser {
         hasAttributeError || this._scanner.getMode() == CssLexerMode.ATTRIBUTE_SELECTOR;
     if (hasAttributeError) {
       this._error(
-          `Unbalanced CSS attribute selector at column ${previousToken.line}:${previousToken.column}`,
+          `Unbalanced CSS attribute selector at column ${previousToken.line}:${
+              previousToken.column}`,
           previousToken);
     }
 
@@ -671,8 +682,8 @@ export class CssParser {
       endTokenOrAst = operator;
     }
 
-    const span = this._generateSourceSpan(startTokenOrAst !, endTokenOrAst);
-    return new CssSimpleSelectorAst(span, selectorCssTokens, strValue, pseudoSelectors, operator !);
+    const span = this._generateSourceSpan(startTokenOrAst!, endTokenOrAst);
+    return new CssSimpleSelectorAst(span, selectorCssTokens, strValue, pseudoSelectors, operator!);
   }
 
   /** @internal */
@@ -701,7 +712,7 @@ export class CssParser {
 
     const tokens: CssToken[] = [];
     let wsStr = '';
-    let previous: CssToken = undefined !;
+    let previous: CssToken = undefined!;
     while (!characterContainsDelimiter(this._scanner.peek, delimiters)) {
       let token: CssToken;
       if (previous != null && previous.type == CssTokenType.Identifier &&
@@ -841,7 +852,9 @@ export class CssParser {
           const remainingTokens = this._collectUntilDelim(
               delimiters | COLON_DELIM_FLAG | SEMICOLON_DELIM_FLAG, CssTokenType.Identifier);
           if (remainingTokens.length > 0) {
-            remainingTokens.forEach((token) => { propStr.push(token.strValue); });
+            remainingTokens.forEach((token) => {
+              propStr.push(token.strValue);
+            });
           }
 
           endToken = prop =
@@ -868,7 +881,7 @@ export class CssParser {
     }
 
     const span = this._generateSourceSpan(prop, endToken);
-    return new CssDefinitionAst(span, prop, value !);
+    return new CssDefinitionAst(span, prop, value!);
   }
 
   /** @internal */
@@ -899,5 +912,7 @@ export class CssParseError extends ParseError {
     return new CssParseError(span, 'CSS Parse Error: ' + errMsg);
   }
 
-  constructor(span: ParseSourceSpan, message: string) { super(span, message); }
+  constructor(span: ParseSourceSpan, message: string) {
+    super(span, message);
+  }
 }

--- a/packages/compiler/src/directive_normalizer.ts
+++ b/packages/compiler/src/directive_normalizer.ts
@@ -17,7 +17,7 @@ import {ResourceLoader} from './resource_loader';
 import {extractStyleUrls, isStyleUrlResolvable} from './style_url_resolver';
 import {PreparsedElementType, preparseElement} from './template_parser/template_preparser';
 import {UrlResolver} from './url_resolver';
-import {SyncAsync, isDefined, stringify, syntaxError} from './util';
+import {isDefined, stringify, SyncAsync, syntaxError} from './util';
 
 export interface PrenormalizedTemplateMetadata {
   ngModuleType: any;
@@ -40,16 +40,19 @@ export class DirectiveNormalizer {
       private _resourceLoader: ResourceLoader, private _urlResolver: UrlResolver,
       private _htmlParser: HtmlParser, private _config: CompilerConfig) {}
 
-  clearCache(): void { this._resourceLoaderCache.clear(); }
+  clearCache(): void {
+    this._resourceLoaderCache.clear();
+  }
 
   clearCacheFor(normalizedDirective: CompileDirectiveMetadata): void {
     if (!normalizedDirective.isComponent) {
       return;
     }
     const template = normalizedDirective.template !;
-    this._resourceLoaderCache.delete(template.templateUrl !);
-    template.externalStylesheets.forEach(
-        (stylesheet) => { this._resourceLoaderCache.delete(stylesheet.moduleUrl !); });
+    this._resourceLoaderCache.delete(template.templateUrl!);
+    template.externalStylesheets.forEach((stylesheet) => {
+      this._resourceLoaderCache.delete(stylesheet.moduleUrl!);
+    });
   }
 
   private _fetch(url: string): SyncAsync<string> {
@@ -65,17 +68,18 @@ export class DirectiveNormalizer {
       SyncAsync<CompileTemplateMetadata> {
     if (isDefined(prenormData.template)) {
       if (isDefined(prenormData.templateUrl)) {
-        throw syntaxError(
-            `'${stringify(prenormData.componentType)}' component cannot define both template and templateUrl`);
+        throw syntaxError(`'${
+            stringify(prenormData
+                          .componentType)}' component cannot define both template and templateUrl`);
       }
       if (typeof prenormData.template !== 'string') {
-        throw syntaxError(
-            `The template specified for component ${stringify(prenormData.componentType)} is not a string`);
+        throw syntaxError(`The template specified for component ${
+            stringify(prenormData.componentType)} is not a string`);
       }
     } else if (isDefined(prenormData.templateUrl)) {
       if (typeof prenormData.templateUrl !== 'string') {
-        throw syntaxError(
-            `The templateUrl specified for component ${stringify(prenormData.componentType)} is not a string`);
+        throw syntaxError(`The templateUrl specified for component ${
+            stringify(prenormData.componentType)} is not a string`);
       }
     } else {
       throw syntaxError(
@@ -84,8 +88,8 @@ export class DirectiveNormalizer {
 
     if (isDefined(prenormData.preserveWhitespaces) &&
         typeof prenormData.preserveWhitespaces !== 'boolean') {
-      throw syntaxError(
-          `The preserveWhitespaces option for component ${stringify(prenormData.componentType)} must be a boolean`);
+      throw syntaxError(`The preserveWhitespaces option for component ${
+          stringify(prenormData.componentType)} must be a boolean`);
     }
 
     return SyncAsync.then(
@@ -101,7 +105,7 @@ export class DirectiveNormalizer {
       template = prenomData.template;
       templateUrl = prenomData.moduleUrl;
     } else {
-      templateUrl = this._urlResolver.resolve(prenomData.moduleUrl, prenomData.templateUrl !);
+      templateUrl = this._urlResolver.resolve(prenomData.moduleUrl, prenomData.templateUrl!);
       template = this._fetch(templateUrl);
     }
     return SyncAsync.then(
@@ -112,7 +116,7 @@ export class DirectiveNormalizer {
       prenormData: PrenormalizedTemplateMetadata, template: string,
       templateAbsUrl: string): PreparsedTemplate {
     const isInline = !!prenormData.template;
-    const interpolationConfig = InterpolationConfig.fromArray(prenormData.interpolation !);
+    const interpolationConfig = InterpolationConfig.fromArray(prenormData.interpolation!);
     const templateUrl = templateSourceUrl(
         {reference: prenormData.ngModuleType}, {type: {reference: prenormData.componentType}},
         {isInline, templateUrl: templateAbsUrl});
@@ -140,8 +144,12 @@ export class DirectiveNormalizer {
                           .styleUrls;
     return {
       template,
-      templateUrl: templateAbsUrl, isInline,
-      htmlAst: rootNodesAndErrors, styles, inlineStyleUrls, styleUrls,
+      templateUrl: templateAbsUrl,
+      isInline,
+      htmlAst: rootNodesAndErrors,
+      styles,
+      inlineStyleUrls,
+      styleUrls,
       ngContentSelectors: visitor.ngContentSelectors,
     };
   }
@@ -172,7 +180,7 @@ export class DirectiveNormalizer {
     const styleUrls = preparsedTemplate.styleUrls;
 
     const externalStylesheets = styleUrls.map(styleUrl => {
-      const stylesheet = stylesheets.get(styleUrl) !;
+      const stylesheet = stylesheets.get(styleUrl)!;
       const styles = [...stylesheet.styles];
       this._inlineStyles(stylesheet.styleUrls, stylesheets, styles);
       return new CompileStylesheetMetadata({moduleUrl: styleUrl, styles: styles});
@@ -190,11 +198,14 @@ export class DirectiveNormalizer {
       encapsulation,
       template: preparsedTemplate.template,
       templateUrl: preparsedTemplate.templateUrl,
-      htmlAst: preparsedTemplate.htmlAst, styles, styleUrls,
+      htmlAst: preparsedTemplate.htmlAst,
+      styles,
+      styleUrls,
       ngContentSelectors: preparsedTemplate.ngContentSelectors,
       animations: prenormData.animations,
       interpolation: prenormData.interpolation,
-      isInline: preparsedTemplate.isInline, externalStylesheets,
+      isInline: preparsedTemplate.isInline,
+      externalStylesheets,
       preserveWhitespaces: preserveWhitespacesDefault(
           prenormData.preserveWhitespaces, this._config.preserveWhitespaces),
     });
@@ -204,7 +215,7 @@ export class DirectiveNormalizer {
       styleUrls: string[], stylesheets: Map<string, CompileStylesheetMetadata>,
       targetStyles: string[]) {
     styleUrls.forEach(styleUrl => {
-      const stylesheet = stylesheets.get(styleUrl) !;
+      const stylesheet = stylesheets.get(styleUrl)!;
       stylesheet.styles.forEach(style => targetStyles.push(style));
       this._inlineStyles(stylesheet.styleUrls, stylesheets, targetStyles);
     });
@@ -232,7 +243,7 @@ export class DirectiveNormalizer {
   }
 
   private _normalizeStylesheet(stylesheet: CompileStylesheetMetadata): CompileStylesheetMetadata {
-    const moduleUrl = stylesheet.moduleUrl !;
+    const moduleUrl = stylesheet.moduleUrl!;
     const allStyleUrls = stylesheet.styleUrls.filter(isStyleUrlResolvable)
                              .map(url => this._urlResolver.resolve(moduleUrl, url));
 
@@ -297,13 +308,21 @@ class TemplatePreparseVisitor implements html.Visitor {
     return null;
   }
 
-  visitExpansion(ast: html.Expansion, context: any): any { html.visitAll(this, ast.cases); }
+  visitExpansion(ast: html.Expansion, context: any): any {
+    html.visitAll(this, ast.cases);
+  }
 
   visitExpansionCase(ast: html.ExpansionCase, context: any): any {
     html.visitAll(this, ast.expression);
   }
 
-  visitComment(ast: html.Comment, context: any): any { return null; }
-  visitAttribute(ast: html.Attribute, context: any): any { return null; }
-  visitText(ast: html.Text, context: any): any { return null; }
+  visitComment(ast: html.Comment, context: any): any {
+    return null;
+  }
+  visitAttribute(ast: html.Attribute, context: any): any {
+    return null;
+  }
+  visitText(ast: html.Text, context: any): any {
+    return null;
+  }
 }

--- a/packages/compiler/src/directive_resolver.ts
+++ b/packages/compiler/src/directive_resolver.ts
@@ -7,7 +7,7 @@
  */
 
 import {CompileReflector} from './compile_reflector';
-import {Component, Directive, Type, createComponent, createContentChild, createContentChildren, createDirective, createHostBinding, createHostListener, createInput, createOutput, createViewChild, createViewChildren} from './core';
+import {Component, createComponent, createContentChild, createContentChildren, createDirective, createHostBinding, createHostListener, createInput, createOutput, createViewChild, createViewChildren, Directive, Type} from './core';
 import {resolveForwardRef, splitAtColon, stringify} from './util';
 
 const QUERY_METADATA_IDENTIFIERS = [
@@ -109,7 +109,9 @@ export class DirectiveResolver {
     return this._merge(dm, inputs, outputs, host, queries, guards, directiveType);
   }
 
-  private _extractPublicName(def: string) { return splitAtColon(def, [null !, def])[1].trim(); }
+  private _extractPublicName(def: string) {
+    return splitAtColon(def, [null!, def])[1].trim();
+  }
 
   private _dedupeBindings(bindings: string[]): string[] {
     const names = new Set<string>();
@@ -168,7 +170,8 @@ export class DirectiveResolver {
         host: mergedHost,
         exportAs: directive.exportAs,
         queries: mergedQueries,
-        providers: directive.providers, guards
+        providers: directive.providers,
+        guards
       });
     }
   }

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -31,8 +31,12 @@ export class AST {
        * Absolute location of the expression AST in a source code file.
        */
       public sourceSpan: AbsoluteSourceSpan) {}
-  visit(visitor: AstVisitor, context: any = null): any { return null; }
-  toString(): string { return 'AST'; }
+  visit(visitor: AstVisitor, context: any = null): any {
+    return null;
+  }
+  toString(): string {
+    return 'AST';
+  }
 }
 
 /**
@@ -54,8 +58,12 @@ export class Quote extends AST {
       public uninterpretedExpression: string, public location: any) {
     super(span, sourceSpan);
   }
-  visit(visitor: AstVisitor, context: any = null): any { return visitor.visitQuote(this, context); }
-  toString(): string { return 'Quote'; }
+  visit(visitor: AstVisitor, context: any = null): any {
+    return visitor.visitQuote(this, context);
+  }
+  toString(): string {
+    return 'Quote';
+  }
 }
 
 export class EmptyExpr extends AST {
@@ -77,7 +85,9 @@ export class Chain extends AST {
   constructor(span: ParseSpan, sourceSpan: AbsoluteSourceSpan, public expressions: any[]) {
     super(span, sourceSpan);
   }
-  visit(visitor: AstVisitor, context: any = null): any { return visitor.visitChain(this, context); }
+  visit(visitor: AstVisitor, context: any = null): any {
+    return visitor.visitChain(this, context);
+  }
 }
 
 export class Conditional extends AST {
@@ -148,7 +158,9 @@ export class BindingPipe extends AST {
       public args: any[], public nameSpan: AbsoluteSourceSpan) {
     super(span, sourceSpan);
   }
-  visit(visitor: AstVisitor, context: any = null): any { return visitor.visitPipe(this, context); }
+  visit(visitor: AstVisitor, context: any = null): any {
+    return visitor.visitPipe(this, context);
+  }
 }
 
 export class LiteralPrimitive extends AST {
@@ -280,7 +292,9 @@ export class ASTWithSource extends AST {
     }
     return this.ast.visit(visitor, context);
   }
-  toString(): string { return `${this.source} in ${this.location}`; }
+  toString(): string {
+    return `${this.source} in ${this.location}`;
+  }
 }
 
 /**
@@ -302,7 +316,7 @@ export class ASTWithSource extends AST {
  * the LHS of a HTML attribute to the expression in the RHS. All other bindings
  * in the example above are derived solely from the RHS.
  */
-export type TemplateBinding = VariableBinding | ExpressionBinding;
+export type TemplateBinding = VariableBinding|ExpressionBinding;
 
 export class VariableBinding {
   /**
@@ -379,7 +393,9 @@ export class RecursiveAstVisitor implements AstVisitor {
     this.visit(ast.left, context);
     this.visit(ast.right, context);
   }
-  visitChain(ast: Chain, context: any): any { this.visitAll(ast.expressions, context); }
+  visitChain(ast: Chain, context: any): any {
+    this.visitAll(ast.expressions, context);
+  }
   visitConditional(ast: Conditional, context: any): any {
     this.visit(ast.condition, context);
     this.visit(ast.trueExp, context);
@@ -411,15 +427,23 @@ export class RecursiveAstVisitor implements AstVisitor {
   visitLiteralArray(ast: LiteralArray, context: any): any {
     this.visitAll(ast.expressions, context);
   }
-  visitLiteralMap(ast: LiteralMap, context: any): any { this.visitAll(ast.values, context); }
+  visitLiteralMap(ast: LiteralMap, context: any): any {
+    this.visitAll(ast.values, context);
+  }
   visitLiteralPrimitive(ast: LiteralPrimitive, context: any): any {}
   visitMethodCall(ast: MethodCall, context: any): any {
     this.visit(ast.receiver, context);
     this.visitAll(ast.args, context);
   }
-  visitPrefixNot(ast: PrefixNot, context: any): any { this.visit(ast.expression, context); }
-  visitNonNullAssert(ast: NonNullAssert, context: any): any { this.visit(ast.expression, context); }
-  visitPropertyRead(ast: PropertyRead, context: any): any { this.visit(ast.receiver, context); }
+  visitPrefixNot(ast: PrefixNot, context: any): any {
+    this.visit(ast.expression, context);
+  }
+  visitNonNullAssert(ast: NonNullAssert, context: any): any {
+    this.visit(ast.expression, context);
+  }
+  visitPropertyRead(ast: PropertyRead, context: any): any {
+    this.visit(ast.receiver, context);
+  }
   visitPropertyWrite(ast: PropertyWrite, context: any): any {
     this.visit(ast.receiver, context);
     this.visit(ast.value, context);
@@ -441,7 +465,9 @@ export class RecursiveAstVisitor implements AstVisitor {
 }
 
 export class AstTransformer implements AstVisitor {
-  visitImplicitReceiver(ast: ImplicitReceiver, context: any): AST { return ast; }
+  visitImplicitReceiver(ast: ImplicitReceiver, context: any): AST {
+    return ast;
+  }
 
   visitInterpolation(ast: Interpolation, context: any): AST {
     return new Interpolation(ast.span, ast.sourceSpan, ast.strings, this.visitAll(ast.expressions));
@@ -476,7 +502,7 @@ export class AstTransformer implements AstVisitor {
 
   visitFunctionCall(ast: FunctionCall, context: any): AST {
     return new FunctionCall(
-        ast.span, ast.sourceSpan, ast.target !.visit(this), this.visitAll(ast.args));
+        ast.span, ast.sourceSpan, ast.target!.visit(this), this.visitAll(ast.args));
   }
 
   visitLiteralArray(ast: LiteralArray, context: any): AST {
@@ -542,7 +568,9 @@ export class AstTransformer implements AstVisitor {
 // A transformer that only creates new nodes if the transformer makes a change or
 // a change is made a child node.
 export class AstMemoryEfficientTransformer implements AstVisitor {
-  visitImplicitReceiver(ast: ImplicitReceiver, context: any): AST { return ast; }
+  visitImplicitReceiver(ast: ImplicitReceiver, context: any): AST {
+    return ast;
+  }
 
   visitInterpolation(ast: Interpolation, context: any): Interpolation {
     const expressions = this.visitAll(ast.expressions);
@@ -551,7 +579,9 @@ export class AstMemoryEfficientTransformer implements AstVisitor {
     return ast;
   }
 
-  visitLiteralPrimitive(ast: LiteralPrimitive, context: any): AST { return ast; }
+  visitLiteralPrimitive(ast: LiteralPrimitive, context: any): AST {
+    return ast;
+  }
 
   visitPropertyRead(ast: PropertyRead, context: any): AST {
     const receiver = ast.receiver.visit(this);
@@ -704,7 +734,9 @@ export class AstMemoryEfficientTransformer implements AstVisitor {
     return ast;
   }
 
-  visitQuote(ast: Quote, context: any): AST { return ast; }
+  visitQuote(ast: Quote, context: any): AST {
+    return ast;
+  }
 }
 
 // Bindings

--- a/packages/compiler/src/expression_parser/lexer.ts
+++ b/packages/compiler/src/expression_parser/lexer.ts
@@ -42,37 +42,61 @@ export class Token {
     return this.type == TokenType.Character && this.numValue == code;
   }
 
-  isNumber(): boolean { return this.type == TokenType.Number; }
+  isNumber(): boolean {
+    return this.type == TokenType.Number;
+  }
 
-  isString(): boolean { return this.type == TokenType.String; }
+  isString(): boolean {
+    return this.type == TokenType.String;
+  }
 
   isOperator(operator: string): boolean {
     return this.type == TokenType.Operator && this.strValue == operator;
   }
 
-  isIdentifier(): boolean { return this.type == TokenType.Identifier; }
+  isIdentifier(): boolean {
+    return this.type == TokenType.Identifier;
+  }
 
-  isKeyword(): boolean { return this.type == TokenType.Keyword; }
+  isKeyword(): boolean {
+    return this.type == TokenType.Keyword;
+  }
 
-  isKeywordLet(): boolean { return this.type == TokenType.Keyword && this.strValue == 'let'; }
+  isKeywordLet(): boolean {
+    return this.type == TokenType.Keyword && this.strValue == 'let';
+  }
 
-  isKeywordAs(): boolean { return this.type == TokenType.Keyword && this.strValue == 'as'; }
+  isKeywordAs(): boolean {
+    return this.type == TokenType.Keyword && this.strValue == 'as';
+  }
 
-  isKeywordNull(): boolean { return this.type == TokenType.Keyword && this.strValue == 'null'; }
+  isKeywordNull(): boolean {
+    return this.type == TokenType.Keyword && this.strValue == 'null';
+  }
 
   isKeywordUndefined(): boolean {
     return this.type == TokenType.Keyword && this.strValue == 'undefined';
   }
 
-  isKeywordTrue(): boolean { return this.type == TokenType.Keyword && this.strValue == 'true'; }
+  isKeywordTrue(): boolean {
+    return this.type == TokenType.Keyword && this.strValue == 'true';
+  }
 
-  isKeywordFalse(): boolean { return this.type == TokenType.Keyword && this.strValue == 'false'; }
+  isKeywordFalse(): boolean {
+    return this.type == TokenType.Keyword && this.strValue == 'false';
+  }
 
-  isKeywordThis(): boolean { return this.type == TokenType.Keyword && this.strValue == 'this'; }
+  isKeywordThis(): boolean {
+    return this.type == TokenType.Keyword && this.strValue == 'this';
+  }
 
-  isError(): boolean { return this.type == TokenType.Error; }
+  isError(): boolean {
+    return this.type == TokenType.Error;
+  }
 
-  toNumber(): number { return this.type == TokenType.Number ? this.numValue : -1; }
+  toNumber(): number {
+    return this.type == TokenType.Number ? this.numValue : -1;
+  }
 
   toString(): string|null {
     switch (this.type) {

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -10,8 +10,8 @@ import * as chars from '../chars';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../ml_parser/interpolation_config';
 import {escapeRegExp} from '../util';
 
-import {AST, ASTWithSource, AbsoluteSourceSpan, AstVisitor, Binary, BindingPipe, Chain, Conditional, EmptyExpr, ExpressionBinding, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralMapKey, LiteralPrimitive, MethodCall, NonNullAssert, ParseSpan, ParserError, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead, TemplateBinding, TemplateBindingIdentifier, VariableBinding} from './ast';
-import {EOF, Lexer, Token, TokenType, isIdentifier, isQuote} from './lexer';
+import {AbsoluteSourceSpan, AST, AstVisitor, ASTWithSource, Binary, BindingPipe, Chain, Conditional, EmptyExpr, ExpressionBinding, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralMapKey, LiteralPrimitive, MethodCall, NonNullAssert, ParserError, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead, TemplateBinding, TemplateBindingIdentifier, VariableBinding} from './ast';
+import {EOF, isIdentifier, isQuote, Lexer, Token, TokenType} from './lexer';
 
 export class SplitInterpolation {
   constructor(public strings: string[], public expressions: string[], public offsets: number[]) {}
@@ -253,7 +253,8 @@ export class Parser {
     const parts = input.split(regexp);
     if (parts.length > 1) {
       this._reportError(
-          `Got interpolation (${interpolationConfig.start}${interpolationConfig.end}) where expression was expected`,
+          `Got interpolation (${interpolationConfig.start}${
+              interpolationConfig.end}) where expression was expected`,
           input,
           `at column ${this._findInterpolationErrorColumn(parts, 1, interpolationConfig)} in`,
           location);
@@ -300,7 +301,9 @@ export class _ParseAST {
     return i < this.tokens.length ? this.tokens[i] : EOF;
   }
 
-  get next(): Token { return this.peek(0); }
+  get next(): Token {
+    return this.peek(0);
+  }
 
   get inputIndex(): number {
     return (this.index < this.tokens.length) ? this.next.index + this.offset :
@@ -310,7 +313,9 @@ export class _ParseAST {
   /**
    * Returns the absolute offset of the start of the current token.
    */
-  get currentAbsoluteOffset(): number { return this.absoluteOffset + this.inputIndex; }
+  get currentAbsoluteOffset(): number {
+    return this.absoluteOffset + this.inputIndex;
+  }
 
   span(start: number) {
     // `end` is either the
@@ -326,10 +331,12 @@ export class _ParseAST {
     if (!this.sourceSpanCache.has(serial)) {
       this.sourceSpanCache.set(serial, this.span(start).toAbsolute(this.absoluteOffset));
     }
-    return this.sourceSpanCache.get(serial) !;
+    return this.sourceSpanCache.get(serial)!;
   }
 
-  advance() { this.index++; }
+  advance() {
+    this.index++;
+  }
 
   consumeOptionalCharacter(code: number): boolean {
     if (this.next.isCharacter(code)) {
@@ -340,8 +347,12 @@ export class _ParseAST {
     }
   }
 
-  peekKeywordLet(): boolean { return this.next.isKeywordLet(); }
-  peekKeywordAs(): boolean { return this.next.isKeywordAs(); }
+  peekKeywordLet(): boolean {
+    return this.next.isKeywordLet();
+  }
+  peekKeywordAs(): boolean {
+    return this.next.isKeywordAs();
+  }
 
   expectCharacter(code: number) {
     if (this.consumeOptionalCharacter(code)) return;
@@ -428,7 +439,9 @@ export class _ParseAST {
     return result;
   }
 
-  parseExpression(): AST { return this.parseConditional(); }
+  parseExpression(): AST {
+    return this.parseConditional();
+  }
 
   parseConditional(): AST {
     const start = this.inputIndex;
@@ -984,8 +997,8 @@ export class _ParseAST {
            (this.rbracesExpected <= 0 || !n.isCharacter(chars.$RBRACE)) &&
            (this.rbracketsExpected <= 0 || !n.isCharacter(chars.$RBRACKET))) {
       if (this.next.isError()) {
-        this.errors.push(new ParserError(
-            this.next.toString() !, this.input, this.locationText(), this.location));
+        this.errors.push(
+            new ParserError(this.next.toString()!, this.input, this.locationText(), this.location));
       }
       this.advance();
       n = this.next;
@@ -1014,9 +1027,13 @@ class SimpleExpressionChecker implements AstVisitor {
 
   visitFunctionCall(ast: FunctionCall, context: any) {}
 
-  visitLiteralArray(ast: LiteralArray, context: any) { this.visitAll(ast.expressions); }
+  visitLiteralArray(ast: LiteralArray, context: any) {
+    this.visitAll(ast.expressions);
+  }
 
-  visitLiteralMap(ast: LiteralMap, context: any) { this.visitAll(ast.values); }
+  visitLiteralMap(ast: LiteralMap, context: any) {
+    this.visitAll(ast.values);
+  }
 
   visitBinary(ast: Binary, context: any) {}
 
@@ -1026,13 +1043,17 @@ class SimpleExpressionChecker implements AstVisitor {
 
   visitConditional(ast: Conditional, context: any) {}
 
-  visitPipe(ast: BindingPipe, context: any) { this.errors.push('pipes'); }
+  visitPipe(ast: BindingPipe, context: any) {
+    this.errors.push('pipes');
+  }
 
   visitKeyedRead(ast: KeyedRead, context: any) {}
 
   visitKeyedWrite(ast: KeyedWrite, context: any) {}
 
-  visitAll(asts: any[]): any[] { return asts.map(node => node.visit(this)); }
+  visitAll(asts: any[]): any[] {
+    return asts.map(node => node.visit(this));
+  }
 
   visitChain(ast: Chain, context: any) {}
 
@@ -1052,5 +1073,7 @@ class IvySimpleExpressionChecker extends SimpleExpressionChecker {
     ast.right.visit(this);
   }
 
-  visitPrefixNot(ast: PrefixNot, context: any) { ast.expression.visit(this); }
+  visitPrefixNot(ast: PrefixNot, context: any) {
+    ast.expression.visit(this);
+  }
 }

--- a/packages/compiler/src/i18n/digest.ts
+++ b/packages/compiler/src/i18n/digest.ts
@@ -48,7 +48,9 @@ export function computeDecimalDigest(message: i18n.Message): string {
  * @internal
  */
 class _SerializerVisitor implements i18n.Visitor {
-  visitText(text: i18n.Text, context: any): any { return text.value; }
+  visitText(text: i18n.Text, context: any): any {
+    return text.value;
+  }
 
   visitContainer(container: i18n.Container, context: any): any {
     return `[${container.children.map(child => child.visit(this)).join(', ')}]`;
@@ -63,7 +65,8 @@ class _SerializerVisitor implements i18n.Visitor {
   visitTagPlaceholder(ph: i18n.TagPlaceholder, context: any): any {
     return ph.isVoid ?
         `<ph tag name="${ph.startName}"/>` :
-        `<ph tag name="${ph.startName}">${ph.children.map(child => child.visit(this)).join(', ')}</ph name="${ph.closeName}">`;
+        `<ph tag name="${ph.startName}">${
+            ph.children.map(child => child.visit(this)).join(', ')}</ph name="${ph.closeName}">`;
   }
 
   visitPlaceholder(ph: i18n.Placeholder, context: any): any {

--- a/packages/compiler/src/i18n/extractor.ts
+++ b/packages/compiler/src/i18n/extractor.ts
@@ -78,11 +78,11 @@ export class Extractor {
               // Template URL points to either an HTML or TS file depending on
               // whether the file is used with `templateUrl:` or `template:`,
               // respectively.
-              const templateUrl = compMeta.template !.templateUrl !;
+              const templateUrl = compMeta.template !.templateUrl!;
               const interpolationConfig =
                   InterpolationConfig.fromArray(compMeta.template !.interpolation);
               errors.push(...this.messageBundle.updateFromTemplate(
-                  html, templateUrl, interpolationConfig) !);
+                  html, templateUrl, interpolationConfig)!);
             });
           });
 

--- a/packages/compiler/src/i18n/extractor_merger.ts
+++ b/packages/compiler/src/i18n/extractor_merger.ts
@@ -9,8 +9,9 @@
 import * as html from '../ml_parser/ast';
 import {InterpolationConfig} from '../ml_parser/interpolation_config';
 import {ParseTreeResult} from '../ml_parser/parser';
+
 import * as i18n from './i18n_ast';
-import {I18nMessageFactory, createI18nMessageFactory} from './i18n_parser';
+import {createI18nMessageFactory, I18nMessageFactory} from './i18n_parser';
 import {I18nError} from './parse_util';
 import {TranslationBundle} from './translation_bundle';
 
@@ -56,44 +57,44 @@ enum _VisitorMode {
  */
 class _Visitor implements html.Visitor {
   // TODO(issue/24571): remove '!'.
-  private _depth !: number;
+  private _depth!: number;
 
   // <el i18n>...</el>
   // TODO(issue/24571): remove '!'.
-  private _inI18nNode !: boolean;
+  private _inI18nNode!: boolean;
   // TODO(issue/24571): remove '!'.
-  private _inImplicitNode !: boolean;
+  private _inImplicitNode!: boolean;
 
   // <!--i18n-->...<!--/i18n-->
   // TODO(issue/24571): remove '!'.
-  private _inI18nBlock !: boolean;
+  private _inI18nBlock!: boolean;
   // TODO(issue/24571): remove '!'.
-  private _blockMeaningAndDesc !: string;
+  private _blockMeaningAndDesc!: string;
   // TODO(issue/24571): remove '!'.
-  private _blockChildren !: html.Node[];
+  private _blockChildren!: html.Node[];
   // TODO(issue/24571): remove '!'.
-  private _blockStartDepth !: number;
+  private _blockStartDepth!: number;
 
   // {<icu message>}
   // TODO(issue/24571): remove '!'.
-  private _inIcu !: boolean;
+  private _inIcu!: boolean;
 
   // set to void 0 when not in a section
   private _msgCountAtSectionStart: number|undefined;
   // TODO(issue/24571): remove '!'.
-  private _errors !: I18nError[];
+  private _errors!: I18nError[];
   // TODO(issue/24571): remove '!'.
-  private _mode !: _VisitorMode;
+  private _mode!: _VisitorMode;
 
   // _VisitorMode.Extract only
   // TODO(issue/24571): remove '!'.
-  private _messages !: i18n.Message[];
+  private _messages!: i18n.Message[];
 
   // _VisitorMode.Merge only
   // TODO(issue/24571): remove '!'.
-  private _translations !: TranslationBundle;
+  private _translations!: TranslationBundle;
   // TODO(issue/24571): remove '!'.
-  private _createI18nMessage !: I18nMessageFactory;
+  private _createI18nMessage!: I18nMessageFactory;
 
 
   constructor(private _implicitTags: string[], private _implicitAttrs: {[k: string]: string[]}) {}
@@ -123,7 +124,7 @@ class _Visitor implements html.Visitor {
     this._translations = translations;
 
     // Construct a single fake root element
-    const wrapper = new html.Element('wrapper', [], nodes, undefined !, undefined, undefined);
+    const wrapper = new html.Element('wrapper', [], nodes, undefined!, undefined, undefined);
 
     const translatedNode = wrapper.visit(this, null);
 
@@ -193,14 +194,14 @@ class _Visitor implements html.Visitor {
             i18nCommentsWarned = true;
             const details = comment.sourceSpan.details ? `, ${comment.sourceSpan.details}` : '';
             // TODO(ocombe): use a log service once there is a public one available
-            console.warn(
-                `I18n comments are deprecated, use an <ng-container> element instead (${comment.sourceSpan.start}${details})`);
+            console.warn(`I18n comments are deprecated, use an <ng-container> element instead (${
+                comment.sourceSpan.start}${details})`);
           }
           this._inI18nBlock = true;
           this._blockStartDepth = this._depth;
           this._blockChildren = [];
           this._blockMeaningAndDesc =
-              comment.value !.replace(_I18N_COMMENT_PREFIX_REGEXP, '').trim();
+              comment.value!.replace(_I18N_COMMENT_PREFIX_REGEXP, '').trim();
           this._openTranslatableSection(comment);
         }
       } else {
@@ -208,7 +209,7 @@ class _Visitor implements html.Visitor {
           if (this._depth == this._blockStartDepth) {
             this._closeTranslatableSection(comment, this._blockChildren);
             this._inI18nBlock = false;
-            const message = this._addMessage(this._blockChildren, this._blockMeaningAndDesc) !;
+            const message = this._addMessage(this._blockChildren, this._blockMeaningAndDesc)!;
             // merge attributes in sections
             const nodes = this._translateMessage(comment, message);
             return html.visitAll(this, nodes);
@@ -234,7 +235,7 @@ class _Visitor implements html.Visitor {
     const wasInI18nNode = this._inI18nNode;
     const wasInImplicitNode = this._inImplicitNode;
     let childNodes: html.Node[] = [];
-    let translatedChildNodes: html.Node[] = undefined !;
+    let translatedChildNodes: html.Node[] = undefined!;
 
     // Extract:
     // - top level nodes with the (implicit) "i18n" attribute if not already in a section
@@ -249,7 +250,7 @@ class _Visitor implements html.Visitor {
     if (!this._isInTranslatableSection && !this._inIcu) {
       if (i18nAttr || isTopLevelImplicit) {
         this._inI18nNode = true;
-        const message = this._addMessage(el.children, i18nMeta) !;
+        const message = this._addMessage(el.children, i18nMeta)!;
         translatedChildNodes = this._translateMessage(el, message);
       }
 
@@ -400,12 +401,14 @@ class _Visitor implements html.Visitor {
           } else {
             this._reportError(
                 el,
-                `Unexpected translation for attribute "${attr.name}" (id="${id || this._translations.digest(message)}")`);
+                `Unexpected translation for attribute "${attr.name}" (id="${
+                    id || this._translations.digest(message)}")`);
           }
         } else {
           this._reportError(
               el,
-              `Translation unavailable for attribute "${attr.name}" (id="${id || this._translations.digest(message)}")`);
+              `Translation unavailable for attribute "${attr.name}" (id="${
+                  id || this._translations.digest(message)}")`);
         }
       } else {
         translatedAttributes.push(attr);
@@ -476,7 +479,7 @@ class _Visitor implements html.Visitor {
         0);
 
     if (significantChildren == 1) {
-      for (let i = this._messages.length - 1; i >= startIndex !; i--) {
+      for (let i = this._messages.length - 1; i >= startIndex!; i--) {
         const ast = this._messages[i].nodes;
         if (!(ast.length == 1 && ast[0] instanceof i18n.Text)) {
           this._messages.splice(i, 1);
@@ -489,7 +492,7 @@ class _Visitor implements html.Visitor {
   }
 
   private _reportError(node: html.Node, msg: string): void {
-    this._errors.push(new I18nError(node.sourceSpan !, msg));
+    this._errors.push(new I18nError(node.sourceSpan!, msg));
   }
 }
 

--- a/packages/compiler/src/i18n/i18n_ast.ts
+++ b/packages/compiler/src/i18n/i18n_ast.ts
@@ -57,24 +57,30 @@ export interface Node {
 export class Text implements Node {
   constructor(public value: string, public sourceSpan: ParseSourceSpan) {}
 
-  visit(visitor: Visitor, context?: any): any { return visitor.visitText(this, context); }
+  visit(visitor: Visitor, context?: any): any {
+    return visitor.visitText(this, context);
+  }
 }
 
 // TODO(vicb): do we really need this node (vs an array) ?
 export class Container implements Node {
   constructor(public children: Node[], public sourceSpan: ParseSourceSpan) {}
 
-  visit(visitor: Visitor, context?: any): any { return visitor.visitContainer(this, context); }
+  visit(visitor: Visitor, context?: any): any {
+    return visitor.visitContainer(this, context);
+  }
 }
 
 export class Icu implements Node {
   // TODO(issue/24571): remove '!'.
-  public expressionPlaceholder !: string;
+  public expressionPlaceholder!: string;
   constructor(
       public expression: string, public type: string, public cases: {[k: string]: Node},
       public sourceSpan: ParseSourceSpan) {}
 
-  visit(visitor: Visitor, context?: any): any { return visitor.visitIcu(this, context); }
+  visit(visitor: Visitor, context?: any): any {
+    return visitor.visitIcu(this, context);
+  }
 }
 
 export class TagPlaceholder implements Node {
@@ -83,13 +89,17 @@ export class TagPlaceholder implements Node {
       public closeName: string, public children: Node[], public isVoid: boolean,
       public sourceSpan: ParseSourceSpan) {}
 
-  visit(visitor: Visitor, context?: any): any { return visitor.visitTagPlaceholder(this, context); }
+  visit(visitor: Visitor, context?: any): any {
+    return visitor.visitTagPlaceholder(this, context);
+  }
 }
 
 export class Placeholder implements Node {
   constructor(public value: string, public name: string, public sourceSpan: ParseSourceSpan) {}
 
-  visit(visitor: Visitor, context?: any): any { return visitor.visitPlaceholder(this, context); }
+  visit(visitor: Visitor, context?: any): any {
+    return visitor.visitPlaceholder(this, context);
+  }
 }
 
 export class IcuPlaceholder implements Node {
@@ -97,7 +107,9 @@ export class IcuPlaceholder implements Node {
   previousMessage?: Message;
   constructor(public value: Icu, public name: string, public sourceSpan: ParseSourceSpan) {}
 
-  visit(visitor: Visitor, context?: any): any { return visitor.visitIcuPlaceholder(this, context); }
+  visit(visitor: Visitor, context?: any): any {
+    return visitor.visitIcuPlaceholder(this, context);
+  }
 }
 
 /**
@@ -106,7 +118,7 @@ export class IcuPlaceholder implements Node {
  * This information is either a `Message`, which indicates it is the root of an i18n message, or a
  * `Node`, which indicates is it part of a containing `Message`.
  */
-export type I18nMeta = Message | Node;
+export type I18nMeta = Message|Node;
 
 export interface Visitor {
   visitText(text: Text, context?: any): any;
@@ -119,7 +131,9 @@ export interface Visitor {
 
 // Clone the AST
 export class CloneVisitor implements Visitor {
-  visitText(text: Text, context?: any): Text { return new Text(text.value, text.sourceSpan); }
+  visitText(text: Text, context?: any): Text {
+    return new Text(text.value, text.sourceSpan);
+  }
 
   visitContainer(container: Container, context?: any): Container {
     const children = container.children.map(n => n.visit(this, context));
@@ -158,7 +172,9 @@ export class RecurseVisitor implements Visitor {
   }
 
   visitIcu(icu: Icu, context?: any): any {
-    Object.keys(icu.cases).forEach(k => { icu.cases[k].visit(this); });
+    Object.keys(icu.cases).forEach(k => {
+      icu.cases[k].visit(this);
+    });
   }
 
   visitTagPlaceholder(ph: TagPlaceholder, context?: any): any {

--- a/packages/compiler/src/i18n/i18n_parser.ts
+++ b/packages/compiler/src/i18n/i18n_parser.ts
@@ -83,7 +83,7 @@ class _I18nVisitor implements html.Visitor {
     const isVoid: boolean = getHtmlTagDefinition(el.name).isVoid;
     const startPhName =
         context.placeholderRegistry.getStartTagPlaceholderName(el.name, attrs, isVoid);
-    context.placeholderToContent[startPhName] = el.sourceSpan !.toString();
+    context.placeholderToContent[startPhName] = el.sourceSpan!.toString();
 
     let closePhName = '';
 
@@ -93,7 +93,7 @@ class _I18nVisitor implements html.Visitor {
     }
 
     const node = new i18n.TagPlaceholder(
-        el.name, attrs, startPhName, closePhName, children, isVoid, el.sourceSpan !);
+        el.name, attrs, startPhName, closePhName, children, isVoid, el.sourceSpan!);
     return context.visitNodeFn(el, node);
   }
 
@@ -103,7 +103,7 @@ class _I18nVisitor implements html.Visitor {
   }
 
   visitText(text: html.Text, context: I18nMessageVisitorContext): i18n.Node {
-    const node = this._visitTextWithInterpolation(text.value, text.sourceSpan !, context);
+    const node = this._visitTextWithInterpolation(text.value, text.sourceSpan!, context);
     return context.visitNodeFn(text, node);
   }
 

--- a/packages/compiler/src/i18n/message_bundle.ts
+++ b/packages/compiler/src/i18n/message_bundle.ts
@@ -47,7 +47,9 @@ export class MessageBundle {
 
   // Return the message in the internal format
   // The public (serialized) format might be different, see the `write` method.
-  getMessages(): i18n.Message[] { return this._messages; }
+  getMessages(): i18n.Message[] {
+    return this._messages;
+  }
 
   write(serializer: Serializer, filterSources?: (path: string) => string): string {
     const messages: {[id: string]: i18n.Message} = {};
@@ -88,18 +90,18 @@ class MapPlaceholderNames extends i18n.CloneVisitor {
   }
 
   visitTagPlaceholder(ph: i18n.TagPlaceholder, mapper: PlaceholderMapper): i18n.TagPlaceholder {
-    const startName = mapper.toPublicName(ph.startName) !;
-    const closeName = ph.closeName ? mapper.toPublicName(ph.closeName) ! : ph.closeName;
+    const startName = mapper.toPublicName(ph.startName)!;
+    const closeName = ph.closeName ? mapper.toPublicName(ph.closeName)! : ph.closeName;
     const children = ph.children.map(n => n.visit(this, mapper));
     return new i18n.TagPlaceholder(
         ph.tag, ph.attrs, startName, closeName, children, ph.isVoid, ph.sourceSpan);
   }
 
   visitPlaceholder(ph: i18n.Placeholder, mapper: PlaceholderMapper): i18n.Placeholder {
-    return new i18n.Placeholder(ph.value, mapper.toPublicName(ph.name) !, ph.sourceSpan);
+    return new i18n.Placeholder(ph.value, mapper.toPublicName(ph.name)!, ph.sourceSpan);
   }
 
   visitIcuPlaceholder(ph: i18n.IcuPlaceholder, mapper: PlaceholderMapper): i18n.IcuPlaceholder {
-    return new i18n.IcuPlaceholder(ph.value, mapper.toPublicName(ph.name) !, ph.sourceSpan);
+    return new i18n.IcuPlaceholder(ph.value, mapper.toPublicName(ph.name)!, ph.sourceSpan);
   }
 }

--- a/packages/compiler/src/i18n/parse_util.ts
+++ b/packages/compiler/src/i18n/parse_util.ts
@@ -12,5 +12,7 @@ import {ParseError, ParseSourceSpan} from '../parse_util';
  * An i18n error.
  */
 export class I18nError extends ParseError {
-  constructor(span: ParseSourceSpan, msg: string) { super(span, msg); }
+  constructor(span: ParseSourceSpan, msg: string) {
+    super(span, msg);
+  }
 }

--- a/packages/compiler/src/i18n/serializers/placeholder.ts
+++ b/packages/compiler/src/i18n/serializers/placeholder.ts
@@ -106,7 +106,9 @@ export class PlaceholderRegistry {
     return start + strAttrs + end;
   }
 
-  private _hashClosingTag(tag: string): string { return this._hashTag(`/${tag}`, {}, false); }
+  private _hashClosingTag(tag: string): string {
+    return this._hashTag(`/${tag}`, {}, false);
+  }
 
   private _generateUniqueName(base: string): string {
     const seen = this._placeHolderNameCounts.hasOwnProperty(base);

--- a/packages/compiler/src/i18n/serializers/serializer.ts
+++ b/packages/compiler/src/i18n/serializers/serializer.ts
@@ -15,13 +15,15 @@ export abstract class Serializer {
   abstract write(messages: i18n.Message[], locale: string|null): string;
 
   abstract load(content: string, url: string):
-      {locale: string | null, i18nNodesByMsgId: {[msgId: string]: i18n.Node[]}};
+      {locale: string|null, i18nNodesByMsgId: {[msgId: string]: i18n.Node[]}};
 
   abstract digest(message: i18n.Message): string;
 
   // Creates a name mapper, see `PlaceholderMapper`
   // Returning `null` means that no name mapping is used.
-  createNameMapper(message: i18n.Message): PlaceholderMapper|null { return null; }
+  createNameMapper(message: i18n.Message): PlaceholderMapper|null {
+    return null;
+  }
 }
 
 /**
@@ -61,7 +63,9 @@ export class SimplePlaceholderMapper extends i18n.RecurseVisitor implements Plac
                                                               null;
   }
 
-  visitText(text: i18n.Text, context?: any): any { return null; }
+  visitText(text: i18n.Text, context?: any): any {
+    return null;
+  }
 
   visitTagPlaceholder(ph: i18n.TagPlaceholder, context?: any): any {
     this.visitPlaceholderName(ph.startName);
@@ -69,7 +73,9 @@ export class SimplePlaceholderMapper extends i18n.RecurseVisitor implements Plac
     this.visitPlaceholderName(ph.closeName);
   }
 
-  visitPlaceholder(ph: i18n.Placeholder, context?: any): any { this.visitPlaceholderName(ph.name); }
+  visitPlaceholder(ph: i18n.Placeholder, context?: any): any {
+    this.visitPlaceholderName(ph.name);
+  }
 
   visitIcuPlaceholder(ph: i18n.IcuPlaceholder, context?: any): any {
     this.visitPlaceholderName(ph.name);

--- a/packages/compiler/src/i18n/serializers/xliff.ts
+++ b/packages/compiler/src/i18n/serializers/xliff.ts
@@ -46,9 +46,9 @@ export class Xliff extends Serializer {
             new xml.CR(10),
             new xml.Tag(
                 _CONTEXT_TAG, {'context-type': 'sourcefile'}, [new xml.Text(source.filePath)]),
-            new xml.CR(10), new xml.Tag(
-                                _CONTEXT_TAG, {'context-type': 'linenumber'},
-                                [new xml.Text(`${source.startLine}`)]),
+            new xml.CR(10),
+            new xml.Tag(_CONTEXT_TAG, {'context-type': 'linenumber'}, [new xml.Text(
+                                                                          `${source.startLine}`)]),
             new xml.CR(8));
         contextTags.push(new xml.CR(8), contextGroupTag);
       });
@@ -112,14 +112,18 @@ export class Xliff extends Serializer {
       throw new Error(`xliff parse errors:\n${errors.join('\n')}`);
     }
 
-    return {locale: locale !, i18nNodesByMsgId};
+    return {locale: locale!, i18nNodesByMsgId};
   }
 
-  digest(message: i18n.Message): string { return digest(message); }
+  digest(message: i18n.Message): string {
+    return digest(message);
+  }
 }
 
 class _WriteVisitor implements i18n.Visitor {
-  visitText(text: i18n.Text, context?: any): xml.Node[] { return [new xml.Text(text.value)]; }
+  visitText(text: i18n.Text, context?: any): xml.Node[] {
+    return [new xml.Text(text.value)];
+  }
 
   visitContainer(container: i18n.Container, context?: any): xml.Node[] {
     const nodes: xml.Node[] = [];
@@ -161,8 +165,8 @@ class _WriteVisitor implements i18n.Visitor {
   }
 
   visitIcuPlaceholder(ph: i18n.IcuPlaceholder, context?: any): xml.Node[] {
-    const equivText =
-        `{${ph.value.expression}, ${ph.value.type}, ${Object.keys(ph.value.cases).map((value: string) => value + ' {...}').join(' ')}}`;
+    const equivText = `{${ph.value.expression}, ${ph.value.type}, ${
+        Object.keys(ph.value.cases).map((value: string) => value + ' {...}').join(' ')}}`;
     return [new xml.Tag(_PLACEHOLDER_TAG, {id: ph.name, 'equiv-text': equivText})];
   }
 
@@ -175,11 +179,11 @@ class _WriteVisitor implements i18n.Visitor {
 // Extract messages as xml nodes from the xliff file
 class XliffParser implements ml.Visitor {
   // TODO(issue/24571): remove '!'.
-  private _unitMlString !: string | null;
+  private _unitMlString!: string|null;
   // TODO(issue/24571): remove '!'.
-  private _errors !: I18nError[];
+  private _errors!: I18nError[];
   // TODO(issue/24571): remove '!'.
-  private _msgIdToHtml !: {[msgId: string]: string};
+  private _msgIdToHtml!: {[msgId: string]: string};
   private _locale: string|null = null;
 
   parse(xliff: string, url: string) {
@@ -201,7 +205,7 @@ class XliffParser implements ml.Visitor {
   visitElement(element: ml.Element, context: any): any {
     switch (element.name) {
       case _UNIT_TAG:
-        this._unitMlString = null !;
+        this._unitMlString = null!;
         const idAttr = element.attrs.find((attr) => attr.name === 'id');
         if (!idAttr) {
           this._addError(element, `<${_UNIT_TAG}> misses the "id" attribute`);
@@ -227,9 +231,9 @@ class XliffParser implements ml.Visitor {
         break;
 
       case _TARGET_TAG:
-        const innerTextStart = element.startSourceSpan !.end.offset;
-        const innerTextEnd = element.endSourceSpan !.start.offset;
-        const content = element.startSourceSpan !.start.file.content;
+        const innerTextStart = element.startSourceSpan!.end.offset;
+        const innerTextEnd = element.endSourceSpan!.start.offset;
+        const content = element.startSourceSpan!.start.file.content;
         const innerText = content.slice(innerTextStart, innerTextEnd);
         this._unitMlString = innerText;
         break;
@@ -260,14 +264,14 @@ class XliffParser implements ml.Visitor {
   visitExpansionCase(expansionCase: ml.ExpansionCase, context: any): any {}
 
   private _addError(node: ml.Node, message: string): void {
-    this._errors.push(new I18nError(node.sourceSpan !, message));
+    this._errors.push(new I18nError(node.sourceSpan!, message));
   }
 }
 
 // Convert ml nodes (xliff syntax) to i18n nodes
 class XmlToI18n implements ml.Visitor {
   // TODO(issue/24571): remove '!'.
-  private _errors !: I18nError[];
+  private _errors!: I18nError[];
 
   convert(message: string, url: string) {
     const xmlIcu = new XmlParser().parse(message, url, {tokenizeExpansionForms: true});
@@ -283,13 +287,15 @@ class XmlToI18n implements ml.Visitor {
     };
   }
 
-  visitText(text: ml.Text, context: any) { return new i18n.Text(text.value, text.sourceSpan !); }
+  visitText(text: ml.Text, context: any) {
+    return new i18n.Text(text.value, text.sourceSpan!);
+  }
 
   visitElement(el: ml.Element, context: any): i18n.Placeholder|ml.Node[]|null {
     if (el.name === _PLACEHOLDER_TAG) {
       const nameAttr = el.attrs.find((attr) => attr.name === 'id');
       if (nameAttr) {
-        return new i18n.Placeholder('', nameAttr.value, el.sourceSpan !);
+        return new i18n.Placeholder('', nameAttr.value, el.sourceSpan!);
       }
 
       this._addError(el, `<${_PLACEHOLDER_TAG}> misses the "id" attribute`);
@@ -326,7 +332,7 @@ class XmlToI18n implements ml.Visitor {
   visitAttribute(attribute: ml.Attribute, context: any) {}
 
   private _addError(node: ml.Node, message: string): void {
-    this._errors.push(new I18nError(node.sourceSpan !, message));
+    this._errors.push(new I18nError(node.sourceSpan!, message));
   }
 }
 

--- a/packages/compiler/src/i18n/serializers/xliff2.ts
+++ b/packages/compiler/src/i18n/serializers/xliff2.ts
@@ -54,8 +54,8 @@ export class Xliff2 extends Serializer {
 
       message.sources.forEach((source: i18n.MessageSpan) => {
         notes.children.push(new xml.CR(8), new xml.Tag('note', {category: 'location'}, [
-          new xml.Text(
-              `${source.filePath}:${source.startLine}${source.endLine !== source.startLine ? ',' + source.endLine : ''}`)
+          new xml.Text(`${source.filePath}:${source.startLine}${
+              source.endLine !== source.startLine ? ',' + source.endLine : ''}`)
         ]));
       });
 
@@ -105,17 +105,21 @@ export class Xliff2 extends Serializer {
       throw new Error(`xliff2 parse errors:\n${errors.join('\n')}`);
     }
 
-    return {locale: locale !, i18nNodesByMsgId};
+    return {locale: locale!, i18nNodesByMsgId};
   }
 
-  digest(message: i18n.Message): string { return decimalDigest(message); }
+  digest(message: i18n.Message): string {
+    return decimalDigest(message);
+  }
 }
 
 class _WriteVisitor implements i18n.Visitor {
   // TODO(issue/24571): remove '!'.
-  private _nextPlaceholderId !: number;
+  private _nextPlaceholderId!: number;
 
-  visitText(text: i18n.Text, context?: any): xml.Node[] { return [new xml.Text(text.value)]; }
+  visitText(text: i18n.Text, context?: any): xml.Node[] {
+    return [new xml.Text(text.value)];
+  }
 
   visitContainer(container: i18n.Container, context?: any): xml.Node[] {
     const nodes: xml.Node[] = [];
@@ -192,11 +196,11 @@ class _WriteVisitor implements i18n.Visitor {
 // Extract messages as xml nodes from the xliff file
 class Xliff2Parser implements ml.Visitor {
   // TODO(issue/24571): remove '!'.
-  private _unitMlString !: string | null;
+  private _unitMlString!: string|null;
   // TODO(issue/24571): remove '!'.
-  private _errors !: I18nError[];
+  private _errors!: I18nError[];
   // TODO(issue/24571): remove '!'.
-  private _msgIdToHtml !: {[msgId: string]: string};
+  private _msgIdToHtml!: {[msgId: string]: string};
   private _locale: string|null = null;
 
   parse(xliff: string, url: string) {
@@ -242,9 +246,9 @@ class Xliff2Parser implements ml.Visitor {
         break;
 
       case _TARGET_TAG:
-        const innerTextStart = element.startSourceSpan !.end.offset;
-        const innerTextEnd = element.endSourceSpan !.start.offset;
-        const content = element.startSourceSpan !.start.file.content;
+        const innerTextStart = element.startSourceSpan!.end.offset;
+        const innerTextEnd = element.endSourceSpan!.start.offset;
+        const content = element.startSourceSpan!.start.file.content;
         const innerText = content.slice(innerTextStart, innerTextEnd);
         this._unitMlString = innerText;
         break;
@@ -290,7 +294,7 @@ class Xliff2Parser implements ml.Visitor {
 // Convert ml nodes (xliff syntax) to i18n nodes
 class XmlToI18n implements ml.Visitor {
   // TODO(issue/24571): remove '!'.
-  private _errors !: I18nError[];
+  private _errors!: I18nError[];
 
   convert(message: string, url: string) {
     const xmlIcu = new XmlParser().parse(message, url, {tokenizeExpansionForms: true});
@@ -306,7 +310,9 @@ class XmlToI18n implements ml.Visitor {
     };
   }
 
-  visitText(text: ml.Text, context: any) { return new i18n.Text(text.value, text.sourceSpan); }
+  visitText(text: ml.Text, context: any) {
+    return new i18n.Text(text.value, text.sourceSpan);
+  }
 
   visitElement(el: ml.Element, context: any): i18n.Node[]|null {
     switch (el.name) {

--- a/packages/compiler/src/i18n/serializers/xmb.ts
+++ b/packages/compiler/src/i18n/serializers/xmb.ts
@@ -57,10 +57,10 @@ export class Xmb extends Serializer {
 
       let sourceTags: xml.Tag[] = [];
       message.sources.forEach((source: i18n.MessageSpan) => {
-        sourceTags.push(new xml.Tag(_SOURCE_TAG, {}, [
-          new xml.Text(
-              `${source.filePath}:${source.startLine}${source.endLine !== source.startLine ? ',' + source.endLine : ''}`)
-        ]));
+        sourceTags.push(new xml.Tag(
+            _SOURCE_TAG, {},
+            [new xml.Text(`${source.filePath}:${source.startLine}${
+                source.endLine !== source.startLine ? ',' + source.endLine : ''}`)]));
       });
 
       rootNode.children.push(
@@ -85,7 +85,9 @@ export class Xmb extends Serializer {
     throw new Error('Unsupported');
   }
 
-  digest(message: i18n.Message): string { return digest(message); }
+  digest(message: i18n.Message): string {
+    return digest(message);
+  }
 
 
   createNameMapper(message: i18n.Message): PlaceholderMapper {
@@ -94,7 +96,9 @@ export class Xmb extends Serializer {
 }
 
 class _Visitor implements i18n.Visitor {
-  visitText(text: i18n.Text, context?: any): xml.Node[] { return [new xml.Text(text.value)]; }
+  visitText(text: i18n.Text, context?: any): xml.Node[] {
+    return [new xml.Text(text.value)];
+  }
 
   visitContainer(container: i18n.Container, context: any): xml.Node[] {
     const nodes: xml.Node[] = [];

--- a/packages/compiler/src/i18n/serializers/xml_helper.ts
+++ b/packages/compiler/src/i18n/serializers/xml_helper.ts
@@ -25,7 +25,9 @@ class _Visitor implements IVisitor {
     return `<${tag.name}${strAttrs}>${strChildren.join('')}</${tag.name}>`;
   }
 
-  visitText(text: Text): string { return text.value; }
+  visitText(text: Text): string {
+    return text.value;
+  }
 
   visitDeclaration(decl: Declaration): string {
     return `<?xml${this._serializeAttributes(decl.attrs)} ?>`;
@@ -47,7 +49,9 @@ export function serialize(nodes: Node[]): string {
   return nodes.map((node: Node): string => node.visit(_visitor)).join('');
 }
 
-export interface Node { visit(visitor: IVisitor): any; }
+export interface Node {
+  visit(visitor: IVisitor): any;
+}
 
 export class Declaration implements Node {
   public attrs: {[k: string]: string} = {};
@@ -58,13 +62,17 @@ export class Declaration implements Node {
     });
   }
 
-  visit(visitor: IVisitor): any { return visitor.visitDeclaration(this); }
+  visit(visitor: IVisitor): any {
+    return visitor.visitDeclaration(this);
+  }
 }
 
 export class Doctype implements Node {
   constructor(public rootTag: string, public dtd: string) {}
 
-  visit(visitor: IVisitor): any { return visitor.visitDoctype(this); }
+  visit(visitor: IVisitor): any {
+    return visitor.visitDoctype(this);
+  }
 }
 
 export class Tag implements Node {
@@ -78,18 +86,26 @@ export class Tag implements Node {
     });
   }
 
-  visit(visitor: IVisitor): any { return visitor.visitTag(this); }
+  visit(visitor: IVisitor): any {
+    return visitor.visitTag(this);
+  }
 }
 
 export class Text implements Node {
   value: string;
-  constructor(unescapedValue: string) { this.value = escapeXml(unescapedValue); }
+  constructor(unescapedValue: string) {
+    this.value = escapeXml(unescapedValue);
+  }
 
-  visit(visitor: IVisitor): any { return visitor.visitText(this); }
+  visit(visitor: IVisitor): any {
+    return visitor.visitText(this);
+  }
 }
 
 export class CR extends Text {
-  constructor(ws: number = 0) { super(`\n${new Array(ws + 1).join(' ')}`); }
+  constructor(ws: number = 0) {
+    super(`\n${new Array(ws + 1).join(' ')}`);
+  }
 }
 
 const _ESCAPED_CHARS: [RegExp, string][] = [

--- a/packages/compiler/src/i18n/serializers/xtb.ts
+++ b/packages/compiler/src/i18n/serializers/xtb.ts
@@ -19,7 +19,9 @@ const _TRANSLATION_TAG = 'translation';
 const _PLACEHOLDER_TAG = 'ph';
 
 export class Xtb extends Serializer {
-  write(messages: i18n.Message[], locale: string|null): string { throw new Error('Unsupported'); }
+  write(messages: i18n.Message[], locale: string|null): string {
+    throw new Error('Unsupported');
+  }
 
   load(content: string, url: string):
       {locale: string, i18nNodesByMsgId: {[msgId: string]: i18n.Node[]}} {
@@ -49,10 +51,12 @@ export class Xtb extends Serializer {
       throw new Error(`xtb parse errors:\n${errors.join('\n')}`);
     }
 
-    return {locale: locale !, i18nNodesByMsgId};
+    return {locale: locale!, i18nNodesByMsgId};
   }
 
-  digest(message: i18n.Message): string { return digest(message); }
+  digest(message: i18n.Message): string {
+    return digest(message);
+  }
 
   createNameMapper(message: i18n.Message): PlaceholderMapper {
     return new SimplePlaceholderMapper(message, toPublicName);
@@ -68,18 +72,20 @@ function createLazyProperty(messages: any, id: string, valueFn: () => any) {
       Object.defineProperty(messages, id, {enumerable: true, value});
       return value;
     },
-    set: _ => { throw new Error('Could not overwrite an XTB translation'); },
+    set: _ => {
+      throw new Error('Could not overwrite an XTB translation');
+    },
   });
 }
 
 // Extract messages as xml nodes from the xtb file
 class XtbParser implements ml.Visitor {
   // TODO(issue/24571): remove '!'.
-  private _bundleDepth !: number;
+  private _bundleDepth!: number;
   // TODO(issue/24571): remove '!'.
-  private _errors !: I18nError[];
+  private _errors!: I18nError[];
   // TODO(issue/24571): remove '!'.
-  private _msgIdToHtml !: {[msgId: string]: string};
+  private _msgIdToHtml!: {[msgId: string]: string};
   private _locale: string|null = null;
 
   parse(xtb: string, url: string) {
@@ -124,10 +130,10 @@ class XtbParser implements ml.Visitor {
           if (this._msgIdToHtml.hasOwnProperty(id)) {
             this._addError(element, `Duplicated translations for msg ${id}`);
           } else {
-            const innerTextStart = element.startSourceSpan !.end.offset;
-            const innerTextEnd = element.endSourceSpan !.start.offset;
-            const content = element.startSourceSpan !.start.file.content;
-            const innerText = content.slice(innerTextStart !, innerTextEnd !);
+            const innerTextStart = element.startSourceSpan!.end.offset;
+            const innerTextEnd = element.endSourceSpan!.start.offset;
+            const content = element.startSourceSpan!.start.file.content;
+            const innerText = content.slice(innerTextStart!, innerTextEnd!);
             this._msgIdToHtml[id] = innerText;
           }
         }
@@ -149,14 +155,14 @@ class XtbParser implements ml.Visitor {
   visitExpansionCase(expansionCase: ml.ExpansionCase, context: any): any {}
 
   private _addError(node: ml.Node, message: string): void {
-    this._errors.push(new I18nError(node.sourceSpan !, message));
+    this._errors.push(new I18nError(node.sourceSpan!, message));
   }
 }
 
 // Convert ml nodes (xtb syntax) to i18n nodes
 class XmlToI18n implements ml.Visitor {
   // TODO(issue/24571): remove '!'.
-  private _errors !: I18nError[];
+  private _errors!: I18nError[];
 
   convert(message: string, url: string) {
     const xmlIcu = new XmlParser().parse(message, url, {tokenizeExpansionForms: true});
@@ -172,7 +178,9 @@ class XmlToI18n implements ml.Visitor {
     };
   }
 
-  visitText(text: ml.Text, context: any) { return new i18n.Text(text.value, text.sourceSpan !); }
+  visitText(text: ml.Text, context: any) {
+    return new i18n.Text(text.value, text.sourceSpan!);
+  }
 
   visitExpansion(icu: ml.Expansion, context: any) {
     const caseMap: {[value: string]: i18n.Node} = {};
@@ -195,7 +203,7 @@ class XmlToI18n implements ml.Visitor {
     if (el.name === _PLACEHOLDER_TAG) {
       const nameAttr = el.attrs.find((attr) => attr.name === 'name');
       if (nameAttr) {
-        return new i18n.Placeholder('', nameAttr.value, el.sourceSpan !);
+        return new i18n.Placeholder('', nameAttr.value, el.sourceSpan!);
       }
 
       this._addError(el, `<${_PLACEHOLDER_TAG}> misses the "name" attribute`);
@@ -210,6 +218,6 @@ class XmlToI18n implements ml.Visitor {
   visitAttribute(attribute: ml.Attribute, context: any) {}
 
   private _addError(node: ml.Node, message: string): void {
-    this._errors.push(new I18nError(node.sourceSpan !, message));
+    this._errors.push(new I18nError(node.sourceSpan!, message));
   }
 }

--- a/packages/compiler/src/i18n/translation_bundle.ts
+++ b/packages/compiler/src/i18n/translation_bundle.ts
@@ -30,7 +30,7 @@ export class TranslationBundle {
       missingTranslationStrategy: MissingTranslationStrategy = MissingTranslationStrategy.Warning,
       console?: Console) {
     this._i18nToHtml = new I18nToHtmlVisitor(
-        _i18nNodesByMsgId, locale, digest, mapperFactory !, missingTranslationStrategy, console);
+        _i18nNodesByMsgId, locale, digest, mapperFactory!, missingTranslationStrategy, console);
   }
 
   // Creates a `TranslationBundle` by parsing the given `content` with the `serializer`.
@@ -40,7 +40,7 @@ export class TranslationBundle {
       console?: Console): TranslationBundle {
     const {locale, i18nNodesByMsgId} = serializer.load(content, url);
     const digestFn = (m: i18n.Message) => serializer.digest(m);
-    const mapperFactory = (m: i18n.Message) => serializer.createNameMapper(m) !;
+    const mapperFactory = (m: i18n.Message) => serializer.createNameMapper(m)!;
     return new TranslationBundle(
         i18nNodesByMsgId, locale, digestFn, mapperFactory, missingTranslationStrategy, console);
   }
@@ -56,16 +56,18 @@ export class TranslationBundle {
     return html.nodes;
   }
 
-  has(srcMsg: i18n.Message): boolean { return this.digest(srcMsg) in this._i18nNodesByMsgId; }
+  has(srcMsg: i18n.Message): boolean {
+    return this.digest(srcMsg) in this._i18nNodesByMsgId;
+  }
 }
 
 class I18nToHtmlVisitor implements i18n.Visitor {
   // TODO(issue/24571): remove '!'.
-  private _srcMsg !: i18n.Message;
+  private _srcMsg!: i18n.Message;
   private _contextStack: {msg: i18n.Message, mapper: (name: string) => string}[] = [];
   private _errors: I18nError[] = [];
   // TODO(issue/24571): remove '!'.
-  private _mapper !: (name: string) => string;
+  private _mapper!: (name: string) => string;
 
   constructor(
       private _i18nNodesByMsgId: {[msgId: string]: i18n.Node[]} = {}, private _locale: string|null,
@@ -166,7 +168,7 @@ class I18nToHtmlVisitor implements i18n.Visitor {
       // When there is a translation use its nodes as the source
       // And create a mapper to convert serialized placeholder names to internal names
       nodes = this._i18nNodesByMsgId[id];
-      this._mapper = (name: string) => mapper ? mapper.toInternalName(name) ! : name;
+      this._mapper = (name: string) => mapper ? mapper.toInternalName(name)! : name;
     } else {
       // When no translation has been found
       // - report an error / a warning / nothing,
@@ -185,7 +187,7 @@ class I18nToHtmlVisitor implements i18n.Visitor {
       this._mapper = (name: string) => name;
     }
     const text = nodes.map(node => node.visit(this)).join('');
-    const context = this._contextStack.pop() !;
+    const context = this._contextStack.pop()!;
     this._srcMsg = context.msg;
     this._mapper = context.mapper;
     return text;

--- a/packages/compiler/src/injectable_compiler.ts
+++ b/packages/compiler/src/injectable_compiler.ts
@@ -121,7 +121,7 @@ export class InjectableCompiler {
 
   compile(injectable: CompileInjectableMetadata, ctx: OutputContext): void {
     if (this.alwaysGenerateDef || injectable.providedIn !== undefined) {
-      const className = identifierName(injectable.type) !;
+      const className = identifierName(injectable.type)!;
       const clazz = new o.ClassStmt(
           className, null,
           [

--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -8,8 +8,8 @@
 
 import {Identifiers} from './identifiers';
 import * as o from './output/output_ast';
-import {R3DependencyMetadata, R3FactoryDelegateType, R3FactoryMetadata, R3FactoryTarget, compileFactoryFunction} from './render3/r3_factory';
-import {R3Reference, mapToMapExpression, typeWithParameters} from './render3/util';
+import {compileFactoryFunction, R3DependencyMetadata, R3FactoryDelegateType, R3FactoryMetadata, R3FactoryTarget} from './render3/r3_factory';
+import {mapToMapExpression, R3Reference, typeWithParameters} from './render3/util';
 
 export interface InjectableDef {
   expression: o.Expression;

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -16,13 +16,13 @@ import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from './ml_parser/int
 import {DeclareVarStmt, Expression, LiteralExpr, Statement, StmtModifier, WrappedNodeExpr} from './output/output_ast';
 import {JitEvaluator} from './output/output_jit';
 import {ParseError, ParseSourceSpan, r3JitTypeSourceSpan} from './parse_util';
-import {R3DependencyMetadata, R3FactoryTarget, R3ResolvedDependencyType, compileFactoryFunction} from './render3/r3_factory';
+import {compileFactoryFunction, R3DependencyMetadata, R3FactoryTarget, R3ResolvedDependencyType} from './render3/r3_factory';
 import {R3JitReflector} from './render3/r3_jit';
-import {R3InjectorMetadata, R3NgModuleMetadata, compileInjector, compileNgModule} from './render3/r3_module_compiler';
-import {R3PipeMetadata, compilePipeFromMetadata} from './render3/r3_pipe_compiler';
+import {compileInjector, compileNgModule, R3InjectorMetadata, R3NgModuleMetadata} from './render3/r3_module_compiler';
+import {compilePipeFromMetadata, R3PipeMetadata} from './render3/r3_pipe_compiler';
 import {R3Reference} from './render3/util';
 import {R3DirectiveMetadata, R3QueryMetadata} from './render3/view/api';
-import {ParsedHostBindings, compileComponentFromMetadata, compileDirectiveFromMetadata, parseHostBindings, verifyHostBindings} from './render3/view/compiler';
+import {compileComponentFromMetadata, compileDirectiveFromMetadata, ParsedHostBindings, parseHostBindings, verifyHostBindings} from './render3/view/compiler';
 import {makeBindingParser, parseTemplate} from './render3/view/template';
 import {ResourceLoader} from './resource_loader';
 import {DomElementSchemaRegistry} from './schema/dom_element_schema_registry';
@@ -277,7 +277,7 @@ function wrapExpression(obj: any, property: string): WrappedNodeExpr<any>|undefi
   }
 }
 
-function computeProvidedIn(providedIn: Type | string | null | undefined): Expression {
+function computeProvidedIn(providedIn: Type|string|null|undefined): Expression {
   if (providedIn == null || typeof providedIn === 'string') {
     return new LiteralExpr(providedIn);
   } else {
@@ -305,8 +305,8 @@ function convertR3DependencyMetadata(facade: R3DependencyMetadataFacade): R3Depe
   };
 }
 
-function convertR3DependencyMetadataArray(facades: R3DependencyMetadataFacade[] | null | undefined):
-    R3DependencyMetadata[]|null {
+function convertR3DependencyMetadataArray(facades: R3DependencyMetadataFacade[]|null|
+                                          undefined): R3DependencyMetadata[]|null {
   return facades == null ? null : facades.map(convertR3DependencyMetadata);
 }
 
@@ -356,13 +356,11 @@ function isOutput(value: any): value is Output {
 }
 
 function parseInputOutputs(values: string[]): StringMap {
-  return values.reduce(
-      (map, value) => {
-        const [field, property] = value.split(',').map(piece => piece.trim());
-        map[field] = property || field;
-        return map;
-      },
-      {} as StringMap);
+  return values.reduce((map, value) => {
+    const [field, property] = value.split(',').map(piece => piece.trim());
+    map[field] = property || field;
+    return map;
+  }, {} as StringMap);
 }
 
 export function publishFacade(global: any) {

--- a/packages/compiler/src/metadata_resolver.ts
+++ b/packages/compiler/src/metadata_resolver.ts
@@ -12,7 +12,7 @@ import {assertArrayOfStrings, assertInterpolationSymbols} from './assertions';
 import * as cpl from './compile_metadata';
 import {CompileReflector} from './compile_reflector';
 import {CompilerConfig} from './config';
-import {ChangeDetectionStrategy, Component, Directive, Injectable, ModuleWithProviders, Provider, Query, SchemaMetadata, Type, ViewEncapsulation, createAttribute, createComponent, createHost, createInject, createInjectable, createInjectionToken, createNgModule, createOptional, createSelf, createSkipSelf} from './core';
+import {ChangeDetectionStrategy, Component, createAttribute, createComponent, createHost, createInject, createInjectable, createInjectionToken, createNgModule, createOptional, createSelf, createSkipSelf, Directive, Injectable, ModuleWithProviders, Provider, Query, SchemaMetadata, Type, ViewEncapsulation} from './core';
 import {DirectiveNormalizer} from './directive_normalizer';
 import {DirectiveResolver, findLast} from './directive_resolver';
 import {Identifiers} from './identifiers';
@@ -23,7 +23,7 @@ import {PipeResolver} from './pipe_resolver';
 import {ElementSchemaRegistry} from './schema/element_schema_registry';
 import {CssSelector} from './selector';
 import {SummaryResolver} from './summary_resolver';
-import {Console, SyncAsync, ValueTransformer, isPromise, noUndefined, resolveForwardRef, stringify, syntaxError, visitValue} from './util';
+import {Console, isPromise, noUndefined, resolveForwardRef, stringify, SyncAsync, syntaxError, ValueTransformer, visitValue} from './util';
 
 export type ErrorCollector = (error: any, type?: any) => void;
 
@@ -55,7 +55,9 @@ export class CompileMetadataResolver {
       private _staticSymbolCache: StaticSymbolCache, private _reflector: CompileReflector,
       private _errorCollector?: ErrorCollector) {}
 
-  getReflector(): CompileReflector { return this._reflector; }
+  getReflector(): CompileReflector {
+    return this._reflector;
+  }
 
   clearCacheFor(type: Type) {
     const dirMeta = this._directiveCache.get(type);
@@ -176,7 +178,7 @@ export class CompileMetadataResolver {
     }
     // Note: ! is ok here as this method should only be called with normalized directive
     // metadata, which always fills in the selector.
-    const template = CssSelector.parse(compMeta.selector !)[0].getMatchingElementTemplate();
+    const template = CssSelector.parse(compMeta.selector!)[0].getMatchingElementTemplate();
     const templateUrl = '';
     const htmlAst = this._htmlParser.parse(template, templateUrl);
     return cpl.CompileDirectiveMetadata.create({
@@ -209,8 +211,8 @@ export class CompileMetadataResolver {
       guards: {},
       viewQueries: [],
       componentViewType: hostViewType,
-      rendererType:
-          {id: '__Host__', encapsulation: ViewEncapsulation.None, styles: [], data: {}} as object,
+      rendererType: {id: '__Host__', encapsulation: ViewEncapsulation.None, styles: [], data: {}} as
+          object,
       entryComponents: [],
       componentFactory: null
     });
@@ -221,9 +223,9 @@ export class CompileMetadataResolver {
       return null;
     }
     directiveType = resolveForwardRef(directiveType);
-    const {annotation, metadata} = this.getNonNormalizedDirectiveMetadata(directiveType) !;
+    const {annotation, metadata} = this.getNonNormalizedDirectiveMetadata(directiveType)!;
 
-    const createDirectiveMetadata = (templateMetadata: cpl.CompileTemplateMetadata | null) => {
+    const createDirectiveMetadata = (templateMetadata: cpl.CompileTemplateMetadata|null) => {
       const normalizedDirMeta = new cpl.CompileDirectiveMetadata({
         isHost: false,
         type: metadata.type,
@@ -248,7 +250,7 @@ export class CompileMetadataResolver {
         template: templateMetadata
       });
       if (templateMetadata) {
-        this.initComponentFactory(metadata.componentFactory !, templateMetadata.ngContentSelectors);
+        this.initComponentFactory(metadata.componentFactory!, templateMetadata.ngContentSelectors);
       }
       this._directiveCache.set(directiveType, normalizedDirMeta);
       this._summaryCache.set(directiveType, normalizedDirMeta.toSummary());
@@ -296,7 +298,7 @@ export class CompileMetadataResolver {
     if (!dirMeta) {
       return null;
     }
-    let nonNormalizedTemplateMetadata: cpl.CompileTemplateMetadata = undefined !;
+    let nonNormalizedTemplateMetadata: cpl.CompileTemplateMetadata = undefined!;
 
     if (createComponent.isTypeOf(dirMeta)) {
       // component
@@ -323,7 +325,7 @@ export class CompileMetadataResolver {
       });
     }
 
-    let changeDetectionStrategy: ChangeDetectionStrategy = null !;
+    let changeDetectionStrategy: ChangeDetectionStrategy = null!;
     let viewProviders: cpl.CompileProviderMetadata[] = [];
     let entryComponentMetadata: cpl.CompileEntryComponentMetadata[] = [];
     let selector = dirMeta.selector;
@@ -331,7 +333,7 @@ export class CompileMetadataResolver {
     if (createComponent.isTypeOf(dirMeta)) {
       // Component
       const compMeta = dirMeta as Component;
-      changeDetectionStrategy = compMeta.changeDetection !;
+      changeDetectionStrategy = compMeta.changeDetection!;
       if (compMeta.viewProviders) {
         viewProviders = this._getProvidersMetadata(
             compMeta.viewProviders, entryComponentMetadata,
@@ -339,7 +341,7 @@ export class CompileMetadataResolver {
       }
       if (compMeta.entryComponents) {
         entryComponentMetadata = flattenAndDedupeArray(compMeta.entryComponents)
-                                     .map((type) => this._getEntryComponentMetadata(type) !)
+                                     .map((type) => this._getEntryComponentMetadata(type)!)
                                      .concat(entryComponentMetadata);
       }
       if (!selector) {
@@ -348,7 +350,7 @@ export class CompileMetadataResolver {
     } else {
       // Directive
       if (!selector) {
-        selector = null !;
+        selector = null!;
       }
     }
 
@@ -401,11 +403,12 @@ export class CompileMetadataResolver {
    * This assumes `loadNgModuleDirectiveAndPipeMetadata` has been called first.
    */
   getDirectiveMetadata(directiveType: any): cpl.CompileDirectiveMetadata {
-    const dirMeta = this._directiveCache.get(directiveType) !;
+    const dirMeta = this._directiveCache.get(directiveType)!;
     if (!dirMeta) {
       this._reportError(
           syntaxError(
-              `Illegal state: getDirectiveMetadata can only be called after loadNgModuleDirectiveAndPipeMetadata for a module that declares it. Directive ${stringifyType(directiveType)}.`),
+              `Illegal state: getDirectiveMetadata can only be called after loadNgModuleDirectiveAndPipeMetadata for a module that declares it. Directive ${
+                  stringifyType(directiveType)}.`),
           directiveType);
     }
     return dirMeta;
@@ -530,7 +533,7 @@ export class CompileMetadataResolver {
 
     if (meta.imports) {
       flattenAndDedupeArray(meta.imports).forEach((importedType) => {
-        let importedModuleType: Type = undefined !;
+        let importedModuleType: Type = undefined!;
         if (isValidType(importedType)) {
           importedModuleType = importedType;
         } else if (importedType && importedType.ngModule) {
@@ -549,8 +552,9 @@ export class CompileMetadataResolver {
           if (!alreadyCollecting) alreadyCollecting = new Set();
           if (alreadyCollecting.has(importedModuleType)) {
             this._reportError(
-                syntaxError(
-                    `${this._getTypeDescriptor(importedModuleType)} '${stringifyType(importedType)}' is imported recursively by the module '${stringifyType(moduleType)}'.`),
+                syntaxError(`${this._getTypeDescriptor(importedModuleType)} '${
+                    stringifyType(importedType)}' is imported recursively by the module '${
+                    stringifyType(moduleType)}'.`),
                 moduleType);
             return;
           }
@@ -560,8 +564,9 @@ export class CompileMetadataResolver {
           alreadyCollecting.delete(importedModuleType);
           if (!importedModuleSummary) {
             this._reportError(
-                syntaxError(
-                    `Unexpected ${this._getTypeDescriptor(importedType)} '${stringifyType(importedType)}' imported by the module '${stringifyType(moduleType)}'. Please add a @NgModule annotation.`),
+                syntaxError(`Unexpected ${this._getTypeDescriptor(importedType)} '${
+                    stringifyType(importedType)}' imported by the module '${
+                    stringifyType(moduleType)}'. Please add a @NgModule annotation.`),
                 moduleType);
             return;
           }
@@ -569,7 +574,8 @@ export class CompileMetadataResolver {
         } else {
           this._reportError(
               syntaxError(
-                  `Unexpected value '${stringifyType(importedType)}' imported by the module '${stringifyType(moduleType)}'`),
+                  `Unexpected value '${stringifyType(importedType)}' imported by the module '${
+                      stringifyType(moduleType)}'`),
               moduleType);
           return;
         }
@@ -581,15 +587,17 @@ export class CompileMetadataResolver {
         if (!isValidType(exportedType)) {
           this._reportError(
               syntaxError(
-                  `Unexpected value '${stringifyType(exportedType)}' exported by the module '${stringifyType(moduleType)}'`),
+                  `Unexpected value '${stringifyType(exportedType)}' exported by the module '${
+                      stringifyType(moduleType)}'`),
               moduleType);
           return;
         }
         if (!alreadyCollecting) alreadyCollecting = new Set();
         if (alreadyCollecting.has(exportedType)) {
           this._reportError(
-              syntaxError(
-                  `${this._getTypeDescriptor(exportedType)} '${stringify(exportedType)}' is exported recursively by the module '${stringifyType(moduleType)}'`),
+              syntaxError(`${this._getTypeDescriptor(exportedType)} '${
+                  stringify(exportedType)}' is exported recursively by the module '${
+                  stringifyType(moduleType)}'`),
               moduleType);
           return;
         }
@@ -612,7 +620,8 @@ export class CompileMetadataResolver {
         if (!isValidType(declaredType)) {
           this._reportError(
               syntaxError(
-                  `Unexpected value '${stringifyType(declaredType)}' declared by the module '${stringifyType(moduleType)}'`),
+                  `Unexpected value '${stringifyType(declaredType)}' declared by the module '${
+                      stringifyType(moduleType)}'`),
               moduleType);
           return;
         }
@@ -634,8 +643,10 @@ export class CompileMetadataResolver {
           this._addTypeToModule(declaredType, moduleType);
         } else {
           this._reportError(
-              syntaxError(
-                  `Unexpected ${this._getTypeDescriptor(declaredType)} '${stringifyType(declaredType)}' declared by the module '${stringifyType(moduleType)}'. Please add a @Pipe/@Directive/@Component annotation.`),
+              syntaxError(`Unexpected ${this._getTypeDescriptor(declaredType)} '${
+                  stringifyType(declaredType)}' declared by the module '${
+                  stringifyType(
+                      moduleType)}'. Please add a @Pipe/@Directive/@Component annotation.`),
               moduleType);
           return;
         }
@@ -653,8 +664,9 @@ export class CompileMetadataResolver {
         transitiveModule.addExportedPipe(exportedId);
       } else {
         this._reportError(
-            syntaxError(
-                `Can't export ${this._getTypeDescriptor(exportedId.reference)} ${stringifyType(exportedId.reference)} from ${stringifyType(moduleType)} as it was neither declared nor imported!`),
+            syntaxError(`Can't export ${this._getTypeDescriptor(exportedId.reference)} ${
+                stringifyType(exportedId.reference)} from ${
+                stringifyType(moduleType)} as it was neither declared nor imported!`),
             moduleType);
         return;
       }
@@ -670,15 +682,16 @@ export class CompileMetadataResolver {
 
     if (meta.entryComponents) {
       entryComponents.push(...flattenAndDedupeArray(meta.entryComponents)
-                               .map(type => this._getEntryComponentMetadata(type) !));
+                               .map(type => this._getEntryComponentMetadata(type)!));
     }
 
     if (meta.bootstrap) {
       flattenAndDedupeArray(meta.bootstrap).forEach(type => {
         if (!isValidType(type)) {
           this._reportError(
-              syntaxError(
-                  `Unexpected value '${stringifyType(type)}' used in the bootstrap property of module '${stringifyType(moduleType)}'`),
+              syntaxError(`Unexpected value '${
+                  stringifyType(type)}' used in the bootstrap property of module '${
+                  stringifyType(moduleType)}'`),
               moduleType);
           return;
         }
@@ -687,7 +700,7 @@ export class CompileMetadataResolver {
     }
 
     entryComponents.push(
-        ...bootstrapComponents.map(type => this._getEntryComponentMetadata(type.reference) !));
+        ...bootstrapComponents.map(type => this._getEntryComponentMetadata(type.reference)!));
 
     if (meta.schemas) {
       schemas.push(...flattenAndDedupeArray(meta.schemas));
@@ -710,7 +723,7 @@ export class CompileMetadataResolver {
     });
 
     entryComponents.forEach((id) => transitiveModule.addEntryComponent(id));
-    providers.forEach((provider) => transitiveModule.addProvider(provider, compileMeta !.type));
+    providers.forEach((provider) => transitiveModule.addProvider(provider, compileMeta!.type));
     transitiveModule.addModule(compileMeta.type);
     this._ngModuleCache.set(moduleType, compileMeta);
     return compileMeta;
@@ -753,9 +766,13 @@ export class CompileMetadataResolver {
     if (oldModule && oldModule !== moduleType) {
       this._reportError(
           syntaxError(
-              `Type ${stringifyType(type)} is part of the declarations of 2 modules: ${stringifyType(oldModule)} and ${stringifyType(moduleType)}! ` +
-              `Please consider moving ${stringifyType(type)} to a higher module that imports ${stringifyType(oldModule)} and ${stringifyType(moduleType)}. ` +
-              `You can also create a new NgModule that exports and includes ${stringifyType(type)} then import that NgModule in ${stringifyType(oldModule)} and ${stringifyType(moduleType)}.`),
+              `Type ${stringifyType(type)} is part of the declarations of 2 modules: ${
+                  stringifyType(oldModule)} and ${stringifyType(moduleType)}! ` +
+              `Please consider moving ${stringifyType(type)} to a higher module that imports ${
+                  stringifyType(oldModule)} and ${stringifyType(moduleType)}. ` +
+              `You can also create a new NgModule that exports and includes ${
+                  stringifyType(type)} then import that NgModule in ${
+                  stringifyType(oldModule)} and ${stringifyType(moduleType)}.`),
           moduleType);
       return;
     }
@@ -870,7 +887,8 @@ export class CompileMetadataResolver {
     if (!pipeMeta) {
       this._reportError(
           syntaxError(
-              `Illegal state: getPipeMetadata can only be called after loadNgModuleDirectiveAndPipeMetadata for a module that declares it. Pipe ${stringifyType(pipeType)}.`),
+              `Illegal state: getPipeMetadata can only be called after loadNgModuleDirectiveAndPipeMetadata for a module that declares it. Pipe ${
+                  stringifyType(pipeType)}.`),
           pipeType);
     }
     return pipeMeta || null;
@@ -898,7 +916,7 @@ export class CompileMetadataResolver {
 
   private _loadPipeMetadata(pipeType: any): cpl.CompilePipeMetadata {
     pipeType = resolveForwardRef(pipeType);
-    const pipeAnnotation = this._pipeResolver.resolve(pipeType) !;
+    const pipeAnnotation = this._pipeResolver.resolve(pipeType)!;
 
     const pipeMeta = new cpl.CompilePipeMetadata({
       type: this._getTypeMetadata(pipeType),
@@ -962,7 +980,6 @@ export class CompileMetadataResolver {
         isOptional,
         token: this._getTokenMetadata(token)
       };
-
     });
 
     if (hasUnknownDeps) {
@@ -1000,7 +1017,7 @@ export class CompileMetadataResolver {
         this._getProvidersMetadata(provider, targetEntryComponents, debugInfo, compileProviders);
       } else {
         provider = resolveForwardRef(provider);
-        let providerMeta: cpl.ProviderMeta = undefined !;
+        let providerMeta: cpl.ProviderMeta = undefined!;
         if (provider && typeof provider === 'object' && provider.hasOwnProperty('provide')) {
           this._validateProvider(provider);
           providerMeta = new cpl.ProviderMeta(provider.provide, provider);
@@ -1027,8 +1044,11 @@ export class CompileMetadataResolver {
                       [])
                   .join(', ');
           this._reportError(
-              syntaxError(
-                  `Invalid ${debugInfo ? debugInfo : 'provider'} - only instances of Provider and Type are allowed, got: [${providersInfo}]`),
+              syntaxError(`Invalid ${
+                  debugInfo ?
+                      debugInfo :
+                      'provider'} - only instances of Provider and Type are allowed, got: [${
+                  providersInfo}]`),
               type);
           return;
         }
@@ -1045,8 +1065,8 @@ export class CompileMetadataResolver {
 
   private _validateProvider(provider: any): void {
     if (provider.hasOwnProperty('useClass') && provider.useClass == null) {
-      this._reportError(syntaxError(
-          `Invalid provider for ${stringifyType(provider.provide)}. useClass cannot be ${provider.useClass}.
+      this._reportError(syntaxError(`Invalid provider for ${
+          stringifyType(provider.provide)}. useClass cannot be ${provider.useClass}.
            Usually it happens when:
            1. There's a circular dependency (might be caused by using index.ts (barrel) files).
            2. Class was used before it was declared. Use forwardRef in this case.`));
@@ -1085,12 +1105,12 @@ export class CompileMetadataResolver {
       cpl.CompileEntryComponentMetadata|null {
     const dirMeta = this.getNonNormalizedDirectiveMetadata(dirType);
     if (dirMeta && dirMeta.metadata.isComponent) {
-      return {componentType: dirType, componentFactory: dirMeta.metadata.componentFactory !};
+      return {componentType: dirType, componentFactory: dirMeta.metadata.componentFactory!};
     }
     const dirSummary =
         <cpl.CompileDirectiveSummary>this._loadSummary(dirType, cpl.CompileSummaryKind.Directive);
     if (dirSummary && dirSummary.isComponent) {
-      return {componentType: dirType, componentFactory: dirSummary.componentFactory !};
+      return {componentType: dirType, componentFactory: dirSummary.componentFactory!};
     }
     if (throwIfNotFound) {
       throw syntaxError(`${dirType.name} cannot be used as an entry component.`);
@@ -1108,9 +1128,9 @@ export class CompileMetadataResolver {
   }
 
   getProviderMetadata(provider: cpl.ProviderMeta): cpl.CompileProviderMetadata {
-    let compileDeps: cpl.CompileDiDependencyMetadata[] = undefined !;
-    let compileTypeMetadata: cpl.CompileTypeMetadata = null !;
-    let compileFactoryMetadata: cpl.CompileFactoryMetadata = null !;
+    let compileDeps: cpl.CompileDiDependencyMetadata[] = undefined!;
+    let compileTypeMetadata: cpl.CompileTypeMetadata = null!;
+    let compileFactoryMetadata: cpl.CompileFactoryMetadata = null!;
     let token: cpl.CompileTokenMetadata = this._getTokenMetadata(provider.token);
 
     if (provider.useClass) {
@@ -1152,7 +1172,9 @@ export class CompileMetadataResolver {
     return res;
   }
 
-  private _queryVarBindings(selector: any): string[] { return selector.split(/\s*,\s*/); }
+  private _queryVarBindings(selector: any): string[] {
+    return selector.split(/\s*,\s*/);
+  }
 
   private _getQueryMetadata(q: Query, propertyName: string, typeOrFunc: Type|Function):
       cpl.CompileQueryMetadata {
@@ -1163,8 +1185,8 @@ export class CompileMetadataResolver {
     } else {
       if (!q.selector) {
         this._reportError(
-            syntaxError(
-                `Can't construct a query for the property "${propertyName}" of "${stringifyType(typeOrFunc)}" since the query selector wasn't defined.`),
+            syntaxError(`Can't construct a query for the property "${propertyName}" of "${
+                stringifyType(typeOrFunc)}" since the query selector wasn't defined.`),
             typeOrFunc);
         selectors = [];
       } else {
@@ -1175,8 +1197,9 @@ export class CompileMetadataResolver {
     return {
       selectors,
       first: q.first,
-      descendants: q.descendants, propertyName,
-      read: q.read ? this._getTokenMetadata(q.read) : null !,
+      descendants: q.descendants,
+      propertyName,
+      read: q.read ? this._getTokenMetadata(q.read) : null!,
       static: q.static
     };
   }

--- a/packages/compiler/src/ml_parser/ast.ts
+++ b/packages/compiler/src/ml_parser/ast.ts
@@ -24,7 +24,9 @@ export class Text extends NodeWithI18n {
   constructor(public value: string, sourceSpan: ParseSourceSpan, i18n?: I18nMeta) {
     super(sourceSpan, i18n);
   }
-  visit(visitor: Visitor, context: any): any { return visitor.visitText(this, context); }
+  visit(visitor: Visitor, context: any): any {
+    return visitor.visitText(this, context);
+  }
 }
 
 export class Expansion extends NodeWithI18n {
@@ -33,7 +35,9 @@ export class Expansion extends NodeWithI18n {
       sourceSpan: ParseSourceSpan, public switchValueSourceSpan: ParseSourceSpan, i18n?: I18nMeta) {
     super(sourceSpan, i18n);
   }
-  visit(visitor: Visitor, context: any): any { return visitor.visitExpansion(this, context); }
+  visit(visitor: Visitor, context: any): any {
+    return visitor.visitExpansion(this, context);
+  }
 }
 
 export class ExpansionCase implements Node {
@@ -41,7 +45,9 @@ export class ExpansionCase implements Node {
       public value: string, public expression: Node[], public sourceSpan: ParseSourceSpan,
       public valueSourceSpan: ParseSourceSpan, public expSourceSpan: ParseSourceSpan) {}
 
-  visit(visitor: Visitor, context: any): any { return visitor.visitExpansionCase(this, context); }
+  visit(visitor: Visitor, context: any): any {
+    return visitor.visitExpansionCase(this, context);
+  }
 }
 
 export class Attribute extends NodeWithI18n {
@@ -50,7 +56,9 @@ export class Attribute extends NodeWithI18n {
       public valueSpan?: ParseSourceSpan, i18n?: I18nMeta) {
     super(sourceSpan, i18n);
   }
-  visit(visitor: Visitor, context: any): any { return visitor.visitAttribute(this, context); }
+  visit(visitor: Visitor, context: any): any {
+    return visitor.visitAttribute(this, context);
+  }
 }
 
 export class Element extends NodeWithI18n {
@@ -60,12 +68,16 @@ export class Element extends NodeWithI18n {
       public endSourceSpan: ParseSourceSpan|null = null, i18n?: I18nMeta) {
     super(sourceSpan, i18n);
   }
-  visit(visitor: Visitor, context: any): any { return visitor.visitElement(this, context); }
+  visit(visitor: Visitor, context: any): any {
+    return visitor.visitElement(this, context);
+  }
 }
 
 export class Comment implements Node {
   constructor(public value: string|null, public sourceSpan: ParseSourceSpan) {}
-  visit(visitor: Visitor, context: any): any { return visitor.visitComment(this, context); }
+  visit(visitor: Visitor, context: any): any {
+    return visitor.visitComment(this, context);
+  }
 }
 
 export interface Visitor {
@@ -85,7 +97,7 @@ export function visitAll(visitor: Visitor, nodes: Node[], context: any = null): 
   const result: any[] = [];
 
   const visit = visitor.visit ?
-      (ast: Node) => visitor.visit !(ast, context) || ast.visit(visitor, context) :
+      (ast: Node) => visitor.visit!(ast, context) || ast.visit(visitor, context) :
       (ast: Node) => ast.visit(visitor, context);
   nodes.forEach(ast => {
     const astResult = visit(ast);
@@ -111,7 +123,9 @@ export class RecursiveVisitor implements Visitor {
   visitComment(ast: Comment, context: any): any {}
 
   visitExpansion(ast: Expansion, context: any): any {
-    return this.visitChildren(context, visit => { visit(ast.cases); });
+    return this.visitChildren(context, visit => {
+      visit(ast.cases);
+    });
   }
 
   visitExpansionCase(ast: ExpansionCase, context: any): any {}
@@ -120,7 +134,7 @@ export class RecursiveVisitor implements Visitor {
       context: any, cb: (visit: (<V extends Node>(children: V[]|undefined) => void)) => void) {
     let results: any[][] = [];
     let t = this;
-    function visit<T extends Node>(children: T[] | undefined) {
+    function visit<T extends Node>(children: T[]|undefined) {
       if (children) results.push(visitAll(t, children, context));
     }
     cb(visit);

--- a/packages/compiler/src/ml_parser/html_parser.ts
+++ b/packages/compiler/src/ml_parser/html_parser.ts
@@ -8,12 +8,14 @@
 
 import {getHtmlTagDefinition} from './html_tags';
 import {TokenizeOptions} from './lexer';
-import {ParseTreeResult, Parser} from './parser';
+import {Parser, ParseTreeResult} from './parser';
 
 export {ParseTreeResult, TreeError} from './parser';
 
 export class HtmlParser extends Parser {
-  constructor() { super(getHtmlTagDefinition); }
+  constructor() {
+    super(getHtmlTagDefinition);
+  }
 
   parse(source: string, url: string, options?: TokenizeOptions): ParseTreeResult {
     return super.parse(source, url, options);

--- a/packages/compiler/src/ml_parser/html_tags.ts
+++ b/packages/compiler/src/ml_parser/html_tags.ts
@@ -18,16 +18,21 @@ export class HtmlTagDefinition implements TagDefinition {
   ignoreFirstLf: boolean;
   canSelfClose: boolean = false;
 
-  constructor(
-      {closedByChildren, implicitNamespacePrefix, contentType = TagContentType.PARSABLE_DATA,
-       closedByParent = false, isVoid = false, ignoreFirstLf = false}: {
-        closedByChildren?: string[],
-        closedByParent?: boolean,
-        implicitNamespacePrefix?: string,
-        contentType?: TagContentType,
-        isVoid?: boolean,
-        ignoreFirstLf?: boolean
-      } = {}) {
+  constructor({
+    closedByChildren,
+    implicitNamespacePrefix,
+    contentType = TagContentType.PARSABLE_DATA,
+    closedByParent = false,
+    isVoid = false,
+    ignoreFirstLf = false
+  }: {
+    closedByChildren?: string[],
+    closedByParent?: boolean,
+    implicitNamespacePrefix?: string,
+    contentType?: TagContentType,
+    isVoid?: boolean,
+    ignoreFirstLf?: boolean
+  } = {}) {
     if (closedByChildren && closedByChildren.length > 0) {
       closedByChildren.forEach(tagName => this.closedByChildren[tagName] = true);
     }
@@ -43,11 +48,11 @@ export class HtmlTagDefinition implements TagDefinition {
   }
 }
 
-let _DEFAULT_TAG_DEFINITION !: HtmlTagDefinition;
+let _DEFAULT_TAG_DEFINITION!: HtmlTagDefinition;
 
 // see http://www.w3.org/TR/html51/syntax.html#optional-tags
 // This implementation does not fully conform to the HTML5 spec.
-let TAG_DEFINITIONS !: {[key: string]: HtmlTagDefinition};
+let TAG_DEFINITIONS!: {[key: string]: HtmlTagDefinition};
 
 export function getHtmlTagDefinition(tagName: string): HtmlTagDefinition {
   if (!TAG_DEFINITIONS) {

--- a/packages/compiler/src/ml_parser/html_whitespaces.ts
+++ b/packages/compiler/src/ml_parser/html_whitespaces.ts
@@ -81,11 +81,17 @@ export class WhitespaceVisitor implements html.Visitor {
     return null;
   }
 
-  visitComment(comment: html.Comment, context: any): any { return comment; }
+  visitComment(comment: html.Comment, context: any): any {
+    return comment;
+  }
 
-  visitExpansion(expansion: html.Expansion, context: any): any { return expansion; }
+  visitExpansion(expansion: html.Expansion, context: any): any {
+    return expansion;
+  }
 
-  visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any { return expansionCase; }
+  visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any {
+    return expansionCase;
+  }
 }
 
 export function removeWhitespaces(htmlAstWithErrors: ParseTreeResult): ParseTreeResult {

--- a/packages/compiler/src/ml_parser/icu_ast_expander.ts
+++ b/packages/compiler/src/ml_parser/icu_ast_expander.ts
@@ -46,7 +46,9 @@ export class ExpansionResult {
 }
 
 export class ExpansionError extends ParseError {
-  constructor(span: ParseSourceSpan, errorMsg: string) { super(span, errorMsg); }
+  constructor(span: ParseSourceSpan, errorMsg: string) {
+    super(span, errorMsg);
+  }
 }
 
 /**
@@ -64,11 +66,17 @@ class _Expander implements html.Visitor {
         element.startSourceSpan, element.endSourceSpan);
   }
 
-  visitAttribute(attribute: html.Attribute, context: any): any { return attribute; }
+  visitAttribute(attribute: html.Attribute, context: any): any {
+    return attribute;
+  }
 
-  visitText(text: html.Text, context: any): any { return text; }
+  visitText(text: html.Text, context: any): any {
+    return text;
+  }
 
-  visitComment(comment: html.Comment, context: any): any { return comment; }
+  visitComment(comment: html.Comment, context: any): any {
+    return comment;
+  }
 
   visitExpansion(icu: html.Expansion, context: any): any {
     this.isExpanded = true;
@@ -87,7 +95,7 @@ function _expandPluralForm(ast: html.Expansion, errors: ParseError[]): html.Elem
     if (PLURAL_CASES.indexOf(c.value) == -1 && !c.value.match(/^=\d+$/)) {
       errors.push(new ExpansionError(
           c.valueSourceSpan,
-          `Plural cases should be "=<number>" or one of ${PLURAL_CASES.join(", ")}`));
+          `Plural cases should be "=<number>" or one of ${PLURAL_CASES.join(', ')}`));
     }
 
     const expansionResult = expandNodes(c.expression);

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -764,7 +764,7 @@ function mergeTextTokens(srcTokens: Token[]): Token[] {
   for (let i = 0; i < srcTokens.length; i++) {
     const token = srcTokens[i];
     if (lastDstToken && lastDstToken.type == TokenType.TEXT && token.type == TokenType.TEXT) {
-      lastDstToken.parts[0] ! += token.parts[0];
+      lastDstToken.parts[0]! += token.parts[0];
       lastDstToken.sourceSpan.end = token.sourceSpan.end;
     } else {
       lastDstToken = token;
@@ -849,15 +849,27 @@ class PlainCharacterCursor implements CharacterCursor {
     }
   }
 
-  clone(): PlainCharacterCursor { return new PlainCharacterCursor(this); }
+  clone(): PlainCharacterCursor {
+    return new PlainCharacterCursor(this);
+  }
 
-  peek() { return this.state.peek; }
-  charsLeft() { return this.end - this.state.offset; }
-  diff(other: this) { return this.state.offset - other.state.offset; }
+  peek() {
+    return this.state.peek;
+  }
+  charsLeft() {
+    return this.end - this.state.offset;
+  }
+  diff(other: this) {
+    return this.state.offset - other.state.offset;
+  }
 
-  advance(): void { this.advanceState(this.state); }
+  advance(): void {
+    this.advanceState(this.state);
+  }
 
-  init(): void { this.updatePeek(this.state); }
+  init(): void {
+    this.updatePeek(this.state);
+  }
 
   getSpan(start?: this, leadingTriviaCodePoints?: number[]): ParseSourceSpan {
     start = start || this;
@@ -880,7 +892,9 @@ class PlainCharacterCursor implements CharacterCursor {
     return this.input.substring(start.state.offset, this.state.offset);
   }
 
-  charAt(pos: number): number { return this.input.charCodeAt(pos); }
+  charAt(pos: number): number {
+    return this.input.charCodeAt(pos);
+  }
 
   protected advanceState(state: CursorState) {
     if (state.offset >= this.end) {
@@ -913,7 +927,7 @@ class EscapedCharacterCursor extends PlainCharacterCursor {
       super(fileOrCursor);
       this.internalState = {...fileOrCursor.internalState};
     } else {
-      super(fileOrCursor, range !);
+      super(fileOrCursor, range!);
       this.internalState = this.state;
     }
   }
@@ -929,7 +943,9 @@ class EscapedCharacterCursor extends PlainCharacterCursor {
     this.processEscapeSequence();
   }
 
-  clone(): EscapedCharacterCursor { return new EscapedCharacterCursor(this); }
+  clone(): EscapedCharacterCursor {
+    return new EscapedCharacterCursor(this);
+  }
 
   getChars(start: this): string {
     const cursor = start.clone();

--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -10,7 +10,7 @@ import {ParseError, ParseSourceSpan} from '../parse_util';
 
 import * as html from './ast';
 import * as lex from './lexer';
-import {TagDefinition, getNsPrefix, isNgContainer, mergeNsAndName} from './tags';
+import {getNsPrefix, isNgContainer, mergeNsAndName, TagDefinition} from './tags';
 
 export class TreeError extends ParseError {
   static create(elementName: string|null, span: ParseSourceSpan, msg: string): TreeError {
@@ -43,7 +43,7 @@ export class Parser {
 class _TreeBuilder {
   private _index: number = -1;
   // TODO(issue/24571): remove '!'.
-  private _peek !: lex.Token;
+  private _peek!: lex.Token;
 
   private _rootNodes: html.Node[] = [];
   private _errors: TreeError[] = [];
@@ -283,7 +283,7 @@ class _TreeBuilder {
         endTagToken.parts[0], endTagToken.parts[1], this._getParentElement());
 
     if (this._getParentElement()) {
-      this._getParentElement() !.endSourceSpan = endTagToken.sourceSpan;
+      this._getParentElement()!.endSourceSpan = endTagToken.sourceSpan;
     }
 
     if (this.getTagDefinition(fullName).isVoid) {
@@ -291,8 +291,8 @@ class _TreeBuilder {
           fullName, endTagToken.sourceSpan,
           `Void elements do not have end tags "${endTagToken.parts[1]}"`));
     } else if (!this._popElement(fullName)) {
-      const errMsg =
-          `Unexpected closing tag "${fullName}". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags`;
+      const errMsg = `Unexpected closing tag "${
+          fullName}". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags`;
       this._errors.push(TreeError.create(fullName, endTagToken.sourceSpan, errMsg));
     }
   }
@@ -316,7 +316,7 @@ class _TreeBuilder {
     const fullName = mergeNsAndName(attrName.parts[0], attrName.parts[1]);
     let end = attrName.sourceSpan.end;
     let value = '';
-    let valueSpan: ParseSourceSpan = undefined !;
+    let valueSpan: ParseSourceSpan = undefined!;
     if (this._peek.type === lex.TokenType.ATTR_QUOTE) {
       this._advance();
     }
@@ -344,7 +344,7 @@ class _TreeBuilder {
    * `<ng-container>` elements are skipped as they are not rendered as DOM element.
    */
   private _getParentElementSkippingContainers():
-      {parent: html.Element | null, container: html.Element|null} {
+      {parent: html.Element|null, container: html.Element|null} {
     let container: html.Element|null = null;
 
     for (let i = this._elementStack.length - 1; i >= 0; i--) {

--- a/packages/compiler/src/ml_parser/tags.ts
+++ b/packages/compiler/src/ml_parser/tags.ts
@@ -23,7 +23,7 @@ export interface TagDefinition {
   isClosedByChild(name: string): boolean;
 }
 
-export function splitNsName(elementName: string): [string | null, string] {
+export function splitNsName(elementName: string): [string|null, string] {
   if (elementName[0] != ':') {
     return [null, elementName];
   }
@@ -54,7 +54,7 @@ export function isNgTemplate(tagName: string): boolean {
 
 export function getNsPrefix(fullName: string): string;
 export function getNsPrefix(fullName: null): null;
-export function getNsPrefix(fullName: string | null): string|null {
+export function getNsPrefix(fullName: string|null): string|null {
   return fullName === null ? null : splitNsName(fullName)[0];
 }
 

--- a/packages/compiler/src/ml_parser/xml_parser.ts
+++ b/packages/compiler/src/ml_parser/xml_parser.ts
@@ -7,13 +7,15 @@
  */
 
 import {TokenizeOptions} from './lexer';
-import {ParseTreeResult, Parser} from './parser';
+import {Parser, ParseTreeResult} from './parser';
 import {getXmlTagDefinition} from './xml_tags';
 
 export {ParseTreeResult, TreeError} from './parser';
 
 export class XmlParser extends Parser {
-  constructor() { super(getXmlTagDefinition); }
+  constructor() {
+    super(getXmlTagDefinition);
+  }
 
   parse(source: string, url: string, options?: TokenizeOptions): ParseTreeResult {
     return super.parse(source, url, options);

--- a/packages/compiler/src/ml_parser/xml_tags.ts
+++ b/packages/compiler/src/ml_parser/xml_tags.ts
@@ -11,19 +11,23 @@ import {TagContentType, TagDefinition} from './tags';
 export class XmlTagDefinition implements TagDefinition {
   closedByParent: boolean = false;
   // TODO(issue/24571): remove '!'.
-  requiredParents !: {[key: string]: boolean};
+  requiredParents!: {[key: string]: boolean};
   // TODO(issue/24571): remove '!'.
-  parentToAdd !: string;
+  parentToAdd!: string;
   // TODO(issue/24571): remove '!'.
-  implicitNamespacePrefix !: string;
+  implicitNamespacePrefix!: string;
   contentType: TagContentType = TagContentType.PARSABLE_DATA;
   isVoid: boolean = false;
   ignoreFirstLf: boolean = false;
   canSelfClose: boolean = true;
 
-  requireExtraParent(currentParent: string): boolean { return false; }
+  requireExtraParent(currentParent: string): boolean {
+    return false;
+  }
 
-  isClosedByChild(name: string): boolean { return false; }
+  isClosedByChild(name: string): boolean {
+    return false;
+  }
 }
 
 const _TAG_DEFINITION = new XmlTagDefinition();

--- a/packages/compiler/src/ng_module_compiler.ts
+++ b/packages/compiler/src/ng_module_compiler.ts
@@ -43,8 +43,8 @@ export class NgModuleCompiler {
             });
 
     const ngModuleDef = o.importExpr(Identifiers.moduleDef).callFn([o.literalArr(providerDefs)]);
-    const ngModuleDefFactory = o.fn(
-        [new o.FnParam(LOG_VAR.name !)], [new o.ReturnStatement(ngModuleDef)], o.INFERRED_TYPE);
+    const ngModuleDefFactory =
+        o.fn([new o.FnParam(LOG_VAR.name!)], [new o.ReturnStatement(ngModuleDef)], o.INFERRED_TYPE);
 
     const ngModuleFactoryVar = `${identifierName(ngModuleMeta.type)}NgFactory`;
     this._createNgModuleFactory(
@@ -77,7 +77,7 @@ export class NgModuleCompiler {
             .set(value)
             .toDeclStmt(
                 o.importType(
-                    Identifiers.NgModuleFactory, [o.expressionType(ctx.importExpr(reference)) !],
+                    Identifiers.NgModuleFactory, [o.expressionType(ctx.importExpr(reference))!],
                     [o.TypeModifier.Const]),
                 [o.StmtModifier.Final, o.StmtModifier.Exported]);
 

--- a/packages/compiler/src/ng_module_resolver.ts
+++ b/packages/compiler/src/ng_module_resolver.ts
@@ -7,7 +7,7 @@
  */
 
 import {CompileReflector} from './compile_reflector';
-import {NgModule, Type, createNgModule} from './core';
+import {createNgModule, NgModule, Type} from './core';
 import {findLast} from './directive_resolver';
 import {stringify} from './util';
 
@@ -18,7 +18,9 @@ import {stringify} from './util';
 export class NgModuleResolver {
   constructor(private _reflector: CompileReflector) {}
 
-  isNgModule(type: any) { return this._reflector.annotations(type).some(createNgModule.isTypeOf); }
+  isNgModule(type: any) {
+    return this._reflector.annotations(type).some(createNgModule.isTypeOf);
+  }
 
   resolve(type: Type, throwIfNotFound = true): NgModule|null {
     const ngModuleMeta: NgModule =

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -28,31 +28,39 @@ class _EmittedLine {
 }
 
 export class EmitterVisitorContext {
-  static createRoot(): EmitterVisitorContext { return new EmitterVisitorContext(0); }
+  static createRoot(): EmitterVisitorContext {
+    return new EmitterVisitorContext(0);
+  }
 
   private _lines: _EmittedLine[];
   private _classes: o.ClassStmt[] = [];
   private _preambleLineCount = 0;
 
-  constructor(private _indent: number) { this._lines = [new _EmittedLine(_indent)]; }
+  constructor(private _indent: number) {
+    this._lines = [new _EmittedLine(_indent)];
+  }
 
   /**
    * @internal strip this from published d.ts files due to
    * https://github.com/microsoft/TypeScript/issues/36216
    */
-  private get _currentLine(): _EmittedLine { return this._lines[this._lines.length - 1]; }
+  private get _currentLine(): _EmittedLine {
+    return this._lines[this._lines.length - 1];
+  }
 
-  println(from?: {sourceSpan: ParseSourceSpan | null}|null, lastPart: string = ''): void {
+  println(from?: {sourceSpan: ParseSourceSpan|null}|null, lastPart: string = ''): void {
     this.print(from || null, lastPart, true);
   }
 
-  lineIsEmpty(): boolean { return this._currentLine.parts.length === 0; }
+  lineIsEmpty(): boolean {
+    return this._currentLine.parts.length === 0;
+  }
 
   lineLength(): number {
     return this._currentLine.indent * _INDENT_WITH.length + this._currentLine.partsLength;
   }
 
-  print(from: {sourceSpan: ParseSourceSpan | null}|null, part: string, newLine: boolean = false) {
+  print(from: {sourceSpan: ParseSourceSpan|null}|null, part: string, newLine: boolean = false) {
     if (part.length > 0) {
       this._currentLine.parts.push(part);
       this._currentLine.partsLength += part.length;
@@ -83,9 +91,13 @@ export class EmitterVisitorContext {
     }
   }
 
-  pushClass(clazz: o.ClassStmt) { this._classes.push(clazz); }
+  pushClass(clazz: o.ClassStmt) {
+    this._classes.push(clazz);
+  }
 
-  popClass(): o.ClassStmt { return this._classes.pop() !; }
+  popClass(): o.ClassStmt {
+    return this._classes.pop()!;
+  }
 
   get currentClass(): o.ClassStmt|null {
     return this._classes.length > 0 ? this._classes[this._classes.length - 1] : null;
@@ -135,7 +147,7 @@ export class EmitterVisitorContext {
       }
 
       while (spanIdx < spans.length) {
-        const span = spans[spanIdx] !;
+        const span = spans[spanIdx]!;
         const source = span.start.file;
         const sourceLine = span.start.line;
         const sourceCol = span.start.col;
@@ -156,7 +168,9 @@ export class EmitterVisitorContext {
     return map;
   }
 
-  setPreambleLineCount(count: number) { return this._preambleLineCount = count; }
+  setPreambleLineCount(count: number) {
+    return this._preambleLineCount = count;
+  }
 
   spanOf(line: number, column: number): ParseSourceSpan|null {
     const emittedLine = this._lines[line - this._preambleLineCount];
@@ -243,7 +257,9 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     if (stmt.multiline) {
       ctx.println(stmt, `/* ${stmt.comment} */`);
     } else {
-      stmt.comment.split('\n').forEach((line) => { ctx.println(stmt, `// ${line}`); });
+      stmt.comment.split('\n').forEach((line) => {
+        ctx.println(stmt, `// ${line}`);
+      });
     }
     return null;
   }
@@ -327,7 +343,7 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     expr.expr.visitExpression(this, ctx);
   }
   visitReadVarExpr(ast: o.ReadVarExpr, ctx: EmitterVisitorContext): any {
-    let varName = ast.name !;
+    let varName = ast.name!;
     if (ast.builtin != null) {
       switch (ast.builtin) {
         case o.BuiltinVar.Super:
@@ -337,10 +353,10 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
           varName = 'this';
           break;
         case o.BuiltinVar.CatchError:
-          varName = CATCH_ERROR_VAR.name !;
+          varName = CATCH_ERROR_VAR.name!;
           break;
         case o.BuiltinVar.CatchStack:
-          varName = CATCH_STACK_VAR.name !;
+          varName = CATCH_STACK_VAR.name!;
           break;
         default:
           throw new Error(`Unknown builtin variable ${ast.builtin}`);
@@ -388,7 +404,7 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     ctx.print(ast, '? ');
     ast.trueCase.visitExpression(this, ctx);
     ctx.print(ast, ': ');
-    ast.falseCase !.visitExpression(this, ctx);
+    ast.falseCase!.visitExpression(this, ctx);
     ctx.print(ast, `)`);
     return null;
   }

--- a/packages/compiler/src/output/abstract_js_emitter.ts
+++ b/packages/compiler/src/output/abstract_js_emitter.ts
@@ -11,7 +11,9 @@ import {AbstractEmitterVisitor, CATCH_ERROR_VAR, CATCH_STACK_VAR, EmitterVisitor
 import * as o from './output_ast';
 
 export abstract class AbstractJsEmitterVisitor extends AbstractEmitterVisitor {
-  constructor() { super(false); }
+  constructor() {
+    super(false);
+  }
   visitDeclareClassStmt(stmt: o.ClassStmt, ctx: EmitterVisitorContext): any {
     ctx.pushClass(stmt);
     this._visitClassConstructor(stmt, ctx);
@@ -101,7 +103,7 @@ export abstract class AbstractJsEmitterVisitor extends AbstractEmitterVisitor {
   visitInvokeFunctionExpr(expr: o.InvokeFunctionExpr, ctx: EmitterVisitorContext): string|null {
     const fnExpr = expr.fn;
     if (fnExpr instanceof o.ReadVarExpr && fnExpr.builtin === o.BuiltinVar.Super) {
-      ctx.currentClass !.parent !.visitExpression(this, ctx);
+      ctx.currentClass!.parent!.visitExpression(this, ctx);
       ctx.print(expr, `.call(this`);
       if (expr.args.length > 0) {
         ctx.print(expr, `, `);

--- a/packages/compiler/src/output/js_emitter.ts
+++ b/packages/compiler/src/output/js_emitter.ts
@@ -51,7 +51,7 @@ class JsEmitterVisitor extends AbstractJsEmitterVisitor {
       }
       ctx.print(ast, `${prefix}.`);
     }
-    ctx.print(ast, name !);
+    ctx.print(ast, name!);
     return null;
   }
   visitDeclareVarStmt(stmt: o.DeclareVarStmt, ctx: EmitterVisitorContext): any {

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -24,7 +24,9 @@ export abstract class Type {
   }
   abstract visitType(visitor: TypeVisitor, context: any): any;
 
-  hasModifier(modifier: TypeModifier): boolean { return this.modifiers !.indexOf(modifier) !== -1; }
+  hasModifier(modifier: TypeModifier): boolean {
+    return this.modifiers!.indexOf(modifier) !== -1;
+  }
 }
 
 export enum BuiltinTypeName {
@@ -60,7 +62,9 @@ export class ExpressionType extends Type {
 
 
 export class ArrayType extends Type {
-  constructor(public of : Type, modifiers: TypeModifier[]|null = null) { super(modifiers); }
+  constructor(public of: Type, modifiers: TypeModifier[]|null = null) {
+    super(modifiers);
+  }
   visitType(visitor: TypeVisitor, context: any): any {
     return visitor.visitArrayType(this, context);
   }
@@ -73,7 +77,9 @@ export class MapType extends Type {
     super(modifiers);
     this.valueType = valueType || null;
   }
-  visitType(visitor: TypeVisitor, context: any): any { return visitor.visitMapType(this, context); }
+  visitType(visitor: TypeVisitor, context: any): any {
+    return visitor.visitMapType(this, context);
+  }
 }
 
 export const DYNAMIC_TYPE = new BuiltinType(BuiltinTypeName.Dynamic);
@@ -113,15 +119,15 @@ export enum BinaryOperator {
   BiggerEquals
 }
 
-export function nullSafeIsEquivalent<T extends{isEquivalent(other: T): boolean}>(
-    base: T | null, other: T | null) {
+export function nullSafeIsEquivalent<T extends {isEquivalent(other: T): boolean}>(
+    base: T|null, other: T|null) {
   if (base == null || other == null) {
     return base == other;
   }
   return base.isEquivalent(other);
 }
 
-export function areAllEquivalent<T extends{isEquivalent(other: T): boolean}>(
+export function areAllEquivalent<T extends {isEquivalent(other: T): boolean}>(
     base: T[], other: T[]) {
   const len = base.length;
   if (len !== other.length) {
@@ -243,7 +249,9 @@ export abstract class Expression {
     return new CastExpr(this, type, sourceSpan);
   }
 
-  toStmt(): Statement { return new ExpressionStatement(this, null); }
+  toStmt(): Statement {
+    return new ExpressionStatement(this, null);
+  }
 }
 
 export enum BuiltinVar {
@@ -272,7 +280,9 @@ export class ReadVarExpr extends Expression {
     return e instanceof ReadVarExpr && this.name === e.name && this.builtin === e.builtin;
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitReadVarExpr(this, context);
@@ -299,7 +309,9 @@ export class TypeofExpr extends Expression {
     return e instanceof TypeofExpr && e.expr.isEquivalent(this.expr);
   }
 
-  isConstant(): boolean { return this.expr.isConstant(); }
+  isConstant(): boolean {
+    return this.expr.isConstant();
+  }
 }
 
 export class WrappedNodeExpr<T> extends Expression {
@@ -311,7 +323,9 @@ export class WrappedNodeExpr<T> extends Expression {
     return e instanceof WrappedNodeExpr && this.node === e.node;
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitWrappedNodeExpr(this, context);
@@ -330,7 +344,9 @@ export class WriteVarExpr extends Expression {
     return e instanceof WriteVarExpr && this.name === e.name && this.value.isEquivalent(e.value);
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitWriteVarExpr(this, context);
@@ -340,7 +356,9 @@ export class WriteVarExpr extends Expression {
     return new DeclareVarStmt(this.name, this.value, type, modifiers, this.sourceSpan);
   }
 
-  toConstDecl(): DeclareVarStmt { return this.toDeclStmt(INFERRED_TYPE, [StmtModifier.Final]); }
+  toConstDecl(): DeclareVarStmt {
+    return this.toDeclStmt(INFERRED_TYPE, [StmtModifier.Final]);
+  }
 }
 
 
@@ -358,7 +376,9 @@ export class WriteKeyExpr extends Expression {
         this.index.isEquivalent(e.index) && this.value.isEquivalent(e.value);
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitWriteKeyExpr(this, context);
@@ -380,7 +400,9 @@ export class WritePropExpr extends Expression {
         this.name === e.name && this.value.isEquivalent(e.value);
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitWritePropExpr(this, context);
@@ -414,7 +436,9 @@ export class InvokeMethodExpr extends Expression {
         this.name === e.name && this.builtin === e.builtin && areAllEquivalent(this.args, e.args);
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitInvokeMethodExpr(this, context);
@@ -434,7 +458,9 @@ export class InvokeFunctionExpr extends Expression {
         areAllEquivalent(this.args, e.args) && this.pure === e.pure;
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitInvokeFunctionExpr(this, context);
@@ -454,7 +480,9 @@ export class InstantiateExpr extends Expression {
         areAllEquivalent(this.args, e.args);
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitInstantiateExpr(this, context);
@@ -473,7 +501,9 @@ export class LiteralExpr extends Expression {
     return e instanceof LiteralExpr && this.value === e.value;
   }
 
-  isConstant() { return true; }
+  isConstant() {
+    return true;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitLiteralExpr(this, context);
@@ -494,7 +524,9 @@ export class LocalizedString extends Expression {
     return false;
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitLocalizedString(this, context);
@@ -521,8 +553,9 @@ export class LocalizedString extends Expression {
       metaBlock = `${metaBlock}${ID_SEPARATOR}${this.metaBlock.customId}`;
     }
     if (this.metaBlock.legacyIds) {
-      this.metaBlock.legacyIds.forEach(
-          legacyId => { metaBlock = `${metaBlock}${LEGACY_ID_INDICATOR}${legacyId}`; });
+      this.metaBlock.legacyIds.forEach(legacyId => {
+        metaBlock = `${metaBlock}${LEGACY_ID_INDICATOR}${legacyId}`;
+      });
     }
     return createCookedRawString(metaBlock, this.messageParts[0]);
   }
@@ -588,7 +621,9 @@ export class ExternalExpr extends Expression {
         this.value.moduleName === e.value.moduleName && this.value.runtime === e.value.runtime;
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitExternalExpr(this, context);
@@ -616,7 +651,9 @@ export class ConditionalExpr extends Expression {
         this.trueCase.isEquivalent(e.trueCase) && nullSafeIsEquivalent(this.falseCase, e.falseCase);
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitConditionalExpr(this, context);
@@ -633,7 +670,9 @@ export class NotExpr extends Expression {
     return e instanceof NotExpr && this.condition.isEquivalent(e.condition);
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitNotExpr(this, context);
@@ -649,7 +688,9 @@ export class AssertNotNull extends Expression {
     return e instanceof AssertNotNull && this.condition.isEquivalent(e.condition);
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitAssertNotNullExpr(this, context);
@@ -665,7 +706,9 @@ export class CastExpr extends Expression {
     return e instanceof CastExpr && this.value.isEquivalent(e.value);
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitCastExpr(this, context);
@@ -676,7 +719,9 @@ export class CastExpr extends Expression {
 export class FnParam {
   constructor(public name: string, public type: Type|null = null) {}
 
-  isEquivalent(param: FnParam): boolean { return this.name === param.name; }
+  isEquivalent(param: FnParam): boolean {
+    return this.name === param.name;
+  }
 }
 
 
@@ -692,7 +737,9 @@ export class FunctionExpr extends Expression {
         areAllEquivalent(this.statements, e.statements);
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitFunctionExpr(this, context);
@@ -719,7 +766,9 @@ export class BinaryOperatorExpr extends Expression {
         this.lhs.isEquivalent(e.lhs) && this.rhs.isEquivalent(e.rhs);
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitBinaryOperatorExpr(this, context);
@@ -739,7 +788,9 @@ export class ReadPropExpr extends Expression {
         this.name === e.name;
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitReadPropExpr(this, context);
@@ -763,7 +814,9 @@ export class ReadKeyExpr extends Expression {
         this.index.isEquivalent(e.index);
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitReadKeyExpr(this, context);
@@ -782,7 +835,9 @@ export class LiteralArrayExpr extends Expression {
     this.entries = entries;
   }
 
-  isConstant() { return this.entries.every(e => e.isConstant()); }
+  isConstant() {
+    return this.entries.every(e => e.isConstant());
+  }
 
   isEquivalent(e: Expression): boolean {
     return e instanceof LiteralArrayExpr && areAllEquivalent(this.entries, e.entries);
@@ -813,7 +868,9 @@ export class LiteralMapExpr extends Expression {
     return e instanceof LiteralMapExpr && areAllEquivalent(this.entries, e.entries);
   }
 
-  isConstant() { return this.entries.every(e => e.value.isConstant()); }
+  isConstant() {
+    return this.entries.every(e => e.value.isConstant());
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitLiteralMapExpr(this, context);
@@ -829,7 +886,9 @@ export class CommaExpr extends Expression {
     return e instanceof CommaExpr && areAllEquivalent(this.parts, e.parts);
   }
 
-  isConstant() { return false; }
+  isConstant() {
+    return false;
+  }
 
   visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitCommaExpr(this, context);
@@ -892,7 +951,9 @@ export abstract class Statement {
 
   abstract visitStatement(visitor: StatementVisitor, context: any): any;
 
-  hasModifier(modifier: StmtModifier): boolean { return this.modifiers !.indexOf(modifier) !== -1; }
+  hasModifier(modifier: StmtModifier): boolean {
+    return this.modifiers!.indexOf(modifier) !== -1;
+  }
 }
 
 
@@ -965,7 +1026,9 @@ export class AbstractClassPart {
     }
     this.type = type || null;
   }
-  hasModifier(modifier: StmtModifier): boolean { return this.modifiers !.indexOf(modifier) !== -1; }
+  hasModifier(modifier: StmtModifier): boolean {
+    return this.modifiers!.indexOf(modifier) !== -1;
+  }
 }
 
 export class ClassField extends AbstractClassPart {
@@ -974,7 +1037,9 @@ export class ClassField extends AbstractClassPart {
       public initializer?: Expression) {
     super(type, modifiers);
   }
-  isEquivalent(f: ClassField) { return this.name === f.name; }
+  isEquivalent(f: ClassField) {
+    return this.name === f.name;
+  }
 }
 
 
@@ -1044,7 +1109,9 @@ export class CommentStmt extends Statement {
   constructor(public comment: string, public multiline = false, sourceSpan?: ParseSourceSpan|null) {
     super(null, sourceSpan);
   }
-  isEquivalent(stmt: Statement): boolean { return stmt instanceof CommentStmt; }
+  isEquivalent(stmt: Statement): boolean {
+    return stmt instanceof CommentStmt;
+  }
   visitStatement(visitor: StatementVisitor, context: any): any {
     return visitor.visitCommentStmt(this, context);
   }
@@ -1060,7 +1127,9 @@ export class JSDocCommentStmt extends Statement {
   visitStatement(visitor: StatementVisitor, context: any): any {
     return visitor.visitJSDocCommentStmt(this, context);
   }
-  toString(): string { return serializeTags(this.tags); }
+  toString(): string {
+    return serializeTags(this.tags);
+  }
 }
 
 export class TryCatchStmt extends Statement {
@@ -1105,11 +1174,17 @@ export interface StatementVisitor {
 }
 
 export class AstTransformer implements StatementVisitor, ExpressionVisitor {
-  transformExpr(expr: Expression, context: any): Expression { return expr; }
+  transformExpr(expr: Expression, context: any): Expression {
+    return expr;
+  }
 
-  transformStmt(stmt: Statement, context: any): Statement { return stmt; }
+  transformStmt(stmt: Statement, context: any): Statement {
+    return stmt;
+  }
 
-  visitReadVarExpr(ast: ReadVarExpr, context: any): any { return this.transformExpr(ast, context); }
+  visitReadVarExpr(ast: ReadVarExpr, context: any): any {
+    return this.transformExpr(ast, context);
+  }
 
   visitWrappedNodeExpr(ast: WrappedNodeExpr<any>, context: any): any {
     return this.transformExpr(ast, context);
@@ -1148,7 +1223,7 @@ export class AstTransformer implements StatementVisitor, ExpressionVisitor {
     const method = ast.builtin || ast.name;
     return this.transformExpr(
         new InvokeMethodExpr(
-            ast.receiver.visitExpression(this, context), method !,
+            ast.receiver.visitExpression(this, context), method!,
             this.visitAllExpressions(ast.args, context), ast.type, ast.sourceSpan),
         context);
   }
@@ -1169,7 +1244,9 @@ export class AstTransformer implements StatementVisitor, ExpressionVisitor {
         context);
   }
 
-  visitLiteralExpr(ast: LiteralExpr, context: any): any { return this.transformExpr(ast, context); }
+  visitLiteralExpr(ast: LiteralExpr, context: any): any {
+    return this.transformExpr(ast, context);
+  }
 
   visitLocalizedString(ast: LocalizedString, context: any): any {
     return this.transformExpr(
@@ -1188,7 +1265,7 @@ export class AstTransformer implements StatementVisitor, ExpressionVisitor {
         new ConditionalExpr(
             ast.condition.visitExpression(this, context),
             ast.trueCase.visitExpression(this, context),
-            ast.falseCase !.visitExpression(this, context), ast.type, ast.sourceSpan),
+            ast.falseCase!.visitExpression(this, context), ast.type, ast.sourceSpan),
         context);
   }
 
@@ -1284,7 +1361,7 @@ export class AstTransformer implements StatementVisitor, ExpressionVisitor {
   }
 
   visitDeclareClassStmt(stmt: ClassStmt, context: any): any {
-    const parent = stmt.parent !.visitExpression(this, context);
+    const parent = stmt.parent!.visitExpression(this, context);
     const getters = stmt.getters.map(
         getter => new ClassGetter(
             getter.name, this.visitAllStatements(getter.body, context), getter.type,
@@ -1341,14 +1418,18 @@ export class AstTransformer implements StatementVisitor, ExpressionVisitor {
 
 
 export class RecursiveAstVisitor implements StatementVisitor, ExpressionVisitor {
-  visitType(ast: Type, context: any): any { return ast; }
+  visitType(ast: Type, context: any): any {
+    return ast;
+  }
   visitExpression(ast: Expression, context: any): any {
     if (ast.type) {
       ast.type.visitType(this, context);
     }
     return ast;
   }
-  visitBuiltinType(type: BuiltinType, context: any): any { return this.visitType(type, context); }
+  visitBuiltinType(type: BuiltinType, context: any): any {
+    return this.visitType(type, context);
+  }
   visitExpressionType(type: ExpressionType, context: any): any {
     type.value.visitExpression(this, context);
     if (type.typeParams !== null) {
@@ -1356,10 +1437,18 @@ export class RecursiveAstVisitor implements StatementVisitor, ExpressionVisitor 
     }
     return this.visitType(type, context);
   }
-  visitArrayType(type: ArrayType, context: any): any { return this.visitType(type, context); }
-  visitMapType(type: MapType, context: any): any { return this.visitType(type, context); }
-  visitWrappedNodeExpr(ast: WrappedNodeExpr<any>, context: any): any { return ast; }
-  visitTypeofExpr(ast: TypeofExpr, context: any): any { return this.visitExpression(ast, context); }
+  visitArrayType(type: ArrayType, context: any): any {
+    return this.visitType(type, context);
+  }
+  visitMapType(type: MapType, context: any): any {
+    return this.visitType(type, context);
+  }
+  visitWrappedNodeExpr(ast: WrappedNodeExpr<any>, context: any): any {
+    return ast;
+  }
+  visitTypeofExpr(ast: TypeofExpr, context: any): any {
+    return this.visitExpression(ast, context);
+  }
   visitReadVarExpr(ast: ReadVarExpr, context: any): any {
     return this.visitExpression(ast, context);
   }
@@ -1408,7 +1497,7 @@ export class RecursiveAstVisitor implements StatementVisitor, ExpressionVisitor 
   visitConditionalExpr(ast: ConditionalExpr, context: any): any {
     ast.condition.visitExpression(this, context);
     ast.trueCase.visitExpression(this, context);
-    ast.falseCase !.visitExpression(this, context);
+    ast.falseCase!.visitExpression(this, context);
     return this.visitExpression(ast, context);
   }
   visitNotExpr(ast: NotExpr, context: any): any {
@@ -1482,7 +1571,7 @@ export class RecursiveAstVisitor implements StatementVisitor, ExpressionVisitor 
     return stmt;
   }
   visitDeclareClassStmt(stmt: ClassStmt, context: any): any {
-    stmt.parent !.visitExpression(this, context);
+    stmt.parent!.visitExpression(this, context);
     stmt.getters.forEach(getter => this.visitAllStatements(getter.body, context));
     if (stmt.constructorMethod) {
       this.visitAllStatements(stmt.constructorMethod.body, context);
@@ -1505,8 +1594,12 @@ export class RecursiveAstVisitor implements StatementVisitor, ExpressionVisitor 
     stmt.error.visitExpression(this, context);
     return stmt;
   }
-  visitCommentStmt(stmt: CommentStmt, context: any): any { return stmt; }
-  visitJSDocCommentStmt(stmt: JSDocCommentStmt, context: any): any { return stmt; }
+  visitCommentStmt(stmt: CommentStmt, context: any): any {
+    return stmt;
+  }
+  visitJSDocCommentStmt(stmt: JSDocCommentStmt, context: any): any {
+    return stmt;
+  }
   visitAllStatements(stmts: Statement[], context: any): void {
     stmts.forEach(stmt => stmt.visitStatement(this, context));
   }
@@ -1551,7 +1644,7 @@ class _FindExternalReferencesVisitor extends RecursiveAstVisitor {
 }
 
 export function applySourceSpanToStatementIfNeeded(
-    stmt: Statement, sourceSpan: ParseSourceSpan | null): Statement {
+    stmt: Statement, sourceSpan: ParseSourceSpan|null): Statement {
   if (!sourceSpan) {
     return stmt;
   }
@@ -1560,7 +1653,7 @@ export function applySourceSpanToStatementIfNeeded(
 }
 
 export function applySourceSpanToExpressionIfNeeded(
-    expr: Expression, sourceSpan: ParseSourceSpan | null): Expression {
+    expr: Expression, sourceSpan: ParseSourceSpan|null): Expression {
   if (!sourceSpan) {
     return expr;
   }
@@ -1569,7 +1662,9 @@ export function applySourceSpanToExpressionIfNeeded(
 }
 
 class _ApplySourceSpanTransformer extends AstTransformer {
-  constructor(private sourceSpan: ParseSourceSpan) { super(); }
+  constructor(private sourceSpan: ParseSourceSpan) {
+    super();
+  }
   private _clone(obj: any): any {
     const clone = Object.create(obj.constructor.prototype);
     for (let prop of Object.keys(obj)) {
@@ -1596,25 +1691,25 @@ class _ApplySourceSpanTransformer extends AstTransformer {
 }
 
 export function variable(
-    name: string, type?: Type | null, sourceSpan?: ParseSourceSpan | null): ReadVarExpr {
+    name: string, type?: Type|null, sourceSpan?: ParseSourceSpan|null): ReadVarExpr {
   return new ReadVarExpr(name, type, sourceSpan);
 }
 
 export function importExpr(
-    id: ExternalReference, typeParams: Type[] | null = null,
-    sourceSpan?: ParseSourceSpan | null): ExternalExpr {
+    id: ExternalReference, typeParams: Type[]|null = null,
+    sourceSpan?: ParseSourceSpan|null): ExternalExpr {
   return new ExternalExpr(id, null, typeParams, sourceSpan);
 }
 
 export function importType(
-    id: ExternalReference, typeParams: Type[] | null = null,
-    typeModifiers: TypeModifier[] | null = null): ExpressionType|null {
+    id: ExternalReference, typeParams: Type[]|null = null,
+    typeModifiers: TypeModifier[]|null = null): ExpressionType|null {
   return id != null ? expressionType(importExpr(id, typeParams, null), typeModifiers) : null;
 }
 
 export function expressionType(
-    expr: Expression, typeModifiers: TypeModifier[] | null = null,
-    typeParams: Type[] | null = null): ExpressionType {
+    expr: Expression, typeModifiers: TypeModifier[]|null = null,
+    typeParams: Type[]|null = null): ExpressionType {
   return new ExpressionType(expr, typeModifiers, typeParams);
 }
 
@@ -1623,30 +1718,28 @@ export function typeofExpr(expr: Expression) {
 }
 
 export function literalArr(
-    values: Expression[], type?: Type | null,
-    sourceSpan?: ParseSourceSpan | null): LiteralArrayExpr {
+    values: Expression[], type?: Type|null, sourceSpan?: ParseSourceSpan|null): LiteralArrayExpr {
   return new LiteralArrayExpr(values, type, sourceSpan);
 }
 
 export function literalMap(
     values: {key: string, quoted: boolean, value: Expression}[],
-    type: MapType | null = null): LiteralMapExpr {
+    type: MapType|null = null): LiteralMapExpr {
   return new LiteralMapExpr(
       values.map(e => new LiteralMapEntry(e.key, e.value, e.quoted)), type, null);
 }
 
-export function not(expr: Expression, sourceSpan?: ParseSourceSpan | null): NotExpr {
+export function not(expr: Expression, sourceSpan?: ParseSourceSpan|null): NotExpr {
   return new NotExpr(expr, sourceSpan);
 }
 
-export function assertNotNull(
-    expr: Expression, sourceSpan?: ParseSourceSpan | null): AssertNotNull {
+export function assertNotNull(expr: Expression, sourceSpan?: ParseSourceSpan|null): AssertNotNull {
   return new AssertNotNull(expr, sourceSpan);
 }
 
 export function fn(
-    params: FnParam[], body: Statement[], type?: Type | null, sourceSpan?: ParseSourceSpan | null,
-    name?: string | null): FunctionExpr {
+    params: FnParam[], body: Statement[], type?: Type|null, sourceSpan?: ParseSourceSpan|null,
+    name?: string|null): FunctionExpr {
   return new FunctionExpr(params, body, type, sourceSpan, name);
 }
 
@@ -1655,13 +1748,13 @@ export function ifStmt(condition: Expression, thenClause: Statement[], elseClaus
 }
 
 export function literal(
-    value: any, type?: Type | null, sourceSpan?: ParseSourceSpan | null): LiteralExpr {
+    value: any, type?: Type|null, sourceSpan?: ParseSourceSpan|null): LiteralExpr {
   return new LiteralExpr(value, type, sourceSpan);
 }
 
 export function localizedString(
     metaBlock: I18nMeta, messageParts: string[], placeholderNames: string[],
-    expressions: Expression[], sourceSpan?: ParseSourceSpan | null): LocalizedString {
+    expressions: Expression[], sourceSpan?: ParseSourceSpan|null): LocalizedString {
   return new LocalizedString(metaBlock, messageParts, placeholderNames, expressions, sourceSpan);
 }
 
@@ -1684,13 +1777,12 @@ export const enum JSDocTagName {
  */
 export type JSDocTag = {
   // `tagName` is e.g. "param" in an `@param` declaration
-  tagName: JSDocTagName | string,
+  tagName: JSDocTagName|string,
   // Any remaining text on the tag, e.g. the description
   text?: string,
-} | {
+}|{
   // no `tagName` for plain text documentation that occurs before any `@param` lines
-  tagName?: undefined,
-  text: string,
+  tagName?: undefined, text: string,
 };
 
 /*

--- a/packages/compiler/src/output/output_interpreter.ts
+++ b/packages/compiler/src/output/output_interpreter.ts
@@ -15,7 +15,9 @@ export function interpretStatements(
   const visitor = new StatementInterpreter(reflector);
   visitor.visitAllStatements(statements, ctx);
   const result: {[key: string]: any} = {};
-  ctx.exports.forEach((exportName) => { result[exportName] = ctx.vars.get(exportName); });
+  ctx.exports.forEach((exportName) => {
+    result[exportName] = ctx.vars.get(exportName);
+  });
   return result;
 }
 
@@ -63,7 +65,7 @@ function createDynamicClass(
   _classStmt.methods.forEach(function(method: o.ClassMethod) {
     const paramNames = method.params.map(param => param.name);
     // Note: use `function` instead of arrow function to capture `this`
-    propertyDescriptors[method.name !] = {
+    propertyDescriptors[method.name!] = {
       writable: false,
       configurable: false,
       value: function(...args: any[]) {
@@ -77,7 +79,9 @@ function createDynamicClass(
   // Note: use `function` instead of arrow function to capture `this`
   const ctor = function(this: Object, ...args: any[]) {
     const instanceCtx = new _ExecutionContext(_ctx, this, _classStmt.name, _ctx.vars);
-    _classStmt.fields.forEach((field) => { (this as any)[field.name] = undefined; });
+    _classStmt.fields.forEach((field) => {
+      (this as any)[field.name] = undefined;
+    });
     _executeFunctionStatements(
         ctorParamNames, args, _classStmt.constructorMethod.body, instanceCtx, _visitor);
   };
@@ -88,7 +92,9 @@ function createDynamicClass(
 
 class StatementInterpreter implements o.StatementVisitor, o.ExpressionVisitor {
   constructor(private reflector: CompileReflector) {}
-  debugAst(ast: o.Expression|o.Statement|o.Type): string { return debugOutputAstAsTypeScript(ast); }
+  debugAst(ast: o.Expression|o.Statement|o.Type): string {
+    return debugOutputAstAsTypeScript(ast);
+  }
 
   visitDeclareVarStmt(stmt: o.DeclareVarStmt, ctx: _ExecutionContext): any {
     const initialValue = stmt.value ? stmt.value.visitExpression(this, ctx) : undefined;
@@ -106,7 +112,7 @@ class StatementInterpreter implements o.StatementVisitor, o.ExpressionVisitor {
         currCtx.vars.set(expr.name, value);
         return value;
       }
-      currCtx = currCtx.parent !;
+      currCtx = currCtx.parent!;
     }
     throw new Error(`Not declared variable ${expr.name}`);
   }
@@ -117,7 +123,7 @@ class StatementInterpreter implements o.StatementVisitor, o.ExpressionVisitor {
     throw new Error('Cannot interpret a TypeofExpr');
   }
   visitReadVarExpr(ast: o.ReadVarExpr, ctx: _ExecutionContext): any {
-    let varName = ast.name !;
+    let varName = ast.name!;
     if (ast.builtin != null) {
       switch (ast.builtin) {
         case o.BuiltinVar.Super:
@@ -139,7 +145,7 @@ class StatementInterpreter implements o.StatementVisitor, o.ExpressionVisitor {
       if (currCtx.vars.has(varName)) {
         return currCtx.vars.get(varName);
       }
-      currCtx = currCtx.parent !;
+      currCtx = currCtx.parent!;
     }
     throw new Error(`Not declared variable ${varName}`);
   }
@@ -176,7 +182,7 @@ class StatementInterpreter implements o.StatementVisitor, o.ExpressionVisitor {
           throw new Error(`Unknown builtin method ${expr.builtin}`);
       }
     } else {
-      result = receiver[expr.name !].apply(receiver, args);
+      result = receiver[expr.name!].apply(receiver, args);
     }
     return result;
   }
@@ -184,7 +190,7 @@ class StatementInterpreter implements o.StatementVisitor, o.ExpressionVisitor {
     const args = this.visitAllExpressions(stmt.args, ctx);
     const fnExpr = stmt.fn;
     if (fnExpr instanceof o.ReadVarExpr && fnExpr.builtin === o.BuiltinVar.Super) {
-      ctx.instance !.constructor.prototype.constructor.apply(ctx.instance, args);
+      ctx.instance!.constructor.prototype.constructor.apply(ctx.instance, args);
       return null;
     } else {
       const fn = stmt.fn.visitExpression(this, ctx);
@@ -227,15 +233,23 @@ class StatementInterpreter implements o.StatementVisitor, o.ExpressionVisitor {
   visitThrowStmt(stmt: o.ThrowStmt, ctx: _ExecutionContext): any {
     throw stmt.error.visitExpression(this, ctx);
   }
-  visitCommentStmt(stmt: o.CommentStmt, context?: any): any { return null; }
-  visitJSDocCommentStmt(stmt: o.JSDocCommentStmt, context?: any): any { return null; }
+  visitCommentStmt(stmt: o.CommentStmt, context?: any): any {
+    return null;
+  }
+  visitJSDocCommentStmt(stmt: o.JSDocCommentStmt, context?: any): any {
+    return null;
+  }
   visitInstantiateExpr(ast: o.InstantiateExpr, ctx: _ExecutionContext): any {
     const args = this.visitAllExpressions(ast.args, ctx);
     const clazz = ast.classExpr.visitExpression(this, ctx);
     return new clazz(...args);
   }
-  visitLiteralExpr(ast: o.LiteralExpr, ctx: _ExecutionContext): any { return ast.value; }
-  visitLocalizedString(ast: o.LocalizedString, context: any): any { return null; }
+  visitLiteralExpr(ast: o.LiteralExpr, ctx: _ExecutionContext): any {
+    return ast.value;
+  }
+  visitLocalizedString(ast: o.LocalizedString, context: any): any {
+    return null;
+  }
   visitExternalExpr(ast: o.ExternalExpr, ctx: _ExecutionContext): any {
     return this.reflector.resolveExternalReference(ast.value);
   }

--- a/packages/compiler/src/output/output_jit.ts
+++ b/packages/compiler/src/output/output_jit.ts
@@ -87,7 +87,9 @@ export class JitEvaluator {
    * @param args The arguments to pass to the function being executed.
    * @returns The return value of the executed function.
    */
-  executeFunction(fn: Function, args: any[]) { return fn(...args); }
+  executeFunction(fn: Function, args: any[]) {
+    return fn(...args);
+  }
 }
 
 /**
@@ -98,7 +100,9 @@ export class JitEmitterVisitor extends AbstractJsEmitterVisitor {
   private _evalArgValues: any[] = [];
   private _evalExportedVars: string[] = [];
 
-  constructor(private reflector: CompileReflector) { super(); }
+  constructor(private reflector: CompileReflector) {
+    super();
+  }
 
   createReturnStmt(ctx: EmitterVisitorContext) {
     const stmt = new o.ReturnStatement(new o.LiteralMapExpr(this._evalExportedVars.map(

--- a/packages/compiler/src/output/source_map.ts
+++ b/packages/compiler/src/output/source_map.ts
@@ -23,10 +23,10 @@ type Segment = {
 export type SourceMap = {
   version: number,
   file?: string,
-  sourceRoot: string,
-  sources: string[],
-  sourcesContent: (string | null)[],
-  mappings: string,
+      sourceRoot: string,
+      sources: string[],
+      sourcesContent: (string|null)[],
+      mappings: string,
 };
 
 export class SourceMapGenerator {
@@ -75,10 +75,12 @@ export class SourceMapGenerator {
   }
 
   /**
-  * @internal strip this from published d.ts files due to
-  * https://github.com/microsoft/TypeScript/issues/36216
-  */
-  private get currentLine(): Segment[]|null { return this.lines.slice(-1)[0]; }
+   * @internal strip this from published d.ts files due to
+   * https://github.com/microsoft/TypeScript/issues/36216
+   */
+  private get currentLine(): Segment[]|null {
+    return this.lines.slice(-1)[0];
+  }
 
   toJSON(): SourceMap|null {
     if (!this.hasMappings) {
@@ -87,7 +89,7 @@ export class SourceMapGenerator {
 
     const sourcesIndex = new Map<string, number>();
     const sources: string[] = [];
-    const sourcesContent: (string | null)[] = [];
+    const sourcesContent: (string|null)[] = [];
 
     Array.from(this.sourcesContent.keys()).forEach((url: string, i: number) => {
       sourcesIndex.set(url, i);
@@ -113,14 +115,14 @@ export class SourceMapGenerator {
                         if (segment.sourceUrl != null) {
                           // zero-based index into the “sources” list
                           segAsStr +=
-                              toBase64VLQ(sourcesIndex.get(segment.sourceUrl) ! - lastSourceIndex);
-                          lastSourceIndex = sourcesIndex.get(segment.sourceUrl) !;
+                              toBase64VLQ(sourcesIndex.get(segment.sourceUrl)! - lastSourceIndex);
+                          lastSourceIndex = sourcesIndex.get(segment.sourceUrl)!;
                           // the zero-based starting line in the original source
-                          segAsStr += toBase64VLQ(segment.sourceLine0 ! - lastSourceLine0);
-                          lastSourceLine0 = segment.sourceLine0 !;
+                          segAsStr += toBase64VLQ(segment.sourceLine0! - lastSourceLine0);
+                          lastSourceLine0 = segment.sourceLine0!;
                           // the zero-based starting column in the original source
-                          segAsStr += toBase64VLQ(segment.sourceCol0 ! - lastSourceCol0);
-                          lastSourceCol0 = segment.sourceCol0 !;
+                          segAsStr += toBase64VLQ(segment.sourceCol0! - lastSourceCol0);
+                          lastSourceCol0 = segment.sourceCol0!;
                         }
 
                         return segAsStr;

--- a/packages/compiler/src/output/ts_emitter.ts
+++ b/packages/compiler/src/output/ts_emitter.ts
@@ -15,8 +15,7 @@ import * as o from './output_ast';
 
 const _debugFilePath = '/debug/lib';
 
-export function debugOutputAstAsTypeScript(ast: o.Statement | o.Expression | o.Type | any[]):
-    string {
+export function debugOutputAstAsTypeScript(ast: o.Statement|o.Expression|o.Type|any[]): string {
   const converter = new _TsEmitterVisitor();
   const ctx = EmitterVisitorContext.createRoot();
   const asts: any[] = Array.isArray(ast) ? ast : [ast];
@@ -147,7 +146,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
           reexports = [];
           this.reexports.set(moduleName, reexports);
         }
-        reexports.push({name: name !, as: stmt.name});
+        reexports.push({name: name!, as: stmt.name});
         return null;
       }
     }
@@ -175,7 +174,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
 
   visitCastExpr(ast: o.CastExpr, ctx: EmitterVisitorContext): any {
     ctx.print(ast, `(<`);
-    ast.type !.visitType(this, ctx);
+    ast.type!.visitType(this, ctx);
     ctx.print(ast, `>`);
     ast.value.visitExpression(this, ctx);
     ctx.print(ast, `)`);
@@ -422,7 +421,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
       }
       ctx.print(null, `${prefix}.`);
     }
-    ctx.print(null, name !);
+    ctx.print(null, name!);
 
     if (this.typeExpression > 0) {
       // If we are in a type expression that refers to a generic type then supply
@@ -433,7 +432,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
       const suppliedParameters = typeParams || [];
       if (suppliedParameters.length > 0) {
         ctx.print(null, `<`);
-        this.visitAllObjects(type => type.visitType(this, ctx), typeParams !, ctx, ',');
+        this.visitAllObjects(type => type.visitType(this, ctx), typeParams!, ctx, ',');
         ctx.print(null, `>`);
       }
     }

--- a/packages/compiler/src/output/value_util.ts
+++ b/packages/compiler/src/output/value_util.ts
@@ -14,7 +14,7 @@ import * as o from './output_ast';
 export const QUOTED_KEYS = '$quoted$';
 
 export function convertValueToOutputAst(
-    ctx: OutputContext, value: any, type: o.Type | null = null): o.Expression {
+    ctx: OutputContext, value: any, type: o.Type|null = null): o.Expression {
   return visitValue(value, new _ValueOutputAstTransformer(ctx), type);
 }
 
@@ -43,7 +43,9 @@ class _ValueOutputAstTransformer implements ValueTransformer {
     return new o.LiteralMapExpr(entries, type);
   }
 
-  visitPrimitive(value: any, type: o.Type): o.Expression { return o.literal(value, type); }
+  visitPrimitive(value: any, type: o.Type): o.Expression {
+    return o.literal(value, type);
+  }
 
   visitOther(value: any, type: o.Type): o.Expression {
     if (value instanceof o.Expression) {

--- a/packages/compiler/src/pipe_resolver.ts
+++ b/packages/compiler/src/pipe_resolver.ts
@@ -7,7 +7,7 @@
  */
 
 import {CompileReflector} from './compile_reflector';
-import {Pipe, Type, createPipe} from './core';
+import {createPipe, Pipe, Type} from './core';
 import {findLast} from './directive_resolver';
 import {resolveForwardRef, stringify} from './util';
 

--- a/packages/compiler/src/provider_analyzer.ts
+++ b/packages/compiler/src/provider_analyzer.ts
@@ -9,12 +9,14 @@
 
 import {CompileDiDependencyMetadata, CompileDirectiveMetadata, CompileDirectiveSummary, CompileNgModuleMetadata, CompileProviderMetadata, CompileQueryMetadata, CompileTokenMetadata, CompileTypeMetadata, tokenName, tokenReference} from './compile_metadata';
 import {CompileReflector} from './compile_reflector';
-import {Identifiers, createTokenForExternalReference} from './identifiers';
+import {createTokenForExternalReference, Identifiers} from './identifiers';
 import {ParseError, ParseSourceSpan} from './parse_util';
 import {AttrAst, DirectiveAst, ProviderAst, ProviderAstType, QueryMatch, ReferenceAst} from './template_parser/template_ast';
 
 export class ProviderError extends ParseError {
-  constructor(message: string, span: ParseSourceSpan) { super(span, message); }
+  constructor(message: string, span: ParseSourceSpan) {
+    super(span, message);
+  }
 }
 
 export interface QueryWithId {
@@ -125,7 +127,9 @@ export class ProviderElementContext {
 
   get queryMatches(): QueryMatch[] {
     const allMatches: QueryMatch[] = [];
-    this._queriedTokens.forEach((matches: QueryMatch[]) => { allMatches.push(...matches); });
+    this._queriedTokens.forEach((matches: QueryMatch[]) => {
+      allMatches.push(...matches);
+    });
     return allMatches;
   }
 
@@ -171,9 +175,10 @@ export class ProviderElementContext {
       requestingProviderType: ProviderAstType, token: CompileTokenMetadata,
       eager: boolean): ProviderAst|null {
     const resolvedProvider = this._allProviders.get(tokenReference(token));
-    if (!resolvedProvider || ((requestingProviderType === ProviderAstType.Directive ||
-                               requestingProviderType === ProviderAstType.PublicService) &&
-                              resolvedProvider.providerType === ProviderAstType.PrivateService) ||
+    if (!resolvedProvider ||
+        ((requestingProviderType === ProviderAstType.Directive ||
+          requestingProviderType === ProviderAstType.PublicService) &&
+         resolvedProvider.providerType === ProviderAstType.PrivateService) ||
         ((requestingProviderType === ProviderAstType.PrivateService ||
           requestingProviderType === ProviderAstType.PublicService) &&
          resolvedProvider.providerType === ProviderAstType.Builtin)) {
@@ -191,25 +196,25 @@ export class ProviderElementContext {
     this._seenProviders.set(tokenReference(token), true);
     const transformedProviders = resolvedProvider.providers.map((provider) => {
       let transformedUseValue = provider.useValue;
-      let transformedUseExisting = provider.useExisting !;
-      let transformedDeps: CompileDiDependencyMetadata[] = undefined !;
+      let transformedUseExisting = provider.useExisting!;
+      let transformedDeps: CompileDiDependencyMetadata[] = undefined!;
       if (provider.useExisting != null) {
         const existingDiDep = this._getDependency(
-            resolvedProvider.providerType, {token: provider.useExisting}, eager) !;
+            resolvedProvider.providerType, {token: provider.useExisting}, eager)!;
         if (existingDiDep.token != null) {
           transformedUseExisting = existingDiDep.token;
         } else {
-          transformedUseExisting = null !;
+          transformedUseExisting = null!;
           transformedUseValue = existingDiDep.value;
         }
       } else if (provider.useFactory) {
         const deps = provider.deps || provider.useFactory.diDeps;
         transformedDeps =
-            deps.map((dep) => this._getDependency(resolvedProvider.providerType, dep, eager) !);
+            deps.map((dep) => this._getDependency(resolvedProvider.providerType, dep, eager)!);
       } else if (provider.useClass) {
         const deps = provider.deps || provider.useClass.diDeps;
         transformedDeps =
-            deps.map((dep) => this._getDependency(resolvedProvider.providerType, dep, eager) !);
+            deps.map((dep) => this._getDependency(resolvedProvider.providerType, dep, eager)!);
       }
       return _transformProvider(provider, {
         useExisting: transformedUseExisting,
@@ -227,7 +232,7 @@ export class ProviderElementContext {
       requestingProviderType: ProviderAstType, dep: CompileDiDependencyMetadata,
       eager: boolean = false): CompileDiDependencyMetadata|null {
     if (dep.isAttribute) {
-      const attrValue = this._attrs[dep.token !.value];
+      const attrValue = this._attrs[dep.token!.value];
       return {isValue: true, value: attrValue == null ? null : attrValue};
     }
 
@@ -248,7 +253,7 @@ export class ProviderElementContext {
         }
         if (tokenReference(dep.token) ===
             this.viewContext.reflector.resolveExternalReference(Identifiers.ViewContainerRef)) {
-          (this as{transformedHasViewContainer: boolean}).transformedHasViewContainer = true;
+          (this as {transformedHasViewContainer: boolean}).transformedHasViewContainer = true;
         }
       }
       // access the injector
@@ -290,8 +295,8 @@ export class ProviderElementContext {
       // check @Host restriction
       if (!result) {
         if (!dep.isHost || this.viewContext.component.isHost ||
-            this.viewContext.component.type.reference === tokenReference(dep.token !) ||
-            this.viewContext.viewProviders.get(tokenReference(dep.token !)) != null) {
+            this.viewContext.component.type.reference === tokenReference(dep.token!) ||
+            this.viewContext.viewProviders.get(tokenReference(dep.token!)) != null) {
           result = dep;
         } else {
           result = dep.isOptional ? {isValue: true, value: null} : null;
@@ -368,15 +373,15 @@ export class NgModuleProviderAnalyzer {
     this._seenProviders.set(tokenReference(token), true);
     const transformedProviders = resolvedProvider.providers.map((provider) => {
       let transformedUseValue = provider.useValue;
-      let transformedUseExisting = provider.useExisting !;
-      let transformedDeps: CompileDiDependencyMetadata[] = undefined !;
+      let transformedUseExisting = provider.useExisting!;
+      let transformedDeps: CompileDiDependencyMetadata[] = undefined!;
       if (provider.useExisting != null) {
         const existingDiDep =
             this._getDependency({token: provider.useExisting}, eager, resolvedProvider.sourceSpan);
         if (existingDiDep.token != null) {
           transformedUseExisting = existingDiDep.token;
         } else {
-          transformedUseExisting = null !;
+          transformedUseExisting = null!;
           transformedUseValue = existingDiDep.value;
         }
       } else if (provider.useFactory) {
@@ -478,7 +483,8 @@ function _resolveProviders(
     let resolvedProvider = targetProvidersByToken.get(tokenReference(provider.token));
     if (resolvedProvider != null && !!resolvedProvider.multiProvider !== !!provider.multi) {
       targetErrors.push(new ProviderError(
-          `Mixing multi and non multi provider is not possible for token ${tokenName(resolvedProvider.token)}`,
+          `Mixing multi and non multi provider is not possible for token ${
+              tokenName(resolvedProvider.token)}`,
           sourceSpan));
     }
     if (!resolvedProvider) {

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -18,19 +18,25 @@ export interface Node {
 
 export class Text implements Node {
   constructor(public value: string, public sourceSpan: ParseSourceSpan) {}
-  visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitText(this); }
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitText(this);
+  }
 }
 
 export class BoundText implements Node {
   constructor(public value: AST, public sourceSpan: ParseSourceSpan, public i18n?: I18nMeta) {}
-  visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitBoundText(this); }
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitBoundText(this);
+  }
 }
 
 export class TextAttribute implements Node {
   constructor(
       public name: string, public value: string, public sourceSpan: ParseSourceSpan,
       public valueSpan?: ParseSourceSpan, public i18n?: I18nMeta) {}
-  visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitTextAttribute(this); }
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitTextAttribute(this);
+  }
 }
 
 export class BoundAttribute implements Node {
@@ -45,7 +51,9 @@ export class BoundAttribute implements Node {
         prop.valueSpan, i18n);
   }
 
-  visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitBoundAttribute(this); }
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitBoundAttribute(this);
+  }
 }
 
 export class BoundEvent implements Node {
@@ -62,7 +70,9 @@ export class BoundEvent implements Node {
         event.name, event.type, event.handler, target, phase, event.sourceSpan, event.handlerSpan);
   }
 
-  visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitBoundEvent(this); }
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitBoundEvent(this);
+  }
 }
 
 export class Element implements Node {
@@ -76,7 +86,9 @@ export class Element implements Node {
       this.sourceSpan = new ParseSourceSpan(sourceSpan.start, endSourceSpan.end);
     }
   }
-  visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitElement(this); }
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitElement(this);
+  }
 }
 
 export class Template implements Node {
@@ -86,36 +98,46 @@ export class Template implements Node {
       public children: Node[], public references: Reference[], public variables: Variable[],
       public sourceSpan: ParseSourceSpan, public startSourceSpan: ParseSourceSpan|null,
       public endSourceSpan: ParseSourceSpan|null, public i18n?: I18nMeta) {}
-  visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitTemplate(this); }
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitTemplate(this);
+  }
 }
 
 export class Content implements Node {
   constructor(
       public selector: string, public attributes: TextAttribute[],
       public sourceSpan: ParseSourceSpan, public i18n?: I18nMeta) {}
-  visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitContent(this); }
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitContent(this);
+  }
 }
 
 export class Variable implements Node {
   constructor(
       public name: string, public value: string, public sourceSpan: ParseSourceSpan,
       public valueSpan?: ParseSourceSpan) {}
-  visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitVariable(this); }
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitVariable(this);
+  }
 }
 
 export class Reference implements Node {
   constructor(
       public name: string, public value: string, public sourceSpan: ParseSourceSpan,
       public valueSpan?: ParseSourceSpan) {}
-  visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitReference(this); }
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitReference(this);
+  }
 }
 
 export class Icu implements Node {
   constructor(
       public vars: {[name: string]: BoundText},
-      public placeholders: {[name: string]: Text | BoundText}, public sourceSpan: ParseSourceSpan,
+      public placeholders: {[name: string]: Text|BoundText}, public sourceSpan: ParseSourceSpan,
       public i18n?: I18nMeta) {}
-  visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitIcu(this); }
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitIcu(this);
+  }
 }
 
 export interface Visitor<Result = any> {
@@ -210,16 +232,34 @@ export class TransformVisitor implements Visitor<Node> {
     return template;
   }
 
-  visitContent(content: Content): Node { return content; }
+  visitContent(content: Content): Node {
+    return content;
+  }
 
-  visitVariable(variable: Variable): Node { return variable; }
-  visitReference(reference: Reference): Node { return reference; }
-  visitTextAttribute(attribute: TextAttribute): Node { return attribute; }
-  visitBoundAttribute(attribute: BoundAttribute): Node { return attribute; }
-  visitBoundEvent(attribute: BoundEvent): Node { return attribute; }
-  visitText(text: Text): Node { return text; }
-  visitBoundText(text: BoundText): Node { return text; }
-  visitIcu(icu: Icu): Node { return icu; }
+  visitVariable(variable: Variable): Node {
+    return variable;
+  }
+  visitReference(reference: Reference): Node {
+    return reference;
+  }
+  visitTextAttribute(attribute: TextAttribute): Node {
+    return attribute;
+  }
+  visitBoundAttribute(attribute: BoundAttribute): Node {
+    return attribute;
+  }
+  visitBoundEvent(attribute: BoundEvent): Node {
+    return attribute;
+  }
+  visitText(text: Text): Node {
+    return text;
+  }
+  visitBoundText(text: BoundText): Node {
+    return text;
+  }
+  visitIcu(icu: Icu): Node {
+    return icu;
+  }
 }
 
 export function visitAll<Result>(visitor: Visitor<Result>, nodes: Node[]): Result[] {

--- a/packages/compiler/src/render3/r3_factory.ts
+++ b/packages/compiler/src/render3/r3_factory.ts
@@ -89,8 +89,8 @@ export interface R3ExpressionFactoryMetadata extends R3ConstructorFactoryMetadat
   expression: o.Expression;
 }
 
-export type R3FactoryMetadata = R3ConstructorFactoryMetadata | R3DelegatedFactoryMetadata |
-    R3DelegatedFnOrClassMetadata | R3ExpressionFactoryMetadata;
+export type R3FactoryMetadata = R3ConstructorFactoryMetadata|R3DelegatedFactoryMetadata|
+    R3DelegatedFnOrClassMetadata|R3ExpressionFactoryMetadata;
 
 export enum R3FactoryTarget {
   Directive = 0,
@@ -280,8 +280,7 @@ export function compileFactoryFunction(meta: R3FactoryMetadata): R3FactoryFn {
         `${meta.name}_Factory`),
     statements,
     type: o.expressionType(o.importExpr(
-        R3.FactoryDef,
-        [typeWithParameters(meta.type.type, meta.typeArgumentCount), ctorDepsType]))
+        R3.FactoryDef, [typeWithParameters(meta.type.type, meta.typeArgumentCount), ctorDepsType]))
   };
 }
 
@@ -402,7 +401,8 @@ export function dependenciesFromGlobalMetadata(
       // Construct the dependency.
       deps.push({
         token,
-        attribute: null, resolved,
+        attribute: null,
+        resolved,
         host: !!dependency.isHost,
         optional: !!dependency.isOptional,
         self: !!dependency.isSelf,

--- a/packages/compiler/src/render3/r3_jit.ts
+++ b/packages/compiler/src/render3/r3_jit.ts
@@ -21,28 +21,44 @@ export class R3JitReflector implements CompileReflector {
   resolveExternalReference(ref: o.ExternalReference): any {
     // This reflector only handles @angular/core imports.
     if (ref.moduleName !== '@angular/core') {
-      throw new Error(
-          `Cannot resolve external reference to ${ref.moduleName}, only references to @angular/core are supported.`);
+      throw new Error(`Cannot resolve external reference to ${
+          ref.moduleName}, only references to @angular/core are supported.`);
     }
-    if (!this.context.hasOwnProperty(ref.name !)) {
+    if (!this.context.hasOwnProperty(ref.name!)) {
       throw new Error(`No value provided for @angular/core symbol '${ref.name!}'.`);
     }
-    return this.context[ref.name !];
+    return this.context[ref.name!];
   }
 
-  parameters(typeOrFunc: any): any[][] { throw new Error('Not implemented.'); }
+  parameters(typeOrFunc: any): any[][] {
+    throw new Error('Not implemented.');
+  }
 
-  annotations(typeOrFunc: any): any[] { throw new Error('Not implemented.'); }
+  annotations(typeOrFunc: any): any[] {
+    throw new Error('Not implemented.');
+  }
 
-  shallowAnnotations(typeOrFunc: any): any[] { throw new Error('Not implemented.'); }
+  shallowAnnotations(typeOrFunc: any): any[] {
+    throw new Error('Not implemented.');
+  }
 
-  tryAnnotations(typeOrFunc: any): any[] { throw new Error('Not implemented.'); }
+  tryAnnotations(typeOrFunc: any): any[] {
+    throw new Error('Not implemented.');
+  }
 
-  propMetadata(typeOrFunc: any): {[key: string]: any[];} { throw new Error('Not implemented.'); }
+  propMetadata(typeOrFunc: any): {[key: string]: any[];} {
+    throw new Error('Not implemented.');
+  }
 
-  hasLifecycleHook(type: any, lcProperty: string): boolean { throw new Error('Not implemented.'); }
+  hasLifecycleHook(type: any, lcProperty: string): boolean {
+    throw new Error('Not implemented.');
+  }
 
-  guards(typeOrFunc: any): {[key: string]: any;} { throw new Error('Not implemented.'); }
+  guards(typeOrFunc: any): {[key: string]: any;} {
+    throw new Error('Not implemented.');
+  }
 
-  componentModuleUrl(type: any, cmpMetadata: any): string { throw new Error('Not implemented.'); }
+  componentModuleUrl(type: any, cmpMetadata: any): string {
+    throw new Error('Not implemented.');
+  }
 }

--- a/packages/compiler/src/render3/r3_module_compiler.ts
+++ b/packages/compiler/src/render3/r3_module_compiler.ts
@@ -12,9 +12,9 @@ import {mapLiteral} from '../output/map_util';
 import * as o from '../output/output_ast';
 import {OutputContext} from '../util';
 
-import {R3DependencyMetadata, R3FactoryTarget, compileFactoryFunction} from './r3_factory';
+import {compileFactoryFunction, R3DependencyMetadata, R3FactoryTarget} from './r3_factory';
 import {Identifiers as R3} from './r3_identifiers';
-import {R3Reference, convertMetaToOutput, jitOnlyGuardedExpression, mapToMapExpression} from './util';
+import {convertMetaToOutput, jitOnlyGuardedExpression, mapToMapExpression, R3Reference} from './util';
 
 export interface R3NgModuleDef {
   expression: o.Expression;
@@ -108,9 +108,7 @@ export function compileNgModule(meta: R3NgModuleMetadata): R3NgModuleDef {
   } = meta;
 
   const additionalStatements: o.Statement[] = [];
-  const definitionMap = {
-    type: internalType
-  } as{
+  const definitionMap = {type: internalType} as {
     type: o.Expression,
     bootstrap: o.Expression,
     declarations: o.Expression,
@@ -177,7 +175,7 @@ export function compileNgModule(meta: R3NgModuleMetadata): R3NgModuleDef {
 function generateSetNgModuleScopeCall(meta: R3NgModuleMetadata): o.Statement|null {
   const {adjacentType: moduleType, declarations, imports, exports, containsForwardDecls} = meta;
 
-  const scopeMap = {} as{
+  const scopeMap = {} as {
     declarations: o.Expression,
     imports: o.Expression,
     exports: o.Expression,
@@ -247,7 +245,7 @@ export function compileInjector(meta: R3InjectorMetadata): R3InjectorDef {
   });
   const definitionMap = {
     factory: result.factory,
-  } as{factory: o.Expression, providers: o.Expression, imports: o.Expression};
+  } as {factory: o.Expression, providers: o.Expression, imports: o.Expression};
 
   if (meta.providers !== null) {
     definitionMap.providers = meta.providers;
@@ -267,7 +265,7 @@ export function compileInjector(meta: R3InjectorMetadata): R3InjectorDef {
 export function compileNgModuleFromRender2(
     ctx: OutputContext, ngModule: CompileShallowModuleMetadata,
     injectableCompiler: InjectableCompiler): void {
-  const className = identifierName(ngModule.type) !;
+  const className = identifierName(ngModule.type)!;
 
   const rawImports = ngModule.rawImports ? [ngModule.rawImports] : [];
   const rawExports = ngModule.rawExports ? [ngModule.rawExports] : [];
@@ -288,7 +286,8 @@ export function compileNgModuleFromRender2(
           /* name */ 'ɵinj',
           /* type */ o.INFERRED_TYPE,
           /* modifiers */[o.StmtModifier.Static],
-          /* initializer */ injectorDef, )],
+          /* initializer */ injectorDef,
+          )],
       /* getters */[],
       /* constructorMethod */ new o.ClassMethod(null, [], []),
       /* methods */[]));

--- a/packages/compiler/src/render3/r3_pipe_compiler.ts
+++ b/packages/compiler/src/render3/r3_pipe_compiler.ts
@@ -10,9 +10,9 @@ import {CompilePipeMetadata, identifierName} from '../compile_metadata';
 import {CompileReflector} from '../compile_reflector';
 import {DefinitionKind} from '../constant_pool';
 import * as o from '../output/output_ast';
-import {OutputContext, error} from '../util';
+import {error, OutputContext} from '../util';
 
-import {R3DependencyMetadata, R3FactoryTarget, compileFactoryFunction, dependenciesFromGlobalMetadata} from './r3_factory';
+import {compileFactoryFunction, dependenciesFromGlobalMetadata, R3DependencyMetadata, R3FactoryTarget} from './r3_factory';
 import {Identifiers as R3} from './r3_identifiers';
 import {R3Reference, typeWithParameters, wrapReference} from './util';
 

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -215,7 +215,7 @@ class HtmlAstToIvyAst implements html.Visitor {
       // Moreover, if the node is an element, then we need to hoist its attributes to the template
       // node for matching against content projection selectors.
       const attrs = this.extractAttributes('ng-template', templateParsedProperties, i18nAttrsMeta);
-      const templateAttrs: (t.TextAttribute | t.BoundAttribute)[] = [];
+      const templateAttrs: (t.TextAttribute|t.BoundAttribute)[] = [];
       attrs.literal.forEach(attr => templateAttrs.push(attr));
       attrs.bound.forEach(attr => templateAttrs.push(attr));
       const hoistedAttrs = parsedElement instanceof t.Element ?
@@ -260,12 +260,12 @@ class HtmlAstToIvyAst implements html.Visitor {
       return null;
     }
     if (!isI18nRootNode(expansion.i18n)) {
-      throw new Error(
-          `Invalid type "${expansion.i18n.constructor}" for "i18n" property of ${expansion.sourceSpan.toString()}. Expected a "Message"`);
+      throw new Error(`Invalid type "${expansion.i18n.constructor}" for "i18n" property of ${
+          expansion.sourceSpan.toString()}. Expected a "Message"`);
     }
     const message = expansion.i18n;
     const vars: {[name: string]: t.BoundText} = {};
-    const placeholders: {[name: string]: t.Text | t.BoundText} = {};
+    const placeholders: {[name: string]: t.Text|t.BoundText} = {};
     // extract VARs from ICUs - we process them separately while
     // assembling resulting message via goog.getMsg function, since
     // we need to pass them to top-level goog.getMsg call
@@ -284,9 +284,13 @@ class HtmlAstToIvyAst implements html.Visitor {
     return new t.Icu(vars, placeholders, expansion.sourceSpan, message);
   }
 
-  visitExpansionCase(expansionCase: html.ExpansionCase): null { return null; }
+  visitExpansionCase(expansionCase: html.ExpansionCase): null {
+    return null;
+  }
 
-  visitComment(comment: html.Comment): null { return null; }
+  visitComment(comment: html.Comment): null {
+    return null;
+  }
 
   // convert view engine `ParsedProperty` to a format suitable for IVY
   private extractAttributes(
@@ -460,18 +464,26 @@ class NonBindableVisitor implements html.Visitor {
         ast.startSourceSpan, ast.endSourceSpan);
   }
 
-  visitComment(comment: html.Comment): any { return null; }
+  visitComment(comment: html.Comment): any {
+    return null;
+  }
 
   visitAttribute(attribute: html.Attribute): t.TextAttribute {
     return new t.TextAttribute(
         attribute.name, attribute.value, attribute.sourceSpan, undefined, attribute.i18n);
   }
 
-  visitText(text: html.Text): t.Text { return new t.Text(text.value, text.sourceSpan); }
+  visitText(text: html.Text): t.Text {
+    return new t.Text(text.value, text.sourceSpan);
+  }
 
-  visitExpansion(expansion: html.Expansion): any { return null; }
+  visitExpansion(expansion: html.Expansion): any {
+    return null;
+  }
 
-  visitExpansionCase(expansionCase: html.ExpansionCase): any { return null; }
+  visitExpansionCase(expansionCase: html.ExpansionCase): any {
+    return null;
+  }
 }
 
 const NON_BINDABLE_VISITOR = new NonBindableVisitor();

--- a/packages/compiler/src/render3/util.ts
+++ b/packages/compiler/src/render3/util.ts
@@ -13,14 +13,13 @@ import {OutputContext} from '../util';
 /**
  * Convert an object map with `Expression` values into a `LiteralMapExpr`.
  */
-export function mapToMapExpression(map: {[key: string]: o.Expression | undefined}):
-    o.LiteralMapExpr {
+export function mapToMapExpression(map: {[key: string]: o.Expression|undefined}): o.LiteralMapExpr {
   const result = Object.keys(map).map(
       key => ({
         key,
         // The assertion here is because really TypeScript doesn't allow us to express that if the
         // key is present, it will have a value, but this is true in reality.
-        value: map[key] !,
+        value: map[key]!,
         quoted: false,
       }));
   return o.literalMap(result);

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -88,7 +88,7 @@ export interface R3DirectiveMetadata {
   /**
    * A mapping of input field names to the property names.
    */
-  inputs: {[field: string]: string | [string, string]};
+  inputs: {[field: string]: string|[string, string]};
 
   /**
    * A mapping of output field names to the property names.

--- a/packages/compiler/src/render3/view/i18n/context.ts
+++ b/packages/compiler/src/render3/view/i18n/context.ts
@@ -46,7 +46,7 @@ export class I18nContext {
   public placeholders = new Map<string, any[]>();
   public isEmitted: boolean = false;
 
-  private _registry !: any;
+  private _registry!: any;
   private _unresolvedCtxCount: number = 0;
 
   constructor(
@@ -66,9 +66,15 @@ export class I18nContext {
     updatePlaceholderMap(this.placeholders, ph, content);
   }
 
-  get icus() { return this._registry.icus; }
-  get isRoot() { return this.level === 0; }
-  get isResolved() { return this._unresolvedCtxCount === 0; }
+  get icus() {
+    return this._registry.icus;
+  }
+  get isRoot() {
+    return this.level === 0;
+  }
+  get isResolved() {
+    return this._unresolvedCtxCount === 0;
+  }
 
   getSerializedPlaceholders() {
     const result = new Map<string, any[]>();
@@ -78,7 +84,9 @@ export class I18nContext {
   }
 
   // public API to accumulate i18n-related content
-  appendBinding(binding: AST) { this.bindings.add(binding); }
+  appendBinding(binding: AST) {
+    this.bindings.add(binding);
+  }
   appendIcu(name: string, ref: o.Expression) {
     updatePlaceholderMap(this._registry.icus, name, ref);
   }
@@ -181,7 +189,7 @@ function wrapTag(symbol: string, {index, ctx, isVoid}: any, closed?: boolean): s
                   wrap(symbol, index, ctx, closed);
 }
 
-function findTemplateFn(ctx: number, templateIndex: number | null) {
+function findTemplateFn(ctx: number, templateIndex: number|null) {
   return (token: any) => typeof token === 'object' && token.type === TagType.TEMPLATE &&
       token.index === templateIndex && token.ctx === ctx;
 }

--- a/packages/compiler/src/render3/view/i18n/get_msg_utils.ts
+++ b/packages/compiler/src/render3/view/i18n/get_msg_utils.ts
@@ -47,23 +47,32 @@ export function createGoogleGetMsgStatements(
  * placeholders in `{$placeholder}` (for plain messages) or `{PLACEHOLDER}` (inside ICUs) format.
  */
 class GetMsgSerializerVisitor implements i18n.Visitor {
-  private formatPh(value: string): string { return `{$${formatI18nPlaceholderName(value)}}`; }
+  private formatPh(value: string): string {
+    return `{$${formatI18nPlaceholderName(value)}}`;
+  }
 
-  visitText(text: i18n.Text): any { return text.value; }
+  visitText(text: i18n.Text): any {
+    return text.value;
+  }
 
   visitContainer(container: i18n.Container): any {
     return container.children.map(child => child.visit(this)).join('');
   }
 
-  visitIcu(icu: i18n.Icu): any { return serializeIcuNode(icu); }
+  visitIcu(icu: i18n.Icu): any {
+    return serializeIcuNode(icu);
+  }
 
   visitTagPlaceholder(ph: i18n.TagPlaceholder): any {
     return ph.isVoid ?
         this.formatPh(ph.startName) :
-        `${this.formatPh(ph.startName)}${ph.children.map(child => child.visit(this)).join('')}${this.formatPh(ph.closeName)}`;
+        `${this.formatPh(ph.startName)}${ph.children.map(child => child.visit(this)).join('')}${
+            this.formatPh(ph.closeName)}`;
   }
 
-  visitPlaceholder(ph: i18n.Placeholder): any { return this.formatPh(ph.name); }
+  visitPlaceholder(ph: i18n.Placeholder): any {
+    return this.formatPh(ph.name);
+  }
 
   visitIcuPlaceholder(ph: i18n.IcuPlaceholder, context?: any): any {
     return this.formatPh(ph.name);

--- a/packages/compiler/src/render3/view/i18n/icu_serializer.ts
+++ b/packages/compiler/src/render3/view/i18n/icu_serializer.ts
@@ -11,7 +11,9 @@ import * as i18n from '../../../i18n/i18n_ast';
 import {formatI18nPlaceholderName} from './util';
 
 class IcuSerializerVisitor implements i18n.Visitor {
-  visitText(text: i18n.Text): any { return text.value; }
+  visitText(text: i18n.Text): any {
+    return text.value;
+  }
 
   visitContainer(container: i18n.Container): any {
     return container.children.map(child => child.visit(this)).join('');
@@ -27,10 +29,13 @@ class IcuSerializerVisitor implements i18n.Visitor {
   visitTagPlaceholder(ph: i18n.TagPlaceholder): any {
     return ph.isVoid ?
         this.formatPh(ph.startName) :
-        `${this.formatPh(ph.startName)}${ph.children.map(child => child.visit(this)).join('')}${this.formatPh(ph.closeName)}`;
+        `${this.formatPh(ph.startName)}${ph.children.map(child => child.visit(this)).join('')}${
+            this.formatPh(ph.closeName)}`;
   }
 
-  visitPlaceholder(ph: i18n.Placeholder): any { return this.formatPh(ph.name); }
+  visitPlaceholder(ph: i18n.Placeholder): any {
+    return this.formatPh(ph.name);
+  }
 
   visitIcuPlaceholder(ph: i18n.IcuPlaceholder, context?: any): any {
     return this.formatPh(ph.name);

--- a/packages/compiler/src/render3/view/i18n/localize_utils.ts
+++ b/packages/compiler/src/render3/view/i18n/localize_utils.ts
@@ -28,7 +28,9 @@ class MessagePiece {
 }
 class LiteralPiece extends MessagePiece {}
 class PlaceholderPiece extends MessagePiece {
-  constructor(name: string) { super(formatI18nPlaceholderName(name, /* useCamelCase */ false)); }
+  constructor(name: string) {
+    super(formatI18nPlaceholderName(name, /* useCamelCase */ false));
+  }
 }
 
 /**

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -8,12 +8,12 @@
 
 import {computeDecimalDigest, computeDigest, decimalDigest} from '../../../i18n/digest';
 import * as i18n from '../../../i18n/i18n_ast';
-import {VisitNodeFn, createI18nMessageFactory} from '../../../i18n/i18n_parser';
+import {createI18nMessageFactory, VisitNodeFn} from '../../../i18n/i18n_parser';
 import * as html from '../../../ml_parser/ast';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../../ml_parser/interpolation_config';
 import * as o from '../../../output/output_ast';
 
-import {I18N_ATTR, I18N_ATTR_PREFIX, hasI18nAttrs, icuFromI18nMessage} from './util';
+import {hasI18nAttrs, I18N_ATTR, I18N_ATTR_PREFIX, icuFromI18nMessage} from './util';
 
 export type I18nMeta = {
   id?: string,
@@ -134,10 +134,18 @@ export class I18nMetaVisitor implements html.Visitor {
     return expansion;
   }
 
-  visitText(text: html.Text): any { return text; }
-  visitAttribute(attribute: html.Attribute): any { return attribute; }
-  visitComment(comment: html.Comment): any { return comment; }
-  visitExpansionCase(expansionCase: html.ExpansionCase): any { return expansionCase; }
+  visitText(text: html.Text): any {
+    return text;
+  }
+  visitAttribute(attribute: html.Attribute): any {
+    return attribute;
+  }
+  visitComment(comment: html.Comment): any {
+    return comment;
+  }
+  visitExpansionCase(expansionCase: html.ExpansionCase): any {
+    return expansionCase;
+  }
 
   /**
    * Parse the general form `meta` passed into extract the explicit metadata needed to create a

--- a/packages/compiler/src/render3/view/i18n/util.ts
+++ b/packages/compiler/src/render3/view/i18n/util.ts
@@ -49,7 +49,7 @@ export function icuFromI18nMessage(message: i18n.Message) {
   return message.nodes[0] as i18n.IcuPlaceholder;
 }
 
-export function wrapI18nPlaceholder(content: string | number, contextId: number = 0): string {
+export function wrapI18nPlaceholder(content: string|number, contextId: number = 0): string {
   const blockId = contextId > 0 ? `:${contextId}` : '';
   return `${I18N_PLACEHOLDER_SYMBOL}${content}${blockId}${I18N_PLACEHOLDER_SYMBOL}`;
 }
@@ -147,7 +147,7 @@ export function formatI18nPlaceholderName(name: string, useCamelCase: boolean = 
   if (/^\d+$/.test(chunks[chunks.length - 1])) {
     postfix = chunks.pop();
   }
-  let raw = chunks.shift() !.toLowerCase();
+  let raw = chunks.shift()!.toLowerCase();
   if (chunks.length) {
     raw += chunks.map(c => c.charAt(0).toUpperCase() + c.slice(1).toLowerCase()).join('');
   }
@@ -170,5 +170,5 @@ export function getTranslationConstPrefix(extra: string): string {
  */
 export function declareI18nVariable(variable: o.ReadVarExpr): o.Statement {
   return new o.DeclareVarStmt(
-      variable.name !, undefined, o.INFERRED_TYPE, null, variable.sourceSpan);
+      variable.name!, undefined, o.INFERRED_TYPE, null, variable.sourceSpan);
 }

--- a/packages/compiler/src/render3/view/style_parser.ts
+++ b/packages/compiler/src/render3/view/style_parser.ts
@@ -110,7 +110,11 @@ export function stripUnnecessaryQuotes(value: string): string {
 }
 
 export function hyphenate(value: string): string {
-  return value.replace(/[a-z][A-Z]/g, v => {
-                return v.charAt(0) + '-' + v.charAt(1);
-              }).toLowerCase();
+  return value
+      .replace(
+          /[a-z][A-Z]/g,
+          v => {
+            return v.charAt(0) + '-' + v.charAt(1);
+          })
+      .toLowerCase();
 }

--- a/packages/compiler/src/render3/view/styling_builder.ts
+++ b/packages/compiler/src/render3/view/styling_builder.ts
@@ -226,7 +226,10 @@ export class StylingBuilder {
     const entry: BoundStylingEntry = {
       name: property,
       sanitize: property ? isStyleSanitizable(property) : true,
-      unit: unit || bindingUnit, value, sourceSpan, hasOverrideFlag
+      unit: unit || bindingUnit,
+      value,
+      sourceSpan,
+      hasOverrideFlag
     };
     if (isMapBased) {
       this._styleMapInput = entry;
@@ -385,7 +388,7 @@ export class StylingBuilder {
         supportsInterpolation: true,
         sourceSpan: stylingInput.sourceSpan,
         allocateBindingSlots: totalBindingSlotsRequired,
-        params: (convertFn: (value: any) => o.Expression | o.Expression[]) => {
+        params: (convertFn: (value: any) => o.Expression|o.Expression[]) => {
           const convertResult = convertFn(mapValue);
           const params = Array.isArray(convertResult) ? convertResult : [convertResult];
           return params;

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -22,7 +22,9 @@ import {BoundAttribute, BoundEvent, Element, Node, Reference, Template, TextAttr
 /**
  * A logical target for analysis, which could contain a template or other types of bindings.
  */
-export interface Target { template?: Node[]; }
+export interface Target {
+  template?: Node[];
+}
 
 /**
  * Metadata regarding a directive that's needed to match it against template elements. This is
@@ -44,7 +46,7 @@ export interface DirectiveMeta {
    *
    * Goes from property names to field names.
    */
-  inputs: {[property: string]: string | [string, string]};
+  inputs: {[property: string]: string|[string, string]};
 
   /**
    * Set of outputs which this directive claims.
@@ -67,7 +69,9 @@ export interface DirectiveMeta {
  *
  * The returned `BoundTarget` has an API for extracting information about the processed target.
  */
-export interface TargetBinder<D extends DirectiveMeta> { bind(target: Target): BoundTarget<D>; }
+export interface TargetBinder<D extends DirectiveMeta> {
+  bind(target: Target): BoundTarget<D>;
+}
 
 /**
  * Result of performing the binding operation against a `Target`.

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -152,7 +152,7 @@ class Scope implements Visitor {
   lookup(name: string): Reference|Variable|null {
     if (this.namedEntities.has(name)) {
       // Found in the local scope.
-      return this.namedEntities.get(name) !;
+      return this.namedEntities.get(name)!;
     } else if (this.parentScope !== undefined) {
       // Not in the local scope, but there's a parent scope so check there.
       return this.parentScope.lookup(name);
@@ -217,11 +217,17 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
     return {directives, bindings, references};
   }
 
-  private ingest(template: Node[]): void { template.forEach(node => node.visit(this)); }
+  private ingest(template: Node[]): void {
+    template.forEach(node => node.visit(this));
+  }
 
-  visitElement(element: Element): void { this.visitElementOrTemplate(element.name, element); }
+  visitElement(element: Element): void {
+    this.visitElementOrTemplate(element.name, element);
+  }
 
-  visitTemplate(template: Template): void { this.visitElementOrTemplate('ng-template', template); }
+  visitTemplate(template: Template): void {
+    this.visitElementOrTemplate('ng-template', template);
+  }
 
   visitElementOrTemplate(elementName: string, node: Element|Template): void {
     // First, determine the HTML shape of the node for the purpose of directive matching.
@@ -269,7 +275,7 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
     });
 
     // Associate attributes/bindings on the node with directives or with the node itself.
-    type BoundNode = BoundAttribute | BoundEvent | TextAttribute;
+    type BoundNode = BoundAttribute|BoundEvent|TextAttribute;
     const setAttributeBinding =
         (attribute: BoundNode, ioType: keyof Pick<DirectiveMeta, 'inputs'|'outputs'>) => {
           const dir = directives.find(dir => dir[ioType].hasOwnProperty(attribute.name));
@@ -432,11 +438,17 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
 
   // The remaining visitors are concerned with processing AST expressions within template bindings
 
-  visitBoundAttribute(attribute: BoundAttribute) { attribute.value.visit(this); }
+  visitBoundAttribute(attribute: BoundAttribute) {
+    attribute.value.visit(this);
+  }
 
-  visitBoundEvent(event: BoundEvent) { event.handler.visit(this); }
+  visitBoundEvent(event: BoundEvent) {
+    event.handler.visit(this);
+  }
 
-  visitBoundText(text: BoundText) { text.value.visit(this); }
+  visitBoundText(text: BoundText) {
+    text.value.visit(this);
+  }
   visitPipe(ast: BindingPipe, context: any): any {
     this.usedPipes.add(ast.name);
     return super.visitPipe(ast, context);
@@ -526,7 +538,9 @@ export class R3BoundTarget<DirectiveT extends DirectiveMeta> implements BoundTar
     return this.symbols.get(symbol) || null;
   }
 
-  getNestingLevel(template: Template): number { return this.nestingLevel.get(template) || 0; }
+  getNestingLevel(template: Template): number {
+    return this.nestingLevel.get(template) || 0;
+  }
 
   getUsedDirectives(): DirectiveT[] {
     const set = new Set<DirectiveT>();
@@ -534,5 +548,7 @@ export class R3BoundTarget<DirectiveT extends DirectiveMeta> implements BoundTar
     return Array.from(set.values());
   }
 
-  getUsedPipes(): string[] { return Array.from(this.usedPipes); }
+  getUsedPipes(): string[] {
+    return Array.from(this.usedPipes);
+  }
 }

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -7,7 +7,7 @@
  */
 
 import {flatten, sanitizeIdentifier} from '../../compile_metadata';
-import {BindingForm, BuiltinFunctionCall, LocalResolver, convertActionBinding, convertPropertyBinding, convertUpdateArguments} from '../../compiler_util/expression_converter';
+import {BindingForm, BuiltinFunctionCall, convertActionBinding, convertPropertyBinding, convertUpdateArguments, LocalResolver} from '../../compiler_util/expression_converter';
 import {ConstantPool} from '../../constant_pool';
 import * as core from '../../core';
 import {AST, AstMemoryEfficientTransformer, BindingPipe, BindingType, FunctionCall, ImplicitReceiver, Interpolation, LiteralArray, LiteralMap, LiteralPrimitive, ParsedEventType, PropertyRead} from '../../expression_parser/ast';
@@ -36,9 +36,9 @@ import {I18nContext} from './i18n/context';
 import {createGoogleGetMsgStatements} from './i18n/get_msg_utils';
 import {createLocalizeStatements} from './i18n/localize_utils';
 import {I18nMetaVisitor} from './i18n/meta';
-import {I18N_ICU_MAPPING_PREFIX, TRANSLATION_PREFIX, assembleBoundTextPlaceholders, assembleI18nBoundString, declareI18nVariable, getTranslationConstPrefix, i18nFormatPlaceholderNames, icuFromI18nMessage, isI18nRootNode, isSingleI18nIcu, placeholdersToParams, wrapI18nPlaceholder} from './i18n/util';
+import {assembleBoundTextPlaceholders, assembleI18nBoundString, declareI18nVariable, getTranslationConstPrefix, I18N_ICU_MAPPING_PREFIX, i18nFormatPlaceholderNames, icuFromI18nMessage, isI18nRootNode, isSingleI18nIcu, placeholdersToParams, TRANSLATION_PREFIX, wrapI18nPlaceholder} from './i18n/util';
 import {StylingBuilder, StylingInstruction} from './styling_builder';
-import {CONTEXT_NAME, IMPLICIT_REFERENCE, NON_BINDABLE_ATTR, REFERENCE_PREFIX, RENDER_FLAGS, asLiteral, chainedInstruction, getAttrsForDirectiveMatching, getInterpolationArgsLength, invalid, trimTrailingNulls, unsupported} from './util';
+import {asLiteral, chainedInstruction, CONTEXT_NAME, getAttrsForDirectiveMatching, getInterpolationArgsLength, IMPLICIT_REFERENCE, invalid, NON_BINDABLE_ATTR, REFERENCE_PREFIX, RENDER_FLAGS, trimTrailingNulls, unsupported} from './util';
 
 
 
@@ -61,8 +61,8 @@ export function renderFlagCheckIfStmt(
 }
 
 export function prepareEventListenerParameters(
-    eventAst: t.BoundEvent, handlerName: string | null = null,
-    scope: BindingScope | null = null): o.Expression[] {
+    eventAst: t.BoundEvent, handlerName: string|null = null,
+    scope: BindingScope|null = null): o.Expression[] {
   const {type, name, target, phase, handler} = eventAst;
   if (target && !GLOBAL_TARGET_RESOLVERS.has(target)) {
     throw new Error(`Unexpected global target '${target}' defined for '${name}' event.
@@ -85,7 +85,7 @@ export function prepareEventListenerParameters(
   statements.push(...bindingExpr.render3Stmts);
 
   const eventName: string =
-      type === ParsedEventType.Animation ? prepareSyntheticListenerName(name, phase !) : name;
+      type === ParsedEventType.Animation ? prepareSyntheticListenerName(name, phase!) : name;
   const fnName = handlerName && sanitizeIdentifier(handlerName);
   const fnArgs: o.FnParam[] = [];
 
@@ -98,7 +98,7 @@ export function prepareEventListenerParameters(
   if (target) {
     params.push(
         o.literal(false),  // `useCapture` flag, defaults to `false`
-        o.importExpr(GLOBAL_TARGET_RESOLVERS.get(target) !));
+        o.importExpr(GLOBAL_TARGET_RESOLVERS.get(target)!));
   }
   return params;
 }
@@ -207,12 +207,12 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     // - this template has parent i18n context
     // - or the template has i18n meta associated with it,
     //   but it's not initiated by the Element (e.g. <ng-template i18n>)
-    const initI18nContext =
-        this.i18nContext || (isI18nRootNode(i18n) && !isSingleI18nIcu(i18n) &&
-                             !(isSingleElementTemplate(nodes) && nodes[0].i18n === i18n));
+    const initI18nContext = this.i18nContext ||
+        (isI18nRootNode(i18n) && !isSingleI18nIcu(i18n) &&
+         !(isSingleElementTemplate(nodes) && nodes[0].i18n === i18n));
     const selfClosingI18nInstruction = hasTextChildrenOnly(nodes);
     if (initI18nContext) {
-      this.i18nStart(null, i18n !, selfClosingI18nInstruction);
+      this.i18nStart(null, i18n!, selfClosingI18nInstruction);
     }
 
     // This is the initial pass through the nodes of this template. In this pass, we
@@ -295,10 +295,14 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   }
 
   // LocalResolver
-  getLocal(name: string): o.Expression|null { return this._bindingScope.get(name); }
+  getLocal(name: string): o.Expression|null {
+    return this._bindingScope.get(name);
+  }
 
   // LocalResolver
-  notifyImplicitReceiverUse(): void { this._bindingScope.notifyImplicitReceiverUse(); }
+  notifyImplicitReceiverUse(): void {
+    this._bindingScope.notifyImplicitReceiverUse();
+  }
 
   private i18nTranslate(
       message: i18n.Message, params: {[name: string]: o.Expression} = {}, ref?: o.ReadVarExpr,
@@ -335,12 +339,11 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
   private i18nAppendBindings(expressions: AST[]) {
     if (expressions.length > 0) {
-      expressions.forEach(expression => this.i18n !.appendBinding(expression));
+      expressions.forEach(expression => this.i18n!.appendBinding(expression));
     }
   }
 
-  private i18nBindProps(props: {[key: string]: t.Text | t.BoundText}):
-      {[key: string]: o.Expression} {
+  private i18nBindProps(props: {[key: string]: t.Text|t.BoundText}): {[key: string]: o.Expression} {
     const bound: {[key: string]: o.Expression} = {};
     Object.keys(props).forEach(key => {
       const prop = props[key];
@@ -351,7 +354,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
         this.allocateBindingSlots(value);
         if (value instanceof Interpolation) {
           const {strings, expressions} = value;
-          const {id, bindings} = this.i18n !;
+          const {id, bindings} = this.i18n!;
           const label = assembleI18nBoundString(strings, bindings.size, id);
           this.i18nAppendBindings(expressions);
           bound[key] = o.literal(label);
@@ -424,7 +427,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       void {
     const index = this.allocateDataSlot();
     if (this.i18nContext) {
-      this.i18n = this.i18nContext.forkChildContext(index, this.templateIndex !, meta);
+      this.i18n = this.i18nContext.forkChildContext(index, this.templateIndex!, meta);
     } else {
       const ref = o.variable(this.constantPool.uniqueName(TRANSLATION_PREFIX));
       this.i18n = new I18nContext(index, ref, 0, this.templateIndex, meta);
@@ -479,7 +482,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     const i18nAttrArgs: o.Expression[] = [];
     const bindings: ChainableBindingInstruction[] = [];
     attrs.forEach(attr => {
-      const message = attr.i18n !as i18n.Message;
+      const message = attr.i18n! as i18n.Message;
       if (attr instanceof t.TextAttribute) {
         i18nAttrArgs.push(o.literal(attr.name), this.i18nTranslate(message));
       } else {
@@ -559,7 +562,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
     this.creationInstruction(ngContent.sourceSpan, R3.projection, parameters);
     if (this.i18n) {
-      this.i18n.appendProjection(ngContent.i18n !, slot);
+      this.i18n.appendProjection(ngContent.i18n!, slot);
     }
   }
 
@@ -571,7 +574,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     const isI18nRootElement: boolean =
         isI18nRootNode(element.i18n) && !isSingleI18nIcu(element.i18n);
 
-    const i18nAttrs: (t.TextAttribute | t.BoundAttribute)[] = [];
+    const i18nAttrs: (t.TextAttribute|t.BoundAttribute)[] = [];
     const outputAttrs: t.TextAttribute[] = [];
 
     const [namespaceKey, elementName] = splitNsName(element.name);
@@ -633,7 +636,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
 
     if (this.i18n) {
-      this.i18n.appendElement(element.i18n !, elementIndex);
+      this.i18n.appendElement(element.i18n!, elementIndex);
     }
 
     // Note that we do not append text node instructions and ICUs inside i18n section,
@@ -676,7 +679,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       // Note: it's important to keep i18n/i18nStart instructions after i18nAttributes and
       // listeners, to make sure i18nAttributes instruction targets current element at runtime.
       if (isI18nRootElement) {
-        this.i18nStart(element.sourceSpan, element.i18n !, createSelfClosingI18nInstruction);
+        this.i18nStart(element.sourceSpan, element.i18n!, createSelfClosingI18nInstruction);
       }
     }
 
@@ -757,7 +760,8 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
               propertyBindings.push({
                 name: attrName,
                 sourceSpan: input.sourceSpan,
-                value: () => this.convertPropertyBinding(value), params
+                value: () => this.convertPropertyBinding(value),
+                params
               });
             }
           } else if (inputType === BindingType.Attribute) {
@@ -773,7 +777,8 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
               attributeBindings.push({
                 name: attrName,
                 sourceSpan: input.sourceSpan,
-                value: () => this.convertPropertyBinding(boundValue), params
+                value: () => this.convertPropertyBinding(boundValue),
+                params
               });
             }
           } else {
@@ -801,7 +806,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     t.visitAll(this, element.children);
 
     if (!isI18nRootElement && this.i18n) {
-      this.i18n.appendElement(element.i18n !, elementIndex, true);
+      this.i18n.appendElement(element.i18n!, elementIndex, true);
     }
 
     if (!createSelfClosingInstruction) {
@@ -823,7 +828,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     const templateIndex = this.allocateDataSlot();
 
     if (this.i18n) {
-      this.i18n.appendTemplate(template.i18n !, templateIndex);
+      this.i18n.appendTemplate(template.i18n!, templateIndex);
     }
 
     const tagName = sanitizeIdentifier(template.tagName || '');
@@ -892,7 +897,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     // Only add normal input/output binding instructions on explicit <ng-template> elements.
     if (template.tagName === NG_TEMPLATE_TAG_NAME) {
       const inputs: t.BoundAttribute[] = [];
-      const i18nAttrs: (t.TextAttribute | t.BoundAttribute)[] =
+      const i18nAttrs: (t.TextAttribute|t.BoundAttribute)[] =
           template.attributes.filter(attr => !!attr.i18n);
 
       template.inputs.forEach(
@@ -935,7 +940,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       const value = text.value.visit(this._valueConverter);
       this.allocateBindingSlots(value);
       if (value instanceof Interpolation) {
-        this.i18n.appendBoundText(text.i18n !);
+        this.i18n.appendBoundText(text.i18n!);
         this.i18nAppendBindings(value.expressions);
       }
       return;
@@ -975,15 +980,15 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     // to generate i18n context and the necessary instructions
     if (!this.i18n) {
       initWasInvoked = true;
-      this.i18nStart(null, icu.i18n !, true);
+      this.i18nStart(null, icu.i18n!, true);
     }
 
-    const i18n = this.i18n !;
+    const i18n = this.i18n!;
     const vars = this.i18nBindProps(icu.vars);
     const placeholders = this.i18nBindProps(icu.placeholders);
 
     // output ICU directly and keep ICU reference in context
-    const message = icu.i18n !as i18n.Message;
+    const message = icu.i18n! as i18n.Message;
 
     // we always need post-processing function for ICUs, to make sure that:
     // - all placeholders in a form of {PLACEHOLDER} are replaced with actual values (note:
@@ -1016,13 +1021,21 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     return null;
   }
 
-  private allocateDataSlot() { return this._dataIndex++; }
+  private allocateDataSlot() {
+    return this._dataIndex++;
+  }
 
-  getConstCount() { return this._dataIndex; }
+  getConstCount() {
+    return this._dataIndex;
+  }
 
-  getVarCount() { return this._pureFunctionSlots; }
+  getVarCount() {
+    return this._pureFunctionSlots;
+  }
 
-  getConsts() { return this._constants; }
+  getConsts() {
+    return this._constants;
+  }
 
   getNgContentSelectors(): o.Expression|null {
     return this._ngContentReservedSlots.length ?
@@ -1030,7 +1043,9 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
         null;
   }
 
-  private bindingContext() { return `${this._bindingContext++}`; }
+  private bindingContext() {
+    return `${this._bindingContext++}`;
+  }
 
   private templatePropertyBindings(
       templateIndex: number, attrs: (t.BoundAttribute|t.TextAttribute)[]) {
@@ -1092,11 +1107,10 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
         calls.push({
           sourceSpan: call.sourceSpan,
           value: () => {
-            return call
-                .params(
-                    value => (call.supportsInterpolation && value instanceof Interpolation) ?
-                        this.getUpdateInstructionArguments(value) :
-                        this.convertPropertyBinding(value)) as o.Expression[];
+            return call.params(
+                       value => (call.supportsInterpolation && value instanceof Interpolation) ?
+                           this.getUpdateInstructionArguments(value) :
+                           this.convertPropertyBinding(value)) as o.Expression[];
           }
         });
       });
@@ -1114,7 +1128,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   }
 
   private creationInstructionChain(reference: o.ExternalReference, calls: {
-    sourceSpan: ParseSourceSpan | null,
+    sourceSpan: ParseSourceSpan|null,
     params: () => o.Expression[]
   }[]) {
     const span = calls.length ? calls[0].sourceSpan : null;
@@ -1228,8 +1242,9 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   private matchDirectives(elementName: string, elOrTpl: t.Element|t.Template) {
     if (this.directiveMatcher) {
       const selector = createCssSelector(elementName, getAttrsForDirectiveMatching(elOrTpl));
-      this.directiveMatcher.match(
-          selector, (cssSelector, staticType) => { this.directives.add(staticType); });
+      this.directiveMatcher.match(selector, (cssSelector, staticType) => {
+        this.directives.add(staticType);
+      });
     }
   }
 
@@ -1277,7 +1292,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       attrExprs.push(...getNgProjectAsLiteral(ngProjectAsAttr));
     }
 
-    function addAttrExpr(key: string | number, value?: o.Expression): void {
+    function addAttrExpr(key: string|number, value?: o.Expression): void {
       if (typeof key === 'string') {
         if (!alreadySeen.has(key)) {
           attrExprs.push(...getAttributeNameLiterals(key));
@@ -1390,7 +1405,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       const eventName: string = outputAst.name;
       const bindingFnName = outputAst.type === ParsedEventType.Animation ?
           // synthetic @listener.foo values are treated the exact same as are standard listeners
-          prepareSyntheticListenerFunctionName(eventName, outputAst.phase !) :
+          prepareSyntheticListenerFunctionName(eventName, outputAst.phase!) :
           sanitizeIdentifier(eventName);
       const handlerName = `${this.templateName}_${tagName}_${bindingFnName}_${index}_listener`;
       const scope = this._bindingScope.nestedScope(this._bindingScope.bindingLevel);
@@ -1492,7 +1507,7 @@ function pureFunctionCallInfo(args: o.Expression[]) {
 }
 
 function instruction(
-    span: ParseSourceSpan | null, reference: o.ExternalReference,
+    span: ParseSourceSpan|null, reference: o.ExternalReference,
     params: o.Expression[]): o.Expression {
   return o.importExpr(reference, null, span).callFn(params, span);
 }
@@ -1504,7 +1519,7 @@ function generateNextContextExpr(relativeLevelDiff: number): o.Expression {
 }
 
 function getLiteralFactory(
-    constantPool: ConstantPool, literal: o.LiteralArrayExpr | o.LiteralMapExpr,
+    constantPool: ConstantPool, literal: o.LiteralArrayExpr|o.LiteralMapExpr,
     allocateSlots: (numSlots: number) => number): o.Expression {
   const {literalFactory, literalFactoryArguments} = constantPool.getLiteralFactory(literal);
   // Allocate 1 slot for the result plus 1 per argument
@@ -1570,9 +1585,8 @@ const SHARED_CONTEXT_KEY = '$$shared_ctx$$';
  * declaration should always come before the local ref declaration.
  */
 type BindingData = {
-  retrievalLevel: number; lhs: o.Expression; declareLocalCallback?: DeclareLocalVarCallback;
-  declare: boolean;
-  priority: number;
+  retrievalLevel: number; lhs: o.Expression;
+  declareLocalCallback?: DeclareLocalVarCallback; declare: boolean; priority: number;
   localRef: boolean;
 };
 
@@ -1580,7 +1594,11 @@ type BindingData = {
  * The sorting priority of a local variable declaration. Higher numbers
  * mean the declaration will appear first in the generated code.
  */
-const enum DeclarationPriority { DEFAULT = 0, CONTEXT = 1, SHARED_CONTEXT = 2 }
+const enum DeclarationPriority {
+  DEFAULT = 0,
+  CONTEXT = 1,
+  SHARED_CONTEXT = 2
+}
 
 export class BindingScope implements LocalResolver {
   /** Keeps a map from local variables to their BindingData. */
@@ -1669,7 +1687,9 @@ export class BindingScope implements LocalResolver {
   }
 
   // Implemented as part of LocalResolver.
-  getLocal(name: string): (o.Expression|null) { return this.get(name); }
+  getLocal(name: string): (o.Expression|null) {
+    return this.get(name);
+  }
 
   // Implemented as part of LocalResolver.
   notifyImplicitReceiverUse(): void {
@@ -1677,7 +1697,7 @@ export class BindingScope implements LocalResolver {
       // Since the implicit receiver is accessed in an embedded view, we need to
       // ensure that we declare a shared context variable for the current template
       // in the update variables.
-      this.map.get(SHARED_CONTEXT_KEY + 0) !.declare = true;
+      this.map.get(SHARED_CONTEXT_KEY + 0)!.declare = true;
     }
   }
 
@@ -1698,7 +1718,7 @@ export class BindingScope implements LocalResolver {
       this.generateSharedContextVar(retrievalLevel);
     }
     // Shared context variables are always generated as "ReadVarExpr".
-    return this.map.get(bindingKey) !.lhs as o.ReadVarExpr;
+    return this.map.get(bindingKey)!.lhs as o.ReadVarExpr;
   }
 
   getSharedContextName(retrievalLevel: number): o.ReadVarExpr|null {
@@ -1735,7 +1755,7 @@ export class BindingScope implements LocalResolver {
   }
 
   getComponentProperty(name: string): o.Expression {
-    const componentValue = this.map.get(SHARED_CONTEXT_KEY + 0) !;
+    const componentValue = this.map.get(SHARED_CONTEXT_KEY + 0)!;
     componentValue.declare = true;
     this.maybeRestoreView(0, false);
     return componentValue.lhs.prop(name);
@@ -1748,11 +1768,11 @@ export class BindingScope implements LocalResolver {
     // 2 - we are looking up a local ref, which requires restoring the view where the local
     // ref is stored
     if (this.isListenerScope() && (retrievalLevel < this.bindingLevel || localRefLookup)) {
-      if (!this.parent !.restoreViewVariable) {
+      if (!this.parent!.restoreViewVariable) {
         // parent saves variable to generate a shared `const $s$ = getCurrentView();` instruction
-        this.parent !.restoreViewVariable = o.variable(this.parent !.freshReferenceName());
+        this.parent!.restoreViewVariable = o.variable(this.parent!.freshReferenceName());
       }
-      this.restoreViewVariable = this.parent !.restoreViewVariable;
+      this.restoreViewVariable = this.parent!.restoreViewVariable;
     }
   }
 
@@ -1771,19 +1791,22 @@ export class BindingScope implements LocalResolver {
         [];
   }
 
-  isListenerScope() { return this.parent && this.parent.bindingLevel === this.bindingLevel; }
+  isListenerScope() {
+    return this.parent && this.parent.bindingLevel === this.bindingLevel;
+  }
 
   variableDeclarations(): o.Statement[] {
     let currentContextLevel = 0;
     return Array.from(this.map.values())
-        .filter(value => value.declare)
-        .sort((a, b) => b.retrievalLevel - a.retrievalLevel || b.priority - a.priority)
-        .reduce((stmts: o.Statement[], value: BindingData) => {
-          const levelDiff = this.bindingLevel - value.retrievalLevel;
-          const currStmts = value.declareLocalCallback !(this, levelDiff - currentContextLevel);
-          currentContextLevel = levelDiff;
-          return stmts.concat(currStmts);
-        }, []) as o.Statement[];
+               .filter(value => value.declare)
+               .sort((a, b) => b.retrievalLevel - a.retrievalLevel || b.priority - a.priority)
+               .reduce((stmts: o.Statement[], value: BindingData) => {
+                 const levelDiff = this.bindingLevel - value.retrievalLevel;
+                 const currStmts =
+                     value.declareLocalCallback!(this, levelDiff - currentContextLevel);
+                 currentContextLevel = levelDiff;
+                 return stmts.concat(currStmts);
+               }, []) as o.Statement[];
   }
 
 
@@ -1985,10 +2008,10 @@ export interface ParseTemplateOptions {
 export function parseTemplate(
     template: string, templateUrl: string, options: ParseTemplateOptions = {}): {
   errors?: ParseError[],
-  nodes: t.Node[],
-  styleUrls: string[],
-  styles: string[],
-  ngContentSelectors: string[]
+        nodes: t.Node[],
+        styleUrls: string[],
+        styles: string[],
+        ngContentSelectors: string[]
 } {
   const {interpolationConfig, preserveWhitespaces, enableI18nLegacyMessageIdFormat} = options;
   const bindingParser = makeBindingParser(interpolationConfig);
@@ -2126,9 +2149,10 @@ export function getTranslationDeclStmts(
   const statements: o.Statement[] = [
     declareI18nVariable(variable),
     o.ifStmt(
-        createClosureModeGuard(), createGoogleGetMsgStatements(
-                                      variable, message, closureVar,
-                                      i18nFormatPlaceholderNames(params, /* useCamelCase */ true)),
+        createClosureModeGuard(),
+        createGoogleGetMsgStatements(
+            variable, message, closureVar,
+            i18nFormatPlaceholderNames(params, /* useCamelCase */ true)),
         createLocalizeStatements(
             variable, message, i18nFormatPlaceholderNames(params, /* useCamelCase */ false))),
   ];

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -69,7 +69,7 @@ export function unsupported(this: void|Function, feature: string): never {
   throw new Error(`Feature ${feature} is not supported yet`);
 }
 
-export function invalid<T>(this: t.Visitor, arg: o.Expression | o.Statement | t.Node): never {
+export function invalid<T>(this: t.Visitor, arg: o.Expression|o.Statement|t.Node): never {
   throw new Error(
       `Invalid state: Visitor ${this.constructor.name} doesn't handle ${arg.constructor.name}`);
 }
@@ -82,7 +82,7 @@ export function asLiteral(value: any): o.Expression {
 }
 
 export function conditionallyCreateMapObjectLiteral(
-    keys: {[key: string]: string | string[]}, keepDeclared?: boolean): o.Expression|null {
+    keys: {[key: string]: string|string[]}, keepDeclared?: boolean): o.Expression|null {
   if (Object.getOwnPropertyNames(keys).length > 0) {
     return mapToExpression(keys, keepDeclared);
   }
@@ -90,7 +90,7 @@ export function conditionallyCreateMapObjectLiteral(
 }
 
 function mapToExpression(
-    map: {[key: string]: string | string[]}, keepDeclared?: boolean): o.Expression {
+    map: {[key: string]: string|string[]}, keepDeclared?: boolean): o.Expression {
   return o.literalMap(Object.getOwnPropertyNames(map).map(key => {
     // canonical syntax: `dirProp: publicProp`
     // if there is no `:`, use dirProp = elProp
@@ -153,7 +153,9 @@ export class DefinitionMap {
     }
   }
 
-  toLiteralMap(): o.LiteralMapExpr { return o.literalMap(this.values); }
+  toLiteralMap(): o.LiteralMapExpr {
+    return o.literalMap(this.values);
+  }
 }
 
 /**
@@ -165,8 +167,8 @@ export class DefinitionMap {
  * object maps a property name to its (static) value. For any bindings, this map simply maps the
  * property name to an empty string.
  */
-export function getAttrsForDirectiveMatching(elOrTpl: t.Element | t.Template):
-    {[name: string]: string} {
+export function getAttrsForDirectiveMatching(elOrTpl: t.Element|
+                                             t.Template): {[name: string]: string} {
   const attributesMap: {[name: string]: string} = {};
 
 
@@ -179,8 +181,12 @@ export function getAttrsForDirectiveMatching(elOrTpl: t.Element | t.Template):
       }
     });
 
-    elOrTpl.inputs.forEach(i => { attributesMap[i.name] = ''; });
-    elOrTpl.outputs.forEach(o => { attributesMap[o.name] = ''; });
+    elOrTpl.inputs.forEach(i => {
+      attributesMap[i.name] = '';
+    });
+    elOrTpl.outputs.forEach(o => {
+      attributesMap[o.name] = '';
+    });
   }
 
   return attributesMap;
@@ -188,7 +194,7 @@ export function getAttrsForDirectiveMatching(elOrTpl: t.Element | t.Template):
 
 /** Returns a call expression to a chained instruction, e.g. `property(params[0])(params[1])`. */
 export function chainedInstruction(
-    reference: o.ExternalReference, calls: o.Expression[][], span?: ParseSourceSpan | null) {
+    reference: o.ExternalReference, calls: o.Expression[][], span?: ParseSourceSpan|null) {
   let expression = o.importExpr(reference, null, span) as o.Expression;
 
   if (calls.length > 0) {

--- a/packages/compiler/src/resource_loader.ts
+++ b/packages/compiler/src/resource_loader.ts
@@ -11,5 +11,7 @@
  * to load templates.
  */
 export class ResourceLoader {
-  get(url: string): Promise<string>|string { return ''; }
+  get(url: string): Promise<string>|string {
+    return '';
+  }
 }

--- a/packages/compiler/src/schema/dom_element_schema_registry.ts
+++ b/packages/compiler/src/schema/dom_element_schema_registry.ts
@@ -253,7 +253,9 @@ export class DomElementSchemaRegistry extends ElementSchemaRegistry {
       typeNames.split(',').forEach(tag => this._schema[tag.toLowerCase()] = type);
       const superType = superName && this._schema[superName.toLowerCase()];
       if (superType) {
-        Object.keys(superType).forEach((prop: string) => { type[prop] = superType[prop]; });
+        Object.keys(superType).forEach((prop: string) => {
+          type[prop] = superType[prop];
+        });
       }
       properties.forEach((property: string) => {
         if (property.length > 0) {
@@ -350,9 +352,13 @@ export class DomElementSchemaRegistry extends ElementSchemaRegistry {
     return ctx ? ctx : SecurityContext.NONE;
   }
 
-  getMappedPropName(propName: string): string { return _ATTR_TO_PROP[propName] || propName; }
+  getMappedPropName(propName: string): string {
+    return _ATTR_TO_PROP[propName] || propName;
+  }
 
-  getDefaultComponentElementName(): string { return 'ng-component'; }
+  getDefaultComponentElementName(): string {
+    return 'ng-component';
+  }
 
   validateProperty(name: string): {error: boolean, msg?: string} {
     if (name.toLowerCase().startsWith('on')) {
@@ -376,7 +382,9 @@ export class DomElementSchemaRegistry extends ElementSchemaRegistry {
     }
   }
 
-  allKnownElementNames(): string[] { return Object.keys(this._schema); }
+  allKnownElementNames(): string[] {
+    return Object.keys(this._schema);
+  }
 
   normalizeAnimationStyleProperty(propName: string): string {
     return dashCaseToCamelCase(propName);
@@ -386,7 +394,7 @@ export class DomElementSchemaRegistry extends ElementSchemaRegistry {
       {error: string, value: string} {
     let unit: string = '';
     const strVal = val.toString().trim();
-    let errorMsg: string = null !;
+    let errorMsg: string = null!;
 
     if (_isPixelDimensionStyle(camelCaseProp) && val !== 0 && val !== '0') {
       if (typeof val === 'number') {

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -20,7 +20,7 @@ import {SecurityContext} from '../core';
 // =================================================================================================
 
 /** Map from tagName|propertyName SecurityContext. Properties applying to all tags use '*'. */
-let _SECURITY_SCHEMA !: {[k: string]: SecurityContext};
+let _SECURITY_SCHEMA!: {[k: string]: SecurityContext};
 
 export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
   if (!_SECURITY_SCHEMA) {

--- a/packages/compiler/src/selector.ts
+++ b/packages/compiler/src/selector.ts
@@ -118,9 +118,13 @@ export class CssSelector {
         this.notSelectors.length === 0;
   }
 
-  hasElementSelector(): boolean { return !!this.element; }
+  hasElementSelector(): boolean {
+    return !!this.element;
+  }
 
-  setElement(element: string|null = null) { this.element = element; }
+  setElement(element: string|null = null) {
+    this.element = element;
+  }
 
   /** Gets a template string for an element that matches the selector. */
   getMatchingElementTemplate(): string {
@@ -150,7 +154,9 @@ export class CssSelector {
     this.attrs.push(name, value && value.toLowerCase() || '');
   }
 
-  addClassName(name: string) { this.classNames.push(name.toLowerCase()); }
+  addClassName(name: string) {
+    this.classNames.push(name.toLowerCase());
+  }
 
   toString(): string {
     let res: string = this.element || '';
@@ -189,7 +195,7 @@ export class SelectorMatcher<T = any> {
   private _listContexts: SelectorListContext[] = [];
 
   addSelectables(cssSelectors: CssSelector[], callbackCtxt?: T) {
-    let listContext: SelectorListContext = null !;
+    let listContext: SelectorListContext = null!;
     if (cssSelectors.length > 1) {
       listContext = new SelectorListContext(cssSelectors);
       this._listContexts.push(listContext);
@@ -284,10 +290,10 @@ export class SelectorMatcher<T = any> {
    * @param cssSelector A css selector
    * @param matchedCallback This callback will be called with the object handed into `addSelectable`
    * @return boolean true if a match was found
-  */
+   */
   match(cssSelector: CssSelector, matchedCallback: ((c: CssSelector, a: T) => void)|null): boolean {
     let result = false;
-    const element = cssSelector.element !;
+    const element = cssSelector.element!;
     const classNames = cssSelector.classNames;
     const attrs = cssSelector.attrs;
 
@@ -315,7 +321,7 @@ export class SelectorMatcher<T = any> {
         const name = attrs[i];
         const value = attrs[i + 1];
 
-        const terminalValuesMap = this._attrValueMap.get(name) !;
+        const terminalValuesMap = this._attrValueMap.get(name)!;
         if (value) {
           result =
               this._matchTerminal(terminalValuesMap, '', cssSelector, matchedCallback) || result;
@@ -323,7 +329,7 @@ export class SelectorMatcher<T = any> {
         result =
             this._matchTerminal(terminalValuesMap, value, cssSelector, matchedCallback) || result;
 
-        const partialValuesMap = this._attrValuePartialMap.get(name) !;
+        const partialValuesMap = this._attrValuePartialMap.get(name)!;
         if (value) {
           result = this._matchPartial(partialValuesMap, '', cssSelector, matchedCallback) || result;
         }
@@ -343,7 +349,7 @@ export class SelectorMatcher<T = any> {
     }
 
     let selectables: SelectorContext<T>[] = map.get(name) || [];
-    const starSelectables: SelectorContext<T>[] = map.get('*') !;
+    const starSelectables: SelectorContext<T>[] = map.get('*')!;
     if (starSelectables) {
       selectables = selectables.concat(starSelectables);
     }

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -138,13 +138,13 @@ export class ShadowCss {
   constructor() {}
 
   /*
-  * Shim some cssText with the given selector. Returns cssText that can
-  * be included in the document via WebComponents.ShadowCSS.addCssToDocument(css).
-  *
-  * When strictStyling is true:
-  * - selector is the attribute added to all elements inside the host,
-  * - hostSelector is the attribute added to the host itself.
-  */
+   * Shim some cssText with the given selector. Returns cssText that can
+   * be included in the document via WebComponents.ShadowCSS.addCssToDocument(css).
+   *
+   * When strictStyling is true:
+   * - selector is the attribute added to all elements inside the host,
+   * - hostSelector is the attribute added to the host itself.
+   */
   shimCssText(cssText: string, selector: string, hostSelector: string = ''): string {
     const commentsWithHash = extractCommentsWithHash(cssText);
     cssText = stripComments(cssText);
@@ -172,11 +172,12 @@ export class ShadowCss {
    *
    * scopeName menu-item {
    *
-  **/
+   **/
   private _insertPolyfillDirectivesInCssText(cssText: string): string {
     // Difference with webcomponents.js: does not handle comments
-    return cssText.replace(
-        _cssContentNextSelectorRe, function(...m: string[]) { return m[2] + '{'; });
+    return cssText.replace(_cssContentNextSelectorRe, function(...m: string[]) {
+      return m[2] + '{';
+    });
   }
 
   /*
@@ -193,7 +194,7 @@ export class ShadowCss {
    *
    * scopeName menu-item {...}
    *
-  **/
+   **/
   private _insertPolyfillRulesInCssText(cssText: string): string {
     // Difference with webcomponents.js: does not handle comments
     return cssText.replace(_cssContentRuleRe, (...m: string[]) => {
@@ -209,7 +210,7 @@ export class ShadowCss {
    *  and converts this to
    *
    *  scopeName .foo { ... }
-  */
+   */
   private _scopeCssText(cssText: string, scopeSelector: string, hostSelector: string): string {
     const unscopedRules = this._extractUnscopedRulesFromCssText(cssText);
     // replace :host and :host-context -shadowcsshost and -shadowcsshost respectively
@@ -238,7 +239,7 @@ export class ShadowCss {
    *
    * menu-item {...}
    *
-  **/
+   **/
   private _extractUnscopedRulesFromCssText(cssText: string): string {
     // Difference with webcomponents.js: does not handle comments
     let r = '';
@@ -257,7 +258,7 @@ export class ShadowCss {
    * to
    *
    * .foo<scopeName> > .bar
-  */
+   */
   private _convertColonHost(cssText: string): string {
     return this._convertColonRule(cssText, _cssColonHostRe, this._colonHostPartReplacer);
   }
@@ -276,7 +277,7 @@ export class ShadowCss {
    * to
    *
    * .foo<scopeName> .bar { ... }
-  */
+   */
   private _convertColonHostContext(cssText: string): string {
     return this._convertColonRule(
         cssText, _cssColonHostContextRe, this._colonHostContextPartReplacer);
@@ -315,7 +316,7 @@ export class ShadowCss {
   /*
    * Convert combinators like ::shadow and pseudo-elements like ::content
    * by replacing with space.
-  */
+   */
   private _convertShadowDOMSelectors(cssText: string): string {
     return _shadowDOMSelectorsRe.reduce((result, pattern) => result.replace(pattern, ' '), cssText);
   }
@@ -505,7 +506,9 @@ class SafeSelector {
     return content.replace(/__ph-(\d+)__/g, (ph, index) => this.placeholders[+index]);
   }
 
-  content(): string { return this._content; }
+  content(): string {
+    return this._content;
+  }
 }
 
 const _cssContentNextSelectorRe =

--- a/packages/compiler/src/style_compiler.ts
+++ b/packages/compiler/src/style_compiler.ts
@@ -66,7 +66,7 @@ export class StyleCompiler {
     stylesheet.styleUrls.forEach((styleUrl) => {
       const exprIndex = styleExpressions.length;
       // Note: This placeholder will be filled later.
-      styleExpressions.push(null !);
+      styleExpressions.push(null!);
       dependencies.push(new StylesCompileDependency(
           getStylesVarName(null), styleUrl,
           (value) => styleExpressions[exprIndex] = outputCtx.importExpr(value)));
@@ -89,7 +89,7 @@ export class StyleCompiler {
   }
 }
 
-function getStylesVarName(component: CompileDirectiveMetadata | null): string {
+function getStylesVarName(component: CompileDirectiveMetadata|null): string {
   let result = `styles`;
   if (component) {
     result += `_${identifierName(component.type)}`;

--- a/packages/compiler/src/summary_resolver.ts
+++ b/packages/compiler/src/summary_resolver.ts
@@ -28,14 +28,28 @@ export abstract class SummaryResolver<T> {
 export class JitSummaryResolver implements SummaryResolver<Type> {
   private _summaries = new Map<Type, Summary<Type>>();
 
-  isLibraryFile(): boolean { return false; }
-  toSummaryFileName(fileName: string): string { return fileName; }
-  fromSummaryFileName(fileName: string): string { return fileName; }
+  isLibraryFile(): boolean {
+    return false;
+  }
+  toSummaryFileName(fileName: string): string {
+    return fileName;
+  }
+  fromSummaryFileName(fileName: string): string {
+    return fileName;
+  }
   resolveSummary(reference: Type): Summary<Type>|null {
     return this._summaries.get(reference) || null;
   }
-  getSymbolsOf(): Type[] { return []; }
-  getImportAs(reference: Type): Type { return reference; }
-  getKnownModuleName(fileName: string) { return null; }
-  addSummary(summary: Summary<Type>) { this._summaries.set(summary.symbol, summary); }
+  getSymbolsOf(): Type[] {
+    return [];
+  }
+  getImportAs(reference: Type): Type {
+    return reference;
+  }
+  getKnownModuleName(fileName: string) {
+    return null;
+  }
+  addSummary(summary: Summary<Type>) {
+    this._summaries.set(summary.symbol, summary);
+  }
 }

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -8,7 +8,7 @@
 
 import {CompileDirectiveSummary, CompilePipeSummary} from '../compile_metadata';
 import {SecurityContext} from '../core';
-import {ASTWithSource, AbsoluteSourceSpan, BindingPipe, BindingType, BoundElementProperty, EmptyExpr, ParsedEvent, ParsedEventType, ParsedProperty, ParsedPropertyType, ParsedVariable, ParserError, RecursiveAstVisitor, TemplateBinding, VariableBinding} from '../expression_parser/ast';
+import {AbsoluteSourceSpan, ASTWithSource, BindingPipe, BindingType, BoundElementProperty, EmptyExpr, ParsedEvent, ParsedEventType, ParsedProperty, ParsedPropertyType, ParsedVariable, ParserError, RecursiveAstVisitor, TemplateBinding, VariableBinding} from '../expression_parser/ast';
 import {Parser} from '../expression_parser/parser';
 import {InterpolationConfig} from '../ml_parser/interpolation_config';
 import {mergeNsAndName} from '../ml_parser/tags';
@@ -45,9 +45,13 @@ export class BindingParser {
     }
   }
 
-  get interpolationConfig(): InterpolationConfig { return this._interpolationConfig; }
+  get interpolationConfig(): InterpolationConfig {
+    return this._interpolationConfig;
+  }
 
-  getUsedPipes(): CompilePipeSummary[] { return Array.from(this._usedPipes.values()); }
+  getUsedPipes(): CompilePipeSummary[] {
+    return Array.from(this._usedPipes.values());
+  }
 
   createBoundHostProperties(dirMeta: CompileDirectiveSummary, sourceSpan: ParseSourceSpan):
       ParsedProperty[]|null {
@@ -61,7 +65,9 @@ export class BindingParser {
               boundProps);
         } else {
           this._reportError(
-              `Value of the host property binding "${propName}" needs to be a string representing an expression but got "${expression}" (${typeof expression})`,
+              `Value of the host property binding "${
+                  propName}" needs to be a string representing an expression but got "${
+                  expression}" (${typeof expression})`,
               sourceSpan);
         }
       });
@@ -89,7 +95,9 @@ export class BindingParser {
           this.parseEvent(propName, expression, sourceSpan, sourceSpan, [], targetEvents);
         } else {
           this._reportError(
-              `Value of the host listener "${propName}" needs to be a string representing an expression but got "${expression}" (${typeof expression})`,
+              `Value of the host listener "${
+                  propName}" needs to be a string representing an expression but got "${
+                  expression}" (${typeof expression})`,
               sourceSpan);
         }
       });
@@ -103,7 +111,7 @@ export class BindingParser {
 
     try {
       const ast = this._exprParser.parseInterpolation(
-          value, sourceInfo, sourceSpan.start.offset, this._interpolationConfig) !;
+          value, sourceInfo, sourceSpan.start.offset, this._interpolationConfig)!;
       if (ast) this._reportExpressionParserErrors(ast.errors, sourceSpan);
       this._checkPipes(ast, sourceSpan);
       return ast;
@@ -183,8 +191,9 @@ export class BindingParser {
           this._checkPipes(binding.value, sourceSpan);
         }
       });
-      bindingsResult.warnings.forEach(
-          (warning) => { this._reportError(warning, sourceSpan, ParseErrorLevel.WARNING); });
+      bindingsResult.warnings.forEach((warning) => {
+        this._reportError(warning, sourceSpan, ParseErrorLevel.WARNING);
+      });
       return bindingsResult.templateBindings;
     } catch (e) {
       this._reportError(`${e}`, sourceSpan);
@@ -257,7 +266,7 @@ export class BindingParser {
       name: string, ast: ASTWithSource, sourceSpan: ParseSourceSpan,
       valueSpan: ParseSourceSpan|undefined, targetMatchableAttrs: string[][],
       targetProps: ParsedProperty[]) {
-    targetMatchableAttrs.push([name, ast.source !]);
+    targetMatchableAttrs.push([name, ast.source!]);
     targetProps.push(
         new ParsedProperty(name, ast, ParsedPropertyType.DEFAULT, sourceSpan, valueSpan));
   }
@@ -275,7 +284,7 @@ export class BindingParser {
     // states will be applied by angular when the element is attached/detached
     const ast = this._parseBinding(
         expression || 'undefined', false, valueSpan || sourceSpan, absoluteOffset);
-    targetMatchableAttrs.push([name, ast.source !]);
+    targetMatchableAttrs.push([name, ast.source!]);
     targetProps.push(
         new ParsedProperty(name, ast, ParsedPropertyType.ANIMATION, sourceSpan, valueSpan));
   }
@@ -310,10 +319,10 @@ export class BindingParser {
     }
 
     let unit: string|null = null;
-    let bindingType: BindingType = undefined !;
+    let bindingType: BindingType = undefined!;
     let boundPropertyName: string|null = null;
     const parts = boundProp.name.split(PROPERTY_PARTS_SEPARATOR);
-    let securityContexts: SecurityContext[] = undefined !;
+    let securityContexts: SecurityContext[] = undefined!;
 
     // Check for special cases (prefix style, attr, class)
     if (parts.length > 1) {
@@ -401,13 +410,15 @@ export class BindingParser {
 
         default:
           this._reportError(
-              `The provided animation output phase value "${phase}" for "@${eventName}" is not supported (use start or done)`,
+              `The provided animation output phase value "${phase}" for "@${
+                  eventName}" is not supported (use start or done)`,
               sourceSpan);
           break;
       }
     } else {
       this._reportError(
-          `The animation trigger output event (@${eventName}) is missing its phase value name (start or done are currently supported)`,
+          `The animation trigger output event (@${
+              eventName}) is missing its phase value name (start or done are currently supported)`,
           sourceSpan);
     }
   }
@@ -416,9 +427,9 @@ export class BindingParser {
       name: string, expression: string, sourceSpan: ParseSourceSpan, handlerSpan: ParseSourceSpan,
       targetMatchableAttrs: string[][], targetEvents: ParsedEvent[]) {
     // long format: 'target: eventName'
-    const [target, eventName] = splitAtColon(name, [null !, name]);
+    const [target, eventName] = splitAtColon(name, [null!, name]);
     const ast = this._parseAction(expression, handlerSpan);
-    targetMatchableAttrs.push([name !, ast.source !]);
+    targetMatchableAttrs.push([name!, ast.source!]);
     targetEvents.push(
         new ParsedEvent(eventName, target, ParsedEventType.Regular, ast, sourceSpan, handlerSpan));
     // Don't detect directives for event names for now,
@@ -465,7 +476,7 @@ export class BindingParser {
       const collector = new PipeCollector();
       ast.visit(collector);
       collector.pipes.forEach((ast, pipeName) => {
-        const pipeMeta = this.pipesByName !.get(pipeName);
+        const pipeMeta = this.pipesByName!.get(pipeName);
         if (!pipeMeta) {
           this._reportError(
               `The pipe '${pipeName}' could not be found`,
@@ -488,7 +499,7 @@ export class BindingParser {
     const report = isAttr ? this._schemaRegistry.validateAttribute(propName) :
                             this._schemaRegistry.validateProperty(propName);
     if (report.error) {
-      this._reportError(report.msg !, sourceSpan, ParseErrorLevel.ERROR);
+      this._reportError(report.msg!, sourceSpan, ParseErrorLevel.ERROR);
     }
   }
 }

--- a/packages/compiler/src/template_parser/template_ast.ts
+++ b/packages/compiler/src/template_parser/template_ast.ts
@@ -36,7 +36,9 @@ export interface TemplateAst {
 export class TextAst implements TemplateAst {
   constructor(
       public value: string, public ngContentIndex: number, public sourceSpan: ParseSourceSpan) {}
-  visit(visitor: TemplateAstVisitor, context: any): any { return visitor.visitText(this, context); }
+  visit(visitor: TemplateAstVisitor, context: any): any {
+    return visitor.visitText(this, context);
+  }
 }
 
 /**
@@ -56,7 +58,9 @@ export class BoundTextAst implements TemplateAst {
  */
 export class AttrAst implements TemplateAst {
   constructor(public name: string, public value: string, public sourceSpan: ParseSourceSpan) {}
-  visit(visitor: TemplateAstVisitor, context: any): any { return visitor.visitAttr(this, context); }
+  visit(visitor: TemplateAstVisitor, context: any): any {
+    return visitor.visitAttr(this, context);
+  }
 }
 
 export const enum PropertyBindingType {
@@ -319,7 +323,9 @@ export class NullTemplateVisitor implements TemplateAstVisitor {
  * in an template ast recursively.
  */
 export class RecursiveTemplateAstVisitor extends NullTemplateVisitor implements TemplateAstVisitor {
-  constructor() { super(); }
+  constructor() {
+    super();
+  }
 
   // Nodes with children
   visitEmbeddedTemplate(ast: EmbeddedTemplateAst, context: any): any {
@@ -358,7 +364,7 @@ export class RecursiveTemplateAstVisitor extends NullTemplateVisitor implements 
       cb: (visit: (<V extends TemplateAst>(children: V[]|undefined) => void)) => void) {
     let results: any[][] = [];
     let t = this;
-    function visit<T extends TemplateAst>(children: T[] | undefined) {
+    function visit<T extends TemplateAst>(children: T[]|undefined) {
       if (children && children.length) results.push(templateVisitAll(t, children, context));
     }
     cb(visit);
@@ -373,7 +379,7 @@ export function templateVisitAll(
     visitor: TemplateAstVisitor, asts: TemplateAst[], context: any = null): any[] {
   const result: any[] = [];
   const visit = visitor.visit ?
-      (ast: TemplateAst) => visitor.visit !(ast, context) || ast.visit(visitor, context) :
+      (ast: TemplateAst) => visitor.visit!(ast, context) || ast.visit(visitor, context) :
       (ast: TemplateAst) => ast.visit(visitor, context);
   asts.forEach(ast => {
     const astResult = visit(ast);

--- a/packages/compiler/src/template_parser/template_parser.ts
+++ b/packages/compiler/src/template_parser/template_parser.ts
@@ -12,7 +12,7 @@ import {CompilerConfig} from '../config';
 import {SchemaMetadata} from '../core';
 import {AST, ASTWithSource, EmptyExpr, ParsedEvent, ParsedProperty, ParsedVariable} from '../expression_parser/ast';
 import {Parser} from '../expression_parser/parser';
-import {Identifiers, createTokenForExternalReference, createTokenForReference} from '../identifiers';
+import {createTokenForExternalReference, createTokenForReference, Identifiers} from '../identifiers';
 import * as html from '../ml_parser/ast';
 import {HtmlParser, ParseTreeResult} from '../ml_parser/html_parser';
 import {removeWhitespaces, replaceNgsp} from '../ml_parser/html_whitespaces';
@@ -57,7 +57,7 @@ const IDENT_EVENT_IDX = 10;
 const TEMPLATE_ATTR_PREFIX = '*';
 const CLASS_ATTR = 'class';
 
-let _TEXT_CSS_SELECTOR !: CssSelector;
+let _TEXT_CSS_SELECTOR!: CssSelector;
 function TEXT_CSS_SELECTOR(): CssSelector {
   if (!_TEXT_CSS_SELECTOR) {
     _TEXT_CSS_SELECTOR = CssSelector.parse('*')[0];
@@ -84,7 +84,9 @@ export class TemplateParser {
       private _htmlParser: HtmlParser, private _console: Console,
       public transforms: t.TemplateAstVisitor[]) {}
 
-  public get expressionParser() { return this._exprParser; }
+  public get expressionParser() {
+    return this._exprParser;
+  }
 
   parse(
       component: CompileDirectiveMetadata, template: string|ParseTreeResult,
@@ -93,9 +95,9 @@ export class TemplateParser {
       preserveWhitespaces: boolean): {template: t.TemplateAst[], pipes: CompilePipeSummary[]} {
     const result = this.tryParse(
         component, template, directives, pipes, schemas, templateUrl, preserveWhitespaces);
-    const warnings = result.errors !.filter(error => error.level === ParseErrorLevel.WARNING);
+    const warnings = result.errors!.filter(error => error.level === ParseErrorLevel.WARNING);
 
-    const errors = result.errors !.filter(error => error.level === ParseErrorLevel.ERROR);
+    const errors = result.errors!.filter(error => error.level === ParseErrorLevel.ERROR);
 
     if (warnings.length > 0) {
       this._console.warn(`Template parse warnings:\n${warnings.join('\n')}`);
@@ -106,7 +108,7 @@ export class TemplateParser {
       throw syntaxError(`Template parse errors:\n${errorString}`, errors);
     }
 
-    return {template: result.templateAst !, pipes: result.usedPipes !};
+    return {template: result.templateAst!, pipes: result.usedPipes!};
   }
 
   tryParse(
@@ -114,7 +116,7 @@ export class TemplateParser {
       directives: CompileDirectiveSummary[], pipes: CompilePipeSummary[], schemas: SchemaMetadata[],
       templateUrl: string, preserveWhitespaces: boolean): TemplateParseResult {
     let htmlParseResult = typeof template === 'string' ?
-        this._htmlParser !.parse(template, templateUrl, {
+        this._htmlParser!.parse(template, templateUrl, {
           tokenizeExpansionForms: true,
           interpolationConfig: this.getInterpolationConfig(component)
         }) :
@@ -139,7 +141,7 @@ export class TemplateParser {
       const uniqDirectives = removeSummaryDuplicates(directives);
       const uniqPipes = removeSummaryDuplicates(pipes);
       const providerViewContext = new ProviderViewContext(this._reflector, component);
-      let interpolationConfig: InterpolationConfig = undefined !;
+      let interpolationConfig: InterpolationConfig = undefined!;
       if (component.template && component.template.interpolation) {
         interpolationConfig = {
           start: component.template.interpolation[0],
@@ -147,7 +149,7 @@ export class TemplateParser {
         };
       }
       const bindingParser = new BindingParser(
-          this._exprParser, interpolationConfig !, this._schemaRegistry, uniqPipes, errors);
+          this._exprParser, interpolationConfig!, this._schemaRegistry, uniqPipes, errors);
       const parseVisitor = new TemplateParseVisitor(
           this._reflector, this._config, providerViewContext, uniqDirectives, bindingParser,
           this._schemaRegistry, schemas, errors);
@@ -164,8 +166,9 @@ export class TemplateParser {
     }
 
     if (this.transforms) {
-      this.transforms.forEach(
-          (transform: t.TemplateAstVisitor) => { result = t.templateVisitAll(transform, result); });
+      this.transforms.forEach((transform: t.TemplateAstVisitor) => {
+        result = t.templateVisitAll(transform, result);
+      });
     }
 
     return new TemplateParseResult(result, usedPipes, errors);
@@ -224,29 +227,35 @@ class TemplateParseVisitor implements html.Visitor {
     // Note: queries start with id 1 so we can use the number in a Bloom filter!
     this.contentQueryStartId = providerViewContext.component.viewQueries.length + 1;
     directives.forEach((directive, index) => {
-      const selector = CssSelector.parse(directive.selector !);
+      const selector = CssSelector.parse(directive.selector!);
       this.selectorMatcher.addSelectables(selector, directive);
       this.directivesIndex.set(directive, index);
     });
   }
 
-  visitExpansion(expansion: html.Expansion, context: any): any { return null; }
+  visitExpansion(expansion: html.Expansion, context: any): any {
+    return null;
+  }
 
-  visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any { return null; }
+  visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any {
+    return null;
+  }
 
   visitText(text: html.Text, parent: ElementContext): any {
-    const ngContentIndex = parent.findNgContentIndex(TEXT_CSS_SELECTOR()) !;
+    const ngContentIndex = parent.findNgContentIndex(TEXT_CSS_SELECTOR())!;
     const valueNoNgsp = replaceNgsp(text.value);
-    const expr = this._bindingParser.parseInterpolation(valueNoNgsp, text.sourceSpan !);
-    return expr ? new t.BoundTextAst(expr, ngContentIndex, text.sourceSpan !) :
-                  new t.TextAst(valueNoNgsp, ngContentIndex, text.sourceSpan !);
+    const expr = this._bindingParser.parseInterpolation(valueNoNgsp, text.sourceSpan!);
+    return expr ? new t.BoundTextAst(expr, ngContentIndex, text.sourceSpan!) :
+                  new t.TextAst(valueNoNgsp, ngContentIndex, text.sourceSpan!);
   }
 
   visitAttribute(attribute: html.Attribute, context: any): any {
     return new t.AttrAst(attribute.name, attribute.value, attribute.sourceSpan);
   }
 
-  visitComment(comment: html.Comment, context: any): any { return null; }
+  visitComment(comment: html.Comment, context: any): any {
+    return null;
+  }
 
   visitElement(element: html.Element, parent: ElementContext): any {
     const queryStartIndex = this.contentQueryStartId;
@@ -307,7 +316,7 @@ class TemplateParseVisitor implements html.Visitor {
         const parsedVariables: ParsedVariable[] = [];
         const absoluteOffset = (attr.valueSpan || attr.sourceSpan).start.offset;
         this._bindingParser.parseInlineTemplateBinding(
-            templateKey !, templateValue !, attr.sourceSpan, absoluteOffset, templateMatchableAttrs,
+            templateKey!, templateValue!, attr.sourceSpan, absoluteOffset, templateMatchableAttrs,
             templateElementOrDirectiveProps, parsedVariables);
         templateElementVars.push(...parsedVariables.map(v => t.VariableAst.fromParsedVariable(v)));
       }
@@ -326,52 +335,51 @@ class TemplateParseVisitor implements html.Visitor {
     const boundDirectivePropNames = new Set<string>();
     const directiveAsts = this._createDirectiveAsts(
         isTemplateElement, element.name, directiveMetas, elementOrDirectiveProps,
-        elementOrDirectiveRefs, element.sourceSpan !, references, boundDirectivePropNames);
+        elementOrDirectiveRefs, element.sourceSpan!, references, boundDirectivePropNames);
     const elementProps: t.BoundElementPropertyAst[] = this._createElementPropertyAsts(
         element.name, elementOrDirectiveProps, boundDirectivePropNames);
     const isViewRoot = parent.isTemplateElement || hasInlineTemplates;
 
     const providerContext = new ProviderElementContext(
-        this.providerViewContext, parent.providerContext !, isViewRoot, directiveAsts, attrs,
-        references, isTemplateElement, queryStartIndex, element.sourceSpan !);
+        this.providerViewContext, parent.providerContext!, isViewRoot, directiveAsts, attrs,
+        references, isTemplateElement, queryStartIndex, element.sourceSpan!);
 
     const children: t.TemplateAst[] = html.visitAll(
         preparsedElement.nonBindable ? NON_BINDABLE_VISITOR : this, element.children,
         ElementContext.create(
             isTemplateElement, directiveAsts,
-            isTemplateElement ? parent.providerContext ! : providerContext));
+            isTemplateElement ? parent.providerContext! : providerContext));
     providerContext.afterElement();
     // Override the actual selector when the `ngProjectAs` attribute is provided
     const projectionSelector = preparsedElement.projectAs != '' ?
         CssSelector.parse(preparsedElement.projectAs)[0] :
         elementCssSelector;
-    const ngContentIndex = parent.findNgContentIndex(projectionSelector) !;
+    const ngContentIndex = parent.findNgContentIndex(projectionSelector)!;
     let parsedElement: t.TemplateAst;
 
     if (preparsedElement.type === PreparsedElementType.NG_CONTENT) {
       // `<ng-content>` element
       if (element.children && !element.children.every(_isEmptyTextNode)) {
-        this._reportError(`<ng-content> element cannot have content.`, element.sourceSpan !);
+        this._reportError(`<ng-content> element cannot have content.`, element.sourceSpan!);
       }
 
       parsedElement = new t.NgContentAst(
-          this.ngContentCount++, hasInlineTemplates ? null ! : ngContentIndex,
-          element.sourceSpan !);
+          this.ngContentCount++, hasInlineTemplates ? null! : ngContentIndex, element.sourceSpan!);
     } else if (isTemplateElement) {
       // `<ng-template>` element
       this._assertAllEventsPublishedByDirectives(directiveAsts, events);
       this._assertNoComponentsNorElementBindingsOnTemplate(
-          directiveAsts, elementProps, element.sourceSpan !);
+          directiveAsts, elementProps, element.sourceSpan!);
 
       parsedElement = new t.EmbeddedTemplateAst(
           attrs, events, references, elementVars, providerContext.transformedDirectiveAsts,
           providerContext.transformProviders, providerContext.transformedHasViewContainer,
-          providerContext.queryMatches, children, hasInlineTemplates ? null ! : ngContentIndex,
-          element.sourceSpan !);
+          providerContext.queryMatches, children, hasInlineTemplates ? null! : ngContentIndex,
+          element.sourceSpan!);
     } else {
       // element other than `<ng-content>` and `<ng-template>`
       this._assertElementExists(matchElement, element);
-      this._assertOnlyOneComponent(directiveAsts, element.sourceSpan !);
+      this._assertOnlyOneComponent(directiveAsts, element.sourceSpan!);
 
       const ngContentIndex =
           hasInlineTemplates ? null : parent.findNgContentIndex(projectionSelector);
@@ -389,22 +397,22 @@ class TemplateParseVisitor implements html.Visitor {
       const {directives} = this._parseDirectives(this.selectorMatcher, templateSelector);
       const templateBoundDirectivePropNames = new Set<string>();
       const templateDirectiveAsts = this._createDirectiveAsts(
-          true, elName, directives, templateElementOrDirectiveProps, [], element.sourceSpan !, [],
+          true, elName, directives, templateElementOrDirectiveProps, [], element.sourceSpan!, [],
           templateBoundDirectivePropNames);
       const templateElementProps: t.BoundElementPropertyAst[] = this._createElementPropertyAsts(
           elName, templateElementOrDirectiveProps, templateBoundDirectivePropNames);
       this._assertNoComponentsNorElementBindingsOnTemplate(
-          templateDirectiveAsts, templateElementProps, element.sourceSpan !);
+          templateDirectiveAsts, templateElementProps, element.sourceSpan!);
       const templateProviderContext = new ProviderElementContext(
-          this.providerViewContext, parent.providerContext !, parent.isTemplateElement,
-          templateDirectiveAsts, [], [], true, templateQueryStartIndex, element.sourceSpan !);
+          this.providerViewContext, parent.providerContext!, parent.isTemplateElement,
+          templateDirectiveAsts, [], [], true, templateQueryStartIndex, element.sourceSpan!);
       templateProviderContext.afterElement();
 
       parsedElement = new t.EmbeddedTemplateAst(
           [], [], [], templateElementVars, templateProviderContext.transformedDirectiveAsts,
           templateProviderContext.transformProviders,
           templateProviderContext.transformedHasViewContainer, templateProviderContext.queryMatches,
-          [parsedElement], ngContentIndex, element.sourceSpan !);
+          [parsedElement], ngContentIndex, element.sourceSpan!);
     }
 
     return parsedElement;
@@ -538,7 +546,7 @@ class TemplateParseVisitor implements html.Visitor {
     let matchElement = false;
 
     selectorMatcher.match(elementCssSelector, (selector, directive) => {
-      directives[this.directivesIndex.get(directive) !] = directive;
+      directives[this.directivesIndex.get(directive)!] = directive;
       matchElement = matchElement || selector.hasElementSelector();
     });
 
@@ -554,7 +562,7 @@ class TemplateParseVisitor implements html.Visitor {
       elementSourceSpan: ParseSourceSpan, targetReferences: t.ReferenceAst[],
       targetBoundDirectivePropNames: Set<string>): t.DirectiveAst[] {
     const matchedReferences = new Set<string>();
-    let component: CompileDirectiveSummary = null !;
+    let component: CompileDirectiveSummary = null!;
 
     const directiveAsts = directives.map((directive) => {
       const sourceSpan = new ParseSourceSpan(
@@ -566,15 +574,14 @@ class TemplateParseVisitor implements html.Visitor {
       }
       const directiveProperties: t.BoundDirectivePropertyAst[] = [];
       const boundProperties =
-          this._bindingParser.createDirectiveHostPropertyAsts(directive, elementName, sourceSpan) !;
+          this._bindingParser.createDirectiveHostPropertyAsts(directive, elementName, sourceSpan)!;
 
       let hostProperties =
           boundProperties.map(prop => t.BoundElementPropertyAst.fromBoundProperty(prop));
       // Note: We need to check the host properties here as well,
       // as we don't know the element name in the DirectiveWrapperCompiler yet.
       hostProperties = this._checkPropertiesInSchema(elementName, hostProperties);
-      const parsedEvents =
-          this._bindingParser.createDirectiveHostEventAsts(directive, sourceSpan) !;
+      const parsedEvents = this._bindingParser.createDirectiveHostEventAsts(directive, sourceSpan)!;
       this._createDirectivePropertyAsts(
           directive.inputs, props, directiveProperties, targetBoundDirectivePropNames);
       elementOrDirectiveRefs.forEach((elOrDirRef) => {
@@ -602,7 +609,7 @@ class TemplateParseVisitor implements html.Visitor {
               elOrDirRef.sourceSpan);
         }
       } else if (!component) {
-        let refToken: CompileTokenMetadata = null !;
+        let refToken: CompileTokenMetadata = null!;
         if (isTemplateElement) {
           refToken = createTokenForExternalReference(this.reflector, Identifiers.TemplateRef);
         }
@@ -663,7 +670,7 @@ class TemplateParseVisitor implements html.Visitor {
 
   private _findComponentDirectiveNames(directives: t.DirectiveAst[]): string[] {
     return this._findComponentDirectives(directives)
-        .map(directive => identifierName(directive.directive.type) !);
+        .map(directive => identifierName(directive.directive.type)!);
   }
 
   private _assertOnlyOneComponent(directives: t.DirectiveAst[], sourceSpan: ParseSourceSpan) {
@@ -691,16 +698,16 @@ class TemplateParseVisitor implements html.Visitor {
 
     if (!matchElement && !this._schemaRegistry.hasElement(elName, this._schemas)) {
       let errorMsg = `'${elName}' is not a known element:\n`;
-      errorMsg +=
-          `1. If '${elName}' is an Angular component, then verify that it is part of this module.\n`;
+      errorMsg += `1. If '${
+          elName}' is an Angular component, then verify that it is part of this module.\n`;
       if (elName.indexOf('-') > -1) {
-        errorMsg +=
-            `2. If '${elName}' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.`;
+        errorMsg += `2. If '${
+            elName}' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.`;
       } else {
         errorMsg +=
             `2. To allow any element add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.`;
       }
-      this._reportError(errorMsg, element.sourceSpan !);
+      this._reportError(errorMsg, element.sourceSpan!);
     }
   }
 
@@ -714,7 +721,8 @@ class TemplateParseVisitor implements html.Visitor {
     }
     elementProps.forEach(prop => {
       this._reportError(
-          `Property binding ${prop.name} not used by any directive on an embedded template. Make sure that the property name is spelled correctly and all directives are listed in the "@NgModule.declarations".`,
+          `Property binding ${
+              prop.name} not used by any directive on an embedded template. Make sure that the property name is spelled correctly and all directives are listed in the "@NgModule.declarations".`,
           sourceSpan);
     });
   }
@@ -733,7 +741,9 @@ class TemplateParseVisitor implements html.Visitor {
     events.forEach(event => {
       if (event.target != null || !allDirectiveEvents.has(event.name)) {
         this._reportError(
-            `Event binding ${event.fullName} not emitted by any directive on an embedded template. Make sure that the event name is spelled correctly and all directives are listed in the "@NgModule.declarations".`,
+            `Event binding ${
+                event
+                    .fullName} not emitted by any directive on an embedded template. Make sure that the event name is spelled correctly and all directives are listed in the "@NgModule.declarations".`,
             event.sourceSpan);
       }
     });
@@ -746,16 +756,20 @@ class TemplateParseVisitor implements html.Visitor {
     return boundProps.filter((boundProp) => {
       if (boundProp.type === t.PropertyBindingType.Property &&
           !this._schemaRegistry.hasProperty(elementName, boundProp.name, this._schemas)) {
-        let errorMsg =
-            `Can't bind to '${boundProp.name}' since it isn't a known property of '${elementName}'.`;
+        let errorMsg = `Can't bind to '${boundProp.name}' since it isn't a known property of '${
+            elementName}'.`;
         if (elementName.startsWith('ng-')) {
           errorMsg +=
-              `\n1. If '${boundProp.name}' is an Angular directive, then add 'CommonModule' to the '@NgModule.imports' of this component.` +
+              `\n1. If '${
+                  boundProp
+                      .name}' is an Angular directive, then add 'CommonModule' to the '@NgModule.imports' of this component.` +
               `\n2. To allow any property add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.`;
         } else if (elementName.indexOf('-') > -1) {
           errorMsg +=
-              `\n1. If '${elementName}' is an Angular component and it has '${boundProp.name}' input, then verify that it is part of this module.` +
-              `\n2. If '${elementName}' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.` +
+              `\n1. If '${elementName}' is an Angular component and it has '${
+                  boundProp.name}' input, then verify that it is part of this module.` +
+              `\n2. If '${
+                  elementName}' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.` +
               `\n3. To allow any property add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.`;
         }
         this._reportError(errorMsg, boundProp.sourceSpan);
@@ -791,20 +805,26 @@ class NonBindableVisitor implements html.Visitor {
         ast.name, html.visitAll(this, ast.attrs), [], [], [], [], [], false, [], children,
         ngContentIndex, ast.sourceSpan, ast.endSourceSpan);
   }
-  visitComment(comment: html.Comment, context: any): any { return null; }
+  visitComment(comment: html.Comment, context: any): any {
+    return null;
+  }
 
   visitAttribute(attribute: html.Attribute, context: any): t.AttrAst {
     return new t.AttrAst(attribute.name, attribute.value, attribute.sourceSpan);
   }
 
   visitText(text: html.Text, parent: ElementContext): t.TextAst {
-    const ngContentIndex = parent.findNgContentIndex(TEXT_CSS_SELECTOR()) !;
-    return new t.TextAst(text.value, ngContentIndex, text.sourceSpan !);
+    const ngContentIndex = parent.findNgContentIndex(TEXT_CSS_SELECTOR())!;
+    return new t.TextAst(text.value, ngContentIndex, text.sourceSpan!);
   }
 
-  visitExpansion(expansion: html.Expansion, context: any): any { return expansion; }
+  visitExpansion(expansion: html.Expansion, context: any): any {
+    return expansion;
+  }
 
-  visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any { return expansionCase; }
+  visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any {
+    return expansionCase;
+  }
 }
 
 /**
@@ -824,7 +844,7 @@ class ElementOrDirectiveRef {
 }
 
 /** Splits a raw, potentially comma-delimited `exportAs` value into an array of names. */
-function splitExportAs(exportAs: string | null): string[] {
+function splitExportAs(exportAs: string|null): string[] {
   return exportAs ? exportAs.split(',').map(e => e.trim()) : [];
 }
 
@@ -837,7 +857,7 @@ class ElementContext {
       isTemplateElement: boolean, directives: t.DirectiveAst[],
       providerContext: ProviderElementContext): ElementContext {
     const matcher = new SelectorMatcher();
-    let wildcardNgContentIndex: number = null !;
+    let wildcardNgContentIndex: number = null!;
     const component = directives.find(directive => directive.directive.isComponent);
     if (component) {
       const ngContentSelectors = component.directive.template !.ngContentSelectors;
@@ -859,8 +879,9 @@ class ElementContext {
 
   findNgContentIndex(selector: CssSelector): number|null {
     const ngContentIndices: number[] = [];
-    this._ngContentIndexMatcher.match(
-        selector, (selector, ngContentIndex) => { ngContentIndices.push(ngContentIndex); });
+    this._ngContentIndexMatcher.match(selector, (selector, ngContentIndex) => {
+      ngContentIndices.push(ngContentIndex);
+    });
     ngContentIndices.sort();
     if (this._wildcardNgContentIndex != null) {
       ngContentIndices.push(this._wildcardNgContentIndex);
@@ -897,7 +918,7 @@ function _isEmptyTextNode(node: html.Node): boolean {
   return node instanceof html.Text && node.value.trim().length == 0;
 }
 
-export function removeSummaryDuplicates<T extends{type: CompileTypeMetadata}>(items: T[]): T[] {
+export function removeSummaryDuplicates<T extends {type: CompileTypeMetadata}>(items: T[]): T[] {
   const map = new Map<any, T>();
 
   items.forEach((item) => {

--- a/packages/compiler/src/template_parser/template_preparser.ts
+++ b/packages/compiler/src/template_parser/template_preparser.ts
@@ -20,9 +20,9 @@ const NG_NON_BINDABLE_ATTR = 'ngNonBindable';
 const NG_PROJECT_AS = 'ngProjectAs';
 
 export function preparseElement(ast: html.Element): PreparsedElement {
-  let selectAttr: string = null !;
-  let hrefAttr: string = null !;
-  let relAttr: string = null !;
+  let selectAttr: string = null!;
+  let hrefAttr: string = null!;
+  let relAttr: string = null!;
   let nonBindable = false;
   let projectAs = '';
   ast.attrs.forEach(attr => {

--- a/packages/compiler/src/url_resolver.ts
+++ b/packages/compiler/src/url_resolver.ts
@@ -33,9 +33,13 @@ export function createOfflineCompileUrlResolver(): UrlResolver {
  * Attacker-controlled data introduced by a template could expose your
  * application to XSS risks. For more detail, see the [Security Guide](http://g.co/ng/security).
  */
-export interface UrlResolver { resolve(baseUrl: string, url: string): string; }
+export interface UrlResolver {
+  resolve(baseUrl: string, url: string): string;
+}
 
-export interface UrlResolverCtor { new (packagePrefix?: string|null): UrlResolver; }
+export interface UrlResolverCtor {
+  new(packagePrefix?: string|null): UrlResolver;
+}
 
 export const UrlResolver: UrlResolverCtor = class UrlResolverImpl {
   constructor(private _packagePrefix: string|null = null) {}
@@ -242,16 +246,16 @@ enum _ComponentIndex {
  *     arbitrary strings may still look like path names.
  */
 function _split(uri: string): Array<string|any> {
-  return uri.match(_splitRe) !;
+  return uri.match(_splitRe)!;
 }
 
 /**
-  * Removes dot segments in given path component, as described in
-  * RFC 3986, section 5.2.4.
-  *
-  * @param path A non-empty path component.
-  * @return Path component with removed dot segments.
-  */
+ * Removes dot segments in given path component, as described in
+ * RFC 3986, section 5.2.4.
+ *
+ * @param path A non-empty path component.
+ * @return Path component with removed dot segments.
+ */
 function _removeDotSegments(path: string): string {
   if (path == '/') return '/';
 

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -52,8 +52,8 @@ export function isDefined(val: any): boolean {
   return val !== null && val !== undefined;
 }
 
-export function noUndefined<T>(val: T | undefined): T {
-  return val === undefined ? null ! : val;
+export function noUndefined<T>(val: T|undefined): T {
+  return val === undefined ? null! : val;
 }
 
 export interface ValueVisitor {
@@ -69,14 +69,20 @@ export class ValueTransformer implements ValueVisitor {
   }
   visitStringMap(map: {[key: string]: any}, context: any): any {
     const result: {[key: string]: any} = {};
-    Object.keys(map).forEach(key => { result[key] = visitValue(map[key], this, context); });
+    Object.keys(map).forEach(key => {
+      result[key] = visitValue(map[key], this, context);
+    });
     return result;
   }
-  visitPrimitive(value: any, context: any): any { return value; }
-  visitOther(value: any, context: any): any { return value; }
+  visitPrimitive(value: any, context: any): any {
+    return value;
+  }
+  visitOther(value: any, context: any): any {
+    return value;
+  }
 }
 
-export type SyncAsync<T> = T | Promise<T>;
+export type SyncAsync<T> = T|Promise<T>;
 
 export const SyncAsync = {
   assertSync: <T>(value: SyncAsync<T>): T => {
@@ -86,7 +92,9 @@ export const SyncAsync = {
     return value;
   },
   then: <T, R>(value: SyncAsync<T>, cb: (value: T) => R | Promise<R>| SyncAsync<R>):
-            SyncAsync<R> => { return isPromise(value) ? value.then(cb) : cb(value);},
+      SyncAsync<R> => {
+        return isPromise(value) ? value.then(cb) : cb(value);
+      },
   all: <T>(syncAsyncValues: SyncAsync<T>[]): SyncAsync<T[]> => {
     return syncAsyncValues.some(isPromise) ? Promise.all(syncAsyncValues) : syncAsyncValues as T[];
   }
@@ -259,7 +267,7 @@ export function newArray<T>(size: number, value: T): T[];
 export function newArray<T>(size: number, value?: T): T[] {
   const list: T[] = [];
   for (let i = 0; i < size; i++) {
-    list.push(value !);
+    list.push(value!);
   }
   return list;
 }

--- a/packages/compiler/src/view_compiler/provider_compiler.ts
+++ b/packages/compiler/src/view_compiler/provider_compiler.ts
@@ -9,7 +9,7 @@
 import {CompileDiDependencyMetadata, CompileEntryComponentMetadata, CompileProviderMetadata, CompileTokenMetadata} from '../compile_metadata';
 import {CompileReflector} from '../compile_reflector';
 import {DepFlags, NodeFlags} from '../core';
-import {Identifiers, createTokenForExternalReference} from '../identifiers';
+import {createTokenForExternalReference, Identifiers} from '../identifiers';
 import {LifecycleHooks} from '../lifecycle_reflector';
 import * as o from '../output/output_ast';
 import {convertValueToOutputAst} from '../output/value_util';
@@ -45,7 +45,8 @@ export function providerDef(ctx: OutputContext, providerAst: ProviderAst): {
       singleProviderDef(ctx, flags, providerAst.providerType, providerAst.providers[0]);
   return {
     providerExpr,
-    flags: providerFlags, depsExpr,
+    flags: providerFlags,
+    depsExpr,
     tokenExpr: tokenExpr(ctx, providerAst.token),
   };
 }
@@ -96,9 +97,9 @@ function singleProviderDef(
   let providerExpr: o.Expression;
   let deps: CompileDiDependencyMetadata[];
   if (providerType === ProviderAstType.Directive || providerType === ProviderAstType.Component) {
-    providerExpr = ctx.importExpr(providerMeta.useClass !.reference);
+    providerExpr = ctx.importExpr(providerMeta.useClass!.reference);
     flags |= NodeFlags.TypeDirective;
-    deps = providerMeta.deps || providerMeta.useClass !.diDeps;
+    deps = providerMeta.deps || providerMeta.useClass!.diDeps;
   } else {
     if (providerMeta.useClass) {
       providerExpr = ctx.importExpr(providerMeta.useClass.reference);
@@ -130,7 +131,7 @@ function tokenExpr(ctx: OutputContext, tokenMeta: CompileTokenMetadata): o.Expre
 export function depDef(ctx: OutputContext, dep: CompileDiDependencyMetadata): o.Expression {
   // Note: the following fields have already been normalized out by provider_analyzer:
   // - isAttribute, isHost
-  const expr = dep.isValue ? convertValueToOutputAst(ctx, dep.value) : tokenExpr(ctx, dep.token !);
+  const expr = dep.isValue ? convertValueToOutputAst(ctx, dep.value) : tokenExpr(ctx, dep.token!);
   let flags = DepFlags.None;
   if (dep.isSkipSelf) {
     flags |= DepFlags.SkipSelf;

--- a/packages/compiler/src/view_compiler/type_check_compiler.ts
+++ b/packages/compiler/src/view_compiler/type_check_compiler.ts
@@ -10,11 +10,11 @@ import {AotCompilerOptions} from '../aot/compiler_options';
 import {StaticReflector} from '../aot/static_reflector';
 import {StaticSymbol} from '../aot/static_symbol';
 import {CompileDirectiveMetadata, CompilePipeSummary} from '../compile_metadata';
-import {BindingForm, EventHandlerVars, LocalResolver, convertActionBinding, convertPropertyBinding, convertPropertyBindingBuiltins} from '../compiler_util/expression_converter';
+import {BindingForm, convertActionBinding, convertPropertyBinding, convertPropertyBindingBuiltins, EventHandlerVars, LocalResolver} from '../compiler_util/expression_converter';
 import {AST, ASTWithSource, Interpolation} from '../expression_parser/ast';
 import * as o from '../output/output_ast';
 import {ParseSourceSpan} from '../parse_util';
-import {AttrAst, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, DirectiveAst, ElementAst, EmbeddedTemplateAst, NgContentAst, ReferenceAst, TemplateAst, TemplateAstVisitor, TextAst, VariableAst, templateVisitAll} from '../template_parser/template_ast';
+import {AttrAst, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, DirectiveAst, ElementAst, EmbeddedTemplateAst, NgContentAst, ReferenceAst, TemplateAst, TemplateAstVisitor, templateVisitAll, TextAst, VariableAst} from '../template_parser/template_ast';
 import {OutputContext} from '../util';
 
 
@@ -40,7 +40,7 @@ export class TypeCheckCompiler {
     usedPipes.forEach(p => pipes.set(p.name, p.type.reference));
     let embeddedViewCount = 0;
     const viewBuilderFactory =
-        (parent: ViewBuilder | null, guards: GuardExpression[]): ViewBuilder => {
+        (parent: ViewBuilder|null, guards: GuardExpression[]): ViewBuilder => {
           const embeddedViewIndex = embeddedViewCount++;
           return new ViewBuilder(
               this.options, this.reflector, externalReferenceVars, parent, component.type.reference,
@@ -66,7 +66,7 @@ interface ViewBuilderFactory {
 
 // Note: This is used as key in Map and should therefore be
 // unique per value.
-type OutputVarType = o.BuiltinTypeName | StaticSymbol;
+type OutputVarType = o.BuiltinTypeName|StaticSymbol;
 
 interface Expression {
   context: OutputVarType;
@@ -247,10 +247,12 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
     directives: DirectiveAst[],
     references: ReferenceAst[],
   }) {
-    ast.directives.forEach((dirAst) => { this.visitDirective(dirAst); });
+    ast.directives.forEach((dirAst) => {
+      this.visitDirective(dirAst);
+    });
 
     ast.references.forEach((ref) => {
-      let outputVarType: OutputVarType = null !;
+      let outputVarType: OutputVarType = null!;
       // Note: The old view compiler used to use an `any` type
       // for directives exposed via `exportAs`.
       // We keep this behaivor behind a flag for now.
@@ -331,8 +333,8 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
               // for arrays.
               return this.options.fullTemplateTypeCheck ? arr : arr.cast(o.DYNAMIC_TYPE);
             },
-            createLiteralMapConverter:
-                (keys: {key: string, quoted: boolean}[]) => (values: o.Expression[]) => {
+            createLiteralMapConverter: (keys: {key: string, quoted: boolean}[]) =>
+                (values: o.Expression[]) => {
                   const entries = keys.map((k, i) => ({
                                              key: k.key,
                                              value: values[i],

--- a/packages/compiler/src/view_compiler/view_compiler.ts
+++ b/packages/compiler/src/view_compiler/view_compiler.ts
@@ -8,7 +8,7 @@
 
 import {CompileDirectiveMetadata, CompilePipeSummary, CompileQueryMetadata, rendererTypeName, tokenReference, viewClassName} from '../compile_metadata';
 import {CompileReflector} from '../compile_reflector';
-import {BindingForm, BuiltinConverter, EventHandlerVars, LocalResolver, convertActionBinding, convertPropertyBinding, convertPropertyBindingBuiltins} from '../compiler_util/expression_converter';
+import {BindingForm, BuiltinConverter, convertActionBinding, convertPropertyBinding, convertPropertyBindingBuiltins, EventHandlerVars, LocalResolver} from '../compiler_util/expression_converter';
 import {ArgumentType, BindingFlags, ChangeDetectionStrategy, NodeFlags, QueryBindingType, QueryValueType, ViewFlags} from '../core';
 import {AST, ASTWithSource, Interpolation} from '../expression_parser/ast';
 import {Identifiers} from '../identifiers';
@@ -17,7 +17,7 @@ import {isNgContainer} from '../ml_parser/tags';
 import * as o from '../output/output_ast';
 import {convertValueToOutputAst} from '../output/value_util';
 import {ParseSourceSpan} from '../parse_util';
-import {AttrAst, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, DirectiveAst, ElementAst, EmbeddedTemplateAst, NgContentAst, PropertyBindingType, ProviderAst, QueryMatch, ReferenceAst, TemplateAst, TemplateAstVisitor, TextAst, VariableAst, templateVisitAll} from '../template_parser/template_ast';
+import {AttrAst, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, DirectiveAst, ElementAst, EmbeddedTemplateAst, NgContentAst, PropertyBindingType, ProviderAst, QueryMatch, ReferenceAst, TemplateAst, TemplateAstVisitor, templateVisitAll, TextAst, VariableAst} from '../template_parser/template_ast';
 import {OutputContext} from '../util';
 
 import {componentFactoryResolverProviderDef, depDef, lifecycleHookToNodeFlag, providerDef} from './provider_compiler';
@@ -38,7 +38,7 @@ export class ViewCompiler {
       styles: o.Expression, usedPipes: CompilePipeSummary[]): ViewCompileResult {
     let embeddedViewCount = 0;
 
-    let renderComponentVarName: string = undefined !;
+    let renderComponentVarName: string = undefined!;
     if (!component.isHost) {
       const template = component.template !;
       const customRenderData: o.LiteralMapEntry[] = [];
@@ -48,7 +48,7 @@ export class ViewCompiler {
       }
 
       const renderComponentVar = o.variable(rendererTypeName(component.type.reference));
-      renderComponentVarName = renderComponentVar.name !;
+      renderComponentVarName = renderComponentVar.name!;
       outputCtx.statements.push(
           renderComponentVar
               .set(o.importExpr(Identifiers.createRendererType2).callFn([new o.LiteralMapExpr([
@@ -61,7 +61,7 @@ export class ViewCompiler {
                   [o.StmtModifier.Final, o.StmtModifier.Exported]));
     }
 
-    const viewBuilderFactory = (parent: ViewBuilder | null): ViewBuilder => {
+    const viewBuilderFactory = (parent: ViewBuilder|null): ViewBuilder => {
       const embeddedViewIndex = embeddedViewCount++;
       return new ViewBuilder(
           this._reflector, outputCtx, parent, component, embeddedViewIndex, usedPipes,
@@ -101,7 +101,9 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
   private nodes: (() => {
     sourceSpan: ParseSourceSpan | null,
     nodeDef: o.Expression,
-    nodeFlags: NodeFlags, updateDirectives?: UpdateExpression[], updateRenderer?: UpdateExpression[]
+    nodeFlags: NodeFlags,
+    updateDirectives?: UpdateExpression[],
+    updateRenderer?: UpdateExpression[]
   })[] = [];
   private purePipeNodeIndices: {[pipeName: string]: number} = Object.create(null);
   // Need Object.create so that we don't have builtin values...
@@ -121,7 +123,7 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
     // to be able to introduce the new view compiler without too many errors.
     this.compType = this.embeddedViewIndex > 0 ?
         o.DYNAMIC_TYPE :
-        o.expressionType(outputCtx.importExpr(this.component.type.reference)) !;
+        o.expressionType(outputCtx.importExpr(this.component.type.reference))!;
     this.viewName = viewClassName(this.component.type.reference, this.embeddedViewIndex);
   }
 
@@ -181,7 +183,7 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
       viewFlags |= ViewFlags.OnPush;
     }
     const viewFactory = new o.DeclareFunctionStmt(
-        this.viewName, [new o.FnParam(LOG_VAR.name !)],
+        this.viewName, [new o.FnParam(LOG_VAR.name!)],
         [new o.ReturnStatement(o.importExpr(Identifiers.viewDef).callFn([
           o.literal(viewFlags),
           o.literalArr(nodeDefExprs),
@@ -199,13 +201,13 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
     let updateFn: o.Expression;
     if (updateStmts.length > 0) {
       const preStmts: o.Statement[] = [];
-      if (!this.component.isHost && o.findReadVarNames(updateStmts).has(COMP_VAR.name !)) {
+      if (!this.component.isHost && o.findReadVarNames(updateStmts).has(COMP_VAR.name!)) {
         preStmts.push(COMP_VAR.set(VIEW_VAR.prop('component')).toDeclStmt(this.compType));
       }
       updateFn = o.fn(
           [
-            new o.FnParam(CHECK_VAR.name !, o.INFERRED_TYPE),
-            new o.FnParam(VIEW_VAR.name !, o.INFERRED_TYPE)
+            new o.FnParam(CHECK_VAR.name!, o.INFERRED_TYPE),
+            new o.FnParam(VIEW_VAR.name!, o.INFERRED_TYPE)
           ],
           [...preStmts, ...updateStmts], o.INFERRED_TYPE);
     } else {
@@ -219,9 +221,8 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
     this.nodes.push(() => ({
                       sourceSpan: ast.sourceSpan,
                       nodeFlags: NodeFlags.TypeNgContent,
-                      nodeDef: o.importExpr(Identifiers.ngContentDef).callFn([
-                        o.literal(ast.ngContentIndex), o.literal(ast.index)
-                      ])
+                      nodeDef: o.importExpr(Identifiers.ngContentDef)
+                                   .callFn([o.literal(ast.ngContentIndex), o.literal(ast.index)])
                     }));
   }
 
@@ -242,7 +243,7 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
   visitBoundText(ast: BoundTextAst, context: any): any {
     const nodeIndex = this.nodes.length;
     // reserve the space in the nodeDefs array
-    this.nodes.push(null !);
+    this.nodes.push(null!);
 
     const astWithSource = <ASTWithSource>ast.value;
     const inter = <Interpolation>astWithSource.ast;
@@ -270,7 +271,7 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
   visitEmbeddedTemplate(ast: EmbeddedTemplateAst, context: any): any {
     const nodeIndex = this.nodes.length;
     // reserve the space in the nodeDefs array
-    this.nodes.push(null !);
+    this.nodes.push(null!);
 
     const {flags, queryMatchesExpr, hostEvents} = this._visitElementOrTemplate(nodeIndex, ast);
 
@@ -301,7 +302,7 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
   visitElement(ast: ElementAst, context: any): any {
     const nodeIndex = this.nodes.length;
     // reserve the space in the nodeDefs array so we can add children
-    this.nodes.push(null !);
+    this.nodes.push(null!);
 
     // Using a null element name creates an anchor.
     const elName: string|null = isNgContainer(ast.name) ? null : ast.name;
@@ -382,7 +383,7 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
     queryMatches: QueryMatch[]
   }): {
     flags: NodeFlags,
-    usedEvents: [string | null, string][],
+    usedEvents: [string|null, string][],
     queryMatchesExpr: o.Expression,
     hostBindings:
         {context: o.Expression, inputAst: BoundElementPropertyAst, dirAst: DirectiveAst}[],
@@ -409,7 +410,7 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
     this._visitComponentFactoryResolverProvider(ast.directives);
 
     ast.providers.forEach(providerAst => {
-      let dirAst: DirectiveAst = undefined !;
+      let dirAst: DirectiveAst = undefined!;
       ast.directives.forEach(localDirAst => {
         if (localDirAst.directive.type.reference === tokenReference(providerAst.token)) {
           dirAst = localDirAst;
@@ -427,7 +428,7 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
 
     let queryMatchExprs: o.Expression[] = [];
     ast.queryMatches.forEach((match) => {
-      let valueType: QueryValueType = undefined !;
+      let valueType: QueryValueType = undefined!;
       if (tokenReference(match.value) ===
           this.reflector.resolveExternalReference(Identifiers.ElementRef)) {
         valueType = QueryValueType.ElementRef;
@@ -445,7 +446,7 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
       }
     });
     ast.references.forEach((ref) => {
-      let valueType: QueryValueType = undefined !;
+      let valueType: QueryValueType = undefined!;
       if (!ref.value) {
         valueType = QueryValueType.RenderElement;
       } else if (
@@ -459,7 +460,7 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
       }
     });
     ast.outputs.forEach((outputAst) => {
-      hostEvents.push({context: COMP_VAR, eventAst: outputAst, dirAst: null !});
+      hostEvents.push({context: COMP_VAR, eventAst: outputAst, dirAst: null!});
     });
 
     return {
@@ -480,7 +481,7 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
   } {
     const nodeIndex = this.nodes.length;
     // reserve the space in the nodeDefs array so we can add children
-    this.nodes.push(null !);
+    this.nodes.push(null!);
 
     dirAst.directive.queries.forEach((query, queryIndex) => {
       const queryId = dirAst.contentQueryStartId + queryIndex;
@@ -554,7 +555,8 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
                                                    }));
     const hostEvents = dirAst.hostEvents.map((hostEventAst) => ({
                                                context: dirContextExpr,
-                                               eventAst: hostEventAst, dirAst,
+                                               eventAst: hostEventAst,
+                                               dirAst,
                                              }));
 
     // Check index is the same as the node index during compilation
@@ -727,7 +729,7 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
 
   private _createPipeConverter(expression: UpdateExpression, name: string, argCount: number):
       BuiltinConverter {
-    const pipe = this.usedPipes.find((pipeSummary) => pipeSummary.name === name) !;
+    const pipe = this.usedPipes.find((pipeSummary) => pipeSummary.name === name)!;
     if (pipe.pure) {
       const checkIndex = this.nodes.length;
       this.nodes.push(() => ({
@@ -803,13 +805,12 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
       context: expression.context,
       value: convertPropertyBindingBuiltins(
           {
-            createLiteralArrayConverter: (argCount: number) => this._createLiteralArrayConverter(
-                                             expression.sourceSpan, argCount),
-            createLiteralMapConverter:
-                (keys: {key: string, quoted: boolean}[]) =>
-                    this._createLiteralMapConverter(expression.sourceSpan, keys),
+            createLiteralArrayConverter: (argCount: number) =>
+                this._createLiteralArrayConverter(expression.sourceSpan, argCount),
+            createLiteralMapConverter: (keys: {key: string, quoted: boolean}[]) =>
+                this._createLiteralMapConverter(expression.sourceSpan, keys),
             createPipeConverter: (name: string, argCount: number) =>
-                                     this._createPipeConverter(expression, name, argCount)
+                this._createPipeConverter(expression, name, argCount)
           },
           expression.value)
     };
@@ -848,7 +849,7 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
     return {updateRendererStmts, updateDirectivesStmts, nodeDefExprs};
 
     function createUpdateStatements(
-        nodeIndex: number, sourceSpan: ParseSourceSpan | null, expressions: UpdateExpression[],
+        nodeIndex: number, sourceSpan: ParseSourceSpan|null, expressions: UpdateExpression[],
         allowEmptyExprs: boolean): o.Statement[] {
       const updateStmts: o.Statement[] = [];
       const exprs = expressions.map(({sourceSpan, context, value}) => {
@@ -892,14 +893,14 @@ class ViewBuilder implements TemplateAstVisitor, LocalResolver {
     if (handleEventStmts.length > 0) {
       const preStmts: o.Statement[] =
           [ALLOW_DEFAULT_VAR.set(o.literal(true)).toDeclStmt(o.BOOL_TYPE)];
-      if (!this.component.isHost && o.findReadVarNames(handleEventStmts).has(COMP_VAR.name !)) {
+      if (!this.component.isHost && o.findReadVarNames(handleEventStmts).has(COMP_VAR.name!)) {
         preStmts.push(COMP_VAR.set(VIEW_VAR.prop('component')).toDeclStmt(this.compType));
       }
       handleEventFn = o.fn(
           [
-            new o.FnParam(VIEW_VAR.name !, o.INFERRED_TYPE),
-            new o.FnParam(EVENT_NAME_VAR.name !, o.INFERRED_TYPE),
-            new o.FnParam(EventHandlerVars.event.name !, o.INFERRED_TYPE)
+            new o.FnParam(VIEW_VAR.name!, o.INFERRED_TYPE),
+            new o.FnParam(EVENT_NAME_VAR.name!, o.INFERRED_TYPE),
+            new o.FnParam(EventHandlerVars.event.name!, o.INFERRED_TYPE)
           ],
           [...preStmts, ...handleEventStmts, new o.ReturnStatement(ALLOW_DEFAULT_VAR)],
           o.INFERRED_TYPE);
@@ -975,7 +976,9 @@ function elementBindingDef(inputAst: BoundElementPropertyAst, dirAst: DirectiveA
 
 function fixedAttrsDef(elementAst: ElementAst): o.Expression {
   const mapResult: {[key: string]: string} = Object.create(null);
-  elementAst.attrs.forEach(attrAst => { mapResult[attrAst.name] = attrAst.value; });
+  elementAst.attrs.forEach(attrAst => {
+    mapResult[attrAst.name] = attrAst.value;
+  });
   elementAst.directives.forEach(dirAst => {
     Object.keys(dirAst.directive.hostAttributes).forEach(name => {
       const value = dirAst.directive.hostAttributes[name];
@@ -1014,7 +1017,7 @@ function callUnwrapValue(nodeIndex: number, bindingIdx: number, expr: o.Expressi
 }
 
 function elementEventNameAndTarget(
-    eventAst: BoundEventAst, dirAst: DirectiveAst | null): {name: string, target: string | null} {
+    eventAst: BoundEventAst, dirAst: DirectiveAst|null): {name: string, target: string|null} {
   if (eventAst.isAnimation) {
     return {
       name: `@${eventAst.name}.${eventAst.phase}`,
@@ -1037,6 +1040,6 @@ function calcStaticDynamicQueryFlags(query: CompileQueryMetadata) {
   return flags;
 }
 
-export function elementEventFullName(target: string | null, name: string): string {
+export function elementEventFullName(target: string|null, name: string): string {
   return target ? `${target}:${name}` : name;
 }

--- a/packages/compiler/test/aot/compiler_spec.ts
+++ b/packages/compiler/test/aot/compiler_spec.ts
@@ -13,7 +13,7 @@ import {extractSourceMap, originalPositionFor} from '@angular/compiler/testing/s
 import {NodeFlags} from '@angular/core/src/view/index';
 import * as ts from 'typescript';
 
-import {EmittingCompilerHost, MockAotCompilerHost, MockCompilerHost, MockDirectory, MockMetadataBundlerHost, arrayToMockDir, compile, expectNoDiagnostics, isInBazel, settings, setup, toMockFileArray} from './test_util';
+import {arrayToMockDir, compile, EmittingCompilerHost, expectNoDiagnostics, isInBazel, MockAotCompilerHost, MockCompilerHost, MockDirectory, MockMetadataBundlerHost, settings, setup, toMockFileArray} from './test_util';
 
 describe('compiler (unbundled Angular)', () => {
   let angularFiles = setup();
@@ -53,11 +53,11 @@ describe('compiler (unbundled Angular)', () => {
     function compileApp(): GeneratedFile {
       const {genFiles} = compile([rootDir, angularFiles]);
       return genFiles.find(
-          genFile => genFile.srcFileUrl === componentPath && genFile.genFileUrl.endsWith('.ts')) !;
+          genFile => genFile.srcFileUrl === componentPath && genFile.genFileUrl.endsWith('.ts'))!;
     }
 
     function findLineAndColumn(
-        file: string, token: string): {line: number | null, column: number | null} {
+        file: string, token: string): {line: number|null, column: number|null} {
       const index = file.indexOf(token);
       if (index === -1) {
         return {line: null, column: null};
@@ -84,7 +84,9 @@ describe('compiler (unbundled Angular)', () => {
     describe('inline templates', () => {
       const ngUrl = `${componentPath}.AppComponent.html`;
 
-      function templateDecorator(template: string) { return `template: \`${template}\`,`; }
+      function templateDecorator(template: string) {
+        return `template: \`${template}\`,`;
+      }
 
       declareTests({ngUrl, templateDecorator});
     });
@@ -125,7 +127,7 @@ describe('compiler (unbundled Angular)', () => {
 
         const genFile = compileApp();
         const genSource = toTypeScript(genFile);
-        const sourceMap = extractSourceMap(genSource) !;
+        const sourceMap = extractSourceMap(genSource)!;
         expect(sourceMap.file).toEqual(genFile.genFileUrl);
 
         // Note: the generated file also contains code that is not mapped to
@@ -146,7 +148,7 @@ describe('compiler (unbundled Angular)', () => {
 
         const genFile = compileApp();
         const genSource = toTypeScript(genFile);
-        const sourceMap = extractSourceMap(genSource) !;
+        const sourceMap = extractSourceMap(genSource)!;
         expect(originalPositionFor(sourceMap, findLineAndColumn(genSource, `'span'`)))
             .toEqual({line: 2, column: 3, source: ngUrl});
       });
@@ -158,7 +160,7 @@ describe('compiler (unbundled Angular)', () => {
 
         const genFile = compileApp();
         const genSource = toTypeScript(genFile);
-        const sourceMap = extractSourceMap(genSource) !;
+        const sourceMap = extractSourceMap(genSource)!;
         expect(originalPositionFor(sourceMap, findLineAndColumn(genSource, `someMethod()`)))
             .toEqual({line: 2, column: 9, source: ngUrl});
       });
@@ -170,7 +172,7 @@ describe('compiler (unbundled Angular)', () => {
 
         const genFile = compileApp();
         const genSource = toTypeScript(genFile);
-        const sourceMap = extractSourceMap(genSource) !;
+        const sourceMap = extractSourceMap(genSource)!;
         expect(originalPositionFor(sourceMap, findLineAndColumn(genSource, `someMethod()`)))
             .toEqual({line: 2, column: 9, source: ngUrl});
       });
@@ -180,7 +182,7 @@ describe('compiler (unbundled Angular)', () => {
 
         const genFile = compileApp();
         const genSource = toTypeScript(genFile);
-        const sourceMap = extractSourceMap(genSource) !;
+        const sourceMap = extractSourceMap(genSource)!;
         expect(originalPositionFor(sourceMap, {line: 1, column: 0}))
             .toEqual({line: 1, column: 0, source: ngFactoryPath});
       });
@@ -205,7 +207,6 @@ describe('compiler (unbundled Angular)', () => {
       compile([FILES, angularFiles]);
       expect(warnSpy).toHaveBeenCalledWith(
           `Warning: Can't resolve all parameters for MyService in /app/app.ts: (?). This will become an error in Angular v6.x`);
-
     });
 
     it('should error if not all arguments of an @Injectable class can be resolved if strictInjectionParameters is true',
@@ -279,7 +280,7 @@ describe('compiler (unbundled Angular)', () => {
       };
       compile([FILES, angularFiles], {
         postCompile: program => {
-          const factorySource = program.getSourceFile('/app/app.ngfactory.ts') !;
+          const factorySource = program.getSourceFile('/app/app.ngfactory.ts')!;
           expect(factorySource.text).not.toContain('\'/app/app.ngfactory\'');
         }
       });
@@ -321,7 +322,7 @@ describe('compiler (unbundled Angular)', () => {
     const genFilePreamble = '/* Hello world! */';
     const {genFiles} = compile([FILES, angularFiles]);
     const genFile =
-        genFiles.find(gf => gf.srcFileUrl === '/app/app.ts' && gf.genFileUrl.endsWith('.ts')) !;
+        genFiles.find(gf => gf.srcFileUrl === '/app/app.ts' && gf.genFileUrl.endsWith('.ts'))!;
     const genSource = toTypeScript(genFile, genFilePreamble);
     expect(genSource.startsWith(genFilePreamble)).toBe(true);
   });
@@ -445,9 +446,9 @@ describe('compiler (unbundled Angular)', () => {
         }
       };
       const {genFiles} = compile([FILES, angularFiles]);
-      const genFile = genFiles.find(genFile => genFile.srcFileUrl === '/app/app.ts') !;
+      const genFile = genFiles.find(genFile => genFile.srcFileUrl === '/app/app.ts')!;
       const genSource = toTypeScript(genFile);
-      const createComponentFactoryCall = /ɵccf\([^)]*\)/m.exec(genSource) ![0].replace(/\s*/g, '');
+      const createComponentFactoryCall = /ɵccf\([^)]*\)/m.exec(genSource)![0].replace(/\s*/g, '');
       // selector
       expect(createComponentFactoryCall).toContain('my-comp');
       // inputs
@@ -476,10 +477,9 @@ describe('compiler (unbundled Angular)', () => {
       };
       const {genFiles} = compile([FILES, angularFiles]);
       const genFile =
-          genFiles.find(gf => gf.srcFileUrl === '/app/app.ts' && gf.genFileUrl.endsWith('.ts')) !;
+          genFiles.find(gf => gf.srcFileUrl === '/app/app.ts' && gf.genFileUrl.endsWith('.ts'))!;
       const genSource = toTypeScript(genFile);
       expect(genSource).not.toContain('check(');
-
     });
   });
 
@@ -492,7 +492,6 @@ describe('compiler (unbundled Angular)', () => {
     inheritanceWithSummariesSpecs(() => angularSummaryFiles);
 
     describe('external symbol re-exports enabled', () => {
-
       it('should not reexport type symbols mentioned in constructors', () => {
         const libInput: MockDirectory = {
           'lib': {
@@ -520,7 +519,7 @@ describe('compiler (unbundled Angular)', () => {
         const {genFiles: appGenFiles} = compile(
             [appInput, libOutDir, angularSummaryFiles],
             {useSummaries: true, createExternalSymbolFactoryReexports: true});
-        const appNgFactory = appGenFiles.find((f) => f.genFileUrl === '/app/main.ngfactory.ts') !;
+        const appNgFactory = appGenFiles.find((f) => f.genFileUrl === '/app/main.ngfactory.ts')!;
         const appNgFactoryTs = toTypeScript(appNgFactory);
         expect(appNgFactoryTs).not.toContain('AType');
         expect(appNgFactoryTs).toContain('AValue');
@@ -570,7 +569,7 @@ describe('compiler (unbundled Angular)', () => {
         const {genFiles: appGenFiles} = compile(
             [appInput, libOutDir, angularSummaryFiles],
             {useSummaries: true, createExternalSymbolFactoryReexports: true});
-        const appNgFactory = appGenFiles.find((f) => f.genFileUrl === '/app/main.ngfactory.ts') !;
+        const appNgFactory = appGenFiles.find((f) => f.genFileUrl === '/app/main.ngfactory.ts')!;
         const appNgFactoryTs = toTypeScript(appNgFactory);
 
         // metadata of ctor calls is preserved, so we reexport the argument
@@ -614,7 +613,7 @@ describe('compiler (unbundled Angular)', () => {
         const {genFiles: appGenFiles} = compile(
             [appInput, libOutDir, angularSummaryFiles],
             {useSummaries: true, createExternalSymbolFactoryReexports: true});
-        const appNgFactory = appGenFiles.find((f) => f.genFileUrl === '/app/main.ngfactory.ts') !;
+        const appNgFactory = appGenFiles.find((f) => f.genFileUrl === '/app/main.ngfactory.ts')!;
         const appNgFactoryTs = toTypeScript(appNgFactory);
 
         // we don't need to reexport exported symbols via the .ngfactory
@@ -707,7 +706,7 @@ describe('compiler (unbundled Angular)', () => {
           compile([libInput, getAngularSummaryFiles()], {useSummaries: true});
       const {genFiles} =
           compile([libOutDir, appInput, getAngularSummaryFiles()], {useSummaries: true});
-      const mainNgFactory = genFiles.find(gf => gf.srcFileUrl === '/app/main.ts') !;
+      const mainNgFactory = genFiles.find(gf => gf.srcFileUrl === '/app/main.ts')!;
       const flags = NodeFlags.TypeDirective | NodeFlags.Component | NodeFlags.OnDestroy;
       expect(toTypeScript(mainNgFactory))
           .toContain(`${flags},(null as any),0,i1.Extends,[i2.AParam]`);
@@ -761,7 +760,7 @@ describe('compiler (unbundled Angular)', () => {
          const {genFiles} = compile(
              [lib1OutDir, lib2OutDir, appInput, getAngularSummaryFiles()], {useSummaries: true});
 
-         const mainNgFactory = genFiles.find(gf => gf.srcFileUrl === '/app/main.ts') !;
+         const mainNgFactory = genFiles.find(gf => gf.srcFileUrl === '/app/main.ts')!;
          const flags = NodeFlags.TypeDirective | NodeFlags.Component | NodeFlags.OnDestroy;
          const mainNgFactorySource = toTypeScript(mainNgFactory);
          expect(mainNgFactorySource).toContain(`import * as i2 from '/lib1/base';`);

--- a/packages/compiler/test/aot/jit_summaries_spec.ts
+++ b/packages/compiler/test/aot/jit_summaries_spec.ts
@@ -8,7 +8,7 @@
 
 import {AotCompiler, AotCompilerHost, AotCompilerOptions, CompileSummaryKind, GeneratedFile, toTypeScript} from '@angular/compiler';
 
-import {MockDirectory, compile, setup} from './test_util';
+import {compile, MockDirectory, setup} from './test_util';
 
 describe('aot summaries for jit', () => {
   let angularFiles = setup();
@@ -19,7 +19,7 @@ describe('aot summaries for jit', () => {
   });
 
   function compileApp(
-      rootDir: MockDirectory, options: {useSummaries?: boolean}& AotCompilerOptions = {}):
+      rootDir: MockDirectory, options: {useSummaries?: boolean}&AotCompilerOptions = {}):
       {genFiles: GeneratedFile[], outDir: MockDirectory} {
     return compile(
         [rootDir, options.useSummaries ? angularSummaryFiles : angularFiles],
@@ -42,7 +42,7 @@ describe('aot summaries for jit', () => {
     const rootDir = {'app': appDir};
 
     const genFile =
-        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts') !;
+        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts')!;
     const genSource = toTypeScript(genFile);
 
     expect(genSource).toContain(`import * as i0 from '/app/app.module'`);
@@ -71,7 +71,7 @@ describe('aot summaries for jit', () => {
     const rootDir = {'app': appDir};
 
     const genFile =
-        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts') !;
+        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts')!;
     const genSource = toTypeScript(genFile);
 
     expect(genSource).toContain(`import * as i0 from '/app/app.module'`);
@@ -100,7 +100,7 @@ describe('aot summaries for jit', () => {
     const rootDir = {'app': appDir};
 
     const genFile =
-        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts') !;
+        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts')!;
     const genSource = toTypeScript(genFile);
 
     expect(genSource).toContain(`import * as i0 from '/app/app.module'`);
@@ -126,7 +126,7 @@ describe('aot summaries for jit', () => {
     const rootDir = {'app': appDir};
 
     const genFile =
-        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts') !;
+        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts')!;
     const genSource = toTypeScript(genFile);
 
     expect(genSource).toContain(`import * as i0 from '/app/app.module'`);
@@ -165,7 +165,7 @@ describe('aot summaries for jit', () => {
     const rootDir = {'app': appDir};
 
     const genFile =
-        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts') !;
+        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts')!;
     const genSource = toTypeScript(genFile);
 
     expect(genSource).toMatch(/useClass:\{\s*reference:i1.MyService/);
@@ -199,7 +199,7 @@ describe('aot summaries for jit', () => {
     const rootDir = {'app': appDir};
 
     const genFile =
-        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts') !;
+        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts')!;
     const genSource = toTypeScript(genFile);
 
     expect(genSource).toMatch(/useClass:\{\s*reference:i1.MyService/);
@@ -226,7 +226,7 @@ describe('aot summaries for jit', () => {
     const rootDir = {'app': appDir};
 
     const genFile =
-        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts') !;
+        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts')!;
     const genSource = toTypeScript(genFile);
 
     expect(genSource).toMatch(
@@ -248,7 +248,7 @@ describe('aot summaries for jit', () => {
     const rootDir = {'app': appDir};
 
     const genFile =
-        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts') !;
+        compileApp(rootDir).genFiles.find(f => f.genFileUrl === '/app/app.module.ngsummary.ts')!;
     const genSource = toTypeScript(genFile);
 
     expect(genSource).toMatch(
@@ -301,10 +301,9 @@ describe('aot summaries for jit', () => {
          createExternalSymbolFactoryReexports: true,
        });
 
-       const lib2ModuleNgSummary =
-           lib2Gen.find(f => f.genFileUrl === '/lib2/module.ngsummary.ts') !;
+       const lib2ModuleNgSummary = lib2Gen.find(f => f.genFileUrl === '/lib2/module.ngsummary.ts')!;
        const lib2ReexportNgSummary =
-           lib2Gen.find(f => f.genFileUrl === '/lib2/reexport.ngsummary.ts') !;
+           lib2Gen.find(f => f.genFileUrl === '/lib2/reexport.ngsummary.ts')!;
 
        // ngsummaries should add reexports for imported NgModules from a direct dependency
        expect(toTypeScript(lib2ModuleNgSummary))
@@ -336,10 +335,9 @@ describe('aot summaries for jit', () => {
                          useSummaries: true,
                          createExternalSymbolFactoryReexports: true
                        }).genFiles;
-       const lib3ModuleNgSummary =
-           lib3Gen.find(f => f.genFileUrl === '/lib3/module.ngsummary.ts') !;
+       const lib3ModuleNgSummary = lib3Gen.find(f => f.genFileUrl === '/lib3/module.ngsummary.ts')!;
        const lib3ReexportNgSummary =
-           lib3Gen.find(f => f.genFileUrl === '/lib3/reexport.ngsummary.ts') !;
+           lib3Gen.find(f => f.genFileUrl === '/lib3/reexport.ngsummary.ts')!;
 
        // ngsummary.ts files should use the reexported values from direct and deep deps
        const lib3ModuleNgSummarySource = toTypeScript(lib3ModuleNgSummary);
@@ -398,9 +396,9 @@ describe('aot summaries for jit', () => {
 
     const {outDir: lib2Out, genFiles: lib2Gen} = compileApp(lib2In, {useSummaries: true});
 
-    const lib2ModuleNgSummary = lib2Gen.find(f => f.genFileUrl === '/lib2/module.ngsummary.ts') !;
+    const lib2ModuleNgSummary = lib2Gen.find(f => f.genFileUrl === '/lib2/module.ngsummary.ts')!;
     const lib2ReexportNgSummary =
-        lib2Gen.find(f => f.genFileUrl === '/lib2/reexport.ngsummary.ts') !;
+        lib2Gen.find(f => f.genFileUrl === '/lib2/reexport.ngsummary.ts')!;
 
     // ngsummaries should not add reexports by default for imported NgModules from a direct
     // dependency
@@ -435,9 +433,9 @@ describe('aot summaries for jit', () => {
     };
 
     const lib3Gen = compileApp(lib3In, {useSummaries: true}).genFiles;
-    const lib3ModuleNgSummary = lib3Gen.find(f => f.genFileUrl === '/lib3/module.ngsummary.ts') !;
+    const lib3ModuleNgSummary = lib3Gen.find(f => f.genFileUrl === '/lib3/module.ngsummary.ts')!;
     const lib3ReexportNgSummary =
-        lib3Gen.find(f => f.genFileUrl === '/lib3/reexport.ngsummary.ts') !;
+        lib3Gen.find(f => f.genFileUrl === '/lib3/reexport.ngsummary.ts')!;
 
     // ngsummary.ts files should use the external symbols which are manually re-exported from
     // "lib2" from their original symbol location. With re-exported external symbols this would

--- a/packages/compiler/test/aot/regression_spec.ts
+++ b/packages/compiler/test/aot/regression_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {MockDirectory, compile, expectNoDiagnostics, setup} from './test_util';
+import {compile, expectNoDiagnostics, MockDirectory, setup} from './test_util';
 
 describe('regressions', () => {
   let angularFiles = setup();

--- a/packages/compiler/test/aot/static_reflector_spec.ts
+++ b/packages/compiler/test/aot/static_reflector_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, StaticSymbolResolverHost, core as compilerCore} from '@angular/compiler';
+import {core as compilerCore, StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, StaticSymbolResolverHost} from '@angular/compiler';
 import {CollectorOptions, METADATA_VERSION} from '@angular/compiler-cli';
 
 import {MockStaticSymbolResolverHost, MockSummaryResolver} from './static_symbol_resolver_spec';
@@ -358,7 +358,7 @@ describe('StaticReflector', () => {
   it('should record data about the error in the exception', () => {
     let threw = false;
     try {
-      const metadata = host.getMetadataFor('/tmp/src/invalid-metadata.ts') !;
+      const metadata = host.getMetadataFor('/tmp/src/invalid-metadata.ts')!;
       expect(metadata).toBeDefined();
       const moduleMetadata: any = metadata[0]['metadata'];
       expect(moduleMetadata).toBeDefined();
@@ -1334,10 +1334,9 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
         'decorators': [{
           '__symbolic': 'call',
           'expression': {'__symbolic': 'reference', 'name': 'Directive', 'module': '@angular/core'},
-          'arguments': [{
-            'selector': '[ngFor][ngForOf]',
-            'inputs': ['ngForTrackBy', 'ngForOf', 'ngForTemplate']
-          }]
+          'arguments': [
+            {'selector': '[ngFor][ngForOf]', 'inputs': ['ngForTrackBy', 'ngForOf', 'ngForTemplate']}
+          ]
         }],
         'members': {
           '__ctor__': [{
@@ -1345,11 +1344,8 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
             'parameters': [
               {'__symbolic': 'reference', 'module': '@angular/core', 'name': 'ViewContainerRef'},
               {'__symbolic': 'reference', 'module': '@angular/core', 'name': 'TemplateRef'},
-              {'__symbolic': 'reference', 'module': '@angular/core', 'name': 'IterableDiffers'}, {
-                '__symbolic': 'reference',
-                'module': '@angular/core',
-                'name': 'ChangeDetectorRef'
-              }
+              {'__symbolic': 'reference', 'module': '@angular/core', 'name': 'IterableDiffers'},
+              {'__symbolic': 'reference', 'module': '@angular/core', 'name': 'ChangeDetectorRef'}
             ]
           }]
         }
@@ -1387,8 +1383,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
             '__symbolic': 'property',
             'decorators': [{
               '__symbolic': 'call',
-              'expression':
-                  {'__symbolic': 'reference', 'name': 'Input', 'module': '@angular/core'}
+              'expression': {'__symbolic': 'reference', 'name': 'Input', 'module': '@angular/core'}
             }]
           }],
           'onMouseOver': [{

--- a/packages/compiler/test/aot/static_symbol_resolver_spec.ts
+++ b/packages/compiler/test/aot/static_symbol_resolver_spec.ts
@@ -19,7 +19,9 @@ describe('StaticSymbolResolver', () => {
   let symbolResolver: StaticSymbolResolver;
   let symbolCache: StaticSymbolCache;
 
-  beforeEach(() => { symbolCache = new StaticSymbolCache(); });
+  beforeEach(() => {
+    symbolCache = new StaticSymbolCache();
+  });
 
   function init(
       testData: {[key: string]: any} = DEFAULT_TEST_DATA, summaries: Summary<StaticSymbol>[] = [],
@@ -36,7 +38,8 @@ describe('StaticSymbolResolver', () => {
         () => symbolResolver.resolveSymbol(
             symbolResolver.getSymbolByModule('src/version-error', 'e')))
         .toThrow(new Error(
-            `Metadata version mismatch for module /tmp/src/version-error.d.ts, found version 100, expected ${METADATA_VERSION}`));
+            `Metadata version mismatch for module /tmp/src/version-error.d.ts, found version 100, expected ${
+                METADATA_VERSION}`));
   });
 
   it('should throw an exception for version 2 metadata', () => {
@@ -159,7 +162,6 @@ describe('StaticSymbolResolver', () => {
      });
 
   describe('importAs', () => {
-
     it('should calculate importAs relationship for non source files without summaries', () => {
       init(
           {
@@ -241,7 +243,6 @@ describe('StaticSymbolResolver', () => {
          expect(symbolResolver.getImportAs(symbolCache.get('/test2.d.ts', 'a', ['someMember'])))
              .toBe(symbolCache.get('/test3.d.ts', 'b', ['someMember']));
        });
-
   });
 
   it('should replace references by StaticSymbols', () => {
@@ -345,10 +346,9 @@ describe('StaticSymbolResolver', () => {
             __symbolic: 'class',
             arity: 1,
             members: {
-              __ctor__: [{
-                __symbolic: 'constructor',
-                parameters: [symbolCache.get('/test.d.ts', 'AParam')]
-              }]
+              __ctor__: [
+                {__symbolic: 'constructor', parameters: [symbolCache.get('/test.d.ts', 'AParam')]}
+              ]
             }
           }
         }
@@ -423,7 +423,6 @@ describe('StaticSymbolResolver', () => {
     expect(symbol.name).toEqual('One');
     expect(symbol.filePath).toEqual('/tmp/src/reexport/src/origin1.d.ts');
   });
-
 });
 
 export class MockSummaryResolver implements SummaryResolver<StaticSymbol> {
@@ -431,9 +430,11 @@ export class MockSummaryResolver implements SummaryResolver<StaticSymbol> {
     symbol: StaticSymbol,
     importAs: StaticSymbol
   }[] = []) {}
-  addSummary(summary: Summary<StaticSymbol>) { this.summaries.push(summary); }
+  addSummary(summary: Summary<StaticSymbol>) {
+    this.summaries.push(summary);
+  }
   resolveSummary(reference: StaticSymbol): Summary<StaticSymbol> {
-    return this.summaries.find(summary => summary.symbol === reference) !;
+    return this.summaries.find(summary => summary.symbol === reference)!;
   }
   getSymbolsOf(filePath: string): StaticSymbol[]|null {
     const symbols = this.summaries.filter(summary => summary.symbol.filePath === filePath)
@@ -442,12 +443,20 @@ export class MockSummaryResolver implements SummaryResolver<StaticSymbol> {
   }
   getImportAs(symbol: StaticSymbol): StaticSymbol {
     const entry = this.importAs.find(entry => entry.symbol === symbol);
-    return entry ? entry.importAs : undefined !;
+    return entry ? entry.importAs : undefined!;
   }
-  getKnownModuleName(fileName: string): string|null { return null; }
-  isLibraryFile(filePath: string): boolean { return filePath.endsWith('.d.ts'); }
-  toSummaryFileName(filePath: string): string { return filePath.replace(/(\.d)?\.ts$/, '.d.ts'); }
-  fromSummaryFileName(filePath: string): string { return filePath; }
+  getKnownModuleName(fileName: string): string|null {
+    return null;
+  }
+  isLibraryFile(filePath: string): boolean {
+    return filePath.endsWith('.d.ts');
+  }
+  toSummaryFileName(filePath: string): string {
+    return filePath.replace(/(\.d)?\.ts$/, '.d.ts');
+  }
+  fromSummaryFileName(filePath: string): string {
+    return filePath;
+  }
 }
 
 export class MockStaticSymbolResolverHost implements StaticSymbolResolverHost {
@@ -459,7 +468,9 @@ export class MockStaticSymbolResolverHost implements StaticSymbolResolverHost {
 
   // In tests, assume that symbols are not re-exported
   moduleNameToFileName(modulePath: string, containingFile?: string): string {
-    function splitPath(path: string): string[] { return path.split(/\/|\\/g); }
+    function splitPath(path: string): string[] {
+      return path.split(/\/|\\/g);
+    }
 
     function resolvePath(pathParts: string[]): string {
       const result: string[] = [];
@@ -490,7 +501,7 @@ export class MockStaticSymbolResolverHost implements StaticSymbolResolverHost {
     }
 
     if (modulePath.indexOf('.') === 0) {
-      const baseName = pathTo(containingFile !, modulePath);
+      const baseName = pathTo(containingFile!, modulePath);
       const tsName = baseName + '.ts';
       if (this._getMetadataFor(tsName)) {
         return tsName;
@@ -498,14 +509,18 @@ export class MockStaticSymbolResolverHost implements StaticSymbolResolverHost {
       return baseName + '.d.ts';
     }
     if (modulePath == 'unresolved') {
-      return undefined !;
+      return undefined!;
     }
     return '/tmp/' + modulePath + '.d.ts';
   }
 
-  getMetadataFor(moduleId: string): any { return this._getMetadataFor(moduleId); }
+  getMetadataFor(moduleId: string): any {
+    return this._getMetadataFor(moduleId);
+  }
 
-  getOutputName(filePath: string): string { return filePath; }
+  getOutputName(filePath: string): string {
+    return filePath;
+  }
 
   private _getMetadataFor(filePath: string): any {
     if (this.data[filePath] && filePath.match(TS_EXT)) {
@@ -515,13 +530,13 @@ export class MockStaticSymbolResolverHost implements StaticSymbolResolverHost {
             filePath, this.data[filePath], ts.ScriptTarget.ES5, /* setParentNodes */ true);
         const diagnostics: ts.Diagnostic[] = (<any>sf).parseDiagnostics;
         if (diagnostics && diagnostics.length) {
-          const errors =
-              diagnostics
-                  .map(d => {
-                    const {line, character} = ts.getLineAndCharacterOfPosition(d.file !, d.start !);
-                    return `(${line}:${character}): ${d.messageText}`;
-                  })
-                  .join('\n');
+          const errors = diagnostics
+                             .map(d => {
+                               const {line, character} =
+                                   ts.getLineAndCharacterOfPosition(d.file!, d.start!);
+                               return `(${line}:${character}): ${d.messageText}`;
+                             })
+                             .join('\n');
           throw Error(`Error encountered during parse of file ${filePath}\n${errors}`);
         }
         return [this.collector.getMetadata(sf)];

--- a/packages/compiler/test/aot/summary_resolver_spec.ts
+++ b/packages/compiler/test/aot/summary_resolver_spec.ts
@@ -23,7 +23,9 @@ const EXT = /(\.d)?\.ts$/;
     let symbolCache: StaticSymbolCache;
     let host: MockAotSummaryResolverHost;
 
-    beforeEach(() => { symbolCache = new StaticSymbolCache(); });
+    beforeEach(() => {
+      symbolCache = new StaticSymbolCache();
+    });
 
     function init(summaries: {[filePath: string]: string} = {}) {
       host = new MockAotSummaryResolverHost(summaries);
@@ -121,11 +123,17 @@ export class MockAotSummaryResolverHost implements AotSummaryResolverHost {
     return sourceFileName.replace(EXT, '') + '.d.ts';
   }
 
-  fromSummaryFileName(filePath: string): string { return filePath; }
+  fromSummaryFileName(filePath: string): string {
+    return filePath;
+  }
 
-  isSourceFile(filePath: string) { return !filePath.endsWith('.d.ts'); }
+  isSourceFile(filePath: string) {
+    return !filePath.endsWith('.d.ts');
+  }
 
-  loadSummary(filePath: string): string { return this.summaries[filePath]; }
+  loadSummary(filePath: string): string {
+    return this.summaries[filePath];
+  }
 }
 
 export function createMockOutputContext(): OutputContext {

--- a/packages/compiler/test/aot/summary_serializer_spec.ts
+++ b/packages/compiler/test/aot/summary_serializer_spec.ts
@@ -12,7 +12,7 @@ import {deserializeSummaries, serializeSummaries} from '@angular/compiler/src/ao
 import {summaryFileName} from '@angular/compiler/src/aot/util';
 
 import {MockStaticSymbolResolverHost} from './static_symbol_resolver_spec';
-import {MockAotSummaryResolverHost, createMockOutputContext} from './summary_resolver_spec';
+import {createMockOutputContext, MockAotSummaryResolverHost} from './summary_resolver_spec';
 
 
 {
@@ -22,7 +22,9 @@ import {MockAotSummaryResolverHost, createMockOutputContext} from './summary_res
     let symbolCache: StaticSymbolCache;
     let host: MockAotSummaryResolverHost;
 
-    beforeEach(() => { symbolCache = new StaticSymbolCache(); });
+    beforeEach(() => {
+      symbolCache = new StaticSymbolCache();
+    });
 
     function init(
         summaries: {[filePath: string]: string} = {}, metadata: {[key: string]: any} = {}) {
@@ -101,7 +103,7 @@ import {MockAotSummaryResolverHost, createMockOutputContext} from './summary_res
         members: {aMethod: {__symbolic: 'function'}},
         statics: {aStatic: true}
       });
-      expect(summaries[1].type !.type.reference)
+      expect(summaries[1].type!.type.reference)
           .toBe(symbolCache.get('/tmp/some_service.d.ts', 'SomeService'));
     });
 
@@ -274,7 +276,7 @@ import {MockAotSummaryResolverHost, createMockOutputContext} from './summary_res
              '/tmp/external_svc.d.ts', 'SomeService')]);
          // SomService is a transitive dep, but should have been serialized as well.
          expect(summaries[2].symbol).toBe(symbolCache.get('/tmp/external_svc.d.ts', 'SomeService'));
-         expect(summaries[2].type !.type.reference)
+         expect(summaries[2].type!.type.reference)
              .toBe(symbolCache.get('/tmp/external_svc.d.ts', 'SomeService'));
          // there was no summary for non_summary, but it should have
          // been serialized as well.
@@ -387,7 +389,6 @@ import {MockAotSummaryResolverHost, createMockOutputContext} from './summary_res
 
 
     describe('symbol re-exports enabled', () => {
-
       it('should not create "importAs" names for ctor arguments which are types of reexported classes in libraries',
          () => {
            init();

--- a/packages/compiler/test/aot/test_util.ts
+++ b/packages/compiler/test/aot/test_util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AotCompilerHost, AotCompilerOptions, GeneratedFile, createAotCompiler, toTypeScript} from '@angular/compiler';
+import {AotCompilerHost, AotCompilerOptions, createAotCompiler, GeneratedFile, toTypeScript} from '@angular/compiler';
 import {MetadataBundlerHost} from '@angular/compiler-cli/src/metadata/bundler';
 import {MetadataCollector} from '@angular/compiler-cli/src/metadata/collector';
 import {ModuleMetadata} from '@angular/compiler-cli/src/metadata/index';
@@ -15,7 +15,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
-export interface MetadataProvider { getMetadata(source: ts.SourceFile): ModuleMetadata|undefined; }
+export interface MetadataProvider {
+  getMetadata(source: ts.SourceFile): ModuleMetadata|undefined;
+}
 
 let nodeModulesPath: string;
 let angularSourcePath: string;
@@ -23,13 +25,13 @@ let rootPath: string;
 
 calcPathsOnDisc();
 
-export type MockFileOrDirectory = string | MockDirectory;
+export type MockFileOrDirectory = string|MockDirectory;
 
 export type MockDirectory = {
-  [name: string]: MockFileOrDirectory | undefined;
+  [name: string]: MockFileOrDirectory|undefined;
 };
 
-export function isDirectory(data: MockFileOrDirectory | undefined): data is MockDirectory {
+export function isDirectory(data: MockFileOrDirectory|undefined): data is MockDirectory {
   return typeof data !== 'string';
 }
 
@@ -119,9 +121,13 @@ export class EmittingCompilerHost implements ts.CompilerHost {
     return Array.from(this.writtenFiles).map(f => ({name: f[0], content: f[1]}));
   }
 
-  public get scripts(): string[] { return this.scriptNames; }
+  public get scripts(): string[] {
+    return this.scriptNames;
+  }
 
-  public get written(): Map<string, string> { return this.writtenFiles; }
+  public get written(): Map<string, string> {
+    return this.writtenFiles;
+  }
 
   public effectiveName(fileName: string): string {
     const prefix = '@angular/';
@@ -154,7 +160,9 @@ export class EmittingCompilerHost implements ts.CompilerHost {
         (fs.existsSync(directoryName) && fs.statSync(directoryName).isDirectory());
   }
 
-  getCurrentDirectory(): string { return this.root; }
+  getCurrentDirectory(): string {
+    return this.root;
+  }
 
   getDirectories(dir: string): string[] {
     const result = open(dir, this.options.mockData);
@@ -179,7 +187,9 @@ export class EmittingCompilerHost implements ts.CompilerHost {
     throw new Error(`File not found '${fileName}'.`);
   }
 
-  getDefaultLibFileName(options: ts.CompilerOptions): string { return 'lib.d.ts'; }
+  getDefaultLibFileName(options: ts.CompilerOptions): string {
+    return 'lib.d.ts';
+  }
 
   writeFile: ts.WriteFileCallback =
       (fileName: string, data: string, writeByteOrderMark: boolean,
@@ -197,8 +207,12 @@ export class EmittingCompilerHost implements ts.CompilerHost {
   getCanonicalFileName(fileName: string): string {
     return fileName;
   }
-  useCaseSensitiveFileNames(): boolean { return false; }
-  getNewLine(): string { return '\n'; }
+  useCaseSensitiveFileNames(): boolean {
+    return false;
+  }
+  getNewLine(): string {
+    return '\n';
+  }
 
   private getAddedDirectories(): Set<string> {
     let result = this.cachedAddedDirectories;
@@ -247,7 +261,9 @@ export class MockCompilerHost implements ts.CompilerHost {
     this.sourceFiles.delete(fileName);
   }
 
-  assumeFileExists(fileName: string) { this.assumeExists.add(fileName); }
+  assumeFileExists(fileName: string) {
+    this.assumeExists.add(fileName);
+  }
 
   remove(files: string[]) {
     // Remove the files from the list of scripts.
@@ -274,11 +290,17 @@ export class MockCompilerHost implements ts.CompilerHost {
     return false;
   }
 
-  readFile(fileName: string): string { return this.getFileContent(fileName) !; }
+  readFile(fileName: string): string {
+    return this.getFileContent(fileName)!;
+  }
 
-  trace(s: string): void { this.traces.push(s); }
+  trace(s: string): void {
+    this.traces.push(s);
+  }
 
-  getCurrentDirectory(): string { return '/'; }
+  getCurrentDirectory(): string {
+    return '/';
+  }
 
   getDirectories(dir: string): string[] {
     const effectiveName = this.getEffectiveName(dir);
@@ -303,10 +325,12 @@ export class MockCompilerHost implements ts.CompilerHost {
         this.sourceFiles.set(fileName, result);
       }
     }
-    return result !;
+    return result!;
   }
 
-  getDefaultLibFileName(options: ts.CompilerOptions): string { return 'lib.d.ts'; }
+  getDefaultLibFileName(options: ts.CompilerOptions): string {
+    return 'lib.d.ts';
+  }
 
   writeFile: ts.WriteFileCallback =
       (fileName: string, data: string, writeByteOrderMark: boolean) => {
@@ -317,8 +341,12 @@ export class MockCompilerHost implements ts.CompilerHost {
   getCanonicalFileName(fileName: string): string {
     return fileName;
   }
-  useCaseSensitiveFileNames(): boolean { return false; }
-  getNewLine(): string { return '\n'; }
+  useCaseSensitiveFileNames(): boolean {
+    return false;
+  }
+  getNewLine(): string {
+    return '\n';
+  }
 
   // Private methods
   private getFileContent(fileName: string): string|undefined {
@@ -373,9 +401,13 @@ export class MockAotCompilerHost implements AotCompilerHost {
     };
   }
 
-  hideMetadata() { this.metadataVisible = false; }
+  hideMetadata() {
+    this.metadataVisible = false;
+  }
 
-  tsFilesOnly() { this.dtsAreSource = false; }
+  tsFilesOnly() {
+    this.dtsAreSource = false;
+  }
 
   // StaticSymbolResolverHost
   getMetadataFor(modulePath: string): {[key: string]: any}[]|undefined {
@@ -414,7 +446,9 @@ export class MockAotCompilerHost implements AotCompilerHost {
     return resolved ? resolved.resolvedFileName : null;
   }
 
-  getOutputName(filePath: string) { return filePath; }
+  getOutputName(filePath: string) {
+    return filePath;
+  }
 
   resourceNameToFileName(resourceName: string, containingFile: string) {
     // Note: we convert package paths into relative paths to be compatible with the the
@@ -428,16 +462,22 @@ export class MockAotCompilerHost implements AotCompilerHost {
   }
 
   // AotSummaryResolverHost
-  loadSummary(filePath: string): string|null { return this.tsHost.readFile(filePath); }
+  loadSummary(filePath: string): string|null {
+    return this.tsHost.readFile(filePath);
+  }
 
   isSourceFile(sourceFilePath: string): boolean {
     return !GENERATED_FILES.test(sourceFilePath) &&
         (this.dtsAreSource || !DTS.test(sourceFilePath));
   }
 
-  toSummaryFileName(filePath: string): string { return filePath.replace(EXT, '') + '.d.ts'; }
+  toSummaryFileName(filePath: string): string {
+    return filePath.replace(EXT, '') + '.d.ts';
+  }
 
-  fromSummaryFileName(filePath: string): string { return filePath; }
+  fromSummaryFileName(filePath: string): string {
+    return filePath;
+  }
 
   // AotCompilerHost
   fileNameToModuleName(importedFile: string, containingFile: string): string {
@@ -464,7 +504,7 @@ export class MockMetadataBundlerHost implements MetadataBundlerHost {
   }
 }
 
-function find(fileName: string, data: MockFileOrDirectory | undefined): MockFileOrDirectory|
+function find(fileName: string, data: MockFileOrDirectory|undefined): MockFileOrDirectory|
     undefined {
   if (!data) return undefined;
   const names = fileName.split('/');
@@ -479,7 +519,7 @@ function find(fileName: string, data: MockFileOrDirectory | undefined): MockFile
   return current;
 }
 
-function open(fileName: string, data: MockFileOrDirectory | undefined): string|undefined {
+function open(fileName: string, data: MockFileOrDirectory|undefined): string|undefined {
   let result = find(fileName, data);
   if (typeof result === 'string') {
     return result;
@@ -487,7 +527,7 @@ function open(fileName: string, data: MockFileOrDirectory | undefined): string|u
   return undefined;
 }
 
-function directoryExists(dirname: string, data: MockFileOrDirectory | undefined): boolean {
+function directoryExists(dirname: string, data: MockFileOrDirectory|undefined): boolean {
   let result = find(dirname, data);
   return !!result && typeof result !== 'string';
 }
@@ -497,7 +537,7 @@ export type MockFileArray = {
   content: string
 }[];
 
-export type MockData = MockDirectory | Map<string, string>| (MockDirectory | Map<string, string>)[];
+export type MockData = MockDirectory|Map<string, string>|(MockDirectory|Map<string, string>)[];
 
 export function toMockFileArray(data: MockData, target: MockFileArray = []): MockFileArray {
   if (data instanceof Map) {
@@ -512,7 +552,7 @@ export function toMockFileArray(data: MockData, target: MockFileArray = []): Moc
 
 function mockDirToFileArray(dir: MockDirectory, path: string, target: MockFileArray) {
   Object.keys(dir).forEach((localFileName) => {
-    const value = dir[localFileName] !;
+    const value = dir[localFileName]!;
     const fileName = `${path}/${localFileName}`;
     if (typeof value === 'string') {
       target.push({fileName, content: value});
@@ -523,12 +563,16 @@ function mockDirToFileArray(dir: MockDirectory, path: string, target: MockFileAr
 }
 
 function mapToMockFileArray(files: Map<string, string>, target: MockFileArray) {
-  files.forEach((content, fileName) => { target.push({fileName, content}); });
+  files.forEach((content, fileName) => {
+    target.push({fileName, content});
+  });
 }
 
 export function arrayToMockMap(arr: MockFileArray): Map<string, string> {
   const map = new Map<string, string>();
-  arr.forEach(({fileName, content}) => { map.set(fileName, content); });
+  arr.forEach(({fileName, content}) => {
+    map.set(fileName, content);
+  });
   return map;
 }
 
@@ -594,8 +638,8 @@ function readBazelWrittenFilesFrom(
       map.set(path.posix.join('/node_modules/@angular', packageName, 'index.d.ts'), content);
     }
   } catch (e) {
-    console.error(
-        `Consider adding //packages/${packageName} as a data dependency in the BUILD.bazel rule for the failing test`);
+    console.error(`Consider adding //packages/${
+        packageName} as a data dependency in the BUILD.bazel rule for the failing test`);
     throw e;
   }
 }
@@ -606,8 +650,8 @@ export function isInBazel(): boolean {
 
 export function setup(options: {
   compileAngular: boolean,
-  compileFakeCore?: boolean,
-  compileAnimations: boolean, compileCommon?: boolean
+  compileFakeCore?: boolean, compileAnimations: boolean,
+  compileCommon?: boolean
 } = {
   compileAngular: true,
   compileAnimations: true,
@@ -687,7 +731,9 @@ export function expectNoDiagnostics(program: ts.Program) {
     return '';
   }
 
-  function chars(len: number, ch: string): string { return newArray(len, ch).join(''); }
+  function chars(len: number, ch: string): string {
+    return newArray(len, ch).join('');
+  }
 
   function lineNoOf(offset: number, text: string): number {
     let result = 1;
@@ -699,8 +745,8 @@ export function expectNoDiagnostics(program: ts.Program) {
 
   function lineInfo(diagnostic: ts.Diagnostic): string {
     if (diagnostic.file) {
-      const start = diagnostic.start !;
-      let end = diagnostic.start ! + diagnostic.length !;
+      const start = diagnostic.start!;
+      let end = diagnostic.start! + diagnostic.length!;
       const source = diagnostic.file.text;
       let lineStart = start;
       let lineEnd = end;
@@ -726,8 +772,8 @@ export function expectNoDiagnostics(program: ts.Program) {
           'Errors from TypeScript:\n' +
           diagnostics
               .map(
-                  d =>
-                      `${fileInfo(d)}${ts.flattenDiagnosticMessageText(d.messageText, '\n')}${lineInfo(d)}`)
+                  d => `${fileInfo(d)}${ts.flattenDiagnosticMessageText(d.messageText, '\n')}${
+                      lineInfo(d)}`)
               .join(' \n'));
     }
   }
@@ -758,7 +804,7 @@ export function compile(
       useSummaries?: boolean,
       preCompile?: (program: ts.Program) => void,
       postCompile?: (program: ts.Program) => void,
-    }& AotCompilerOptions = {},
+    }&AotCompilerOptions = {},
     tsOptions: ts.CompilerOptions = {}): {genFiles: GeneratedFile[], outDir: MockDirectory} {
   // when using summaries, always emit so the next step can use the results.
   const emit = options.emit || options.useSummaries;
@@ -777,7 +823,9 @@ export function compile(
   const tsSettings = {...settings, ...tsOptions};
   const program = ts.createProgram([...host.scriptNames], tsSettings, host);
   preCompile(program);
-  const {compiler, reflector} = createAotCompiler(aotHost, options, (err) => { throw err; });
+  const {compiler, reflector} = createAotCompiler(aotHost, options, (err) => {
+    throw err;
+  });
   const analyzedModules =
       compiler.analyzeModulesSync(program.getSourceFiles().map(sf => sf.fileName));
   const genFiles = compiler.emitAllImpls(analyzedModules);

--- a/packages/compiler/test/compiler_facade_interface_spec.ts
+++ b/packages/compiler/test/compiler_facade_interface_spec.ts
@@ -26,87 +26,87 @@ import * as compiler from '../src/compiler_facade_interface';
  */
 
 const coreExportedCompilerFacade1: core.ExportedCompilerFacade =
-    null !as compiler.ExportedCompilerFacade;
+    null! as compiler.ExportedCompilerFacade;
 const compilerExportedCompilerFacade2: compiler.ExportedCompilerFacade =
-    null !as core.ExportedCompilerFacade;
+    null! as core.ExportedCompilerFacade;
 
-const coreCompilerFacade: core.CompilerFacade = null !as compiler.CompilerFacade;
-const compilerCompilerFacade: compiler.CompilerFacade = null !as core.CompilerFacade;
+const coreCompilerFacade: core.CompilerFacade = null! as compiler.CompilerFacade;
+const compilerCompilerFacade: compiler.CompilerFacade = null! as core.CompilerFacade;
 
-const coreCoreEnvironment: core.CoreEnvironment = null !as compiler.CoreEnvironment;
-const compilerCoreEnvironment: compiler.CoreEnvironment = null !as core.CoreEnvironment;
+const coreCoreEnvironment: core.CoreEnvironment = null! as compiler.CoreEnvironment;
+const compilerCoreEnvironment: compiler.CoreEnvironment = null! as core.CoreEnvironment;
 
-const coreResourceLoader: core.ResourceLoader = null !as compiler.ResourceLoader;
-const compilerResourceLoader: compiler.ResourceLoader = null !as core.ResourceLoader;
+const coreResourceLoader: core.ResourceLoader = null! as compiler.ResourceLoader;
+const compilerResourceLoader: compiler.ResourceLoader = null! as core.ResourceLoader;
 
-const coreStringMap: core.StringMap = null !as compiler.StringMap;
-const compilerStringMap: compiler.StringMap = null !as core.StringMap;
+const coreStringMap: core.StringMap = null! as compiler.StringMap;
+const compilerStringMap: compiler.StringMap = null! as core.StringMap;
 
-const coreProvider: core.Provider = null !as compiler.Provider;
-const compilerProvider: compiler.Provider = null !as core.Provider;
+const coreProvider: core.Provider = null! as compiler.Provider;
+const compilerProvider: compiler.Provider = null! as core.Provider;
 
 const coreR3ResolvedDependencyType: core.R3ResolvedDependencyType =
-    null !as compiler.R3ResolvedDependencyType;
+    null! as compiler.R3ResolvedDependencyType;
 const compilerR3ResolvedDependencyType: compiler.R3ResolvedDependencyType =
-    null !as core.R3ResolvedDependencyType;
+    null! as core.R3ResolvedDependencyType;
 
 const coreR3ResolvedDependencyType2: R3ResolvedDependencyType =
-    null !as core.R3ResolvedDependencyType;
+    null! as core.R3ResolvedDependencyType;
 const compilerR3ResolvedDependencyType2: R3ResolvedDependencyType =
-    null !as core.R3ResolvedDependencyType;
+    null! as core.R3ResolvedDependencyType;
 
 const coreR3ResolvedDependencyType3: core.R3ResolvedDependencyType =
-    null !as R3ResolvedDependencyType;
+    null! as R3ResolvedDependencyType;
 const compilerR3ResolvedDependencyType3: compiler.R3ResolvedDependencyType =
-    null !as R3ResolvedDependencyType;
+    null! as R3ResolvedDependencyType;
 
-const coreR3FactoryTarget: core.R3FactoryTarget = null !as compiler.R3FactoryTarget;
-const compilerR3FactoryTarget: compiler.R3FactoryTarget = null !as core.R3FactoryTarget;
+const coreR3FactoryTarget: core.R3FactoryTarget = null! as compiler.R3FactoryTarget;
+const compilerR3FactoryTarget: compiler.R3FactoryTarget = null! as core.R3FactoryTarget;
 
-const coreR3FactoryTarget2: R3FactoryTarget = null !as core.R3FactoryTarget;
-const compilerR3FactoryTarget2: R3FactoryTarget = null !as core.R3FactoryTarget;
+const coreR3FactoryTarget2: R3FactoryTarget = null! as core.R3FactoryTarget;
+const compilerR3FactoryTarget2: R3FactoryTarget = null! as core.R3FactoryTarget;
 
-const coreR3FactoryTarget3: core.R3FactoryTarget = null !as R3FactoryTarget;
-const compilerR3FactoryTarget3: compiler.R3FactoryTarget = null !as R3FactoryTarget;
+const coreR3FactoryTarget3: core.R3FactoryTarget = null! as R3FactoryTarget;
+const compilerR3FactoryTarget3: compiler.R3FactoryTarget = null! as R3FactoryTarget;
 
 const coreR3DependencyMetadataFacade: core.R3DependencyMetadataFacade =
-    null !as compiler.R3DependencyMetadataFacade;
+    null! as compiler.R3DependencyMetadataFacade;
 const compilerR3DependencyMetadataFacade: compiler.R3DependencyMetadataFacade =
-    null !as core.R3DependencyMetadataFacade;
+    null! as core.R3DependencyMetadataFacade;
 
-const coreR3PipeMetadataFacade: core.R3PipeMetadataFacade = null !as compiler.R3PipeMetadataFacade;
+const coreR3PipeMetadataFacade: core.R3PipeMetadataFacade = null! as compiler.R3PipeMetadataFacade;
 const compilerR3PipeMetadataFacade: compiler.R3PipeMetadataFacade =
-    null !as core.R3PipeMetadataFacade;
+    null! as core.R3PipeMetadataFacade;
 
 const coreR3InjectableMetadataFacade: core.R3InjectableMetadataFacade =
-    null !as compiler.R3InjectableMetadataFacade;
+    null! as compiler.R3InjectableMetadataFacade;
 const compilerR3InjectableMetadataFacade: compiler.R3InjectableMetadataFacade =
-    null !as core.R3InjectableMetadataFacade;
+    null! as core.R3InjectableMetadataFacade;
 
 const coreR3NgModuleMetadataFacade: core.R3NgModuleMetadataFacade =
-    null !as compiler.R3NgModuleMetadataFacade;
+    null! as compiler.R3NgModuleMetadataFacade;
 const compilerR3NgModuleMetadataFacade: compiler.R3NgModuleMetadataFacade =
-    null !as core.R3NgModuleMetadataFacade;
+    null! as core.R3NgModuleMetadataFacade;
 
 const coreR3InjectorMetadataFacade: core.R3InjectorMetadataFacade =
-    null !as compiler.R3InjectorMetadataFacade;
+    null! as compiler.R3InjectorMetadataFacade;
 const compilerR3InjectorMetadataFacade: compiler.R3InjectorMetadataFacade =
-    null !as core.R3InjectorMetadataFacade;
+    null! as core.R3InjectorMetadataFacade;
 
 const coreR3DirectiveMetadataFacade: core.R3DirectiveMetadataFacade =
-    null !as compiler.R3DirectiveMetadataFacade;
+    null! as compiler.R3DirectiveMetadataFacade;
 const compilerR3DirectiveMetadataFacade: compiler.R3DirectiveMetadataFacade =
-    null !as core.R3DirectiveMetadataFacade;
+    null! as core.R3DirectiveMetadataFacade;
 
 const coreR3ComponentMetadataFacade: core.R3ComponentMetadataFacade =
-    null !as compiler.R3ComponentMetadataFacade;
+    null! as compiler.R3ComponentMetadataFacade;
 const compilerR3ComponentMetadataFacade: compiler.R3ComponentMetadataFacade =
-    null !as core.R3ComponentMetadataFacade;
+    null! as core.R3ComponentMetadataFacade;
 
-const coreViewEncapsulation: core.ViewEncapsulation = null !as compiler.ViewEncapsulation;
-const compilerViewEncapsulation: compiler.ViewEncapsulation = null !as core.ViewEncapsulation;
+const coreViewEncapsulation: core.ViewEncapsulation = null! as compiler.ViewEncapsulation;
+const compilerViewEncapsulation: compiler.ViewEncapsulation = null! as core.ViewEncapsulation;
 
 const coreR3QueryMetadataFacade: core.R3QueryMetadataFacade =
-    null !as compiler.R3QueryMetadataFacade;
+    null! as compiler.R3QueryMetadataFacade;
 const compilerR3QueryMetadataFacade: compiler.R3QueryMetadataFacade =
-    null !as core.R3QueryMetadataFacade;
+    null! as core.R3QueryMetadataFacade;

--- a/packages/compiler/test/config_spec.ts
+++ b/packages/compiler/test/config_spec.ts
@@ -19,7 +19,9 @@ import {CompilerConfig, preserveWhitespacesDefault} from '../src/config';
 
   describe('preserveWhitespacesDefault', () => {
     it('should return the default `false` setting when no preserveWhitespacesOption are provided',
-       () => { expect(preserveWhitespacesDefault(null)).toEqual(false); });
+       () => {
+         expect(preserveWhitespacesDefault(null)).toEqual(false);
+       });
     it('should return the preserveWhitespacesOption when provided as a parameter', () => {
       expect(preserveWhitespacesDefault(true)).toEqual(true);
       expect(preserveWhitespacesDefault(false)).toEqual(false);

--- a/packages/compiler/test/core_spec.ts
+++ b/packages/compiler/test/core_spec.ts
@@ -190,7 +190,9 @@ import * as core from '@angular/core';
 function compareRuntimeShape(a: any, b: any) {
   const keys = metadataKeys(a);
   expect(keys).toEqual(metadataKeys(b));
-  keys.forEach(key => { expect(a[key]).toBe(b[key]); });
+  keys.forEach(key => {
+    expect(a[key]).toBe(b[key]);
+  });
   // Need to check 'ngMetadataName' separately, as this is
   // on the prototype in @angular/core, but a regular property in @angular/compiler.
   expect(a.ngMetadataName).toBe(b.ngMetadataName);

--- a/packages/compiler/test/css_parser/css_lexer_spec.ts
+++ b/packages/compiler/test/css_parser/css_lexer_spec.ts
@@ -7,370 +7,381 @@
  */
 
 import {describe, expect, it} from '../../../core/testing/src/testing_internal';
-import {CssLexer, CssLexerMode, CssToken, CssTokenType, cssScannerError, getRawMessage, getToken} from '../../src/css_parser/css_lexer';
+import {CssLexer, CssLexerMode, cssScannerError, CssToken, CssTokenType, getRawMessage, getToken} from '../../src/css_parser/css_lexer';
 
 (function() {
-  function tokenize(
-      code: string, trackComments: boolean = false,
-      mode: CssLexerMode = CssLexerMode.ALL): CssToken[] {
-    const scanner = new CssLexer().scan(code, trackComments);
-    scanner.setMode(mode);
+function tokenize(
+    code: string, trackComments: boolean = false,
+    mode: CssLexerMode = CssLexerMode.ALL): CssToken[] {
+  const scanner = new CssLexer().scan(code, trackComments);
+  scanner.setMode(mode);
 
-    const tokens: CssToken[] = [];
-    let output = scanner.scan();
-    while (output != null) {
-      const error = output.error;
-      if (error != null) {
-        throw cssScannerError(getToken(error), getRawMessage(error));
-      }
-      tokens.push(output.token);
-      output = scanner.scan();
+  const tokens: CssToken[] = [];
+  let output = scanner.scan();
+  while (output != null) {
+    const error = output.error;
+    if (error != null) {
+      throw cssScannerError(getToken(error), getRawMessage(error));
     }
-
-    return tokens;
+    tokens.push(output.token);
+    output = scanner.scan();
   }
 
-  describe('CssLexer', () => {
-    it('should lex newline characters as whitespace when whitespace mode is on', () => {
-      const newlines = ['\n', '\r\n', '\r', '\f'];
-      newlines.forEach((line) => {
-        const token = tokenize(line, false, CssLexerMode.ALL_TRACK_WS)[0];
-        expect(token.type).toEqual(CssTokenType.Whitespace);
-      });
-    });
+  return tokens;
+}
 
-    it('should combined newline characters as one newline token when whitespace mode is on', () => {
-      const newlines = ['\n', '\r\n', '\r', '\f'].join('');
-      const tokens = tokenize(newlines, false, CssLexerMode.ALL_TRACK_WS);
-      expect(tokens.length).toEqual(1);
-      expect(tokens[0].type).toEqual(CssTokenType.Whitespace);
+describe('CssLexer', () => {
+  it('should lex newline characters as whitespace when whitespace mode is on', () => {
+    const newlines = ['\n', '\r\n', '\r', '\f'];
+    newlines.forEach((line) => {
+      const token = tokenize(line, false, CssLexerMode.ALL_TRACK_WS)[0];
+      expect(token.type).toEqual(CssTokenType.Whitespace);
     });
+  });
 
-    it('should not consider whitespace or newline values at all when whitespace mode is off',
+  it('should combined newline characters as one newline token when whitespace mode is on', () => {
+    const newlines = ['\n', '\r\n', '\r', '\f'].join('');
+    const tokens = tokenize(newlines, false, CssLexerMode.ALL_TRACK_WS);
+    expect(tokens.length).toEqual(1);
+    expect(tokens[0].type).toEqual(CssTokenType.Whitespace);
+  });
+
+  it('should not consider whitespace or newline values at all when whitespace mode is off', () => {
+    const newlines = ['\n', '\r\n', '\r', '\f'].join('');
+    const tokens = tokenize(newlines);
+    expect(tokens.length).toEqual(0);
+  });
+
+  it('should lex simple selectors and their inner properties', () => {
+    const cssCode = '\n' +
+        '  .selector { my-prop: my-value; }\n';
+    const tokens = tokenize(cssCode);
+
+    expect(tokens[0].type).toEqual(CssTokenType.Character);
+    expect(tokens[0].strValue).toEqual('.');
+
+    expect(tokens[1].type).toEqual(CssTokenType.Identifier);
+    expect(tokens[1].strValue).toEqual('selector');
+
+    expect(tokens[2].type).toEqual(CssTokenType.Character);
+    expect(tokens[2].strValue).toEqual('{');
+
+    expect(tokens[3].type).toEqual(CssTokenType.Identifier);
+    expect(tokens[3].strValue).toEqual('my-prop');
+
+    expect(tokens[4].type).toEqual(CssTokenType.Character);
+    expect(tokens[4].strValue).toEqual(':');
+
+    expect(tokens[5].type).toEqual(CssTokenType.Identifier);
+    expect(tokens[5].strValue).toEqual('my-value');
+
+    expect(tokens[6].type).toEqual(CssTokenType.Character);
+    expect(tokens[6].strValue).toEqual(';');
+
+    expect(tokens[7].type).toEqual(CssTokenType.Character);
+    expect(tokens[7].strValue).toEqual('}');
+  });
+
+  it('should capture the column and line values for each token', () => {
+    const cssCode = '#id {\n' +
+        '  prop:value;\n' +
+        '}';
+
+    const tokens = tokenize(cssCode);
+
+    // #
+    expect(tokens[0].type).toEqual(CssTokenType.Character);
+    expect(tokens[0].column).toEqual(0);
+    expect(tokens[0].line).toEqual(0);
+
+    // id
+    expect(tokens[1].type).toEqual(CssTokenType.Identifier);
+    expect(tokens[1].column).toEqual(1);
+    expect(tokens[1].line).toEqual(0);
+
+    // {
+    expect(tokens[2].type).toEqual(CssTokenType.Character);
+    expect(tokens[2].column).toEqual(4);
+    expect(tokens[2].line).toEqual(0);
+
+    // prop
+    expect(tokens[3].type).toEqual(CssTokenType.Identifier);
+    expect(tokens[3].column).toEqual(2);
+    expect(tokens[3].line).toEqual(1);
+
+    // :
+    expect(tokens[4].type).toEqual(CssTokenType.Character);
+    expect(tokens[4].column).toEqual(6);
+    expect(tokens[4].line).toEqual(1);
+
+    // value
+    expect(tokens[5].type).toEqual(CssTokenType.Identifier);
+    expect(tokens[5].column).toEqual(7);
+    expect(tokens[5].line).toEqual(1);
+
+    // ;
+    expect(tokens[6].type).toEqual(CssTokenType.Character);
+    expect(tokens[6].column).toEqual(12);
+    expect(tokens[6].line).toEqual(1);
+
+    // }
+    expect(tokens[7].type).toEqual(CssTokenType.Character);
+    expect(tokens[7].column).toEqual(0);
+    expect(tokens[7].line).toEqual(2);
+  });
+
+  it('should lex quoted strings and escape accordingly', () => {
+    const cssCode = 'prop: \'some { value } \\\' that is quoted\'';
+    const tokens = tokenize(cssCode);
+
+    expect(tokens[0].type).toEqual(CssTokenType.Identifier);
+    expect(tokens[1].type).toEqual(CssTokenType.Character);
+    expect(tokens[2].type).toEqual(CssTokenType.String);
+    expect(tokens[2].strValue).toEqual('\'some { value } \\\' that is quoted\'');
+  });
+
+  it('should treat attribute operators as regular characters', () => {
+    tokenize('^|~+*').forEach((token) => {
+      expect(token.type).toEqual(CssTokenType.Character);
+    });
+  });
+
+  it('should lex numbers properly and set them as numbers', () => {
+    const cssCode = '0 1 -2 3.0 -4.001';
+    const tokens = tokenize(cssCode);
+
+    expect(tokens[0].type).toEqual(CssTokenType.Number);
+    expect(tokens[0].strValue).toEqual('0');
+
+    expect(tokens[1].type).toEqual(CssTokenType.Number);
+    expect(tokens[1].strValue).toEqual('1');
+
+    expect(tokens[2].type).toEqual(CssTokenType.Number);
+    expect(tokens[2].strValue).toEqual('-2');
+
+    expect(tokens[3].type).toEqual(CssTokenType.Number);
+    expect(tokens[3].strValue).toEqual('3.0');
+
+    expect(tokens[4].type).toEqual(CssTokenType.Number);
+    expect(tokens[4].strValue).toEqual('-4.001');
+  });
+
+  it('should lex @keywords', () => {
+    const cssCode = '@import()@something';
+    const tokens = tokenize(cssCode);
+
+    expect(tokens[0].type).toEqual(CssTokenType.AtKeyword);
+    expect(tokens[0].strValue).toEqual('@import');
+
+    expect(tokens[1].type).toEqual(CssTokenType.Character);
+    expect(tokens[1].strValue).toEqual('(');
+
+    expect(tokens[2].type).toEqual(CssTokenType.Character);
+    expect(tokens[2].strValue).toEqual(')');
+
+    expect(tokens[3].type).toEqual(CssTokenType.AtKeyword);
+    expect(tokens[3].strValue).toEqual('@something');
+  });
+
+  it('should still lex a number even if it has a dimension suffix', () => {
+    const cssCode = '40% is 40 percent';
+    const tokens = tokenize(cssCode);
+
+    expect(tokens[0].type).toEqual(CssTokenType.Number);
+    expect(tokens[0].strValue).toEqual('40');
+
+    expect(tokens[1].type).toEqual(CssTokenType.Character);
+    expect(tokens[1].strValue).toEqual('%');
+
+    expect(tokens[2].type).toEqual(CssTokenType.Identifier);
+    expect(tokens[2].strValue).toEqual('is');
+
+    expect(tokens[3].type).toEqual(CssTokenType.Number);
+    expect(tokens[3].strValue).toEqual('40');
+  });
+
+  it('should allow escaped character and unicode character-strings in CSS selectors', () => {
+    const cssCode = '\\123456 .some\\thing \{\}';
+    const tokens = tokenize(cssCode);
+
+    expect(tokens[0].type).toEqual(CssTokenType.Identifier);
+    expect(tokens[0].strValue).toEqual('\\123456');
+
+    expect(tokens[1].type).toEqual(CssTokenType.Character);
+    expect(tokens[2].type).toEqual(CssTokenType.Identifier);
+    expect(tokens[2].strValue).toEqual('some\\thing');
+  });
+
+  it('should distinguish identifiers and numbers from special characters', () => {
+    const cssCode = 'one*two=-4+three-4-equals_value$';
+    const tokens = tokenize(cssCode);
+
+    expect(tokens[0].type).toEqual(CssTokenType.Identifier);
+    expect(tokens[0].strValue).toEqual('one');
+
+    expect(tokens[1].type).toEqual(CssTokenType.Character);
+    expect(tokens[1].strValue).toEqual('*');
+
+    expect(tokens[2].type).toEqual(CssTokenType.Identifier);
+    expect(tokens[2].strValue).toEqual('two');
+
+    expect(tokens[3].type).toEqual(CssTokenType.Character);
+    expect(tokens[3].strValue).toEqual('=');
+
+    expect(tokens[4].type).toEqual(CssTokenType.Number);
+    expect(tokens[4].strValue).toEqual('-4');
+
+    expect(tokens[5].type).toEqual(CssTokenType.Character);
+    expect(tokens[5].strValue).toEqual('+');
+
+    expect(tokens[6].type).toEqual(CssTokenType.Identifier);
+    expect(tokens[6].strValue).toEqual('three-4-equals_value');
+
+    expect(tokens[7].type).toEqual(CssTokenType.Character);
+    expect(tokens[7].strValue).toEqual('$');
+  });
+
+  it('should filter out comments and whitespace by default', () => {
+    const cssCode = '.selector /* comment */ { /* value */ }';
+    const tokens = tokenize(cssCode);
+
+    expect(tokens[0].strValue).toEqual('.');
+    expect(tokens[1].strValue).toEqual('selector');
+    expect(tokens[2].strValue).toEqual('{');
+    expect(tokens[3].strValue).toEqual('}');
+  });
+
+  it('should track comments when the flag is set to true', () => {
+    const cssCode = '.selector /* comment */ { /* value */ }';
+    const trackComments = true;
+    const tokens = tokenize(cssCode, trackComments, CssLexerMode.ALL_TRACK_WS);
+
+    expect(tokens[0].strValue).toEqual('.');
+    expect(tokens[1].strValue).toEqual('selector');
+    expect(tokens[2].strValue).toEqual(' ');
+
+    expect(tokens[3].type).toEqual(CssTokenType.Comment);
+    expect(tokens[3].strValue).toEqual('/* comment */');
+
+    expect(tokens[4].strValue).toEqual(' ');
+    expect(tokens[5].strValue).toEqual('{');
+    expect(tokens[6].strValue).toEqual(' ');
+
+    expect(tokens[7].type).toEqual(CssTokenType.Comment);
+    expect(tokens[7].strValue).toEqual('/* value */');
+  });
+
+  describe('Selector Mode', () => {
+    it('should throw an error if a selector is being parsed while in the wrong mode', () => {
+      const cssCode = '.class > tag';
+
+      let capturedMessage: string|null = null;
+      try {
+        tokenize(cssCode, false, CssLexerMode.STYLE_BLOCK);
+      } catch (e) {
+        capturedMessage = getRawMessage(e);
+      }
+
+      expect(capturedMessage).toMatch(/Unexpected character \[\>\] at column 0:7 in expression/g);
+
+      capturedMessage = null;
+      try {
+        tokenize(cssCode, false, CssLexerMode.SELECTOR);
+      } catch (e) {
+        capturedMessage = getRawMessage(e);
+      }
+
+      expect(capturedMessage).toEqual(null);
+    });
+  });
+
+  describe('Attribute Mode', () => {
+    it('should consider attribute selectors as valid input and throw when an invalid modifier is used',
        () => {
-         const newlines = ['\n', '\r\n', '\r', '\f'].join('');
-         const tokens = tokenize(newlines);
-         expect(tokens.length).toEqual(0);
+         function tokenizeAttr(modifier: string) {
+           const cssCode = 'value' + modifier + '=\'something\'';
+           return tokenize(cssCode, false, CssLexerMode.ATTRIBUTE_SELECTOR);
+         }
+
+         expect(tokenizeAttr('*').length).toEqual(4);
+         expect(tokenizeAttr('|').length).toEqual(4);
+         expect(tokenizeAttr('^').length).toEqual(4);
+         expect(tokenizeAttr('$').length).toEqual(4);
+         expect(tokenizeAttr('~').length).toEqual(4);
+         expect(tokenizeAttr('').length).toEqual(3);
+
+         expect(() => {
+           tokenizeAttr('+');
+         }).toThrow();
        });
+  });
 
-    it('should lex simple selectors and their inner properties', () => {
-      const cssCode = '\n' +
-          '  .selector { my-prop: my-value; }\n';
-      const tokens = tokenize(cssCode);
+  describe('Media Query Mode', () => {
+    it('should validate media queries with a reduced subset of valid characters', () => {
+      function tokenizeQuery(code: string) {
+        return tokenize(code, false, CssLexerMode.MEDIA_QUERY);
+      }
 
-      expect(tokens[0].type).toEqual(CssTokenType.Character);
-      expect(tokens[0].strValue).toEqual('.');
+      // the reason why the numbers are so high is because MediaQueries keep
+      // track of the whitespace values
+      expect(tokenizeQuery('(prop: value)').length).toEqual(5);
+      expect(tokenizeQuery('(prop: value) and (prop2: value2)').length).toEqual(11);
+      expect(tokenizeQuery('tv and (prop: value)').length).toEqual(7);
+      expect(tokenizeQuery('print and ((prop: value) or (prop2: value2))').length).toEqual(15);
+      expect(tokenizeQuery('(content: \'something $ crazy inside &\')').length).toEqual(5);
 
-      expect(tokens[1].type).toEqual(CssTokenType.Identifier);
-      expect(tokens[1].strValue).toEqual('selector');
+      expect(() => {
+        tokenizeQuery('(max-height: 10 + 20)');
+      }).toThrow();
 
-      expect(tokens[2].type).toEqual(CssTokenType.Character);
-      expect(tokens[2].strValue).toEqual('{');
-
-      expect(tokens[3].type).toEqual(CssTokenType.Identifier);
-      expect(tokens[3].strValue).toEqual('my-prop');
-
-      expect(tokens[4].type).toEqual(CssTokenType.Character);
-      expect(tokens[4].strValue).toEqual(':');
-
-      expect(tokens[5].type).toEqual(CssTokenType.Identifier);
-      expect(tokens[5].strValue).toEqual('my-value');
-
-      expect(tokens[6].type).toEqual(CssTokenType.Character);
-      expect(tokens[6].strValue).toEqual(';');
-
-      expect(tokens[7].type).toEqual(CssTokenType.Character);
-      expect(tokens[7].strValue).toEqual('}');
+      expect(() => {
+        tokenizeQuery('(max-height: fifty < 100)');
+      }).toThrow();
     });
-
-    it('should capture the column and line values for each token', () => {
-      const cssCode = '#id {\n' +
-          '  prop:value;\n' +
-          '}';
-
-      const tokens = tokenize(cssCode);
-
-      // #
-      expect(tokens[0].type).toEqual(CssTokenType.Character);
-      expect(tokens[0].column).toEqual(0);
-      expect(tokens[0].line).toEqual(0);
-
-      // id
-      expect(tokens[1].type).toEqual(CssTokenType.Identifier);
-      expect(tokens[1].column).toEqual(1);
-      expect(tokens[1].line).toEqual(0);
-
-      // {
-      expect(tokens[2].type).toEqual(CssTokenType.Character);
-      expect(tokens[2].column).toEqual(4);
-      expect(tokens[2].line).toEqual(0);
-
-      // prop
-      expect(tokens[3].type).toEqual(CssTokenType.Identifier);
-      expect(tokens[3].column).toEqual(2);
-      expect(tokens[3].line).toEqual(1);
-
-      // :
-      expect(tokens[4].type).toEqual(CssTokenType.Character);
-      expect(tokens[4].column).toEqual(6);
-      expect(tokens[4].line).toEqual(1);
-
-      // value
-      expect(tokens[5].type).toEqual(CssTokenType.Identifier);
-      expect(tokens[5].column).toEqual(7);
-      expect(tokens[5].line).toEqual(1);
-
-      // ;
-      expect(tokens[6].type).toEqual(CssTokenType.Character);
-      expect(tokens[6].column).toEqual(12);
-      expect(tokens[6].line).toEqual(1);
-
-      // }
-      expect(tokens[7].type).toEqual(CssTokenType.Character);
-      expect(tokens[7].column).toEqual(0);
-      expect(tokens[7].line).toEqual(2);
-    });
-
-    it('should lex quoted strings and escape accordingly', () => {
-      const cssCode = 'prop: \'some { value } \\\' that is quoted\'';
-      const tokens = tokenize(cssCode);
-
-      expect(tokens[0].type).toEqual(CssTokenType.Identifier);
-      expect(tokens[1].type).toEqual(CssTokenType.Character);
-      expect(tokens[2].type).toEqual(CssTokenType.String);
-      expect(tokens[2].strValue).toEqual('\'some { value } \\\' that is quoted\'');
-    });
-
-    it('should treat attribute operators as regular characters', () => {
-      tokenize('^|~+*').forEach((token) => { expect(token.type).toEqual(CssTokenType.Character); });
-    });
-
-    it('should lex numbers properly and set them as numbers', () => {
-      const cssCode = '0 1 -2 3.0 -4.001';
-      const tokens = tokenize(cssCode);
-
-      expect(tokens[0].type).toEqual(CssTokenType.Number);
-      expect(tokens[0].strValue).toEqual('0');
-
-      expect(tokens[1].type).toEqual(CssTokenType.Number);
-      expect(tokens[1].strValue).toEqual('1');
-
-      expect(tokens[2].type).toEqual(CssTokenType.Number);
-      expect(tokens[2].strValue).toEqual('-2');
-
-      expect(tokens[3].type).toEqual(CssTokenType.Number);
-      expect(tokens[3].strValue).toEqual('3.0');
-
-      expect(tokens[4].type).toEqual(CssTokenType.Number);
-      expect(tokens[4].strValue).toEqual('-4.001');
-    });
-
-    it('should lex @keywords', () => {
-      const cssCode = '@import()@something';
-      const tokens = tokenize(cssCode);
-
-      expect(tokens[0].type).toEqual(CssTokenType.AtKeyword);
-      expect(tokens[0].strValue).toEqual('@import');
-
-      expect(tokens[1].type).toEqual(CssTokenType.Character);
-      expect(tokens[1].strValue).toEqual('(');
-
-      expect(tokens[2].type).toEqual(CssTokenType.Character);
-      expect(tokens[2].strValue).toEqual(')');
-
-      expect(tokens[3].type).toEqual(CssTokenType.AtKeyword);
-      expect(tokens[3].strValue).toEqual('@something');
-    });
-
-    it('should still lex a number even if it has a dimension suffix', () => {
-      const cssCode = '40% is 40 percent';
-      const tokens = tokenize(cssCode);
-
-      expect(tokens[0].type).toEqual(CssTokenType.Number);
-      expect(tokens[0].strValue).toEqual('40');
-
-      expect(tokens[1].type).toEqual(CssTokenType.Character);
-      expect(tokens[1].strValue).toEqual('%');
-
-      expect(tokens[2].type).toEqual(CssTokenType.Identifier);
-      expect(tokens[2].strValue).toEqual('is');
-
-      expect(tokens[3].type).toEqual(CssTokenType.Number);
-      expect(tokens[3].strValue).toEqual('40');
-    });
-
-    it('should allow escaped character and unicode character-strings in CSS selectors', () => {
-      const cssCode = '\\123456 .some\\thing \{\}';
-      const tokens = tokenize(cssCode);
-
-      expect(tokens[0].type).toEqual(CssTokenType.Identifier);
-      expect(tokens[0].strValue).toEqual('\\123456');
-
-      expect(tokens[1].type).toEqual(CssTokenType.Character);
-      expect(tokens[2].type).toEqual(CssTokenType.Identifier);
-      expect(tokens[2].strValue).toEqual('some\\thing');
-    });
-
-    it('should distinguish identifiers and numbers from special characters', () => {
-      const cssCode = 'one*two=-4+three-4-equals_value$';
-      const tokens = tokenize(cssCode);
-
-      expect(tokens[0].type).toEqual(CssTokenType.Identifier);
-      expect(tokens[0].strValue).toEqual('one');
-
-      expect(tokens[1].type).toEqual(CssTokenType.Character);
-      expect(tokens[1].strValue).toEqual('*');
-
-      expect(tokens[2].type).toEqual(CssTokenType.Identifier);
-      expect(tokens[2].strValue).toEqual('two');
-
-      expect(tokens[3].type).toEqual(CssTokenType.Character);
-      expect(tokens[3].strValue).toEqual('=');
-
-      expect(tokens[4].type).toEqual(CssTokenType.Number);
-      expect(tokens[4].strValue).toEqual('-4');
-
-      expect(tokens[5].type).toEqual(CssTokenType.Character);
-      expect(tokens[5].strValue).toEqual('+');
-
-      expect(tokens[6].type).toEqual(CssTokenType.Identifier);
-      expect(tokens[6].strValue).toEqual('three-4-equals_value');
-
-      expect(tokens[7].type).toEqual(CssTokenType.Character);
-      expect(tokens[7].strValue).toEqual('$');
-    });
-
-    it('should filter out comments and whitespace by default', () => {
-      const cssCode = '.selector /* comment */ { /* value */ }';
-      const tokens = tokenize(cssCode);
-
-      expect(tokens[0].strValue).toEqual('.');
-      expect(tokens[1].strValue).toEqual('selector');
-      expect(tokens[2].strValue).toEqual('{');
-      expect(tokens[3].strValue).toEqual('}');
-    });
-
-    it('should track comments when the flag is set to true', () => {
-      const cssCode = '.selector /* comment */ { /* value */ }';
-      const trackComments = true;
-      const tokens = tokenize(cssCode, trackComments, CssLexerMode.ALL_TRACK_WS);
-
-      expect(tokens[0].strValue).toEqual('.');
-      expect(tokens[1].strValue).toEqual('selector');
-      expect(tokens[2].strValue).toEqual(' ');
-
-      expect(tokens[3].type).toEqual(CssTokenType.Comment);
-      expect(tokens[3].strValue).toEqual('/* comment */');
-
-      expect(tokens[4].strValue).toEqual(' ');
-      expect(tokens[5].strValue).toEqual('{');
-      expect(tokens[6].strValue).toEqual(' ');
-
-      expect(tokens[7].type).toEqual(CssTokenType.Comment);
-      expect(tokens[7].strValue).toEqual('/* value */');
-    });
-
-    describe('Selector Mode', () => {
-      it('should throw an error if a selector is being parsed while in the wrong mode', () => {
-        const cssCode = '.class > tag';
-
-        let capturedMessage: string|null = null;
-        try {
-          tokenize(cssCode, false, CssLexerMode.STYLE_BLOCK);
-        } catch (e) {
-          capturedMessage = getRawMessage(e);
-        }
-
-        expect(capturedMessage).toMatch(/Unexpected character \[\>\] at column 0:7 in expression/g);
-
-        capturedMessage = null;
-        try {
-          tokenize(cssCode, false, CssLexerMode.SELECTOR);
-        } catch (e) {
-          capturedMessage = getRawMessage(e);
-        }
-
-        expect(capturedMessage).toEqual(null);
-      });
-    });
-
-    describe('Attribute Mode', () => {
-      it('should consider attribute selectors as valid input and throw when an invalid modifier is used',
-         () => {
-           function tokenizeAttr(modifier: string) {
-             const cssCode = 'value' + modifier + '=\'something\'';
-             return tokenize(cssCode, false, CssLexerMode.ATTRIBUTE_SELECTOR);
-           }
-
-           expect(tokenizeAttr('*').length).toEqual(4);
-           expect(tokenizeAttr('|').length).toEqual(4);
-           expect(tokenizeAttr('^').length).toEqual(4);
-           expect(tokenizeAttr('$').length).toEqual(4);
-           expect(tokenizeAttr('~').length).toEqual(4);
-           expect(tokenizeAttr('').length).toEqual(3);
-
-           expect(() => { tokenizeAttr('+'); }).toThrow();
-         });
-    });
-
-    describe('Media Query Mode', () => {
-      it('should validate media queries with a reduced subset of valid characters', () => {
-        function tokenizeQuery(code: string) {
-          return tokenize(code, false, CssLexerMode.MEDIA_QUERY);
-        }
-
-        // the reason why the numbers are so high is because MediaQueries keep
-        // track of the whitespace values
-        expect(tokenizeQuery('(prop: value)').length).toEqual(5);
-        expect(tokenizeQuery('(prop: value) and (prop2: value2)').length).toEqual(11);
-        expect(tokenizeQuery('tv and (prop: value)').length).toEqual(7);
-        expect(tokenizeQuery('print and ((prop: value) or (prop2: value2))').length).toEqual(15);
-        expect(tokenizeQuery('(content: \'something $ crazy inside &\')').length).toEqual(5);
-
-        expect(() => { tokenizeQuery('(max-height: 10 + 20)'); }).toThrow();
-
-        expect(() => { tokenizeQuery('(max-height: fifty < 100)'); }).toThrow();
-      });
-    });
-
-    describe('Pseudo Selector Mode', () => {
-      it('should validate pseudo selector identifiers with a reduced subset of valid characters',
-         () => {
-           function tokenizePseudo(code: string, withArgs = false): CssToken[] {
-             const mode = withArgs ? CssLexerMode.PSEUDO_SELECTOR_WITH_ARGUMENTS :
-                                     CssLexerMode.PSEUDO_SELECTOR;
-             return tokenize(code, false, mode);
-           }
-
-           expect(tokenizePseudo('hover').length).toEqual(1);
-           expect(tokenizePseudo('focus').length).toEqual(1);
-           expect(tokenizePseudo('lang(en-us)', true).length).toEqual(4);
-
-           expect(() => { tokenizePseudo('lang(something:broken)', true); }).toThrow();
-
-           expect(() => { tokenizePseudo('not(.selector)', true); }).toThrow();
-         });
-    });
-
-    describe(
-        'Style Block Mode', () => {
-          it('should style blocks with a reduced subset of valid characters',
-             () => {
-               function tokenizeStyles(code: string) {
-                 return tokenize(code, false, CssLexerMode.STYLE_BLOCK);
-               }
-
-               expect(tokenizeStyles(`
+  });
+
+  describe('Pseudo Selector Mode', () => {
+    it('should validate pseudo selector identifiers with a reduced subset of valid characters',
+       () => {
+         function tokenizePseudo(code: string, withArgs = false): CssToken[] {
+           const mode = withArgs ? CssLexerMode.PSEUDO_SELECTOR_WITH_ARGUMENTS :
+                                   CssLexerMode.PSEUDO_SELECTOR;
+           return tokenize(code, false, mode);
+         }
+
+         expect(tokenizePseudo('hover').length).toEqual(1);
+         expect(tokenizePseudo('focus').length).toEqual(1);
+         expect(tokenizePseudo('lang(en-us)', true).length).toEqual(4);
+
+         expect(() => {
+           tokenizePseudo('lang(something:broken)', true);
+         }).toThrow();
+
+         expect(() => {
+           tokenizePseudo('not(.selector)', true);
+         }).toThrow();
+       });
+  });
+
+  describe(
+      'Style Block Mode', () => {
+        it(
+            'should style blocks with a reduced subset of valid characters', () => {
+              function tokenizeStyles(code: string) {
+                return tokenize(code, false, CssLexerMode.STYLE_BLOCK);
+              }
+
+              expect(tokenizeStyles(`
           key: value;
           prop: 100;
           style: value3!important;
         `).length).toEqual(14);
 
-               expect(() => tokenizeStyles(` key$: value; `)).toThrow();
-               expect(() => tokenizeStyles(` key: value$; `)).toThrow();
-               expect(() => tokenizeStyles(` key: value + 10; `)).toThrow();
-               expect(() => tokenizeStyles(` key: &value; `)).toThrow();
-             });
-        });
-  });
+              expect(() => tokenizeStyles(` key$: value; `)).toThrow();
+              expect(() => tokenizeStyles(` key: value$; `)).toThrow();
+              expect(() => tokenizeStyles(` key: value + 10; `)).toThrow();
+              expect(() => tokenizeStyles(` key: &value; `)).toThrow();
+            });
+      });
+});
 })();

--- a/packages/compiler/test/css_parser/css_parser_spec.ts
+++ b/packages/compiler/test/css_parser/css_parser_spec.ts
@@ -111,26 +111,26 @@ export function assertTokens(tokens: CssToken[], valuesArr: string[]) {
       expect(ast.rules.length).toEqual(1);
 
       const rule = <CssKeyframeRuleAst>ast.rules[0];
-      expect(rule.name !.strValue).toEqual('rotateMe');
+      expect(rule.name!.strValue).toEqual('rotateMe');
 
       const block = <CssBlockAst>rule.block;
       const fromRule = <CssKeyframeDefinitionAst>block.entries[0];
 
-      expect(fromRule.name !.strValue).toEqual('from');
+      expect(fromRule.name!.strValue).toEqual('from');
       const fromStyle = <CssDefinitionAst>(<CssBlockAst>fromRule.block).entries[0];
       expect(fromStyle.property.strValue).toEqual('transform');
       assertTokens(fromStyle.value.tokens, ['rotate', '(', '-360', 'deg', ')']);
 
       const midRule = <CssKeyframeDefinitionAst>block.entries[1];
 
-      expect(midRule.name !.strValue).toEqual('50%');
+      expect(midRule.name!.strValue).toEqual('50%');
       const midStyle = <CssDefinitionAst>(<CssBlockAst>midRule.block).entries[0];
       expect(midStyle.property.strValue).toEqual('transform');
       assertTokens(midStyle.value.tokens, ['rotate', '(', '0', 'deg', ')']);
 
       const toRule = <CssKeyframeDefinitionAst>block.entries[2];
 
-      expect(toRule.name !.strValue).toEqual('to');
+      expect(toRule.name!.strValue).toEqual('to');
       const toStyle = <CssDefinitionAst>(<CssBlockAst>toRule.block).entries[0];
       expect(toStyle.property.strValue).toEqual('transform');
       assertTokens(toStyle.value.tokens, ['rotate', '(', '360', 'deg', ')']);
@@ -695,7 +695,7 @@ export function assertTokens(tokens: CssToken[], valuesArr: string[]) {
         const ast = output.ast;
 
         assertMatchesOffsetAndChar(ast.location.start, 0, '#');
-        assertMatchesOffsetAndChar(ast.location.end, 22, undefined !);
+        assertMatchesOffsetAndChar(ast.location.end, 22, undefined!);
       });
     });
 

--- a/packages/compiler/test/css_parser/css_visitor_spec.ts
+++ b/packages/compiler/test/css_parser/css_visitor_spec.ts
@@ -8,7 +8,7 @@
 
 
 import {beforeEach, describe, expect, it} from '../../../core/testing/src/testing_internal';
-import {CssAst, CssAstVisitor, CssAtRulePredicateAst, CssBlockAst, CssDefinitionAst, CssInlineRuleAst, CssKeyframeDefinitionAst, CssKeyframeRuleAst, CssMediaQueryRuleAst, CssPseudoSelectorAst, CssRuleAst, CssSelectorAst, CssSelectorRuleAst, CssSimpleSelectorAst, CssStyleSheetAst, CssStyleValueAst, CssStylesBlockAst, CssUnknownRuleAst, CssUnknownTokenListAst} from '../../src/css_parser/css_ast';
+import {CssAst, CssAstVisitor, CssAtRulePredicateAst, CssBlockAst, CssDefinitionAst, CssInlineRuleAst, CssKeyframeDefinitionAst, CssKeyframeRuleAst, CssMediaQueryRuleAst, CssPseudoSelectorAst, CssRuleAst, CssSelectorAst, CssSelectorRuleAst, CssSimpleSelectorAst, CssStylesBlockAst, CssStyleSheetAst, CssStyleValueAst, CssUnknownRuleAst, CssUnknownTokenListAst} from '../../src/css_parser/css_ast';
 import {BlockType, CssParseError, CssParser, CssToken} from '../../src/css_parser/css_parser';
 
 function _assertTokens(tokens: CssToken[], valuesArr: string[]): void {
@@ -29,7 +29,9 @@ class MyVisitor implements CssAstVisitor {
     this.captures[method].push([ast, context]);
   }
 
-  constructor(ast: CssStyleSheetAst, context: any) { ast.visit(this, context); }
+  constructor(ast: CssStyleSheetAst, context: any) {
+    ast.visit(this, context);
+  }
 
   visitCssValue(ast: CssStyleValueAst, context: any): void {
     this._capture('visitCssValue', ast, context);
@@ -61,20 +63,24 @@ class MyVisitor implements CssAstVisitor {
 
   visitCssSelectorRule(ast: CssSelectorRuleAst, context: any): void {
     this._capture('visitCssSelectorRule', ast, context);
-    ast.selectors.forEach((selAst: CssSelectorAst) => { selAst.visit(this, context); });
+    ast.selectors.forEach((selAst: CssSelectorAst) => {
+      selAst.visit(this, context);
+    });
     ast.block.visit(this, context);
   }
 
   visitCssSelector(ast: CssSelectorAst, context: any): void {
     this._capture('visitCssSelector', ast, context);
-    ast.selectorParts.forEach(
-        (simpleAst: CssSimpleSelectorAst) => { simpleAst.visit(this, context); });
+    ast.selectorParts.forEach((simpleAst: CssSimpleSelectorAst) => {
+      simpleAst.visit(this, context);
+    });
   }
 
   visitCssSimpleSelector(ast: CssSimpleSelectorAst, context: any): void {
     this._capture('visitCssSimpleSelector', ast, context);
-    ast.pseudoSelectors.forEach(
-        (pseudoAst: CssPseudoSelectorAst) => { pseudoAst.visit(this, context); });
+    ast.pseudoSelectors.forEach((pseudoAst: CssPseudoSelectorAst) => {
+      pseudoAst.visit(this, context);
+    });
   }
 
   visitCssDefinition(ast: CssDefinitionAst, context: any): void {
@@ -84,18 +90,23 @@ class MyVisitor implements CssAstVisitor {
 
   visitCssBlock(ast: CssBlockAst, context: any): void {
     this._capture('visitCssBlock', ast, context);
-    ast.entries.forEach((entryAst: CssAst) => { entryAst.visit(this, context); });
+    ast.entries.forEach((entryAst: CssAst) => {
+      entryAst.visit(this, context);
+    });
   }
 
   visitCssStylesBlock(ast: CssStylesBlockAst, context: any): void {
     this._capture('visitCssStylesBlock', ast, context);
-    ast.definitions.forEach(
-        (definitionAst: CssDefinitionAst) => { definitionAst.visit(this, context); });
+    ast.definitions.forEach((definitionAst: CssDefinitionAst) => {
+      definitionAst.visit(this, context);
+    });
   }
 
   visitCssStyleSheet(ast: CssStyleSheetAst, context: any): void {
     this._capture('visitCssStyleSheet', ast, context);
-    ast.rules.forEach((ruleAst: CssRuleAst) => { ruleAst.visit(this, context); });
+    ast.rules.forEach((ruleAst: CssRuleAst) => {
+      ruleAst.visit(this, context);
+    });
   }
 
   visitCssUnknownRule(ast: CssUnknownRuleAst, context: any): void {
@@ -116,21 +127,21 @@ function _getCaptureAst(capture: any[], index = 0): CssAst {
 }
 
 (function() {
-  function parse(cssCode: string, ignoreErrors: boolean = false) {
-    const output = new CssParser().parse(cssCode, 'some-fake-css-file.css');
-    const errors = output.errors;
-    if (errors.length > 0 && !ignoreErrors) {
-      throw new Error(errors.map((error: CssParseError) => error.msg).join(', '));
-    }
-    return output.ast;
+function parse(cssCode: string, ignoreErrors: boolean = false) {
+  const output = new CssParser().parse(cssCode, 'some-fake-css-file.css');
+  const errors = output.errors;
+  if (errors.length > 0 && !ignoreErrors) {
+    throw new Error(errors.map((error: CssParseError) => error.msg).join(', '));
   }
+  return output.ast;
+}
 
-  describe('CSS parsing and visiting', () => {
-    let ast: CssStyleSheetAst;
-    const context = {};
+describe('CSS parsing and visiting', () => {
+  let ast: CssStyleSheetAst;
+  const context = {};
 
-    beforeEach(() => {
-      const cssCode = `
+  beforeEach(() => {
+    const cssCode = `
         .rule1 { prop1: value1 }
         .rule2 { prop2: value2 }
 
@@ -149,174 +160,174 @@ function _getCaptureAst(capture: any[], index = 0): CssAst {
           }
         }
       `;
-      ast = parse(cssCode);
-    });
+    ast = parse(cssCode);
+  });
 
-    it('should parse and visit a stylesheet', () => {
-      const visitor = new MyVisitor(ast, context);
-      const captures = visitor.captures['visitCssStyleSheet'];
+  it('should parse and visit a stylesheet', () => {
+    const visitor = new MyVisitor(ast, context);
+    const captures = visitor.captures['visitCssStyleSheet'];
 
-      expect(captures.length).toEqual(1);
+    expect(captures.length).toEqual(1);
 
-      const capture = captures[0];
-      expect(capture[0]).toEqual(ast);
-      expect(capture[1]).toEqual(context);
-    });
+    const capture = captures[0];
+    expect(capture[0]).toEqual(ast);
+    expect(capture[1]).toEqual(context);
+  });
 
-    it('should parse and visit each of the stylesheet selectors', () => {
-      const visitor = new MyVisitor(ast, context);
-      const captures = visitor.captures['visitCssSelectorRule'];
+  it('should parse and visit each of the stylesheet selectors', () => {
+    const visitor = new MyVisitor(ast, context);
+    const captures = visitor.captures['visitCssSelectorRule'];
 
-      expect(captures.length).toEqual(3);
+    expect(captures.length).toEqual(3);
 
-      const rule1 = <CssSelectorRuleAst>_getCaptureAst(captures, 0);
-      expect(rule1).toEqual(ast.rules[0] as CssSelectorRuleAst);
+    const rule1 = <CssSelectorRuleAst>_getCaptureAst(captures, 0);
+    expect(rule1).toEqual(ast.rules[0] as CssSelectorRuleAst);
 
-      const firstSelector = rule1.selectors[0];
-      const firstSimpleSelector = firstSelector.selectorParts[0];
-      _assertTokens(firstSimpleSelector.tokens, ['.', 'rule1']);
+    const firstSelector = rule1.selectors[0];
+    const firstSimpleSelector = firstSelector.selectorParts[0];
+    _assertTokens(firstSimpleSelector.tokens, ['.', 'rule1']);
 
-      const rule2 = <CssSelectorRuleAst>_getCaptureAst(captures, 1);
-      expect(rule2).toEqual(ast.rules[1] as CssSelectorRuleAst);
+    const rule2 = <CssSelectorRuleAst>_getCaptureAst(captures, 1);
+    expect(rule2).toEqual(ast.rules[1] as CssSelectorRuleAst);
 
-      const secondSelector = rule2.selectors[0];
-      const secondSimpleSelector = secondSelector.selectorParts[0];
-      _assertTokens(secondSimpleSelector.tokens, ['.', 'rule2']);
+    const secondSelector = rule2.selectors[0];
+    const secondSimpleSelector = secondSelector.selectorParts[0];
+    _assertTokens(secondSimpleSelector.tokens, ['.', 'rule2']);
 
-      const rule3 = <CssSelectorRuleAst>_getCaptureAst(captures, 2);
-      expect(rule3).toEqual(
-          (ast.rules[2] as CssSelectorRuleAst).block.entries[0] as CssSelectorRuleAst);
+    const rule3 = <CssSelectorRuleAst>_getCaptureAst(captures, 2);
+    expect(rule3).toEqual(
+        (ast.rules[2] as CssSelectorRuleAst).block.entries[0] as CssSelectorRuleAst);
 
-      const thirdSelector = rule3.selectors[0];
-      const thirdSimpleSelector = thirdSelector.selectorParts[0];
-      _assertTokens(thirdSimpleSelector.tokens, ['#', 'rule3']);
-    });
+    const thirdSelector = rule3.selectors[0];
+    const thirdSimpleSelector = thirdSelector.selectorParts[0];
+    _assertTokens(thirdSimpleSelector.tokens, ['#', 'rule3']);
+  });
 
-    it('should parse and visit each of the stylesheet style key/value definitions', () => {
-      const visitor = new MyVisitor(ast, context);
-      const captures = visitor.captures['visitCssDefinition'];
+  it('should parse and visit each of the stylesheet style key/value definitions', () => {
+    const visitor = new MyVisitor(ast, context);
+    const captures = visitor.captures['visitCssDefinition'];
 
-      expect(captures.length).toEqual(5);
+    expect(captures.length).toEqual(5);
 
-      const def1 = <CssDefinitionAst>_getCaptureAst(captures, 0);
-      expect(def1.property.strValue).toEqual('prop1');
-      expect(def1.value.tokens[0].strValue).toEqual('value1');
+    const def1 = <CssDefinitionAst>_getCaptureAst(captures, 0);
+    expect(def1.property.strValue).toEqual('prop1');
+    expect(def1.value.tokens[0].strValue).toEqual('value1');
 
-      const def2 = <CssDefinitionAst>_getCaptureAst(captures, 1);
-      expect(def2.property.strValue).toEqual('prop2');
-      expect(def2.value.tokens[0].strValue).toEqual('value2');
+    const def2 = <CssDefinitionAst>_getCaptureAst(captures, 1);
+    expect(def2.property.strValue).toEqual('prop2');
+    expect(def2.value.tokens[0].strValue).toEqual('value2');
 
-      const def3 = <CssDefinitionAst>_getCaptureAst(captures, 2);
-      expect(def3.property.strValue).toEqual('prop3');
-      expect(def3.value.tokens[0].strValue).toEqual('value3');
+    const def3 = <CssDefinitionAst>_getCaptureAst(captures, 2);
+    expect(def3.property.strValue).toEqual('prop3');
+    expect(def3.value.tokens[0].strValue).toEqual('value3');
 
-      const def4 = <CssDefinitionAst>_getCaptureAst(captures, 3);
-      expect(def4.property.strValue).toEqual('prop4');
-      expect(def4.value.tokens[0].strValue).toEqual('value4');
+    const def4 = <CssDefinitionAst>_getCaptureAst(captures, 3);
+    expect(def4.property.strValue).toEqual('prop4');
+    expect(def4.value.tokens[0].strValue).toEqual('value4');
 
-      const def5 = <CssDefinitionAst>_getCaptureAst(captures, 4);
-      expect(def5.property.strValue).toEqual('prop5');
-      expect(def5.value.tokens[0].strValue).toEqual('value5');
-    });
+    const def5 = <CssDefinitionAst>_getCaptureAst(captures, 4);
+    expect(def5.property.strValue).toEqual('prop5');
+    expect(def5.value.tokens[0].strValue).toEqual('value5');
+  });
 
-    it('should parse and visit the associated media query values', () => {
-      const visitor = new MyVisitor(ast, context);
-      const captures = visitor.captures['visitCssMediaQueryRule'];
+  it('should parse and visit the associated media query values', () => {
+    const visitor = new MyVisitor(ast, context);
+    const captures = visitor.captures['visitCssMediaQueryRule'];
 
-      expect(captures.length).toEqual(1);
+    expect(captures.length).toEqual(1);
 
-      const query1 = <CssMediaQueryRuleAst>_getCaptureAst(captures, 0);
-      _assertTokens(query1.query.tokens, ['all', 'and', '(', 'max-width', '100', 'px', ')']);
-      expect(query1.block.entries.length).toEqual(1);
-    });
+    const query1 = <CssMediaQueryRuleAst>_getCaptureAst(captures, 0);
+    _assertTokens(query1.query.tokens, ['all', 'and', '(', 'max-width', '100', 'px', ')']);
+    expect(query1.block.entries.length).toEqual(1);
+  });
 
-    it('should capture the media query predicate', () => {
-      const visitor = new MyVisitor(ast, context);
-      const captures = visitor.captures['visitCssAtRulePredicate'];
+  it('should capture the media query predicate', () => {
+    const visitor = new MyVisitor(ast, context);
+    const captures = visitor.captures['visitCssAtRulePredicate'];
 
-      expect(captures.length).toEqual(1);
+    expect(captures.length).toEqual(1);
 
-      const predicate = <CssAtRulePredicateAst>_getCaptureAst(captures, 0);
-      expect(predicate.strValue).toEqual('@media all (max-width: 100px)');
-    });
+    const predicate = <CssAtRulePredicateAst>_getCaptureAst(captures, 0);
+    expect(predicate.strValue).toEqual('@media all (max-width: 100px)');
+  });
 
-    it('should parse and visit the associated "@inline" rule values', () => {
-      const visitor = new MyVisitor(ast, context);
-      const captures = visitor.captures['visitCssInlineRule'];
+  it('should parse and visit the associated "@inline" rule values', () => {
+    const visitor = new MyVisitor(ast, context);
+    const captures = visitor.captures['visitCssInlineRule'];
 
-      expect(captures.length).toEqual(1);
+    expect(captures.length).toEqual(1);
 
-      const inline1 = <CssInlineRuleAst>_getCaptureAst(captures, 0);
-      expect(inline1.type).toEqual(BlockType.Import);
-      _assertTokens(inline1.value.tokens, ['url', '(', 'file.css', ')']);
-    });
+    const inline1 = <CssInlineRuleAst>_getCaptureAst(captures, 0);
+    expect(inline1.type).toEqual(BlockType.Import);
+    _assertTokens(inline1.value.tokens, ['url', '(', 'file.css', ')']);
+  });
 
-    it('should parse and visit the keyframe blocks', () => {
-      const visitor = new MyVisitor(ast, context);
-      const captures = visitor.captures['visitCssKeyframeRule'];
+  it('should parse and visit the keyframe blocks', () => {
+    const visitor = new MyVisitor(ast, context);
+    const captures = visitor.captures['visitCssKeyframeRule'];
 
-      expect(captures.length).toEqual(1);
+    expect(captures.length).toEqual(1);
 
-      const keyframe1 = <CssKeyframeRuleAst>_getCaptureAst(captures, 0);
-      expect(keyframe1.name !.strValue).toEqual('rotate');
-      expect(keyframe1.block.entries.length).toEqual(2);
-    });
+    const keyframe1 = <CssKeyframeRuleAst>_getCaptureAst(captures, 0);
+    expect(keyframe1.name!.strValue).toEqual('rotate');
+    expect(keyframe1.block.entries.length).toEqual(2);
+  });
 
-    it('should parse and visit the associated keyframe rules', () => {
-      const visitor = new MyVisitor(ast, context);
-      const captures = visitor.captures['visitCssKeyframeDefinition'];
+  it('should parse and visit the associated keyframe rules', () => {
+    const visitor = new MyVisitor(ast, context);
+    const captures = visitor.captures['visitCssKeyframeDefinition'];
 
-      expect(captures.length).toEqual(2);
+    expect(captures.length).toEqual(2);
 
-      const def1 = <CssKeyframeDefinitionAst>_getCaptureAst(captures, 0);
-      _assertTokens(def1.steps, ['from']);
-      expect(def1.block.entries.length).toEqual(1);
+    const def1 = <CssKeyframeDefinitionAst>_getCaptureAst(captures, 0);
+    _assertTokens(def1.steps, ['from']);
+    expect(def1.block.entries.length).toEqual(1);
 
-      const def2 = <CssKeyframeDefinitionAst>_getCaptureAst(captures, 1);
-      _assertTokens(def2.steps, ['50%', '100%']);
-      expect(def2.block.entries.length).toEqual(1);
-    });
+    const def2 = <CssKeyframeDefinitionAst>_getCaptureAst(captures, 1);
+    _assertTokens(def2.steps, ['50%', '100%']);
+    expect(def2.block.entries.length).toEqual(1);
+  });
 
-    it('should visit an unknown `@` rule', () => {
-      const cssCode = `
+  it('should visit an unknown `@` rule', () => {
+    const cssCode = `
         @someUnknownRule param {
           one two three
         }
       `;
-      ast = parse(cssCode, true);
-      const visitor = new MyVisitor(ast, context);
-      const captures = visitor.captures['visitCssUnknownRule'];
+    ast = parse(cssCode, true);
+    const visitor = new MyVisitor(ast, context);
+    const captures = visitor.captures['visitCssUnknownRule'];
 
-      expect(captures.length).toEqual(1);
+    expect(captures.length).toEqual(1);
 
-      const rule = <CssUnknownRuleAst>_getCaptureAst(captures, 0);
-      expect(rule.ruleName).toEqual('@someUnknownRule');
+    const rule = <CssUnknownRuleAst>_getCaptureAst(captures, 0);
+    expect(rule.ruleName).toEqual('@someUnknownRule');
 
-      _assertTokens(rule.tokens, ['param', '{', 'one', 'two', 'three', '}']);
-    });
-
-    it('should collect an invalid list of tokens before a valid selector', () => {
-      const cssCode = 'one two three four five; selector { }';
-      ast = parse(cssCode, true);
-      const visitor = new MyVisitor(ast, context);
-      const captures = visitor.captures['visitCssUnknownTokenList'];
-
-      expect(captures.length).toEqual(1);
-
-      const rule = <CssUnknownTokenListAst>_getCaptureAst(captures, 0);
-      _assertTokens(rule.tokens, ['one', 'two', 'three', 'four', 'five']);
-    });
-
-    it('should collect an invalid list of tokens after a valid selector', () => {
-      const cssCode = 'selector { } six seven eight';
-      ast = parse(cssCode, true);
-      const visitor = new MyVisitor(ast, context);
-      const captures = visitor.captures['visitCssUnknownTokenList'];
-
-      expect(captures.length).toEqual(1);
-
-      const rule = <CssUnknownTokenListAst>_getCaptureAst(captures, 0);
-      _assertTokens(rule.tokens, ['six', 'seven', 'eight']);
-    });
+    _assertTokens(rule.tokens, ['param', '{', 'one', 'two', 'three', '}']);
   });
+
+  it('should collect an invalid list of tokens before a valid selector', () => {
+    const cssCode = 'one two three four five; selector { }';
+    ast = parse(cssCode, true);
+    const visitor = new MyVisitor(ast, context);
+    const captures = visitor.captures['visitCssUnknownTokenList'];
+
+    expect(captures.length).toEqual(1);
+
+    const rule = <CssUnknownTokenListAst>_getCaptureAst(captures, 0);
+    _assertTokens(rule.tokens, ['one', 'two', 'three', 'four', 'five']);
+  });
+
+  it('should collect an invalid list of tokens after a valid selector', () => {
+    const cssCode = 'selector { } six seven eight';
+    ast = parse(cssCode, true);
+    const visitor = new MyVisitor(ast, context);
+    const captures = visitor.captures['visitCssUnknownTokenList'];
+
+    expect(captures.length).toEqual(1);
+
+    const rule = <CssUnknownTokenListAst>_getCaptureAst(captures, 0);
+    _assertTokens(rule.tokens, ['six', 'seven', 'eight']);
+  });
+});
 })();

--- a/packages/compiler/test/directive_lifecycle_spec.ts
+++ b/packages/compiler/test/directive_lifecycle_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {LifecycleHooks as Hooks, hasLifecycleHook as hasLifecycleHookImpl} from '@angular/compiler/src/lifecycle_reflector';
+import {hasLifecycleHook as hasLifecycleHookImpl, LifecycleHooks as Hooks} from '@angular/compiler/src/lifecycle_reflector';
 import {SimpleChanges} from '@angular/core';
 import {JitReflector} from '@angular/platform-browser-dynamic/src/compiler_reflector';
 
@@ -17,14 +17,14 @@ function hasLifecycleHook(hook: Hooks, directive: any): boolean {
 {
   describe('Create Directive', () => {
     describe('lifecycle', () => {
-
       describe('ngOnChanges', () => {
         it('should be true when the directive has the ngOnChanges method', () => {
           expect(hasLifecycleHook(Hooks.OnChanges, DirectiveWithOnChangesMethod)).toBe(true);
         });
 
-        it('should be false otherwise',
-           () => { expect(hasLifecycleHook(Hooks.OnChanges, DirectiveNoHooks)).toBe(false); });
+        it('should be false otherwise', () => {
+          expect(hasLifecycleHook(Hooks.OnChanges, DirectiveNoHooks)).toBe(false);
+        });
       });
 
       describe('ngOnDestroy', () => {
@@ -32,16 +32,19 @@ function hasLifecycleHook(hook: Hooks, directive: any): boolean {
           expect(hasLifecycleHook(Hooks.OnDestroy, DirectiveWithOnDestroyMethod)).toBe(true);
         });
 
-        it('should be false otherwise',
-           () => { expect(hasLifecycleHook(Hooks.OnDestroy, DirectiveNoHooks)).toBe(false); });
+        it('should be false otherwise', () => {
+          expect(hasLifecycleHook(Hooks.OnDestroy, DirectiveNoHooks)).toBe(false);
+        });
       });
 
       describe('ngOnInit', () => {
-        it('should be true when the directive has the ngOnInit method',
-           () => { expect(hasLifecycleHook(Hooks.OnInit, DirectiveWithOnInitMethod)).toBe(true); });
+        it('should be true when the directive has the ngOnInit method', () => {
+          expect(hasLifecycleHook(Hooks.OnInit, DirectiveWithOnInitMethod)).toBe(true);
+        });
 
-        it('should be false otherwise',
-           () => { expect(hasLifecycleHook(Hooks.OnInit, DirectiveNoHooks)).toBe(false); });
+        it('should be false otherwise', () => {
+          expect(hasLifecycleHook(Hooks.OnInit, DirectiveNoHooks)).toBe(false);
+        });
       });
 
       describe('ngDoCheck', () => {
@@ -49,8 +52,9 @@ function hasLifecycleHook(hook: Hooks, directive: any): boolean {
           expect(hasLifecycleHook(Hooks.DoCheck, DirectiveWithOnCheckMethod)).toBe(true);
         });
 
-        it('should be false otherwise',
-           () => { expect(hasLifecycleHook(Hooks.DoCheck, DirectiveNoHooks)).toBe(false); });
+        it('should be false otherwise', () => {
+          expect(hasLifecycleHook(Hooks.DoCheck, DirectiveNoHooks)).toBe(false);
+        });
       });
 
       describe('ngAfterContentInit', () => {
@@ -83,8 +87,9 @@ function hasLifecycleHook(hook: Hooks, directive: any): boolean {
               .toBe(true);
         });
 
-        it('should be false otherwise',
-           () => { expect(hasLifecycleHook(Hooks.AfterViewInit, DirectiveNoHooks)).toBe(false); });
+        it('should be false otherwise', () => {
+          expect(hasLifecycleHook(Hooks.AfterViewInit, DirectiveNoHooks)).toBe(false);
+        });
       });
 
       describe('ngAfterViewChecked', () => {

--- a/packages/compiler/test/directive_normalizer_spec.ts
+++ b/packages/compiler/test/directive_normalizer_spec.ts
@@ -10,7 +10,7 @@ import {CompilerConfig, preserveWhitespacesDefault} from '@angular/compiler/src/
 import {DirectiveNormalizer} from '@angular/compiler/src/directive_normalizer';
 import {ResourceLoader} from '@angular/compiler/src/resource_loader';
 import {ViewEncapsulation} from '@angular/core/src/metadata/view';
-import {TestBed, inject} from '@angular/core/testing';
+import {inject, TestBed} from '@angular/core/testing';
 
 import {noUndefined} from '../src/util';
 
@@ -20,7 +20,10 @@ const SOME_MODULE_URL = 'package:some/module/a.js';
 const SOME_HTTP_MODULE_URL = 'http://some/module/a.js';
 
 function normalizeTemplate(normalizer: DirectiveNormalizer, o: {
-  moduleUrl?: string; template?: string | null; templateUrl?: string | null; styles?: string[];
+  moduleUrl?: string;
+  template?: string | null;
+  templateUrl?: string | null;
+  styles?: string[];
   styleUrls?: string[];
   interpolation?: [string, string] | null;
   encapsulation?: ViewEncapsulation | null;
@@ -51,8 +54,7 @@ function normalizeTemplate(normalizer: DirectiveNormalizer, o: {
           jasmine.createSpy('get').and.callFake((url: string) => `resource(${url})`);
       const resourceLoader = {get: resourceLoaderSpy};
       TestBed.configureCompiler({
-        providers:
-            [...TEST_COMPILER_PROVIDERS, {provide: ResourceLoader, useValue: resourceLoader}]
+        providers: [...TEST_COMPILER_PROVIDERS, {provide: ResourceLoader, useValue: resourceLoader}]
       });
     });
 
@@ -64,12 +66,12 @@ function normalizeTemplate(normalizer: DirectiveNormalizer, o: {
          }));
       it('should throw if template is not a string',
          inject([DirectiveNormalizer], (normalizer: DirectiveNormalizer) => {
-           expect(() => normalizeTemplate(normalizer, {template: <any>{}}))
+           expect(() => normalizeTemplate(normalizer, {template: <any> {}}))
                .toThrowError('The template specified for component SomeComp is not a string');
          }));
       it('should throw if templateUrl is not a string',
          inject([DirectiveNormalizer], (normalizer: DirectiveNormalizer) => {
-           expect(() => normalizeTemplate(normalizer, {templateUrl: <any>{}}))
+           expect(() => normalizeTemplate(normalizer, {templateUrl: <any> {}}))
                .toThrowError('The templateUrl specified for component SomeComp is not a string');
          }));
       it('should throw if both template and templateUrl are defined',
@@ -89,11 +91,9 @@ function normalizeTemplate(normalizer: DirectiveNormalizer, o: {
                .toThrowError(
                    'The preserveWhitespaces option for component SomeComp must be a boolean');
          }));
-
     });
 
     describe('inline template', () => {
-
       it('should store the template',
          inject([DirectiveNormalizer], (normalizer: DirectiveNormalizer) => {
            const template = <CompileTemplateMetadata>normalizeTemplate(normalizer, {
@@ -174,7 +174,6 @@ function normalizeTemplate(normalizer: DirectiveNormalizer, o: {
        }));
 
     describe('externalStylesheets', () => {
-
       it('should load an external stylesheet',
          inject([DirectiveNormalizer], (normalizer: DirectiveNormalizer) => {
            const template = <CompileTemplateMetadata>normalizeTemplate(
@@ -222,7 +221,6 @@ function normalizeTemplate(normalizer: DirectiveNormalizer, o: {
 
            expect(resourceLoaderSpy).toHaveBeenCalledTimes(1);
          }));
-
     });
 
     describe('normalizeLoadedTemplate', () => {

--- a/packages/compiler/test/directive_resolver_mock_spec.ts
+++ b/packages/compiler/test/directive_resolver_mock_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, Directive, Injector} from '@angular/core';
-import {TestBed, inject} from '@angular/core/testing';
+import {inject, TestBed} from '@angular/core/testing';
 import {JitReflector} from '@angular/platform-browser-dynamic/src/compiler_reflector';
 
 import {MockDirectiveResolver} from '../testing';

--- a/packages/compiler/test/directive_resolver_spec.ts
+++ b/packages/compiler/test/directive_resolver_spec.ts
@@ -32,13 +32,16 @@ class SomeDirectiveWithOutputs {
 @Directive({selector: 'someDirective'})
 class SomeDirectiveWithSetterProps {
   @Input('renamed')
-  set a(value: any) {}
+  set a(value: any) {
+  }
 }
 
 @Directive({selector: 'someDirective'})
 class SomeDirectiveWithGetterOutputs {
   @Output('renamed')
-  get a(): any { return null; }
+  get a(): any {
+    return null;
+  }
 }
 
 @Directive({selector: 'someDirective', host: {'[c]': 'c'}})
@@ -51,9 +54,11 @@ class SomeDirectiveWithHostBindings {
 @Directive({selector: 'someDirective', host: {'(c)': 'onC()'}})
 class SomeDirectiveWithHostListeners {
   @HostListener('a')
-  onA() {}
+  onA() {
+  }
   @HostListener('b', ['$event.value'])
-  onB(value: any) {}
+  onB(value: any) {
+  }
 }
 
 @Directive({selector: 'someDirective', queries: {'cs': new ContentChildren('c')}})
@@ -101,13 +106,15 @@ class SomeDirectiveWithSameHostBindingAndInput {
 @Directive({selector: 'someDirective'})
 class SomeDirectiveWithMalformedHostBinding1 {
   @HostBinding('(a)')
-  onA() {}
+  onA() {
+  }
 }
 
 @Directive({selector: 'someDirective'})
 class SomeDirectiveWithMalformedHostBinding2 {
   @HostBinding('[a]')
-  onA() {}
+  onA() {
+  }
 }
 
 class SomeDirectiveWithoutMetadata {}
@@ -116,7 +123,9 @@ class SomeDirectiveWithoutMetadata {}
   describe('DirectiveResolver', () => {
     let resolver: DirectiveResolver;
 
-    beforeEach(() => { resolver = new DirectiveResolver(new JitReflector()); });
+    beforeEach(() => {
+      resolver = new DirectiveResolver(new JitReflector());
+    });
 
     it('should read out the Directive metadata', () => {
       const directiveMetadata = resolver.resolve(SomeDirective);
@@ -204,8 +213,7 @@ class SomeDirectiveWithoutMetadata {}
       it('should prefer @Input over @Directive.inputs', () => {
         @Directive({selector: 'someDirective', inputs: ['a']})
         class SomeDirectiveWithDuplicateInputs {
-          @Input('a')
-          propA: any;
+          @Input('a') propA: any;
         }
         const directiveMetadata = resolver.resolve(SomeDirectiveWithDuplicateInputs);
         expect(directiveMetadata.inputs).toEqual(['propA: a']);
@@ -214,17 +222,13 @@ class SomeDirectiveWithoutMetadata {}
       it('should support inheriting inputs', () => {
         @Directive({selector: 'p'})
         class Parent {
-          @Input()
-          p1: any;
-          @Input('p21')
-          p2: any;
+          @Input() p1: any;
+          @Input('p21') p2: any;
         }
 
         class Child extends Parent {
-          @Input('p22')
-          p2: any;
-          @Input()
-          p3: any;
+          @Input('p22') p2: any;
+          @Input() p3: any;
         }
 
         const directiveMetadata = resolver.resolve(Child);
@@ -264,8 +268,7 @@ class SomeDirectiveWithoutMetadata {}
       it('should prefer @Output over @Directive.outputs', () => {
         @Directive({selector: 'someDirective', outputs: ['a']})
         class SomeDirectiveWithDuplicateOutputs {
-          @Output('a')
-          propA: any;
+          @Output('a') propA: any;
         }
         const directiveMetadata = resolver.resolve(SomeDirectiveWithDuplicateOutputs);
         expect(directiveMetadata.outputs).toEqual(['propA: a']);
@@ -274,17 +277,13 @@ class SomeDirectiveWithoutMetadata {}
       it('should support inheriting outputs', () => {
         @Directive({selector: 'p'})
         class Parent {
-          @Output()
-          p1: any;
-          @Output('p21')
-          p2: any;
+          @Output() p1: any;
+          @Output('p21') p2: any;
         }
 
         class Child extends Parent {
-          @Output('p22')
-          p2: any;
-          @Output()
-          p3: any;
+          @Output('p22') p2: any;
+          @Output() p3: any;
         }
 
         const directiveMetadata = resolver.resolve(Child);
@@ -324,17 +323,13 @@ class SomeDirectiveWithoutMetadata {}
       it('should support inheriting host bindings', () => {
         @Directive({selector: 'p'})
         class Parent {
-          @HostBinding()
-          p1: any;
-          @HostBinding('p21')
-          p2: any;
+          @HostBinding() p1: any;
+          @HostBinding('p21') p2: any;
         }
 
         class Child extends Parent {
-          @HostBinding('p22')
-          p2: any;
-          @HostBinding()
-          p3: any;
+          @HostBinding('p22') p2: any;
+          @HostBinding() p3: any;
         }
 
         const directiveMetadata = resolver.resolve(Child);
@@ -346,16 +341,20 @@ class SomeDirectiveWithoutMetadata {}
         @Directive({selector: 'p'})
         class Parent {
           @HostListener('p1')
-          p1() {}
+          p1() {
+          }
           @HostListener('p21')
-          p2() {}
+          p2() {
+          }
         }
 
         class Child extends Parent {
           @HostListener('p22')
-          p2() {}
+          p2() {
+          }
           @HostListener('p3')
-          p3() {}
+          p3() {
+          }
         }
 
         const directiveMetadata = resolver.resolve(Child);
@@ -366,19 +365,20 @@ class SomeDirectiveWithoutMetadata {}
       it('should combine host bindings and listeners during inheritance', () => {
         @Directive({selector: 'p'})
         class Parent {
-          @HostListener('p11') @HostListener('p12')
-          p1() {}
+          @HostListener('p11')
+          @HostListener('p12')
+          p1() {
+          }
 
-          @HostBinding('p21') @HostBinding('p22')
-          p2: any;
+          @HostBinding('p21') @HostBinding('p22') p2: any;
         }
 
         class Child extends Parent {
           @HostListener('c1')
-          p1() {}
+          p1() {
+          }
 
-          @HostBinding('c2')
-          p2: any;
+          @HostBinding('c2') p2: any;
         }
 
         const directiveMetadata = resolver.resolve(Child);
@@ -421,17 +421,13 @@ class SomeDirectiveWithoutMetadata {}
       it('should support inheriting queries', () => {
         @Directive({selector: 'p'})
         class Parent {
-          @ContentChild('p1')
-          p1: any;
-          @ContentChild('p21')
-          p2: any;
+          @ContentChild('p1') p1: any;
+          @ContentChild('p21') p2: any;
         }
 
         class Child extends Parent {
-          @ContentChild('p22')
-          p2: any;
-          @ContentChild('p3')
-          p3: any;
+          @ContentChild('p22') p2: any;
+          @ContentChild('p3') p3: any;
         }
 
         const directiveMetadata = resolver.resolve(Child);

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -101,14 +101,17 @@ function expectErrorToken(token: Token, index: any, end: number, message: string
         expectNumberToken(tokens[0], 0, 2, 88);
       });
 
-      it('should tokenize numbers within index ops',
-         () => { expectNumberToken(lex('a[22]')[2], 2, 4, 22); });
+      it('should tokenize numbers within index ops', () => {
+        expectNumberToken(lex('a[22]')[2], 2, 4, 22);
+      });
 
-      it('should tokenize simple quoted strings',
-         () => { expectStringToken(lex('"a"')[0], 0, 3, 'a'); });
+      it('should tokenize simple quoted strings', () => {
+        expectStringToken(lex('"a"')[0], 0, 3, 'a');
+      });
 
-      it('should tokenize quoted strings with escaped quotes',
-         () => { expectStringToken(lex('"a\\""')[0], 0, 5, 'a"'); });
+      it('should tokenize quoted strings with escaped quotes', () => {
+        expectStringToken(lex('"a\\""')[0], 0, 5, 'a"');
+      });
 
       it('should tokenize a string', () => {
         const tokens: Token[] = lex('j-a.bc[22]+1.3|f:\'a\\\'c\':"d\\"e"');
@@ -213,7 +216,9 @@ function expectErrorToken(token: Token, index: any, end: number, message: string
         expectCharacterToken(tokens[13], 16, 17, ')');
       });
 
-      it('should tokenize number', () => { expectNumberToken(lex('0.5')[0], 0, 3, 0.5); });
+      it('should tokenize number', () => {
+        expectNumberToken(lex('0.5')[0], 0, 3, 0.5);
+      });
 
       it('should tokenize number with exponent', () => {
         let tokens: Token[] = lex('0.5E-10');
@@ -233,8 +238,9 @@ function expectErrorToken(token: Token, index: any, end: number, message: string
             'Lexer Error: Invalid exponent at column 4 in expression [0.5E-A]');
       });
 
-      it('should tokenize number starting with a dot',
-         () => { expectNumberToken(lex('.5')[0], 0, 2, 0.5); });
+      it('should tokenize number starting with a dot', () => {
+        expectNumberToken(lex('.5')[0], 0, 2, 0.5);
+      });
 
       it('should throw error on invalid unicode', () => {
         expectErrorToken(
@@ -242,11 +248,13 @@ function expectErrorToken(token: Token, index: any, end: number, message: string
             'Lexer Error: Invalid unicode escape [\\u1\'\'b] at column 2 in expression [\'\\u1\'\'bla\']');
       });
 
-      it('should tokenize hash as operator',
-         () => { expectOperatorToken(lex('#')[0], 0, 1, '#'); });
+      it('should tokenize hash as operator', () => {
+        expectOperatorToken(lex('#')[0], 0, 1, '#');
+      });
 
-      it('should tokenize ?. as operator',
-         () => { expectOperatorToken(lex('?.')[0], 0, 2, '?.'); });
+      it('should tokenize ?. as operator', () => {
+        expectOperatorToken(lex('?.')[0], 0, 2, '?.');
+      });
     });
   });
 }

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -17,16 +17,22 @@ import {validate} from './utils/validator';
 
 describe('parser', () => {
   describe('parseAction', () => {
-    it('should parse numbers', () => { checkAction('1'); });
+    it('should parse numbers', () => {
+      checkAction('1');
+    });
 
     it('should parse strings', () => {
       checkAction('\'1\'', '"1"');
       checkAction('"1"');
     });
 
-    it('should parse null', () => { checkAction('null'); });
+    it('should parse null', () => {
+      checkAction('null');
+    });
 
-    it('should parse undefined', () => { checkAction('undefined'); });
+    it('should parse undefined', () => {
+      checkAction('undefined');
+    });
 
     it('should parse unary - expressions', () => {
       checkAction('-1', '0 - 1');
@@ -47,10 +53,13 @@ describe('parser', () => {
       checkAction('a!!!!.b');
     });
 
-    it('should parse multiplicative expressions',
-       () => { checkAction('3*4/2%5', '3 * 4 / 2 % 5'); });
+    it('should parse multiplicative expressions', () => {
+      checkAction('3*4/2%5', '3 * 4 / 2 % 5');
+    });
 
-    it('should parse additive expressions', () => { checkAction('3 + 6 - 2'); });
+    it('should parse additive expressions', () => {
+      checkAction('3 + 6 - 2');
+    });
 
     it('should parse relational expressions', () => {
       checkAction('2 < 3');
@@ -74,14 +83,21 @@ describe('parser', () => {
       checkAction('true || false');
     });
 
-    it('should parse grouped expressions', () => { checkAction('(1 + 2) * 3', '1 + 2 * 3'); });
+    it('should parse grouped expressions', () => {
+      checkAction('(1 + 2) * 3', '1 + 2 * 3');
+    });
 
-    it('should ignore comments in expressions', () => { checkAction('a //comment', 'a'); });
+    it('should ignore comments in expressions', () => {
+      checkAction('a //comment', 'a');
+    });
 
-    it('should retain // in string literals',
-       () => { checkAction(`"http://www.google.com"`, `"http://www.google.com"`); });
+    it('should retain // in string literals', () => {
+      checkAction(`"http://www.google.com"`, `"http://www.google.com"`);
+    });
 
-    it('should parse an empty string', () => { checkAction(''); });
+    it('should parse an empty string', () => {
+      checkAction('');
+    });
 
     describe('literals', () => {
       it('should parse array', () => {
@@ -133,7 +149,9 @@ describe('parser', () => {
     });
 
     describe('functional calls', () => {
-      it('should parse function calls', () => { checkAction('fn()(1, 2)'); });
+      it('should parse function calls', () => {
+        checkAction('fn()(1, 2)');
+      });
     });
 
     describe('conditional', () => {
@@ -154,20 +172,26 @@ describe('parser', () => {
         checkAction('a = 123; b = 234;');
       });
 
-      it('should report on safe field assignments',
-         () => { expectActionError('a?.a = 123', 'cannot be used in the assignment'); });
+      it('should report on safe field assignments', () => {
+        expectActionError('a?.a = 123', 'cannot be used in the assignment');
+      });
 
-      it('should support array updates', () => { checkAction('a[0] = 200'); });
+      it('should support array updates', () => {
+        checkAction('a[0] = 200');
+      });
     });
 
-    it('should error when using pipes',
-       () => { expectActionError('x|blah', 'Cannot have a pipe'); });
+    it('should error when using pipes', () => {
+      expectActionError('x|blah', 'Cannot have a pipe');
+    });
 
-    it('should store the source in the result',
-       () => { expect(parseAction('someExpr', 'someExpr')); });
+    it('should store the source in the result', () => {
+      expect(parseAction('someExpr', 'someExpr'));
+    });
 
-    it('should store the passed-in location',
-       () => { expect(parseAction('someExpr', 'location').location).toBe('location'); });
+    it('should store the passed-in location', () => {
+      expect(parseAction('someExpr', 'location').location).toBe('location');
+    });
 
     it('should report when encountering interpolation', () => {
       expectActionError('{{a()}}', 'Got interpolation ({{}}) where expression was expected');
@@ -175,11 +199,13 @@ describe('parser', () => {
   });
 
   describe('general error handling', () => {
-    it('should report an unexpected token',
-       () => { expectActionError('[1,2] trac', 'Unexpected token \'trac\''); });
+    it('should report an unexpected token', () => {
+      expectActionError('[1,2] trac', 'Unexpected token \'trac\'');
+    });
 
-    it('should report reasonable error for unconsumed tokens',
-       () => { expectActionError(')', 'Unexpected token ) at column 1 in [)]'); });
+    it('should report reasonable error for unconsumed tokens', () => {
+      expectActionError(')', 'Unexpected token ) at column 1 in [)]');
+    });
 
     it('should report a missing expected token', () => {
       expectActionError('a(b', 'Missing expected ) at the end of the expression [a(b]');
@@ -206,12 +232,17 @@ describe('parser', () => {
         expectBindingError('"Foo"|"uppercase"', 'identifier or keyword');
       });
 
-      it('should parse quoted expressions', () => { checkBinding('a:b', 'a:b'); });
+      it('should parse quoted expressions', () => {
+        checkBinding('a:b', 'a:b');
+      });
 
-      it('should not crash when prefix part is not tokenizable',
-         () => { checkBinding('"a:b"', '"a:b"'); });
+      it('should not crash when prefix part is not tokenizable', () => {
+        checkBinding('"a:b"', '"a:b"');
+      });
 
-      it('should ignore whitespace around quote prefix', () => { checkBinding(' a :b', 'a:b'); });
+      it('should ignore whitespace around quote prefix', () => {
+        checkBinding(' a :b', 'a:b');
+      });
 
       it('should refuse prefixes that are not single identifiers', () => {
         expectBindingError('a + b:c', '');
@@ -219,31 +250,41 @@ describe('parser', () => {
       });
     });
 
-    it('should store the source in the result',
-       () => { expect(parseBinding('someExpr').source).toBe('someExpr'); });
+    it('should store the source in the result', () => {
+      expect(parseBinding('someExpr').source).toBe('someExpr');
+    });
 
-    it('should store the passed-in location',
-       () => { expect(parseBinding('someExpr', 'location').location).toBe('location'); });
+    it('should store the passed-in location', () => {
+      expect(parseBinding('someExpr', 'location').location).toBe('location');
+    });
 
-    it('should report chain expressions',
-       () => { expectError(parseBinding('1;2'), 'contain chained expression'); });
+    it('should report chain expressions', () => {
+      expectError(parseBinding('1;2'), 'contain chained expression');
+    });
 
-    it('should report assignment',
-       () => { expectError(parseBinding('a=2'), 'contain assignments'); });
+    it('should report assignment', () => {
+      expectError(parseBinding('a=2'), 'contain assignments');
+    });
 
     it('should report when encountering interpolation', () => {
       expectBindingError('{{a.b}}', 'Got interpolation ({{}}) where expression was expected');
     });
 
-    it('should parse conditional expression', () => { checkBinding('a < b ? a : b'); });
+    it('should parse conditional expression', () => {
+      checkBinding('a < b ? a : b');
+    });
 
-    it('should ignore comments in bindings', () => { checkBinding('a //comment', 'a'); });
+    it('should ignore comments in bindings', () => {
+      checkBinding('a //comment', 'a');
+    });
 
-    it('should retain // in string literals',
-       () => { checkBinding(`"http://www.google.com"`, `"http://www.google.com"`); });
+    it('should retain // in string literals', () => {
+      checkBinding(`"http://www.google.com"`, `"http://www.google.com"`);
+    });
 
-    it('should retain // in : microsyntax', () => { checkBinding('one:a//b', 'one:a//b'); });
-
+    it('should retain // in : microsyntax', () => {
+      checkBinding('one:a//b', 'one:a//b');
+    });
   });
 
   describe('parseTemplateBindings', () => {
@@ -555,11 +596,12 @@ describe('parser', () => {
   });
 
   describe('parseInterpolation', () => {
-    it('should return null if no interpolation',
-       () => { expect(parseInterpolation('nothing')).toBe(null); });
+    it('should return null if no interpolation', () => {
+      expect(parseInterpolation('nothing')).toBe(null);
+    });
 
     it('should parse no prefix/suffix interpolation', () => {
-      const ast = parseInterpolation('{{a}}') !.ast as Interpolation;
+      const ast = parseInterpolation('{{a}}')!.ast as Interpolation;
       expect(ast.strings).toEqual(['', '']);
       expect(ast.expressions.length).toEqual(1);
       expect(ast.expressions[0].name).toEqual('a');
@@ -567,22 +609,23 @@ describe('parser', () => {
 
     it('should parse prefix/suffix with multiple interpolation', () => {
       const originalExp = 'before {{ a }} middle {{ b }} after';
-      const ast = parseInterpolation(originalExp) !.ast;
+      const ast = parseInterpolation(originalExp)!.ast;
       expect(unparse(ast)).toEqual(originalExp);
       validate(ast);
     });
 
     it('should report empty interpolation expressions', () => {
       expectError(
-          parseInterpolation('{{}}') !,
-          'Blank expressions are not allowed in interpolated strings');
+          parseInterpolation('{{}}')!, 'Blank expressions are not allowed in interpolated strings');
 
       expectError(
-          parseInterpolation('foo {{  }}') !,
+          parseInterpolation('foo {{  }}')!,
           'Parser Error: Blank expressions are not allowed in interpolated strings');
     });
 
-    it('should parse conditional expression', () => { checkInterpolation('{{ a < b ? a : b }}'); });
+    it('should parse conditional expression', () => {
+      checkInterpolation('{{ a < b ? a : b }}');
+    });
 
     it('should parse expression with newline characters', () => {
       checkInterpolation(`{{ 'foo' +\n 'bar' +\r 'baz' }}`, `{{ "foo" + "bar" + "baz" }}`);
@@ -591,15 +634,16 @@ describe('parser', () => {
     it('should support custom interpolation', () => {
       const parser = new Parser(new Lexer());
       const ast =
-          parser.parseInterpolation('{% a %}', null, 0, {start: '{%', end: '%}'}) !.ast as any;
+          parser.parseInterpolation('{% a %}', null, 0, {start: '{%', end: '%}'})!.ast as any;
       expect(ast.strings).toEqual(['', '']);
       expect(ast.expressions.length).toEqual(1);
       expect(ast.expressions[0].name).toEqual('a');
     });
 
     describe('comments', () => {
-      it('should ignore comments in interpolation expressions',
-         () => { checkInterpolation('{{a //comment}}', '{{ a }}'); });
+      it('should ignore comments in interpolation expressions', () => {
+        checkInterpolation('{{a //comment}}', '{{ a }}');
+      });
 
       it('should retain // in single quote strings', () => {
         checkInterpolation(`{{ 'http://www.google.com' }}`, `{{ "http://www.google.com" }}`);
@@ -609,18 +653,19 @@ describe('parser', () => {
         checkInterpolation(`{{ "http://www.google.com" }}`, `{{ "http://www.google.com" }}`);
       });
 
-      it('should ignore comments after string literals',
-         () => { checkInterpolation(`{{ "a//b" //comment }}`, `{{ "a//b" }}`); });
+      it('should ignore comments after string literals', () => {
+        checkInterpolation(`{{ "a//b" //comment }}`, `{{ "a//b" }}`);
+      });
 
       it('should retain // in complex strings', () => {
         checkInterpolation(
             `{{"//a\'//b\`//c\`//d\'//e" //comment}}`, `{{ "//a\'//b\`//c\`//d\'//e" }}`);
       });
 
-      it('should retain // in nested, unterminated strings',
-         () => { checkInterpolation(`{{ "a\'b\`" //comment}}`, `{{ "a\'b\`" }}`); });
+      it('should retain // in nested, unterminated strings', () => {
+        checkInterpolation(`{{ "a\'b\`" //comment}}`, `{{ "a\'b\`" }}`);
+      });
     });
-
   });
 
   describe('parseSimpleBinding', () => {
@@ -670,12 +715,12 @@ describe('parser', () => {
 
   describe('offsets', () => {
     it('should retain the offsets of an interpolation', () => {
-      const interpolations = splitInterpolation('{{a}}  {{b}}  {{c}}') !;
+      const interpolations = splitInterpolation('{{a}}  {{b}}  {{c}}')!;
       expect(interpolations.offsets).toEqual([2, 9, 16]);
     });
 
     it('should retain the offsets into the expression AST of interpolations', () => {
-      const source = parseInterpolation('{{a}}  {{b}}  {{c}}') !;
+      const source = parseInterpolation('{{a}}  {{b}}  {{c}}')!;
       const interpolation = source.ast as Interpolation;
       expect(interpolation.expressions.map(e => e.span.start)).toEqual([2, 9, 16]);
     });
@@ -722,7 +767,7 @@ function parseSimpleBinding(text: string, location: any = null, offset: number =
 }
 
 function checkInterpolation(exp: string, expected?: string) {
-  const ast = parseInterpolation(exp) !;
+  const ast = parseInterpolation(exp)!;
   if (expected == null) expected = exp;
   expect(unparse(ast)).toEqual(expected);
   validate(ast);

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -12,9 +12,9 @@ import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../../src/ml
 class Unparser implements AstVisitor {
   private static _quoteRegExp = /"/g;
   // TODO(issue/24571): remove '!'.
-  private _expression !: string;
+  private _expression!: string;
   // TODO(issue/24571): remove '!'.
-  private _interpolationConfig !: InterpolationConfig;
+  private _interpolationConfig!: InterpolationConfig;
 
   unparse(ast: AST, interpolationConfig: InterpolationConfig) {
     this._expression = '';
@@ -69,7 +69,7 @@ class Unparser implements AstVisitor {
   }
 
   visitFunctionCall(ast: FunctionCall, context: any) {
-    this._visit(ast.target !);
+    this._visit(ast.target!);
     this._expression += '(';
     let isFirst = true;
     ast.args.forEach(arg => {
@@ -137,7 +137,7 @@ class Unparser implements AstVisitor {
 
   visitLiteralPrimitive(ast: LiteralPrimitive, context: any) {
     if (typeof ast.value === 'string') {
-      this._expression += `"${ast.value.replace( Unparser._quoteRegExp,  '\"')}"`;
+      this._expression += `"${ast.value.replace(Unparser._quoteRegExp, '\"')}"`;
     } else {
       this._expression += `${ast.value}`;
     }
@@ -186,7 +186,9 @@ class Unparser implements AstVisitor {
     this._expression += `${ast.prefix}:${ast.uninterpretedExpression}`;
   }
 
-  private _visit(ast: AST) { ast.visit(this); }
+  private _visit(ast: AST) {
+    ast.visit(this);
+  }
 }
 
 const sharedUnparser = new Unparser();

--- a/packages/compiler/test/expression_parser/utils/validator.ts
+++ b/packages/compiler/test/expression_parser/utils/validator.ts
@@ -22,8 +22,8 @@ class ASTValidator extends RecursiveAstVisitor {
     if (!inSpan(ast.span, this.parentSpan)) {
       if (this.parentSpan) {
         const parentSpan = this.parentSpan as ParseSpan;
-        throw Error(
-            `Invalid AST span [expected (${ast.span.start}, ${ast.span.end}) to be in (${parentSpan.start},  ${parentSpan.end}) for ${unparse(ast)}`);
+        throw Error(`Invalid AST span [expected (${ast.span.start}, ${ast.span.end}) to be in (${
+            parentSpan.start},  ${parentSpan.end}) for ${unparse(ast)}`);
       } else {
         throw Error(`Invalid root AST span for ${unparse(ast)}`);
       }
@@ -111,7 +111,7 @@ class ASTValidator extends RecursiveAstVisitor {
   }
 }
 
-function inSpan(span: ParseSpan, parentSpan: ParseSpan | undefined): parentSpan is ParseSpan {
+function inSpan(span: ParseSpan, parentSpan: ParseSpan|undefined): parentSpan is ParseSpan {
   return !parentSpan || (span.start >= parentSpan.start && span.end <= parentSpan.end);
 }
 

--- a/packages/compiler/test/i18n/digest_spec.ts
+++ b/packages/compiler/test/i18n/digest_spec.ts
@@ -27,14 +27,17 @@ import {computeMsgId, digest, sha1} from '../../src/i18n/digest';
     });
 
     describe('sha1', () => {
-      it('should work on empty strings',
-         () => { expect(sha1('')).toEqual('da39a3ee5e6b4b0d3255bfef95601890afd80709'); });
+      it('should work on empty strings', () => {
+        expect(sha1('')).toEqual('da39a3ee5e6b4b0d3255bfef95601890afd80709');
+      });
 
-      it('should returns the sha1 of "hello world"',
-         () => { expect(sha1('abc')).toEqual('a9993e364706816aba3e25717850c26c9cd0d89d'); });
+      it('should returns the sha1 of "hello world"', () => {
+        expect(sha1('abc')).toEqual('a9993e364706816aba3e25717850c26c9cd0d89d');
+      });
 
-      it('should returns the sha1 of unicode strings',
-         () => { expect(sha1('你好，世界')).toEqual('3becb03b015ed48050611c8d7afe4b88f70d5a20'); });
+      it('should returns the sha1 of unicode strings', () => {
+        expect(sha1('你好，世界')).toEqual('3becb03b015ed48050611c8d7afe4b88f70d5a20');
+      });
 
       it('should support arbitrary string size', () => {
         // node.js reference code:
@@ -89,8 +92,9 @@ import {computeMsgId, digest, sha1} from '../../src/i18n/digest';
           '': '4416290763660062288',
         };
 
-        Object.keys(fixtures).forEach(
-            msg => { expect(computeMsgId(msg, '')).toEqual(fixtures[msg]); });
+        Object.keys(fixtures).forEach(msg => {
+          expect(computeMsgId(msg, '')).toEqual(fixtures[msg]);
+        });
       });
 
       it('should work on well known inputs with meaning', () => {
@@ -100,8 +104,9 @@ import {computeMsgId, digest, sha1} from '../../src/i18n/digest';
           '3993998469942805487': ['View', 'Gmail UI'],
         };
 
-        Object.keys(fixtures).forEach(
-            id => { expect(computeMsgId(fixtures[id][0], fixtures[id][1])).toEqual(id); });
+        Object.keys(fixtures).forEach(id => {
+          expect(computeMsgId(fixtures[id][0], fixtures[id][1])).toEqual(id);
+        });
       });
 
       it('should support arbitrary string size', () => {
@@ -116,7 +121,6 @@ import {computeMsgId, digest, sha1} from '../../src/i18n/digest';
         }
         expect(computeMsgId(result, '')).toEqual('2122606631351252558');
       });
-
     });
   });
 }

--- a/packages/compiler/test/i18n/extractor_merger_spec.ts
+++ b/packages/compiler/test/i18n/extractor_merger_spec.ts
@@ -94,8 +94,9 @@ import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
             ]);
       });
 
-      it('should not create a message for empty elements',
-         () => { expect(extract('<div i18n="m|d"></div>')).toEqual([]); });
+      it('should not create a message for empty elements', () => {
+        expect(extract('<div i18n="m|d"></div>')).toEqual([]);
+      });
 
       it('should ignore implicit elements in translatable elements', () => {
         expect(extract('<div i18n="m|d"><p></p></div>', ['p'])).toEqual([
@@ -138,7 +139,8 @@ import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
               ],
               [
                 [
-                  'text', '<ph tag name="START_PARAGRAPH">html, <ph tag' +
+                  'text',
+                  '<ph tag name="START_PARAGRAPH">html, <ph tag' +
                       ' name="START_BOLD_TEXT">nested</ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">',
                   '<ph icu name="ICU">{count, plural, =0 {[<ph tag' +
                       ' name="START_TAG_SPAN">html</ph name="CLOSE_TAG_SPAN">]}}</ph>',
@@ -156,8 +158,9 @@ import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
             ]);
       });
 
-      it('should not create a message for empty blocks',
-         () => { expect(extract(`<!-- i18n: meaning1|desc1 --><!-- /i18n -->`)).toEqual([]); });
+      it('should not create a message for empty blocks', () => {
+        expect(extract(`<!-- i18n: meaning1|desc1 --><!-- /i18n -->`)).toEqual([]);
+      });
     });
 
     describe('ICU messages', () => {
@@ -199,8 +202,9 @@ import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
             ]);
       });
 
-      it('should not extract ICU messages outside of i18n sections',
-         () => { expect(extract('{count, plural, =0 {text}}')).toEqual([]); });
+      it('should not extract ICU messages outside of i18n sections', () => {
+        expect(extract('{count, plural, =0 {text}}')).toEqual([]);
+      });
 
       it('should ignore nested ICU messages', () => {
         expect(extract('<div i18n="m|d">{count, plural, =0 { {sex, select, male {m}} }}</div>'))
@@ -280,8 +284,9 @@ import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
             ]);
       });
 
-      it('should not create a message for empty attributes',
-         () => { expect(extract('<div i18n-title="m|d" title></div>')).toEqual([]); });
+      it('should not create a message for empty attributes', () => {
+        expect(extract('<div i18n-title="m|d" title></div>')).toEqual([]);
+      });
     });
 
     describe('implicit elements', () => {
@@ -292,7 +297,7 @@ import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
       });
 
       it('should allow nested implicit elements', () => {
-        let result: any[] = undefined !;
+        let result: any[] = undefined!;
 
         expect(() => {
           result = extract('<div>outer<div>inner</div></div>', ['div']);
@@ -302,7 +307,6 @@ import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
           [['outer', '<ph tag name="START_TAG_DIV">inner</ph name="CLOSE_TAG_DIV">'], '', '', ''],
         ]);
       });
-
     });
 
     describe('implicit attributes', () => {
@@ -341,7 +345,6 @@ import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
             ['Could not start a block inside a translatable section', '<!--'],
             ['Trying to close an unopened block', '<!--'],
           ]);
-
         });
 
         it('should report unclosed blocks', () => {
@@ -527,7 +530,7 @@ function fakeTranslate(
   messages.forEach(message => {
     const id = digest(message);
     const text = serializeI18nNodes(message.nodes).join('').replace(/</g, '[');
-    i18nMsgMap[id] = [new i18n.Text(`**${text}**`, null !)];
+    i18nMsgMap[id] = [new i18n.Text(`**${text}**`, null!)];
   });
 
   const translationBundle = new TranslationBundle(i18nMsgMap, null, digest);

--- a/packages/compiler/test/i18n/i18n_html_parser_spec.ts
+++ b/packages/compiler/test/i18n/i18n_html_parser_spec.ts
@@ -26,6 +26,5 @@ import {ParseTreeResult} from '@angular/compiler/src/ml_parser/parser';
       i18nHtmlParser.parse('source', 'url');
       expect(TranslationBundle.load).toHaveBeenCalledTimes(1);
     });
-
   });
 }

--- a/packages/compiler/test/i18n/i18n_parser_spec.ts
+++ b/packages/compiler/test/i18n/i18n_parser_spec.ts
@@ -14,7 +14,6 @@ import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/inte
 
 {
   describe('I18nParser', () => {
-
     describe('elements', () => {
       it('should extract from elements', () => {
         expect(_humanizeMessages('<div i18n="m|d">text</div>')).toEqual([
@@ -34,11 +33,13 @@ import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/inte
         ]);
       });
 
-      it('should not create a message for empty elements',
-         () => { expect(_humanizeMessages('<div i18n="m|d"></div>')).toEqual([]); });
+      it('should not create a message for empty elements', () => {
+        expect(_humanizeMessages('<div i18n="m|d"></div>')).toEqual([]);
+      });
 
-      it('should not create a message for plain elements',
-         () => { expect(_humanizeMessages('<div></div>')).toEqual([]); });
+      it('should not create a message for plain elements', () => {
+        expect(_humanizeMessages('<div></div>')).toEqual([]);
+      });
 
       it('should support void elements', () => {
         expect(_humanizeMessages('<div i18n="m|d"><p><br></p></div>')).toEqual([
@@ -115,8 +116,9 @@ import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/inte
             ]);
       });
 
-      it('should not create a message for empty attributes',
-         () => { expect(_humanizeMessages('<div i18n-title="m|d" title></div>')).toEqual([]); });
+      it('should not create a message for empty attributes', () => {
+        expect(_humanizeMessages('<div i18n-title="m|d" title></div>')).toEqual([]);
+      });
     });
 
     describe('interpolation', () => {
@@ -252,7 +254,6 @@ import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/inte
         expect(_humanizePlaceholders(html)).toEqual([
           'START_PARAGRAPH=<p>, CLOSE_PARAGRAPH=</p>, START_PARAGRAPH_1=<p other>',
         ]);
-
       });
 
       it('should reuse the same placeholder name for interpolations', () => {
@@ -302,7 +303,6 @@ import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/inte
           '',
           '',
         ]);
-
       });
     });
   });

--- a/packages/compiler/test/i18n/integration_common.ts
+++ b/packages/compiler/test/i18n/integration_common.ts
@@ -20,11 +20,11 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 })
 export class I18nComponent {
   // TODO(issue/24571): remove '!'.
-  count !: number;
+  count!: number;
   // TODO(issue/24571): remove '!'.
-  sex !: string;
+  sex!: string;
   // TODO(issue/24571): remove '!'.
-  sexB !: string;
+  sexB!: string;
   response: any = {getItemsList: (): any[] => []};
 }
 

--- a/packages/compiler/test/i18n/integration_xliff2_spec.ts
+++ b/packages/compiler/test/i18n/integration_xliff2_spec.ts
@@ -13,7 +13,7 @@ import {Xliff2} from '@angular/compiler/src/i18n/serializers/xliff2';
 import {HtmlParser} from '@angular/compiler/src/ml_parser/html_parser';
 import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/interpolation_config';
 import {DebugElement, TRANSLATIONS, TRANSLATIONS_FORMAT} from '@angular/core';
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 import {SpyResourceLoader} from '../spies';
@@ -22,7 +22,6 @@ import {FrLocalization, HTML, I18nComponent, validateHtml} from './integration_c
 
 {
   describe('i18n XLIFF 2.0 integration spec', () => {
-
     beforeEach(async(() => {
       TestBed.configureCompiler({
         providers: [

--- a/packages/compiler/test/i18n/integration_xliff_spec.ts
+++ b/packages/compiler/test/i18n/integration_xliff_spec.ts
@@ -13,7 +13,7 @@ import {Xliff} from '@angular/compiler/src/i18n/serializers/xliff';
 import {HtmlParser} from '@angular/compiler/src/ml_parser/html_parser';
 import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/interpolation_config';
 import {DebugElement, TRANSLATIONS, TRANSLATIONS_FORMAT} from '@angular/core';
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 import {SpyResourceLoader} from '../spies';
@@ -22,7 +22,6 @@ import {FrLocalization, HTML, I18nComponent, validateHtml} from './integration_c
 
 {
   describe('i18n XLIFF integration spec', () => {
-
     beforeEach(async(() => {
       TestBed.configureCompiler({
         providers: [

--- a/packages/compiler/test/i18n/integration_xmb_xtb_spec.ts
+++ b/packages/compiler/test/i18n/integration_xmb_xtb_spec.ts
@@ -13,7 +13,7 @@ import {Xmb} from '@angular/compiler/src/i18n/serializers/xmb';
 import {HtmlParser} from '@angular/compiler/src/ml_parser/html_parser';
 import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/interpolation_config';
 import {DebugElement, TRANSLATIONS, TRANSLATIONS_FORMAT} from '@angular/core';
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 import {SpyResourceLoader} from '../spies';
@@ -22,7 +22,6 @@ import {FrLocalization, HTML, I18nComponent, validateHtml} from './integration_c
 
 {
   describe('i18n XMB/XTB integration spec', () => {
-
     beforeEach(async(() => {
       TestBed.configureCompiler({
         providers: [

--- a/packages/compiler/test/i18n/message_bundle_spec.ts
+++ b/packages/compiler/test/i18n/message_bundle_spec.ts
@@ -18,7 +18,9 @@ import {DEFAULT_INTERPOLATION_CONFIG} from '../../src/ml_parser/interpolation_co
     describe('Messages', () => {
       let messages: MessageBundle;
 
-      beforeEach(() => { messages = new MessageBundle(new HtmlParser, [], {}); });
+      beforeEach(() => {
+        messages = new MessageBundle(new HtmlParser, [], {});
+      });
 
       it('should extract the message to the catalog', () => {
         messages.updateFromTemplate(
@@ -48,11 +50,13 @@ class _TestSerializer extends Serializer {
   }
 
   load(content: string, url: string):
-      {locale: string | null, i18nNodesByMsgId: {[id: string]: i18n.Node[]}} {
+      {locale: string|null, i18nNodesByMsgId: {[id: string]: i18n.Node[]}} {
     return {locale: null, i18nNodesByMsgId: {}};
   }
 
-  digest(msg: i18n.Message): string { return msg.id || `default`; }
+  digest(msg: i18n.Message): string {
+    return msg.id || `default`;
+  }
 }
 
 function humanizeMessages(catalog: MessageBundle): string[] {

--- a/packages/compiler/test/i18n/serializers/i18n_ast_spec.ts
+++ b/packages/compiler/test/i18n/serializers/i18n_ast_spec.ts
@@ -36,13 +36,13 @@ import {_extractMessages} from '../i18n_parser_spec';
         const visitor = new RecurseVisitor();
         const container = new i18n.Container(
             [
-              new i18n.Text('', null !),
-              new i18n.Placeholder('', '', null !),
-              new i18n.IcuPlaceholder(null !, '', null !),
+              new i18n.Text('', null!),
+              new i18n.Placeholder('', '', null!),
+              new i18n.IcuPlaceholder(null!, '', null!),
             ],
-            null !);
-        const tag = new i18n.TagPlaceholder('', {}, '', '', [container], false, null !);
-        const icu = new i18n.Icu('', '', {tag}, null !);
+            null!);
+        const tag = new i18n.TagPlaceholder('', {}, '', '', [container], false, null!);
+        const icu = new i18n.Icu('', '', {tag}, null!);
 
         icu.visit(visitor);
         expect(visitor.textCount).toEqual(1);
@@ -58,9 +58,15 @@ class RecurseVisitor extends i18n.RecurseVisitor {
   phCount = 0;
   icuPhCount = 0;
 
-  visitText(text: i18n.Text, context?: any): any { this.textCount++; }
+  visitText(text: i18n.Text, context?: any): any {
+    this.textCount++;
+  }
 
-  visitPlaceholder(ph: i18n.Placeholder, context?: any): any { this.phCount++; }
+  visitPlaceholder(ph: i18n.Placeholder, context?: any): any {
+    this.phCount++;
+  }
 
-  visitIcuPlaceholder(ph: i18n.IcuPlaceholder, context?: any): any { this.icuPhCount++; }
+  visitIcuPlaceholder(ph: i18n.IcuPlaceholder, context?: any): any {
+    this.icuPhCount++;
+  }
 }

--- a/packages/compiler/test/i18n/serializers/placeholder_spec.ts
+++ b/packages/compiler/test/i18n/serializers/placeholder_spec.ts
@@ -12,7 +12,9 @@ import {PlaceholderRegistry} from '../../../src/i18n/serializers/placeholder';
   describe('PlaceholderRegistry', () => {
     let reg: PlaceholderRegistry;
 
-    beforeEach(() => { reg = new PlaceholderRegistry(); });
+    beforeEach(() => {
+      reg = new PlaceholderRegistry();
+    });
 
     describe('tag placeholder', () => {
       it('should generate names for well known tags', () => {
@@ -84,7 +86,6 @@ import {PlaceholderRegistry} from '../../../src/i18n/serializers/placeholder';
         expect(reg.getPlaceholderName('name1', 'content')).toEqual('NAME1');
         expect(reg.getPlaceholderName('name2', 'content')).toEqual('NAME2');
       });
-
     });
   });
 }

--- a/packages/compiler/test/i18n/serializers/xliff2_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xliff2_spec.ts
@@ -261,65 +261,67 @@ lignes</target>
 `;
 
 (function() {
-  const serializer = new Xliff2();
+const serializer = new Xliff2();
 
-  function toXliff(html: string, locale: string | null = null): string {
-    const catalog = new MessageBundle(new HtmlParser, [], {}, locale);
-    catalog.updateFromTemplate(html, 'file.ts', DEFAULT_INTERPOLATION_CONFIG);
-    return catalog.write(serializer);
-  }
+function toXliff(html: string, locale: string|null = null): string {
+  const catalog = new MessageBundle(new HtmlParser, [], {}, locale);
+  catalog.updateFromTemplate(html, 'file.ts', DEFAULT_INTERPOLATION_CONFIG);
+  return catalog.write(serializer);
+}
 
-  function loadAsMap(xliff: string): {[id: string]: string} {
-    const {i18nNodesByMsgId} = serializer.load(xliff, 'url');
+function loadAsMap(xliff: string): {[id: string]: string} {
+  const {i18nNodesByMsgId} = serializer.load(xliff, 'url');
 
-    const msgMap: {[id: string]: string} = {};
-    Object.keys(i18nNodesByMsgId)
-        .forEach(id => msgMap[id] = serializeNodes(i18nNodesByMsgId[id]).join(''));
+  const msgMap: {[id: string]: string} = {};
+  Object.keys(i18nNodesByMsgId)
+      .forEach(id => msgMap[id] = serializeNodes(i18nNodesByMsgId[id]).join(''));
 
-    return msgMap;
-  }
+  return msgMap;
+}
 
-  describe('XLIFF 2.0 serializer', () => {
-    describe('write', () => {
-      it('should write a valid xliff 2.0 file',
-         () => { expect(toXliff(HTML)).toEqual(WRITE_XLIFF); });
-      it('should write a valid xliff 2.0 file with a source language',
-         () => { expect(toXliff(HTML, 'fr')).toContain('srcLang="fr"'); });
+describe('XLIFF 2.0 serializer', () => {
+  describe('write', () => {
+    it('should write a valid xliff 2.0 file', () => {
+      expect(toXliff(HTML)).toEqual(WRITE_XLIFF);
     });
+    it('should write a valid xliff 2.0 file with a source language', () => {
+      expect(toXliff(HTML, 'fr')).toContain('srcLang="fr"');
+    });
+  });
 
-    describe('load', () => {
-      it('should load XLIFF files', () => {
-        expect(loadAsMap(LOAD_XLIFF)).toEqual({
-          '1933478729560469763': 'etubirtta elbatalsnart',
-          '7056919470098446707':
-              '<ph name="INTERPOLATION"/> <ph name="START_BOLD_TEXT"/>sredlohecalp htiw<ph name="CLOSE_BOLD_TEXT"/> tnemele elbatalsnart',
-          '2981514368455622387':
-              '{VAR_PLURAL, plural, =0 {[<ph name="START_PARAGRAPH"/>, TEST, <ph name="CLOSE_PARAGRAPH"/>]}}',
-          'i': 'oof',
-          '6440235004920703622':
-              '<ph name="START_BOLD_TEXT"/><ph name="START_UNDERLINED_TEXT"/>txeT <ph name="INTERPOLATION"/><ph name="CLOSE_UNDERLINED_TEXT"/><ph name="CLOSE_BOLD_TEXT"/>',
-          '8779402634269838862':
-              '<ph name="TAG_IMG_1"/><ph name="TAG_IMG"/><ph name="LINE_BREAK"/>',
-          '6536355551500405293': '<ph name="START_TAG_SPAN"/><ph name="CLOSE_TAG_SPAN"/> olleh',
-          'baz':
-              '{VAR_PLURAL, plural, =0 {[{VAR_SELECT, select, other {[<ph name="START_PARAGRAPH"/>, profondément imbriqué, <ph name="CLOSE_PARAGRAPH"/>]}},  ]}}',
-          '6997386649824869937': 'Test: <ph name="ICU"/>',
-          '5229984852258993423': '{VAR_PLURAL, plural, =0 {[{VAR_SELECT, select, other {[<ph' +
-              ' name="START_PARAGRAPH"/>, profondément imbriqué, <ph name="CLOSE_PARAGRAPH"/>]}},  ]}, =other {[beaucoup]}}',
-          '2340165783990709777': `multi
+  describe('load', () => {
+    it('should load XLIFF files', () => {
+      expect(loadAsMap(LOAD_XLIFF)).toEqual({
+        '1933478729560469763': 'etubirtta elbatalsnart',
+        '7056919470098446707':
+            '<ph name="INTERPOLATION"/> <ph name="START_BOLD_TEXT"/>sredlohecalp htiw<ph name="CLOSE_BOLD_TEXT"/> tnemele elbatalsnart',
+        '2981514368455622387':
+            '{VAR_PLURAL, plural, =0 {[<ph name="START_PARAGRAPH"/>, TEST, <ph name="CLOSE_PARAGRAPH"/>]}}',
+        'i': 'oof',
+        '6440235004920703622':
+            '<ph name="START_BOLD_TEXT"/><ph name="START_UNDERLINED_TEXT"/>txeT <ph name="INTERPOLATION"/><ph name="CLOSE_UNDERLINED_TEXT"/><ph name="CLOSE_BOLD_TEXT"/>',
+        '8779402634269838862': '<ph name="TAG_IMG_1"/><ph name="TAG_IMG"/><ph name="LINE_BREAK"/>',
+        '6536355551500405293': '<ph name="START_TAG_SPAN"/><ph name="CLOSE_TAG_SPAN"/> olleh',
+        'baz':
+            '{VAR_PLURAL, plural, =0 {[{VAR_SELECT, select, other {[<ph name="START_PARAGRAPH"/>, profondément imbriqué, <ph name="CLOSE_PARAGRAPH"/>]}},  ]}}',
+        '6997386649824869937': 'Test: <ph name="ICU"/>',
+        '5229984852258993423': '{VAR_PLURAL, plural, =0 {[{VAR_SELECT, select, other {[<ph' +
+            ' name="START_PARAGRAPH"/>, profondément imbriqué, <ph name="CLOSE_PARAGRAPH"/>]}},  ]}, =other {[beaucoup]}}',
+        '2340165783990709777': `multi
 lignes`,
-          'mrk-test': 'Vous pouvez utiliser votre propre namespace.',
-          'mrk-test2': 'Vous pouvez utiliser votre propre namespace.'
-        });
+        'mrk-test': 'Vous pouvez utiliser votre propre namespace.',
+        'mrk-test2': 'Vous pouvez utiliser votre propre namespace.'
       });
-
-      it('should return the target locale',
-         () => { expect(serializer.load(LOAD_XLIFF, 'url').locale).toEqual('fr'); });
     });
 
-    describe('structure errors', () => {
-      it('should throw when a wrong xliff version is used', () => {
-        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+    it('should return the target locale', () => {
+      expect(serializer.load(LOAD_XLIFF, 'url').locale).toEqual('fr');
+    });
+  });
+
+  describe('structure errors', () => {
+    it('should throw when a wrong xliff version is used', () => {
+      const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en" datatype="plaintext" original="ng2.template">
     <body>
@@ -331,13 +333,13 @@ lignes`,
   </file>
 </xliff>`;
 
-        expect(() => {
-          loadAsMap(XLIFF);
-        }).toThrowError(/The XLIFF file version 1.2 is not compatible with XLIFF 2.0 serializer/);
-      });
+      expect(() => {
+        loadAsMap(XLIFF);
+      }).toThrowError(/The XLIFF file version 1.2 is not compatible with XLIFF 2.0 serializer/);
+    });
 
-      it('should throw when an unit has no translation', () => {
-        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+    it('should throw when an unit has no translation', () => {
+      const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en">
   <file original="ng.template" id="ngi18n">
     <unit id="missingtarget">
@@ -348,14 +350,14 @@ lignes`,
   </file>
 </xliff>`;
 
-        expect(() => {
-          loadAsMap(XLIFF);
-        }).toThrowError(/Message missingtarget misses a translation/);
-      });
+      expect(() => {
+        loadAsMap(XLIFF);
+      }).toThrowError(/Message missingtarget misses a translation/);
+    });
 
 
-      it('should throw when an unit has no id attribute', () => {
-        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+    it('should throw when an unit has no id attribute', () => {
+      const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en">
   <file original="ng.template" id="ngi18n">
     <unit>
@@ -367,11 +369,13 @@ lignes`,
   </file>
 </xliff>`;
 
-        expect(() => { loadAsMap(XLIFF); }).toThrowError(/<unit> misses the "id" attribute/);
-      });
+      expect(() => {
+        loadAsMap(XLIFF);
+      }).toThrowError(/<unit> misses the "id" attribute/);
+    });
 
-      it('should throw on duplicate unit id', () => {
-        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+    it('should throw on duplicate unit id', () => {
+      const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en">
   <file original="ng.template" id="ngi18n">
     <unit id="deadbeef">
@@ -389,15 +393,15 @@ lignes`,
   </file>
 </xliff>`;
 
-        expect(() => {
-          loadAsMap(XLIFF);
-        }).toThrowError(/Duplicated translations for msg deadbeef/);
-      });
+      expect(() => {
+        loadAsMap(XLIFF);
+      }).toThrowError(/Duplicated translations for msg deadbeef/);
     });
+  });
 
-    describe('message errors', () => {
-      it('should throw on unknown message tags', () => {
-        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+  describe('message errors', () => {
+    it('should throw on unknown message tags', () => {
+      const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en">
   <file original="ng.template" id="ngi18n">
     <unit id="deadbeef">
@@ -409,13 +413,15 @@ lignes`,
   </file>
 </xliff>`;
 
-        expect(() => { loadAsMap(XLIFF); })
-            .toThrowError(new RegExp(
-                escapeRegExp(`[ERROR ->]<b>msg should contain only ph and pc tags</b>`)));
-      });
+      expect(() => {
+        loadAsMap(XLIFF);
+      })
+          .toThrowError(
+              new RegExp(escapeRegExp(`[ERROR ->]<b>msg should contain only ph and pc tags</b>`)));
+    });
 
-      it('should throw when a placeholder misses an id attribute', () => {
-        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+    it('should throw when a placeholder misses an id attribute', () => {
+      const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en">
   <file original="ng.template" id="ngi18n">
     <unit id="deadbeef">
@@ -427,10 +433,10 @@ lignes`,
   </file>
 </xliff>`;
 
-        expect(() => {
-          loadAsMap(XLIFF);
-        }).toThrowError(new RegExp(escapeRegExp(`<ph> misses the "equiv" attribute`)));
-      });
+      expect(() => {
+        loadAsMap(XLIFF);
+      }).toThrowError(new RegExp(escapeRegExp(`<ph> misses the "equiv" attribute`)));
     });
   });
+});
 })();

--- a/packages/compiler/test/i18n/serializers/xliff_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xliff_spec.ts
@@ -241,63 +241,67 @@ lignes</target>
 `;
 
 (function() {
-  const serializer = new Xliff();
+const serializer = new Xliff();
 
-  function toXliff(html: string, locale: string | null = null): string {
-    const catalog = new MessageBundle(new HtmlParser, [], {}, locale);
-    catalog.updateFromTemplate(html, 'file.ts', DEFAULT_INTERPOLATION_CONFIG);
-    return catalog.write(serializer);
-  }
+function toXliff(html: string, locale: string|null = null): string {
+  const catalog = new MessageBundle(new HtmlParser, [], {}, locale);
+  catalog.updateFromTemplate(html, 'file.ts', DEFAULT_INTERPOLATION_CONFIG);
+  return catalog.write(serializer);
+}
 
-  function loadAsMap(xliff: string): {[id: string]: string} {
-    const {i18nNodesByMsgId} = serializer.load(xliff, 'url');
+function loadAsMap(xliff: string): {[id: string]: string} {
+  const {i18nNodesByMsgId} = serializer.load(xliff, 'url');
 
-    const msgMap: {[id: string]: string} = {};
-    Object.keys(i18nNodesByMsgId)
-        .forEach(id => msgMap[id] = serializeNodes(i18nNodesByMsgId[id]).join(''));
+  const msgMap: {[id: string]: string} = {};
+  Object.keys(i18nNodesByMsgId)
+      .forEach(id => msgMap[id] = serializeNodes(i18nNodesByMsgId[id]).join(''));
 
-    return msgMap;
-  }
+  return msgMap;
+}
 
-  describe('XLIFF serializer', () => {
-    describe('write', () => {
-      it('should write a valid xliff file', () => { expect(toXliff(HTML)).toEqual(WRITE_XLIFF); });
-      it('should write a valid xliff file with a source language',
-         () => { expect(toXliff(HTML, 'fr')).toContain('file source-language="fr"'); });
+describe('XLIFF serializer', () => {
+  describe('write', () => {
+    it('should write a valid xliff file', () => {
+      expect(toXliff(HTML)).toEqual(WRITE_XLIFF);
+    });
+    it('should write a valid xliff file with a source language', () => {
+      expect(toXliff(HTML, 'fr')).toContain('file source-language="fr"');
+    });
+  });
+
+  describe('load', () => {
+    it('should load XLIFF files', () => {
+      expect(loadAsMap(LOAD_XLIFF)).toEqual({
+        '983775b9a51ce14b036be72d4cfd65d68d64e231': 'etubirtta elbatalsnart',
+        'ec1d033f2436133c14ab038286c4f5df4697484a':
+            '<ph name="INTERPOLATION"/> footnemele elbatalsnart <ph name="START_BOLD_TEXT"/>sredlohecalp htiw<ph name="CLOSE_BOLD_TEXT"/>',
+        'e2ccf3d131b15f54aa1fcf1314b1ca77c14bfcc2':
+            '{VAR_PLURAL, plural, =0 {[<ph name="START_PARAGRAPH"/>, TEST, <ph name="CLOSE_PARAGRAPH"/>]}}',
+        'db3e0a6a5a96481f60aec61d98c3eecddef5ac23': 'oof',
+        'i': 'toto',
+        'bar': 'tata',
+        'd7fa2d59aaedcaa5309f13028c59af8c85b8c49d':
+            '<ph name="START_TAG_DIV"/><ph name="CLOSE_TAG_DIV"/><ph name="TAG_IMG"/><ph name="LINE_BREAK"/>',
+        'empty target': '',
+        'baz':
+            '{VAR_PLURAL, plural, =0 {[{VAR_SELECT, select, other {[<ph name="START_PARAGRAPH"/>, profondément imbriqué, <ph name="CLOSE_PARAGRAPH"/>]}},  ]}}',
+        '52ffa620dcd76247a56d5331f34e73f340a43cdb': 'Test: <ph name="ICU"/>',
+        '1503afd0ccc20ff01d5e2266a9157b7b342ba494':
+            '{VAR_PLURAL, plural, =0 {[{VAR_SELECT, select, other {[<ph' +
+            ' name="START_PARAGRAPH"/>, profondément imbriqué, <ph name="CLOSE_PARAGRAPH"/>]}},  ]}, =other {[beaucoup]}}',
+        'fcfa109b0e152d4c217dbc02530be0bcb8123ad1': `multi
+lignes`,
+        'mrk-test': 'Translated first sentence.',
+        'mrk-test2': 'Translated first sentence.'
+      });
     });
 
-    describe('load', () => {
-      it('should load XLIFF files', () => {
-        expect(loadAsMap(LOAD_XLIFF)).toEqual({
-          '983775b9a51ce14b036be72d4cfd65d68d64e231': 'etubirtta elbatalsnart',
-          'ec1d033f2436133c14ab038286c4f5df4697484a':
-              '<ph name="INTERPOLATION"/> footnemele elbatalsnart <ph name="START_BOLD_TEXT"/>sredlohecalp htiw<ph name="CLOSE_BOLD_TEXT"/>',
-          'e2ccf3d131b15f54aa1fcf1314b1ca77c14bfcc2':
-              '{VAR_PLURAL, plural, =0 {[<ph name="START_PARAGRAPH"/>, TEST, <ph name="CLOSE_PARAGRAPH"/>]}}',
-          'db3e0a6a5a96481f60aec61d98c3eecddef5ac23': 'oof',
-          'i': 'toto',
-          'bar': 'tata',
-          'd7fa2d59aaedcaa5309f13028c59af8c85b8c49d':
-              '<ph name="START_TAG_DIV"/><ph name="CLOSE_TAG_DIV"/><ph name="TAG_IMG"/><ph name="LINE_BREAK"/>',
-          'empty target': '',
-          'baz':
-              '{VAR_PLURAL, plural, =0 {[{VAR_SELECT, select, other {[<ph name="START_PARAGRAPH"/>, profondément imbriqué, <ph name="CLOSE_PARAGRAPH"/>]}},  ]}}',
-          '52ffa620dcd76247a56d5331f34e73f340a43cdb': 'Test: <ph name="ICU"/>',
-          '1503afd0ccc20ff01d5e2266a9157b7b342ba494':
-              '{VAR_PLURAL, plural, =0 {[{VAR_SELECT, select, other {[<ph' +
-              ' name="START_PARAGRAPH"/>, profondément imbriqué, <ph name="CLOSE_PARAGRAPH"/>]}},  ]}, =other {[beaucoup]}}',
-          'fcfa109b0e152d4c217dbc02530be0bcb8123ad1': `multi
-lignes`,
-          'mrk-test': 'Translated first sentence.',
-          'mrk-test2': 'Translated first sentence.'
-        });
-      });
+    it('should return the target locale', () => {
+      expect(serializer.load(LOAD_XLIFF, 'url').locale).toEqual('fr');
+    });
 
-      it('should return the target locale',
-         () => { expect(serializer.load(LOAD_XLIFF, 'url').locale).toEqual('fr'); });
-
-      it('should ignore alt-trans targets', () => {
-        const XLIFF = `
+    it('should ignore alt-trans targets', () => {
+      const XLIFF = `
           <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
             <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
               <body>
@@ -318,12 +322,12 @@ lignes`,
             </file>
           </xliff>`;
 
-        expect(loadAsMap(XLIFF)).toEqual({'registration.submit': 'Weiter'});
-      });
+      expect(loadAsMap(XLIFF)).toEqual({'registration.submit': 'Weiter'});
+    });
 
-      describe('structure errors', () => {
-        it('should throw when a trans-unit has no translation', () => {
-          const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+    describe('structure errors', () => {
+      it('should throw when a trans-unit has no translation', () => {
+        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en" datatype="plaintext" original="ng2.template">
     <body>
@@ -334,14 +338,14 @@ lignes`,
   </file>
 </xliff>`;
 
-          expect(() => {
-            loadAsMap(XLIFF);
-          }).toThrowError(/Message missingtarget misses a translation/);
-        });
+        expect(() => {
+          loadAsMap(XLIFF);
+        }).toThrowError(/Message missingtarget misses a translation/);
+      });
 
 
-        it('should throw when a trans-unit has no id attribute', () => {
-          const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+      it('should throw when a trans-unit has no id attribute', () => {
+        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en" datatype="plaintext" original="ng2.template">
     <body>
@@ -353,13 +357,13 @@ lignes`,
   </file>
 </xliff>`;
 
-          expect(() => {
-            loadAsMap(XLIFF);
-          }).toThrowError(/<trans-unit> misses the "id" attribute/);
-        });
+        expect(() => {
+          loadAsMap(XLIFF);
+        }).toThrowError(/<trans-unit> misses the "id" attribute/);
+      });
 
-        it('should throw on duplicate trans-unit id', () => {
-          const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+      it('should throw on duplicate trans-unit id', () => {
+        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en" datatype="plaintext" original="ng2.template">
     <body>
@@ -375,15 +379,15 @@ lignes`,
   </file>
 </xliff>`;
 
-          expect(() => {
-            loadAsMap(XLIFF);
-          }).toThrowError(/Duplicated translations for msg deadbeef/);
-        });
+        expect(() => {
+          loadAsMap(XLIFF);
+        }).toThrowError(/Duplicated translations for msg deadbeef/);
       });
+    });
 
-      describe('message errors', () => {
-        it('should throw on unknown message tags', () => {
-          const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+    describe('message errors', () => {
+      it('should throw on unknown message tags', () => {
+        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en" datatype="plaintext" original="ng2.template">
     <body>
@@ -395,13 +399,15 @@ lignes`,
   </file>
 </xliff>`;
 
-          expect(() => { loadAsMap(XLIFF); })
-              .toThrowError(
-                  new RegExp(escapeRegExp(`[ERROR ->]<b>msg should contain only ph tags</b>`)));
-        });
+        expect(() => {
+          loadAsMap(XLIFF);
+        })
+            .toThrowError(
+                new RegExp(escapeRegExp(`[ERROR ->]<b>msg should contain only ph tags</b>`)));
+      });
 
-        it('should throw when a placeholder misses an id attribute', () => {
-          const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+      it('should throw when a placeholder misses an id attribute', () => {
+        const XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en" datatype="plaintext" original="ng2.template">
     <body>
@@ -413,12 +419,11 @@ lignes`,
   </file>
 </xliff>`;
 
-          expect(() => {
-            loadAsMap(XLIFF);
-          }).toThrowError(new RegExp(escapeRegExp(`<x> misses the "id" attribute`)));
-        });
-
+        expect(() => {
+          loadAsMap(XLIFF);
+        }).toThrowError(new RegExp(escapeRegExp(`<x> misses the "id" attribute`)));
       });
     });
   });
+});
 })();

--- a/packages/compiler/test/i18n/serializers/xmb_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xmb_spec.ts
@@ -76,7 +76,7 @@ lines</msg>
   });
 }
 
-function toXmb(html: string, url: string, locale: string | null = null): string {
+function toXmb(html: string, url: string, locale: string|null = null): string {
   const catalog = new MessageBundle(new HtmlParser, [], {}, locale);
   const serializer = new Xmb();
 

--- a/packages/compiler/test/i18n/serializers/xml_helper_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xml_helper_spec.ts
@@ -15,11 +15,13 @@ import * as xml from '../../../src/i18n/serializers/xml_helper';
           .toEqual('<?xml version="1.0" ?>');
     });
 
-    it('should serialize text node',
-       () => { expect(xml.serialize([new xml.Text('foo bar')])).toEqual('foo bar'); });
+    it('should serialize text node', () => {
+      expect(xml.serialize([new xml.Text('foo bar')])).toEqual('foo bar');
+    });
 
-    it('should escape text nodes',
-       () => { expect(xml.serialize([new xml.Text('<>')])).toEqual('&lt;&gt;'); });
+    it('should escape text nodes', () => {
+      expect(xml.serialize([new xml.Text('<>')])).toEqual('&lt;&gt;');
+    });
 
     it('should serialize xml nodes without children', () => {
       expect(xml.serialize([new xml.Tag('el', {foo: 'bar'}, [])])).toEqual('<el foo="bar"/>');
@@ -42,6 +44,5 @@ import * as xml from '../../../src/i18n/serializers/xml_helper';
       expect(xml.serialize([new xml.Tag('el', {foo: '<">'}, [])]))
           .toEqual('<el foo="&lt;&quot;&gt;"/>');
     });
-
   });
 }

--- a/packages/compiler/test/i18n/serializers/xtb_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xtb_spec.ts
@@ -117,7 +117,7 @@ import {Xtb} from '../../../src/i18n/serializers/xtb';
 </translationbundle>`;
 
         // Invalid messages should not cause the parser to throw
-        let i18nNodesByMsgId: {[id: string]: i18n.Node[]} = undefined !;
+        let i18nNodesByMsgId: {[id: string]: i18n.Node[]} = undefined!;
         expect(() => {
           i18nNodesByMsgId = serializer.load(XTB, 'url').i18nNodesByMsgId;
         }).not.toThrow();
@@ -144,7 +144,9 @@ import {Xtb} from '../../../src/i18n/serializers/xtb';
   <translation></translation>
 </translationbundle>`;
 
-        expect(() => { loadAsMap(XTB); }).toThrowError(/<translation> misses the "id" attribute/);
+        expect(() => {
+          loadAsMap(XTB);
+        }).toThrowError(/<translation> misses the "id" attribute/);
       });
 
       it('should throw when a placeholder has no name attribute', () => {
@@ -152,7 +154,9 @@ import {Xtb} from '../../../src/i18n/serializers/xtb';
   <translation id="1186013544048295927"><ph /></translation>
 </translationbundle>`;
 
-        expect(() => { loadAsMap(XTB); }).toThrowError(/<ph> misses the "name" attribute/);
+        expect(() => {
+          loadAsMap(XTB);
+        }).toThrowError(/<ph> misses the "name" attribute/);
       });
 
       it('should throw on unknown xtb tags', () => {
@@ -168,7 +172,9 @@ import {Xtb} from '../../../src/i18n/serializers/xtb';
   <translation id="1186013544048295927"><b>msg should contain only ph tags</b></translation>
 </translationbundle>`;
 
-        expect(() => { loadAsMap(XTB); })
+        expect(() => {
+          loadAsMap(XTB);
+        })
             .toThrowError(
                 new RegExp(escapeRegExp(`[ERROR ->]<b>msg should contain only ph tags</b>`)));
       });
@@ -184,9 +190,11 @@ import {Xtb} from '../../../src/i18n/serializers/xtb';
         }).toThrowError(/Duplicated translations for msg 1186013544048295927/);
       });
 
-      it('should throw when trying to save an xtb file',
-         () => { expect(() => { serializer.write([], null); }).toThrowError(/Unsupported/); });
-
+      it('should throw when trying to save an xtb file', () => {
+        expect(() => {
+          serializer.write([], null);
+        }).toThrowError(/Unsupported/);
+      });
     });
   });
 }

--- a/packages/compiler/test/i18n/translation_bundle_spec.ts
+++ b/packages/compiler/test/i18n/translation_bundle_spec.ts
@@ -25,14 +25,14 @@ import {_extractMessages} from './i18n_parser_spec';
     const srcNode = new i18n.Text('src', span);
 
     it('should translate a plain text', () => {
-      const msgMap = {foo: [new i18n.Text('bar', null !)]};
+      const msgMap = {foo: [new i18n.Text('bar', null!)]};
       const tb = new TranslationBundle(msgMap, null, (_) => 'foo');
       const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
       expect(serializeNodes(tb.get(msg))).toEqual(['bar']);
     });
 
     it('should translate html-like plain text', () => {
-      const msgMap = {foo: [new i18n.Text('<p>bar</p>', null !)]};
+      const msgMap = {foo: [new i18n.Text('<p>bar</p>', null!)]};
       const tb = new TranslationBundle(msgMap, null, (_) => 'foo');
       const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
       const nodes = tb.get(msg);
@@ -45,8 +45,8 @@ import {_extractMessages} from './i18n_parser_spec';
     it('should translate a message with placeholder', () => {
       const msgMap = {
         foo: [
-          new i18n.Text('bar', null !),
-          new i18n.Placeholder('', 'ph1', null !),
+          new i18n.Text('bar', null!),
+          new i18n.Placeholder('', 'ph1', null!),
         ]
       };
       const phMap = {
@@ -60,12 +60,12 @@ import {_extractMessages} from './i18n_parser_spec';
     it('should translate a message with placeholder referencing messages', () => {
       const msgMap = {
         foo: [
-          new i18n.Text('--', null !),
-          new i18n.Placeholder('', 'ph1', null !),
-          new i18n.Text('++', null !),
+          new i18n.Text('--', null!),
+          new i18n.Placeholder('', 'ph1', null!),
+          new i18n.Text('++', null!),
         ],
         ref: [
-          new i18n.Text('*refMsg*', null !),
+          new i18n.Text('*refMsg*', null!),
         ],
       };
       const refMsg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
@@ -84,13 +84,13 @@ import {_extractMessages} from './i18n_parser_spec';
 
       const digest = (_: any) => `no matching id`;
       // Empty message map -> use source messages in Ignore mode
-      let tb = new TranslationBundle({}, null, digest, null !, MissingTranslationStrategy.Ignore);
+      let tb = new TranslationBundle({}, null, digest, null!, MissingTranslationStrategy.Ignore);
       expect(serializeNodes(tb.get(messages[0])).join('')).toEqual(src);
       // Empty message map -> use source messages in Warning mode
-      tb = new TranslationBundle({}, null, digest, null !, MissingTranslationStrategy.Warning);
+      tb = new TranslationBundle({}, null, digest, null!, MissingTranslationStrategy.Warning);
       expect(serializeNodes(tb.get(messages[0])).join('')).toEqual(src);
       // Empty message map -> throw in Error mode
-      tb = new TranslationBundle({}, null, digest, null !, MissingTranslationStrategy.Error);
+      tb = new TranslationBundle({}, null, digest, null!, MissingTranslationStrategy.Error);
       expect(() => serializeNodes(tb.get(messages[0])).join('')).toThrow();
     });
 
@@ -98,7 +98,7 @@ import {_extractMessages} from './i18n_parser_spec';
       it('should report unknown placeholders', () => {
         const msgMap = {
           foo: [
-            new i18n.Text('bar', null !),
+            new i18n.Text('bar', null!),
             new i18n.Placeholder('', 'ph1', span),
           ]
         };
@@ -109,7 +109,7 @@ import {_extractMessages} from './i18n_parser_spec';
 
       it('should report missing translation', () => {
         const tb =
-            new TranslationBundle({}, null, (_) => 'foo', null !, MissingTranslationStrategy.Error);
+            new TranslationBundle({}, null, (_) => 'foo', null!, MissingTranslationStrategy.Error);
         const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
         expect(() => tb.get(msg)).toThrowError(/Missing translation for message "foo"/);
       });
@@ -117,12 +117,14 @@ import {_extractMessages} from './i18n_parser_spec';
       it('should report missing translation with MissingTranslationStrategy.Warning', () => {
         const log: string[] = [];
         const console = {
-          log: (msg: string) => { throw `unexpected`; },
+          log: (msg: string) => {
+            throw `unexpected`;
+          },
           warn: (msg: string) => log.push(msg),
         };
 
         const tb = new TranslationBundle(
-            {}, 'en', (_) => 'foo', null !, MissingTranslationStrategy.Warning, console);
+            {}, 'en', (_) => 'foo', null!, MissingTranslationStrategy.Warning, console);
         const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
 
         expect(() => tb.get(msg)).not.toThrowError();
@@ -131,8 +133,8 @@ import {_extractMessages} from './i18n_parser_spec';
       });
 
       it('should not report missing translation with MissingTranslationStrategy.Ignore', () => {
-        const tb = new TranslationBundle(
-            {}, null, (_) => 'foo', null !, MissingTranslationStrategy.Ignore);
+        const tb =
+            new TranslationBundle({}, null, (_) => 'foo', null!, MissingTranslationStrategy.Ignore);
         const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
         expect(() => tb.get(msg)).not.toThrowError();
       });
@@ -146,15 +148,15 @@ import {_extractMessages} from './i18n_parser_spec';
         let count = 0;
         const digest = (_: any) => count++ ? 'ref' : 'foo';
         const tb =
-            new TranslationBundle(msgMap, null, digest, null !, MissingTranslationStrategy.Error);
+            new TranslationBundle(msgMap, null, digest, null!, MissingTranslationStrategy.Error);
         expect(() => tb.get(msg)).toThrowError(/Missing translation for message "ref"/);
       });
 
       it('should report invalid translated html', () => {
         const msgMap = {
           foo: [
-            new i18n.Text('text', null !),
-            new i18n.Placeholder('', 'ph1', null !),
+            new i18n.Text('text', null!),
+            new i18n.Placeholder('', 'ph1', null!),
           ]
         };
         const phMap = {

--- a/packages/compiler/test/integration_spec.ts
+++ b/packages/compiler/test/integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, Directive, Input} from '@angular/core';
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -21,7 +21,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
            @Directive({selector: '[dot.name]'})
            class MyDir {
              // TODO(issue/24571): remove '!'.
-             @Input('dot.name') value !: string;
+             @Input('dot.name') value!: string;
            }
 
            TestBed.configureTestingModule({

--- a/packages/compiler/test/metadata_resolver_spec.ts
+++ b/packages/compiler/test/metadata_resolver_spec.ts
@@ -8,7 +8,7 @@
 
 import {LIFECYCLE_HOOKS_VALUES, LifecycleHooks} from '@angular/compiler/src/lifecycle_reflector';
 import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, Component, Directive, DoCheck, Injectable, NgModule, OnChanges, OnDestroy, OnInit, Pipe, SimpleChanges, ViewEncapsulation, ɵstringify as stringify} from '@angular/core';
-import {TestBed, async, inject} from '@angular/core/testing';
+import {async, inject, TestBed} from '@angular/core/testing';
 
 import {CompileDiDependencyMetadata, identifierName} from '../src/compile_metadata';
 import {CompileMetadataResolver} from '../src/metadata_resolver';
@@ -20,7 +20,9 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
 {
   describe('CompileMetadataResolver', () => {
-    beforeEach(() => { TestBed.configureCompiler({providers: TEST_COMPILER_PROVIDERS}); });
+    beforeEach(() => {
+      TestBed.configureCompiler({providers: TEST_COMPILER_PROVIDERS});
+    });
 
     it('should throw on the getDirectiveMetadata/getPipeMetadata methods if the module has not been loaded yet',
        inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
@@ -70,8 +72,8 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
          }
 
          expect(() => resolver.loadNgModuleDirectiveAndPipeMetadata(SomeModule, true))
-             .toThrowError(
-                 `Can't compile synchronously as ${stringify(ComponentWithExternalResources)} is still being loaded!`);
+             .toThrowError(`Can't compile synchronously as ${
+                 stringify(ComponentWithExternalResources)} is still being loaded!`);
        }));
 
     it('should read external metadata when sync=false',
@@ -106,7 +108,7 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
          resolver.loadNgModuleDirectiveAndPipeMetadata(SomeModule, false).then(() => {
            const value: string =
-               resolver.getDirectiveMetadata(ComponentWithoutModuleId).template !.templateUrl !;
+               resolver.getDirectiveMetadata(ComponentWithoutModuleId).template !.templateUrl!;
            const expectedEndValue = './someUrl';
            expect(value.endsWith(expectedEndValue)).toBe(true);
          });
@@ -217,7 +219,7 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
     it('should throw with descriptive error message when null is passed to declarations',
        inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
-         @NgModule({declarations: [null !]})
+         @NgModule({declarations: [null!]})
          class ModuleWithNullDeclared {
          }
          expect(() => resolver.loadNgModuleDirectiveAndPipeMetadata(ModuleWithNullDeclared, true))
@@ -227,7 +229,7 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
     it('should throw with descriptive error message when null is passed to imports',
        inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
-         @NgModule({imports: [null !]})
+         @NgModule({imports: [null!]})
          class ModuleWithNullImported {
          }
          expect(() => resolver.loadNgModuleDirectiveAndPipeMetadata(ModuleWithNullImported, true))
@@ -248,7 +250,7 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
     it('should throw with descriptive error message when encounter invalid provider',
        inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
-         @NgModule({providers: [{provide: SimpleService, useClass: undefined !}]})
+         @NgModule({providers: [{provide: SimpleService, useClass: undefined!}]})
          class SomeModule {
          }
 
@@ -258,7 +260,7 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
     it('should throw with descriptive error message when provider is undefined',
        inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
-         @NgModule({providers: [undefined !]})
+         @NgModule({providers: [undefined!]})
          class SomeModule {
          }
 
@@ -290,10 +292,10 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
     it('should throw with descriptive error message when null or undefined is passed to module bootstrap',
        inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
-         @NgModule({bootstrap: [null !]})
+         @NgModule({bootstrap: [null!]})
          class ModuleWithNullBootstrap {
          }
-         @NgModule({bootstrap: [undefined !]})
+         @NgModule({bootstrap: [undefined!]})
          class ModuleWithUndefinedBootstrap {
          }
 
@@ -347,7 +349,6 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
     it(`should throw an error when a Pipe is added to module's bootstrap list`,
        inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
-
          @Pipe({name: 'pipe'})
          class MyPipe {
          }
@@ -362,7 +363,6 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
     it(`should throw an error when a Service is added to module's bootstrap list`,
        inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
-
          @NgModule({declarations: [], bootstrap: [SimpleService]})
          class ModuleWithServiceInBootstrap {
          }
@@ -373,7 +373,6 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
     it('should generate an error when a dependency could not be resolved',
        inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
-
          // Override the errorCollector so that error gets collected instead of
          // being thrown.
          (resolver as any)._errorCollector = (error: Error, type?: any) => {
@@ -390,12 +389,11 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
          class AppModule {
          }
 
-         const moduleMetadata = resolver.getNgModuleMetadata(AppModule) !;
+         const moduleMetadata = resolver.getNgModuleMetadata(AppModule)!;
          expect(moduleMetadata).toBeTruthy();
          expect(moduleMetadata.declaredDirectives.length).toBe(1);
          const directive = moduleMetadata.declaredDirectives[0];
-         const directiveMetadata =
-             resolver.getNonNormalizedDirectiveMetadata(directive.reference) !;
+         const directiveMetadata = resolver.getNonNormalizedDirectiveMetadata(directive.reference)!;
          expect(directiveMetadata).toBeTruthy();
          const {metadata} = directiveMetadata;
          const diDeps: CompileDiDependencyMetadata[] = metadata.type.diDeps;
@@ -405,7 +403,6 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
     it(`should throw an error when a Directive is added to module's bootstrap list`,
        inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
-
          @Directive({selector: 'directive'})
          class MyDirective {
          }
@@ -420,7 +417,6 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
     it(`should not throw an error when a Component is added to module's bootstrap list`,
        inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
-
          @Component({template: ''})
          class MyComp {
          }
@@ -439,7 +435,9 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
          class InvalidModule {
          }
 
-         expect(() => { resolver.getNgModuleMetadata(InvalidModule); })
+         expect(() => {
+           resolver.getNgModuleMetadata(InvalidModule);
+         })
              .toThrowError(
                  `Unexpected value '[object Object]' imported by the module 'InvalidModule'. Please add a @NgModule annotation.`);
        }));
@@ -447,7 +445,6 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
   it('should dedupe declarations in NgModule',
      inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
-
        @Component({template: ''})
        class MyComp {
        }
@@ -456,7 +453,7 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
        class MyModule {
        }
 
-       const modMeta = resolver.getNgModuleMetadata(MyModule) !;
+       const modMeta = resolver.getNgModuleMetadata(MyModule)!;
        expect(modMeta.declaredDirectives.length).toBe(1);
        expect(modMeta.declaredDirectives[0].reference).toBe(MyComp);
      }));
@@ -495,9 +492,9 @@ class ComponentWithExternalResources {
   styles: ['someStyle'],
   interpolation: ['{{', '}}']
 })
-class ComponentWithEverythingInline implements OnChanges,
-    OnInit, DoCheck, OnDestroy, AfterContentInit, AfterContentChecked, AfterViewInit,
-    AfterViewChecked {
+class ComponentWithEverythingInline implements OnChanges, OnInit, DoCheck, OnDestroy,
+                                               AfterContentInit, AfterContentChecked, AfterViewInit,
+                                               AfterViewChecked {
   ngOnChanges(changes: SimpleChanges): void {}
   ngOnInit(): void {}
   ngDoCheck(): void {}
@@ -526,12 +523,12 @@ class MyBrokenComp2 {
 class SimpleService {
 }
 
-@Component({selector: 'my-broken-comp', template: '', providers: [SimpleService, null !, [null]]})
+@Component({selector: 'my-broken-comp', template: '', providers: [SimpleService, null!, [null]]})
 class MyBrokenComp3 {
 }
 
 @Component(
-    {selector: 'my-broken-comp', template: '', viewProviders: [null !, SimpleService, [null]]})
+    {selector: 'my-broken-comp', template: '', viewProviders: [null!, SimpleService, [null]]})
 class MyBrokenComp4 {
 }
 

--- a/packages/compiler/test/ml_parser/ast_serializer_spec.ts
+++ b/packages/compiler/test/ml_parser/ast_serializer_spec.ts
@@ -13,7 +13,9 @@ import {serializeNodes} from './util/util';
   describe('Node serializer', () => {
     let parser: HtmlParser;
 
-    beforeEach(() => { parser = new HtmlParser(); });
+    beforeEach(() => {
+      parser = new HtmlParser();
+    });
 
     it('should support element', () => {
       const html = '<p></p>';

--- a/packages/compiler/test/ml_parser/ast_spec_utils.ts
+++ b/packages/compiler/test/ml_parser/ast_spec_utils.ts
@@ -78,7 +78,7 @@ class _Humanizer implements html.Visitor {
 
   private _appendContext(ast: html.Node, input: any[]): any[] {
     if (!this.includeSourceSpan) return input;
-    input.push(ast.sourceSpan !.toString());
+    input.push(ast.sourceSpan!.toString());
     return input;
   }
 }

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -17,7 +17,9 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './ast_spe
   describe('HtmlParser', () => {
     let parser: HtmlParser;
 
-    beforeEach(() => { parser = new HtmlParser(); });
+    beforeEach(() => {
+      parser = new HtmlParser();
+    });
 
     describe('parse', () => {
       describe('text nodes', () => {
@@ -77,11 +79,20 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './ast_spe
              // <meta> - it can be present in head only
              // <command> - obsolete
              // <keygen> - obsolete
-             ['<map><area></map>', '<div><br></div>', '<colgroup><col></colgroup>',
-              '<div><embed></div>', '<div><hr></div>', '<div><img></div>', '<div><input></div>',
-              '<object><param>/<object>', '<audio><source></audio>', '<audio><track></audio>',
+             ['<map><area></map>',
+              '<div><br></div>',
+              '<colgroup><col></colgroup>',
+              '<div><embed></div>',
+              '<div><hr></div>',
+              '<div><img></div>',
+              '<div><input></div>',
+              '<object><param>/<object>',
+              '<audio><source></audio>',
+              '<audio><track></audio>',
               '<p><wbr></p>',
-             ].forEach((html) => { expect(parser.parse(html, 'TestComp').errors).toEqual([]); });
+             ].forEach((html) => {
+               expect(parser.parse(html, 'TestComp').errors).toEqual([]);
+             });
            });
 
         it('should close void elements on text nodes', () => {
@@ -189,7 +200,6 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './ast_spe
                 [html.Text, '\n', 1],
               ]);
         });
-
       });
 
       describe('attributes', () => {
@@ -263,8 +273,9 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './ast_spe
             [html.Text, ' messages', 0],
           ]);
 
-          expect(humanizeDom(new ParseTreeResult(cases[1].expression, [
-          ]))).toEqual([[html.Text, 'One {{message}}', 0]]);
+          expect(humanizeDom(new ParseTreeResult(cases[1].expression, []))).toEqual([
+            [html.Text, 'One {{message}}', 0]
+          ]);
         });
 
         it('should parse out expansion forms', () => {
@@ -367,11 +378,11 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './ast_spe
         it('should set the start and end source spans', () => {
           const node = <html.Element>parser.parse('<div>a</div>', 'TestComp').rootNodes[0];
 
-          expect(node.startSourceSpan !.start.offset).toEqual(0);
-          expect(node.startSourceSpan !.end.offset).toEqual(5);
+          expect(node.startSourceSpan!.start.offset).toEqual(0);
+          expect(node.startSourceSpan!.end.offset).toEqual(5);
 
-          expect(node.endSourceSpan !.start.offset).toEqual(6);
-          expect(node.endSourceSpan !.end.offset).toEqual(12);
+          expect(node.endSourceSpan!.start.offset).toEqual(6);
+          expect(node.endSourceSpan!.end.offset).toEqual(12);
         });
 
         it('should support expansion form', () => {
@@ -393,15 +404,15 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './ast_spe
         it('should report a value span for an attribute with a value', () => {
           const ast = parser.parse('<div bar="12"></div>', 'TestComp');
           const attr = (ast.rootNodes[0] as html.Element).attrs[0];
-          expect(attr.valueSpan !.start.offset).toEqual(10);
-          expect(attr.valueSpan !.end.offset).toEqual(12);
+          expect(attr.valueSpan!.start.offset).toEqual(10);
+          expect(attr.valueSpan!.end.offset).toEqual(12);
         });
 
         it('should report a value span for an unquoted attribute value', () => {
           const ast = parser.parse('<div bar=12></div>', 'TestComp');
           const attr = (ast.rootNodes[0] as html.Element).attrs[0];
-          expect(attr.valueSpan !.start.offset).toEqual(9);
-          expect(attr.valueSpan !.end.offset).toEqual(11);
+          expect(attr.valueSpan!.start.offset).toEqual(9);
+          expect(attr.valueSpan!.end.offset).toEqual(11);
         });
       });
 
@@ -426,7 +437,9 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './ast_spe
               parser.parse('<div id="foo"><span id="bar">a</span><span>b</span></div>', 'TestComp');
           const accumulator: html.Node[] = [];
           const visitor = new class {
-            visit(node: html.Node, context: any) { accumulator.push(node); }
+            visit(node: html.Node, context: any) {
+              accumulator.push(node);
+            }
             visitElement(element: html.Element, context: any): any {
               html.visitAll(this, element.attrs);
               html.visitAll(this, element.children);
@@ -449,13 +462,21 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './ast_spe
 
         it('should skip typed visit if visit() returns a truthy value', () => {
           const visitor = new class {
-            visit(node: html.Node, context: any) { return true; }
-            visitElement(element: html.Element, context: any): any { throw Error('Unexpected'); }
+            visit(node: html.Node, context: any) {
+              return true;
+            }
+            visitElement(element: html.Element, context: any): any {
+              throw Error('Unexpected');
+            }
             visitAttribute(attribute: html.Attribute, context: any): any {
               throw Error('Unexpected');
             }
-            visitText(text: html.Text, context: any): any { throw Error('Unexpected'); }
-            visitComment(comment: html.Comment, context: any): any { throw Error('Unexpected'); }
+            visitText(text: html.Text, context: any): any {
+              throw Error('Unexpected');
+            }
+            visitComment(comment: html.Comment, context: any): any {
+              throw Error('Unexpected');
+            }
             visitExpansion(expansion: html.Expansion, context: any): any {
               throw Error('Unexpected');
             }

--- a/packages/compiler/test/ml_parser/html_whitespaces_spec.ts
+++ b/packages/compiler/test/ml_parser/html_whitespaces_spec.ts
@@ -15,7 +15,6 @@ import {humanizeDom} from './ast_spec_utils';
 
 {
   describe('removeWhitespaces', () => {
-
     function parseAndRemoveWS(template: string, options?: TokenizeOptions): any[] {
       return humanizeDom(removeWhitespaces(new HtmlParser().parse(template, 'TestComp', options)));
     }

--- a/packages/compiler/test/ml_parser/icu_ast_expander_spec.ts
+++ b/packages/compiler/test/ml_parser/icu_ast_expander_spec.ts
@@ -8,7 +8,7 @@
 
 import * as html from '../../src/ml_parser/ast';
 import {HtmlParser} from '../../src/ml_parser/html_parser';
-import {ExpansionResult, expandNodes} from '../../src/ml_parser/icu_ast_expander';
+import {expandNodes, ExpansionResult} from '../../src/ml_parser/icu_ast_expander';
 import {ParseError} from '../../src/parse_util';
 
 import {humanizeNodes} from './ast_spec_utils';
@@ -56,28 +56,28 @@ import {humanizeNodes} from './ast_spec_utils';
       const nodes = expand(`{messages.length, plural,=0 {<b>bold</b>}}`).nodes;
 
       const container: html.Element = <html.Element>nodes[0];
-      expect(container.sourceSpan !.start.col).toEqual(0);
-      expect(container.sourceSpan !.end.col).toEqual(42);
-      expect(container.startSourceSpan !.start.col).toEqual(0);
-      expect(container.startSourceSpan !.end.col).toEqual(42);
-      expect(container.endSourceSpan !.start.col).toEqual(0);
-      expect(container.endSourceSpan !.end.col).toEqual(42);
+      expect(container.sourceSpan!.start.col).toEqual(0);
+      expect(container.sourceSpan!.end.col).toEqual(42);
+      expect(container.startSourceSpan!.start.col).toEqual(0);
+      expect(container.startSourceSpan!.end.col).toEqual(42);
+      expect(container.endSourceSpan!.start.col).toEqual(0);
+      expect(container.endSourceSpan!.end.col).toEqual(42);
 
       const switchExp = container.attrs[0];
       expect(switchExp.sourceSpan.start.col).toEqual(1);
       expect(switchExp.sourceSpan.end.col).toEqual(16);
 
       const template: html.Element = <html.Element>container.children[0];
-      expect(template.sourceSpan !.start.col).toEqual(25);
-      expect(template.sourceSpan !.end.col).toEqual(41);
+      expect(template.sourceSpan!.start.col).toEqual(25);
+      expect(template.sourceSpan!.end.col).toEqual(41);
 
       const switchCheck = template.attrs[0];
       expect(switchCheck.sourceSpan.start.col).toEqual(25);
       expect(switchCheck.sourceSpan.end.col).toEqual(28);
 
       const b: html.Element = <html.Element>template.children[0];
-      expect(b.sourceSpan !.start.col).toEqual(29);
-      expect(b.endSourceSpan !.end.col).toEqual(40);
+      expect(b.sourceSpan!.start.col).toEqual(29);
+      expect(b.endSourceSpan!.end.col).toEqual(40);
     });
 
     it('should handle other special forms', () => {

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -232,7 +232,6 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
           [lex.TokenType.EOF, ''],
         ]);
       });
-
     });
 
     describe('attributes', () => {
@@ -400,7 +399,6 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
           [lex.TokenType.ATTR_VALUE, 'Unexpected character "EOF"', '0:8'],
         ]);
       });
-
     });
 
     describe('closing tags', () => {
@@ -729,7 +727,6 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
           [lex.TokenType.EOF, ''],
         ]);
       });
-
     });
 
     describe('expansion forms', () => {
@@ -898,7 +895,7 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
         const file = new ParseSourceFile(src, 'file://');
         const location = new ParseLocation(file, 12, 123, 456);
         const span = new ParseSourceSpan(location, location);
-        const error = new lex.TokenError('**ERROR**', null !, span);
+        const error = new lex.TokenError('**ERROR**', null!, span);
         expect(error.toString())
             .toEqual(`**ERROR** ("\n222\n333\n[ERROR ->]E\n444\n555\n"): file://@123:456`);
       });

--- a/packages/compiler/test/ml_parser/util/util.ts
+++ b/packages/compiler/test/ml_parser/util/util.ts
@@ -15,16 +15,21 @@ class _SerializerVisitor implements html.Visitor {
       return `<${element.name}${this._visitAll(element.attrs, ' ')}/>`;
     }
 
-    return `<${element.name}${this._visitAll(element.attrs, ' ')}>${this._visitAll(element.children)}</${element.name}>`;
+    return `<${element.name}${this._visitAll(element.attrs, ' ')}>${
+        this._visitAll(element.children)}</${element.name}>`;
   }
 
   visitAttribute(attribute: html.Attribute, context: any): any {
     return `${attribute.name}="${attribute.value}"`;
   }
 
-  visitText(text: html.Text, context: any): any { return text.value; }
+  visitText(text: html.Text, context: any): any {
+    return text.value;
+  }
 
-  visitComment(comment: html.Comment, context: any): any { return `<!--${comment.value}-->`; }
+  visitComment(comment: html.Comment, context: any): any {
+    return `<!--${comment.value}-->`;
+  }
 
   visitExpansion(expansion: html.Expansion, context: any): any {
     return `{${expansion.switchValue}, ${expansion.type},${this._visitAll(expansion.cases)}}`;

--- a/packages/compiler/test/ng_module_resolver_spec.ts
+++ b/packages/compiler/test/ng_module_resolver_spec.ts
@@ -33,7 +33,9 @@ class SimpleClass {}
   describe('NgModuleResolver', () => {
     let resolver: NgModuleResolver;
 
-    beforeEach(() => { resolver = new NgModuleResolver(new JitReflector()); });
+    beforeEach(() => {
+      resolver = new NgModuleResolver(new JitReflector());
+    });
 
     it('should read out the metadata from the class', () => {
       const moduleMetadata = resolver.resolve(SomeModule);
@@ -66,6 +68,5 @@ class SimpleClass {}
 
       expect(resolver.resolve(ChildWithDecorator)).toEqual(new NgModule({id: 'c'}));
     });
-
   });
 }

--- a/packages/compiler/test/output/abstract_emitter_node_only_spec.ts
+++ b/packages/compiler/test/output/abstract_emitter_node_only_spec.ts
@@ -18,14 +18,16 @@ import {extractSourceMap, originalPositionFor} from '@angular/compiler/testing/s
       const fileB = new ParseSourceFile('b0b1b2b3b4b5b6b7b8b9', 'b.js');
       let ctx: EmitterVisitorContext;
 
-      beforeEach(() => { ctx = EmitterVisitorContext.createRoot(); });
+      beforeEach(() => {
+        ctx = EmitterVisitorContext.createRoot();
+      });
 
       it('should add source files to the source map', () => {
         ctx.print(createSourceSpan(fileA, 0), 'o0');
         ctx.print(createSourceSpan(fileA, 1), 'o1');
         ctx.print(createSourceSpan(fileB, 0), 'o2');
         ctx.print(createSourceSpan(fileB, 1), 'o3');
-        const sm = ctx.toSourceMapGenerator('o.ts').toJSON() !;
+        const sm = ctx.toSourceMapGenerator('o.ts').toJSON()!;
         expect(sm.sources).toEqual([fileA.url, fileB.url]);
         expect(sm.sourcesContent).toEqual([fileA.content, fileB.content]);
       });
@@ -43,7 +45,7 @@ import {extractSourceMap, originalPositionFor} from '@angular/compiler/testing/s
       it('should be able to shift the content', () => {
         ctx.print(createSourceSpan(fileA, 0), 'fileA-0');
 
-        const sm = ctx.toSourceMapGenerator('o.ts', 10).toJSON() !;
+        const sm = ctx.toSourceMapGenerator('o.ts', 10).toJSON()!;
         expect(originalPositionFor(sm, {line: 11, column: 0})).toEqual({
           line: 1,
           column: 0,
@@ -111,9 +113,9 @@ import {extractSourceMap, originalPositionFor} from '@angular/compiler/testing/s
 // All lines / columns indexes are 0-based
 // Note: source-map line indexes are 1-based, column 0-based
 function expectMap(
-    ctx: EmitterVisitorContext, genLine: number, genCol: number, source: string | null = null,
-    srcLine: number | null = null, srcCol: number | null = null) {
-  const sm = ctx.toSourceMapGenerator('o.ts').toJSON() !;
+    ctx: EmitterVisitorContext, genLine: number, genCol: number, source: string|null = null,
+    srcLine: number|null = null, srcCol: number|null = null) {
+  const sm = ctx.toSourceMapGenerator('o.ts').toJSON()!;
   const genPosition = {line: genLine + 1, column: genCol};
   const origPosition = originalPositionFor(sm, genPosition);
   // TODO: Review use of `any` here (#19904)
@@ -124,7 +126,7 @@ function expectMap(
 
 // returns the number of segments per line
 function nbSegmentsPerLine(ctx: EmitterVisitorContext) {
-  const sm = ctx.toSourceMapGenerator('o.ts').toJSON() !;
+  const sm = ctx.toSourceMapGenerator('o.ts').toJSON()!;
   const lines = sm.mappings.split(';');
   return lines.map(l => {
     const m = l.match(/,/g);

--- a/packages/compiler/test/output/abstract_emitter_spec.ts
+++ b/packages/compiler/test/output/abstract_emitter_spec.ts
@@ -11,24 +11,34 @@ import {escapeIdentifier} from '@angular/compiler/src/output/abstract_emitter';
 {
   describe('AbstractEmitter', () => {
     describe('escapeIdentifier', () => {
-      it('should escape single quotes',
-         () => { expect(escapeIdentifier(`'`, false)).toEqual(`'\\''`); });
+      it('should escape single quotes', () => {
+        expect(escapeIdentifier(`'`, false)).toEqual(`'\\''`);
+      });
 
-      it('should escape backslash',
-         () => { expect(escapeIdentifier('\\', false)).toEqual(`'\\\\'`); });
+      it('should escape backslash', () => {
+        expect(escapeIdentifier('\\', false)).toEqual(`'\\\\'`);
+      });
 
-      it('should escape newlines',
-         () => { expect(escapeIdentifier('\n', false)).toEqual(`'\\n'`); });
+      it('should escape newlines', () => {
+        expect(escapeIdentifier('\n', false)).toEqual(`'\\n'`);
+      });
 
-      it('should escape carriage returns',
-         () => { expect(escapeIdentifier('\r', false)).toEqual(`'\\r'`); });
+      it('should escape carriage returns', () => {
+        expect(escapeIdentifier('\r', false)).toEqual(`'\\r'`);
+      });
 
-      it('should escape $', () => { expect(escapeIdentifier('$', true)).toEqual(`'\\$'`); });
-      it('should not escape $', () => { expect(escapeIdentifier('$', false)).toEqual(`'$'`); });
-      it('should add quotes for non-identifiers',
-         () => { expect(escapeIdentifier('==', false, false)).toEqual(`'=='`); });
-      it('does not escape class (but it probably should)',
-         () => { expect(escapeIdentifier('class', false, false)).toEqual('class'); });
+      it('should escape $', () => {
+        expect(escapeIdentifier('$', true)).toEqual(`'\\$'`);
+      });
+      it('should not escape $', () => {
+        expect(escapeIdentifier('$', false)).toEqual(`'$'`);
+      });
+      it('should add quotes for non-identifiers', () => {
+        expect(escapeIdentifier('==', false, false)).toEqual(`'=='`);
+      });
+      it('does not escape class (but it probably should)', () => {
+        expect(escapeIdentifier('class', false, false)).toEqual('class');
+      });
     });
   });
 }

--- a/packages/compiler/test/output/js_emitter_node_only_spec.ts
+++ b/packages/compiler/test/output/js_emitter_node_only_spec.ts
@@ -22,12 +22,14 @@ const someGenFilePath = 'somePackage/someGenFile';
     let emitter: JavaScriptEmitter;
     let someVar: o.ReadVarExpr;
 
-    beforeEach(() => { emitter = new JavaScriptEmitter(); });
+    beforeEach(() => {
+      emitter = new JavaScriptEmitter();
+    });
 
-    function emitSourceMap(stmt: o.Statement | o.Statement[], preamble?: string): SourceMap {
+    function emitSourceMap(stmt: o.Statement|o.Statement[], preamble?: string): SourceMap {
       const stmts = Array.isArray(stmt) ? stmt : [stmt];
       const source = emitter.emitStatements(someGenFilePath, stmts, preamble);
-      return extractSourceMap(source) !;
+      return extractSourceMap(source)!;
     }
 
     describe('source maps', () => {

--- a/packages/compiler/test/output/js_emitter_spec.ts
+++ b/packages/compiler/test/output/js_emitter_spec.ts
@@ -171,8 +171,9 @@ const externalModuleIdentifier = new o.ExternalReference(anotherModuleUrl, 'some
     });
 
     it('should support function statements', () => {
-      expect(emitStmt(new o.DeclareFunctionStmt('someFn', [], [
-      ]))).toEqual(['function someFn() {', '}'].join('\n'));
+      expect(emitStmt(new o.DeclareFunctionStmt('someFn', [], []))).toEqual([
+        'function someFn() {', '}'
+      ].join('\n'));
       expect(emitStmt(new o.DeclareFunctionStmt('someFn', [], [], null, [o.StmtModifier.Exported])))
           .toEqual([
             'function someFn() {', '}',
@@ -181,8 +182,9 @@ const externalModuleIdentifier = new o.ExternalReference(anotherModuleUrl, 'some
       expect(emitStmt(new o.DeclareFunctionStmt('someFn', [], [
         new o.ReturnStatement(o.literal(1))
       ]))).toEqual(['function someFn() {', '  return 1;', '}'].join('\n'));
-      expect(emitStmt(new o.DeclareFunctionStmt('someFn', [new o.FnParam('param1')], [
-      ]))).toEqual(['function someFn(param1) {', '}'].join('\n'));
+      expect(emitStmt(new o.DeclareFunctionStmt('someFn', [new o.FnParam('param1')], []))).toEqual([
+        'function someFn(param1) {', '}'
+      ].join('\n'));
     });
 
     it('should support comments', () => {
@@ -219,25 +221,29 @@ const externalModuleIdentifier = new o.ExternalReference(anotherModuleUrl, 'some
       ].join('\n'));
     });
 
-    it('should support support throwing',
-       () => { expect(emitStmt(new o.ThrowStmt(someVar))).toEqual('throw someVar;'); });
+    it('should support support throwing', () => {
+      expect(emitStmt(new o.ThrowStmt(someVar))).toEqual('throw someVar;');
+    });
 
     describe('classes', () => {
       let callSomeMethod: o.Statement;
 
-      beforeEach(() => { callSomeMethod = o.THIS_EXPR.callMethod('someMethod', []).toStmt(); });
+      beforeEach(() => {
+        callSomeMethod = o.THIS_EXPR.callMethod('someMethod', []).toStmt();
+      });
 
       it('should support declaring classes', () => {
-        expect(emitStmt(new o.ClassStmt('SomeClass', null !, [], [], null !, [
-        ]))).toEqual(['function SomeClass() {', '}'].join('\n'));
+        expect(emitStmt(new o.ClassStmt('SomeClass', null!, [], [], null!, []))).toEqual([
+          'function SomeClass() {', '}'
+        ].join('\n'));
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [], null !, [], [o.StmtModifier.Exported])))
+                   'SomeClass', null!, [], [], null!, [], [o.StmtModifier.Exported])))
             .toEqual([
               'function SomeClass() {', '}',
               `Object.defineProperty(exports, 'SomeClass', { get: function() { return SomeClass; }});`
             ].join('\n'));
-        expect(emitStmt(
-                   new o.ClassStmt('SomeClass', o.variable('SomeSuperClass'), [], [], null !, [])))
+        expect(
+            emitStmt(new o.ClassStmt('SomeClass', o.variable('SomeSuperClass'), [], [], null!, [])))
             .toEqual([
               'function SomeClass() {', '}',
               'SomeClass.prototype = Object.create(SomeSuperClass.prototype);'
@@ -247,23 +253,22 @@ const externalModuleIdentifier = new o.ExternalReference(anotherModuleUrl, 'some
       it('should support declaring constructors', () => {
         const superCall = o.SUPER_EXPR.callFn([o.variable('someParam')]).toStmt();
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [], new o.ClassMethod(null !, [], []), [])))
+                   'SomeClass', null!, [], [], new o.ClassMethod(null!, [], []), [])))
             .toEqual(['function SomeClass() {', '}'].join('\n'));
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [],
-                   new o.ClassMethod(null !, [new o.FnParam('someParam')], []), [])))
+                   'SomeClass', null!, [], [],
+                   new o.ClassMethod(null!, [new o.FnParam('someParam')], []), [])))
             .toEqual(['function SomeClass(someParam) {', '}'].join('\n'));
         expect(emitStmt(new o.ClassStmt(
                    'SomeClass', o.variable('SomeSuperClass'), [], [],
-                   new o.ClassMethod(null !, [], [superCall]), [])))
+                   new o.ClassMethod(null!, [], [superCall]), [])))
             .toEqual([
               'function SomeClass() {', '  var self = this;',
               '  SomeSuperClass.call(this, someParam);', '}',
               'SomeClass.prototype = Object.create(SomeSuperClass.prototype);'
             ].join('\n'));
-        expect(
-            emitStmt(new o.ClassStmt(
-                'SomeClass', null !, [], [], new o.ClassMethod(null !, [], [callSomeMethod]), [])))
+        expect(emitStmt(new o.ClassStmt(
+                   'SomeClass', null!, [], [], new o.ClassMethod(null!, [], [callSomeMethod]), [])))
             .toEqual([
               'function SomeClass() {', '  var self = this;', '  self.someMethod();', '}'
             ].join('\n'));
@@ -271,14 +276,14 @@ const externalModuleIdentifier = new o.ExternalReference(anotherModuleUrl, 'some
 
       it('should support declaring getters', () => {
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [new o.ClassGetter('someGetter', [])], null !, [])))
+                   'SomeClass', null!, [], [new o.ClassGetter('someGetter', [])], null!, [])))
             .toEqual([
               'function SomeClass() {', '}',
               `Object.defineProperty(SomeClass.prototype, 'someGetter', { get: function() {`, `}});`
             ].join('\n'));
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [new o.ClassGetter('someGetter', [callSomeMethod])],
-                   null !, [])))
+                   'SomeClass', null!, [], [new o.ClassGetter('someGetter', [callSomeMethod])],
+                   null!, [])))
             .toEqual([
               'function SomeClass() {', '}',
               `Object.defineProperty(SomeClass.prototype, 'someGetter', { get: function() {`,
@@ -288,19 +293,19 @@ const externalModuleIdentifier = new o.ExternalReference(anotherModuleUrl, 'some
 
       it('should support methods', () => {
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [], null !, [new o.ClassMethod('someMethod', [], [])])))
+                   'SomeClass', null!, [], [], null!, [new o.ClassMethod('someMethod', [], [])])))
             .toEqual([
               'function SomeClass() {', '}', 'SomeClass.prototype.someMethod = function() {', '};'
             ].join('\n'));
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [], null !,
+                   'SomeClass', null!, [], [], null!,
                    [new o.ClassMethod('someMethod', [new o.FnParam('someParam')], [])])))
             .toEqual([
               'function SomeClass() {', '}',
               'SomeClass.prototype.someMethod = function(someParam) {', '};'
             ].join('\n'));
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [], null !,
+                   'SomeClass', null!, [], [], null!,
                    [new o.ClassMethod('someMethod', [], [callSomeMethod])])))
             .toEqual([
               'function SomeClass() {', '}', 'SomeClass.prototype.someMethod = function() {',

--- a/packages/compiler/test/output/output_ast_spec.ts
+++ b/packages/compiler/test/output/output_ast_spec.ts
@@ -15,8 +15,8 @@ import * as o from '../../src/output/output_ast';
         const ref1 = new o.ExternalReference('aModule', 'name1');
         const ref2 = new o.ExternalReference('aModule', 'name2');
         const stmt =
-            o.variable('test').set(o.NULL_EXPR).toDeclStmt(o.importType(ref1, [o.importType(
-                                                                                  ref2) !]));
+            o.variable('test').set(o.NULL_EXPR).toDeclStmt(o.importType(ref1, [o.importType(ref2)!
+            ]));
 
         expect(o.collectExternalReferences([stmt])).toEqual([ref1, ref2]);
       });

--- a/packages/compiler/test/output/output_jit_spec.ts
+++ b/packages/compiler/test/output/output_jit_spec.ts
@@ -57,7 +57,7 @@ const anotherModuleUrl = 'somePackage/someOtherPath';
             o.literal('use strict').toStmt(),
           ],
           ctx);
-      const matches = ctx.toSource().match(/'use strict';/g) !;
+      const matches = ctx.toSource().match(/'use strict';/g)!;
       expect(matches.length).toBe(1);
     });
   });

--- a/packages/compiler/test/output/source_map_spec.ts
+++ b/packages/compiler/test/output/source_map_spec.ts
@@ -52,7 +52,7 @@ import {SourceMapGenerator, toBase64String} from '@angular/compiler/src/output/s
                         .addMapping(3, 'a.js', 5, 2);
 
         // Generated with https://sokra.github.io/source-map-visualization using a TS source map
-        expect(map.toJSON() !.mappings)
+        expect(map.toJSON()!.mappings)
             .toEqual(
                 'AAAA,IAAM,CAAC,GAAe,CAAC,CAAC;AACxB,IAAM,CAAC,GAAG,CAAC,CAAC;AAEZ,EAAE,CAAC,OAAO,CAAC,UAAA,CAAC;IACR,OAAO,CAAC,GAAG,CAAC,KAAK,CAAC,CAAC;AACvB,CAAC,CAAC,CAAA');
       });
@@ -64,7 +64,7 @@ import {SourceMapGenerator, toBase64String} from '@angular/compiler/src/output/s
                         .addSource('url.ts', null)
                         .addLine()
                         .addMapping(0, 'inline.ts', 0, 0)
-                        .toJSON() !;
+                        .toJSON()!;
 
         expect(map.file).toEqual('out.js');
         expect(map.sources).toEqual(['inline.ts', 'url.ts']);
@@ -81,7 +81,11 @@ import {SourceMapGenerator, toBase64String} from '@angular/compiler/src/output/s
 
     describe('encodeB64String', () => {
       it('should return the b64 encoded value', () => {
-        [['', ''], ['a', 'YQ=='], ['Foo', 'Rm9v'], ['Foo1', 'Rm9vMQ=='], ['Foo12', 'Rm9vMTI='],
+        [['', ''],
+         ['a', 'YQ=='],
+         ['Foo', 'Rm9v'],
+         ['Foo1', 'Rm9vMQ=='],
+         ['Foo12', 'Rm9vMTI='],
          ['Foo123', 'Rm9vMTIz'],
         ].forEach(([src, b64]) => expect(toBase64String(src)).toEqual(b64));
       });
@@ -113,7 +117,7 @@ import {SourceMapGenerator, toBase64String} from '@angular/compiler/src/output/s
 
       it('should throw when adding segments without column', () => {
         expect(() => {
-          new SourceMapGenerator('out.js').addSource('in.js').addLine().addMapping(null !);
+          new SourceMapGenerator('out.js').addSource('in.js').addLine().addMapping(null!);
         }).toThrowError('The column in the generated code must be provided');
       });
 

--- a/packages/compiler/test/output/ts_emitter_node_only_spec.ts
+++ b/packages/compiler/test/output/ts_emitter_node_only_spec.ts
@@ -31,10 +31,10 @@ const someGenFilePath = 'somePackage/someGenFile';
       someVar = o.variable('someVar');
     });
 
-    function emitSourceMap(stmt: o.Statement | o.Statement[], preamble?: string): SourceMap {
+    function emitSourceMap(stmt: o.Statement|o.Statement[], preamble?: string): SourceMap {
       const stmts = Array.isArray(stmt) ? stmt : [stmt];
       const source = emitter.emitStatements(someGenFilePath, stmts, preamble);
-      return extractSourceMap(source) !;
+      return extractSourceMap(source)!;
     }
 
     describe('source maps', () => {

--- a/packages/compiler/test/output/ts_emitter_spec.ts
+++ b/packages/compiler/test/output/ts_emitter_spec.ts
@@ -35,7 +35,7 @@ const externalModuleIdentifier = new o.ExternalReference(anotherModuleUrl, 'some
       someVar = o.variable('someVar', null, null);
     });
 
-    function emitStmt(stmt: o.Statement | o.Statement[], preamble?: string): string {
+    function emitStmt(stmt: o.Statement|o.Statement[], preamble?: string): string {
       const stmts = Array.isArray(stmt) ? stmt : [stmt];
       const source = emitter.emitStatements(someGenFilePath, stmts, preamble);
       return stripSourceMapAndNewLine(source);
@@ -223,15 +223,17 @@ const externalModuleIdentifier = new o.ExternalReference(anotherModuleUrl, 'some
     });
 
     it('should support function statements', () => {
-      expect(emitStmt(new o.DeclareFunctionStmt('someFn', [], [
-      ]))).toEqual(['function someFn():void {', '}'].join('\n'));
+      expect(emitStmt(new o.DeclareFunctionStmt('someFn', [], []))).toEqual([
+        'function someFn():void {', '}'
+      ].join('\n'));
       expect(emitStmt(new o.DeclareFunctionStmt('someFn', [], [], null, [o.StmtModifier.Exported])))
           .toEqual(['export function someFn():void {', '}'].join('\n'));
       expect(emitStmt(new o.DeclareFunctionStmt(
                  'someFn', [], [new o.ReturnStatement(o.literal(1))], o.INT_TYPE)))
           .toEqual(['function someFn():number {', '  return 1;', '}'].join('\n'));
-      expect(emitStmt(new o.DeclareFunctionStmt('someFn', [new o.FnParam('param1', o.INT_TYPE)], [
-      ]))).toEqual(['function someFn(param1:number):void {', '}'].join('\n'));
+      expect(
+          emitStmt(new o.DeclareFunctionStmt('someFn', [new o.FnParam('param1', o.INT_TYPE)], [])))
+          .toEqual(['function someFn(param1:number):void {', '}'].join('\n'));
     });
 
     it('should support comments', () => {
@@ -266,43 +268,47 @@ const externalModuleIdentifier = new o.ExternalReference(anotherModuleUrl, 'some
       ].join('\n'));
     });
 
-    it('should support support throwing',
-       () => { expect(emitStmt(new o.ThrowStmt(someVar))).toEqual('throw someVar;'); });
+    it('should support support throwing', () => {
+      expect(emitStmt(new o.ThrowStmt(someVar))).toEqual('throw someVar;');
+    });
 
     describe('classes', () => {
       let callSomeMethod: o.Statement;
 
-      beforeEach(() => { callSomeMethod = o.THIS_EXPR.callMethod('someMethod', []).toStmt(); });
+      beforeEach(() => {
+        callSomeMethod = o.THIS_EXPR.callMethod('someMethod', []).toStmt();
+      });
 
 
       it('should support declaring classes', () => {
-        expect(emitStmt(new o.ClassStmt('SomeClass', null !, [], [], null !, [
-        ]))).toEqual(['class SomeClass {', '}'].join('\n'));
-        expect(emitStmt(new o.ClassStmt('SomeClass', null !, [], [], null !, [], [
+        expect(emitStmt(new o.ClassStmt('SomeClass', null!, [], [], null!, []))).toEqual([
+          'class SomeClass {', '}'
+        ].join('\n'));
+        expect(emitStmt(new o.ClassStmt('SomeClass', null!, [], [], null!, [], [
           o.StmtModifier.Exported
         ]))).toEqual(['export class SomeClass {', '}'].join('\n'));
-        expect(emitStmt(new o.ClassStmt('SomeClass', o.variable('SomeSuperClass'), [], [], null !, [
-        ]))).toEqual(['class SomeClass extends SomeSuperClass {', '}'].join('\n'));
+        expect(
+            emitStmt(new o.ClassStmt('SomeClass', o.variable('SomeSuperClass'), [], [], null!, [])))
+            .toEqual(['class SomeClass extends SomeSuperClass {', '}'].join('\n'));
       });
 
       it('should support declaring constructors', () => {
         const superCall = o.SUPER_EXPR.callFn([o.variable('someParam')]).toStmt();
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [], new o.ClassMethod(null !, [], []), [])))
+                   'SomeClass', null!, [], [], new o.ClassMethod(null!, [], []), [])))
             .toEqual(['class SomeClass {', '  constructor() {', '  }', '}'].join('\n'));
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [],
-                   new o.ClassMethod(null !, [new o.FnParam('someParam', o.INT_TYPE)], []), [])))
+                   'SomeClass', null!, [], [],
+                   new o.ClassMethod(null!, [new o.FnParam('someParam', o.INT_TYPE)], []), [])))
             .toEqual(
                 ['class SomeClass {', '  constructor(someParam:number) {', '  }', '}'].join('\n'));
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [], new o.ClassMethod(null !, [], [superCall]), [])))
+                   'SomeClass', null!, [], [], new o.ClassMethod(null!, [], [superCall]), [])))
             .toEqual([
               'class SomeClass {', '  constructor() {', '    super(someParam);', '  }', '}'
             ].join('\n'));
-        expect(
-            emitStmt(new o.ClassStmt(
-                'SomeClass', null !, [], [], new o.ClassMethod(null !, [], [callSomeMethod]), [])))
+        expect(emitStmt(new o.ClassStmt(
+                   'SomeClass', null!, [], [], new o.ClassMethod(null!, [], [callSomeMethod]), [])))
             .toEqual([
               'class SomeClass {', '  constructor() {', '    this.someMethod();', '  }', '}'
             ].join('\n'));
@@ -310,57 +316,56 @@ const externalModuleIdentifier = new o.ExternalReference(anotherModuleUrl, 'some
 
       it('should support declaring fields', () => {
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [new o.ClassField('someField')], [], null !, [])))
+                   'SomeClass', null!, [new o.ClassField('someField')], [], null!, [])))
             .toEqual(['class SomeClass {', '  someField:any;', '}'].join('\n'));
-        expect(
-            emitStmt(new o.ClassStmt(
-                'SomeClass', null !, [new o.ClassField('someField', o.INT_TYPE)], [], null !, [])))
+        expect(emitStmt(new o.ClassStmt(
+                   'SomeClass', null!, [new o.ClassField('someField', o.INT_TYPE)], [], null!, [])))
             .toEqual(['class SomeClass {', '  someField:number;', '}'].join('\n'));
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !,
-                   [new o.ClassField('someField', o.INT_TYPE, [o.StmtModifier.Private])], [],
-                   null !, [])))
+                   'SomeClass', null!,
+                   [new o.ClassField('someField', o.INT_TYPE, [o.StmtModifier.Private])], [], null!,
+                   [])))
             .toEqual(['class SomeClass {', '  /*private*/ someField:number;', '}'].join('\n'));
       });
 
       it('should support declaring getters', () => {
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [new o.ClassGetter('someGetter', [])], null !, [])))
+                   'SomeClass', null!, [], [new o.ClassGetter('someGetter', [])], null!, [])))
             .toEqual(['class SomeClass {', '  get someGetter():any {', '  }', '}'].join('\n'));
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [new o.ClassGetter('someGetter', [], o.INT_TYPE)],
-                   null !, [])))
+                   'SomeClass', null!, [], [new o.ClassGetter('someGetter', [], o.INT_TYPE)], null!,
+                   [])))
             .toEqual(['class SomeClass {', '  get someGetter():number {', '  }', '}'].join('\n'));
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [new o.ClassGetter('someGetter', [callSomeMethod])],
-                   null !, [])))
+                   'SomeClass', null!, [], [new o.ClassGetter('someGetter', [callSomeMethod])],
+                   null!, [])))
             .toEqual([
               'class SomeClass {', '  get someGetter():any {', '    this.someMethod();', '  }', '}'
             ].join('\n'));
-        expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [],
-                   [new o.ClassGetter('someGetter', [], null !, [o.StmtModifier.Private])], null !,
-                   [])))
+        expect(
+            emitStmt(new o.ClassStmt(
+                'SomeClass', null!, [],
+                [new o.ClassGetter('someGetter', [], null!, [o.StmtModifier.Private])], null!, [])))
             .toEqual(
                 ['class SomeClass {', '  private get someGetter():any {', '  }', '}'].join('\n'));
       });
 
       it('should support methods', () => {
-        expect(emitStmt(new o.ClassStmt('SomeClass', null !, [], [], null !, [
+        expect(emitStmt(new o.ClassStmt('SomeClass', null!, [], [], null!, [
           new o.ClassMethod('someMethod', [], [])
         ]))).toEqual(['class SomeClass {', '  someMethod():void {', '  }', '}'].join('\n'));
-        expect(emitStmt(new o.ClassStmt('SomeClass', null !, [], [], null !, [
+        expect(emitStmt(new o.ClassStmt('SomeClass', null!, [], [], null!, [
           new o.ClassMethod('someMethod', [], [], o.INT_TYPE)
         ]))).toEqual(['class SomeClass {', '  someMethod():number {', '  }', '}'].join('\n'));
         expect(
             emitStmt(new o.ClassStmt(
-                'SomeClass', null !, [], [], null !,
+                'SomeClass', null!, [], [], null!,
                 [new o.ClassMethod('someMethod', [new o.FnParam('someParam', o.INT_TYPE)], [])])))
             .toEqual([
               'class SomeClass {', '  someMethod(someParam:number):void {', '  }', '}'
             ].join('\n'));
         expect(emitStmt(new o.ClassStmt(
-                   'SomeClass', null !, [], [], null !,
+                   'SomeClass', null!, [], [], null!,
                    [new o.ClassMethod('someMethod', [], [callSomeMethod])])))
             .toEqual([
               'class SomeClass {', '  someMethod():void {', '    this.someMethod();', '  }', '}'
@@ -412,7 +417,7 @@ const externalModuleIdentifier = new o.ExternalReference(anotherModuleUrl, 'some
 
     it('should support combined types', () => {
       const writeVarExpr = o.variable('a').set(o.NULL_EXPR);
-      expect(emitStmt(writeVarExpr.toDeclStmt(new o.ArrayType(null !))))
+      expect(emitStmt(writeVarExpr.toDeclStmt(new o.ArrayType(null!))))
           .toEqual('var a:any[] = (null as any);');
       expect(emitStmt(writeVarExpr.toDeclStmt(new o.ArrayType(o.INT_TYPE))))
           .toEqual('var a:number[] = (null as any);');

--- a/packages/compiler/test/pipe_resolver_spec.ts
+++ b/packages/compiler/test/pipe_resolver_spec.ts
@@ -21,7 +21,9 @@ class SimpleClass {}
   describe('PipeResolver', () => {
     let resolver: PipeResolver;
 
-    beforeEach(() => { resolver = new PipeResolver(new JitReflector()); });
+    beforeEach(() => {
+      resolver = new PipeResolver(new JitReflector());
+    });
 
     it('should read out the metadata from the class', () => {
       const moduleMetadata = resolver.resolve(SomePipe);
@@ -48,6 +50,5 @@ class SimpleClass {}
 
       expect(resolver.resolve(ChildWithDecorator)).toEqual(new Pipe({name: 'c'}));
     });
-
   });
 }

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -74,18 +74,24 @@ class R3AstSourceSpans implements t.Visitor<void> {
         ['BoundEvent', humanizeSpan(event.sourceSpan), humanizeSpan(event.handlerSpan)]);
   }
 
-  visitText(text: t.Text) { this.result.push(['Text', humanizeSpan(text.sourceSpan)]); }
+  visitText(text: t.Text) {
+    this.result.push(['Text', humanizeSpan(text.sourceSpan)]);
+  }
 
   visitBoundText(text: t.BoundText) {
     this.result.push(['BoundText', humanizeSpan(text.sourceSpan)]);
   }
 
-  visitIcu(icu: t.Icu) { return null; }
+  visitIcu(icu: t.Icu) {
+    return null;
+  }
 
-  private visitAll(nodes: t.Node[][]) { nodes.forEach(node => t.visitAll(this, node)); }
+  private visitAll(nodes: t.Node[][]) {
+    nodes.forEach(node => t.visitAll(this, node));
+  }
 }
 
-function humanizeSpan(span: ParseSourceSpan | null | undefined): string {
+function humanizeSpan(span: ParseSourceSpan|null|undefined): string {
   if (span === null || span === undefined) {
     return `<empty>`;
   }

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -75,13 +75,21 @@ class R3AstHumanizer implements t.Visitor<void> {
     ]);
   }
 
-  visitText(text: t.Text) { this.result.push(['Text', text.value]); }
+  visitText(text: t.Text) {
+    this.result.push(['Text', text.value]);
+  }
 
-  visitBoundText(text: t.BoundText) { this.result.push(['BoundText', unparse(text.value)]); }
+  visitBoundText(text: t.BoundText) {
+    this.result.push(['BoundText', unparse(text.value)]);
+  }
 
-  visitIcu(icu: t.Icu) { return null; }
+  visitIcu(icu: t.Icu) {
+    return null;
+  }
 
-  private visitAll(nodes: t.Node[][]) { nodes.forEach(node => t.visitAll(this, node)); }
+  private visitAll(nodes: t.Node[][]) {
+    nodes.forEach(node => t.visitAll(this, node));
+  }
 }
 
 function expectFromHtml(html: string) {
@@ -97,13 +105,14 @@ function expectFromR3Nodes(nodes: t.Node[]) {
 
 function expectSpanFromHtml(html: string) {
   const {nodes} = parse(html);
-  return expect(nodes[0] !.sourceSpan.toString());
+  return expect(nodes[0]!.sourceSpan.toString());
 }
 
 describe('R3 template transform', () => {
   describe('ParseSpan on nodes toString', () => {
-    it('should create valid text span on Element with adjacent start and end tags',
-       () => { expectSpanFromHtml('<div></div>').toBe('<div></div>'); });
+    it('should create valid text span on Element with adjacent start and end tags', () => {
+      expectSpanFromHtml('<div></div>').toBe('<div></div>');
+    });
   });
 
   describe('Nodes without binding', () => {

--- a/packages/compiler/test/render3/style_parser_spec.ts
+++ b/packages/compiler/test/render3/style_parser_spec.ts
@@ -90,7 +90,8 @@ describe('style parsing', () => {
       expect(hyphenate('-fooBar-man')).toEqual('-foo-bar-man');
     });
 
-    it('should make everything lowercase',
-       () => { expect(hyphenate('-WebkitAnimation')).toEqual('-webkit-animation'); });
+    it('should make everything lowercase', () => {
+      expect(hyphenate('-WebkitAnimation')).toEqual('-webkit-animation');
+    });
   });
 });

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -15,7 +15,9 @@ type HumanizedExpressionSource = [string, AbsoluteSourceSpan];
 class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visitor {
   result: HumanizedExpressionSource[] = [];
 
-  private recordAst(ast: e.AST) { this.result.push([unparse(ast), ast.sourceSpan]); }
+  private recordAst(ast: e.AST) {
+    this.result.push([unparse(ast), ast.sourceSpan]);
+  }
 
   // This method is defined to reconcile the type of ExpressionSourceHumanizer
   // since both RecursiveAstVisitor and Visitor define the visit() method in
@@ -124,11 +126,19 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
   }
   visitReference(ast: t.Reference) {}
   visitVariable(ast: t.Variable) {}
-  visitEvent(ast: t.BoundEvent) { ast.handler.visit(this); }
+  visitEvent(ast: t.BoundEvent) {
+    ast.handler.visit(this);
+  }
   visitTextAttribute(ast: t.TextAttribute) {}
-  visitBoundAttribute(ast: t.BoundAttribute) { ast.value.visit(this); }
-  visitBoundEvent(ast: t.BoundEvent) { ast.handler.visit(this); }
-  visitBoundText(ast: t.BoundText) { ast.value.visit(this); }
+  visitBoundAttribute(ast: t.BoundAttribute) {
+    ast.value.visit(this);
+  }
+  visitBoundEvent(ast: t.BoundEvent) {
+    ast.handler.visit(this);
+  }
+  visitBoundText(ast: t.BoundText) {
+    ast.value.visit(this);
+  }
   visitContent(ast: t.Content) {}
   visitText(ast: t.Text) {}
   visitIcu(ast: t.Icu) {}

--- a/packages/compiler/test/render3/view/binding_spec.ts
+++ b/packages/compiler/test/render3/view/binding_spec.ts
@@ -54,8 +54,9 @@ describe('t2 binding', () => {
     const binder = new R3TargetBinder(new SelectorMatcher<DirectiveMeta>());
     const res = binder.bind({template: template.nodes});
 
-    const itemBinding = (findExpression(template.nodes, '{{item.name}}') !as e.Interpolation)
-                            .expressions[0] as e.PropertyRead;
+    const itemBinding =
+        (findExpression(template.nodes, '{{item.name}}')! as e.Interpolation).expressions[0] as
+        e.PropertyRead;
     const item = itemBinding.receiver;
     const itemTarget = res.getExpressionTarget(item);
     if (!(itemTarget instanceof a.Variable)) {
@@ -64,7 +65,7 @@ describe('t2 binding', () => {
     expect(itemTarget.value).toBe('$implicit');
     const itemTemplate = res.getTemplateOfSymbol(itemTarget);
     expect(itemTemplate).not.toBeNull();
-    expect(res.getNestingLevel(itemTemplate !)).toBe(1);
+    expect(res.getNestingLevel(itemTemplate!)).toBe(1);
   });
 
   it('should match directives when binding a simple template', () => {
@@ -72,7 +73,7 @@ describe('t2 binding', () => {
     const binder = new R3TargetBinder(makeSelectorMatcher());
     const res = binder.bind({template: template.nodes});
     const tmpl = template.nodes[0] as a.Template;
-    const directives = res.getDirectivesOfNode(tmpl) !;
+    const directives = res.getDirectivesOfNode(tmpl)!;
     expect(directives).not.toBeNull();
     expect(directives.length).toBe(1);
     expect(directives[0].name).toBe('NgFor');
@@ -92,7 +93,7 @@ describe('t2 binding', () => {
     const res = binder.bind({template: template.nodes});
     const svgNode = template.nodes[0] as a.Element;
     const textNode = svgNode.children[0] as a.Element;
-    const directives = res.getDirectivesOfNode(textNode) !;
+    const directives = res.getDirectivesOfNode(textNode)!;
     expect(directives).not.toBeNull();
     expect(directives.length).toBe(1);
     expect(directives[0].name).toBe('Dir');
@@ -103,11 +104,11 @@ describe('t2 binding', () => {
     const binder = new R3TargetBinder(makeSelectorMatcher());
     const res = binder.bind({template: template.nodes});
     const tmpl = template.nodes[0] as a.Template;
-    const tmplDirectives = res.getDirectivesOfNode(tmpl) !;
+    const tmplDirectives = res.getDirectivesOfNode(tmpl)!;
     expect(tmplDirectives).not.toBeNull();
     expect(tmplDirectives.length).toBe(1);
     expect(tmplDirectives[0].name).toBe('NgFor');
-    const elDirectives = res.getDirectivesOfNode(tmpl.children[0] as a.Element) !;
+    const elDirectives = res.getDirectivesOfNode(tmpl.children[0] as a.Element)!;
     expect(elDirectives).not.toBeNull();
     expect(elDirectives.length).toBe(1);
     expect(elDirectives[0].name).toBe('Dir');

--- a/packages/compiler/test/render3/view/i18n_spec.ts
+++ b/packages/compiler/test/render3/view/i18n_spec.ts
@@ -21,7 +21,7 @@ import {formatI18nPlaceholderName} from '../../../src/render3/view/i18n/util';
 import {parseR3 as parse} from './util';
 
 const expressionParser = new Parser(new Lexer());
-const i18nOf = (element: t.Node & {i18n?: i18n.I18nMeta}) => element.i18n !;
+const i18nOf = (element: t.Node&{i18n?: i18n.I18nMeta}) => element.i18n!;
 
 describe('I18nContext', () => {
   it('should support i18n content collection', () => {
@@ -74,7 +74,7 @@ describe('I18nContext', () => {
     const [boundTextB, elementC, boundTextC] = (elementB as t.Element).children;
 
     // simulate I18nContext for a given template
-    const ctx = new I18nContext(1, o.variable('ctx'), 0, null, root.i18n !);
+    const ctx = new I18nContext(1, o.variable('ctx'), 0, null, root.i18n!);
 
     // set data for root ctx
     ctx.appendBoundText(i18nOf(boundTextA));
@@ -87,7 +87,7 @@ describe('I18nContext', () => {
     expect(ctx.isResolved).toBe(false);
 
     // create child context
-    const childCtx = ctx.forkChildContext(2, 1, (templateA as t.Template).i18n !);
+    const childCtx = ctx.forkChildContext(2, 1, (templateA as t.Template).i18n!);
     expect(childCtx.bindings.size).toBe(0);
     expect(childCtx.isRoot).toBe(false);
 
@@ -116,11 +116,12 @@ describe('I18nContext', () => {
     const expected = new Map([
       ['INTERPOLATION', '�0�'], ['START_TAG_DIV', '�#0�|�#1:1�'],
       ['START_BOLD_TEXT', '�*1:1��#0:1�'], ['CLOSE_BOLD_TEXT', '�/#0:1��/*1:1�'],
-      ['CLOSE_TAG_DIV', '�/#0�|�/#1:1�'], ['INTERPOLATION_1', '�0:1�'],
-      ['INTERPOLATION_2', '�1:1�']
+      ['CLOSE_TAG_DIV', '�/#0�|�/#1:1�'], ['INTERPOLATION_1', '�0:1�'], ['INTERPOLATION_2', '�1:1�']
     ]);
     const phs = ctx.getSerializedPlaceholders();
-    expected.forEach((value, key) => { expect(phs.get(key) !.join('|')).toEqual(value); });
+    expected.forEach((value, key) => {
+      expect(phs.get(key)!.join('|')).toEqual(value);
+    });
 
     // placeholders are added into the root ctx
     expect(phs.size).toBe(expected.size);
@@ -152,7 +153,7 @@ describe('I18nContext', () => {
     const [textC] = (templateB as t.Template).children;
 
     // simulate I18nContext for a given template
-    const ctxLevelA = new I18nContext(0, o.variable('ctx'), 0, null, root.i18n !);
+    const ctxLevelA = new I18nContext(0, o.variable('ctx'), 0, null, root.i18n!);
 
     // create Level A context
     ctxLevelA.appendTemplate(i18nOf(templateA), 1);
@@ -160,12 +161,12 @@ describe('I18nContext', () => {
     expect(ctxLevelA.isResolved).toBe(false);
 
     // create Level B context
-    const ctxLevelB = ctxLevelA.forkChildContext(0, 1, (templateA as t.Template).i18n !);
+    const ctxLevelB = ctxLevelA.forkChildContext(0, 1, (templateA as t.Template).i18n!);
     ctxLevelB.appendTemplate(i18nOf(templateB), 1);
     expect(ctxLevelB.isRoot).toBe(false);
 
     // create Level 2 context
-    const ctxLevelC = ctxLevelB.forkChildContext(0, 1, (templateB as t.Template).i18n !);
+    const ctxLevelC = ctxLevelB.forkChildContext(0, 1, (templateB as t.Template).i18n!);
     expect(ctxLevelC.isRoot).toBe(false);
 
     // reconcile
@@ -176,7 +177,9 @@ describe('I18nContext', () => {
     const expected = new Map(
         [['START_TAG_NG-TEMPLATE', '�*1:1�|�*1:2�'], ['CLOSE_TAG_NG-TEMPLATE', '�/*1:2�|�/*1:1�']]);
     const phs = ctxLevelA.getSerializedPlaceholders();
-    expected.forEach((value, key) => { expect(phs.get(key) !.join('|')).toEqual(value); });
+    expected.forEach((value, key) => {
+      expect(phs.get(key)!.join('|')).toEqual(value);
+    });
 
     // placeholders are added into the root ctx
     expect(phs.size).toBe(expected.size);
@@ -195,8 +198,9 @@ describe('Utils', () => {
       ['START_TAG_NG-CONTAINER_1', 'startTagNgContainer_1'], ['CLOSE_TAG_ITALIC', 'closeTagItalic'],
       ['CLOSE_TAG_BOLD_1', 'closeTagBold_1']
     ];
-    cases.forEach(
-        ([input, output]) => { expect(formatI18nPlaceholderName(input)).toEqual(output); });
+    cases.forEach(([input, output]) => {
+      expect(formatI18nPlaceholderName(input)).toEqual(output);
+    });
   });
 
   describe('metadata serialization', () => {
@@ -292,8 +296,9 @@ describe('serializeI18nMessageForGetMsg', () => {
     return serializeI18nMessageForGetMsg(root.i18n as i18n.Message);
   };
 
-  it('should serialize plain text for `GetMsg()`',
-     () => { expect(serialize('Some text')).toEqual('Some text'); });
+  it('should serialize plain text for `GetMsg()`', () => {
+    expect(serialize('Some text')).toEqual('Some text');
+  });
 
   it('should serialize text with interpolation for `GetMsg()`', () => {
     expect(serialize('Some text {{ valueA }} and {{ valueB + valueC }}'))

--- a/packages/compiler/test/render3/view/util.ts
+++ b/packages/compiler/test/render3/view/util.ts
@@ -14,7 +14,7 @@ import {HtmlParser, ParseTreeResult} from '../../../src/ml_parser/html_parser';
 import {WhitespaceVisitor} from '../../../src/ml_parser/html_whitespaces';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../../src/ml_parser/interpolation_config';
 import * as a from '../../../src/render3/r3_ast';
-import {Render3ParseResult, htmlAstToRender3Ast} from '../../../src/render3/r3_template_transform';
+import {htmlAstToRender3Ast, Render3ParseResult} from '../../../src/render3/r3_template_transform';
 import {I18nMetaVisitor} from '../../../src/render3/view/i18n/meta';
 import {BindingParser} from '../../../src/template_parser/binding_parser';
 import {MockSchemaRegistry} from '../../../testing';

--- a/packages/compiler/test/resource_loader_mock_spec.ts
+++ b/packages/compiler/test/resource_loader_mock_spec.ts
@@ -13,10 +13,12 @@ import {AsyncTestCompleter, beforeEach, describe, expect, inject, it} from '@ang
   describe('MockResourceLoader', () => {
     let resourceLoader: MockResourceLoader;
 
-    beforeEach(() => { resourceLoader = new MockResourceLoader(); });
+    beforeEach(() => {
+      resourceLoader = new MockResourceLoader();
+    });
 
     function expectResponse(
-        request: Promise<string>, url: string, response: string, done: () => void = null !) {
+        request: Promise<string>, url: string, response: string, done: () => void = null!) {
       function onResponse(text: string): string {
         if (response === null) {
           throw `Unexpected response ${url} -> ${text}`;
@@ -52,7 +54,7 @@ import {AsyncTestCompleter, beforeEach, describe, expect, inject, it} from '@ang
     it('should return an error from the definitions',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          const url = '/foo';
-         const response: string = null !;
+         const response: string = null!;
          resourceLoader.when(url, response);
          expectResponse(resourceLoader.get(url), url, response, () => async.done());
          resourceLoader.flush();
@@ -70,7 +72,7 @@ import {AsyncTestCompleter, beforeEach, describe, expect, inject, it} from '@ang
     it('should return an error from the expectations',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          const url = '/foo';
-         const response: string = null !;
+         const response: string = null!;
          resourceLoader.expect(url, response);
          expectResponse(resourceLoader.get(url), url, response, () => async.done());
          resourceLoader.flush();
@@ -82,7 +84,9 @@ import {AsyncTestCompleter, beforeEach, describe, expect, inject, it} from '@ang
       resourceLoader.expect(url, response);
       resourceLoader.get(url);
       resourceLoader.get(url);
-      expect(() => { resourceLoader.flush(); }).toThrowError('Unexpected request /foo');
+      expect(() => {
+        resourceLoader.flush();
+      }).toThrowError('Unexpected request /foo');
     });
 
     it('should return expectations before definitions',
@@ -97,18 +101,24 @@ import {AsyncTestCompleter, beforeEach, describe, expect, inject, it} from '@ang
 
     it('should throw when there is no definitions or expectations', () => {
       resourceLoader.get('/foo');
-      expect(() => { resourceLoader.flush(); }).toThrowError('Unexpected request /foo');
+      expect(() => {
+        resourceLoader.flush();
+      }).toThrowError('Unexpected request /foo');
     });
 
     it('should throw when flush is called without any pending requests', () => {
-      expect(() => { resourceLoader.flush(); }).toThrowError('No pending requests to flush');
+      expect(() => {
+        resourceLoader.flush();
+      }).toThrowError('No pending requests to flush');
     });
 
     it('should throw on unsatisfied expectations', () => {
       resourceLoader.expect('/foo', 'bar');
       resourceLoader.when('/bar', 'foo');
       resourceLoader.get('/bar');
-      expect(() => { resourceLoader.flush(); }).toThrowError('Unsatisfied requests: /foo');
+      expect(() => {
+        resourceLoader.flush();
+      }).toThrowError('Unsatisfied requests: /foo');
     });
   });
 }

--- a/packages/compiler/test/runtime_compiler_spec.ts
+++ b/packages/compiler/test/runtime_compiler_spec.ts
@@ -8,9 +8,11 @@
 
 import {DirectiveResolver, ResourceLoader} from '@angular/compiler';
 import {Compiler, Component, Injector, NgModule, NgModuleFactory, ɵstringify as stringify} from '@angular/core';
-import {TestBed, async, fakeAsync, inject, tick} from '@angular/core/testing';
+import {async, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
+
 import {MockDirectiveResolver} from '../testing';
+
 import {SpyResourceLoader} from './spies';
 
 @Component({selector: 'child-cmp'})
@@ -27,11 +29,12 @@ class SomeCompWithUrlTemplate {
 
 {
   describe('RuntimeCompiler', () => {
-
     describe('compilerComponentSync', () => {
       describe('never resolving loader', () => {
         class StubResourceLoader {
-          get(url: string) { return new Promise(() => {}); }
+          get(url: string) {
+            return new Promise(() => {});
+          }
         }
 
         beforeEach(() => {
@@ -43,8 +46,8 @@ class SomeCompWithUrlTemplate {
              TestBed.configureTestingModule({declarations: [SomeCompWithUrlTemplate]});
              TestBed.compileComponents().then(() => {
                expect(() => TestBed.createComponent(SomeCompWithUrlTemplate))
-                   .toThrowError(
-                       `Can't compile synchronously as ${stringify(SomeCompWithUrlTemplate)} is still being loaded!`);
+                   .toThrowError(`Can't compile synchronously as ${
+                       stringify(SomeCompWithUrlTemplate)} is still being loaded!`);
              });
            }));
 
@@ -55,15 +58,17 @@ class SomeCompWithUrlTemplate {
              TestBed.overrideComponent(SomeComp, {set: {template: '<child-cmp></child-cmp>'}});
              TestBed.compileComponents().then(() => {
                expect(() => TestBed.createComponent(SomeComp))
-                   .toThrowError(
-                       `Can't compile synchronously as ${stringify(ChildComp)} is still being loaded!`);
+                   .toThrowError(`Can't compile synchronously as ${
+                       stringify(ChildComp)} is still being loaded!`);
              });
            });
       });
 
       describe('resolving loader', () => {
         class StubResourceLoader {
-          get(url: string) { return Promise.resolve('hello'); }
+          get(url: string) {
+            return Promise.resolve('hello');
+          }
         }
 
         beforeEach(() => {
@@ -88,7 +93,9 @@ class SomeCompWithUrlTemplate {
     let dirResolver: MockDirectiveResolver;
     let injector: Injector;
 
-    beforeEach(() => { TestBed.configureCompiler({providers: [SpyResourceLoader.PROVIDE]}); });
+    beforeEach(() => {
+      TestBed.configureCompiler({providers: [SpyResourceLoader.PROVIDE]});
+    });
 
     beforeEach(fakeAsync(inject(
         [Compiler, ResourceLoader, DirectiveResolver, Injector],
@@ -110,7 +117,7 @@ class SomeCompWithUrlTemplate {
            }
 
            resourceLoader.spy('get').and.callFake(() => Promise.resolve('hello'));
-           let ngModuleFactory: NgModuleFactory<any> = undefined !;
+           let ngModuleFactory: NgModuleFactory<any> = undefined!;
            compiler.compileModuleAsync(SomeModule).then((f) => ngModuleFactory = f);
            tick();
            expect(ngModuleFactory.moduleType).toBe(SomeModule);
@@ -126,8 +133,8 @@ class SomeCompWithUrlTemplate {
 
         resourceLoader.spy('get').and.callFake(() => Promise.resolve(''));
         expect(() => compiler.compileModuleSync(SomeModule))
-            .toThrowError(
-                `Can't compile synchronously as ${stringify(SomeCompWithUrlTemplate)} is still being loaded!`);
+            .toThrowError(`Can't compile synchronously as ${
+                stringify(SomeCompWithUrlTemplate)} is still being loaded!`);
       });
 
       it('should throw when using a templateUrl in a nested component that has not been compiled before',

--- a/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
+++ b/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
@@ -19,7 +19,9 @@ import {extractSchema} from './schema_extractor';
 {
   describe('DOMElementSchema', () => {
     let registry: DomElementSchemaRegistry;
-    beforeEach(() => { registry = new DomElementSchemaRegistry(); });
+    beforeEach(() => {
+      registry = new DomElementSchemaRegistry();
+    });
 
     it('should detect elements', () => {
       expect(registry.hasElement('div', [])).toBeTruthy();
@@ -97,8 +99,9 @@ import {extractSchema} from './schema_extractor';
       expect(registry.hasElement('unknown', [NO_ERRORS_SCHEMA])).toBeTruthy();
     });
 
-    it('should re-map property names that are specified in DOM facade',
-       () => { expect(registry.getMappedPropName('readonly')).toEqual('readOnly'); });
+    it('should re-map property names that are specified in DOM facade', () => {
+      expect(registry.getMappedPropName('readonly')).toEqual('readOnly');
+    });
 
     it('should not re-map property names that are not specified in DOM facade', () => {
       expect(registry.getMappedPropName('title')).toEqual('title');
@@ -173,8 +176,9 @@ If 'onAnything' is a directive input, make sure the directive is imported by the
     });
 
     describe('Angular custom elements', () => {
-      it('should support <ng-container>',
-         () => { expect(registry.hasProperty('ng-container', 'id', [])).toBeFalsy(); });
+      it('should support <ng-container>', () => {
+        expect(registry.hasProperty('ng-container', 'id', [])).toBeFalsy();
+      });
 
       it('should support <ng-content>', () => {
         expect(registry.hasProperty('ng-content', 'id', [])).toBeFalsy();
@@ -185,8 +189,9 @@ If 'onAnything' is a directive input, make sure the directive is imported by the
     if (browserDetection.isChromeDesktop) {
       it('generate a new schema', () => {
         let schema = '\n';
-        extractSchema() !.forEach(
-            (props, name) => { schema += `'${name}|${props.join(',')}',\n`; });
+        extractSchema()!.forEach((props, name) => {
+          schema += `'${name}|${props.join(',')}',\n`;
+        });
         // Uncomment this line to see:
         // the generated schema which can then be pasted to the DomElementSchemaRegistry
         // console.log(schema);

--- a/packages/compiler/test/schema/schema_extractor.ts
+++ b/packages/compiler/test/schema/schema_extractor.ts
@@ -97,7 +97,9 @@ export function extractSchema(): Map<string, string[]>|null {
 
   types.sort();
 
-  types.forEach(type => { extractRecursiveProperties(visited, descMap, (window as any)[type]); });
+  types.forEach(type => {
+    extractRecursiveProperties(visited, descMap, (window as any)[type]);
+  });
 
   // Add elements missed by Chrome auto-detection
   Object.keys(MISSING_FROM_CHROME).forEach(elHierarchy => {
@@ -125,7 +127,7 @@ function assertNoMissingTags(descMap: Map<string, string[]>): void {
 
 function extractRecursiveProperties(
     visited: {[name: string]: boolean}, descMap: Map<string, string[]>, type: Function): string {
-  const name = extractName(type) !;
+  const name = extractName(type)!;
 
   if (visited[name]) {
     return name;
@@ -181,7 +183,7 @@ function extractProperties(
 
   const fullName = name + (superName ? '^' + superName : '');
 
-  const props: string[] = descMap.has(fullName) ? descMap.get(fullName) ! : [];
+  const props: string[] = descMap.has(fullName) ? descMap.get(fullName)! : [];
 
   const prototype = type.prototype;
   const keys = Object.getOwnPropertyNames(prototype);

--- a/packages/compiler/test/selector/selector_spec.ts
+++ b/packages/compiler/test/selector/selector_spec.ts
@@ -17,13 +17,16 @@ import {el} from '@angular/platform-browser/testing/src/browser_util';
     let s1: any[], s2: any[], s3: any[], s4: any[];
     let matched: any[];
 
-    function reset() { matched = []; }
+    function reset() {
+      matched = [];
+    }
 
     beforeEach(() => {
       reset();
-      s1 = s2 = s3 = s4 = null !;
-      selectableCollector =
-          (selector: CssSelector, context: any) => { matched.push(selector, context); };
+      s1 = s2 = s3 = s4 = null!;
+      selectableCollector = (selector: CssSelector, context: any) => {
+        matched.push(selector, context);
+      };
       matcher = new SelectorMatcher();
     });
 
@@ -128,7 +131,7 @@ import {el} from '@angular/platform-browser/testing/src/browser_util';
 
       const elementSelector = new CssSelector();
       const element = el('<div attr></div>');
-      const empty = element.getAttribute('attr') !;
+      const empty = element.getAttribute('attr')!;
       elementSelector.addAttribute('some-decor', empty);
       matcher.match(elementSelector, selectableCollector);
       expect(matched).toEqual([s1[0], 1]);
@@ -458,9 +461,13 @@ function getSelectorFor(
   const selector = new CssSelector();
   selector.setElement(tag);
 
-  attrs.forEach(nameValue => { selector.addAttribute(nameValue[0], nameValue[1]); });
+  attrs.forEach(nameValue => {
+    selector.addAttribute(nameValue[0], nameValue[1]);
+  });
 
-  classes.trim().split(/\s+/g).forEach(cName => { selector.addClassName(cName); });
+  classes.trim().split(/\s+/g).forEach(cName => {
+    selector.addClassName(cName);
+  });
 
   return selector;
 }

--- a/packages/compiler/test/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css_spec.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CssRule, ShadowCss, processRules} from '@angular/compiler/src/shadow_css';
+import {CssRule, processRules, ShadowCss} from '@angular/compiler/src/shadow_css';
 import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
 
 {
   describe('ShadowCss', function() {
-
     function s(css: string, contentAttr: string, hostAttr: string = '') {
       const shadowCss = new ShadowCss();
       const shim = shadowCss.shimCssText(css, contentAttr, hostAttr);
@@ -19,7 +18,9 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
       return normalizeCSS(shim.replace(nlRegexp, ''));
     }
 
-    it('should handle empty string', () => { expect(s('', 'contenta')).toEqual(''); });
+    it('should handle empty string', () => {
+      expect(s('', 'contenta')).toEqual('');
+    });
 
     it('should add an attribute to every rule', () => {
       const css = 'one {color: red;}two {color: red;}';
@@ -112,14 +113,17 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
     });
 
     describe((':host'), () => {
-      it('should handle no context',
-         () => { expect(s(':host {}', 'contenta', 'a-host')).toEqual('[a-host] {}'); });
+      it('should handle no context', () => {
+        expect(s(':host {}', 'contenta', 'a-host')).toEqual('[a-host] {}');
+      });
 
-      it('should handle tag selector',
-         () => { expect(s(':host(ul) {}', 'contenta', 'a-host')).toEqual('ul[a-host] {}'); });
+      it('should handle tag selector', () => {
+        expect(s(':host(ul) {}', 'contenta', 'a-host')).toEqual('ul[a-host] {}');
+      });
 
-      it('should handle class selector',
-         () => { expect(s(':host(.x) {}', 'contenta', 'a-host')).toEqual('.x[a-host] {}'); });
+      it('should handle class selector', () => {
+        expect(s(':host(.x) {}', 'contenta', 'a-host')).toEqual('.x[a-host] {}');
+      });
 
       it('should handle attribute selector', () => {
         expect(s(':host([a="b"]) {}', 'contenta', 'a-host')).toEqual('[a="b"][a-host] {}');
@@ -285,14 +289,17 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
       expect(css).toEqual('div[contenta] {height:calc(100% - 55px);}');
     });
 
-    it('should strip comments',
-       () => { expect(s('/* x */b {c}', 'contenta')).toEqual('b[contenta] {c}'); });
+    it('should strip comments', () => {
+      expect(s('/* x */b {c}', 'contenta')).toEqual('b[contenta] {c}');
+    });
 
-    it('should ignore special characters in comments',
-       () => { expect(s('/* {;, */b {c}', 'contenta')).toEqual('b[contenta] {c}'); });
+    it('should ignore special characters in comments', () => {
+      expect(s('/* {;, */b {c}', 'contenta')).toEqual('b[contenta] {c}');
+    });
 
-    it('should support multiline comments',
-       () => { expect(s('/* \n */b {c}', 'contenta')).toEqual('b[contenta] {c}'); });
+    it('should support multiline comments', () => {
+      expect(s('/* \n */b {c}', 'contenta')).toEqual('b[contenta] {c}');
+    });
 
     it('should keep sourceMappingURL comments', () => {
       expect(s('b {c}/*# sourceMappingURL=data:x */', 'contenta'))
@@ -318,13 +325,17 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
         return result;
       }
 
-      it('should work with empty css', () => { expect(captureRules('')).toEqual([]); });
+      it('should work with empty css', () => {
+        expect(captureRules('')).toEqual([]);
+      });
 
-      it('should capture a rule without body',
-         () => { expect(captureRules('a;')).toEqual([new CssRule('a', '')]); });
+      it('should capture a rule without body', () => {
+        expect(captureRules('a;')).toEqual([new CssRule('a', '')]);
+      });
 
-      it('should capture css rules with body',
-         () => { expect(captureRules('a {b}')).toEqual([new CssRule('a', 'b')]); });
+      it('should capture css rules with body', () => {
+        expect(captureRules('a {b}')).toEqual([new CssRule('a', 'b')]);
+      });
 
       it('should capture css rules with nested rules', () => {
         expect(captureRules('a {b {c}} d {e}')).toEqual([

--- a/packages/compiler/test/spies.ts
+++ b/packages/compiler/test/spies.ts
@@ -12,5 +12,7 @@ import {SpyObject} from '@angular/core/testing/src/testing_internal';
 
 export class SpyResourceLoader extends SpyObject {
   public static PROVIDE = {provide: ResourceLoader, useClass: SpyResourceLoader, deps: []};
-  constructor() { super(ResourceLoader); }
+  constructor() {
+    super(ResourceLoader);
+  }
 }

--- a/packages/compiler/test/style_url_resolver_spec.ts
+++ b/packages/compiler/test/style_url_resolver_spec.ts
@@ -13,7 +13,9 @@ import {UrlResolver} from '@angular/compiler/src/url_resolver';
   describe('extractStyleUrls', () => {
     let urlResolver: UrlResolver;
 
-    beforeEach(() => { urlResolver = new UrlResolver(); });
+    beforeEach(() => {
+      urlResolver = new UrlResolver();
+    });
 
     it('should not resolve "url()" urls', () => {
       const css = `
@@ -104,23 +106,25 @@ import {UrlResolver} from '@angular/compiler/src/url_resolver';
       expect(styleWithImports.style.trim()).toEqual(``);
       expect(styleWithImports.styleUrls).toEqual(['fake_resolved_url']);
     });
-
   });
 
   describe('isStyleUrlResolvable', () => {
-    it('should resolve relative urls',
-       () => { expect(isStyleUrlResolvable('someUrl.css')).toBe(true); });
+    it('should resolve relative urls', () => {
+      expect(isStyleUrlResolvable('someUrl.css')).toBe(true);
+    });
 
-    it('should resolve package: urls',
-       () => { expect(isStyleUrlResolvable('package:someUrl.css')).toBe(true); });
+    it('should resolve package: urls', () => {
+      expect(isStyleUrlResolvable('package:someUrl.css')).toBe(true);
+    });
 
     it('should not resolve empty urls', () => {
-      expect(isStyleUrlResolvable(null !)).toBe(false);
+      expect(isStyleUrlResolvable(null!)).toBe(false);
       expect(isStyleUrlResolvable('')).toBe(false);
     });
 
-    it('should not resolve urls with other schema',
-       () => { expect(isStyleUrlResolvable('http://otherurl')).toBe(false); });
+    it('should not resolve urls with other schema', () => {
+      expect(isStyleUrlResolvable('http://otherurl')).toBe(false);
+    });
 
     it('should not resolve urls with absolute paths', () => {
       expect(isStyleUrlResolvable('/otherurl')).toBe(false);
@@ -130,7 +134,11 @@ import {UrlResolver} from '@angular/compiler/src/url_resolver';
 }
 
 class FakeUrlResolver extends UrlResolver {
-  constructor() { super(); }
+  constructor() {
+    super();
+  }
 
-  resolve(baseUrl: string, url: string): string { return 'fake_resolved_url'; }
+  resolve(baseUrl: string, url: string): string {
+    return 'fake_resolved_url';
+  }
 }

--- a/packages/compiler/test/template_parser/binding_parser_spec.ts
+++ b/packages/compiler/test/template_parser/binding_parser_spec.ts
@@ -16,16 +16,18 @@ import {calcPossibleSecurityContexts} from '../../src/template_parser/binding_pa
   describe('BindingParser', () => {
     let registry: ElementSchemaRegistry;
 
-    beforeEach(inject(
-        [ElementSchemaRegistry], (_registry: ElementSchemaRegistry) => { registry = _registry; }));
+    beforeEach(inject([ElementSchemaRegistry], (_registry: ElementSchemaRegistry) => {
+      registry = _registry;
+    }));
 
     describe('possibleSecurityContexts', () => {
       function hrefSecurityContexts(selector: string) {
         return calcPossibleSecurityContexts(registry, selector, 'href', false);
       }
 
-      it('should return a single security context if the selector as an element name',
-         () => { expect(hrefSecurityContexts('a')).toEqual([SecurityContext.URL]); });
+      it('should return a single security context if the selector as an element name', () => {
+        expect(hrefSecurityContexts('a')).toEqual([SecurityContext.URL]);
+      });
 
       it('should return the possible security contexts if the selector has no element name', () => {
         expect(hrefSecurityContexts('[myDir]')).toEqual([
@@ -45,8 +47,9 @@ import {calcPossibleSecurityContexts} from '../../src/template_parser/binding_pa
         ]);
       });
 
-      it('should return SecurityContext.NONE if there are no possible elements',
-         () => { expect(hrefSecurityContexts('img:not(img)')).toEqual([SecurityContext.NONE]); });
+      it('should return SecurityContext.NONE if there are no possible elements', () => {
+        expect(hrefSecurityContexts('img:not(img)')).toEqual([SecurityContext.NONE]);
+      });
 
       it('should return the union of the possible security contexts if multiple selectors are specified',
          () => {

--- a/packages/compiler/test/template_parser/template_parser_absolute_span_spec.ts
+++ b/packages/compiler/test/template_parser/template_parser_absolute_span_spec.ts
@@ -36,7 +36,7 @@ describe('expression AST absolute source spans', () => {
   beforeEach(inject([TemplateParser], (parser: TemplateParser) => {
     parse =
         (template: string, directives: CompileDirectiveSummary[] = [],
-         pipes: CompilePipeSummary[] | null = null, schemas: SchemaMetadata[] = [],
+         pipes: CompilePipeSummary[]|null = null, schemas: SchemaMetadata[] = [],
          preserveWhitespaces = true): TemplateAst[] => {
           if (pipes === null) {
             pipes = [];

--- a/packages/compiler/test/template_parser/template_parser_spec.ts
+++ b/packages/compiler/test/template_parser/template_parser_spec.ts
@@ -9,19 +9,20 @@ import {preserveWhitespacesDefault} from '@angular/compiler';
 import {CompileDiDependencyMetadata, CompileDirectiveMetadata, CompileDirectiveSummary, CompilePipeMetadata, CompilePipeSummary, CompileProviderMetadata, CompileTemplateMetadata, CompileTokenMetadata, tokenReference} from '@angular/compiler/src/compile_metadata';
 import {DomElementSchemaRegistry} from '@angular/compiler/src/schema/dom_element_schema_registry';
 import {ElementSchemaRegistry} from '@angular/compiler/src/schema/element_schema_registry';
-import {AttrAst, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, DirectiveAst, ElementAst, EmbeddedTemplateAst, NgContentAst, PropertyBindingType, ProviderAstType, ReferenceAst, TemplateAst, TemplateAstVisitor, TextAst, VariableAst, templateVisitAll} from '@angular/compiler/src/template_parser/template_ast';
-import {TemplateParser, splitClasses} from '@angular/compiler/src/template_parser/template_parser';
+import {AttrAst, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, DirectiveAst, ElementAst, EmbeddedTemplateAst, NgContentAst, PropertyBindingType, ProviderAstType, ReferenceAst, TemplateAst, TemplateAstVisitor, templateVisitAll, TextAst, VariableAst} from '@angular/compiler/src/template_parser/template_ast';
+import {splitClasses, TemplateParser} from '@angular/compiler/src/template_parser/template_parser';
 import {SchemaMetadata, SecurityContext} from '@angular/core';
 import {Console} from '@angular/core/src/console';
-import {TestBed, inject} from '@angular/core/testing';
+import {inject, TestBed} from '@angular/core/testing';
 import {JitReflector} from '@angular/platform-browser-dynamic/src/compiler_reflector';
 
-import {Identifiers, createTokenForExternalReference, createTokenForReference} from '../../src/identifiers';
+import {createTokenForExternalReference, createTokenForReference, Identifiers} from '../../src/identifiers';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../src/ml_parser/interpolation_config';
 import {newArray} from '../../src/util';
 import {MockSchemaRegistry} from '../../testing';
 import {unparse} from '../expression_parser/utils/unparser';
 import {TEST_COMPILER_PROVIDERS} from '../test_bindings';
+
 import {compileDirectiveMetadataCreate, compileTemplateMetadata, createTypeMeta} from './util/metadata';
 
 const someModuleUrl = 'package:someModule';
@@ -139,7 +140,7 @@ class TemplateHumanizer implements TemplateAstVisitor {
 
   private _appendSourceSpan(ast: TemplateAst, input: any[]): any[] {
     if (!this.includeSourceSpan) return input;
-    input.push(ast.sourceSpan !.toString());
+    input.push(ast.sourceSpan!.toString());
     return input;
   }
 }
@@ -166,11 +167,21 @@ class TemplateContentProjectionHumanizer implements TemplateAstVisitor {
     templateVisitAll(this, ast.children);
     return null;
   }
-  visitReference(ast: ReferenceAst, context: any): any { return null; }
-  visitVariable(ast: VariableAst, context: any): any { return null; }
-  visitEvent(ast: BoundEventAst, context: any): any { return null; }
-  visitElementProperty(ast: BoundElementPropertyAst, context: any): any { return null; }
-  visitAttr(ast: AttrAst, context: any): any { return null; }
+  visitReference(ast: ReferenceAst, context: any): any {
+    return null;
+  }
+  visitVariable(ast: VariableAst, context: any): any {
+    return null;
+  }
+  visitEvent(ast: BoundEventAst, context: any): any {
+    return null;
+  }
+  visitElementProperty(ast: BoundElementPropertyAst, context: any): any {
+    return null;
+  }
+  visitAttr(ast: AttrAst, context: any): any {
+    return null;
+  }
   visitBoundText(ast: BoundTextAst, context: any): any {
     this.result.push([`#text(${unparse(ast.value)})`, ast.ngContentIndex]);
     return null;
@@ -179,22 +190,48 @@ class TemplateContentProjectionHumanizer implements TemplateAstVisitor {
     this.result.push([`#text(${ast.value})`, ast.ngContentIndex]);
     return null;
   }
-  visitDirective(ast: DirectiveAst, context: any): any { return null; }
-  visitDirectiveProperty(ast: BoundDirectivePropertyAst, context: any): any { return null; }
+  visitDirective(ast: DirectiveAst, context: any): any {
+    return null;
+  }
+  visitDirectiveProperty(ast: BoundDirectivePropertyAst, context: any): any {
+    return null;
+  }
 }
 
 class ThrowingVisitor implements TemplateAstVisitor {
-  visitNgContent(ast: NgContentAst, context: any): any { throw 'not implemented'; }
-  visitEmbeddedTemplate(ast: EmbeddedTemplateAst, context: any): any { throw 'not implemented'; }
-  visitElement(ast: ElementAst, context: any): any { throw 'not implemented'; }
-  visitReference(ast: ReferenceAst, context: any): any { throw 'not implemented'; }
-  visitVariable(ast: VariableAst, context: any): any { throw 'not implemented'; }
-  visitEvent(ast: BoundEventAst, context: any): any { throw 'not implemented'; }
-  visitElementProperty(ast: BoundElementPropertyAst, context: any): any { throw 'not implemented'; }
-  visitAttr(ast: AttrAst, context: any): any { throw 'not implemented'; }
-  visitBoundText(ast: BoundTextAst, context: any): any { throw 'not implemented'; }
-  visitText(ast: TextAst, context: any): any { throw 'not implemented'; }
-  visitDirective(ast: DirectiveAst, context: any): any { throw 'not implemented'; }
+  visitNgContent(ast: NgContentAst, context: any): any {
+    throw 'not implemented';
+  }
+  visitEmbeddedTemplate(ast: EmbeddedTemplateAst, context: any): any {
+    throw 'not implemented';
+  }
+  visitElement(ast: ElementAst, context: any): any {
+    throw 'not implemented';
+  }
+  visitReference(ast: ReferenceAst, context: any): any {
+    throw 'not implemented';
+  }
+  visitVariable(ast: VariableAst, context: any): any {
+    throw 'not implemented';
+  }
+  visitEvent(ast: BoundEventAst, context: any): any {
+    throw 'not implemented';
+  }
+  visitElementProperty(ast: BoundElementPropertyAst, context: any): any {
+    throw 'not implemented';
+  }
+  visitAttr(ast: AttrAst, context: any): any {
+    throw 'not implemented';
+  }
+  visitBoundText(ast: BoundTextAst, context: any): any {
+    throw 'not implemented';
+  }
+  visitText(ast: TextAst, context: any): any {
+    throw 'not implemented';
+  }
+  visitDirective(ast: DirectiveAst, context: any): any {
+    throw 'not implemented';
+  }
   visitDirectiveProperty(ast: BoundDirectivePropertyAst, context: any): any {
     throw 'not implemented';
   }
@@ -236,2014 +273,2012 @@ class NullVisitor implements TemplateAstVisitor {
 class ArrayConsole implements Console {
   logs: string[] = [];
   warnings: string[] = [];
-  log(msg: string) { this.logs.push(msg); }
-  warn(msg: string) { this.warnings.push(msg); }
+  log(msg: string) {
+    this.logs.push(msg);
+  }
+  warn(msg: string) {
+    this.warnings.push(msg);
+  }
 }
 
 
 (function() {
-  let ngIf: CompileDirectiveSummary;
-  let parse: (
-      template: string, directives: CompileDirectiveSummary[], pipes?: CompilePipeSummary[],
-      schemas?: SchemaMetadata[], preserveWhitespaces?: boolean) => TemplateAst[];
-  let console: ArrayConsole;
+let ngIf: CompileDirectiveSummary;
+let parse: (
+    template: string, directives: CompileDirectiveSummary[], pipes?: CompilePipeSummary[],
+    schemas?: SchemaMetadata[], preserveWhitespaces?: boolean) => TemplateAst[];
+let console: ArrayConsole;
 
-  function configureCompiler() {
-    console = new ArrayConsole();
-    beforeEach(() => {
-      TestBed.configureCompiler({
-        providers: [
-          {provide: Console, useValue: console},
-        ],
-      });
+function configureCompiler() {
+  console = new ArrayConsole();
+  beforeEach(() => {
+    TestBed.configureCompiler({
+      providers: [
+        {provide: Console, useValue: console},
+      ],
     });
+  });
+}
+
+function commonBeforeEach() {
+  beforeEach(inject([TemplateParser], (parser: TemplateParser) => {
+    const someAnimation = ['someAnimation'];
+    const someTemplate = compileTemplateMetadata({animations: [someAnimation]});
+    const component = compileDirectiveMetadataCreate({
+      isHost: false,
+      selector: 'root',
+      template: someTemplate,
+      type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'Root'}}),
+      isComponent: true
+    });
+    ngIf = compileDirectiveMetadataCreate({
+             selector: '[ngIf]',
+             template: someTemplate,
+             type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'NgIf'}}),
+             inputs: ['ngIf']
+           }).toSummary();
+
+    parse =
+        (template: string, directives: CompileDirectiveSummary[],
+         pipes: CompilePipeSummary[]|null = null, schemas: SchemaMetadata[] = [],
+         preserveWhitespaces = true): TemplateAst[] => {
+          if (pipes === null) {
+            pipes = [];
+          }
+          return parser
+              .parse(
+                  component, template, directives, pipes, schemas, 'TestComp', preserveWhitespaces)
+              .template;
+        };
+  }));
+}
+
+describe('TemplateAstVisitor', () => {
+  function expectVisitedNode(visitor: TemplateAstVisitor, node: TemplateAst) {
+    expect(node.visit(visitor, null)).toEqual(node);
   }
 
-  function commonBeforeEach() {
-    beforeEach(inject([TemplateParser], (parser: TemplateParser) => {
-      const someAnimation = ['someAnimation'];
-      const someTemplate = compileTemplateMetadata({animations: [someAnimation]});
-      const component = compileDirectiveMetadataCreate({
-        isHost: false,
-        selector: 'root',
-        template: someTemplate,
-        type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'Root'}}),
-        isComponent: true
-      });
-      ngIf = compileDirectiveMetadataCreate({
-               selector: '[ngIf]',
-               template: someTemplate,
-               type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'NgIf'}}),
-               inputs: ['ngIf']
-             }).toSummary();
+  it('should visit NgContentAst', () => {
+    expectVisitedNode(new class extends NullVisitor {
+      visitNgContent(ast: NgContentAst, context: any): any {
+        return ast;
+      }
+    }, new NgContentAst(0, 0, null!));
+  });
 
-      parse =
-          (template: string, directives: CompileDirectiveSummary[],
-           pipes: CompilePipeSummary[] | null = null, schemas: SchemaMetadata[] = [],
-           preserveWhitespaces = true): TemplateAst[] => {
-            if (pipes === null) {
-              pipes = [];
-            }
-            return parser
-                .parse(
-                    component, template, directives, pipes, schemas, 'TestComp',
-                    preserveWhitespaces)
-                .template;
-          };
-    }));
-  }
+  it('should visit EmbeddedTemplateAst', () => {
+    expectVisitedNode(new class extends NullVisitor {
+      visitEmbeddedTemplate(ast: EmbeddedTemplateAst, context: any) {
+        return ast;
+      }
+    }, new EmbeddedTemplateAst([], [], [], [], [], [], false, [], [], 0, null!));
+  });
 
-  describe('TemplateAstVisitor', () => {
-    function expectVisitedNode(visitor: TemplateAstVisitor, node: TemplateAst) {
-      expect(node.visit(visitor, null)).toEqual(node);
+  it('should visit ElementAst', () => {
+    expectVisitedNode(new class extends NullVisitor {
+      visitElement(ast: ElementAst, context: any) {
+        return ast;
+      }
+    }, new ElementAst('foo', [], [], [], [], [], [], false, [], [], 0, null!, null!));
+  });
+
+  it('should visit RefererenceAst', () => {
+    expectVisitedNode(new class extends NullVisitor {
+      visitReference(ast: ReferenceAst, context: any): any {
+        return ast;
+      }
+    }, new ReferenceAst('foo', null!, null!, null!));
+  });
+
+  it('should visit VariableAst', () => {
+    expectVisitedNode(new class extends NullVisitor {
+      visitVariable(ast: VariableAst, context: any): any {
+        return ast;
+      }
+    }, new VariableAst('foo', 'bar', null!));
+  });
+
+  it('should visit BoundEventAst', () => {
+    expectVisitedNode(new class extends NullVisitor {
+      visitEvent(ast: BoundEventAst, context: any): any {
+        return ast;
+      }
+    }, new BoundEventAst('foo', 'bar', 'goo', null!, null!, null!));
+  });
+
+  it('should visit BoundElementPropertyAst', () => {
+    expectVisitedNode(new class extends NullVisitor {
+      visitElementProperty(ast: BoundElementPropertyAst, context: any): any {
+        return ast;
+      }
+    }, new BoundElementPropertyAst('foo', null!, null!, null!, 'bar', null!));
+  });
+
+  it('should visit AttrAst', () => {
+    expectVisitedNode(new class extends NullVisitor {
+      visitAttr(ast: AttrAst, context: any): any {
+        return ast;
+      }
+    }, new AttrAst('foo', 'bar', null!));
+  });
+
+  it('should visit BoundTextAst', () => {
+    expectVisitedNode(new class extends NullVisitor {
+      visitBoundText(ast: BoundTextAst, context: any): any {
+        return ast;
+      }
+    }, new BoundTextAst(null!, 0, null!));
+  });
+
+  it('should visit TextAst', () => {
+    expectVisitedNode(new class extends NullVisitor {
+      visitText(ast: TextAst, context: any): any {
+        return ast;
+      }
+    }, new TextAst('foo', 0, null!));
+  });
+
+  it('should visit DirectiveAst', () => {
+    expectVisitedNode(new class extends NullVisitor {
+      visitDirective(ast: DirectiveAst, context: any): any {
+        return ast;
+      }
+    }, new DirectiveAst(null!, [], [], [], 0, null!));
+  });
+
+  it('should visit DirectiveAst', () => {
+    expectVisitedNode(new class extends NullVisitor {
+      visitDirectiveProperty(ast: BoundDirectivePropertyAst, context: any): any {
+        return ast;
+      }
+    }, new BoundDirectivePropertyAst('foo', 'bar', null!, null!));
+  });
+
+  it('should skip the typed call of a visitor if visit() returns a truthy value', () => {
+    const visitor = new class extends ThrowingVisitor {
+      visit(ast: TemplateAst, context: any): any {
+        return true;
+      }
+    };
+    const nodes: TemplateAst[] = [
+      new NgContentAst(0, 0, null!),
+      new EmbeddedTemplateAst([], [], [], [], [], [], false, [], [], 0, null!),
+      new ElementAst('foo', [], [], [], [], [], [], false, [], [], 0, null!, null!),
+      new ReferenceAst('foo', null!, 'bar', null!), new VariableAst('foo', 'bar', null!),
+      new BoundEventAst('foo', 'bar', 'goo', null!, null!, null!),
+      new BoundElementPropertyAst('foo', null!, null!, null!, 'bar', null!),
+      new AttrAst('foo', 'bar', null!), new BoundTextAst(null!, 0, null!),
+      new TextAst('foo', 0, null!), new DirectiveAst(null!, [], [], [], 0, null!),
+      new BoundDirectivePropertyAst('foo', 'bar', null!, null!)
+    ];
+    const result = templateVisitAll(visitor, nodes, null);
+    expect(result).toEqual(newArray(nodes.length).fill(true));
+  });
+});
+
+describe('TemplateParser Security', () => {
+  // Semi-integration test to make sure TemplateParser properly sets the security context.
+  // Uses the actual DomElementSchemaRegistry.
+  beforeEach(() => {
+    TestBed.configureCompiler({
+      providers: [
+        TEST_COMPILER_PROVIDERS,
+        {provide: ElementSchemaRegistry, useClass: DomElementSchemaRegistry, deps: []}
+      ]
+    });
+  });
+
+  configureCompiler();
+  commonBeforeEach();
+
+  describe('security context', () => {
+    function secContext(tpl: string): SecurityContext {
+      const ast = parse(tpl, []);
+      const propBinding = (<ElementAst>ast[0]).inputs[0];
+      return propBinding.securityContext;
     }
 
-    it('should visit NgContentAst', () => {
-      expectVisitedNode(
-          new class extends
-          NullVisitor{visitNgContent(ast: NgContentAst, context: any): any{return ast;}},
-          new NgContentAst(0, 0, null !));
+    it('should set for properties', () => {
+      expect(secContext('<div [title]="v">')).toBe(SecurityContext.NONE);
+      expect(secContext('<div [innerHTML]="v">')).toBe(SecurityContext.HTML);
     });
-
-    it('should visit EmbeddedTemplateAst', () => {
-      expectVisitedNode(
-          new class extends NullVisitor{
-            visitEmbeddedTemplate(ast: EmbeddedTemplateAst, context: any) { return ast; }
-          },
-          new EmbeddedTemplateAst([], [], [], [], [], [], false, [], [], 0, null !));
+    it('should set for property value bindings', () => {
+      expect(secContext('<div innerHTML="{{v}}">')).toBe(SecurityContext.HTML);
     });
-
-    it('should visit ElementAst', () => {
-      expectVisitedNode(
-          new class extends
-          NullVisitor{visitElement(ast: ElementAst, context: any) { return ast; }},
-          new ElementAst('foo', [], [], [], [], [], [], false, [], [], 0, null !, null !));
+    it('should set for attributes', () => {
+      expect(secContext('<a [attr.href]="v">')).toBe(SecurityContext.URL);
+      // NB: attributes below need to change case.
+      expect(secContext('<a [attr.innerHtml]="v">')).toBe(SecurityContext.HTML);
+      expect(secContext('<a [attr.formaction]="v">')).toBe(SecurityContext.URL);
     });
-
-    it('should visit RefererenceAst', () => {
-      expectVisitedNode(
-          new class extends
-          NullVisitor{visitReference(ast: ReferenceAst, context: any): any{return ast;}},
-          new ReferenceAst('foo', null !, null !, null !));
-    });
-
-    it('should visit VariableAst', () => {
-      expectVisitedNode(
-          new class extends
-          NullVisitor{visitVariable(ast: VariableAst, context: any): any{return ast;}},
-          new VariableAst('foo', 'bar', null !));
-    });
-
-    it('should visit BoundEventAst', () => {
-      expectVisitedNode(
-          new class extends
-          NullVisitor{visitEvent(ast: BoundEventAst, context: any): any{return ast;}},
-          new BoundEventAst('foo', 'bar', 'goo', null !, null !, null !));
-    });
-
-    it('should visit BoundElementPropertyAst', () => {
-      expectVisitedNode(
-          new class extends NullVisitor{
-            visitElementProperty(ast: BoundElementPropertyAst, context: any): any{return ast;}
-          },
-          new BoundElementPropertyAst('foo', null !, null !, null !, 'bar', null !));
-    });
-
-    it('should visit AttrAst', () => {
-      expectVisitedNode(
-          new class extends NullVisitor{visitAttr(ast: AttrAst, context: any): any{return ast;}},
-          new AttrAst('foo', 'bar', null !));
-    });
-
-    it('should visit BoundTextAst', () => {
-      expectVisitedNode(
-          new class extends
-          NullVisitor{visitBoundText(ast: BoundTextAst, context: any): any{return ast;}},
-          new BoundTextAst(null !, 0, null !));
-    });
-
-    it('should visit TextAst', () => {
-      expectVisitedNode(
-          new class extends NullVisitor{visitText(ast: TextAst, context: any): any{return ast;}},
-          new TextAst('foo', 0, null !));
-    });
-
-    it('should visit DirectiveAst', () => {
-      expectVisitedNode(
-          new class extends
-          NullVisitor{visitDirective(ast: DirectiveAst, context: any): any{return ast;}},
-          new DirectiveAst(null !, [], [], [], 0, null !));
-    });
-
-    it('should visit DirectiveAst', () => {
-      expectVisitedNode(
-          new class extends NullVisitor{
-            visitDirectiveProperty(ast: BoundDirectivePropertyAst, context: any): any{return ast;}
-          },
-          new BoundDirectivePropertyAst('foo', 'bar', null !, null !));
-    });
-
-    it('should skip the typed call of a visitor if visit() returns a truthy value', () => {
-      const visitor = new class extends ThrowingVisitor {
-        visit(ast: TemplateAst, context: any): any { return true; }
-      };
-      const nodes: TemplateAst[] = [
-        new NgContentAst(0, 0, null !),
-        new EmbeddedTemplateAst([], [], [], [], [], [], false, [], [], 0, null !),
-        new ElementAst('foo', [], [], [], [], [], [], false, [], [], 0, null !, null !),
-        new ReferenceAst('foo', null !, 'bar', null !), new VariableAst('foo', 'bar', null !),
-        new BoundEventAst('foo', 'bar', 'goo', null !, null !, null !),
-        new BoundElementPropertyAst('foo', null !, null !, null !, 'bar', null !),
-        new AttrAst('foo', 'bar', null !), new BoundTextAst(null !, 0, null !),
-        new TextAst('foo', 0, null !), new DirectiveAst(null !, [], [], [], 0, null !),
-        new BoundDirectivePropertyAst('foo', 'bar', null !, null !)
-      ];
-      const result = templateVisitAll(visitor, nodes, null);
-      expect(result).toEqual(newArray(nodes.length).fill(true));
+    it('should set for style', () => {
+      expect(secContext('<a [style.backgroundColor]="v">')).toBe(SecurityContext.STYLE);
     });
   });
+});
 
-  describe('TemplateParser Security', () => {
-    // Semi-integration test to make sure TemplateParser properly sets the security context.
-    // Uses the actual DomElementSchemaRegistry.
-    beforeEach(() => {
-      TestBed.configureCompiler({
-        providers: [
-          TEST_COMPILER_PROVIDERS,
-          {provide: ElementSchemaRegistry, useClass: DomElementSchemaRegistry, deps: []}
-        ]
-      });
-    });
-
-    configureCompiler();
-    commonBeforeEach();
-
-    describe('security context', () => {
-      function secContext(tpl: string): SecurityContext {
-        const ast = parse(tpl, []);
-        const propBinding = (<ElementAst>ast[0]).inputs[0];
-        return propBinding.securityContext;
-      }
-
-      it('should set for properties', () => {
-        expect(secContext('<div [title]="v">')).toBe(SecurityContext.NONE);
-        expect(secContext('<div [innerHTML]="v">')).toBe(SecurityContext.HTML);
-      });
-      it('should set for property value bindings',
-         () => { expect(secContext('<div innerHTML="{{v}}">')).toBe(SecurityContext.HTML); });
-      it('should set for attributes', () => {
-        expect(secContext('<a [attr.href]="v">')).toBe(SecurityContext.URL);
-        // NB: attributes below need to change case.
-        expect(secContext('<a [attr.innerHtml]="v">')).toBe(SecurityContext.HTML);
-        expect(secContext('<a [attr.formaction]="v">')).toBe(SecurityContext.URL);
-      });
-      it('should set for style', () => {
-        expect(secContext('<a [style.backgroundColor]="v">')).toBe(SecurityContext.STYLE);
-      });
-    });
+describe('TemplateParser', () => {
+  beforeEach(() => {
+    TestBed.configureCompiler({providers: [TEST_COMPILER_PROVIDERS, MOCK_SCHEMA_REGISTRY]});
   });
 
-  describe('TemplateParser', () => {
-    beforeEach(() => {
-      TestBed.configureCompiler({providers: [TEST_COMPILER_PROVIDERS, MOCK_SCHEMA_REGISTRY]});
+  configureCompiler();
+  commonBeforeEach();
+
+  describe('parse', () => {
+    describe('nodes without bindings', () => {
+      it('should parse text nodes', () => {
+        expect(humanizeTplAst(parse('a', []))).toEqual([[TextAst, 'a']]);
+      });
+
+      it('should parse elements with attributes', () => {
+        expect(humanizeTplAst(parse('<div a=b>', []))).toEqual([
+          [ElementAst, 'div'], [AttrAst, 'a', 'b']
+        ]);
+      });
     });
 
-    configureCompiler();
-    commonBeforeEach();
+    it('should parse ngContent', () => {
+      const parsed = parse('<ng-content select="a"></ng-content>', []);
+      expect(humanizeTplAst(parsed)).toEqual([[NgContentAst]]);
+    });
 
-    describe('parse', () => {
-      describe('nodes without bindings', () => {
+    it('should parse ngContent when it contains WS only', () => {
+      const parsed = parse('<ng-content select="a">    \n   </ng-content>', []);
+      expect(humanizeTplAst(parsed)).toEqual([[NgContentAst]]);
+    });
 
-        it('should parse text nodes', () => {
-          expect(humanizeTplAst(parse('a', []))).toEqual([[TextAst, 'a']]);
-        });
+    it('should parse ngContent regardless the namespace', () => {
+      const parsed = parse('<svg><ng-content></ng-content></svg>', []);
+      expect(humanizeTplAst(parsed)).toEqual([
+        [ElementAst, ':svg:svg'],
+        [NgContentAst],
+      ]);
+    });
 
-        it('should parse elements with attributes', () => {
-          expect(humanizeTplAst(parse('<div a=b>', [
-          ]))).toEqual([[ElementAst, 'div'], [AttrAst, 'a', 'b']]);
-        });
-      });
+    it('should parse bound text nodes', () => {
+      expect(humanizeTplAst(parse('{{a}}', []))).toEqual([[BoundTextAst, '{{ a }}']]);
+    });
 
-      it('should parse ngContent', () => {
-        const parsed = parse('<ng-content select="a"></ng-content>', []);
-        expect(humanizeTplAst(parsed)).toEqual([[NgContentAst]]);
-      });
+    it('should parse with custom interpolation config',
+       inject([TemplateParser], (parser: TemplateParser) => {
+         const component = CompileDirectiveMetadata.create({
+           selector: 'test',
+           type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'Test'}}),
+           isComponent: true,
+           template: new CompileTemplateMetadata({
+             interpolation: ['{%', '%}'],
+             isInline: false,
+             animations: [],
+             template: null,
+             templateUrl: null,
+             htmlAst: null,
+             ngContentSelectors: [],
+             externalStylesheets: [],
+             styleUrls: [],
+             styles: [],
+             encapsulation: null,
+             preserveWhitespaces: preserveWhitespacesDefault(null),
+           }),
+           isHost: false,
+           exportAs: null,
+           changeDetection: null,
+           inputs: [],
+           outputs: [],
+           host: {},
+           providers: [],
+           viewProviders: [],
+           queries: [],
+           guards: {},
+           viewQueries: [],
+           entryComponents: [],
+           componentViewType: null,
+           rendererType: null,
+           componentFactory: null
 
-      it('should parse ngContent when it contains WS only', () => {
-        const parsed = parse('<ng-content select="a">    \n   </ng-content>', []);
-        expect(humanizeTplAst(parsed)).toEqual([[NgContentAst]]);
-      });
+         });
+         expect(humanizeTplAst(
+                    parser.parse(component, '{%a%}', [], [], [], 'TestComp', true).template,
+                    {start: '{%', end: '%}'}))
+             .toEqual([[BoundTextAst, '{% a %}']]);
+       }));
 
-      it('should parse ngContent regardless the namespace', () => {
-        const parsed = parse('<svg><ng-content></ng-content></svg>', []);
-        expect(humanizeTplAst(parsed)).toEqual([
-          [ElementAst, ':svg:svg'],
-          [NgContentAst],
+    describe('bound properties', () => {
+      it('should parse mixed case bound properties', () => {
+        expect(humanizeTplAst(parse('<div [someProp]="v">', []))).toEqual([
+          [ElementAst, 'div'],
+          [BoundElementPropertyAst, PropertyBindingType.Property, 'someProp', 'v', null]
         ]);
       });
 
-      it('should parse bound text nodes', () => {
-        expect(humanizeTplAst(parse('{{a}}', []))).toEqual([[BoundTextAst, '{{ a }}']]);
+      it('should parse dash case bound properties', () => {
+        expect(humanizeTplAst(parse('<div [some-prop]="v">', []))).toEqual([
+          [ElementAst, 'div'],
+          [BoundElementPropertyAst, PropertyBindingType.Property, 'some-prop', 'v', null]
+        ]);
       });
 
-      it('should parse with custom interpolation config',
-         inject([TemplateParser], (parser: TemplateParser) => {
-           const component = CompileDirectiveMetadata.create({
-             selector: 'test',
-             type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'Test'}}),
-             isComponent: true,
-             template: new CompileTemplateMetadata({
-               interpolation: ['{%', '%}'],
-               isInline: false,
-               animations: [],
-               template: null,
-               templateUrl: null,
-               htmlAst: null,
-               ngContentSelectors: [],
-               externalStylesheets: [],
-               styleUrls: [],
-               styles: [],
-               encapsulation: null,
-               preserveWhitespaces: preserveWhitespacesDefault(null),
-             }),
-             isHost: false,
-             exportAs: null,
-             changeDetection: null,
-             inputs: [],
-             outputs: [],
-             host: {},
-             providers: [],
-             viewProviders: [],
-             queries: [],
-             guards: {},
-             viewQueries: [],
-             entryComponents: [],
-             componentViewType: null,
-             rendererType: null,
-             componentFactory: null
+      it('should parse dotted name bound properties', () => {
+        expect(humanizeTplAst(parse('<div [dot.name]="v">', []))).toEqual([
+          [ElementAst, 'div'],
+          [BoundElementPropertyAst, PropertyBindingType.Property, 'dot.name', 'v', null]
+        ]);
+      });
 
-           });
-           expect(humanizeTplAst(
-                      parser.parse(component, '{%a%}', [], [], [], 'TestComp', true).template,
-                      {start: '{%', end: '%}'}))
-               .toEqual([[BoundTextAst, '{% a %}']]);
-         }));
+      it('should normalize property names via the element schema', () => {
+        expect(humanizeTplAst(parse('<div [mappedAttr]="v">', []))).toEqual([
+          [ElementAst, 'div'],
+          [BoundElementPropertyAst, PropertyBindingType.Property, 'mappedProp', 'v', null]
+        ]);
+      });
 
-      describe('bound properties', () => {
+      it('should parse mixed case bound attributes', () => {
+        expect(humanizeTplAst(parse('<div [attr.someAttr]="v">', []))).toEqual([
+          [ElementAst, 'div'],
+          [BoundElementPropertyAst, PropertyBindingType.Attribute, 'someAttr', 'v', null]
+        ]);
+      });
 
-        it('should parse mixed case bound properties', () => {
-          expect(humanizeTplAst(parse('<div [someProp]="v">', []))).toEqual([
-            [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'someProp', 'v', null]
-          ]);
-        });
+      it('should parse mixed case bound attributes with dot in the attribute name', () => {
+        expect(humanizeTplAst(parse('<div [attr.someAttr.someAttrSuffix]="v">', []))).toEqual([
+          [ElementAst, 'div'],
+          [
+            BoundElementPropertyAst, PropertyBindingType.Attribute, 'someAttr.someAttrSuffix', 'v',
+            null
+          ]
+        ]);
+      });
 
-        it('should parse dash case bound properties', () => {
-          expect(humanizeTplAst(parse('<div [some-prop]="v">', []))).toEqual([
-            [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'some-prop', 'v', null]
-          ]);
-        });
+      it('should parse and dash case bound classes', () => {
+        expect(humanizeTplAst(parse('<div [class.some-class]="v">', []))).toEqual([
+          [ElementAst, 'div'],
+          [BoundElementPropertyAst, PropertyBindingType.Class, 'some-class', 'v', null]
+        ]);
+      });
 
-        it('should parse dotted name bound properties', () => {
-          expect(humanizeTplAst(parse('<div [dot.name]="v">', []))).toEqual([
-            [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'dot.name', 'v', null]
-          ]);
-        });
+      it('should parse mixed case bound classes', () => {
+        expect(humanizeTplAst(parse('<div [class.someClass]="v">', []))).toEqual([
+          [ElementAst, 'div'],
+          [BoundElementPropertyAst, PropertyBindingType.Class, 'someClass', 'v', null]
+        ]);
+      });
 
-        it('should normalize property names via the element schema', () => {
-          expect(humanizeTplAst(parse('<div [mappedAttr]="v">', []))).toEqual([
-            [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'mappedProp', 'v', null]
-          ]);
-        });
+      it('should parse mixed case bound styles', () => {
+        expect(humanizeTplAst(parse('<div [style.someStyle]="v">', []))).toEqual([
+          [ElementAst, 'div'],
+          [BoundElementPropertyAst, PropertyBindingType.Style, 'someStyle', 'v', null]
+        ]);
+      });
 
-        it('should parse mixed case bound attributes', () => {
-          expect(humanizeTplAst(parse('<div [attr.someAttr]="v">', []))).toEqual([
-            [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Attribute, 'someAttr', 'v', null]
-          ]);
-        });
-
-        it('should parse mixed case bound attributes with dot in the attribute name', () => {
-          expect(humanizeTplAst(parse('<div [attr.someAttr.someAttrSuffix]="v">', []))).toEqual([
-            [ElementAst, 'div'],
-            [
-              BoundElementPropertyAst, PropertyBindingType.Attribute, 'someAttr.someAttrSuffix',
-              'v', null
-            ]
-          ]);
-        });
-
-        it('should parse and dash case bound classes', () => {
-          expect(humanizeTplAst(parse('<div [class.some-class]="v">', []))).toEqual([
-            [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Class, 'some-class', 'v', null]
-          ]);
-        });
-
-        it('should parse mixed case bound classes', () => {
-          expect(humanizeTplAst(parse('<div [class.someClass]="v">', []))).toEqual([
-            [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Class, 'someClass', 'v', null]
-          ]);
-        });
-
-        it('should parse mixed case bound styles', () => {
-          expect(humanizeTplAst(parse('<div [style.someStyle]="v">', []))).toEqual([
-            [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Style, 'someStyle', 'v', null]
-          ]);
-        });
-
-        describe('errors', () => {
-          it('should throw error when binding to an unknown property', () => {
-            expect(() => parse('<my-component [invalidProp]="bar"></my-component>', []))
-                .toThrowError(`Template parse errors:
+      describe('errors', () => {
+        it('should throw error when binding to an unknown property', () => {
+          expect(() => parse('<my-component [invalidProp]="bar"></my-component>', []))
+              .toThrowError(`Template parse errors:
 Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
 1. If 'my-component' is an Angular component and it has 'invalidProp' input, then verify that it is part of this module.
 2. If 'my-component' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.
 3. To allow any property add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component. ("<my-component [ERROR ->][invalidProp]="bar"></my-component>"): TestComp@0:14`);
-          });
+        });
 
-          it('should throw error when binding to an unknown property of ng-container', () => {
-            expect(() => parse('<ng-container [invalidProp]="bar"></ng-container>', []))
-                .toThrowError(
-                    `Template parse errors:
+        it('should throw error when binding to an unknown property of ng-container', () => {
+          expect(() => parse('<ng-container [invalidProp]="bar"></ng-container>', []))
+              .toThrowError(
+                  `Template parse errors:
 Can't bind to 'invalidProp' since it isn't a known property of 'ng-container'.
 1. If 'invalidProp' is an Angular directive, then add 'CommonModule' to the '@NgModule.imports' of this component.
 2. To allow any property add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.` +
-                    ` ("<ng-container [ERROR ->][invalidProp]="bar"></ng-container>"): TestComp@0:14`);
-          });
+                  ` ("<ng-container [ERROR ->][invalidProp]="bar"></ng-container>"): TestComp@0:14`);
+        });
 
-          it('should throw error when binding to an unknown element w/o bindings', () => {
-            expect(() => parse('<unknown></unknown>', [])).toThrowError(`Template parse errors:
+        it('should throw error when binding to an unknown element w/o bindings', () => {
+          expect(() => parse('<unknown></unknown>', [])).toThrowError(`Template parse errors:
 'unknown' is not a known element:
 1. If 'unknown' is an Angular component, then verify that it is part of this module.
 2. To allow any element add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component. ("[ERROR ->]<unknown></unknown>"): TestComp@0:0`);
-          });
+        });
 
-          it('should throw error when binding to an unknown custom element w/o bindings', () => {
-            expect(() => parse('<un-known></un-known>', [])).toThrowError(`Template parse errors:
+        it('should throw error when binding to an unknown custom element w/o bindings', () => {
+          expect(() => parse('<un-known></un-known>', [])).toThrowError(`Template parse errors:
 'un-known' is not a known element:
 1. If 'un-known' is an Angular component, then verify that it is part of this module.
 2. If 'un-known' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message. ("[ERROR ->]<un-known></un-known>"): TestComp@0:0`);
-          });
+        });
 
-          it('should throw error when binding to an invalid property', () => {
-            expect(() => parse('<my-component [onEvent]="bar"></my-component>', []))
-                .toThrowError(`Template parse errors:
+        it('should throw error when binding to an invalid property', () => {
+          expect(() => parse('<my-component [onEvent]="bar"></my-component>', []))
+              .toThrowError(`Template parse errors:
 Binding to property 'onEvent' is disallowed for security reasons ("<my-component [ERROR ->][onEvent]="bar"></my-component>"): TestComp@0:14`);
-          });
+        });
 
-          it('should throw error when binding to an invalid attribute', () => {
-            expect(() => parse('<my-component [attr.onEvent]="bar"></my-component>', []))
-                .toThrowError(`Template parse errors:
+        it('should throw error when binding to an invalid attribute', () => {
+          expect(() => parse('<my-component [attr.onEvent]="bar"></my-component>', []))
+              .toThrowError(`Template parse errors:
 Binding to attribute 'onEvent' is disallowed for security reasons ("<my-component [ERROR ->][attr.onEvent]="bar"></my-component>"): TestComp@0:14`);
-          });
         });
+      });
 
-        it('should parse bound properties via [...] and not report them as attributes', () => {
-          expect(humanizeTplAst(parse('<div [prop]="v">', []))).toEqual([
-            [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'v', null]
-          ]);
-        });
+      it('should parse bound properties via [...] and not report them as attributes', () => {
+        expect(humanizeTplAst(parse('<div [prop]="v">', []))).toEqual([
+          [ElementAst, 'div'],
+          [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'v', null]
+        ]);
+      });
 
-        it('should parse bound properties via bind- and not report them as attributes', () => {
-          expect(humanizeTplAst(parse('<div bind-prop="v">', []))).toEqual([
-            [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'v', null]
-          ]);
-        });
+      it('should parse bound properties via bind- and not report them as attributes', () => {
+        expect(humanizeTplAst(parse('<div bind-prop="v">', []))).toEqual([
+          [ElementAst, 'div'],
+          [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'v', null]
+        ]);
+      });
 
-        it('should report missing property names in bind- syntax', () => {
-          expect(() => parse('<div bind-></div>', [])).toThrowError(`Template parse errors:
+      it('should report missing property names in bind- syntax', () => {
+        expect(() => parse('<div bind-></div>', [])).toThrowError(`Template parse errors:
 Property name is missing in binding ("<div [ERROR ->]bind-></div>"): TestComp@0:5`);
-        });
+      });
 
-        it('should parse bound properties via {{...}} and not report them as attributes', () => {
-          expect(humanizeTplAst(parse('<div prop="{{v}}">', []))).toEqual([
-            [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', '{{ v }}', null]
-          ]);
-        });
+      it('should parse bound properties via {{...}} and not report them as attributes', () => {
+        expect(humanizeTplAst(parse('<div prop="{{v}}">', []))).toEqual([
+          [ElementAst, 'div'],
+          [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', '{{ v }}', null]
+        ]);
+      });
 
-        it('should parse bound properties via bind-animate- and not report them as attributes',
-           () => {
-             expect(humanizeTplAst(parse('<div bind-animate-someAnimation="value2">', [], [], [])))
-                 .toEqual([
-                   [ElementAst, 'div'],
-                   [
-                     BoundElementPropertyAst, PropertyBindingType.Animation, 'someAnimation',
-                     'value2', null
-                   ]
-                 ]);
-           });
+      it('should parse bound properties via bind-animate- and not report them as attributes',
+         () => {
+           expect(humanizeTplAst(parse('<div bind-animate-someAnimation="value2">', [], [], [])))
+               .toEqual([
+                 [ElementAst, 'div'],
+                 [
+                   BoundElementPropertyAst, PropertyBindingType.Animation, 'someAnimation',
+                   'value2', null
+                 ]
+               ]);
+         });
 
-        it('should throw an error when parsing detects non-bound properties via @ that contain a value',
-           () => {
-             expect(() => { parse('<div @someAnimation="value2">', [], [], []); })
-                 .toThrowError(
-                     /Assigning animation triggers via @prop="exp" attributes with an expression is invalid. Use property bindings \(e.g. \[@prop\]="exp"\) or use an attribute without a value \(e.g. @prop\) instead. \("<div \[ERROR ->\]@someAnimation="value2">"\): TestComp@0:5/);
-           });
+      it('should throw an error when parsing detects non-bound properties via @ that contain a value',
+         () => {
+           expect(() => {
+             parse('<div @someAnimation="value2">', [], [], []);
+           })
+               .toThrowError(
+                   /Assigning animation triggers via @prop="exp" attributes with an expression is invalid. Use property bindings \(e.g. \[@prop\]="exp"\) or use an attribute without a value \(e.g. @prop\) instead. \("<div \[ERROR ->\]@someAnimation="value2">"\): TestComp@0:5/);
+         });
 
-        it('should report missing animation trigger in @ syntax', () => {
-          expect(() => parse('<div @></div>', [])).toThrowError(`Template parse errors:
+      it('should report missing animation trigger in @ syntax', () => {
+        expect(() => parse('<div @></div>', [])).toThrowError(`Template parse errors:
 Animation trigger is missing ("<div [ERROR ->]@></div>"): TestComp@0:5`);
-        });
-
-        it('should not issue a warning when host attributes contain a valid property-bound animation trigger',
-           () => {
-             const animationEntries = ['prop'];
-             const dirA = compileDirectiveMetadataCreate({
-                            selector: 'div',
-                            template: compileTemplateMetadata({animations: animationEntries}),
-                            type: createTypeMeta({
-                              reference: {filePath: someModuleUrl, name: 'DirA'},
-                            }),
-                            host: {'[@prop]': 'expr'}
-                          }).toSummary();
-
-             humanizeTplAst(parse('<div></div>', [dirA]));
-             expect(console.warnings.length).toEqual(0);
-           });
-
-        it('should throw descriptive error when a host binding is not a string expression', () => {
-          const dirA = compileDirectiveMetadataCreate({
-                         selector: 'broken',
-                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                         host: {'[class.foo]': null !}
-                       }).toSummary();
-
-          expect(() => { parse('<broken></broken>', [dirA]); })
-              .toThrowError(
-                  `Template parse errors:\nValue of the host property binding "class.foo" needs to be a string representing an expression but got "null" (object) ("[ERROR ->]<broken></broken>"): TestComp@0:0, Directive DirA`);
-        });
-
-        it('should throw descriptive error when a host event is not a string expression', () => {
-          const dirA = compileDirectiveMetadataCreate({
-                         selector: 'broken',
-                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                         host: {'(click)': null !}
-                       }).toSummary();
-
-          expect(() => { parse('<broken></broken>', [dirA]); })
-              .toThrowError(
-                  `Template parse errors:\nValue of the host listener "click" needs to be a string representing an expression but got "null" (object) ("[ERROR ->]<broken></broken>"): TestComp@0:0, Directive DirA`);
-        });
-
-        it('should not issue a warning when an animation property is bound without an expression',
-           () => {
-             humanizeTplAst(parse('<div @someAnimation>', [], [], []));
-             expect(console.warnings.length).toEqual(0);
-           });
-
-        it('should parse bound properties via [@] and not report them as attributes', () => {
-          expect(humanizeTplAst(parse('<div [@someAnimation]="value2">', [], [], []))).toEqual([
-            [ElementAst, 'div'],
-            [
-              BoundElementPropertyAst, PropertyBindingType.Animation, 'someAnimation', 'value2',
-              null
-            ]
-          ]);
-        });
-
-        it('should support * directives', () => {
-          expect(humanizeTplAst(parse('<div *ngIf>', [ngIf]))).toEqual([
-            [EmbeddedTemplateAst],
-            [DirectiveAst, ngIf],
-            [BoundDirectivePropertyAst, 'ngIf', 'null'],
-            [ElementAst, 'div'],
-          ]);
-        });
-
-        it('should support <ng-template>', () => {
-          expect(humanizeTplAst(parse('<ng-template>', []))).toEqual([
-            [EmbeddedTemplateAst],
-          ]);
-        });
-
-        it('should treat <template> as a regular tag', () => {
-          expect(humanizeTplAst(parse('<template>', []))).toEqual([
-            [ElementAst, 'template'],
-          ]);
-        });
-
-        it('should not special case the template attribute', () => {
-          expect(humanizeTplAst(parse('<p template="ngFor">', []))).toEqual([
-            [ElementAst, 'p'],
-            [AttrAst, 'template', 'ngFor'],
-          ]);
-        });
-
       });
 
-      describe('events', () => {
+      it('should not issue a warning when host attributes contain a valid property-bound animation trigger',
+         () => {
+           const animationEntries = ['prop'];
+           const dirA = compileDirectiveMetadataCreate({
+                          selector: 'div',
+                          template: compileTemplateMetadata({animations: animationEntries}),
+                          type: createTypeMeta({
+                            reference: {filePath: someModuleUrl, name: 'DirA'},
+                          }),
+                          host: {'[@prop]': 'expr'}
+                        }).toSummary();
 
-        it('should parse bound events with a target', () => {
-          expect(humanizeTplAst(parse('<div (window:event)="v">', []))).toEqual([
-            [ElementAst, 'div'],
-            [BoundEventAst, 'event', 'window', 'v'],
-          ]);
-        });
+           humanizeTplAst(parse('<div></div>', [dirA]));
+           expect(console.warnings.length).toEqual(0);
+         });
 
-        it('should report an error on empty expression', () => {
-          expect(() => parse('<div (event)="">', []))
-              .toThrowError(/Empty expressions are not allowed/);
+      it('should throw descriptive error when a host binding is not a string expression', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: 'broken',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                       host: {'[class.foo]': null!}
+                     }).toSummary();
 
-          expect(() => parse('<div (event)="  ">', []))
-              .toThrowError(/Empty expressions are not allowed/);
-        });
-
-        it('should parse bound events via (...) and not report them as attributes', () => {
-          expect(humanizeTplAst(parse('<div (event)="v">', [
-          ]))).toEqual([[ElementAst, 'div'], [BoundEventAst, 'event', null, 'v']]);
-        });
-
-        it('should parse event names case sensitive', () => {
-          expect(humanizeTplAst(parse('<div (some-event)="v">', [
-          ]))).toEqual([[ElementAst, 'div'], [BoundEventAst, 'some-event', null, 'v']]);
-          expect(humanizeTplAst(parse('<div (someEvent)="v">', [
-          ]))).toEqual([[ElementAst, 'div'], [BoundEventAst, 'someEvent', null, 'v']]);
-        });
-
-        it('should parse bound events via on- and not report them as attributes', () => {
-          expect(humanizeTplAst(parse('<div on-event="v">', [
-          ]))).toEqual([[ElementAst, 'div'], [BoundEventAst, 'event', null, 'v']]);
-        });
-
-        it('should report missing event names in on- syntax', () => {
-          expect(() => parse('<div on-></div>', []))
-              .toThrowError(/Event name is missing in binding/);
-        });
-
-        it('should allow events on explicit embedded templates that are emitted by a directive',
-           () => {
-             const dirA =
-                 compileDirectiveMetadataCreate({
-                   selector: 'ng-template',
-                   outputs: ['e'],
-                   type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
-                 }).toSummary();
-
-             expect(humanizeTplAst(parse('<ng-template (e)="f"></ng-template>', [dirA]))).toEqual([
-               [EmbeddedTemplateAst],
-               [BoundEventAst, 'e', null, 'f'],
-               [DirectiveAst, dirA],
-             ]);
-           });
+        expect(() => {
+          parse('<broken></broken>', [dirA]);
+        })
+            .toThrowError(
+                `Template parse errors:\nValue of the host property binding "class.foo" needs to be a string representing an expression but got "null" (object) ("[ERROR ->]<broken></broken>"): TestComp@0:0, Directive DirA`);
       });
 
-      describe('bindon', () => {
-        it('should parse bound events and properties via [(...)] and not report them as attributes',
-           () => {
-             expect(humanizeTplAst(parse('<div [(prop)]="v">', []))).toEqual([
-               [ElementAst, 'div'],
-               [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'v', null],
-               [BoundEventAst, 'propChange', null, 'v = $event']
-             ]);
-           });
+      it('should throw descriptive error when a host event is not a string expression', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: 'broken',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                       host: {'(click)': null!}
+                     }).toSummary();
 
-        it('should parse bound events and properties via bindon- and not report them as attributes',
-           () => {
-             expect(humanizeTplAst(parse('<div bindon-prop="v">', []))).toEqual([
-               [ElementAst, 'div'],
-               [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'v', null],
-               [BoundEventAst, 'propChange', null, 'v = $event']
-             ]);
-           });
+        expect(() => {
+          parse('<broken></broken>', [dirA]);
+        })
+            .toThrowError(
+                `Template parse errors:\nValue of the host listener "click" needs to be a string representing an expression but got "null" (object) ("[ERROR ->]<broken></broken>"): TestComp@0:0, Directive DirA`);
+      });
 
-        it('should report missing property names in bindon- syntax', () => {
-          expect(() => parse('<div bindon-></div>', []))
-              .toThrowError(/Property name is missing in binding/);
-        });
+      it('should not issue a warning when an animation property is bound without an expression',
+         () => {
+           humanizeTplAst(parse('<div @someAnimation>', [], [], []));
+           expect(console.warnings.length).toEqual(0);
+         });
+
+      it('should parse bound properties via [@] and not report them as attributes', () => {
+        expect(humanizeTplAst(parse('<div [@someAnimation]="value2">', [], [], []))).toEqual([
+          [ElementAst, 'div'],
+          [BoundElementPropertyAst, PropertyBindingType.Animation, 'someAnimation', 'value2', null]
+        ]);
+      });
+
+      it('should support * directives', () => {
+        expect(humanizeTplAst(parse('<div *ngIf>', [ngIf]))).toEqual([
+          [EmbeddedTemplateAst],
+          [DirectiveAst, ngIf],
+          [BoundDirectivePropertyAst, 'ngIf', 'null'],
+          [ElementAst, 'div'],
+        ]);
+      });
+
+      it('should support <ng-template>', () => {
+        expect(humanizeTplAst(parse('<ng-template>', []))).toEqual([
+          [EmbeddedTemplateAst],
+        ]);
+      });
+
+      it('should treat <template> as a regular tag', () => {
+        expect(humanizeTplAst(parse('<template>', []))).toEqual([
+          [ElementAst, 'template'],
+        ]);
+      });
+
+      it('should not special case the template attribute', () => {
+        expect(humanizeTplAst(parse('<p template="ngFor">', []))).toEqual([
+          [ElementAst, 'p'],
+          [AttrAst, 'template', 'ngFor'],
+        ]);
+      });
+    });
+
+    describe('events', () => {
+      it('should parse bound events with a target', () => {
+        expect(humanizeTplAst(parse('<div (window:event)="v">', []))).toEqual([
+          [ElementAst, 'div'],
+          [BoundEventAst, 'event', 'window', 'v'],
+        ]);
+      });
+
+      it('should report an error on empty expression', () => {
+        expect(() => parse('<div (event)="">', []))
+            .toThrowError(/Empty expressions are not allowed/);
+
+        expect(() => parse('<div (event)="  ">', []))
+            .toThrowError(/Empty expressions are not allowed/);
+      });
+
+      it('should parse bound events via (...) and not report them as attributes', () => {
+        expect(humanizeTplAst(parse('<div (event)="v">', []))).toEqual([
+          [ElementAst, 'div'], [BoundEventAst, 'event', null, 'v']
+        ]);
+      });
+
+      it('should parse event names case sensitive', () => {
+        expect(humanizeTplAst(parse('<div (some-event)="v">', []))).toEqual([
+          [ElementAst, 'div'], [BoundEventAst, 'some-event', null, 'v']
+        ]);
+        expect(humanizeTplAst(parse('<div (someEvent)="v">', []))).toEqual([
+          [ElementAst, 'div'], [BoundEventAst, 'someEvent', null, 'v']
+        ]);
+      });
+
+      it('should parse bound events via on- and not report them as attributes', () => {
+        expect(humanizeTplAst(parse('<div on-event="v">', []))).toEqual([
+          [ElementAst, 'div'], [BoundEventAst, 'event', null, 'v']
+        ]);
+      });
+
+      it('should report missing event names in on- syntax', () => {
+        expect(() => parse('<div on-></div>', [])).toThrowError(/Event name is missing in binding/);
+      });
+
+      it('should allow events on explicit embedded templates that are emitted by a directive',
+         () => {
+           const dirA = compileDirectiveMetadataCreate({
+                          selector: 'ng-template',
+                          outputs: ['e'],
+                          type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
+                        }).toSummary();
+
+           expect(humanizeTplAst(parse('<ng-template (e)="f"></ng-template>', [dirA]))).toEqual([
+             [EmbeddedTemplateAst],
+             [BoundEventAst, 'e', null, 'f'],
+             [DirectiveAst, dirA],
+           ]);
+         });
+    });
+
+    describe('bindon', () => {
+      it('should parse bound events and properties via [(...)] and not report them as attributes',
+         () => {
+           expect(humanizeTplAst(parse('<div [(prop)]="v">', []))).toEqual([
+             [ElementAst, 'div'],
+             [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'v', null],
+             [BoundEventAst, 'propChange', null, 'v = $event']
+           ]);
+         });
+
+      it('should parse bound events and properties via bindon- and not report them as attributes',
+         () => {
+           expect(humanizeTplAst(parse('<div bindon-prop="v">', []))).toEqual([
+             [ElementAst, 'div'],
+             [BoundElementPropertyAst, PropertyBindingType.Property, 'prop', 'v', null],
+             [BoundEventAst, 'propChange', null, 'v = $event']
+           ]);
+         });
+
+      it('should report missing property names in bindon- syntax', () => {
+        expect(() => parse('<div bindon-></div>', []))
+            .toThrowError(/Property name is missing in binding/);
+      });
+    });
+
+    describe('directives', () => {
+      it('should order directives by the directives array in the View and match them only once',
+         () => {
+           const dirA = compileDirectiveMetadataCreate({
+                          selector: '[a]',
+                          type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
+                        }).toSummary();
+           const dirB = compileDirectiveMetadataCreate({
+                          selector: '[b]',
+                          type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirB'}})
+                        }).toSummary();
+           const dirC = compileDirectiveMetadataCreate({
+                          selector: '[c]',
+                          type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirC'}})
+                        }).toSummary();
+           expect(humanizeTplAst(parse('<div a c b a b>', [dirA, dirB, dirC]))).toEqual([
+             [ElementAst, 'div'], [AttrAst, 'a', ''], [AttrAst, 'c', ''], [AttrAst, 'b', ''],
+             [AttrAst, 'a', ''], [AttrAst, 'b', ''], [DirectiveAst, dirA], [DirectiveAst, dirB],
+             [DirectiveAst, dirC]
+           ]);
+         });
+
+      it('should parse directive dotted properties', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: '[dot.name]',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                       inputs: ['localName: dot.name'],
+                     }).toSummary();
+
+        expect(humanizeTplAst(parse('<div [dot.name]="expr"></div>', [dirA]))).toEqual([
+          [ElementAst, 'div'],
+          [DirectiveAst, dirA],
+          [BoundDirectivePropertyAst, 'localName', 'expr'],
+        ]);
+      });
+
+      it('should locate directives in property bindings', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: '[a=b]',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
+                     }).toSummary();
+        const dirB = compileDirectiveMetadataCreate({
+                       selector: '[b]',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirB'}})
+                     }).toSummary();
+        expect(humanizeTplAst(parse('<div [a]="b">', [dirA, dirB]))).toEqual([
+          [ElementAst, 'div'],
+          [BoundElementPropertyAst, PropertyBindingType.Property, 'a', 'b', null],
+          [DirectiveAst, dirA]
+        ]);
+      });
+
+      it('should locate directives in inline templates', () => {
+        const dirTemplate =
+            compileDirectiveMetadataCreate({
+              selector: 'ng-template',
+              type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'onTemplate'}})
+            }).toSummary();
+        expect(humanizeTplAst(parse('<div *ngIf="cond">', [ngIf, dirTemplate]))).toEqual([
+          [EmbeddedTemplateAst],
+          [DirectiveAst, ngIf],
+          [BoundDirectivePropertyAst, 'ngIf', 'cond'],
+          [DirectiveAst, dirTemplate],
+          [ElementAst, 'div'],
+        ]);
+      });
+
+      it('should locate directives in event bindings', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: '[a]',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirB'}})
+                     }).toSummary();
+
+        expect(humanizeTplAst(parse('<div (a)="b">', [dirA]))).toEqual([
+          [ElementAst, 'div'], [BoundEventAst, 'a', null, 'b'], [DirectiveAst, dirA]
+        ]);
+      });
+
+      it('should parse directive host properties', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: 'div',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                       host: {'[a]': 'expr'}
+                     }).toSummary();
+        expect(humanizeTplAst(parse('<div></div>', [dirA]))).toEqual([
+          [ElementAst, 'div'], [DirectiveAst, dirA],
+          [BoundElementPropertyAst, PropertyBindingType.Property, 'a', 'expr', null]
+        ]);
+      });
+
+      it('should parse directive host listeners', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: 'div',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                       host: {'(a)': 'expr'}
+                     }).toSummary();
+        expect(humanizeTplAst(parse('<div></div>', [dirA]))).toEqual([
+          [ElementAst, 'div'], [DirectiveAst, dirA], [BoundEventAst, 'a', null, 'expr']
+        ]);
+      });
+
+      it('should parse directive properties', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: 'div',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                       inputs: ['aProp']
+                     }).toSummary();
+        expect(humanizeTplAst(parse('<div [aProp]="expr"></div>', [dirA]))).toEqual([
+          [ElementAst, 'div'], [DirectiveAst, dirA], [BoundDirectivePropertyAst, 'aProp', 'expr']
+        ]);
+      });
+
+      it('should parse renamed directive properties', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: 'div',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                       inputs: ['b:a']
+                     }).toSummary();
+        expect(humanizeTplAst(parse('<div [a]="expr"></div>', [dirA]))).toEqual([
+          [ElementAst, 'div'], [DirectiveAst, dirA], [BoundDirectivePropertyAst, 'b', 'expr']
+        ]);
+      });
+
+      it('should parse literal directive properties', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: 'div',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                       inputs: ['a']
+                     }).toSummary();
+        expect(humanizeTplAst(parse('<div a="literal"></div>', [dirA]))).toEqual([
+          [ElementAst, 'div'], [AttrAst, 'a', 'literal'], [DirectiveAst, dirA],
+          [BoundDirectivePropertyAst, 'a', '"literal"']
+        ]);
+      });
+
+      it('should favor explicit bound properties over literal properties', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: 'div',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                       inputs: ['a']
+                     }).toSummary();
+        expect(humanizeTplAst(parse('<div a="literal" [a]="\'literal2\'"></div>', [dirA])))
+            .toEqual([
+              [ElementAst, 'div'], [AttrAst, 'a', 'literal'], [DirectiveAst, dirA],
+              [BoundDirectivePropertyAst, 'a', '"literal2"']
+            ]);
+      });
+
+      it('should support optional directive properties', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: 'div',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                       inputs: ['a']
+                     }).toSummary();
+        expect(humanizeTplAst(parse('<div></div>', [dirA]))).toEqual([
+          [ElementAst, 'div'], [DirectiveAst, dirA]
+        ]);
+      });
+    });
+
+    describe('providers', () => {
+      let nextProviderId: number;
+
+      function createToken(value: string): CompileTokenMetadata {
+        let token: CompileTokenMetadata;
+        if (value.startsWith('type:')) {
+          const name = value.substring(5);
+          token = {identifier: createTypeMeta({reference: <any>name})};
+        } else {
+          token = {value: value};
+        }
+        return token;
+      }
+
+      function createDep(value: string): CompileDiDependencyMetadata {
+        let isOptional = false;
+        if (value.startsWith('optional:')) {
+          isOptional = true;
+          value = value.substring(9);
+        }
+        let isSelf = false;
+        if (value.startsWith('self:')) {
+          isSelf = true;
+          value = value.substring(5);
+        }
+        let isHost = false;
+        if (value.startsWith('host:')) {
+          isHost = true;
+          value = value.substring(5);
+        }
+        return {token: createToken(value), isOptional: isOptional, isSelf: isSelf, isHost: isHost};
+      }
+
+      function createProvider(
+          token: string, {multi = false, deps = []}: {multi?: boolean, deps?: string[]} = {}):
+          CompileProviderMetadata {
+        const compileToken = createToken(token);
+        return {
+          token: compileToken,
+          multi: multi,
+          useClass: createTypeMeta({reference: tokenReference(compileToken)}),
+          deps: deps.map(createDep),
+          useExisting: undefined,
+          useFactory: undefined,
+          useValue: undefined
+        };
+      }
+
+      function createDir(
+          selector: string,
+          {providers = undefined, viewProviders = undefined, deps = [], queries = []}: {
+            providers?: CompileProviderMetadata[]|undefined,
+            viewProviders?: CompileProviderMetadata[]|undefined,
+            deps?: string[],
+            queries?: string[]
+          } = {}): CompileDirectiveSummary {
+        const isComponent = !selector.startsWith('[');
+        return compileDirectiveMetadataCreate({
+                 selector: selector,
+                 type: createTypeMeta({
+                   reference: <any>selector,
+                   diDeps: deps.map(createDep),
+                 }),
+                 isComponent: isComponent,
+                 template: compileTemplateMetadata({ngContentSelectors: []}),
+                 providers: providers,
+                 viewProviders: viewProviders,
+                 queries: queries.map((value) => {
+                   return {
+                     selectors: [createToken(value)],
+                     descendants: false,
+                     first: false,
+                     propertyName: 'test',
+                     read: undefined!
+                   };
+                 })
+               })
+            .toSummary();
+      }
+
+      beforeEach(() => {
+        nextProviderId = 0;
+      });
+
+      it('should provide a component', () => {
+        const comp = createDir('my-comp');
+        const elAst: ElementAst = <ElementAst>parse('<my-comp>', [comp])[0];
+        expect(elAst.providers.length).toBe(1);
+        expect(elAst.providers[0].providerType).toBe(ProviderAstType.Component);
+        expect(elAst.providers[0].providers[0].useClass).toBe(comp.type);
+      });
+
+      it('should provide a directive', () => {
+        const dirA = createDir('[dirA]');
+        const elAst: ElementAst = <ElementAst>parse('<div dirA>', [dirA])[0];
+        expect(elAst.providers.length).toBe(1);
+        expect(elAst.providers[0].providerType).toBe(ProviderAstType.Directive);
+        expect(elAst.providers[0].providers[0].useClass).toBe(dirA.type);
+      });
+
+      it('should use the public providers of a directive', () => {
+        const provider = createProvider('service');
+        const dirA = createDir('[dirA]', {providers: [provider]});
+        const elAst: ElementAst = <ElementAst>parse('<div dirA>', [dirA])[0];
+        expect(elAst.providers.length).toBe(2);
+        expect(elAst.providers[0].providerType).toBe(ProviderAstType.PublicService);
+        expect(elAst.providers[0].providers).toEqual([provider]);
+      });
+
+      it('should use the private providers of a component', () => {
+        const provider = createProvider('service');
+        const comp = createDir('my-comp', {viewProviders: [provider]});
+        const elAst: ElementAst = <ElementAst>parse('<my-comp>', [comp])[0];
+        expect(elAst.providers.length).toBe(2);
+        expect(elAst.providers[0].providerType).toBe(ProviderAstType.PrivateService);
+        expect(elAst.providers[0].providers).toEqual([provider]);
+      });
+
+      it('should support multi providers', () => {
+        const provider0 = createProvider('service0', {multi: true});
+        const provider1 = createProvider('service1', {multi: true});
+        const provider2 = createProvider('service0', {multi: true});
+        const dirA = createDir('[dirA]', {providers: [provider0, provider1]});
+        const dirB = createDir('[dirB]', {providers: [provider2]});
+        const elAst: ElementAst = <ElementAst>parse('<div dirA dirB>', [dirA, dirB])[0];
+        expect(elAst.providers.length).toBe(4);
+        expect(elAst.providers[0].providers).toEqual([provider0, provider2]);
+        expect(elAst.providers[1].providers).toEqual([provider1]);
+      });
+
+      it('should overwrite non multi providers', () => {
+        const provider1 = createProvider('service0');
+        const provider2 = createProvider('service1');
+        const provider3 = createProvider('service0');
+        const dirA = createDir('[dirA]', {providers: [provider1, provider2]});
+        const dirB = createDir('[dirB]', {providers: [provider3]});
+        const elAst: ElementAst = <ElementAst>parse('<div dirA dirB>', [dirA, dirB])[0];
+        expect(elAst.providers.length).toBe(4);
+        expect(elAst.providers[0].providers).toEqual([provider3]);
+        expect(elAst.providers[1].providers).toEqual([provider2]);
+      });
+
+      it('should overwrite component providers by directive providers', () => {
+        const compProvider = createProvider('service0');
+        const dirProvider = createProvider('service0');
+        const comp = createDir('my-comp', {providers: [compProvider]});
+        const dirA = createDir('[dirA]', {providers: [dirProvider]});
+        const elAst: ElementAst = <ElementAst>parse('<my-comp dirA>', [dirA, comp])[0];
+        expect(elAst.providers.length).toBe(3);
+        expect(elAst.providers[0].providers).toEqual([dirProvider]);
+      });
+
+      it('should overwrite view providers by directive providers', () => {
+        const viewProvider = createProvider('service0');
+        const dirProvider = createProvider('service0');
+        const comp = createDir('my-comp', {viewProviders: [viewProvider]});
+        const dirA = createDir('[dirA]', {providers: [dirProvider]});
+        const elAst: ElementAst = <ElementAst>parse('<my-comp dirA>', [dirA, comp])[0];
+        expect(elAst.providers.length).toBe(3);
+        expect(elAst.providers[0].providers).toEqual([dirProvider]);
+      });
+
+      it('should overwrite directives by providers', () => {
+        const dirProvider = createProvider('type:my-comp');
+        const comp = createDir('my-comp', {providers: [dirProvider]});
+        const elAst: ElementAst = <ElementAst>parse('<my-comp>', [comp])[0];
+        expect(elAst.providers.length).toBe(1);
+        expect(elAst.providers[0].providers).toEqual([dirProvider]);
+      });
+
+      it('if mixing multi and non multi providers', () => {
+        const provider0 = createProvider('service0');
+        const provider1 = createProvider('service0', {multi: true});
+        const dirA = createDir('[dirA]', {providers: [provider0]});
+        const dirB = createDir('[dirB]', {providers: [provider1]});
+        expect(() => parse('<div dirA dirB>', [dirA, dirB]))
+            .toThrowError(
+                `Template parse errors:\n` +
+                `Mixing multi and non multi provider is not possible for token service0 ("[ERROR ->]<div dirA dirB>"): TestComp@0:0`);
+      });
+
+      it('should sort providers by their DI order, lazy providers first', () => {
+        const provider0 = createProvider('service0', {deps: ['type:[dir2]']});
+        const provider1 = createProvider('service1');
+        const dir2 = createDir('[dir2]', {deps: ['service1']});
+        const comp = createDir('my-comp', {providers: [provider0, provider1]});
+        const elAst: ElementAst = <ElementAst>parse('<my-comp dir2>', [comp, dir2])[0];
+        expect(elAst.providers.length).toBe(4);
+        expect(elAst.providers[1].providers[0].useClass).toEqual(comp.type);
+        expect(elAst.providers[2].providers).toEqual([provider1]);
+        expect(elAst.providers[3].providers[0].useClass).toEqual(dir2.type);
+        expect(elAst.providers[0].providers).toEqual([provider0]);
+      });
+
+      it('should sort directives by their DI order', () => {
+        const dir0 = createDir('[dir0]', {deps: ['type:my-comp']});
+        const dir1 = createDir('[dir1]', {deps: ['type:[dir0]']});
+        const dir2 = createDir('[dir2]', {deps: ['type:[dir1]']});
+        const comp = createDir('my-comp');
+        const elAst: ElementAst =
+            <ElementAst>parse('<my-comp dir2 dir0 dir1>', [comp, dir2, dir0, dir1])[0];
+        expect(elAst.providers.length).toBe(4);
+        expect(elAst.directives[0].directive).toBe(comp);
+        expect(elAst.directives[1].directive).toBe(dir0);
+        expect(elAst.directives[2].directive).toBe(dir1);
+        expect(elAst.directives[3].directive).toBe(dir2);
+      });
+
+      it('should mark directives and dependencies of directives as eager', () => {
+        const provider0 = createProvider('service0');
+        const provider1 = createProvider('service1');
+        const dirA = createDir('[dirA]', {providers: [provider0, provider1], deps: ['service0']});
+        const elAst: ElementAst = <ElementAst>parse('<div dirA>', [dirA])[0];
+        expect(elAst.providers.length).toBe(3);
+        expect(elAst.providers[1].providers).toEqual([provider0]);
+        expect(elAst.providers[1].eager).toBe(true);
+        expect(elAst.providers[2].providers[0].useClass).toEqual(dirA.type);
+        expect(elAst.providers[2].eager).toBe(true);
+        expect(elAst.providers[0].providers).toEqual([provider1]);
+        expect(elAst.providers[0].eager).toBe(false);
+      });
+
+      it('should mark dependencies on parent elements as eager', () => {
+        const provider0 = createProvider('service0');
+        const provider1 = createProvider('service1');
+        const dirA = createDir('[dirA]', {providers: [provider0, provider1]});
+        const dirB = createDir('[dirB]', {deps: ['service0']});
+        const elAst: ElementAst =
+            <ElementAst>parse('<div dirA><div dirB></div></div>', [dirA, dirB])[0];
+        expect(elAst.providers.length).toBe(3);
+        expect(elAst.providers[1].providers[0].useClass).toEqual(dirA.type);
+        expect(elAst.providers[1].eager).toBe(true);
+        expect(elAst.providers[2].providers).toEqual([provider0]);
+        expect(elAst.providers[2].eager).toBe(true);
+        expect(elAst.providers[0].providers).toEqual([provider1]);
+        expect(elAst.providers[0].eager).toBe(false);
+      });
+
+      it('should mark queried providers as eager', () => {
+        const provider0 = createProvider('service0');
+        const provider1 = createProvider('service1');
+        const dirA =
+            createDir('[dirA]', {providers: [provider0, provider1], queries: ['service0']});
+        const elAst: ElementAst = <ElementAst>parse('<div dirA></div>', [dirA])[0];
+        expect(elAst.providers.length).toBe(3);
+        expect(elAst.providers[1].providers[0].useClass).toEqual(dirA.type);
+        expect(elAst.providers[1].eager).toBe(true);
+        expect(elAst.providers[2].providers).toEqual([provider0]);
+        expect(elAst.providers[2].eager).toBe(true);
+        expect(elAst.providers[0].providers).toEqual([provider1]);
+        expect(elAst.providers[0].eager).toBe(false);
+      });
+
+      it('should not mark dependencies across embedded views as eager', () => {
+        const provider0 = createProvider('service0');
+        const dirA = createDir('[dirA]', {providers: [provider0]});
+        const dirB = createDir('[dirB]', {deps: ['service0']});
+        const elAst: ElementAst =
+            <ElementAst>parse('<div dirA><div *ngIf dirB></div></div>', [dirA, dirB])[0];
+        expect(elAst.providers.length).toBe(2);
+        expect(elAst.providers[1].providers[0].useClass).toEqual(dirA.type);
+        expect(elAst.providers[1].eager).toBe(true);
+        expect(elAst.providers[0].providers).toEqual([provider0]);
+        expect(elAst.providers[0].eager).toBe(false);
+      });
+
+      it('should report missing @Self() deps as errors', () => {
+        const dirA = createDir('[dirA]', {deps: ['self:provider0']});
+        expect(() => parse('<div dirA></div>', [dirA]))
+            .toThrowError(
+                'Template parse errors:\nNo provider for provider0 ("[ERROR ->]<div dirA></div>"): TestComp@0:0');
+      });
+
+      it('should change missing @Self() that are optional to nulls', () => {
+        const dirA = createDir('[dirA]', {deps: ['optional:self:provider0']});
+        const elAst: ElementAst = <ElementAst>parse('<div dirA></div>', [dirA])[0];
+        expect(elAst.providers[0].providers[0].deps![0].isValue).toBe(true);
+        expect(elAst.providers[0].providers[0].deps![0].value).toBe(null);
+      });
+
+      it('should report missing @Host() deps as errors', () => {
+        const dirA = createDir('[dirA]', {deps: ['host:provider0']});
+        expect(() => parse('<div dirA></div>', [dirA]))
+            .toThrowError(
+                'Template parse errors:\nNo provider for provider0 ("[ERROR ->]<div dirA></div>"): TestComp@0:0');
+      });
+
+      it('should change missing @Host() that are optional to nulls', () => {
+        const dirA = createDir('[dirA]', {deps: ['optional:host:provider0']});
+        const elAst: ElementAst = <ElementAst>parse('<div dirA></div>', [dirA])[0];
+        expect(elAst.providers[0].providers[0].deps![0].isValue).toBe(true);
+        expect(elAst.providers[0].providers[0].deps![0].value).toBe(null);
+      });
+    });
+
+    describe('references', () => {
+      it('should parse references via #... and not report them as attributes', () => {
+        expect(humanizeTplAst(parse('<div #a>', []))).toEqual([
+          [ElementAst, 'div'], [ReferenceAst, 'a', null]
+        ]);
+      });
+
+      it('should parse references via ref-... and not report them as attributes', () => {
+        expect(humanizeTplAst(parse('<div ref-a>', []))).toEqual([
+          [ElementAst, 'div'], [ReferenceAst, 'a', null]
+        ]);
+      });
+
+      it('should parse camel case references', () => {
+        expect(humanizeTplAst(parse('<div ref-someA>', []))).toEqual([
+          [ElementAst, 'div'], [ReferenceAst, 'someA', null]
+        ]);
+      });
+
+      it('should assign references with empty value to the element', () => {
+        expect(humanizeTplAst(parse('<div #a></div>', []))).toEqual([
+          [ElementAst, 'div'], [ReferenceAst, 'a', null]
+        ]);
+      });
+
+      it('should assign references to directives via exportAs', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: '[a]',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                       exportAs: 'dirA'
+                     }).toSummary();
+        expect(humanizeTplAst(parse('<div a #a="dirA"></div>', [dirA]))).toEqual([
+          [ElementAst, 'div'],
+          [AttrAst, 'a', ''],
+          [ReferenceAst, 'a', createTokenForReference(dirA.type.reference)],
+          [DirectiveAst, dirA],
+        ]);
+      });
+
+      it('should assign references to directives via exportAs with multiple names', () => {
+        const pizzaTestDirective =
+            compileDirectiveMetadataCreate({
+              selector: 'pizza-test',
+              type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'Pizza'}}),
+              exportAs: 'pizza, cheeseSauceBread'
+            }).toSummary();
+
+        const template = '<pizza-test #food="pizza" #yum="cheeseSauceBread"></pizza-test>';
+
+        expect(humanizeTplAst(parse(template, [pizzaTestDirective]))).toEqual([
+          [ElementAst, 'pizza-test'],
+          [ReferenceAst, 'food', createTokenForReference(pizzaTestDirective.type.reference)],
+          [ReferenceAst, 'yum', createTokenForReference(pizzaTestDirective.type.reference)],
+          [DirectiveAst, pizzaTestDirective],
+        ]);
+      });
+
+      it('should report references with values that don\'t match a directive as errors', () => {
+        expect(() => parse('<div #a="dirA"></div>', [])).toThrowError(`Template parse errors:
+There is no directive with "exportAs" set to "dirA" ("<div [ERROR ->]#a="dirA"></div>"): TestComp@0:5`);
+      });
+
+      it('should report invalid reference names', () => {
+        expect(() => parse('<div #a-b></div>', [])).toThrowError(`Template parse errors:
+"-" is not allowed in reference names ("<div [ERROR ->]#a-b></div>"): TestComp@0:5`);
+      });
+
+      it('should report missing reference names', () => {
+        expect(() => parse('<div #></div>', [])).toThrowError(`Template parse errors:
+Reference does not have a name ("<div [ERROR ->]#></div>"): TestComp@0:5`);
+      });
+
+      it('should report variables as errors', () => {
+        expect(() => parse('<div let-a></div>', [])).toThrowError(`Template parse errors:
+"let-" is only supported on ng-template elements. ("<div [ERROR ->]let-a></div>"): TestComp@0:5`);
+      });
+
+      it('should report missing variable names', () => {
+        expect(() => parse('<ng-template let-></ng-template>', []))
+            .toThrowError(`Template parse errors:
+Variable does not have a name ("<ng-template [ERROR ->]let-></ng-template>"): TestComp@0:13`);
+      });
+
+      it('should report duplicate reference names', () => {
+        expect(() => parse('<div #a></div><div #a></div>', [])).toThrowError(`Template parse errors:
+Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>"): TestComp@0:19`);
+      });
+
+      it('should report duplicate reference names when using multiple exportAs names', () => {
+        const pizzaDirective =
+            compileDirectiveMetadataCreate({
+              selector: '[dessert-pizza]',
+              type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'Pizza'}}),
+              exportAs: 'dessertPizza, chocolate'
+            }).toSummary();
+
+        const chocolateDirective =
+            compileDirectiveMetadataCreate({
+              selector: '[chocolate]',
+              type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'Chocolate'}}),
+              exportAs: 'chocolate'
+            }).toSummary();
+
+        const template = '<div dessert-pizza chocolate #snack="chocolate"></div>';
+        const compileTemplate = () => parse(template, [pizzaDirective, chocolateDirective]);
+        const duplicateReferenceError = 'Template parse errors:\n' +
+            'Reference "#snack" is defined several times ' +
+            '("<div dessert-pizza chocolate [ERROR ->]#snack="chocolate"></div>")' +
+            ': TestComp@0:29';
+
+        expect(compileTemplate).toThrowError(duplicateReferenceError);
+      });
+
+      it('should not throw error when there is same reference name in different templates', () => {
+        expect(() => parse('<div #a><ng-template #a><span>OK</span></ng-template></div>', []))
+            .not.toThrowError();
+      });
+
+      it('should assign references with empty value to components', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: '[a]',
+                       isComponent: true,
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                       exportAs: 'dirA',
+                       template: compileTemplateMetadata({ngContentSelectors: []})
+                     }).toSummary();
+        expect(humanizeTplAst(parse('<div a #a></div>', [dirA]))).toEqual([
+          [ElementAst, 'div'],
+          [AttrAst, 'a', ''],
+          [ReferenceAst, 'a', createTokenForReference(dirA.type.reference)],
+          [DirectiveAst, dirA],
+        ]);
+      });
+
+      it('should not locate directives in references', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: '[a]',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
+                     }).toSummary();
+        expect(humanizeTplAst(parse('<div ref-a>', [dirA]))).toEqual([
+          [ElementAst, 'div'], [ReferenceAst, 'a', null]
+        ]);
+      });
+    });
+
+    describe('explicit templates', () => {
+      let reflector: JitReflector;
+
+      beforeEach(() => {
+        reflector = new JitReflector();
+      });
+
+      it('should create embedded templates for <ng-template> elements', () => {
+        expect(humanizeTplAst(parse('<ng-template></ng-template>', []))).toEqual([
+          [EmbeddedTemplateAst]
+        ]);
+      });
+
+      it('should create embedded templates for <ng-template> elements regardless the namespace',
+         () => {
+           expect(humanizeTplAst(parse('<svg><ng-template></ng-template></svg>', []))).toEqual([
+             [ElementAst, ':svg:svg'],
+             [EmbeddedTemplateAst],
+           ]);
+         });
+
+      it('should support references via #...', () => {
+        expect(humanizeTplAst(parse('<ng-template #a>', []))).toEqual([
+          [EmbeddedTemplateAst],
+          [ReferenceAst, 'a', createTokenForExternalReference(reflector, Identifiers.TemplateRef)],
+        ]);
+      });
+
+      it('should support references via ref-...', () => {
+        expect(humanizeTplAst(parse('<ng-template ref-a>', []))).toEqual([
+          [EmbeddedTemplateAst],
+          [ReferenceAst, 'a', createTokenForExternalReference(reflector, Identifiers.TemplateRef)]
+        ]);
+      });
+
+      it('should parse variables via let-...', () => {
+        expect(humanizeTplAst(parse('<ng-template let-a="b">', []))).toEqual([
+          [EmbeddedTemplateAst],
+          [VariableAst, 'a', 'b'],
+        ]);
+      });
+
+      it('should not locate directives in variables', () => {
+        const dirA = compileDirectiveMetadataCreate({
+                       selector: '[a]',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
+                     }).toSummary();
+        expect(humanizeTplAst(parse('<ng-template let-a="b"></ng-template>', [dirA]))).toEqual([
+          [EmbeddedTemplateAst],
+          [VariableAst, 'a', 'b'],
+        ]);
+      });
+    });
+
+    describe('inline templates', () => {
+      it('should report an error on variables declared with #', () => {
+        expect(() => humanizeTplAst(parse('<div *ngIf="#a=b">', [])))
+            .toThrowError(/Parser Error: Unexpected token # at column 1/);
+      });
+
+      it('should parse variables via let ...', () => {
+        const targetAst = [
+          [EmbeddedTemplateAst],
+          [VariableAst, 'a', 'b'],
+          [ElementAst, 'div'],
+        ];
+
+        expect(humanizeTplAst(parse('<div *ngIf="let a=b">', []))).toEqual(targetAst);
+
+        expect(humanizeTplAst(parse('<div data-*ngIf="let a=b">', []))).toEqual(targetAst);
+      });
+
+      it('should parse variables via as ...', () => {
+        const targetAst = [
+          [EmbeddedTemplateAst],
+          [VariableAst, 'local', 'ngIf'],
+          [DirectiveAst, ngIf],
+          [BoundDirectivePropertyAst, 'ngIf', 'expr'],
+          [ElementAst, 'div'],
+        ];
+
+        expect(humanizeTplAst(parse('<div *ngIf="expr as local">', [ngIf]))).toEqual(targetAst);
       });
 
       describe('directives', () => {
-        it('should order directives by the directives array in the View and match them only once',
-           () => {
-             const dirA =
-                 compileDirectiveMetadataCreate({
-                   selector: '[a]',
-                   type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
-                 }).toSummary();
-             const dirB =
-                 compileDirectiveMetadataCreate({
-                   selector: '[b]',
-                   type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirB'}})
-                 }).toSummary();
-             const dirC =
-                 compileDirectiveMetadataCreate({
-                   selector: '[c]',
-                   type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirC'}})
-                 }).toSummary();
-             expect(humanizeTplAst(parse('<div a c b a b>', [dirA, dirB, dirC]))).toEqual([
-               [ElementAst, 'div'], [AttrAst, 'a', ''], [AttrAst, 'c', ''], [AttrAst, 'b', ''],
-               [AttrAst, 'a', ''], [AttrAst, 'b', ''], [DirectiveAst, dirA], [DirectiveAst, dirB],
-               [DirectiveAst, dirC]
-             ]);
-           });
-
-        it('should parse directive dotted properties', () => {
-          const dirA = compileDirectiveMetadataCreate({
-                         selector: '[dot.name]',
-                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                         inputs: ['localName: dot.name'],
-                       }).toSummary();
-
-          expect(humanizeTplAst(parse('<div [dot.name]="expr"></div>', [dirA]))).toEqual([
-            [ElementAst, 'div'],
-            [DirectiveAst, dirA],
-            [BoundDirectivePropertyAst, 'localName', 'expr'],
-          ]);
-        });
-
         it('should locate directives in property bindings', () => {
-          const dirA =
-              compileDirectiveMetadataCreate({
-                selector: '[a=b]',
-                type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
-              }).toSummary();
-          const dirB =
-              compileDirectiveMetadataCreate({
-                selector: '[b]',
-                type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirB'}})
-              }).toSummary();
-          expect(humanizeTplAst(parse('<div [a]="b">', [dirA, dirB]))).toEqual([
-            [ElementAst, 'div'],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'a', 'b', null],
-            [DirectiveAst, dirA]
-          ]);
-        });
-
-        it('should locate directives in inline templates', () => {
-          const dirTemplate =
-              compileDirectiveMetadataCreate({
-                selector: 'ng-template',
-                type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'onTemplate'}})
-              }).toSummary();
-          expect(humanizeTplAst(parse('<div *ngIf="cond">', [ngIf, dirTemplate]))).toEqual([
-            [EmbeddedTemplateAst],
-            [DirectiveAst, ngIf],
-            [BoundDirectivePropertyAst, 'ngIf', 'cond'],
-            [DirectiveAst, dirTemplate],
-            [ElementAst, 'div'],
-          ]);
-        });
-
-        it('should locate directives in event bindings', () => {
-          const dirA =
-              compileDirectiveMetadataCreate({
-                selector: '[a]',
-                type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirB'}})
-              }).toSummary();
-
-          expect(humanizeTplAst(parse('<div (a)="b">', [dirA]))).toEqual([
-            [ElementAst, 'div'], [BoundEventAst, 'a', null, 'b'], [DirectiveAst, dirA]
-          ]);
-        });
-
-        it('should parse directive host properties', () => {
           const dirA = compileDirectiveMetadataCreate({
-                         selector: 'div',
-                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                         host: {'[a]': 'expr'}
-                       }).toSummary();
-          expect(humanizeTplAst(parse('<div></div>', [dirA]))).toEqual([
-            [ElementAst, 'div'], [DirectiveAst, dirA],
-            [BoundElementPropertyAst, PropertyBindingType.Property, 'a', 'expr', null]
-          ]);
-        });
-
-        it('should parse directive host listeners', () => {
-          const dirA = compileDirectiveMetadataCreate({
-                         selector: 'div',
-                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                         host: {'(a)': 'expr'}
-                       }).toSummary();
-          expect(humanizeTplAst(parse('<div></div>', [dirA]))).toEqual([
-            [ElementAst, 'div'], [DirectiveAst, dirA], [BoundEventAst, 'a', null, 'expr']
-          ]);
-        });
-
-        it('should parse directive properties', () => {
-          const dirA = compileDirectiveMetadataCreate({
-                         selector: 'div',
-                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                         inputs: ['aProp']
-                       }).toSummary();
-          expect(humanizeTplAst(parse('<div [aProp]="expr"></div>', [dirA]))).toEqual([
-            [ElementAst, 'div'], [DirectiveAst, dirA],
-            [BoundDirectivePropertyAst, 'aProp', 'expr']
-          ]);
-        });
-
-        it('should parse renamed directive properties', () => {
-          const dirA = compileDirectiveMetadataCreate({
-                         selector: 'div',
-                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                         inputs: ['b:a']
-                       }).toSummary();
-          expect(humanizeTplAst(parse('<div [a]="expr"></div>', [dirA]))).toEqual([
-            [ElementAst, 'div'], [DirectiveAst, dirA], [BoundDirectivePropertyAst, 'b', 'expr']
-          ]);
-        });
-
-        it('should parse literal directive properties', () => {
-          const dirA = compileDirectiveMetadataCreate({
-                         selector: 'div',
+                         selector: '[a=b]',
                          type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
                          inputs: ['a']
                        }).toSummary();
-          expect(humanizeTplAst(parse('<div a="literal"></div>', [dirA]))).toEqual([
-            [ElementAst, 'div'], [AttrAst, 'a', 'literal'], [DirectiveAst, dirA],
-            [BoundDirectivePropertyAst, 'a', '"literal"']
+          const dirB = compileDirectiveMetadataCreate({
+                         selector: '[b]',
+                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirB'}})
+                       }).toSummary();
+          expect(humanizeTplAst(parse('<div *a="b" b>', [dirA, dirB]))).toEqual([
+            [EmbeddedTemplateAst], [DirectiveAst, dirA], [BoundDirectivePropertyAst, 'a', 'b'],
+            [ElementAst, 'div'], [AttrAst, 'b', ''], [DirectiveAst, dirB]
           ]);
         });
 
-        it('should favor explicit bound properties over literal properties', () => {
+        it('should not locate directives in variables', () => {
           const dirA = compileDirectiveMetadataCreate({
-                         selector: 'div',
-                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                         inputs: ['a']
+                         selector: '[a]',
+                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
                        }).toSummary();
-          expect(humanizeTplAst(parse('<div a="literal" [a]="\'literal2\'"></div>', [dirA])))
+          expect(humanizeTplAst(parse('<ng-template let-a="b"><div></div></ng-template>', [dirA])))
               .toEqual([
-                [ElementAst, 'div'], [AttrAst, 'a', 'literal'], [DirectiveAst, dirA],
-                [BoundDirectivePropertyAst, 'a', '"literal2"']
+                [EmbeddedTemplateAst],
+                [VariableAst, 'a', 'b'],
+                [ElementAst, 'div'],
               ]);
         });
 
-        it('should support optional directive properties', () => {
-          const dirA = compileDirectiveMetadataCreate({
-                         selector: 'div',
-                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                         inputs: ['a']
-                       }).toSummary();
-          expect(humanizeTplAst(parse('<div></div>', [dirA]))).toEqual([
-            [ElementAst, 'div'], [DirectiveAst, dirA]
-          ]);
-        });
-
-      });
-
-      describe('providers', () => {
-        let nextProviderId: number;
-
-        function createToken(value: string): CompileTokenMetadata {
-          let token: CompileTokenMetadata;
-          if (value.startsWith('type:')) {
-            const name = value.substring(5);
-            token = {identifier: createTypeMeta({reference: <any>name})};
-          } else {
-            token = {value: value};
-          }
-          return token;
-        }
-
-        function createDep(value: string): CompileDiDependencyMetadata {
-          let isOptional = false;
-          if (value.startsWith('optional:')) {
-            isOptional = true;
-            value = value.substring(9);
-          }
-          let isSelf = false;
-          if (value.startsWith('self:')) {
-            isSelf = true;
-            value = value.substring(5);
-          }
-          let isHost = false;
-          if (value.startsWith('host:')) {
-            isHost = true;
-            value = value.substring(5);
-          }
-          return {
-            token: createToken(value),
-            isOptional: isOptional,
-            isSelf: isSelf,
-            isHost: isHost
-          };
-        }
-
-        function createProvider(
-            token: string, {multi = false, deps = []}: {multi?: boolean, deps?: string[]} = {}):
-            CompileProviderMetadata {
-          const compileToken = createToken(token);
-          return {
-            token: compileToken,
-            multi: multi,
-            useClass: createTypeMeta({reference: tokenReference(compileToken)}),
-            deps: deps.map(createDep),
-            useExisting: undefined,
-            useFactory: undefined,
-            useValue: undefined
-          };
-        }
-
-        function createDir(
-            selector: string,
-            {providers = undefined, viewProviders = undefined, deps = [], queries = []}: {
-              providers?: CompileProviderMetadata[] | undefined,
-              viewProviders?: CompileProviderMetadata[] | undefined,
-              deps?: string[],
-              queries?: string[]
-            } = {}): CompileDirectiveSummary {
-          const isComponent = !selector.startsWith('[');
-          return compileDirectiveMetadataCreate({
-                   selector: selector,
-                   type: createTypeMeta({
-                     reference: <any>selector,
-                     diDeps: deps.map(createDep),
-                   }),
-                   isComponent: isComponent,
-                   template: compileTemplateMetadata({ngContentSelectors: []}),
-                   providers: providers,
-                   viewProviders: viewProviders,
-                   queries: queries.map((value) => {
-                     return {
-                       selectors: [createToken(value)],
-                       descendants: false,
-                       first: false,
-                       propertyName: 'test',
-                       read: undefined !
-                     };
-                   })
-                 })
-              .toSummary();
-        }
-
-        beforeEach(() => { nextProviderId = 0; });
-
-        it('should provide a component', () => {
-          const comp = createDir('my-comp');
-          const elAst: ElementAst = <ElementAst>parse('<my-comp>', [comp])[0];
-          expect(elAst.providers.length).toBe(1);
-          expect(elAst.providers[0].providerType).toBe(ProviderAstType.Component);
-          expect(elAst.providers[0].providers[0].useClass).toBe(comp.type);
-        });
-
-        it('should provide a directive', () => {
-          const dirA = createDir('[dirA]');
-          const elAst: ElementAst = <ElementAst>parse('<div dirA>', [dirA])[0];
-          expect(elAst.providers.length).toBe(1);
-          expect(elAst.providers[0].providerType).toBe(ProviderAstType.Directive);
-          expect(elAst.providers[0].providers[0].useClass).toBe(dirA.type);
-        });
-
-        it('should use the public providers of a directive', () => {
-          const provider = createProvider('service');
-          const dirA = createDir('[dirA]', {providers: [provider]});
-          const elAst: ElementAst = <ElementAst>parse('<div dirA>', [dirA])[0];
-          expect(elAst.providers.length).toBe(2);
-          expect(elAst.providers[0].providerType).toBe(ProviderAstType.PublicService);
-          expect(elAst.providers[0].providers).toEqual([provider]);
-        });
-
-        it('should use the private providers of a component', () => {
-          const provider = createProvider('service');
-          const comp = createDir('my-comp', {viewProviders: [provider]});
-          const elAst: ElementAst = <ElementAst>parse('<my-comp>', [comp])[0];
-          expect(elAst.providers.length).toBe(2);
-          expect(elAst.providers[0].providerType).toBe(ProviderAstType.PrivateService);
-          expect(elAst.providers[0].providers).toEqual([provider]);
-        });
-
-        it('should support multi providers', () => {
-          const provider0 = createProvider('service0', {multi: true});
-          const provider1 = createProvider('service1', {multi: true});
-          const provider2 = createProvider('service0', {multi: true});
-          const dirA = createDir('[dirA]', {providers: [provider0, provider1]});
-          const dirB = createDir('[dirB]', {providers: [provider2]});
-          const elAst: ElementAst = <ElementAst>parse('<div dirA dirB>', [dirA, dirB])[0];
-          expect(elAst.providers.length).toBe(4);
-          expect(elAst.providers[0].providers).toEqual([provider0, provider2]);
-          expect(elAst.providers[1].providers).toEqual([provider1]);
-        });
-
-        it('should overwrite non multi providers', () => {
-          const provider1 = createProvider('service0');
-          const provider2 = createProvider('service1');
-          const provider3 = createProvider('service0');
-          const dirA = createDir('[dirA]', {providers: [provider1, provider2]});
-          const dirB = createDir('[dirB]', {providers: [provider3]});
-          const elAst: ElementAst = <ElementAst>parse('<div dirA dirB>', [dirA, dirB])[0];
-          expect(elAst.providers.length).toBe(4);
-          expect(elAst.providers[0].providers).toEqual([provider3]);
-          expect(elAst.providers[1].providers).toEqual([provider2]);
-        });
-
-        it('should overwrite component providers by directive providers', () => {
-          const compProvider = createProvider('service0');
-          const dirProvider = createProvider('service0');
-          const comp = createDir('my-comp', {providers: [compProvider]});
-          const dirA = createDir('[dirA]', {providers: [dirProvider]});
-          const elAst: ElementAst = <ElementAst>parse('<my-comp dirA>', [dirA, comp])[0];
-          expect(elAst.providers.length).toBe(3);
-          expect(elAst.providers[0].providers).toEqual([dirProvider]);
-        });
-
-        it('should overwrite view providers by directive providers', () => {
-          const viewProvider = createProvider('service0');
-          const dirProvider = createProvider('service0');
-          const comp = createDir('my-comp', {viewProviders: [viewProvider]});
-          const dirA = createDir('[dirA]', {providers: [dirProvider]});
-          const elAst: ElementAst = <ElementAst>parse('<my-comp dirA>', [dirA, comp])[0];
-          expect(elAst.providers.length).toBe(3);
-          expect(elAst.providers[0].providers).toEqual([dirProvider]);
-        });
-
-        it('should overwrite directives by providers', () => {
-          const dirProvider = createProvider('type:my-comp');
-          const comp = createDir('my-comp', {providers: [dirProvider]});
-          const elAst: ElementAst = <ElementAst>parse('<my-comp>', [comp])[0];
-          expect(elAst.providers.length).toBe(1);
-          expect(elAst.providers[0].providers).toEqual([dirProvider]);
-        });
-
-        it('if mixing multi and non multi providers', () => {
-          const provider0 = createProvider('service0');
-          const provider1 = createProvider('service0', {multi: true});
-          const dirA = createDir('[dirA]', {providers: [provider0]});
-          const dirB = createDir('[dirB]', {providers: [provider1]});
-          expect(() => parse('<div dirA dirB>', [dirA, dirB]))
-              .toThrowError(
-                  `Template parse errors:\n` +
-                  `Mixing multi and non multi provider is not possible for token service0 ("[ERROR ->]<div dirA dirB>"): TestComp@0:0`);
-        });
-
-        it('should sort providers by their DI order, lazy providers first', () => {
-          const provider0 = createProvider('service0', {deps: ['type:[dir2]']});
-          const provider1 = createProvider('service1');
-          const dir2 = createDir('[dir2]', {deps: ['service1']});
-          const comp = createDir('my-comp', {providers: [provider0, provider1]});
-          const elAst: ElementAst = <ElementAst>parse('<my-comp dir2>', [comp, dir2])[0];
-          expect(elAst.providers.length).toBe(4);
-          expect(elAst.providers[1].providers[0].useClass).toEqual(comp.type);
-          expect(elAst.providers[2].providers).toEqual([provider1]);
-          expect(elAst.providers[3].providers[0].useClass).toEqual(dir2.type);
-          expect(elAst.providers[0].providers).toEqual([provider0]);
-        });
-
-        it('should sort directives by their DI order', () => {
-          const dir0 = createDir('[dir0]', {deps: ['type:my-comp']});
-          const dir1 = createDir('[dir1]', {deps: ['type:[dir0]']});
-          const dir2 = createDir('[dir2]', {deps: ['type:[dir1]']});
-          const comp = createDir('my-comp');
-          const elAst: ElementAst =
-              <ElementAst>parse('<my-comp dir2 dir0 dir1>', [comp, dir2, dir0, dir1])[0];
-          expect(elAst.providers.length).toBe(4);
-          expect(elAst.directives[0].directive).toBe(comp);
-          expect(elAst.directives[1].directive).toBe(dir0);
-          expect(elAst.directives[2].directive).toBe(dir1);
-          expect(elAst.directives[3].directive).toBe(dir2);
-        });
-
-        it('should mark directives and dependencies of directives as eager', () => {
-          const provider0 = createProvider('service0');
-          const provider1 = createProvider('service1');
-          const dirA = createDir('[dirA]', {providers: [provider0, provider1], deps: ['service0']});
-          const elAst: ElementAst = <ElementAst>parse('<div dirA>', [dirA])[0];
-          expect(elAst.providers.length).toBe(3);
-          expect(elAst.providers[1].providers).toEqual([provider0]);
-          expect(elAst.providers[1].eager).toBe(true);
-          expect(elAst.providers[2].providers[0].useClass).toEqual(dirA.type);
-          expect(elAst.providers[2].eager).toBe(true);
-          expect(elAst.providers[0].providers).toEqual([provider1]);
-          expect(elAst.providers[0].eager).toBe(false);
-        });
-
-        it('should mark dependencies on parent elements as eager', () => {
-          const provider0 = createProvider('service0');
-          const provider1 = createProvider('service1');
-          const dirA = createDir('[dirA]', {providers: [provider0, provider1]});
-          const dirB = createDir('[dirB]', {deps: ['service0']});
-          const elAst: ElementAst =
-              <ElementAst>parse('<div dirA><div dirB></div></div>', [dirA, dirB])[0];
-          expect(elAst.providers.length).toBe(3);
-          expect(elAst.providers[1].providers[0].useClass).toEqual(dirA.type);
-          expect(elAst.providers[1].eager).toBe(true);
-          expect(elAst.providers[2].providers).toEqual([provider0]);
-          expect(elAst.providers[2].eager).toBe(true);
-          expect(elAst.providers[0].providers).toEqual([provider1]);
-          expect(elAst.providers[0].eager).toBe(false);
-        });
-
-        it('should mark queried providers as eager', () => {
-          const provider0 = createProvider('service0');
-          const provider1 = createProvider('service1');
-          const dirA =
-              createDir('[dirA]', {providers: [provider0, provider1], queries: ['service0']});
-          const elAst: ElementAst = <ElementAst>parse('<div dirA></div>', [dirA])[0];
-          expect(elAst.providers.length).toBe(3);
-          expect(elAst.providers[1].providers[0].useClass).toEqual(dirA.type);
-          expect(elAst.providers[1].eager).toBe(true);
-          expect(elAst.providers[2].providers).toEqual([provider0]);
-          expect(elAst.providers[2].eager).toBe(true);
-          expect(elAst.providers[0].providers).toEqual([provider1]);
-          expect(elAst.providers[0].eager).toBe(false);
-        });
-
-        it('should not mark dependencies across embedded views as eager', () => {
-          const provider0 = createProvider('service0');
-          const dirA = createDir('[dirA]', {providers: [provider0]});
-          const dirB = createDir('[dirB]', {deps: ['service0']});
-          const elAst: ElementAst =
-              <ElementAst>parse('<div dirA><div *ngIf dirB></div></div>', [dirA, dirB])[0];
-          expect(elAst.providers.length).toBe(2);
-          expect(elAst.providers[1].providers[0].useClass).toEqual(dirA.type);
-          expect(elAst.providers[1].eager).toBe(true);
-          expect(elAst.providers[0].providers).toEqual([provider0]);
-          expect(elAst.providers[0].eager).toBe(false);
-        });
-
-        it('should report missing @Self() deps as errors', () => {
-          const dirA = createDir('[dirA]', {deps: ['self:provider0']});
-          expect(() => parse('<div dirA></div>', [dirA]))
-              .toThrowError(
-                  'Template parse errors:\nNo provider for provider0 ("[ERROR ->]<div dirA></div>"): TestComp@0:0');
-        });
-
-        it('should change missing @Self() that are optional to nulls', () => {
-          const dirA = createDir('[dirA]', {deps: ['optional:self:provider0']});
-          const elAst: ElementAst = <ElementAst>parse('<div dirA></div>', [dirA])[0];
-          expect(elAst.providers[0].providers[0].deps ![0].isValue).toBe(true);
-          expect(elAst.providers[0].providers[0].deps ![0].value).toBe(null);
-        });
-
-        it('should report missing @Host() deps as errors', () => {
-          const dirA = createDir('[dirA]', {deps: ['host:provider0']});
-          expect(() => parse('<div dirA></div>', [dirA]))
-              .toThrowError(
-                  'Template parse errors:\nNo provider for provider0 ("[ERROR ->]<div dirA></div>"): TestComp@0:0');
-        });
-
-        it('should change missing @Host() that are optional to nulls', () => {
-          const dirA = createDir('[dirA]', {deps: ['optional:host:provider0']});
-          const elAst: ElementAst = <ElementAst>parse('<div dirA></div>', [dirA])[0];
-          expect(elAst.providers[0].providers[0].deps ![0].isValue).toBe(true);
-          expect(elAst.providers[0].providers[0].deps ![0].value).toBe(null);
-        });
-      });
-
-      describe('references', () => {
-
-        it('should parse references via #... and not report them as attributes', () => {
-          expect(humanizeTplAst(parse('<div #a>', [
-          ]))).toEqual([[ElementAst, 'div'], [ReferenceAst, 'a', null]]);
-        });
-
-        it('should parse references via ref-... and not report them as attributes', () => {
-          expect(humanizeTplAst(parse('<div ref-a>', [
-          ]))).toEqual([[ElementAst, 'div'], [ReferenceAst, 'a', null]]);
-        });
-
-        it('should parse camel case references', () => {
-          expect(humanizeTplAst(parse('<div ref-someA>', [
-          ]))).toEqual([[ElementAst, 'div'], [ReferenceAst, 'someA', null]]);
-        });
-
-        it('should assign references with empty value to the element', () => {
-          expect(humanizeTplAst(parse('<div #a></div>', [
-          ]))).toEqual([[ElementAst, 'div'], [ReferenceAst, 'a', null]]);
-        });
-
-        it('should assign references to directives via exportAs', () => {
-          const dirA = compileDirectiveMetadataCreate({
-                         selector: '[a]',
-                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                         exportAs: 'dirA'
-                       }).toSummary();
-          expect(humanizeTplAst(parse('<div a #a="dirA"></div>', [dirA]))).toEqual([
-            [ElementAst, 'div'],
-            [AttrAst, 'a', ''],
-            [ReferenceAst, 'a', createTokenForReference(dirA.type.reference)],
-            [DirectiveAst, dirA],
-          ]);
-        });
-
-        it('should assign references to directives via exportAs with multiple names', () => {
-          const pizzaTestDirective =
-              compileDirectiveMetadataCreate({
-                selector: 'pizza-test',
-                type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'Pizza'}}),
-                exportAs: 'pizza, cheeseSauceBread'
-              }).toSummary();
-
-          const template = '<pizza-test #food="pizza" #yum="cheeseSauceBread"></pizza-test>';
-
-          expect(humanizeTplAst(parse(template, [pizzaTestDirective]))).toEqual([
-            [ElementAst, 'pizza-test'],
-            [ReferenceAst, 'food', createTokenForReference(pizzaTestDirective.type.reference)],
-            [ReferenceAst, 'yum', createTokenForReference(pizzaTestDirective.type.reference)],
-            [DirectiveAst, pizzaTestDirective],
-          ]);
-        });
-
-        it('should report references with values that don\'t match a directive as errors', () => {
-          expect(() => parse('<div #a="dirA"></div>', [])).toThrowError(`Template parse errors:
-There is no directive with "exportAs" set to "dirA" ("<div [ERROR ->]#a="dirA"></div>"): TestComp@0:5`);
-        });
-
-        it('should report invalid reference names', () => {
-          expect(() => parse('<div #a-b></div>', [])).toThrowError(`Template parse errors:
-"-" is not allowed in reference names ("<div [ERROR ->]#a-b></div>"): TestComp@0:5`);
-        });
-
-        it('should report missing reference names', () => {
-          expect(() => parse('<div #></div>', [])).toThrowError(`Template parse errors:
-Reference does not have a name ("<div [ERROR ->]#></div>"): TestComp@0:5`);
-        });
-
-        it('should report variables as errors', () => {
-          expect(() => parse('<div let-a></div>', [])).toThrowError(`Template parse errors:
-"let-" is only supported on ng-template elements. ("<div [ERROR ->]let-a></div>"): TestComp@0:5`);
-        });
-
-        it('should report missing variable names', () => {
-          expect(() => parse('<ng-template let-></ng-template>', []))
-              .toThrowError(`Template parse errors:
-Variable does not have a name ("<ng-template [ERROR ->]let-></ng-template>"): TestComp@0:13`);
-        });
-
-        it('should report duplicate reference names', () => {
-          expect(() => parse('<div #a></div><div #a></div>', []))
-              .toThrowError(`Template parse errors:
-Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>"): TestComp@0:19`);
-
-        });
-
-        it('should report duplicate reference names when using multiple exportAs names', () => {
-          const pizzaDirective =
-              compileDirectiveMetadataCreate({
-                selector: '[dessert-pizza]',
-                type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'Pizza'}}),
-                exportAs: 'dessertPizza, chocolate'
-              }).toSummary();
-
-          const chocolateDirective =
-              compileDirectiveMetadataCreate({
-                selector: '[chocolate]',
-                type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'Chocolate'}}),
-                exportAs: 'chocolate'
-              }).toSummary();
-
-          const template = '<div dessert-pizza chocolate #snack="chocolate"></div>';
-          const compileTemplate = () => parse(template, [pizzaDirective, chocolateDirective]);
-          const duplicateReferenceError = 'Template parse errors:\n' +
-              'Reference "#snack" is defined several times ' +
-              '("<div dessert-pizza chocolate [ERROR ->]#snack="chocolate"></div>")' +
-              ': TestComp@0:29';
-
-          expect(compileTemplate).toThrowError(duplicateReferenceError);
-        });
-
-        it('should not throw error when there is same reference name in different templates',
-           () => {
-             expect(() => parse('<div #a><ng-template #a><span>OK</span></ng-template></div>', []))
-                 .not.toThrowError();
-           });
-
-        it('should assign references with empty value to components', () => {
-          const dirA = compileDirectiveMetadataCreate({
-                         selector: '[a]',
-                         isComponent: true,
-                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                         exportAs: 'dirA',
-                         template: compileTemplateMetadata({ngContentSelectors: []})
-                       }).toSummary();
-          expect(humanizeTplAst(parse('<div a #a></div>', [dirA]))).toEqual([
-            [ElementAst, 'div'],
-            [AttrAst, 'a', ''],
-            [ReferenceAst, 'a', createTokenForReference(dirA.type.reference)],
-            [DirectiveAst, dirA],
-          ]);
-        });
-
         it('should not locate directives in references', () => {
-          const dirA =
-              compileDirectiveMetadataCreate({
-                selector: '[a]',
-                type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
-              }).toSummary();
+          const dirA = compileDirectiveMetadataCreate({
+                         selector: '[a]',
+                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
+                       }).toSummary();
           expect(humanizeTplAst(parse('<div ref-a>', [dirA]))).toEqual([
             [ElementAst, 'div'], [ReferenceAst, 'a', null]
           ]);
         });
       });
 
-      describe('explicit templates', () => {
-        let reflector: JitReflector;
 
-        beforeEach(() => { reflector = new JitReflector(); });
-
-        it('should create embedded templates for <ng-template> elements', () => {
-          expect(humanizeTplAst(parse('<ng-template></ng-template>', [
-          ]))).toEqual([[EmbeddedTemplateAst]]);
-        });
-
-        it('should create embedded templates for <ng-template> elements regardless the namespace',
-           () => {
-             expect(humanizeTplAst(parse('<svg><ng-template></ng-template></svg>', []))).toEqual([
-               [ElementAst, ':svg:svg'],
-               [EmbeddedTemplateAst],
-             ]);
-           });
-
-        it('should support references via #...', () => {
-          expect(humanizeTplAst(parse('<ng-template #a>', []))).toEqual([
-            [EmbeddedTemplateAst],
-            [
-              ReferenceAst, 'a', createTokenForExternalReference(reflector, Identifiers.TemplateRef)
-            ],
-          ]);
-        });
-
-        it('should support references via ref-...', () => {
-          expect(humanizeTplAst(parse('<ng-template ref-a>', []))).toEqual([
-            [EmbeddedTemplateAst],
-            [
-              ReferenceAst, 'a', createTokenForExternalReference(reflector, Identifiers.TemplateRef)
-            ]
-          ]);
-        });
-
-        it('should parse variables via let-...', () => {
-          expect(humanizeTplAst(parse('<ng-template let-a="b">', []))).toEqual([
-            [EmbeddedTemplateAst],
-            [VariableAst, 'a', 'b'],
-          ]);
-        });
-
-        it('should not locate directives in variables', () => {
-          const dirA =
-              compileDirectiveMetadataCreate({
-                selector: '[a]',
-                type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
-              }).toSummary();
-          expect(humanizeTplAst(parse('<ng-template let-a="b"></ng-template>', [dirA]))).toEqual([
-            [EmbeddedTemplateAst],
-            [VariableAst, 'a', 'b'],
-          ]);
-        });
-
-      });
-
-      describe('inline templates', () => {
-        it('should report an error on variables declared with #', () => {
-          expect(() => humanizeTplAst(parse('<div *ngIf="#a=b">', [])))
-              .toThrowError(/Parser Error: Unexpected token # at column 1/);
-        });
-
-        it('should parse variables via let ...', () => {
-          const targetAst = [
-            [EmbeddedTemplateAst],
-            [VariableAst, 'a', 'b'],
-            [ElementAst, 'div'],
-          ];
-
-          expect(humanizeTplAst(parse('<div *ngIf="let a=b">', []))).toEqual(targetAst);
-
-          expect(humanizeTplAst(parse('<div data-*ngIf="let a=b">', []))).toEqual(targetAst);
-        });
-
-        it('should parse variables via as ...', () => {
-          const targetAst = [
-            [EmbeddedTemplateAst],
-            [VariableAst, 'local', 'ngIf'],
-            [DirectiveAst, ngIf],
-            [BoundDirectivePropertyAst, 'ngIf', 'expr'],
-            [ElementAst, 'div'],
-          ];
-
-          expect(humanizeTplAst(parse('<div *ngIf="expr as local">', [ngIf]))).toEqual(targetAst);
-        });
-
-        describe('directives', () => {
-          it('should locate directives in property bindings', () => {
-            const dirA =
-                compileDirectiveMetadataCreate({
-                  selector: '[a=b]',
-                  type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                  inputs: ['a']
-                }).toSummary();
-            const dirB =
-                compileDirectiveMetadataCreate({
-                  selector: '[b]',
-                  type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirB'}})
-                }).toSummary();
-            expect(humanizeTplAst(parse('<div *a="b" b>', [dirA, dirB]))).toEqual([
-              [EmbeddedTemplateAst], [DirectiveAst, dirA], [BoundDirectivePropertyAst, 'a', 'b'],
-              [ElementAst, 'div'], [AttrAst, 'b', ''], [DirectiveAst, dirB]
-            ]);
-          });
-
-          it('should not locate directives in variables', () => {
-            const dirA =
-                compileDirectiveMetadataCreate({
-                  selector: '[a]',
-                  type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
-                }).toSummary();
-            expect(
-                humanizeTplAst(parse('<ng-template let-a="b"><div></div></ng-template>', [dirA])))
-                .toEqual([
-                  [EmbeddedTemplateAst],
-                  [VariableAst, 'a', 'b'],
-                  [ElementAst, 'div'],
-                ]);
-          });
-
-          it('should not locate directives in references', () => {
-            const dirA =
-                compileDirectiveMetadataCreate({
-                  selector: '[a]',
-                  type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
-                }).toSummary();
-            expect(humanizeTplAst(parse('<div ref-a>', [dirA]))).toEqual([
-              [ElementAst, 'div'], [ReferenceAst, 'a', null]
-            ]);
-          });
-
-        });
-
-
-        it('should work with *... and use the attribute name as property binding name', () => {
-          expect(humanizeTplAst(parse('<div *ngIf="test">', [ngIf]))).toEqual([
-            [EmbeddedTemplateAst],
-            [DirectiveAst, ngIf],
-            [BoundDirectivePropertyAst, 'ngIf', 'test'],
-            [ElementAst, 'div'],
-
-          ]);
-
-          // https://github.com/angular/angular/issues/13800
-          expect(humanizeTplAst(parse('<div *ngIf="-1">', [ngIf]))).toEqual([
-            [EmbeddedTemplateAst],
-            [DirectiveAst, ngIf],
-            [BoundDirectivePropertyAst, 'ngIf', '0 - 1'],
-            [ElementAst, 'div'],
-          ]);
-        });
-
-        it('should work with *... and empty value', () => {
-          expect(humanizeTplAst(parse('<div *ngIf>', [ngIf]))).toEqual([
-            [EmbeddedTemplateAst],
-            [DirectiveAst, ngIf],
-            [BoundDirectivePropertyAst, 'ngIf', 'null'],
-            [ElementAst, 'div'],
-          ]);
-        });
-      });
-    });
-
-    describe('content projection', () => {
-      let compCounter: number;
-      beforeEach(() => { compCounter = 0; });
-
-      function createComp(selector: string, ngContentSelectors: string[]): CompileDirectiveSummary {
-        return compileDirectiveMetadataCreate({
-                 selector: selector,
-                 isComponent: true,
-                 type: createTypeMeta(
-                     {reference: {filePath: someModuleUrl, name: `SomeComp${compCounter++}`}}),
-                 template: compileTemplateMetadata({ngContentSelectors: ngContentSelectors})
-               })
-            .toSummary();
-      }
-
-      function createDir(selector: string): CompileDirectiveSummary {
-        return compileDirectiveMetadataCreate({
-                 selector: selector,
-                 type: createTypeMeta(
-                     {reference: {filePath: someModuleUrl, name: `SomeDir${compCounter++}`}})
-               })
-            .toSummary();
-      }
-
-      describe('project text nodes', () => {
-        it('should project text nodes with wildcard selector', () => {
-          expect(humanizeContentProjection(parse('<div>hello</div>', [createComp('div', ['*'])])))
-              .toEqual([
-                ['div', null],
-                ['#text(hello)', 0],
-              ]);
-        });
-      });
-
-      describe('project elements', () => {
-        it('should project elements with wildcard selector', () => {
-          expect(humanizeContentProjection(parse('<div><span></span></div>', [
-            createComp('div', ['*'])
-          ]))).toEqual([['div', null], ['span', 0]]);
-        });
-
-        it('should project elements with css selector', () => {
-          expect(humanizeContentProjection(
-                     parse('<div><a x></a><b></b></div>', [createComp('div', ['a[x]'])])))
-              .toEqual([
-                ['div', null],
-                ['a', 0],
-                ['b', null],
-              ]);
-        });
-      });
-
-      describe('embedded templates', () => {
-        it('should project embedded templates with wildcard selector', () => {
-          expect(humanizeContentProjection(
-                     parse('<div><ng-template></ng-template></div>', [createComp('div', ['*'])])))
-              .toEqual([
-                ['div', null],
-                ['template', 0],
-              ]);
-        });
-
-        it('should project embedded templates with css selector', () => {
-          expect(humanizeContentProjection(parse(
-                     '<div><ng-template x></ng-template><ng-template></ng-template></div>',
-                     [createComp('div', ['ng-template[x]'])])))
-              .toEqual([
-                ['div', null],
-                ['template', 0],
-                ['template', null],
-              ]);
-        });
-      });
-
-      describe('ng-content', () => {
-        it('should project ng-content with wildcard selector', () => {
-          expect(humanizeContentProjection(parse('<div><ng-content></ng-content></div>', [
-            createComp('div', ['*'])
-          ]))).toEqual([['div', null], ['ng-content', 0]]);
-        });
-
-        it('should project ng-content with css selector', () => {
-          expect(humanizeContentProjection(parse(
-                     '<div><ng-content x></ng-content><ng-content></ng-content></div>',
-                     [createComp('div', ['ng-content[x]'])])))
-              .toEqual([['div', null], ['ng-content', 0], ['ng-content', null]]);
-        });
-      });
-
-      it('should project into the first matching ng-content', () => {
-        expect(humanizeContentProjection(parse('<div>hello<b></b><a></a></div>', [
-          createComp('div', ['a', 'b', '*'])
-        ]))).toEqual([['div', null], ['#text(hello)', 2], ['b', 1], ['a', 0]]);
-      });
-
-      it('should project into wildcard ng-content last', () => {
-        expect(humanizeContentProjection(parse('<div>hello<a></a></div>', [
-          createComp('div', ['*', 'a'])
-        ]))).toEqual([['div', null], ['#text(hello)', 0], ['a', 1]]);
-      });
-
-      it('should only project direct child nodes', () => {
-        expect(humanizeContentProjection(parse('<div><span><a></a></span><a></a></div>', [
-          createComp('div', ['a'])
-        ]))).toEqual([['div', null], ['span', null], ['a', null], ['a', 0]]);
-      });
-
-      it('should project nodes of nested components', () => {
-        expect(humanizeContentProjection(parse('<a><b>hello</b></a>', [
-          createComp('a', ['*']), createComp('b', ['*'])
-        ]))).toEqual([['a', null], ['b', 0], ['#text(hello)', 0]]);
-      });
-
-      it('should project children of components with ngNonBindable', () => {
-        expect(humanizeContentProjection(parse('<div ngNonBindable>{{hello}}<span></span></div>', [
-          createComp('div', ['*'])
-        ]))).toEqual([['div', null], ['#text({{hello}})', 0], ['span', 0]]);
-      });
-
-      it('should match the element when there is an inline template', () => {
-        expect(humanizeContentProjection(parse('<div><b *ngIf="cond"></b></div>', [
-          createComp('div', ['a', 'b']), ngIf
-        ]))).toEqual([['div', null], ['template', 1], ['b', null]]);
-      });
-
-      describe('ngProjectAs', () => {
-        it('should override elements', () => {
-          expect(humanizeContentProjection(parse('<div><a ngProjectAs="b"></a></div>', [
-            createComp('div', ['a', 'b'])
-          ]))).toEqual([['div', null], ['a', 1]]);
-        });
-
-        it('should override <ng-content>', () => {
-          expect(humanizeContentProjection(parse(
-                     '<div><ng-content ngProjectAs="b"></ng-content></div>',
-                     [createComp('div', ['ng-content', 'b'])])))
-              .toEqual([['div', null], ['ng-content', 1]]);
-        });
-
-        it('should override <ng-template>', () => {
-          expect(humanizeContentProjection(parse(
-                     '<div><ng-template ngProjectAs="b"></ng-template></div>',
-                     [createComp('div', ['template', 'b'])])))
-              .toEqual([
-                ['div', null],
-                ['template', 1],
-              ]);
-        });
-
-        it('should override inline templates', () => {
-          expect(humanizeContentProjection(parse(
-                     '<div><a *ngIf="cond" ngProjectAs="b"></a></div>',
-                     [createComp('div', ['a', 'b']), ngIf])))
-              .toEqual([
-                ['div', null],
-                ['template', 1],
-                ['a', null],
-              ]);
-        });
-      });
-
-      it('should support other directives before the component', () => {
-        expect(humanizeContentProjection(parse('<div>hello</div>', [
-          createDir('div'), createComp('div', ['*'])
-        ]))).toEqual([['div', null], ['#text(hello)', 0]]);
-      });
-    });
-
-    describe('splitClasses', () => {
-      it('should keep an empty class', () => { expect(splitClasses('a')).toEqual(['a']); });
-
-      it('should split 2 classes', () => { expect(splitClasses('a b')).toEqual(['a', 'b']); });
-
-      it('should trim classes', () => { expect(splitClasses(' a  b ')).toEqual(['a', 'b']); });
-    });
-
-    describe('error cases', () => {
-      it('should report when ng-content has non WS content', () => {
-        expect(() => parse('<ng-content>content</ng-content>', []))
-            .toThrowError(
-                `Template parse errors:\n` +
-                `<ng-content> element cannot have content. ("[ERROR ->]<ng-content>content</ng-content>"): TestComp@0:0`);
-      });
-
-      it('should treat *attr on a template element as valid',
-         () => { expect(() => parse('<ng-template *ngIf>', [])).not.toThrowError(); });
-
-      it('should report when multiple *attrs are used on the same element', () => {
-        expect(() => parse('<div *ngIf *ngFor>', [])).toThrowError(`Template parse errors:
-Can't have multiple template bindings on one element. Use only one attribute prefixed with * ("<div *ngIf [ERROR ->]*ngFor>"): TestComp@0:11`);
-      });
-
-
-      it('should report invalid property names', () => {
-        expect(() => parse('<div [invalidProp]></div>', [])).toThrowError(`Template parse errors:
-Can't bind to 'invalidProp' since it isn't a known property of 'div'. ("<div [ERROR ->][invalidProp]></div>"): TestComp@0:5`);
-      });
-
-      it('should report invalid host property names', () => {
-        const dirA = compileDirectiveMetadataCreate({
-                       selector: 'div',
-                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                       host: {'[invalidProp]': 'someProp'}
-                     }).toSummary();
-        expect(() => parse('<div></div>', [dirA])).toThrowError(`Template parse errors:
-Can't bind to 'invalidProp' since it isn't a known property of 'div'. ("[ERROR ->]<div></div>"): TestComp@0:0, Directive DirA`);
-      });
-
-      it('should report errors in expressions', () => {
-        expect(() => parse('<div [prop]="a b"></div>', [])).toThrowError(`Template parse errors:
-Parser Error: Unexpected token 'b' at column 3 in [a b] in TestComp@0:13 ("<div [prop]="[ERROR ->]a b"></div>"): TestComp@0:13`);
-      });
-
-      it('should not throw on invalid property names if the property is used by a directive',
-         () => {
-           const dirA =
-               compileDirectiveMetadataCreate({
-                 selector: 'div',
-                 type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                 inputs: ['invalidProp']
-               }).toSummary();
-           expect(() => parse('<div [invalid-prop]></div>', [dirA])).not.toThrow();
-         });
-
-      it('should not allow more than 1 component per element', () => {
-        const dirA = compileDirectiveMetadataCreate({
-                       selector: 'div',
-                       isComponent: true,
-                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                       template: compileTemplateMetadata({ngContentSelectors: []})
-                     }).toSummary();
-        const dirB = compileDirectiveMetadataCreate({
-                       selector: 'div',
-                       isComponent: true,
-                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirB'}}),
-                       template: compileTemplateMetadata({ngContentSelectors: []})
-                     }).toSummary();
-        expect(() => parse('<div>', [dirB, dirA]))
-            .toThrowError(
-                `Template parse errors:\n` +
-                `More than one component matched on this element.\n` +
-                `Make sure that only one component's selector can match a given element.\n` +
-                `Conflicting components: DirB,DirA ("[ERROR ->]<div>"): TestComp@0:0`);
-      });
-
-      it('should not allow components or element bindings nor dom events on explicit embedded templates',
-         () => {
-           const dirA =
-               compileDirectiveMetadataCreate({
-                 selector: '[a]',
-                 isComponent: true,
-                 type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                 template: compileTemplateMetadata({ngContentSelectors: []})
-               }).toSummary();
-
-           expect(() => parse('<ng-template [a]="b" (e)="f"></ng-template>', [dirA]))
-               .toThrowError(`Template parse errors:
-Event binding e not emitted by any directive on an embedded template. Make sure that the event name is spelled correctly and all directives are listed in the "@NgModule.declarations". ("<ng-template [a]="b" [ERROR ->](e)="f"></ng-template>"): TestComp@0:21
-Components on an embedded template: DirA ("[ERROR ->]<ng-template [a]="b" (e)="f"></ng-template>"): TestComp@0:0
-Property binding a not used by any directive on an embedded template. Make sure that the property name is spelled correctly and all directives are listed in the "@NgModule.declarations". ("[ERROR ->]<ng-template [a]="b" (e)="f"></ng-template>"): TestComp@0:0`);
-         });
-
-      it('should not allow components or element bindings on inline embedded templates', () => {
-        const dirA = compileDirectiveMetadataCreate({
-                       selector: '[a]',
-                       isComponent: true,
-                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                       template: compileTemplateMetadata({ngContentSelectors: []})
-                     }).toSummary();
-        expect(() => parse('<div *a="b"></div>', [dirA])).toThrowError(`Template parse errors:
-Components on an embedded template: DirA ("[ERROR ->]<div *a="b"></div>"): TestComp@0:0
-Property binding a not used by any directive on an embedded template. Make sure that the property name is spelled correctly and all directives are listed in the "@NgModule.declarations". ("[ERROR ->]<div *a="b"></div>"): TestComp@0:0`);
-      });
-    });
-
-    describe('ignore elements', () => {
-      it('should ignore <script> elements', () => {
-        expect(humanizeTplAst(parse('<script></script>a', []))).toEqual([[TextAst, 'a']]);
-
-      });
-
-      it('should ignore <style> elements', () => {
-        expect(humanizeTplAst(parse('<style></style>a', []))).toEqual([[TextAst, 'a']]);
-      });
-
-      describe('<link rel="stylesheet">', () => {
-
-        it('should keep <link rel="stylesheet"> elements if they have an absolute url', () => {
-          expect(humanizeTplAst(parse('<link rel="stylesheet" href="http://someurl">a', [])))
-              .toEqual([
-                [ElementAst, 'link'], [AttrAst, 'rel', 'stylesheet'],
-                [AttrAst, 'href', 'http://someurl'], [TextAst, 'a']
-              ]);
-        });
-
-        it('should keep <link rel="stylesheet"> elements if they have no uri', () => {
-          expect(humanizeTplAst(parse('<link rel="stylesheet">a', [
-          ]))).toEqual([[ElementAst, 'link'], [AttrAst, 'rel', 'stylesheet'], [TextAst, 'a']]);
-          expect(humanizeTplAst(parse('<link REL="stylesheet">a', [
-          ]))).toEqual([[ElementAst, 'link'], [AttrAst, 'REL', 'stylesheet'], [TextAst, 'a']]);
-        });
-
-        it('should ignore <link rel="stylesheet"> elements if they have a relative uri', () => {
-          expect(humanizeTplAst(parse('<link rel="stylesheet" href="./other.css">a', [
-          ]))).toEqual([[TextAst, 'a']]);
-          expect(humanizeTplAst(parse('<link rel="stylesheet" HREF="./other.css">a', [
-          ]))).toEqual([[TextAst, 'a']]);
-        });
-
-        it('should ignore <link rel="stylesheet"> elements if they have a package: uri', () => {
-          expect(humanizeTplAst(parse('<link rel="stylesheet" href="package:somePackage">a', [
-          ]))).toEqual([[TextAst, 'a']]);
-        });
-
-      });
-
-      it('should ignore bindings on children of elements with ngNonBindable', () => {
-        expect(humanizeTplAst(parse('<div ngNonBindable>{{b}}</div>', [
-        ]))).toEqual([[ElementAst, 'div'], [AttrAst, 'ngNonBindable', ''], [TextAst, '{{b}}']]);
-      });
-
-      it('should keep nested children of elements with ngNonBindable', () => {
-        expect(humanizeTplAst(parse('<div ngNonBindable><span>{{b}}</span></div>', []))).toEqual([
-          [ElementAst, 'div'], [AttrAst, 'ngNonBindable', ''], [ElementAst, 'span'],
-          [TextAst, '{{b}}']
+      it('should work with *... and use the attribute name as property binding name', () => {
+        expect(humanizeTplAst(parse('<div *ngIf="test">', [ngIf]))).toEqual([
+          [EmbeddedTemplateAst],
+          [DirectiveAst, ngIf],
+          [BoundDirectivePropertyAst, 'ngIf', 'test'],
+          [ElementAst, 'div'],
+
+        ]);
+
+        // https://github.com/angular/angular/issues/13800
+        expect(humanizeTplAst(parse('<div *ngIf="-1">', [ngIf]))).toEqual([
+          [EmbeddedTemplateAst],
+          [DirectiveAst, ngIf],
+          [BoundDirectivePropertyAst, 'ngIf', '0 - 1'],
+          [ElementAst, 'div'],
         ]);
       });
 
-      it('should ignore <script> elements inside of elements with ngNonBindable', () => {
-        expect(humanizeTplAst(parse('<div ngNonBindable><script></script>a</div>', [
-        ]))).toEqual([[ElementAst, 'div'], [AttrAst, 'ngNonBindable', ''], [TextAst, 'a']]);
-      });
-
-      it('should ignore <style> elements inside of elements with ngNonBindable', () => {
-        expect(humanizeTplAst(parse('<div ngNonBindable><style></style>a</div>', [
-        ]))).toEqual([[ElementAst, 'div'], [AttrAst, 'ngNonBindable', ''], [TextAst, 'a']]);
-      });
-
-      it('should ignore <link rel="stylesheet"> elements inside of elements with ngNonBindable',
-         () => {
-           expect(humanizeTplAst(parse('<div ngNonBindable><link rel="stylesheet">a</div>', [
-           ]))).toEqual([[ElementAst, 'div'], [AttrAst, 'ngNonBindable', ''], [TextAst, 'a']]);
-         });
-
-      it('should convert <ng-content> elements into regular elements inside of elements with ngNonBindable',
-         () => {
-           expect(humanizeTplAst(parse('<div ngNonBindable><ng-content></ng-content>a</div>', [])))
-               .toEqual([
-                 [ElementAst, 'div'], [AttrAst, 'ngNonBindable', ''], [ElementAst, 'ng-content'],
-                 [TextAst, 'a']
-               ]);
-         });
-
-    });
-
-    describe('source spans', () => {
-      it('should support ng-content', () => {
-        const parsed = parse('<ng-content select="a">', []);
-        expect(humanizeTplAstSourceSpans(parsed)).toEqual([
-          [NgContentAst, '<ng-content select="a">']
-        ]);
-      });
-
-      it('should support embedded template', () => {
-        expect(humanizeTplAstSourceSpans(parse('<ng-template></ng-template>', [
-        ]))).toEqual([[EmbeddedTemplateAst, '<ng-template>']]);
-      });
-
-      it('should support element and attributes', () => {
-        expect(humanizeTplAstSourceSpans(parse('<div key=value>', []))).toEqual([
-          [ElementAst, 'div', '<div key=value>'], [AttrAst, 'key', 'value', 'key=value']
-        ]);
-
-      });
-
-      it('should support references', () => {
-        expect(humanizeTplAstSourceSpans(parse('<div #a></div>', [
-        ]))).toEqual([[ElementAst, 'div', '<div #a>'], [ReferenceAst, 'a', null, '#a']]);
-      });
-
-      it('should support variables', () => {
-        expect(humanizeTplAstSourceSpans(parse('<ng-template let-a="b"></ng-template>', [])))
-            .toEqual([
-              [EmbeddedTemplateAst, '<ng-template let-a="b">'],
-              [VariableAst, 'a', 'b', 'let-a="b"'],
-            ]);
-      });
-
-      it('should support events', () => {
-        expect(humanizeTplAstSourceSpans(parse('<div (window:event)="v">', []))).toEqual([
-          [ElementAst, 'div', '<div (window:event)="v">'],
-          [BoundEventAst, 'event', 'window', 'v', '(window:event)="v"']
-        ]);
-
-      });
-
-      it('should support element property', () => {
-        expect(humanizeTplAstSourceSpans(parse('<div [someProp]="v">', []))).toEqual([
-          [ElementAst, 'div', '<div [someProp]="v">'],
-          [
-            BoundElementPropertyAst, PropertyBindingType.Property, 'someProp', 'v', null,
-            '[someProp]="v"'
-          ]
-        ]);
-      });
-
-      it('should support bound text', () => {
-        expect(humanizeTplAstSourceSpans(parse('{{a}}', [
-        ]))).toEqual([[BoundTextAst, '{{ a }}', '{{a}}']]);
-      });
-
-      it('should support text nodes', () => {
-        expect(humanizeTplAstSourceSpans(parse('a', []))).toEqual([[TextAst, 'a', 'a']]);
-      });
-
-      it('should support directive', () => {
-        const dirA = compileDirectiveMetadataCreate({
-                       selector: '[a]',
-                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
-                     }).toSummary();
-        const comp = compileDirectiveMetadataCreate({
-                       selector: 'div',
-                       isComponent: true,
-                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'ZComp'}}),
-                       template: compileTemplateMetadata({ngContentSelectors: []})
-                     }).toSummary();
-        expect(humanizeTplAstSourceSpans(parse('<div a>', [dirA, comp]))).toEqual([
-          [ElementAst, 'div', '<div a>'], [AttrAst, 'a', '', 'a'], [DirectiveAst, dirA, '<div a>'],
-          [DirectiveAst, comp, '<div a>']
-        ]);
-      });
-
-      it('should support directive in namespace', () => {
-        const tagSel =
-            compileDirectiveMetadataCreate({
-              selector: 'circle',
-              type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'elDir'}})
-            }).toSummary();
-        const attrSel =
-            compileDirectiveMetadataCreate({
-              selector: '[href]',
-              type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'attrDir'}})
-            }).toSummary();
-
-        expect(humanizeTplAstSourceSpans(
-                   parse('<svg><circle /><use xlink:href="Port" /></svg>', [tagSel, attrSel])))
-            .toEqual([
-              [ElementAst, ':svg:svg', '<svg>'],
-              [ElementAst, ':svg:circle', '<circle />'],
-              [DirectiveAst, tagSel, '<circle />'],
-              [ElementAst, ':svg:use', '<use xlink:href="Port" />'],
-              [AttrAst, ':xlink:href', 'Port', 'xlink:href="Port"'],
-              [DirectiveAst, attrSel, '<use xlink:href="Port" />'],
-            ]);
-      });
-
-      it('should support directive property', () => {
-        const dirA = compileDirectiveMetadataCreate({
-                       selector: 'div',
-                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-                       inputs: ['aProp']
-                     }).toSummary();
-        expect(humanizeTplAstSourceSpans(parse('<div [aProp]="foo"></div>', [dirA]))).toEqual([
-          [ElementAst, 'div', '<div [aProp]="foo">'], [DirectiveAst, dirA, '<div [aProp]="foo">'],
-          [BoundDirectivePropertyAst, 'aProp', 'foo', '[aProp]="foo"']
-        ]);
-      });
-
-      it('should support endSourceSpan for elements', () => {
-        const tagSel =
-            compileDirectiveMetadataCreate({
-              selector: 'circle',
-              type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'elDir'}})
-            }).toSummary();
-        const result = parse('<circle></circle>', [tagSel]);
-        const circle = result[0] as ElementAst;
-        expect(circle.endSourceSpan).toBeDefined();
-        expect(circle.endSourceSpan !.start.offset).toBe(8);
-        expect(circle.endSourceSpan !.end.offset).toBe(17);
-      });
-
-      it('should report undefined for endSourceSpan for elements without an end-tag', () => {
-        const ulSel =
-            compileDirectiveMetadataCreate({
-              selector: 'ul',
-              type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'ulDir'}})
-            }).toSummary();
-        const liSel =
-            compileDirectiveMetadataCreate({
-              selector: 'li',
-              type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'liDir'}})
-            }).toSummary();
-        const result = parse('<ul><li><li></ul>', [ulSel, liSel]);
-        const ul = result[0] as ElementAst;
-        const li = ul.children[0] as ElementAst;
-        expect(li.endSourceSpan).toBe(null);
-      });
-    });
-
-    describe('pipes', () => {
-      it('should allow pipes that have been defined as dependencies', () => {
-        const testPipe =
-            new CompilePipeMetadata({
-              name: 'test',
-              type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
-              pure: false
-            }).toSummary();
-        expect(() => parse('{{a | test}}', [], [testPipe])).not.toThrow();
-      });
-
-      it('should report pipes as error that have not been defined as dependencies', () => {
-        expect(() => parse('{{a | test}}', [])).toThrowError(`Template parse errors:
-The pipe 'test' could not be found ("{{[ERROR ->]a | test}}"): TestComp@0:2`);
-      });
-
-    });
-
-    describe('ICU messages', () => {
-      it('should expand plural messages', () => {
-        const shortForm = '{ count, plural, =0 {small} many {big} }';
-        const expandedForm = '<ng-container [ngPlural]="count">' +
-            '<ng-template ngPluralCase="=0">small</ng-template>' +
-            '<ng-template ngPluralCase="many">big</ng-template>' +
-            '</ng-container>';
-
-        expect(humanizeTplAst(parse(shortForm, []))).toEqual(humanizeTplAst(parse(expandedForm, [
-        ])));
-      });
-
-      it('should expand select messages', () => {
-        const shortForm = '{ sex, select, female {foo} other {bar} }';
-        const expandedForm = '<ng-container [ngSwitch]="sex">' +
-            '<ng-template ngSwitchCase="female">foo</ng-template>' +
-            '<ng-template ngSwitchDefault>bar</ng-template>' +
-            '</ng-container>';
-
-        expect(humanizeTplAst(parse(shortForm, []))).toEqual(humanizeTplAst(parse(expandedForm, [
-        ])));
-      });
-
-      it('should be possible to escape ICU messages', () => {
-        const escapedForm = 'escaped {{ "{" }}  }';
-
-        expect(humanizeTplAst(parse(escapedForm, []))).toEqual([
-          [BoundTextAst, 'escaped {{ "{" }}  }'],
+      it('should work with *... and empty value', () => {
+        expect(humanizeTplAst(parse('<div *ngIf>', [ngIf]))).toEqual([
+          [EmbeddedTemplateAst],
+          [DirectiveAst, ngIf],
+          [BoundDirectivePropertyAst, 'ngIf', 'null'],
+          [ElementAst, 'div'],
         ]);
       });
     });
   });
 
-  describe('whitespaces removal', () => {
-
+  describe('content projection', () => {
+    let compCounter: number;
     beforeEach(() => {
-      TestBed.configureCompiler({providers: [TEST_COMPILER_PROVIDERS, MOCK_SCHEMA_REGISTRY]});
+      compCounter = 0;
     });
 
-    commonBeforeEach();
+    function createComp(selector: string, ngContentSelectors: string[]): CompileDirectiveSummary {
+      return compileDirectiveMetadataCreate({
+               selector: selector,
+               isComponent: true,
+               type: createTypeMeta(
+                   {reference: {filePath: someModuleUrl, name: `SomeComp${compCounter++}`}}),
+               template: compileTemplateMetadata({ngContentSelectors: ngContentSelectors})
+             })
+          .toSummary();
+    }
 
-    it('should not remove whitespaces by default', () => {
-      expect(humanizeTplAst(parse(' <br>  <br>\t<br>\n<br> ', []))).toEqual([
-        [TextAst, ' '],
-        [ElementAst, 'br'],
-        [TextAst, '  '],
-        [ElementAst, 'br'],
-        [TextAst, '\t'],
-        [ElementAst, 'br'],
-        [TextAst, '\n'],
-        [ElementAst, 'br'],
-        [TextAst, ' '],
+    function createDir(selector: string): CompileDirectiveSummary {
+      return compileDirectiveMetadataCreate({
+               selector: selector,
+               type: createTypeMeta(
+                   {reference: {filePath: someModuleUrl, name: `SomeDir${compCounter++}`}})
+             })
+          .toSummary();
+    }
+
+    describe('project text nodes', () => {
+      it('should project text nodes with wildcard selector', () => {
+        expect(humanizeContentProjection(parse('<div>hello</div>', [createComp('div', ['*'])])))
+            .toEqual([
+              ['div', null],
+              ['#text(hello)', 0],
+            ]);
+      });
+    });
+
+    describe('project elements', () => {
+      it('should project elements with wildcard selector', () => {
+        expect(humanizeContentProjection(parse('<div><span></span></div>', [
+          createComp('div', ['*'])
+        ]))).toEqual([['div', null], ['span', 0]]);
+      });
+
+      it('should project elements with css selector', () => {
+        expect(humanizeContentProjection(
+                   parse('<div><a x></a><b></b></div>', [createComp('div', ['a[x]'])])))
+            .toEqual([
+              ['div', null],
+              ['a', 0],
+              ['b', null],
+            ]);
+      });
+    });
+
+    describe('embedded templates', () => {
+      it('should project embedded templates with wildcard selector', () => {
+        expect(humanizeContentProjection(
+                   parse('<div><ng-template></ng-template></div>', [createComp('div', ['*'])])))
+            .toEqual([
+              ['div', null],
+              ['template', 0],
+            ]);
+      });
+
+      it('should project embedded templates with css selector', () => {
+        expect(humanizeContentProjection(parse(
+                   '<div><ng-template x></ng-template><ng-template></ng-template></div>',
+                   [createComp('div', ['ng-template[x]'])])))
+            .toEqual([
+              ['div', null],
+              ['template', 0],
+              ['template', null],
+            ]);
+      });
+    });
+
+    describe('ng-content', () => {
+      it('should project ng-content with wildcard selector', () => {
+        expect(humanizeContentProjection(parse('<div><ng-content></ng-content></div>', [
+          createComp('div', ['*'])
+        ]))).toEqual([['div', null], ['ng-content', 0]]);
+      });
+
+      it('should project ng-content with css selector', () => {
+        expect(humanizeContentProjection(parse(
+                   '<div><ng-content x></ng-content><ng-content></ng-content></div>',
+                   [createComp('div', ['ng-content[x]'])])))
+            .toEqual([['div', null], ['ng-content', 0], ['ng-content', null]]);
+      });
+    });
+
+    it('should project into the first matching ng-content', () => {
+      expect(humanizeContentProjection(parse('<div>hello<b></b><a></a></div>', [
+        createComp('div', ['a', 'b', '*'])
+      ]))).toEqual([['div', null], ['#text(hello)', 2], ['b', 1], ['a', 0]]);
+    });
+
+    it('should project into wildcard ng-content last', () => {
+      expect(humanizeContentProjection(parse('<div>hello<a></a></div>', [
+        createComp('div', ['*', 'a'])
+      ]))).toEqual([['div', null], ['#text(hello)', 0], ['a', 1]]);
+    });
+
+    it('should only project direct child nodes', () => {
+      expect(humanizeContentProjection(parse('<div><span><a></a></span><a></a></div>', [
+        createComp('div', ['a'])
+      ]))).toEqual([['div', null], ['span', null], ['a', null], ['a', 0]]);
+    });
+
+    it('should project nodes of nested components', () => {
+      expect(humanizeContentProjection(parse('<a><b>hello</b></a>', [
+        createComp('a', ['*']), createComp('b', ['*'])
+      ]))).toEqual([['a', null], ['b', 0], ['#text(hello)', 0]]);
+    });
+
+    it('should project children of components with ngNonBindable', () => {
+      expect(humanizeContentProjection(parse('<div ngNonBindable>{{hello}}<span></span></div>', [
+        createComp('div', ['*'])
+      ]))).toEqual([['div', null], ['#text({{hello}})', 0], ['span', 0]]);
+    });
+
+    it('should match the element when there is an inline template', () => {
+      expect(humanizeContentProjection(parse('<div><b *ngIf="cond"></b></div>', [
+        createComp('div', ['a', 'b']), ngIf
+      ]))).toEqual([['div', null], ['template', 1], ['b', null]]);
+    });
+
+    describe('ngProjectAs', () => {
+      it('should override elements', () => {
+        expect(humanizeContentProjection(parse('<div><a ngProjectAs="b"></a></div>', [
+          createComp('div', ['a', 'b'])
+        ]))).toEqual([['div', null], ['a', 1]]);
+      });
+
+      it('should override <ng-content>', () => {
+        expect(humanizeContentProjection(parse(
+                   '<div><ng-content ngProjectAs="b"></ng-content></div>',
+                   [createComp('div', ['ng-content', 'b'])])))
+            .toEqual([['div', null], ['ng-content', 1]]);
+      });
+
+      it('should override <ng-template>', () => {
+        expect(humanizeContentProjection(parse(
+                   '<div><ng-template ngProjectAs="b"></ng-template></div>',
+                   [createComp('div', ['template', 'b'])])))
+            .toEqual([
+              ['div', null],
+              ['template', 1],
+            ]);
+      });
+
+      it('should override inline templates', () => {
+        expect(humanizeContentProjection(parse(
+                   '<div><a *ngIf="cond" ngProjectAs="b"></a></div>',
+                   [createComp('div', ['a', 'b']), ngIf])))
+            .toEqual([
+              ['div', null],
+              ['template', 1],
+              ['a', null],
+            ]);
+      });
+    });
+
+    it('should support other directives before the component', () => {
+      expect(humanizeContentProjection(parse('<div>hello</div>', [
+        createDir('div'), createComp('div', ['*'])
+      ]))).toEqual([['div', null], ['#text(hello)', 0]]);
+    });
+  });
+
+  describe('splitClasses', () => {
+    it('should keep an empty class', () => {
+      expect(splitClasses('a')).toEqual(['a']);
+    });
+
+    it('should split 2 classes', () => {
+      expect(splitClasses('a b')).toEqual(['a', 'b']);
+    });
+
+    it('should trim classes', () => {
+      expect(splitClasses(' a  b ')).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('error cases', () => {
+    it('should report when ng-content has non WS content', () => {
+      expect(() => parse('<ng-content>content</ng-content>', []))
+          .toThrowError(
+              `Template parse errors:\n` +
+              `<ng-content> element cannot have content. ("[ERROR ->]<ng-content>content</ng-content>"): TestComp@0:0`);
+    });
+
+    it('should treat *attr on a template element as valid', () => {
+      expect(() => parse('<ng-template *ngIf>', [])).not.toThrowError();
+    });
+
+    it('should report when multiple *attrs are used on the same element', () => {
+      expect(() => parse('<div *ngIf *ngFor>', [])).toThrowError(`Template parse errors:
+Can't have multiple template bindings on one element. Use only one attribute prefixed with * ("<div *ngIf [ERROR ->]*ngFor>"): TestComp@0:11`);
+    });
+
+
+    it('should report invalid property names', () => {
+      expect(() => parse('<div [invalidProp]></div>', [])).toThrowError(`Template parse errors:
+Can't bind to 'invalidProp' since it isn't a known property of 'div'. ("<div [ERROR ->][invalidProp]></div>"): TestComp@0:5`);
+    });
+
+    it('should report invalid host property names', () => {
+      const dirA = compileDirectiveMetadataCreate({
+                     selector: 'div',
+                     type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                     host: {'[invalidProp]': 'someProp'}
+                   }).toSummary();
+      expect(() => parse('<div></div>', [dirA])).toThrowError(`Template parse errors:
+Can't bind to 'invalidProp' since it isn't a known property of 'div'. ("[ERROR ->]<div></div>"): TestComp@0:0, Directive DirA`);
+    });
+
+    it('should report errors in expressions', () => {
+      expect(() => parse('<div [prop]="a b"></div>', [])).toThrowError(`Template parse errors:
+Parser Error: Unexpected token 'b' at column 3 in [a b] in TestComp@0:13 ("<div [prop]="[ERROR ->]a b"></div>"): TestComp@0:13`);
+    });
+
+    it('should not throw on invalid property names if the property is used by a directive', () => {
+      const dirA = compileDirectiveMetadataCreate({
+                     selector: 'div',
+                     type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                     inputs: ['invalidProp']
+                   }).toSummary();
+      expect(() => parse('<div [invalid-prop]></div>', [dirA])).not.toThrow();
+    });
+
+    it('should not allow more than 1 component per element', () => {
+      const dirA = compileDirectiveMetadataCreate({
+                     selector: 'div',
+                     isComponent: true,
+                     type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                     template: compileTemplateMetadata({ngContentSelectors: []})
+                   }).toSummary();
+      const dirB = compileDirectiveMetadataCreate({
+                     selector: 'div',
+                     isComponent: true,
+                     type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirB'}}),
+                     template: compileTemplateMetadata({ngContentSelectors: []})
+                   }).toSummary();
+      expect(() => parse('<div>', [dirB, dirA]))
+          .toThrowError(
+              `Template parse errors:\n` +
+              `More than one component matched on this element.\n` +
+              `Make sure that only one component's selector can match a given element.\n` +
+              `Conflicting components: DirB,DirA ("[ERROR ->]<div>"): TestComp@0:0`);
+    });
+
+    it('should not allow components or element bindings nor dom events on explicit embedded templates',
+       () => {
+         const dirA = compileDirectiveMetadataCreate({
+                        selector: '[a]',
+                        isComponent: true,
+                        type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                        template: compileTemplateMetadata({ngContentSelectors: []})
+                      }).toSummary();
+
+         expect(() => parse('<ng-template [a]="b" (e)="f"></ng-template>', [dirA]))
+             .toThrowError(`Template parse errors:
+Event binding e not emitted by any directive on an embedded template. Make sure that the event name is spelled correctly and all directives are listed in the "@NgModule.declarations". ("<ng-template [a]="b" [ERROR ->](e)="f"></ng-template>"): TestComp@0:21
+Components on an embedded template: DirA ("[ERROR ->]<ng-template [a]="b" (e)="f"></ng-template>"): TestComp@0:0
+Property binding a not used by any directive on an embedded template. Make sure that the property name is spelled correctly and all directives are listed in the "@NgModule.declarations". ("[ERROR ->]<ng-template [a]="b" (e)="f"></ng-template>"): TestComp@0:0`);
+       });
+
+    it('should not allow components or element bindings on inline embedded templates', () => {
+      const dirA = compileDirectiveMetadataCreate({
+                     selector: '[a]',
+                     isComponent: true,
+                     type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                     template: compileTemplateMetadata({ngContentSelectors: []})
+                   }).toSummary();
+      expect(() => parse('<div *a="b"></div>', [dirA])).toThrowError(`Template parse errors:
+Components on an embedded template: DirA ("[ERROR ->]<div *a="b"></div>"): TestComp@0:0
+Property binding a not used by any directive on an embedded template. Make sure that the property name is spelled correctly and all directives are listed in the "@NgModule.declarations". ("[ERROR ->]<div *a="b"></div>"): TestComp@0:0`);
+    });
+  });
+
+  describe('ignore elements', () => {
+    it('should ignore <script> elements', () => {
+      expect(humanizeTplAst(parse('<script></script>a', []))).toEqual([[TextAst, 'a']]);
+    });
+
+    it('should ignore <style> elements', () => {
+      expect(humanizeTplAst(parse('<style></style>a', []))).toEqual([[TextAst, 'a']]);
+    });
+
+    describe('<link rel="stylesheet">', () => {
+      it('should keep <link rel="stylesheet"> elements if they have an absolute url', () => {
+        expect(humanizeTplAst(parse('<link rel="stylesheet" href="http://someurl">a', [])))
+            .toEqual([
+              [ElementAst, 'link'], [AttrAst, 'rel', 'stylesheet'],
+              [AttrAst, 'href', 'http://someurl'], [TextAst, 'a']
+            ]);
+      });
+
+      it('should keep <link rel="stylesheet"> elements if they have no uri', () => {
+        expect(humanizeTplAst(parse('<link rel="stylesheet">a', []))).toEqual([
+          [ElementAst, 'link'], [AttrAst, 'rel', 'stylesheet'], [TextAst, 'a']
+        ]);
+        expect(humanizeTplAst(parse('<link REL="stylesheet">a', []))).toEqual([
+          [ElementAst, 'link'], [AttrAst, 'REL', 'stylesheet'], [TextAst, 'a']
+        ]);
+      });
+
+      it('should ignore <link rel="stylesheet"> elements if they have a relative uri', () => {
+        expect(humanizeTplAst(parse('<link rel="stylesheet" href="./other.css">a', []))).toEqual([
+          [TextAst, 'a']
+        ]);
+        expect(humanizeTplAst(parse('<link rel="stylesheet" HREF="./other.css">a', []))).toEqual([
+          [TextAst, 'a']
+        ]);
+      });
+
+      it('should ignore <link rel="stylesheet"> elements if they have a package: uri', () => {
+        expect(humanizeTplAst(parse('<link rel="stylesheet" href="package:somePackage">a', [])))
+            .toEqual([[TextAst, 'a']]);
+      });
+    });
+
+    it('should ignore bindings on children of elements with ngNonBindable', () => {
+      expect(humanizeTplAst(parse('<div ngNonBindable>{{b}}</div>', []))).toEqual([
+        [ElementAst, 'div'], [AttrAst, 'ngNonBindable', ''], [TextAst, '{{b}}']
       ]);
     });
 
-    it('should replace each &ngsp; with a space when preserveWhitespaces is true', () => {
-      expect(humanizeTplAst(parse('foo&ngsp;&ngsp;&ngsp;bar', [], [], [], true))).toEqual([
-        [TextAst, 'foo   bar'],
+    it('should keep nested children of elements with ngNonBindable', () => {
+      expect(humanizeTplAst(parse('<div ngNonBindable><span>{{b}}</span></div>', []))).toEqual([
+        [ElementAst, 'div'], [AttrAst, 'ngNonBindable', ''], [ElementAst, 'span'],
+        [TextAst, '{{b}}']
       ]);
     });
 
-    it('should replace every &ngsp; with a single space when preserveWhitespaces is false', () => {
-      expect(humanizeTplAst(parse('foo&ngsp;&ngsp;&ngsp;bar', [], [], [], false))).toEqual([
-        [TextAst, 'foo bar'],
+    it('should ignore <script> elements inside of elements with ngNonBindable', () => {
+      expect(humanizeTplAst(parse('<div ngNonBindable><script></script>a</div>', []))).toEqual([
+        [ElementAst, 'div'], [AttrAst, 'ngNonBindable', ''], [TextAst, 'a']
       ]);
     });
 
-    it('should remove whitespaces when explicitly requested', () => {
-      expect(humanizeTplAst(parse(' <br>  <br>\t<br>\n<br> ', [], [], [], false))).toEqual([
-        [ElementAst, 'br'],
-        [ElementAst, 'br'],
-        [ElementAst, 'br'],
-        [ElementAst, 'br'],
+    it('should ignore <style> elements inside of elements with ngNonBindable', () => {
+      expect(humanizeTplAst(parse('<div ngNonBindable><style></style>a</div>', []))).toEqual([
+        [ElementAst, 'div'], [AttrAst, 'ngNonBindable', ''], [TextAst, 'a']
       ]);
     });
 
-    it('should remove whitespace between ICU expansions when not preserving whitespaces', () => {
+    it('should ignore <link rel="stylesheet"> elements inside of elements with ngNonBindable',
+       () => {
+         expect(humanizeTplAst(parse('<div ngNonBindable><link rel="stylesheet">a</div>', [])))
+             .toEqual([[ElementAst, 'div'], [AttrAst, 'ngNonBindable', ''], [TextAst, 'a']]);
+       });
+
+    it('should convert <ng-content> elements into regular elements inside of elements with ngNonBindable',
+       () => {
+         expect(humanizeTplAst(parse('<div ngNonBindable><ng-content></ng-content>a</div>', [])))
+             .toEqual([
+               [ElementAst, 'div'], [AttrAst, 'ngNonBindable', ''], [ElementAst, 'ng-content'],
+               [TextAst, 'a']
+             ]);
+       });
+  });
+
+  describe('source spans', () => {
+    it('should support ng-content', () => {
+      const parsed = parse('<ng-content select="a">', []);
+      expect(humanizeTplAstSourceSpans(parsed)).toEqual([
+        [NgContentAst, '<ng-content select="a">']
+      ]);
+    });
+
+    it('should support embedded template', () => {
+      expect(humanizeTplAstSourceSpans(parse('<ng-template></ng-template>', []))).toEqual([
+        [EmbeddedTemplateAst, '<ng-template>']
+      ]);
+    });
+
+    it('should support element and attributes', () => {
+      expect(humanizeTplAstSourceSpans(parse('<div key=value>', []))).toEqual([
+        [ElementAst, 'div', '<div key=value>'], [AttrAst, 'key', 'value', 'key=value']
+      ]);
+    });
+
+    it('should support references', () => {
+      expect(humanizeTplAstSourceSpans(parse('<div #a></div>', []))).toEqual([
+        [ElementAst, 'div', '<div #a>'], [ReferenceAst, 'a', null, '#a']
+      ]);
+    });
+
+    it('should support variables', () => {
+      expect(humanizeTplAstSourceSpans(parse('<ng-template let-a="b"></ng-template>', [])))
+          .toEqual([
+            [EmbeddedTemplateAst, '<ng-template let-a="b">'],
+            [VariableAst, 'a', 'b', 'let-a="b"'],
+          ]);
+    });
+
+    it('should support events', () => {
+      expect(humanizeTplAstSourceSpans(parse('<div (window:event)="v">', []))).toEqual([
+        [ElementAst, 'div', '<div (window:event)="v">'],
+        [BoundEventAst, 'event', 'window', 'v', '(window:event)="v"']
+      ]);
+    });
+
+    it('should support element property', () => {
+      expect(humanizeTplAstSourceSpans(parse('<div [someProp]="v">', []))).toEqual([
+        [ElementAst, 'div', '<div [someProp]="v">'],
+        [
+          BoundElementPropertyAst, PropertyBindingType.Property, 'someProp', 'v', null,
+          '[someProp]="v"'
+        ]
+      ]);
+    });
+
+    it('should support bound text', () => {
+      expect(humanizeTplAstSourceSpans(parse('{{a}}', []))).toEqual([
+        [BoundTextAst, '{{ a }}', '{{a}}']
+      ]);
+    });
+
+    it('should support text nodes', () => {
+      expect(humanizeTplAstSourceSpans(parse('a', []))).toEqual([[TextAst, 'a', 'a']]);
+    });
+
+    it('should support directive', () => {
+      const dirA = compileDirectiveMetadataCreate({
+                     selector: '[a]',
+                     type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}})
+                   }).toSummary();
+      const comp = compileDirectiveMetadataCreate({
+                     selector: 'div',
+                     isComponent: true,
+                     type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'ZComp'}}),
+                     template: compileTemplateMetadata({ngContentSelectors: []})
+                   }).toSummary();
+      expect(humanizeTplAstSourceSpans(parse('<div a>', [dirA, comp]))).toEqual([
+        [ElementAst, 'div', '<div a>'], [AttrAst, 'a', '', 'a'], [DirectiveAst, dirA, '<div a>'],
+        [DirectiveAst, comp, '<div a>']
+      ]);
+    });
+
+    it('should support directive in namespace', () => {
+      const tagSel = compileDirectiveMetadataCreate({
+                       selector: 'circle',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'elDir'}})
+                     }).toSummary();
+      const attrSel =
+          compileDirectiveMetadataCreate({
+            selector: '[href]',
+            type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'attrDir'}})
+          }).toSummary();
+
+      expect(humanizeTplAstSourceSpans(
+                 parse('<svg><circle /><use xlink:href="Port" /></svg>', [tagSel, attrSel])))
+          .toEqual([
+            [ElementAst, ':svg:svg', '<svg>'],
+            [ElementAst, ':svg:circle', '<circle />'],
+            [DirectiveAst, tagSel, '<circle />'],
+            [ElementAst, ':svg:use', '<use xlink:href="Port" />'],
+            [AttrAst, ':xlink:href', 'Port', 'xlink:href="Port"'],
+            [DirectiveAst, attrSel, '<use xlink:href="Port" />'],
+          ]);
+    });
+
+    it('should support directive property', () => {
+      const dirA = compileDirectiveMetadataCreate({
+                     selector: 'div',
+                     type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                     inputs: ['aProp']
+                   }).toSummary();
+      expect(humanizeTplAstSourceSpans(parse('<div [aProp]="foo"></div>', [dirA]))).toEqual([
+        [ElementAst, 'div', '<div [aProp]="foo">'], [DirectiveAst, dirA, '<div [aProp]="foo">'],
+        [BoundDirectivePropertyAst, 'aProp', 'foo', '[aProp]="foo"']
+      ]);
+    });
+
+    it('should support endSourceSpan for elements', () => {
+      const tagSel = compileDirectiveMetadataCreate({
+                       selector: 'circle',
+                       type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'elDir'}})
+                     }).toSummary();
+      const result = parse('<circle></circle>', [tagSel]);
+      const circle = result[0] as ElementAst;
+      expect(circle.endSourceSpan).toBeDefined();
+      expect(circle.endSourceSpan!.start.offset).toBe(8);
+      expect(circle.endSourceSpan!.end.offset).toBe(17);
+    });
+
+    it('should report undefined for endSourceSpan for elements without an end-tag', () => {
+      const ulSel = compileDirectiveMetadataCreate({
+                      selector: 'ul',
+                      type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'ulDir'}})
+                    }).toSummary();
+      const liSel = compileDirectiveMetadataCreate({
+                      selector: 'li',
+                      type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'liDir'}})
+                    }).toSummary();
+      const result = parse('<ul><li><li></ul>', [ulSel, liSel]);
+      const ul = result[0] as ElementAst;
+      const li = ul.children[0] as ElementAst;
+      expect(li.endSourceSpan).toBe(null);
+    });
+  });
+
+  describe('pipes', () => {
+    it('should allow pipes that have been defined as dependencies', () => {
+      const testPipe = new CompilePipeMetadata({
+                         name: 'test',
+                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                         pure: false
+                       }).toSummary();
+      expect(() => parse('{{a | test}}', [], [testPipe])).not.toThrow();
+    });
+
+    it('should report pipes as error that have not been defined as dependencies', () => {
+      expect(() => parse('{{a | test}}', [])).toThrowError(`Template parse errors:
+The pipe 'test' could not be found ("{{[ERROR ->]a | test}}"): TestComp@0:2`);
+    });
+  });
+
+  describe('ICU messages', () => {
+    it('should expand plural messages', () => {
       const shortForm = '{ count, plural, =0 {small} many {big} }';
       const expandedForm = '<ng-container [ngPlural]="count">' +
           '<ng-template ngPluralCase="=0">small</ng-template>' +
           '<ng-template ngPluralCase="many">big</ng-template>' +
           '</ng-container>';
-      const humanizedExpandedForm = humanizeTplAst(parse(expandedForm, []));
 
-      // ICU expansions are converted to `<ng-container>` tags and all blank text nodes are reomved
-      // so any whitespace between ICU exansions are removed as well
-      expect(humanizeTplAst(parse(`${shortForm} ${shortForm}`, [], [], [], false))).toEqual([
-        ...humanizedExpandedForm, ...humanizedExpandedForm
+      expect(humanizeTplAst(parse(shortForm, []))).toEqual(humanizeTplAst(parse(expandedForm, [])));
+    });
+
+    it('should expand select messages', () => {
+      const shortForm = '{ sex, select, female {foo} other {bar} }';
+      const expandedForm = '<ng-container [ngSwitch]="sex">' +
+          '<ng-template ngSwitchCase="female">foo</ng-template>' +
+          '<ng-template ngSwitchDefault>bar</ng-template>' +
+          '</ng-container>';
+
+      expect(humanizeTplAst(parse(shortForm, []))).toEqual(humanizeTplAst(parse(expandedForm, [])));
+    });
+
+    it('should be possible to escape ICU messages', () => {
+      const escapedForm = 'escaped {{ "{" }}  }';
+
+      expect(humanizeTplAst(parse(escapedForm, []))).toEqual([
+        [BoundTextAst, 'escaped {{ "{" }}  }'],
       ]);
     });
   });
+});
 
+describe('whitespaces removal', () => {
+  beforeEach(() => {
+    TestBed.configureCompiler({providers: [TEST_COMPILER_PROVIDERS, MOCK_SCHEMA_REGISTRY]});
+  });
+
+  commonBeforeEach();
+
+  it('should not remove whitespaces by default', () => {
+    expect(humanizeTplAst(parse(' <br>  <br>\t<br>\n<br> ', []))).toEqual([
+      [TextAst, ' '],
+      [ElementAst, 'br'],
+      [TextAst, '  '],
+      [ElementAst, 'br'],
+      [TextAst, '\t'],
+      [ElementAst, 'br'],
+      [TextAst, '\n'],
+      [ElementAst, 'br'],
+      [TextAst, ' '],
+    ]);
+  });
+
+  it('should replace each &ngsp; with a space when preserveWhitespaces is true', () => {
+    expect(humanizeTplAst(parse('foo&ngsp;&ngsp;&ngsp;bar', [], [], [], true))).toEqual([
+      [TextAst, 'foo   bar'],
+    ]);
+  });
+
+  it('should replace every &ngsp; with a single space when preserveWhitespaces is false', () => {
+    expect(humanizeTplAst(parse('foo&ngsp;&ngsp;&ngsp;bar', [], [], [], false))).toEqual([
+      [TextAst, 'foo bar'],
+    ]);
+  });
+
+  it('should remove whitespaces when explicitly requested', () => {
+    expect(humanizeTplAst(parse(' <br>  <br>\t<br>\n<br> ', [], [], [], false))).toEqual([
+      [ElementAst, 'br'],
+      [ElementAst, 'br'],
+      [ElementAst, 'br'],
+      [ElementAst, 'br'],
+    ]);
+  });
+
+  it('should remove whitespace between ICU expansions when not preserving whitespaces', () => {
+    const shortForm = '{ count, plural, =0 {small} many {big} }';
+    const expandedForm = '<ng-container [ngPlural]="count">' +
+        '<ng-template ngPluralCase="=0">small</ng-template>' +
+        '<ng-template ngPluralCase="many">big</ng-template>' +
+        '</ng-container>';
+    const humanizedExpandedForm = humanizeTplAst(parse(expandedForm, []));
+
+    // ICU expansions are converted to `<ng-container>` tags and all blank text nodes are reomved
+    // so any whitespace between ICU exansions are removed as well
+    expect(humanizeTplAst(parse(`${shortForm} ${shortForm}`, [], [], [], false))).toEqual([
+      ...humanizedExpandedForm, ...humanizedExpandedForm
+    ]);
+  });
+});
 })();

--- a/packages/compiler/test/template_parser/template_preparser_spec.ts
+++ b/packages/compiler/test/template_parser/template_preparser_spec.ts
@@ -14,7 +14,9 @@ import {PreparsedElement, PreparsedElementType, preparseElement} from '../../src
 {
   describe('preparseElement', () => {
     let htmlParser: HtmlParser;
-    beforeEach(inject([HtmlParser], (_htmlParser: HtmlParser) => { htmlParser = _htmlParser; }));
+    beforeEach(inject([HtmlParser], (_htmlParser: HtmlParser) => {
+      htmlParser = _htmlParser;
+    }));
 
     function preparse(html: string): PreparsedElement {
       return preparseElement(htmlParser.parse(html, 'TestComp').rootNodes[0] as Element);

--- a/packages/compiler/test/template_parser/util/expression.ts
+++ b/packages/compiler/test/template_parser/util/expression.ts
@@ -15,12 +15,16 @@ type HumanizedExpressionSource = [string, AbsoluteSourceSpan];
 class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.TemplateAstVisitor {
   result: HumanizedExpressionSource[] = [];
 
-  private recordAst(ast: e.AST) { this.result.push([unparse(ast), ast.sourceSpan]); }
+  private recordAst(ast: e.AST) {
+    this.result.push([unparse(ast), ast.sourceSpan]);
+  }
 
   // This method is defined to reconcile the type of ExpressionSourceHumanizer
   // since both RecursiveAstVisitor and TemplateAstVisitor define the visit()
   // method in their interfaces.
-  visit(node: e.AST|t.TemplateAst, context?: any) { node.visit(this, context); }
+  visit(node: e.AST|t.TemplateAst, context?: any) {
+    node.visit(this, context);
+  }
 
   visitASTWithSource(ast: e.ASTWithSource) {
     this.recordAst(ast);
@@ -128,17 +132,25 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Templ
   }
   visitReference(ast: t.ReferenceAst) {}
   visitVariable(ast: t.VariableAst) {}
-  visitEvent(ast: t.BoundEventAst) { ast.handler.visit(this); }
-  visitElementProperty(ast: t.BoundElementPropertyAst) { ast.value.visit(this); }
+  visitEvent(ast: t.BoundEventAst) {
+    ast.handler.visit(this);
+  }
+  visitElementProperty(ast: t.BoundElementPropertyAst) {
+    ast.value.visit(this);
+  }
   visitAttr(ast: t.AttrAst) {}
-  visitBoundText(ast: t.BoundTextAst) { ast.value.visit(this); }
+  visitBoundText(ast: t.BoundTextAst) {
+    ast.value.visit(this);
+  }
   visitText(ast: t.TextAst) {}
   visitDirective(ast: t.DirectiveAst) {
     t.templateVisitAll(this, ast.hostEvents);
     t.templateVisitAll(this, ast.hostProperties);
     t.templateVisitAll(this, ast.inputs);
   }
-  visitDirectiveProperty(ast: t.BoundDirectivePropertyAst) { ast.value.visit(this); }
+  visitDirectiveProperty(ast: t.BoundDirectivePropertyAst) {
+    ast.value.visit(this);
+  }
 }
 
 /**

--- a/packages/compiler/test/template_parser/util/metadata.ts
+++ b/packages/compiler/test/template_parser/util/metadata.ts
@@ -5,8 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {CompileDirectiveMetadata, CompileEntryComponentMetadata, CompileProviderMetadata, CompileQueryMetadata, CompileStylesheetMetadata, CompileTemplateMetadata, CompileTypeMetadata, ProxyClass, StaticSymbol, preserveWhitespacesDefault} from '@angular/compiler';
+import {CompileDirectiveMetadata, CompileEntryComponentMetadata, CompileProviderMetadata, CompileQueryMetadata, CompileStylesheetMetadata, CompileTemplateMetadata, CompileTypeMetadata, preserveWhitespacesDefault, ProxyClass, StaticSymbol} from '@angular/compiler';
 import {ChangeDetectionStrategy, RendererType2, ViewEncapsulation} from '@angular/core';
+
 import {noUndefined} from '../../../src/util';
 
 export function createTypeMeta({reference, diDeps}: {reference: any, diDeps?: any[]}):
@@ -14,13 +15,28 @@ export function createTypeMeta({reference, diDeps}: {reference: any, diDeps?: an
   return {reference: reference, diDeps: diDeps || [], lifecycleHooks: []};
 }
 
-export function compileDirectiveMetadataCreate(
-    {isHost, type, isComponent, selector, exportAs, inputs, outputs, host, providers, viewProviders,
-     queries, guards, viewQueries, entryComponents, template, componentViewType,
-     rendererType}: Partial<Parameters<typeof CompileDirectiveMetadata.create>[0]>) {
+export function compileDirectiveMetadataCreate({
+  isHost,
+  type,
+  isComponent,
+  selector,
+  exportAs,
+  inputs,
+  outputs,
+  host,
+  providers,
+  viewProviders,
+  queries,
+  guards,
+  viewQueries,
+  entryComponents,
+  template,
+  componentViewType,
+  rendererType
+}: Partial<Parameters<typeof CompileDirectiveMetadata.create>[0]>) {
   return CompileDirectiveMetadata.create({
     isHost: !!isHost,
-    type: noUndefined(type) !,
+    type: noUndefined(type)!,
     isComponent: !!isComponent,
     selector: noUndefined(selector),
     exportAs: noUndefined(exportAs),
@@ -34,17 +50,26 @@ export function compileDirectiveMetadataCreate(
     guards: guards || {},
     viewQueries: viewQueries || [],
     entryComponents: entryComponents || [],
-    template: noUndefined(template) !,
+    template: noUndefined(template)!,
     componentViewType: noUndefined(componentViewType),
     rendererType: noUndefined(rendererType),
     componentFactory: null,
   });
 }
 
-export function compileTemplateMetadata(
-    {encapsulation, template, templateUrl, styles, styleUrls, externalStylesheets, animations,
-     ngContentSelectors, interpolation, isInline,
-     preserveWhitespaces}: Partial<CompileTemplateMetadata>): CompileTemplateMetadata {
+export function compileTemplateMetadata({
+  encapsulation,
+  template,
+  templateUrl,
+  styles,
+  styleUrls,
+  externalStylesheets,
+  animations,
+  ngContentSelectors,
+  interpolation,
+  isInline,
+  preserveWhitespaces
+}: Partial<CompileTemplateMetadata>): CompileTemplateMetadata {
   return new CompileTemplateMetadata({
     encapsulation: noUndefined(encapsulation),
     template: noUndefined(template),

--- a/packages/compiler/test/url_resolver_spec.ts
+++ b/packages/compiler/test/url_resolver_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {UrlResolver, createOfflineCompileUrlResolver} from '@angular/compiler/src/url_resolver';
+import {createOfflineCompileUrlResolver, UrlResolver} from '@angular/compiler/src/url_resolver';
 import {beforeEach, describe, expect, inject, it} from '@angular/core/testing/src/testing_internal';
 
 {
@@ -65,7 +65,6 @@ import {beforeEach, describe, expect, inject, it} from '@angular/core/testing/sr
         expect(resolver.resolve('foo/', './bar')).toEqual('foo/bar');
         expect(resolver.resolve('foo/baz', './bar')).toEqual('foo/bar');
         expect(resolver.resolve('foo/baz', 'bar')).toEqual('foo/bar');
-
       });
 
       it('should support ".." in the path', () => {
@@ -89,14 +88,14 @@ import {beforeEach, describe, expect, inject, it} from '@angular/core/testing/sr
     describe('packages', () => {
       it('should resolve a url based on the application package', () => {
         resolver = new UrlResolver('my_packages_dir');
-        expect(resolver.resolve(null !, 'package:some/dir/file.txt'))
+        expect(resolver.resolve(null!, 'package:some/dir/file.txt'))
             .toEqual('my_packages_dir/some/dir/file.txt');
-        expect(resolver.resolve(null !, 'some/dir/file.txt')).toEqual('some/dir/file.txt');
+        expect(resolver.resolve(null!, 'some/dir/file.txt')).toEqual('some/dir/file.txt');
       });
 
       it('should contain a default value of "/" when nothing is provided',
          inject([UrlResolver], (resolver: UrlResolver) => {
-           expect(resolver.resolve(null !, 'package:file')).toEqual('/file');
+           expect(resolver.resolve(null!, 'package:file')).toEqual('/file');
          }));
 
       it('should resolve a package value when present within the baseurl', () => {

--- a/packages/compiler/test/util_spec.ts
+++ b/packages/compiler/test/util_spec.ts
@@ -15,7 +15,9 @@ import {escapeRegExp, splitAtColon, stringify, utf8Encode} from '../src/util';
         expect(splitAtColon('a:b', [])).toEqual(['a', 'b']);
       });
 
-      it('should trim parts', () => { expect(splitAtColon(' a : b ', [])).toEqual(['a', 'b']); });
+      it('should trim parts', () => {
+        expect(splitAtColon(' a : b ', [])).toEqual(['a', 'b']);
+      });
 
       it('should support multiple ":"', () => {
         expect(splitAtColon('a:b:c', [])).toEqual(['a', 'b:c']);
@@ -70,13 +72,16 @@ import {escapeRegExp, splitAtColon, stringify, utf8Encode} from '../src/util';
           ['\uDEEE', '\xED\xBB\xAE'],
           ['\uDFFF', '\xED\xBF\xBF'],
         ];
-        tests.forEach(([input, output]) => { expect(utf8Encode(input)).toEqual(output); });
+        tests.forEach(([input, output]) => {
+          expect(utf8Encode(input)).toEqual(output);
+        });
       });
     });
 
     describe('stringify()', () => {
-      it('should handle objects with no prototype.',
-         () => { expect(stringify(Object.create(null))).toEqual('object'); });
+      it('should handle objects with no prototype.', () => {
+        expect(stringify(Object.create(null))).toEqual('object');
+      });
     });
   });
 }

--- a/packages/compiler/testing/src/directive_resolver_mock.ts
+++ b/packages/compiler/testing/src/directive_resolver_mock.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {CompileReflector, DirectiveResolver, core} from '@angular/compiler';
+import {CompileReflector, core, DirectiveResolver} from '@angular/compiler';
 
 /**
  * An implementation of {@link DirectiveResolver} that allows overriding
@@ -14,7 +14,9 @@ import {CompileReflector, DirectiveResolver, core} from '@angular/compiler';
 export class MockDirectiveResolver extends DirectiveResolver {
   private _directives = new Map<core.Type, core.Directive>();
 
-  constructor(reflector: CompileReflector) { super(reflector); }
+  constructor(reflector: CompileReflector) {
+    super(reflector);
+  }
 
   resolve(type: core.Type): core.Directive;
   resolve(type: core.Type, throwIfNotFound: true): core.Directive;

--- a/packages/compiler/testing/src/ng_module_resolver_mock.ts
+++ b/packages/compiler/testing/src/ng_module_resolver_mock.ts
@@ -6,12 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CompileReflector, NgModuleResolver, core} from '@angular/compiler';
+import {CompileReflector, core, NgModuleResolver} from '@angular/compiler';
 
 export class MockNgModuleResolver extends NgModuleResolver {
   private _ngModules = new Map<core.Type, core.NgModule>();
 
-  constructor(reflector: CompileReflector) { super(reflector); }
+  constructor(reflector: CompileReflector) {
+    super(reflector);
+  }
 
   /**
    * Overrides the {@link NgModule} for a module.
@@ -27,6 +29,6 @@ export class MockNgModuleResolver extends NgModuleResolver {
    * `NgModuleResolver`, see `setNgModule`.
    */
   resolve(type: core.Type, throwIfNotFound = true): core.NgModule {
-    return this._ngModules.get(type) || super.resolve(type, throwIfNotFound) !;
+    return this._ngModules.get(type) || super.resolve(type, throwIfNotFound)!;
   }
 }

--- a/packages/compiler/testing/src/output/source_map_util.ts
+++ b/packages/compiler/testing/src/output/source_map_util.ts
@@ -17,8 +17,7 @@ export interface SourceLocation {
 }
 
 export function originalPositionFor(
-    sourceMap: SourceMap,
-    genPosition: {line: number | null, column: number | null}): SourceLocation {
+    sourceMap: SourceMap, genPosition: {line: number|null, column: number|null}): SourceLocation {
   const smc = new SourceMapConsumer(sourceMap);
   // Note: We don't return the original object as it also contains a `name` property
   // which is always null and we don't want to include that in our assertions...

--- a/packages/compiler/testing/src/pipe_resolver_mock.ts
+++ b/packages/compiler/testing/src/pipe_resolver_mock.ts
@@ -6,17 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CompileReflector, PipeResolver, core} from '@angular/compiler';
+import {CompileReflector, core, PipeResolver} from '@angular/compiler';
 
 export class MockPipeResolver extends PipeResolver {
   private _pipes = new Map<core.Type, core.Pipe>();
 
-  constructor(refector: CompileReflector) { super(refector); }
+  constructor(refector: CompileReflector) {
+    super(refector);
+  }
 
   /**
    * Overrides the {@link Pipe} for a pipe.
    */
-  setPipe(type: core.Type, metadata: core.Pipe): void { this._pipes.set(type, metadata); }
+  setPipe(type: core.Type, metadata: core.Pipe): void {
+    this._pipes.set(type, metadata);
+  }
 
   /**
    * Returns the {@link Pipe} for a pipe:
@@ -27,7 +31,7 @@ export class MockPipeResolver extends PipeResolver {
   resolve(type: core.Type, throwIfNotFound = true): core.Pipe {
     let metadata = this._pipes.get(type);
     if (!metadata) {
-      metadata = super.resolve(type, throwIfNotFound) !;
+      metadata = super.resolve(type, throwIfNotFound)!;
     }
     return metadata;
   }

--- a/packages/compiler/testing/src/resource_loader_mock.ts
+++ b/packages/compiler/testing/src/resource_loader_mock.ts
@@ -23,7 +23,9 @@ export class MockResourceLoader extends ResourceLoader {
     return request.getPromise();
   }
 
-  hasPendingRequests() { return !!this._requests.length; }
+  hasPendingRequests() {
+    return !!this._requests.length;
+  }
 
   /**
    * Add an expectation for the given URL. Incoming requests will be checked against
@@ -43,7 +45,9 @@ export class MockResourceLoader extends ResourceLoader {
    * unlike expectations, unused definitions do not cause `verifyNoOutstandingExpectations`
    * to return an error.
    */
-  when(url: string, response: string) { this._definitions.set(url, response); }
+  when(url: string, response: string) {
+    this._definitions.set(url, response);
+  }
 
   /**
    * Process pending requests and verify there are no outstanding expectations. Also fails
@@ -55,7 +59,7 @@ export class MockResourceLoader extends ResourceLoader {
     }
 
     do {
-      this._processRequest(this._requests.shift() !);
+      this._processRequest(this._requests.shift()!);
     } while (this._requests.length > 0);
 
     this.verifyNoOutstandingExpectations();
@@ -100,9 +104,9 @@ export class MockResourceLoader extends ResourceLoader {
 
 class _PendingRequest {
   // TODO(issue/24571): remove '!'.
-  resolve !: (result: string) => void;
+  resolve!: (result: string) => void;
   // TODO(issue/24571): remove '!'.
-  reject !: (error: any) => void;
+  reject!: (error: any) => void;
   promise: Promise<string>;
 
   constructor(public url: string) {
@@ -120,7 +124,9 @@ class _PendingRequest {
     }
   }
 
-  getPromise(): Promise<string> { return this.promise; }
+  getPromise(): Promise<string> {
+    return this.promise;
+  }
 }
 
 class _Expectation {

--- a/packages/compiler/testing/src/schema_registry_mock.ts
+++ b/packages/compiler/testing/src/schema_registry_mock.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ElementSchemaRegistry, core} from '@angular/compiler';
+import {core, ElementSchemaRegistry} from '@angular/compiler';
 
 export class MockSchemaRegistry implements ElementSchemaRegistry {
   constructor(
@@ -25,15 +25,21 @@ export class MockSchemaRegistry implements ElementSchemaRegistry {
     return value === void 0 ? true : value;
   }
 
-  allKnownElementNames(): string[] { return Object.keys(this.existingElements); }
+  allKnownElementNames(): string[] {
+    return Object.keys(this.existingElements);
+  }
 
   securityContext(selector: string, property: string, isAttribute: boolean): core.SecurityContext {
     return core.SecurityContext.NONE;
   }
 
-  getMappedPropName(attrName: string): string { return this.attrPropMapping[attrName] || attrName; }
+  getMappedPropName(attrName: string): string {
+    return this.attrPropMapping[attrName] || attrName;
+  }
 
-  getDefaultComponentElementName(): string { return 'ng-component'; }
+  getDefaultComponentElementName(): string {
+    return 'ng-component';
+  }
 
   validateProperty(name: string): {error: boolean, msg?: string} {
     if (this.invalidProperties.indexOf(name) > -1) {
@@ -54,9 +60,11 @@ export class MockSchemaRegistry implements ElementSchemaRegistry {
     }
   }
 
-  normalizeAnimationStyleProperty(propName: string): string { return propName; }
+  normalizeAnimationStyleProperty(propName: string): string {
+    return propName;
+  }
   normalizeAnimationStyleValue(camelCaseProp: string, userProvidedProp: string, val: string|number):
       {error: string, value: string} {
-    return {error: null !, value: val.toString()};
+    return {error: null!, value: val.toString()};
   }
 }


### PR DESCRIPTION
This PR bundles two commits, constituting a reformat of packages/compiler and packages/compiler-cli with the new clang-format.