### PR TITLE
fix(router): lazy loaded modules without RouterModule.forChild() won't cause infinite loop

### DIFF
--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Compiler, InjectionToken, Injector, NgModuleFactory, NgModuleFactoryLoader} from '@angular/core';
+import {Compiler, InjectFlags, InjectionToken, Injector, NgModuleFactory, NgModuleFactoryLoader} from '@angular/core';
 import {from, Observable, of} from 'rxjs';
 import {map, mergeMap} from 'rxjs/operators';
 
@@ -41,8 +41,13 @@ export class RouterConfigLoader {
 
       const module = factory.create(parentInjector);
 
+      // When loading a module that doesn't provide `RouterModule.forChild()` preloader will get
+      // stuck in an infinite loop. The child module's Injector will look to its parent `Injector`
+      // when it doesn't find any ROUTES so it will return routes for it's parent module instead.
       return new LoadedRouterConfig(
-          flatten(module.injector.get(ROUTES)).map(standardizeConfig), module);
+          flatten(module.injector.get(ROUTES, undefined, InjectFlags.Self | InjectFlags.Optional))
+              .map(standardizeConfig),
+          module);
     }));
   }
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -5291,6 +5291,10 @@ describe('Integration', () => {
       class LoadedModule1 {
       }
 
+      @NgModule({})
+      class EmptyModule {
+      }
+
       beforeEach(() => {
         log.length = 0;
         TestBed.configureTestingModule({
@@ -5354,6 +5358,19 @@ describe('Integration', () => {
 
            expect(firstConfig).toBeUndefined();
            expect(log.length).toBe(0);
+         }));
+
+      it('should allow navigation to modules with no routes', fakeAsync(() => {
+           (TestBed.inject(NgModuleFactoryLoader) as SpyNgModuleFactoryLoader).stubbedModules = {
+             empty: EmptyModule,
+           };
+           const router = TestBed.inject(Router);
+           const fixture = createRoot(router, RootCmp);
+
+           router.resetConfig([{path: 'lazy', loadChildren: 'empty'}]);
+
+           router.navigateByUrl('/lazy');
+           advance(fixture);
          }));
     });
 

--- a/packages/router/test/router_preloader.spec.ts
+++ b/packages/router/test/router_preloader.spec.ts
@@ -261,4 +261,35 @@ describe('RouterPreloader', () => {
              expect(c[0]._loadedConfig!.routes[0].component).toBe(configs[0].component);
            })));
   });
+
+  describe(
+      'should work with lazy loaded modules that don\'t provide RouterModule.forChild()', () => {
+        @NgModule({
+          declarations: [LazyLoadedCmp],
+          imports: [RouterModule.forChild([{path: 'LoadedModule1', component: LazyLoadedCmp}])]
+        })
+        class LoadedModule {
+        }
+
+        @NgModule({})
+        class EmptyModule {
+        }
+
+        beforeEach(() => {
+          TestBed.configureTestingModule({
+            imports: [RouterTestingModule.withRoutes(
+                [{path: 'lazyEmptyModule', loadChildren: 'expected2'}])],
+            providers: [{provide: PreloadingStrategy, useExisting: PreloadAllModules}]
+          });
+        });
+
+        it('should work',
+           fakeAsync(inject(
+               [NgModuleFactoryLoader, RouterPreloader],
+               (loader: SpyNgModuleFactoryLoader, preloader: RouterPreloader) => {
+                 loader.stubbedModules = {expected2: EmptyModule};
+
+                 preloader.preload().subscribe();
+               })));
+      });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #29164

When loading a module that doesn't provide `RouterModule.forChild()` preloader will get stuck in a infinite loop and throw `ERROR
Error: Maximum call stack size exceeded`.

https://stackblitz.com/edit/angular-issue-repro2-atwzck?file=src%2Fapp%2Ffeature1%2Ffeature1.module.ts

The issue is that child module's `Injector` will look to its parent `Injector` when it doesn't find any `ROUTES` so it will return routes for it's parent module instead. This will load the child again that returns its parent's routes and so on.

## What is the new behavior?

Lazy loaded modules without `RouterModule.forChild()` won't break the app.

I was thinking that this might throw an exception telling me that I'm lazy loading a module that doesn't define any routes but maybe it is a valid use-case (for example I'm loading a module that only does some logic in its constructor).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I only changed one line and added one test that would fail with `Error: 1 timer(s) still in the queue.` without this change:

https://github.com/angular/angular/compare/master...martinsik:issue-29164?expand=1#diff-2a29f955e9e56e86ee957a9768a19929R44

All other changes were made by running `yarn gulp format`

Closes #29164