### PR TITLE
fix(ngcc): force ngcc to exit on error

### DIFF
--- a/packages/compiler-cli/ngcc/main-ngcc.ts
+++ b/packages/compiler-cli/ngcc/main-ngcc.ts
@@ -153,7 +153,7 @@ if (require.main === module) {
       process.exitCode = 0;
     } catch (e) {
       console.error(e.stack || e.message);
-      process.exitCode = 1;
+      process.exit(1);
     }
   })();
 }


### PR DESCRIPTION
For some reason (possibly related to async/await promises)
the ngcc process is not exiting when spawned from the CLI
when there has been an error (such as when it timesout waiting
for a lockfile to become free).

Calling `process.exit()` directly fixes this.

Fixes #36616
