### PR TITLE
fix(ngcc): recognize enum declarations emitted in JavaScript

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/module_with_providers_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/module_with_providers_analyzer.ts
@@ -115,7 +115,7 @@ export class ModuleWithProvidersAnalyzer {
           dtsNgModule.getText()}`);
     }
 
-    return {node: dtsNgModule, known: null, viaModule: null};
+    return {node: dtsNgModule, known: null, viaModule: null, identity: null};
   }
 }
 

--- a/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
@@ -156,7 +156,10 @@ export class CommonJsReflectionHost extends Esm5ReflectionHost {
     const reexports: ExportDeclaration[] = [];
     importedExports.forEach((decl, name) => {
       if (decl.node !== null) {
-        reexports.push({name, declaration: {node: decl.node, known: null, viaModule}});
+        reexports.push({
+          name,
+          declaration: {node: decl.node, known: null, viaModule, identity: decl.identity}
+        });
       } else {
         reexports.push(
             {name, declaration: {node: null, known: null, expression: decl.expression, viaModule}});
@@ -184,7 +187,7 @@ export class CommonJsReflectionHost extends Esm5ReflectionHost {
     }
 
     const viaModule = !importInfo.from.startsWith('.') ? importInfo.from : null;
-    return {node: importedFile, known: getTsHelperFnFromIdentifier(id), viaModule};
+    return {node: importedFile, known: getTsHelperFnFromIdentifier(id), viaModule, identity: null};
   }
 
   private resolveModuleName(moduleName: string, containingFile: ts.SourceFile): ts.SourceFile

--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -13,6 +13,7 @@ import {getNameText, getTsHelperFnFromDeclaration, getTsHelperFnFromIdentifier, 
 
 import {Esm2015ReflectionHost, getPropertyValueFromSymbol, isAssignment, isAssignmentStatement, ParamInfo} from './esm2015_host';
 import {NgccClassSymbol} from './ngcc_host';
+import {stripParentheses} from './utils';
 
 
 /**
@@ -848,8 +849,4 @@ function isUndefinedComparison(expression: ts.Expression): expression is ts.Expr
   return ts.isBinaryExpression(expression) &&
       expression.operatorToken.kind === ts.SyntaxKind.EqualsEqualsEqualsToken &&
       ts.isVoidExpression(expression.right) && ts.isIdentifier(expression.left);
-}
-
-export function stripParentheses(node: ts.Node): ts.Node {
-  return ts.isParenthesizedExpression(node) ? node.expression : node;
 }

--- a/packages/compiler-cli/ngcc/src/host/umd_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/umd_host.ts
@@ -15,7 +15,8 @@ import {BundleProgram} from '../packages/bundle_program';
 import {FactoryMap, getTsHelperFnFromIdentifier, stripExtension} from '../utils';
 
 import {ExportDeclaration, ExportStatement, findNamespaceOfIdentifier, findRequireCallReference, isExportStatement, isReexportStatement, isRequireCall, ReexportStatement} from './commonjs_umd_utils';
-import {Esm5ReflectionHost, stripParentheses} from './esm5_host';
+import {Esm5ReflectionHost} from './esm5_host';
+import {stripParentheses} from './utils';
 
 export class UmdReflectionHost extends Esm5ReflectionHost {
   protected umdModules =
@@ -179,7 +180,10 @@ export class UmdReflectionHost extends Esm5ReflectionHost {
     const reexports: ExportDeclaration[] = [];
     importedExports.forEach((decl, name) => {
       if (decl.node !== null) {
-        reexports.push({name, declaration: {node: decl.node, known: null, viaModule}});
+        reexports.push({
+          name,
+          declaration: {node: decl.node, known: null, viaModule, identity: decl.identity}
+        });
       } else {
         reexports.push(
             {name, declaration: {node: null, known: null, expression: decl.expression, viaModule}});
@@ -211,7 +215,12 @@ export class UmdReflectionHost extends Esm5ReflectionHost {
 
     // We need to add the `viaModule` because  the `getExportsOfModule()` call
     // did not know that we were importing the declaration.
-    return {node: importedFile, known: getTsHelperFnFromIdentifier(id), viaModule: importInfo.from};
+    return {
+      node: importedFile,
+      known: getTsHelperFnFromIdentifier(id),
+      viaModule: importInfo.from,
+      identity: null
+    };
   }
 
   private resolveModuleName(moduleName: string, containingFile: ts.SourceFile): ts.SourceFile

--- a/packages/compiler-cli/ngcc/src/host/utils.ts
+++ b/packages/compiler-cli/ngcc/src/host/utils.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+
+export function stripParentheses(node: ts.Node): ts.Node {
+  return ts.isParenthesizedExpression(node) ? node.expression : node;
+}

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -9,7 +9,7 @@ import * as ts from 'typescript';
 
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
-import {ClassMemberKind, CtorParameter, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, ConcreteDeclaration, CtorParameter, DownleveledEnum, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {CommonJsReflectionHost} from '../../src/host/commonjs_host';
@@ -1706,6 +1706,7 @@ exports.ExternalModule = ExternalModule;
                     known: knownAs,
                     node: getHelperDeclaration(helperName),
                     viaModule,
+                    identity: null,
                   });
                 };
 
@@ -1740,6 +1741,7 @@ exports.ExternalModule = ExternalModule;
           expect(actualDeclaration).not.toBe(null);
           expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
           expect(actualDeclaration!.viaModule).toBe(null);
+          expect((actualDeclaration as ConcreteDeclaration).identity).toBe(null);
         });
 
         it('should return the correct declaration for an outer alias identifier', () => {
@@ -2196,6 +2198,121 @@ exports.ExternalModule = ExternalModule;
                 ['__spreadArrays', KnownDeclaration.TsHelperSpreadArrays],
                 ['__unknownHelper', null],
               ]);
+        });
+
+        it('should recognize enum declarations with string values', () => {
+          const testFile: TestFile = {
+            name: _('/node_modules/test-package/some/file.js'),
+            contents: `
+          var Enum;
+          (function (Enum) {
+              Enum["ValueA"] = "1";
+              Enum["ValueB"] = "2";
+          })(exports.Enum || (exports.Enum = {}));
+
+          var value = Enum;`
+          };
+          loadTestFiles([testFile]);
+          const bundle = makeTestBundleProgram(testFile.name);
+          const host =
+              createHost(bundle, new CommonJsReflectionHost(new MockLogger(), false, bundle));
+          const valueDecl = getDeclaration(
+              bundle.program, _('/node_modules/test-package/some/file.js'), 'value',
+              ts.isVariableDeclaration);
+          const declaration = host.getDeclarationOfIdentifier(
+                                  valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
+
+          const enumMembers = (declaration.identity as DownleveledEnum).enumMembers;
+          expect(declaration.node.parent.parent.getText()).toBe('var Enum;');
+          expect(enumMembers!.length).toBe(2);
+          expect(enumMembers![0].name.getText()).toBe('"ValueA"');
+          expect(enumMembers![0].initializer!.getText()).toBe('"1"');
+          expect(enumMembers![1].name.getText()).toBe('"ValueB"');
+          expect(enumMembers![1].initializer!.getText()).toBe('"2"');
+        });
+
+        it('should recognize enum declarations with numeric values', () => {
+          const testFile: TestFile = {
+            name: _('/node_modules/test-package/some/file.js'),
+            contents: `
+          var Enum;
+          (function (Enum) {
+              Enum[Enum["ValueA"] = "1"] = "ValueA";
+              Enum[Enum["ValueB"] = "2"] = "ValueB";
+          })(exports.Enum || (exports.Enum = {}));
+
+          var value = Enum;`
+          };
+          loadTestFiles([testFile]);
+          const bundle = makeTestBundleProgram(testFile.name);
+          const host =
+              createHost(bundle, new CommonJsReflectionHost(new MockLogger(), false, bundle));
+          const valueDecl = getDeclaration(
+              bundle.program, _('/node_modules/test-package/some/file.js'), 'value',
+              ts.isVariableDeclaration);
+          const declaration = host.getDeclarationOfIdentifier(
+                                  valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
+
+          const enumMembers = (declaration.identity as DownleveledEnum).enumMembers;
+          expect(declaration.node.parent.parent.getText()).toBe('var Enum;');
+          expect(enumMembers!.length).toBe(2);
+          expect(enumMembers![0].name.getText()).toBe('"ValueA"');
+          expect(enumMembers![0].initializer!.getText()).toBe('"1"');
+          expect(enumMembers![1].name.getText()).toBe('"ValueB"');
+          expect(enumMembers![1].initializer!.getText()).toBe('"2"');
+        });
+
+        it('should not consider IIFEs that do no assign members to the parameter as an enum declaration',
+           () => {
+             const testFile: TestFile = {
+               name: _('/node_modules/test-package/some/file.js'),
+               contents: `
+          var Enum;
+          (function (E) {
+              Enum["ValueA"] = "1";
+              Enum["ValueB"] = "2";
+          })(exports.Enum || (exports.Enum = {}));
+
+          var value = Enum;`
+             };
+             loadTestFiles([testFile]);
+             const bundle = makeTestBundleProgram(testFile.name);
+             const host =
+                 createHost(bundle, new CommonJsReflectionHost(new MockLogger(), false, bundle));
+             const valueDecl = getDeclaration(
+                 bundle.program, _('/node_modules/test-package/some/file.js'), 'value',
+                 ts.isVariableDeclaration);
+             const declaration = host.getDeclarationOfIdentifier(
+                                     valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
+
+             expect(declaration.node.parent.parent.getText()).toBe('var Enum;');
+             expect(declaration.identity).toBe(null);
+           });
+
+        it('should not consider IIFEs without call argument as an enum declaration', () => {
+          const testFile: TestFile = {
+            name: _('/node_modules/test-package/some/file.js'),
+            contents: `
+          var Enum;
+          (function (Enum) {
+              Enum["ValueA"] = "1";
+              Enum["ValueB"] = "2";
+          })();
+
+          var value = Enum;`
+          };
+          loadTestFiles([testFile]);
+          const bundle = makeTestBundleProgram(testFile.name);
+          const host =
+              createHost(bundle, new CommonJsReflectionHost(new MockLogger(), false, bundle));
+          const valueDecl = getDeclaration(
+              bundle.program, _('/node_modules/test-package/some/file.js'), 'value',
+              ts.isVariableDeclaration);
+          const declaration = host.getDeclarationOfIdentifier(
+                                  valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
+
+          expect(declaration.node.parent.parent.getText()).toBe('var Enum;');
+          expect(declaration.identity).toBe(null);
         });
       });
 

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
-import {ClassMemberKind, CtorParameter, Decorator, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, ConcreteDeclaration, CtorParameter, Decorator, DownleveledEnum, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {DelegatingReflectionHost} from '../../src/host/delegating_host';
@@ -1754,6 +1754,7 @@ runInEachFileSystem(() => {
                   known: knownAs,
                   node: getHelperDeclaration(helperName),
                   viaModule,
+                  identity: null,
                 });
               };
 
@@ -1786,6 +1787,7 @@ runInEachFileSystem(() => {
         expect(actualDeclaration).not.toBe(null);
         expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
         expect(actualDeclaration!.viaModule).toBe(null);
+        expect((actualDeclaration as ConcreteDeclaration).identity).toBe(null);
       });
 
       it('should return the declaration of an externally defined identifier', () => {
@@ -2185,6 +2187,117 @@ runInEachFileSystem(() => {
         testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
         testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
         testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+      });
+
+      it('should recognize enum declarations with string values', () => {
+        const testFile: TestFile = {
+          name: _('/node_modules/test-package/some/file.js'),
+          contents: `
+          export var Enum;
+          (function (Enum) {
+              Enum["ValueA"] = "1";
+              Enum["ValueB"] = "2";
+          })(Enum || (Enum = {}));
+
+          var value = Enum;`
+        };
+        loadTestFiles([testFile]);
+        const bundle = makeTestBundleProgram(testFile.name);
+        const host = createHost(bundle, new Esm5ReflectionHost(new MockLogger(), false, bundle));
+        const valueDecl = getDeclaration(
+            bundle.program, _('/node_modules/test-package/some/file.js'), 'value',
+            ts.isVariableDeclaration);
+        const declaration = host.getDeclarationOfIdentifier(
+                                valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
+
+        const enumMembers = (declaration.identity as DownleveledEnum).enumMembers;
+        expect(declaration.node.parent.parent.getText()).toBe('export var Enum;');
+        expect(enumMembers!.length).toBe(2);
+        expect(enumMembers![0].name.getText()).toBe('"ValueA"');
+        expect(enumMembers![0].initializer!.getText()).toBe('"1"');
+        expect(enumMembers![1].name.getText()).toBe('"ValueB"');
+        expect(enumMembers![1].initializer!.getText()).toBe('"2"');
+      });
+
+      it('should recognize enum declarations with numeric values', () => {
+        const testFile: TestFile = {
+          name: _('/node_modules/test-package/some/file.js'),
+          contents: `
+          export var Enum;
+          (function (Enum) {
+              Enum[Enum["ValueA"] = "1"] = "ValueA";
+              Enum[Enum["ValueB"] = "2"] = "ValueB";
+          })(Enum || (Enum = {}));
+
+          var value = Enum;`
+        };
+        loadTestFiles([testFile]);
+        const bundle = makeTestBundleProgram(testFile.name);
+        const host = createHost(bundle, new Esm5ReflectionHost(new MockLogger(), false, bundle));
+        const valueDecl = getDeclaration(
+            bundle.program, _('/node_modules/test-package/some/file.js'), 'value',
+            ts.isVariableDeclaration);
+        const declaration = host.getDeclarationOfIdentifier(
+                                valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
+
+        const enumMembers = (declaration.identity as DownleveledEnum).enumMembers;
+        expect(declaration.node.parent.parent.getText()).toBe('export var Enum;');
+        expect(enumMembers!.length).toBe(2);
+        expect(enumMembers![0].name.getText()).toBe('"ValueA"');
+        expect(enumMembers![0].initializer!.getText()).toBe('"1"');
+        expect(enumMembers![1].name.getText()).toBe('"ValueB"');
+        expect(enumMembers![1].initializer!.getText()).toBe('"2"');
+      });
+
+      it('should not consider IIFEs that do no assign members to the parameter as an enum declaration',
+         () => {
+           const testFile: TestFile = {
+             name: _('/node_modules/test-package/some/file.js'),
+             contents: `
+          export var Enum;
+          (function (E) {
+              Enum["ValueA"] = "1";
+              Enum["ValueB"] = "2";
+          })(Enum || (Enum = {}));
+
+          var value = Enum;`
+           };
+           loadTestFiles([testFile]);
+           const bundle = makeTestBundleProgram(testFile.name);
+           const host = createHost(bundle, new Esm5ReflectionHost(new MockLogger(), false, bundle));
+           const valueDecl = getDeclaration(
+               bundle.program, _('/node_modules/test-package/some/file.js'), 'value',
+               ts.isVariableDeclaration);
+           const declaration = host.getDeclarationOfIdentifier(
+                                   valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
+
+           expect(declaration.node.parent.parent.getText()).toBe('export var Enum;');
+           expect(declaration.identity).toBe(null);
+         });
+
+      it('should not consider IIFEs without call argument as an enum declaration', () => {
+        const testFile: TestFile = {
+          name: _('/node_modules/test-package/some/file.js'),
+          contents: `
+          export var Enum;
+          (function (Enum) {
+              Enum["ValueA"] = "1";
+              Enum["ValueB"] = "2";
+          })();
+
+          var value = Enum;`
+        };
+        loadTestFiles([testFile]);
+        const bundle = makeTestBundleProgram(testFile.name);
+        const host = createHost(bundle, new Esm5ReflectionHost(new MockLogger(), false, bundle));
+        const valueDecl = getDeclaration(
+            bundle.program, _('/node_modules/test-package/some/file.js'), 'value',
+            ts.isVariableDeclaration);
+        const declaration = host.getDeclarationOfIdentifier(
+                                valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
+
+        expect(declaration.node.parent.parent.getText()).toBe('export var Enum;');
+        expect(declaration.identity).toBe(null);
       });
     });
 

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -317,6 +317,46 @@ runInEachFileSystem(() => {
       expect(jsContents).toContain('imports: [ɵngcc1.MyOtherModule]');
     });
 
+    it('should be able to resolve enum values', () => {
+      compileIntoApf('test-package', {
+        '/index.ts': `
+          import {Component, NgModule} from '@angular/core';
+
+          export enum StringEnum {
+            ValueA = "a",
+            ValueB = "b",
+          }
+
+          export enum NumericEnum {
+            Value3 = 3,
+            Value4,
+          }
+
+          @Component({
+            template: \`\${StringEnum.ValueA} - \${StringEnum.ValueB} - \${NumericEnum.Value3} - \${NumericEnum.Value4}\`,
+          })
+          export class FooCmp {}
+
+          @NgModule({
+            declarations: [FooCmp],
+          })
+          export class FooModule {}
+        `,
+      });
+
+      mainNgcc({
+        basePath: '/node_modules',
+        targetEntryPointPath: 'test-package',
+        propertiesToConsider: ['esm2015', 'esm5'],
+      });
+
+      const es2015Contents = fs.readFile(_(`/node_modules/test-package/esm2015/src/index.js`));
+      expect(es2015Contents).toContain('ɵngcc0.ɵɵtext(0, "a - b - 3 - 4")');
+
+      const es5Contents = fs.readFile(_(`/node_modules/test-package/esm5/src/index.js`));
+      expect(es5Contents).toContain('ɵngcc0.ɵɵtext(0, "a - b - 3 - 4")');
+    });
+
     it('should add ɵfac but not duplicate ɵprov properties on injectables', () => {
       compileIntoFlatEs5Package('test-package', {
         '/index.ts': `

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/result.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/result.ts
@@ -73,7 +73,7 @@ export class ResolvedModule {
  */
 export class EnumValue {
   constructor(
-      readonly enumRef: Reference<ts.EnumDeclaration>, readonly name: string,
+      readonly enumRef: Reference<ts.Declaration>, readonly name: string,
       readonly resolved: ResolvedValue) {}
 }
 

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -405,6 +405,22 @@ export interface Import {
 }
 
 /**
+ * A single enum member extracted from JavaScript when no `ts.EnumDeclaration` is available.
+ */
+export interface EnumMember {
+  /**
+   * The name of the enum member.
+   */
+  name: ts.PropertyName;
+
+  /**
+   * The initializer expression of the enum member. Unlike in TypeScript, this is always available
+   * in emitted JavaScript.
+   */
+  initializer: ts.Expression;
+}
+
+/**
  * Base type for all `Declaration`s.
  */
 export interface BaseDeclaration<T extends ts.Declaration = ts.Declaration> {
@@ -434,6 +450,28 @@ export interface BaseDeclaration<T extends ts.Declaration = ts.Declaration> {
 export interface ConcreteDeclaration<T extends ts.Declaration = ts.Declaration> extends
     BaseDeclaration<T> {
   node: T;
+
+  /**
+   * Optionally represents a special identity of the declaration, or `null` if the declaration
+   * does not have a special identity.
+   */
+  identity: SpecialDeclarationIdentity|null;
+}
+
+export type SpecialDeclarationIdentity = DownleveledEnum;
+
+export const enum SpecialDeclarationKind {
+  DownleveledEnum,
+}
+
+/**
+ * A special declaration identity that represents an enum. This is used in downleveled forms where
+ * a `ts.EnumDeclaration` is emitted in an alternative form, e.g. an IIFE call that declares all
+ * members.
+ */
+export interface DownleveledEnum {
+  kind: SpecialDeclarationKind.DownleveledEnum;
+  enumMembers: EnumMember[];
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -315,12 +315,14 @@ export class TypeScriptReflectionHost implements ReflectionHost {
         node: symbol.valueDeclaration,
         known: null,
         viaModule,
+        identity: null,
       };
     } else if (symbol.declarations !== undefined && symbol.declarations.length > 0) {
       return {
         node: symbol.declarations[0],
         known: null,
         viaModule,
+        identity: null,
       };
     } else {
       return null;

--- a/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
@@ -363,6 +363,7 @@ runInEachFileSystem(() => {
           node: targetDecl,
           known: null,
           viaModule: 'absolute',
+          identity: null,
         });
       });
 
@@ -393,6 +394,7 @@ runInEachFileSystem(() => {
           node: targetDecl,
           known: null,
           viaModule: 'absolute',
+          identity: null,
         });
       });
     });


### PR DESCRIPTION
An enum declaration in TypeScript code will be emitted into JavaScript
as a regular variable declaration, with the enum members being declared
inside an IIFE. For ngcc to support interpreting such variable
declarations as enum declarations with its members, ngcc needs to
recognize the enum declaration emit structure and extract all member
from the statements in the IIFE.

This commit extends the `ConcreteDeclaration` structure in the
`ReflectionHost` abstraction to be able to capture the enum members
on a variable declaration, as a substitute for the original
`ts.EnumDeclaration` as it existed in TypeScript code. The static
interpreter has been extended to handle the extracted enum members
as it would have done for `ts.EnumDeclaration`.

Fixes #35584
Resolves FW-2069