### PR TITLE
feat(router): allow using single route resolver instead of map of resolvers

### DIFF
--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -266,7 +266,7 @@ export declare interface Resolve<T> {
 
 export declare type ResolveData = {
     [name: string]: any;
-};
+} | any;
 
 export declare class ResolveEnd extends RouterEvent {
     state: RouterStateSnapshot;

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -89,7 +89,7 @@ export type Data = {
  */
 export type ResolveData = {
   [name: string]: any
-};
+}|any;
 
 /**
  *

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -273,7 +273,7 @@ export class ActivatedRouteSnapshot {
   _resolve: ResolveData;
   /** @internal */
   // TODO(issue/24571): remove '!'.
-  _resolvedData!: Data;
+  _resolvedData!: Data|any;
   /** @internal */
   // TODO(issue/24571): remove '!'.
   _routerState!: RouterStateSnapshot;

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1564,6 +1564,7 @@ describe('Integration', () => {
           {provide: 'resolveSix', useClass: ResolveSix},
           {provide: 'resolveError', useValue: (a: any, b: any) => Promise.reject('error')},
           {provide: 'resolveNullError', useValue: (a: any, b: any) => Promise.reject(null)},
+          {provide: 'resolveObject', useValue: (a: any, b: any) => ({foo: 4})},
           {provide: 'numberOfUrlSegments', useValue: (a: any, b: any) => a.url.length},
         ]
       });
@@ -1690,6 +1691,65 @@ describe('Integration', () => {
          advance(fixture);
 
          expect(cmp.route.snapshot.data).toEqual({numberOfUrlSegments: 3});
+       })));
+
+    it('should allow using single service name as a resolver',
+       fakeAsync(inject([Router], (router: Router) => {
+         const fixture = createRoot(router, RootCmp);
+
+         router.resetConfig([{
+           path: 'simple',
+           component: CollectParamsCmp,
+           resolve: 'resolveTwo',
+         }]);
+
+         router.navigateByUrl('/simple');
+         advance(fixture);
+
+         const cmp = fixture.debugElement.children[1].componentInstance;
+         expect(cmp.route.snapshot.data).toEqual(2);
+       })));
+
+    it('should override route data when resolved value is not an object',
+       fakeAsync(inject([Router], (router: Router) => {
+         const fixture = createRoot(router, RootCmp);
+
+         router.resetConfig([{
+           path: 'simple',
+           component: CollectParamsCmp,
+           data: {
+             foo: 1,
+             bar: 2,
+           },
+           resolve: 'resolveTwo',
+         }]);
+
+         router.navigateByUrl('/simple');
+         advance(fixture);
+
+         const cmp = fixture.debugElement.children[1].componentInstance;
+         expect(cmp.route.snapshot.data).toEqual(2);
+       })));
+
+    it('should merge route data with service resolver data',
+       fakeAsync(inject([Router], (router: Router) => {
+         const fixture = createRoot(router, RootCmp);
+
+         router.resetConfig([{
+           path: 'simple',
+           component: CollectParamsCmp,
+           data: {
+             foo: 1,
+             bar: 2,
+           },
+           resolve: 'resolveObject',
+         }]);
+
+         router.navigateByUrl('/simple');
+         advance(fixture);
+
+         const cmp = fixture.debugElement.children[1].componentInstance;
+         expect(cmp.route.snapshot.data).toEqual({foo: 4, bar: 2});
        })));
 
     describe('should run resolvers for the same route concurrently', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #25430

The only way to use route resolvers is by passing an object that maps resolvers to `data` properties:

```
{
  path: 'simple',
  resolve: { two: 'resolveTwo' },
}
```

Resolved data is then available in `ActivatedRoute.data.two`.

## What is the new behavior?

This PR allows using route resolves without defining a map of resolvers. The sorter notation is like this:

```
{
  path: 'simple',
  resolve: 'resolveTwo',
}
```

Resolved values are then available straight in `ActivatedRoute.data`.

There's one special case when defining static route `data` together with this new simplified resolver notation. If the resolver returns an object it'll be merged with `data` using route's `paramsInheritanceStrategy` (it'll work exactly the same way as using an object with resolvers like before this PR). If the resolver returns anything other than an object then `data` is replaced with the resolver value.  
I'm not sure if I'm not making it too complicated.

So there are two use-cases went using with static router `data`:

1. Resolver returns an object:

   ```
   {
     path: 'simple',
     data: { foo: 1, bar: 2 },
     resolve: 'resolveObject', // resolves with `{ foo: 4 }`
   }
   ```

   `ActivatedRoute.data` will contain the following object `{ foo: 4, bar: 2 }`.

2. Resolver returns non object:

   ```
   {
     path: 'simple',
     data: { foo: 1, bar: 2 },
     resolve: 'resolveTwo', // resolves with `2`
   } 
   ```

   `ActivatedRoute.data` will contain the following object `2`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

I had to change public API for `ResolveData` so it's now:

```
export declare type ResolveData = {
   [name: string]: any;
} | any;
```

instead of:

```
export declare type ResolveData = {
   [name: string]: any;
};
```

I think resolvers can be only service names right now so shouldn't there be `string`s instead of `any`s.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I didn't want to update documentation until I have approval from somebody that these changes make sense :). 

Closes #25430