### PR TITLE
build: run pre-check before publishing

### DIFF
--- a/scripts/release/pre-check
+++ b/scripts/release/pre-check
@@ -3,13 +3,9 @@
 # Runs the Bazel workspace status command in order to ensure that the version placeholder
 # will be replaced with the proper version name when building the release output.
 
-# Ensure that the stamping script is executed within the project directory.
-cd $(dirname ${0})/../..
-
-# The "0.0.0-PLACEHOLDER" is based on the value of the "BUILD_SCM_VERSION" status variable.
 versionName=$(node tools/bazel_stamp_vars.js | grep -e "BUILD_SCM_VERSION" | cut -d " " -f2)
 
-if [[ ! ${versionName} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc).[0-9]+)?$ ]]; then
+if [[ ! ${versionName} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(rc|next).[0-9]+)?$ ]]; then
   echo "ERROR: The release will currently have the following version: ${versionName}"
   echo "This does not match the version format for releases to NPM."
   echo ""
@@ -17,13 +13,3 @@ if [[ ! ${versionName} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc).[0-9]+)?$ ]];
   echo "with the proper version tag."
   exit 1
 fi
-
-# Verify peer deps constraints and package.json before publishing to npm
-# There should be no npm errors
-
-mkdir tmp
-cd tmp
-npm init -y
-npm install --save ../dist/packages-dist/* typescript@~2.7 rxjs@^6.0.0-beta.4 zone.js@~0.8.20
-cd ..
-rm -rf ./tmp

--- a/scripts/release/publish-latest
+++ b/scripts/release/publish-latest
@@ -2,6 +2,10 @@
 
 set -u -e -o pipefail
 
+# Runs the pre-check before performing the publish to ensure
+# the version is valid for release.
+exec "$(dirname "$0")/pre-check";
+
 # Use for production releases
 # Query Bazel for npm_package and ng_package rules with tags=["release-with-framework"]
 # Publish them to npm (tagged next)
@@ -22,4 +26,3 @@ for packageLabel in $NPM_PACKAGE_LABELS; do
   echo "publishing $packageLabel"
   $BAZEL run --config=release -- ${packageLabel}.publish --access public --tag latest
 done
-

--- a/scripts/release/publish-next
+++ b/scripts/release/publish-next
@@ -2,6 +2,10 @@
 
 set -u -e -o pipefail
 
+# Runs the pre-check before performing the publish to ensure
+# the version is valid for release.
+exec "$(dirname "$0")/pre-check";
+
 # Use for BETA and RC releases
 # Query Bazel for npm_package and ng_package rules with tags=["release-with-framework"]
 # Publish them to npm (tagged next)


### PR DESCRIPTION
Previously, our process included running the pre-check script before
releasing.  With our new publishing process this was dropped.  This
change adds in automatically executing this check before publish for
both next and latest
