### PR TITLE
docs: place download section in accessibility to the top

### DIFF
--- a/aio/content/guide/accessibility.md
+++ b/aio/content/guide/accessibility.md
@@ -10,6 +10,12 @@ For an in-depth introduction to issues and techniques for designing accessible a
 This page discusses best practices for designing Angular applications that
 work well for all users, including those who rely on assistive technologies.
 
+<div class="alert is-helpful">
+
+  For the sample app that this page describes, see the <live-example></live-example>.
+
+</div>
+
 ## Accessibility attributes
 
 Building accessible web experience often involves setting [ARIA attributes](https://developers.google.com/web/fundamentals/accessibility/semantics-aria)
@@ -91,8 +97,6 @@ The following example shows how to make a simple progress bar accessible by usin
 
    <code-example path="accessibility/src/app/app.component.html" header="src/app/app.component.html" region="template"></code-example>
 
-
-To see the progress bar in a working example app, refer to the <live-example></live-example>.
 
 ## Routing and focus management
 


### PR DESCRIPTION
link is very deep down on acessibility page this commit is part of a larger effort to standardise ownload sections on angular.io

This commit partially addresses #35459

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ \x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No strandised way to download apps

Issue Number: #35459


## What is the new behavior?
A standardized way to download apps

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
