### PR TITLE
docs: add example links to 'DoCheck' lifeycle hook docs

### DIFF
--- a/packages/core/src/interface/lifecycle_hooks.ts
+++ b/packages/core/src/interface/lifecycle_hooks.ts
@@ -85,11 +85,11 @@ export interface OnInit {
  * to invoke it own change-detection cycle.
  *
  * {@example core/ts/metadata/lifecycle_hooks_spec.ts region='DoCheck'}
- * 
- * For more details on the `DoCheck` lifecycle hook see the 
+ *
+ * For more details on the `DoCheck` lifecycle hook see the
  * [Defining custom change detection](guide/lifecycle-hooks#defining-custom-change-detection)
  * section in the Lifecycle hooks guide.
- * 
+ *
  * @publicApi
  */
 export interface DoCheck {

--- a/packages/core/src/interface/lifecycle_hooks.ts
+++ b/packages/core/src/interface/lifecycle_hooks.ts
@@ -85,7 +85,10 @@ export interface OnInit {
  * to invoke it own change-detection cycle.
  *
  * {@example core/ts/metadata/lifecycle_hooks_spec.ts region='DoCheck'}
- *
+ * 
+ * For more detailed examples on the DoCheck lifecycle hook please
+ * visit the [DoCheck](guide/lifecycle-hooks#docheck) Lifecycle hooks guide.
+ * 
  * @publicApi
  */
 export interface DoCheck {

--- a/packages/core/src/interface/lifecycle_hooks.ts
+++ b/packages/core/src/interface/lifecycle_hooks.ts
@@ -86,9 +86,8 @@ export interface OnInit {
  *
  * {@example core/ts/metadata/lifecycle_hooks_spec.ts region='DoCheck'}
  *
- * For more details on the `DoCheck` lifecycle hook see the
- * [Defining custom change detection](guide/lifecycle-hooks#defining-custom-change-detection)
- * section in the Lifecycle hooks guide.
+ * For a more complete example and discussion, see
+ * [Defining custom change detection](guide/lifecycle-hooks#defining-custom-change-detection).
  *
  * @publicApi
  */

--- a/packages/core/src/interface/lifecycle_hooks.ts
+++ b/packages/core/src/interface/lifecycle_hooks.ts
@@ -86,8 +86,9 @@ export interface OnInit {
  *
  * {@example core/ts/metadata/lifecycle_hooks_spec.ts region='DoCheck'}
  * 
- * For more detailed examples on the DoCheck lifecycle hook please
- * visit the [DoCheck](guide/lifecycle-hooks#docheck) Lifecycle hooks guide.
+ * For more details on the `DoCheck` lifecycle hook see the 
+ * [Defining custom change detection](guide/lifecycle-hooks#defining-custom-change-detection)
+ * section in the Lifecycle hooks guide.
  * 
  * @publicApi
  */


### PR DESCRIPTION
There were some examples for 'DoCheck' in the lifeCycle hooks guide. Added a link to the relevant section of the guide in the 'DoCheck()' api docs.

Fixes #35596

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
detailed example of DoCheck not available

Issue Number: #35596


## What is the new behavior?
detailed example of DoCheck available

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
