### PR TITLE
docs: wrong links in lifecylcle hooks api documentation

### DIFF
--- a/packages/core/src/interface/lifecycle_hooks.ts
+++ b/packages/core/src/interface/lifecycle_hooks.ts
@@ -15,7 +15,7 @@ import {SimpleChanges} from './simple_change';
  *
  * @see `DoCheck`
  * @see `OnInit`
- * @see [Lifecycle Hooks](guide/lifecycle-hooks#onchanges) guide
+ * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface to
@@ -43,7 +43,7 @@ export interface OnChanges {
  * Define an `ngOnInit()` method to handle any additional initialization tasks.
  *
  * @see `AfterContentInit`
- * @see [Lifecycle Hooks](guide/lifecycle-hooks#onchanges) guide
+ * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface to
@@ -78,7 +78,7 @@ export interface OnInit {
  * changes on the same input.
  *
  * @see `OnChanges`
- * @see [Lifecycle Hooks](guide/lifecycle-hooks#onchanges) guide
+ * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface
@@ -103,7 +103,7 @@ export interface DoCheck {
  * A lifecycle hook that is called when a directive, pipe, or service is destroyed.
  * Use for any custom cleanup that needs to occur when the
  * instance is destroyed.
- * @see [Lifecycle Hooks](guide/lifecycle-hooks#onchanges) guide
+ * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface
@@ -129,7 +129,7 @@ export interface OnDestroy {
  *
  * @see `OnInit`
  * @see `AfterViewInit`
- * @see [Lifecycle Hooks](guide/lifecycle-hooks#onchanges) guide
+ * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface to
@@ -155,7 +155,7 @@ export interface AfterContentInit {
  * completed checking all content of a directive.
  *
  * @see `AfterViewChecked`
- * @see [Lifecycle Hooks](guide/lifecycle-hooks#onchanges) guide
+ * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface to
@@ -182,7 +182,7 @@ export interface AfterContentChecked {
  *
  * @see `OnInit`
  * @see `AfterContentInit`
- * @see [Lifecycle Hooks](guide/lifecycle-hooks#onchanges) guide
+ * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface to
@@ -208,7 +208,7 @@ export interface AfterViewInit {
  * completed checking a component's view for changes.
  *
  * @see `AfterContentChecked`
- * @see [Lifecycle Hooks](guide/lifecycle-hooks#onchanges) guide
+ * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface to

--- a/packages/core/src/interface/lifecycle_hooks.ts
+++ b/packages/core/src/interface/lifecycle_hooks.ts
@@ -15,7 +15,7 @@ import {SimpleChanges} from './simple_change';
  *
  * @see `DoCheck`
  * @see `OnInit`
- * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
+ * @see [Lifecycle hooks guide](guide/lifecycle-hooks)
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface to
@@ -43,7 +43,7 @@ export interface OnChanges {
  * Define an `ngOnInit()` method to handle any additional initialization tasks.
  *
  * @see `AfterContentInit`
- * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
+ * @see [Lifecycle hooks guide](guide/lifecycle-hooks)
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface to
@@ -78,7 +78,7 @@ export interface OnInit {
  * changes on the same input.
  *
  * @see `OnChanges`
- * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
+ * @see [Lifecycle hooks guide](guide/lifecycle-hooks)
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface
@@ -103,7 +103,7 @@ export interface DoCheck {
  * A lifecycle hook that is called when a directive, pipe, or service is destroyed.
  * Use for any custom cleanup that needs to occur when the
  * instance is destroyed.
- * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
+ * @see [Lifecycle hooks guide](guide/lifecycle-hooks)
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface
@@ -129,7 +129,7 @@ export interface OnDestroy {
  *
  * @see `OnInit`
  * @see `AfterViewInit`
- * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
+ * @see [Lifecycle hooks guide](guide/lifecycle-hooks)
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface to
@@ -155,7 +155,7 @@ export interface AfterContentInit {
  * completed checking all content of a directive.
  *
  * @see `AfterViewChecked`
- * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
+ * @see [Lifecycle hooks guide](guide/lifecycle-hooks)
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface to
@@ -182,7 +182,7 @@ export interface AfterContentChecked {
  *
  * @see `OnInit`
  * @see `AfterContentInit`
- * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
+ * @see [Lifecycle hooks guide](guide/lifecycle-hooks)
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface to
@@ -208,7 +208,7 @@ export interface AfterViewInit {
  * completed checking a component's view for changes.
  *
  * @see `AfterContentChecked`
- * @see [Lifecycle Hooks](guide/lifecycle-hooks) guide
+ * @see [Lifecycle hooks guide](guide/lifecycle-hooks)
  *
  * @usageNotes
  * The following snippet shows how a component can implement this interface to


### PR DESCRIPTION
lifecylcle hooks api detailed documenation contained all links were pointing to onChanges documentaion made them point there own hooks

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Lifecyle points to wrong links

Issue Number: N/A


## What is the new behavior?
Lifecycles pointing to right links

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
