### PR TITLE
build: update `REQUIRED_BASE_SHA` in merge script to clang 1.4.0 upgrade commit

### DIFF
--- a/scripts/github/merge-pr
+++ b/scripts/github/merge-pr
@@ -131,8 +131,8 @@ CHERRY_PICK_PR="git cherry-pick merge_pr_base..merge_pr"
 #
 # This check is used to enforce that we don't merge PRs that have not been rebased recently and could result in merging
 # of non-approved or otherwise bad changes.
-REQUIRED_BASE_SHA_MASTER="296dc0622f0e8c4e803ff4f19a5c6fe02a2ae66e" # CODEOWNERS => PullApprove migration
-REQUIRED_BASE_SHA_PATCH="110f6c91b904819cab639861b54b6a989e176942"  # CODEOWNERS => PullApprove migration
+REQUIRED_BASE_SHA_MASTER="c5c57f673745e9b66a771c49e778a7d2e8d8c56a" # clang 1.4.0 update
+REQUIRED_BASE_SHA_PATCH="f4681b6e407c0f518bc4a27ca04ca60d8eff8a69"  # clang 1.4.0 update
 if [[ $MERGE_MASTER == 1 ]]; then
   REQUIRED_BASE_SHA="$REQUIRED_BASE_SHA_MASTER"
 # check patch only if patch-only PR


### PR DESCRIPTION
Updating `REQUIRED_BASE_SHA` for master and patch branches to make sure PRs that we merge are rebased after clang 1.4.0 upgrade.


## PR Type
What kind of change does this PR introduce?

- [x] Build related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No