### PR TITLE
feat(forms): allow to enable native form validation globally

### DIFF
--- a/goldens/public-api/forms/forms.d.ts
+++ b/goldens/public-api/forms/forms.d.ts
@@ -326,7 +326,11 @@ export declare class FormGroupName extends AbstractFormGroupDirective implements
     constructor(parent: ControlContainer, validators: any[], asyncValidators: any[]);
 }
 
+export declare interface FormsConfigurationOptions extends SharedFormsConfigurationOptions {
+}
+
 export declare class FormsModule {
+    static withConfig(opts: FormsConfigurationOptions): ModuleWithProviders<FormsModule>;
 }
 
 export declare class MaxLengthValidator implements Validator, OnChanges {
@@ -454,7 +458,7 @@ export declare class RadioControlValueAccessor implements ControlValueAccessor, 
     onChange: () => void;
     onTouched: () => void;
     value: any;
-    constructor(_renderer: Renderer2, _elementRef: ElementRef, _registry: ɵangular_packages_forms_forms_n, _injector: Injector);
+    constructor(_renderer: Renderer2, _elementRef: ElementRef, _registry: ɵangular_packages_forms_forms_p, _injector: Injector);
     fireUncheck(value: any): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
@@ -474,9 +478,12 @@ export declare class RangeValueAccessor implements ControlValueAccessor {
     writeValue(value: any): void;
 }
 
+export declare interface ReactiveFormsConfigurationOptions extends SharedFormsConfigurationOptions {
+    /** @deprecated */ warnOnNgModelWithFormControl?: 'never' | 'once' | 'always';
+}
+
 export declare class ReactiveFormsModule {
-    static withConfig(opts: { warnOnNgModelWithFormControl: 'never' | 'once' | 'always';
-    }): ModuleWithProviders<ReactiveFormsModule>;
+    static withConfig(opts: ReactiveFormsConfigurationOptions): ModuleWithProviders<ReactiveFormsModule>;
 }
 
 export declare class RequiredValidator implements Validator {
@@ -508,6 +515,10 @@ export declare class SelectMultipleControlValueAccessor implements ControlValueA
     registerOnTouched(fn: () => any): void;
     setDisabledState(isDisabled: boolean): void;
     writeValue(value: any): void;
+}
+
+export declare interface SharedFormsConfigurationOptions {
+    useNativeValidationAsDefaultFormValidation?: boolean;
 }
 
 export declare type ValidationErrors = {

--- a/packages/forms/src/directives.ts
+++ b/packages/forms/src/directives.ts
@@ -34,6 +34,7 @@ export {NgControlStatus, NgControlStatusGroup} from './directives/ng_control_sta
 export {NgForm} from './directives/ng_form';
 export {NgModel} from './directives/ng_model';
 export {NgModelGroup} from './directives/ng_model_group';
+export {USE_NATIVE_VALIDATION_AS_DEFAULT_FORM_VALIDATION} from './directives/ng_no_validate_directive';
 export {NumberValueAccessor} from './directives/number_value_accessor';
 export {RadioControlValueAccessor} from './directives/radio_control_value_accessor';
 export {RangeValueAccessor} from './directives/range_value_accessor';

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -85,6 +85,11 @@ const resolvedPromise = (() => Promise.resolve(null))();
  *   ...
  * </form>
  * ```
+ * Or you can make native DOM validation the default by configuring the forms module:
+ * ```typescript
+ * FormsModule.withConfig({useNativeValidationAsDefaultFormValidation: true});
+ * ReactiveFormsModule.withConfig({useNativeValidationAsDefaultFormValidation: true});
+ * ```
  *
  * @ngModule FormsModule
  * @publicApi

--- a/packages/forms/src/directives/ng_no_validate_directive.ts
+++ b/packages/forms/src/directives/ng_no_validate_directive.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive} from '@angular/core';
+import {Directive, HostBinding, Inject, InjectionToken, Optional} from '@angular/core';
+
+/**
+ * Token to provide to use native validation as the default form validation.
+ */
+export const USE_NATIVE_VALIDATION_AS_DEFAULT_FORM_VALIDATION =
+    new InjectionToken('UseNativeValidationAsDefaultFormValidation');
 
 /**
  * @description
@@ -27,9 +33,14 @@ import {Directive} from '@angular/core';
  */
 @Directive({
   selector: 'form:not([ngNoForm]):not([ngNativeValidate])',
-  host: {'novalidate': ''},
 })
 export class ɵNgNoValidate {
+  @HostBinding('attr.novalidate') readonly novalidate: string|null;
+
+  constructor(@Optional() @Inject(USE_NATIVE_VALIDATION_AS_DEFAULT_FORM_VALIDATION)
+              useNativeValidationAsDefaultFormValidation: boolean|null) {
+    this.novalidate = useNativeValidationAsDefaultFormValidation ? null : '';
+  }
 }
 
 export {ɵNgNoValidate as NgNoValidate};

--- a/packages/forms/src/form_providers.ts
+++ b/packages/forms/src/form_providers.ts
@@ -8,7 +8,7 @@
 
 import {ModuleWithProviders, NgModule} from '@angular/core';
 
-import {InternalFormsSharedModule, NG_MODEL_WITH_FORM_CONTROL_WARNING, REACTIVE_DRIVEN_DIRECTIVES, TEMPLATE_DRIVEN_DIRECTIVES} from './directives';
+import {InternalFormsSharedModule, NG_MODEL_WITH_FORM_CONTROL_WARNING, REACTIVE_DRIVEN_DIRECTIVES, TEMPLATE_DRIVEN_DIRECTIVES, USE_NATIVE_VALIDATION_AS_DEFAULT_FORM_VALIDATION} from './directives';
 import {RadioControlRegistry} from './directives/radio_control_value_accessor';
 import {FormBuilder} from './form_builder';
 
@@ -27,6 +27,21 @@ import {FormBuilder} from './form_builder';
   exports: [InternalFormsSharedModule, TEMPLATE_DRIVEN_DIRECTIVES]
 })
 export class FormsModule {
+  /**
+   * @description
+   * Provides options for configuring the forms module.
+   *
+   * @param opts An object of configuration options.
+   */
+  static withConfig(opts: FormsConfigurationOptions): ModuleWithProviders<FormsModule> {
+    return {
+      ngModule: FormsModule,
+      providers: [{
+        provide: USE_NATIVE_VALIDATION_AS_DEFAULT_FORM_VALIDATION,
+        useValue: opts.useNativeValidationAsDefaultFormValidation
+      }]
+    };
+  }
 }
 
 /**
@@ -48,18 +63,52 @@ export class ReactiveFormsModule {
    * @description
    * Provides options for configuring the reactive forms module.
    *
-   * @param opts An object of configuration options
-   * * `warnOnNgModelWithFormControl` Configures when to emit a warning when an `ngModel`
-   * binding is used with reactive form directives.
+   * @param opts An object of configuration options.
    */
-  static withConfig(opts: {
-    /** @deprecated as of v6 */ warnOnNgModelWithFormControl: 'never'|'once'|'always'
-  }): ModuleWithProviders<ReactiveFormsModule> {
+  static withConfig(opts: ReactiveFormsConfigurationOptions):
+      ModuleWithProviders<ReactiveFormsModule> {
     return {
       ngModule: ReactiveFormsModule,
       providers: [
-        {provide: NG_MODEL_WITH_FORM_CONTROL_WARNING, useValue: opts.warnOnNgModelWithFormControl}
+        {provide: NG_MODEL_WITH_FORM_CONTROL_WARNING, useValue: opts.warnOnNgModelWithFormControl},
+        {
+          provide: USE_NATIVE_VALIDATION_AS_DEFAULT_FORM_VALIDATION,
+          useValue: opts.useNativeValidationAsDefaultFormValidation
+        }
       ]
     };
   }
+}
+
+/**
+ * A set of configuration options for the forms or reactive forms module
+ *
+ * @publicApi
+ */
+export interface SharedFormsConfigurationOptions {
+  /**
+   * Configures native validation as the default form validation.
+   */
+  useNativeValidationAsDefaultFormValidation?: boolean;
+}
+
+/**
+ * A set of configuration options for the forms module
+ *
+ * @publicApi
+ */
+export interface FormsConfigurationOptions extends SharedFormsConfigurationOptions {}
+
+/**
+ * A set of configuration options for the reactive forms module
+ *
+ * @publicApi
+ */
+export interface ReactiveFormsConfigurationOptions extends SharedFormsConfigurationOptions {
+  /**
+   * Configures when to emit a warning when an `ngModel` binding is used with reactive form
+   * directives.
+   * @deprecated as of v6
+   */
+  warnOnNgModelWithFormControl?: 'never'|'once'|'always';
 }

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -61,6 +61,21 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
       });
 
+      it('should not add novalidate by default to form when native validation is to be used as the default form validation',
+         () => {
+           TestBed.configureTestingModule({
+             imports: [ReactiveFormsModule.withConfig(
+                 {useNativeValidationAsDefaultFormValidation: true})]
+           });
+
+           const fixture = initTest(FormGroupComp);
+           fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
+           fixture.detectChanges();
+
+           const form = fixture.debugElement.query(By.css('form'));
+           expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
+         });
+
       it('work with formGroups (view -> model)', () => {
         const fixture = initTest(FormGroupComp);
         const form = new FormGroup({'login': new FormControl('oldValue')});

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -87,6 +87,21 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
          }));
 
+      it('should not add novalidate by default to form when native validation is to be used as the default form validation',
+         fakeAsync(() => {
+           TestBed.configureTestingModule({
+             declarations: [NgModelForm],
+             imports: [FormsModule.withConfig({useNativeValidationAsDefaultFormValidation: true})]
+           });
+           const fixture = TestBed.createComponent(NgModelForm);
+
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.query(By.css('form'));
+           expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
+         }));
+
       it('should be possible to use native validation and angular forms', fakeAsync(() => {
            const fixture = initTest(NgModelNativeValidateForm);
 


### PR DESCRIPTION
By default, native form validation is disabled on all forms by NgNoValidate
directive. Re-enabling native form validation requires to pass
'ngNativeValidate' to the form. This is not practical on projects having many
forms.

This change alleviates this difficulty by adding a FormsModule configuration
 option. When enabled, the native form validation will be the default
 validation of all forms.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Feature


## What is the current behavior?

Issue Number: #35488


## What is the new behavior?

This change adds a FormsModule configuration option. When enabled, the native form validation will be the default validation of all forms.

## Does this PR introduce a breaking change?

- [X] No