### PR TITLE
fix(ngcc): do not warn if `paths` mapping does not exist

### DIFF
--- a/packages/compiler-cli/ngcc/src/entry_point_finder/utils.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/utils.ts
@@ -50,7 +50,7 @@ export function getBasePaths(
       if (fs.exists(basePath)) {
         basePaths.push(basePath);
       } else {
-        logger.warn(
+        logger.debug(
             `The basePath "${basePath}" computed from baseUrl "${baseUrl}" and path mapping "${
                 path}" does not exist in the file-system.\n` +
             `It will not be scanned for entry-points.`);

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/utils_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/utils_spec.ts
@@ -115,7 +115,7 @@ runInEachFileSystem(() => {
       ]);
     });
 
-    it('should discard basePaths that do not exists and log a warning', () => {
+    it('should discard basePaths that do not exists and log a debug message', () => {
       const projectDirectory = _('/path/to/project');
       const fs = getFileSystem();
       fs.ensureDir(fs.resolve(projectDirectory, 'dist-1'));
@@ -131,7 +131,7 @@ runInEachFileSystem(() => {
         sourceDirectory,
         fs.resolve(projectDirectory, 'dist-1'),
       ]);
-      expect(logger.logs.warn).toEqual([
+      expect(logger.logs.debug).toEqual([
         [`The basePath "${
              fs.resolve(projectDirectory, 'sub-folder/dist-2')}" computed from baseUrl "${
              projectDirectory}" and path mapping "sub-folder/dist-2" does not exist in the file-system.\n` +


### PR DESCRIPTION
In cc4b813e759f16fb0f4dfa92a0e6464ed768a629 the `getBasePaths()`
function was changed to log a warning if a `basePath()` computed from
the `paths` mappings did not exist. It turns out this is a common and
accepted scenario, so we should not log warnings in this case.

Fixes #36518
