### PR TITLE
Revert "refactor(bazel): use runfiles helper in ts-api-guardian (#36471)"

### DIFF
--- a/tools/ts-api-guardian/lib/cli.ts
+++ b/tools/ts-api-guardian/lib/cli.ts
@@ -95,8 +95,8 @@ export function startCli() {
             lines.pop();  // Remove trailing newline
           }
           for (const line of lines) {
-            const chalkMap: {[key: string]:
-                                 any} = {'-': chalk.red, '+': chalk.green, '@': chalk.cyan};
+            const chalkMap:
+                {[key: string]: any} = {'-': chalk.red, '+': chalk.green, '@': chalk.cyan};
             const chalkFunc = chalkMap[line[0]] || chalk.reset;
             console.log(chalkFunc(line));
           }
@@ -109,7 +109,7 @@ export function startCli() {
         if (bazelTarget) {
           console.error('\n\nIf you modify a public API, you must accept the new golden file.');
           console.error('\n\nTo do so, execute the following Bazel target:');
-          console.error(`  yarn bazel run ${bazelTarget.replace(/_bin$/, "")}.accept`);
+          console.error(`  yarn bazel run ${bazelTarget.replace(/_bin$/, '')}.accept`);
           if (process.env['TEST_WORKSPACE'] === 'angular') {
             console.error('\n\nFor more information, see');
             console.error(


### PR DESCRIPTION
This reverts commit 92c4f3d5085b0fa1c30cd5c9d658d20871419320.

Broke Windows CI tests on master. Failure is non-trivial so I'll work on it but it is not a PR that needs to get in soon. Pre-factor for a future rules_nodejs release.
