### PR TITLE
fix(docs-infra): about page tab text not visible on small screens

### DIFF
--- a/aio/src/styles/2-modules/_contributor.scss
+++ b/aio/src/styles/2-modules/_contributor.scss
@@ -19,6 +19,14 @@ aio-contributor-list {
 .group-buttons {
   margin: 32px auto;
 
+  @media (max-width: 480px) {
+    .filter-button.button {
+      font-size: 1.2rem;
+      padding: 0;
+      margin: 0;
+    }
+  }
+
   a {
     &.selected {
       background-color: $blue;


### PR DESCRIPTION
on small mobile in about page screens the top tab bar contains text which was not visible on small screens changed text size, margin and padding so that the text could be contained in these screens (320px to 480px)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Collaborartors not visible right on about page
![Angular - Angular Contributors](https://user-images.githubusercontent.com/39260684/79039618-1e64fb00-7c00-11ea-9c15-ea715da2c730.png)


Issue Number: N/A


## What is the new behavior?
Collaborators visible right on about page
![Angular - Angular Contributors (1)](https://user-images.githubusercontent.com/39260684/79039646-58360180-7c00-11ea-88f6-22eeda28b065.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
