### PR TITLE
fix(core): correct "development mode" console message

### DIFF
--- a/aio/content/guide/deployment.md
+++ b/aio/content/guide/deployment.md
@@ -304,7 +304,7 @@ In addition to build optimizations, Angular also has a runtime production mode. 
 
 <code-example format="nocode">
 
-  Angular is running in the development mode. Call enableProdMode() to enable the production mode.
+  Angular is running in development mode. Call enableProdMode() to enable production mode.
 
 </code-example>
 

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -693,7 +693,7 @@ export class ApplicationRef {
     this._loadComponent(compRef);
     if (isDevMode()) {
       this._console.log(
-          `Angular is running in the development mode. Call enableProdMode() to enable the production mode.`);
+          `Angular is running in development mode. Call enableProdMode() to enable production mode.`);
     }
     return compRef;
   }


### PR DESCRIPTION
The message can be improved by removing the unneeded ‘the’ (x2).

Before:
Angular is running in the development mode. Call enableProdMode() to enable the production mode.

After:
Angular is running in development mode. Call enableProdMode() to enable production mode.

Closes #36570

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Console show "Angular is running in the development mode. Call enableProdMode() to enable the production mode."

Issue Number: #36570


## What is the new behavior?
Console shows "Angular is running in development mode. Call enableProdMode() to enable production mode."

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
First of (hopefully) more contributions.
