### PR TITLE
fix(ngcc): correctly detect external files from nested `node_modules/`

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/util.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/util.ts
@@ -11,7 +11,8 @@ import {absoluteFromSourceFile, AbsoluteFsPath, relative} from '../../../src/ngt
 import {DependencyTracker} from '../../../src/ngtsc/incremental/api';
 
 export function isWithinPackage(packagePath: AbsoluteFsPath, sourceFile: ts.SourceFile): boolean {
-  return !relative(packagePath, absoluteFromSourceFile(sourceFile)).startsWith('..');
+  const relativePath = relative(packagePath, absoluteFromSourceFile(sourceFile));
+  return !relativePath.startsWith('..') && !relativePath.startsWith('node_modules/');
 }
 
 class NoopDependencyTracker implements DependencyTracker {

--- a/packages/compiler-cli/ngcc/test/analysis/migration_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/migration_host_spec.ts
@@ -92,8 +92,6 @@ runInEachFileSystem(() => {
       });
     });
 
-
-
     describe('getAllDecorators', () => {
       it('should include injected decorators', () => {
         const directiveHandler = new DetectDecoratorHandler('Directive', HandlerPrecedence.WEAK);
@@ -143,7 +141,7 @@ runInEachFileSystem(() => {
         expect(host.isInScope(internalClass)).toBe(true);
       });
 
-      it('should be false for nodes outside the entry-point', () => {
+      it('should be false for nodes outside the entry-point (in sibling package)', () => {
         loadTestFiles([
           {name: _('/node_modules/external/index.js'), contents: `export class ExternalClass {}`},
           {
@@ -162,6 +160,30 @@ runInEachFileSystem(() => {
             isNamedClassDeclaration);
 
         expect(host.isInScope(externalClass)).toBe(false);
+      });
+
+      it('should be false for nodes outside the entry-point (in nested `node_modules/`)', () => {
+        loadTestFiles([
+          {
+            name: _('/node_modules/test/index.js'),
+            contents: `
+              export {NestedDependencyClass} from 'nested';
+              export class InternalClass {}
+            `,
+          },
+          {
+            name: _('/node_modules/test/node_modules/nested/index.js'),
+            contents: `export class NestedDependencyClass {}`,
+          },
+        ]);
+        const entryPoint =
+            makeTestEntryPointBundle('test', 'esm2015', false, [_('/node_modules/test/index.js')]);
+        const {host} = createMigrationHost({entryPoint, handlers: []});
+        const nestedDepClass = getDeclaration(
+            entryPoint.src.program, _('/node_modules/test/node_modules/nested/index.js'),
+            'NestedDependencyClass', isNamedClassDeclaration);
+
+        expect(host.isInScope(nestedDepClass)).toBe(false);
       });
     });
   });

--- a/packages/compiler-cli/ngcc/test/analysis/util_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/util_spec.ts
@@ -12,20 +12,36 @@ import {isWithinPackage} from '../../src/analysis/util';
 
 runInEachFileSystem(() => {
   describe('isWithinPackage', () => {
+    let _: typeof absoluteFrom;
+
+    beforeEach(() => _ = absoluteFrom);
+
     it('should return true if the source-file is contained in the package', () => {
-      const _ = absoluteFrom;
+      const packagePath = _('/node_modules/test');
       const file =
           ts.createSourceFile(_('/node_modules/test/src/index.js'), '', ts.ScriptTarget.ES2015);
-      const packagePath = _('/node_modules/test');
       expect(isWithinPackage(packagePath, file)).toBe(true);
     });
 
     it('should return false if the source-file is not contained in the package', () => {
-      const _ = absoluteFrom;
+      const packagePath = _('/node_modules/test');
       const file =
           ts.createSourceFile(_('/node_modules/other/src/index.js'), '', ts.ScriptTarget.ES2015);
-      const packagePath = _('/node_modules/test');
       expect(isWithinPackage(packagePath, file)).toBe(false);
+    });
+
+    it('should return false if the source-file is inside the package\'s `node_modules/`', () => {
+      const packagePath = _('/node_modules/test');
+
+      // An external file inside the package's `node_modules/`.
+      const file1 = ts.createSourceFile(
+          _('/node_modules/test/node_modules/other/src/index.js'), '', ts.ScriptTarget.ES2015);
+      expect(isWithinPackage(packagePath, file1)).toBe(false);
+
+      // An internal file starting with `node_modules`.
+      const file2 = ts.createSourceFile(
+          _('/node_modules/test/node_modules_optimizer.js'), '', ts.ScriptTarget.ES2015);
+      expect(isWithinPackage(packagePath, file2)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Previously, when we needed to detect whether a file is external to a package, we only checked whether the relative path to the file from the package's root started with `..`. This would detect external imports when the packages were siblings (e.g. peer dependencies or hoisted to the top of `node_modules/` by the package manager), but would fail to detect imports from packages located in nested `node_modules/` as external. For example, importing `node_modules/foo/node_modules/bar` from a file in `node_modules/foo/` would be considered internal to the `foo` package.

This could result in processing/analyzing more files than necessary. More importantly it could lead to errors due to trying to analyze non-Angular packages that were direct dependencies of Angular packages.

This commit fixes it by also verifying that the relative path to a file does not start with `node_modules/`.

Jira issue: [FW-2068](https://angular-team.atlassian.net/browse/FW-2068)

Fixes #36526.
