### PR TITLE
fix(ngcc): support recovering when a worker process crashes (and more)

### DIFF
--- a/packages/compiler-cli/ngcc/index.ts
+++ b/packages/compiler-cli/ngcc/index.ts
@@ -12,7 +12,8 @@ import {AsyncNgccOptions, NgccOptions, SyncNgccOptions} from './src/ngcc_options
 
 export {ConsoleLogger} from './src/logging/console_logger';
 export {Logger, LogLevel} from './src/logging/logger';
-export {AsyncNgccOptions, NgccOptions, PathMappings, SyncNgccOptions} from './src/ngcc_options';
+export {AsyncNgccOptions, NgccOptions, SyncNgccOptions} from './src/ngcc_options';
+export {PathMappings} from './src/path_mappings';
 
 export function process(options: AsyncNgccOptions): Promise<void>;
 export function process(options: SyncNgccOptions): void;

--- a/packages/compiler-cli/ngcc/src/dependencies/dts_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dts_dependency_host.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
-import {PathMappings} from '../ngcc_options';
+import {PathMappings} from '../path_mappings';
 import {EsmDependencyHost} from './esm_dependency_host';
 import {ModuleResolver} from './module_resolver';
 

--- a/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {absoluteFrom, AbsoluteFsPath, dirname, FileSystem, isRoot, join, resolve} from '../../../src/ngtsc/file_system';
-import {PathMappings} from '../ngcc_options';
+import {PathMappings} from '../path_mappings';
 import {isRelativePath, resolveFileWithPostfixes} from '../utils';
 
 /**

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/directory_walker_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/directory_walker_entry_point_finder.ts
@@ -9,10 +9,10 @@ import {AbsoluteFsPath, FileSystem, PathSegment} from '../../../src/ngtsc/file_s
 import {EntryPointWithDependencies} from '../dependencies/dependency_host';
 import {DependencyResolver, SortedEntryPointsInfo} from '../dependencies/dependency_resolver';
 import {Logger} from '../logging/logger';
-import {PathMappings} from '../ngcc_options';
 import {NgccConfiguration} from '../packages/configuration';
 import {getEntryPointInfo, INCOMPATIBLE_ENTRY_POINT, NO_ENTRY_POINT} from '../packages/entry_point';
 import {EntryPointManifest} from '../packages/entry_point_manifest';
+import {PathMappings} from '../path_mappings';
 import {NGCC_DIRECTORY} from '../writing/new_entry_point_file_writer';
 
 import {EntryPointFinder} from './interface';

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
@@ -9,10 +9,10 @@ import {AbsoluteFsPath, FileSystem, join, PathSegment, relative, relativeFrom} f
 import {EntryPointWithDependencies} from '../dependencies/dependency_host';
 import {DependencyResolver, SortedEntryPointsInfo} from '../dependencies/dependency_resolver';
 import {Logger} from '../logging/logger';
-import {PathMappings} from '../ngcc_options';
 import {hasBeenProcessed} from '../packages/build_marker';
 import {NgccConfiguration} from '../packages/configuration';
 import {EntryPoint, EntryPointJsonProperty, getEntryPointInfo, INCOMPATIBLE_ENTRY_POINT, NO_ENTRY_POINT} from '../packages/entry_point';
+import {PathMappings} from '../path_mappings';
 
 import {EntryPointFinder} from './interface';
 import {getBasePaths} from './utils';

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/utils.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/utils.ts
@@ -7,7 +7,7 @@
  */
 import {AbsoluteFsPath, getFileSystem, relative, resolve} from '../../../src/ngtsc/file_system';
 import {Logger} from '../logging/logger';
-import {PathMappings} from '../ngcc_options';
+import {PathMappings} from '../path_mappings';
 
 /**
  * Extract all the base-paths that we need to search for entry-points.

--- a/packages/compiler-cli/ngcc/src/execution/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/api.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {FileToWrite} from '../rendering/utils';
 import {Task, TaskCompletedCallback, TaskQueue} from './tasks/api';
 
 /**
@@ -16,10 +17,12 @@ import {Task, TaskCompletedCallback, TaskQueue} from './tasks/api';
 export type AnalyzeEntryPointsFn = () => TaskQueue;
 
 /** The type of the function that can process/compile a task. */
-export type CompileFn = (task: Task) => void;
+export type CompileFn<T> = (task: Task) => void|T;
 
 /** The type of the function that creates the `CompileFn` function used to process tasks. */
-export type CreateCompileFn = (onTaskCompleted: TaskCompletedCallback) => CompileFn;
+export type CreateCompileFn = <T extends void|Promise<void>>(
+    beforeWritingFiles: (transformedFiles: FileToWrite[]) => T,
+    onTaskCompleted: TaskCompletedCallback) => CompileFn<T>;
 
 /**
  * A class that orchestrates and executes the required work (i.e. analyzes the entry-points,

--- a/packages/compiler-cli/ngcc/src/execution/cluster/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/api.ts
@@ -36,6 +36,12 @@ export interface TaskCompletedMessage extends JsonObject {
   message: string|null;
 }
 
+/** A message listing the paths to transformed files about to be written to disk. */
+export interface TransformedFilesMessage extends JsonObject {
+  type: 'transformed-files';
+  files: AbsoluteFsPath[];
+}
+
 /** A message requesting the update of a `package.json` file. */
 export interface UpdatePackageJsonMessage extends JsonObject {
   type: 'update-package-json';
@@ -44,7 +50,8 @@ export interface UpdatePackageJsonMessage extends JsonObject {
 }
 
 /** The type of messages sent from cluster workers to the cluster master. */
-export type MessageFromWorker = ErrorMessage|TaskCompletedMessage|UpdatePackageJsonMessage;
+export type MessageFromWorker =
+    ErrorMessage|TaskCompletedMessage|TransformedFilesMessage|UpdatePackageJsonMessage;
 
 /** The type of messages sent from the cluster master to cluster workers. */
 export type MessageToWorker = ProcessTaskMessage;

--- a/packages/compiler-cli/ngcc/src/execution/cluster/executor.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/executor.ts
@@ -8,6 +8,7 @@
 import {FileSystem} from '../../../../src/ngtsc/file_system';
 import {AsyncLocker} from '../../locking/async_locker';
 import {Logger} from '../../logging/logger';
+import {FileWriter} from '../../writing/file_writer';
 import {PackageJsonUpdater} from '../../writing/package_json_updater';
 import {AnalyzeEntryPointsFn, CreateCompileFn, Executor} from '../api';
 import {CreateTaskCompletedCallback} from '../tasks/api';
@@ -21,7 +22,8 @@ import {ClusterMaster} from './master';
 export class ClusterExecutor implements Executor {
   constructor(
       private workerCount: number, private fileSystem: FileSystem, private logger: Logger,
-      private pkgJsonUpdater: PackageJsonUpdater, private lockFile: AsyncLocker,
+      private fileWriter: FileWriter, private pkgJsonUpdater: PackageJsonUpdater,
+      private lockFile: AsyncLocker,
       private createTaskCompletedCallback: CreateTaskCompletedCallback) {}
 
   async execute(analyzeEntryPoints: AnalyzeEntryPointsFn, _createCompileFn: CreateCompileFn):
@@ -30,8 +32,8 @@ export class ClusterExecutor implements Executor {
       this.logger.debug(
           `Running ngcc on ${this.constructor.name} (using ${this.workerCount} worker processes).`);
       const master = new ClusterMaster(
-          this.workerCount, this.fileSystem, this.logger, this.pkgJsonUpdater, analyzeEntryPoints,
-          this.createTaskCompletedCallback);
+          this.workerCount, this.fileSystem, this.logger, this.fileWriter, this.pkgJsonUpdater,
+          analyzeEntryPoints, this.createTaskCompletedCallback);
       return master.run();
     });
   }

--- a/packages/compiler-cli/ngcc/src/execution/cluster/master.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/master.ts
@@ -17,7 +17,7 @@ import {AnalyzeEntryPointsFn} from '../api';
 import {CreateTaskCompletedCallback, Task, TaskCompletedCallback, TaskQueue} from '../tasks/api';
 import {stringifyTask} from '../tasks/utils';
 
-import {MessageFromWorker, TaskCompletedMessage, UpdatePackageJsonMessage} from './api';
+import {MessageFromWorker, TaskCompletedMessage, TransformedFilesMessage, UpdatePackageJsonMessage} from './api';
 import {Deferred, sendMessageToWorker} from './utils';
 
 
@@ -180,6 +180,8 @@ export class ClusterMaster {
         throw new Error(`Error on worker #${workerId}: ${msg.error}`);
       case 'task-completed':
         return this.onWorkerTaskCompleted(workerId, msg);
+      case 'transformed-files':
+        return this.onWorkerTransformedFiles(workerId, msg);
       case 'update-package-json':
         return this.onWorkerUpdatePackageJson(workerId, msg);
       default:
@@ -218,6 +220,11 @@ export class ClusterMaster {
     this.taskQueue.markAsCompleted(task);
     this.taskAssignments.set(workerId, null);
     this.maybeDistributeWork();
+  }
+
+  /** Handle a worker's message regarding the files transformed while processing its task. */
+  private onWorkerTransformedFiles(workerId: number, msg: TransformedFilesMessage): void {
+    // TODO: Do something useful with this info.
   }
 
   /** Handle a worker's request to update a `package.json` file. */

--- a/packages/compiler-cli/ngcc/src/execution/cluster/master.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/master.ts
@@ -215,7 +215,7 @@ export class ClusterMaster {
 
     this.onTaskCompleted(task, msg.outcome, msg.message);
 
-    this.taskQueue.markTaskCompleted(task);
+    this.taskQueue.markAsCompleted(task);
     this.taskAssignments.set(workerId, null);
     this.maybeDistributeWork();
   }

--- a/packages/compiler-cli/ngcc/src/execution/cluster/master.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/master.ts
@@ -12,6 +12,7 @@ import * as cluster from 'cluster';
 
 import {AbsoluteFsPath, FileSystem} from '../../../../src/ngtsc/file_system';
 import {Logger} from '../../logging/logger';
+import {FileWriter} from '../../writing/file_writer';
 import {PackageJsonUpdater} from '../../writing/package_json_updater';
 import {AnalyzeEntryPointsFn} from '../api';
 import {CreateTaskCompletedCallback, Task, TaskCompletedCallback, TaskQueue} from '../tasks/api';
@@ -34,7 +35,8 @@ export class ClusterMaster {
 
   constructor(
       private maxWorkerCount: number, private fileSystem: FileSystem, private logger: Logger,
-      private pkgJsonUpdater: PackageJsonUpdater, analyzeEntryPoints: AnalyzeEntryPointsFn,
+      private fileWriter: FileWriter, private pkgJsonUpdater: PackageJsonUpdater,
+      analyzeEntryPoints: AnalyzeEntryPointsFn,
       createTaskCompletedCallback: CreateTaskCompletedCallback) {
     if (!cluster.isMaster) {
       throw new Error('Tried to instantiate `ClusterMaster` on a worker process.');
@@ -146,6 +148,7 @@ export class ClusterMaster {
 
     // The worker exited unexpectedly: Determine it's status and take an appropriate action.
     const assignment = this.taskAssignments.get(worker.id);
+    this.taskAssignments.delete(worker.id);
 
     this.logger.warn(
         `Worker #${worker.id} exited unexpectedly (code: ${code} | signal: ${signal}).\n` +
@@ -158,16 +161,33 @@ export class ClusterMaster {
       // The crashed worker process was not in the middle of a task:
       // Just spawn another process.
       this.logger.debug(`Spawning another worker process to replace #${worker.id}...`);
-      this.taskAssignments.delete(worker.id);
       cluster.fork();
     } else {
+      if (assignment.files != null) {
+        // The crashed worker process was in the middle of writing transformed files:
+        // Revert any changes before re-processing the task.
+        this.logger.debug(`Reverting ${assignment.files.length} transformed files...`);
+        for (const file of assignment.files) {
+          this.fileWriter.revertFile(file, assignment.task.entryPoint.package);
+        }
+      }
+
       // The crashed worker process was in the middle of a task:
-      // Impossible to know whether we can recover (without ending up with a corrupted entry-point).
-      // TODO: Use `assignment.files` to revert any changes and rerun the task worker.
-      const currentTask = assignment.task;
-      throw new Error(
-          'Process unexpectedly crashed, while processing format property ' +
-          `${currentTask.formatProperty} for entry-point '${currentTask.entryPoint.path}'.`);
+      // Re-add the task back to the queue.
+      this.taskQueue.markAsUnprocessed(assignment.task);
+
+      // The crashing might be a result of increased memory consumption by ngcc.
+      // Do not spawn another process, unless this was the last worker process.
+      const spawnedWorkerCount = Object.keys(cluster.workers).length;
+      if (spawnedWorkerCount > 0) {
+        this.logger.debug(`Not spawning another worker process to replace #${
+            worker.id}. Continuing with ${spawnedWorkerCount} workers...`);
+        this.maybeDistributeWork();
+      } else {
+        this.logger.debug(`Spawning another worker process to replace #${worker.id}...`);
+        this.remainingRespawnAttempts--;
+        cluster.fork();
+      }
     }
   }
 

--- a/packages/compiler-cli/ngcc/src/execution/cluster/utils.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/utils.ts
@@ -51,12 +51,14 @@ export const sendMessageToMaster = (msg: MessageFromWorker): Promise<void> => {
     throw new Error('Unable to send message to the master process: Already on the master process.');
   }
 
-  if (process.send === undefined) {
-    // Theoretically, this should never happen on a worker process.
-    throw new Error('Unable to send message to the master process: Missing `process.send()`.');
-  }
+  return new Promise((resolve, reject) => {
+    if (process.send === undefined) {
+      // Theoretically, this should never happen on a worker process.
+      throw new Error('Unable to send message to the master process: Missing `process.send()`.');
+    }
 
-  return new Promise(resolve => process.send!(msg, resolve));
+    process.send(msg, (err: Error|null) => (err === null) ? resolve() : reject(err));
+  });
 };
 
 /**
@@ -79,5 +81,7 @@ export const sendMessageToWorker = (workerId: number, msg: MessageToWorker): Pro
         'Unable to send message to worker process: Recipient does not exist or has disconnected.');
   }
 
-  return new Promise(resolve => worker.send(msg, resolve));
+  return new Promise((resolve, reject) => {
+    worker.send(msg, (err: Error|null) => (err === null) ? resolve() : reject(err));
+  });
 };

--- a/packages/compiler-cli/ngcc/src/execution/cluster/utils.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/utils.ts
@@ -44,8 +44,9 @@ export class Deferred<T> {
  * (This function should be invoked from cluster workers only.)
  *
  * @param msg The message to send to the cluster master.
+ * @return A promise that is resolved once the message has been sent.
  */
-export const sendMessageToMaster = (msg: MessageFromWorker): void => {
+export const sendMessageToMaster = (msg: MessageFromWorker): Promise<void> => {
   if (cluster.isMaster) {
     throw new Error('Unable to send message to the master process: Already on the master process.');
   }
@@ -55,7 +56,7 @@ export const sendMessageToMaster = (msg: MessageFromWorker): void => {
     throw new Error('Unable to send message to the master process: Missing `process.send()`.');
   }
 
-  process.send(msg);
+  return new Promise(resolve => process.send!(msg, resolve));
 };
 
 /**
@@ -64,8 +65,9 @@ export const sendMessageToMaster = (msg: MessageFromWorker): void => {
  *
  * @param workerId The ID of the recipient worker.
  * @param msg The message to send to the worker.
+ * @return A promise that is resolved once the message has been sent.
  */
-export const sendMessageToWorker = (workerId: number, msg: MessageToWorker): void => {
+export const sendMessageToWorker = (workerId: number, msg: MessageToWorker): Promise<void> => {
   if (!cluster.isMaster) {
     throw new Error('Unable to send message to worker process: Sender is not the master process.');
   }
@@ -77,5 +79,5 @@ export const sendMessageToWorker = (workerId: number, msg: MessageToWorker): voi
         'Unable to send message to worker process: Recipient does not exist or has disconnected.');
   }
 
-  worker.send(msg);
+  return new Promise(resolve => worker.send(msg, resolve));
 };

--- a/packages/compiler-cli/ngcc/src/execution/cluster/worker.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/worker.ts
@@ -62,7 +62,10 @@ export async function startWorker(logger: Logger, createCompileFn: CreateCompile
   }
 
   const compile = createCompileFn(
-      () => {},
+      transformedFiles => sendMessageToMaster({
+        type: 'transformed-files',
+        files: transformedFiles.map(f => f.path),
+      }),
       (_task, outcome, message) => sendMessageToMaster({type: 'task-completed', outcome, message}));
 
 
@@ -79,7 +82,7 @@ export async function startWorker(logger: Logger, createCompileFn: CreateCompile
               `[Worker #${cluster.worker.id}] Invalid message received: ${JSON.stringify(msg)}`);
       }
     } catch (err) {
-      sendMessageToMaster({
+      await sendMessageToMaster({
         type: 'error',
         error: (err instanceof Error) ? (err.stack || err.message) : err,
       });

--- a/packages/compiler-cli/ngcc/src/execution/cluster/worker.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/worker.ts
@@ -62,17 +62,18 @@ export async function startWorker(logger: Logger, createCompileFn: CreateCompile
   }
 
   const compile = createCompileFn(
+      () => {},
       (_task, outcome, message) => sendMessageToMaster({type: 'task-completed', outcome, message}));
 
 
   // Listen for `ProcessTaskMessage`s and process tasks.
-  cluster.worker.on('message', (msg: MessageToWorker) => {
+  cluster.worker.on('message', async (msg: MessageToWorker) => {
     try {
       switch (msg.type) {
         case 'process-task':
           logger.debug(
               `[Worker #${cluster.worker.id}] Processing task: ${stringifyTask(msg.task)}`);
-          return compile(msg.task);
+          return await compile(msg.task);
         default:
           throw new Error(
               `[Worker #${cluster.worker.id}] Invalid message received: ${JSON.stringify(msg)}`);

--- a/packages/compiler-cli/ngcc/src/execution/cluster/worker.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/worker.ts
@@ -28,24 +28,23 @@ if (require.main === module) {
 
     try {
       const {
-        createNewEntryPointFormats = false,
-        logger = new ConsoleLogger(LogLevel.info),
+        logger,
         pathMappings,
-        errorOnFailedEntryPoint = false,
-        enableI18nLegacyMessageIdFormat = true,
+        enableI18nLegacyMessageIdFormat,
         fileSystem,
-        tsConfig
+        tsConfig,
+        getFileWriter,
       } = getSharedSetup(parseCommandLineOptions(process.argv.slice(2)));
 
       // NOTE: To avoid file corruption, `ngcc` invocation only creates _one_ instance of
       // `PackageJsonUpdater` that actually writes to disk (across all processes).
       // In cluster workers we use a `PackageJsonUpdater` that delegates to the cluster master.
       const pkgJsonUpdater = new ClusterWorkerPackageJsonUpdater();
+      const fileWriter = getFileWriter(pkgJsonUpdater);
 
       // The function for creating the `compile()` function.
       const createCompileFn = getCreateCompileFn(
-          fileSystem, logger, pkgJsonUpdater, createNewEntryPointFormats, errorOnFailedEntryPoint,
-          enableI18nLegacyMessageIdFormat, tsConfig, pathMappings);
+          fileSystem, logger, fileWriter, enableI18nLegacyMessageIdFormat, tsConfig, pathMappings);
 
       await startWorker(logger, createCompileFn);
       process.exitCode = 0;

--- a/packages/compiler-cli/ngcc/src/execution/create_compile_function.ts
+++ b/packages/compiler-cli/ngcc/src/execution/create_compile_function.ts
@@ -57,11 +57,11 @@ export function getCreateCompileFn(
             `${formatProperty} (formatPath: ${formatPath} | format: ${format})`);
       }
 
+      logger.info(`Compiling ${entryPoint.name} : ${formatProperty} as ${format}`);
+
       const bundle = makeEntryPointBundle(
           fileSystem, entryPoint, formatPath, isCore, format, processDts, pathMappings, true,
           enableI18nLegacyMessageIdFormat);
-
-      logger.info(`Compiling ${entryPoint.name} : ${formatProperty} as ${format}`);
 
       const result = transformer.transform(bundle);
       if (result.success) {

--- a/packages/compiler-cli/ngcc/src/execution/create_compile_function.ts
+++ b/packages/compiler-cli/ngcc/src/execution/create_compile_function.ts
@@ -16,9 +16,6 @@ import {PathMappings} from '../ngcc_options';
 import {getEntryPointFormat} from '../packages/entry_point';
 import {makeEntryPointBundle} from '../packages/entry_point_bundle';
 import {FileWriter} from '../writing/file_writer';
-import {InPlaceFileWriter} from '../writing/in_place_file_writer';
-import {NewEntryPointFileWriter} from '../writing/new_entry_point_file_writer';
-import {PackageJsonUpdater} from '../writing/package_json_updater';
 
 import {CreateCompileFn} from './api';
 import {Task, TaskProcessingOutcome} from './tasks/api';
@@ -27,13 +24,10 @@ import {Task, TaskProcessingOutcome} from './tasks/api';
  * The function for creating the `compile()` function.
  */
 export function getCreateCompileFn(
-    fileSystem: FileSystem, logger: Logger, pkgJsonUpdater: PackageJsonUpdater,
-    createNewEntryPointFormats: boolean, errorOnFailedEntryPoint: boolean,
+    fileSystem: FileSystem, logger: Logger, fileWriter: FileWriter,
     enableI18nLegacyMessageIdFormat: boolean, tsConfig: ParsedConfiguration|null,
     pathMappings: PathMappings|undefined): CreateCompileFn {
   return (beforeWritingFiles, onTaskCompleted) => {
-    const fileWriter = getFileWriter(
-        fileSystem, logger, pkgJsonUpdater, createNewEntryPointFormats, errorOnFailedEntryPoint);
     const {Transformer} = require('../packages/transformer');
     const transformer = new Transformer(fileSystem, logger, tsConfig);
 
@@ -90,12 +84,4 @@ export function getCreateCompileFn(
       }
     };
   };
-}
-
-function getFileWriter(
-    fs: FileSystem, logger: Logger, pkgJsonUpdater: PackageJsonUpdater,
-    createNewEntryPointFormats: boolean, errorOnFailedEntryPoint: boolean): FileWriter {
-  return createNewEntryPointFormats ?
-      new NewEntryPointFileWriter(fs, logger, errorOnFailedEntryPoint, pkgJsonUpdater) :
-      new InPlaceFileWriter(fs, logger, errorOnFailedEntryPoint);
 }

--- a/packages/compiler-cli/ngcc/src/execution/create_compile_function.ts
+++ b/packages/compiler-cli/ngcc/src/execution/create_compile_function.ts
@@ -12,9 +12,9 @@ import {replaceTsWithNgInErrors} from '../../../src/ngtsc/diagnostics';
 import {FileSystem} from '../../../src/ngtsc/file_system';
 import {ParsedConfiguration} from '../../../src/perform_compile';
 import {Logger} from '../logging/logger';
-import {PathMappings} from '../ngcc_options';
 import {getEntryPointFormat} from '../packages/entry_point';
 import {makeEntryPointBundle} from '../packages/entry_point_bundle';
+import {PathMappings} from '../path_mappings';
 import {FileWriter} from '../writing/file_writer';
 
 import {CreateCompileFn} from './api';

--- a/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
+++ b/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
@@ -23,7 +23,7 @@ export abstract class SingleProcessorExecutorBase {
 
     const taskQueue = analyzeEntryPoints();
     const onTaskCompleted = this.createTaskCompletedCallback(taskQueue);
-    const compile = createCompileFn(onTaskCompleted);
+    const compile = createCompileFn(() => {}, onTaskCompleted);
 
     // Process all tasks.
     this.logger.debug('Processing tasks...');

--- a/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
+++ b/packages/compiler-cli/ngcc/src/execution/single_process_executor.ts
@@ -32,7 +32,7 @@ export abstract class SingleProcessorExecutorBase {
     while (!taskQueue.allTasksCompleted) {
       const task = taskQueue.getNextTask()!;
       compile(task);
-      taskQueue.markTaskCompleted(task);
+      taskQueue.markAsCompleted(task);
     }
 
     const duration = Math.round((Date.now() - startTime) / 1000);

--- a/packages/compiler-cli/ngcc/src/execution/tasks/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/tasks/api.ts
@@ -108,7 +108,7 @@ export interface TaskQueue {
    *
    * @param task The task to mark as completed.
    */
-  markTaskCompleted(task: Task): void;
+  markAsCompleted(task: Task): void;
 
   /**
    * Mark a task as failed.

--- a/packages/compiler-cli/ngcc/src/execution/tasks/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/tasks/api.ts
@@ -118,6 +118,16 @@ export interface TaskQueue {
   markAsFailed(task: Task): void;
 
   /**
+   * Mark a task as not processed (i.e. add an in-progress task back to the queue).
+   *
+   * This removes the task from the internal list of in-progress tasks and adds it back to the list
+   * of pending tasks.
+   *
+   * @param task The task to mark as not processed.
+   */
+  markTaskUnprocessed(task: Task): void;
+
+  /**
    * Return a string representation of the task queue (for debugging purposes).
    *
    * @return A string representation of the task queue.

--- a/packages/compiler-cli/ngcc/src/execution/tasks/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/tasks/api.ts
@@ -125,7 +125,7 @@ export interface TaskQueue {
    *
    * @param task The task to mark as not processed.
    */
-  markTaskUnprocessed(task: Task): void;
+  markAsUnprocessed(task: Task): void;
 
   /**
    * Return a string representation of the task queue (for debugging purposes).

--- a/packages/compiler-cli/ngcc/src/execution/tasks/queues/base_task_queue.ts
+++ b/packages/compiler-cli/ngcc/src/execution/tasks/queues/base_task_queue.ts
@@ -37,7 +37,7 @@ export abstract class BaseTaskQueue implements TaskQueue {
         break;
       }
       // We are skipping this task so mark it as complete
-      this.markTaskCompleted(nextTask);
+      this.markAsCompleted(nextTask);
       const failedTask = this.tasksToSkip.get(nextTask)!;
       this.logger.warn(`Skipping processing of ${nextTask.entryPoint.name} because its dependency ${
           failedTask.entryPoint.name} failed to compile.`);
@@ -46,21 +46,21 @@ export abstract class BaseTaskQueue implements TaskQueue {
     return nextTask;
   }
 
-  markAsFailed(task: Task) {
-    if (this.dependencies.has(task)) {
-      for (const dependentTask of this.dependencies.get(task)!) {
-        this.skipDependentTasks(dependentTask, task);
-      }
-    }
-  }
-
-  markTaskCompleted(task: Task): void {
+  markAsCompleted(task: Task): void {
     if (!this.inProgressTasks.has(task)) {
       throw new Error(
           `Trying to mark task that was not in progress as completed: ${stringifyTask(task)}`);
     }
 
     this.inProgressTasks.delete(task);
+  }
+
+  markAsFailed(task: Task): void {
+    if (this.dependencies.has(task)) {
+      for (const dependentTask of this.dependencies.get(task)!) {
+        this.skipDependentTasks(dependentTask, task);
+      }
+    }
   }
 
   markAsUnprocessed(task: Task): void {

--- a/packages/compiler-cli/ngcc/src/execution/tasks/queues/base_task_queue.ts
+++ b/packages/compiler-cli/ngcc/src/execution/tasks/queues/base_task_queue.ts
@@ -63,7 +63,7 @@ export abstract class BaseTaskQueue implements TaskQueue {
     this.inProgressTasks.delete(task);
   }
 
-  markTaskUnprocessed(task: Task): void {
+  markAsUnprocessed(task: Task): void {
     if (!this.inProgressTasks.has(task)) {
       throw new Error(
           `Trying to mark task that was not in progress as unprocessed: ${stringifyTask(task)}`);

--- a/packages/compiler-cli/ngcc/src/execution/tasks/queues/base_task_queue.ts
+++ b/packages/compiler-cli/ngcc/src/execution/tasks/queues/base_task_queue.ts
@@ -63,6 +63,16 @@ export abstract class BaseTaskQueue implements TaskQueue {
     this.inProgressTasks.delete(task);
   }
 
+  markTaskUnprocessed(task: Task): void {
+    if (!this.inProgressTasks.has(task)) {
+      throw new Error(
+          `Trying to mark task that was not in progress as unprocessed: ${stringifyTask(task)}`);
+    }
+
+    this.inProgressTasks.delete(task);
+    this.tasks.unshift(task);
+  }
+
   toString(): string {
     const inProgTasks = Array.from(this.inProgressTasks);
 

--- a/packages/compiler-cli/ngcc/src/execution/tasks/queues/parallel_task_queue.ts
+++ b/packages/compiler-cli/ngcc/src/execution/tasks/queues/parallel_task_queue.ts
@@ -41,8 +41,8 @@ export class ParallelTaskQueue extends BaseTaskQueue {
     return nextTask;
   }
 
-  markTaskCompleted(task: Task): void {
-    super.markTaskCompleted(task);
+  markAsCompleted(task: Task): void {
+    super.markAsCompleted(task);
 
     if (!this.dependencies.has(task)) {
       return;

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -32,10 +32,11 @@ import {AsyncLocker} from './locking/async_locker';
 import {LockFileWithChildProcess} from './locking/lock_file_with_child_process';
 import {SyncLocker} from './locking/sync_locker';
 import {Logger} from './logging/logger';
-import {AsyncNgccOptions, getSharedSetup, NgccOptions, PathMappings, SyncNgccOptions} from './ngcc_options';
+import {AsyncNgccOptions, getSharedSetup, NgccOptions, SyncNgccOptions} from './ngcc_options';
 import {NgccConfiguration} from './packages/configuration';
 import {EntryPointJsonProperty, SUPPORTED_FORMAT_PROPERTIES} from './packages/entry_point';
 import {EntryPointManifest, InvalidatingEntryPointManifest} from './packages/entry_point_manifest';
+import {PathMappings} from './path_mappings';
 import {FileWriter} from './writing/file_writer';
 import {DirectPackageJsonUpdater, PackageJsonUpdater} from './writing/package_json_updater';
 

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -86,8 +86,10 @@ export function mainNgcc(options: NgccOptions): void|Promise<void> {
     return;
   }
 
-  // Execute in parallel, if async execution is acceptable and there are more than 1 CPU cores.
-  const inParallel = async && (os.cpus().length > 1);
+  // Execute in parallel, if async execution is acceptable and there are more than 2 CPU cores.
+  // (One CPU core is always reserved for the master process and we need at least 2 worker processes
+  // in order to run tasks in parallel.)
+  const inParallel = async && (os.cpus().length > 2);
 
   const analyzeEntryPoints = getAnalyzeEntryPointsFn(
       logger, finder, fileSystem, supportedPropertiesToConsider, compileAllFormats,

--- a/packages/compiler-cli/ngcc/src/ngcc_options.ts
+++ b/packages/compiler-cli/ngcc/src/ngcc_options.ts
@@ -11,6 +11,10 @@ import {ParsedConfiguration, readConfiguration} from '../../src/perform_compile'
 import {ConsoleLogger} from './logging/console_logger';
 import {Logger, LogLevel} from './logging/logger';
 import {SUPPORTED_FORMAT_PROPERTIES} from './packages/entry_point';
+import {FileWriter} from './writing/file_writer';
+import {InPlaceFileWriter} from './writing/in_place_file_writer';
+import {NewEntryPointFileWriter} from './writing/new_entry_point_file_writer';
+import {PackageJsonUpdater} from './writing/package_json_updater';
 
 /**
  * The options to configure the ngcc compiler for synchronous execution.
@@ -156,6 +160,7 @@ export type OptionalNgccOptions = Pick<NgccOptions, OptionalNgccOptionKeys>;
 export type SharedSetup = {
   fileSystem: FileSystem; absBasePath: AbsoluteFsPath; projectPath: AbsoluteFsPath;
   tsConfig: ParsedConfiguration | null;
+  getFileWriter(pkgJsonUpdater: PackageJsonUpdater): FileWriter;
 };
 
 /**
@@ -210,5 +215,8 @@ export function getSharedSetup(options: NgccOptions): SharedSetup&RequiredNgccOp
     absBasePath,
     projectPath,
     tsConfig,
+    getFileWriter: (pkgJsonUpdater: PackageJsonUpdater) => createNewEntryPointFormats ?
+        new NewEntryPointFileWriter(fileSystem, logger, errorOnFailedEntryPoint, pkgJsonUpdater) :
+        new InPlaceFileWriter(fileSystem, logger, errorOnFailedEntryPoint),
   };
 }

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
@@ -7,7 +7,7 @@
  */
 import * as ts from 'typescript';
 import {AbsoluteFsPath, FileSystem, NgtscCompilerHost} from '../../../src/ngtsc/file_system';
-import {PathMappings} from '../ngcc_options';
+import {PathMappings} from '../path_mappings';
 import {BundleProgram, makeBundleProgram} from './bundle_program';
 import {EntryPoint, EntryPointFormat} from './entry_point';
 import {NgccSourcesCompilerHost} from './ngcc_compiler_host';

--- a/packages/compiler-cli/ngcc/src/path_mappings.ts
+++ b/packages/compiler-cli/ngcc/src/path_mappings.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {AbsoluteFsPath, resolve} from '../../src/ngtsc/file_system';
+import {ParsedConfiguration} from '../../src/perform_compile';
+
+
+export type PathMappings = {
+  baseUrl: string,
+  paths: {[key: string]: string[]}
+};
+
+/**
+ * If `pathMappings` is not provided directly, then try getting it from `tsConfig`, if available.
+ */
+export function getPathMappingsFromTsConfig(
+    tsConfig: ParsedConfiguration|null, projectPath: AbsoluteFsPath): PathMappings|undefined {
+  if (tsConfig !== null && tsConfig.options.baseUrl !== undefined &&
+      tsConfig.options.paths !== undefined) {
+    return {
+      baseUrl: resolve(projectPath, tsConfig.options.baseUrl),
+      paths: tsConfig.options.paths,
+    };
+  }
+}

--- a/packages/compiler-cli/ngcc/src/writing/file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/file_writer.ts
@@ -6,6 +6,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {AbsoluteFsPath} from '../../../src/ngtsc/file_system';
 import {EntryPointJsonProperty} from '../packages/entry_point';
 import {EntryPointBundle} from '../packages/entry_point_bundle';
 import {FileToWrite} from '../rendering/utils';
@@ -17,4 +18,13 @@ export interface FileWriter {
   writeBundle(
       bundle: EntryPointBundle, transformedFiles: FileToWrite[],
       formatProperties: EntryPointJsonProperty[]): void;
+
+  /**
+   * Revert the change to a file written by the same `FileWriter` implementation.
+   *
+   * @param filePath The original path of a transformed file. (The transformed file maybe written
+   *     at the same or a different location, depending on the `FileWriter` implementation.)
+   * @param packagePath The path to the package that contains the entry-point including the file.
+   */
+  revertFile(filePath: AbsoluteFsPath, packagePath: AbsoluteFsPath): void;
 }

--- a/packages/compiler-cli/ngcc/src/writing/file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/file_writer.ts
@@ -7,7 +7,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AbsoluteFsPath} from '../../../src/ngtsc/file_system';
-import {EntryPointJsonProperty} from '../packages/entry_point';
+import {EntryPoint, EntryPointJsonProperty} from '../packages/entry_point';
 import {EntryPointBundle} from '../packages/entry_point_bundle';
 import {FileToWrite} from '../rendering/utils';
 
@@ -20,11 +20,16 @@ export interface FileWriter {
       formatProperties: EntryPointJsonProperty[]): void;
 
   /**
-   * Revert the change to a file written by the same `FileWriter` implementation.
+   * Revert the changes to an entry-point processed for the specified format-properties by the same
+   * `FileWriter` implementation.
    *
-   * @param filePath The original path of a transformed file. (The transformed file maybe written
-   *     at the same or a different location, depending on the `FileWriter` implementation.)
-   * @param packagePath The path to the package that contains the entry-point including the file.
+   * @param entryPoint The entry-point to revert.
+   * @param transformedFilePaths The original paths of the transformed files. (The transformed files
+   *     may be written at the same or a different location, depending on the `FileWriter`
+   *     implementation.)
+   * @param formatProperties The format-properties pointing to the entry-point.
    */
-  revertFile(filePath: AbsoluteFsPath, packagePath: AbsoluteFsPath): void;
+  revertBundle(
+      entryPoint: EntryPoint, transformedFilePaths: AbsoluteFsPath[],
+      formatProperties: EntryPointJsonProperty[]): void;
 }

--- a/packages/compiler-cli/ngcc/src/writing/in_place_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/in_place_file_writer.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {absoluteFrom, dirname, FileSystem} from '../../../src/ngtsc/file_system';
+import {absoluteFrom, AbsoluteFsPath, dirname, FileSystem} from '../../../src/ngtsc/file_system';
 import {Logger} from '../logging/logger';
 import {EntryPointJsonProperty} from '../packages/entry_point';
 import {EntryPointBundle} from '../packages/entry_point_bundle';
@@ -27,6 +27,17 @@ export class InPlaceFileWriter implements FileWriter {
       _bundle: EntryPointBundle, transformedFiles: FileToWrite[],
       _formatProperties?: EntryPointJsonProperty[]) {
     transformedFiles.forEach(file => this.writeFileAndBackup(file));
+  }
+
+  revertFile(filePath: AbsoluteFsPath, _packagePath: AbsoluteFsPath): void {
+    if (this.fs.exists(filePath)) {
+      this.fs.removeFile(filePath);
+
+      const backPath = absoluteFrom(`${filePath}${NGCC_BACKUP_EXTENSION}`);
+      if (this.fs.exists(backPath)) {
+        this.fs.moveFile(backPath, filePath);
+      }
+    }
   }
 
   protected writeFileAndBackup(file: FileToWrite): void {

--- a/packages/compiler-cli/ngcc/src/writing/in_place_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/in_place_file_writer.ts
@@ -7,7 +7,7 @@
  */
 import {absoluteFrom, AbsoluteFsPath, dirname, FileSystem} from '../../../src/ngtsc/file_system';
 import {Logger} from '../logging/logger';
-import {EntryPointJsonProperty} from '../packages/entry_point';
+import {EntryPoint, EntryPointJsonProperty} from '../packages/entry_point';
 import {EntryPointBundle} from '../packages/entry_point_bundle';
 import {FileToWrite} from '../rendering/utils';
 
@@ -29,14 +29,11 @@ export class InPlaceFileWriter implements FileWriter {
     transformedFiles.forEach(file => this.writeFileAndBackup(file));
   }
 
-  revertFile(filePath: AbsoluteFsPath, _packagePath: AbsoluteFsPath): void {
-    if (this.fs.exists(filePath)) {
-      this.fs.removeFile(filePath);
-
-      const backPath = absoluteFrom(`${filePath}${NGCC_BACKUP_EXTENSION}`);
-      if (this.fs.exists(backPath)) {
-        this.fs.moveFile(backPath, filePath);
-      }
+  revertBundle(
+      _entryPoint: EntryPoint, transformedFilePaths: AbsoluteFsPath[],
+      _formatProperties: EntryPointJsonProperty[]): void {
+    for (const filePath of transformedFilePaths) {
+      this.revertFileAndBackup(filePath);
     }
   }
 
@@ -60,6 +57,17 @@ export class InPlaceFileWriter implements FileWriter {
         this.fs.moveFile(file.path, backPath);
       }
       this.fs.writeFile(file.path, file.contents);
+    }
+  }
+
+  protected revertFileAndBackup(filePath: AbsoluteFsPath): void {
+    if (this.fs.exists(filePath)) {
+      this.fs.removeFile(filePath);
+
+      const backPath = absoluteFrom(`${filePath}${NGCC_BACKUP_EXTENSION}`);
+      if (this.fs.exists(backPath)) {
+        this.fs.moveFile(backPath, filePath);
+      }
     }
   }
 }

--- a/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
@@ -54,7 +54,7 @@ export class NewEntryPointFileWriter extends InPlaceFileWriter {
     // are identical to the original ones and they will be overwritten when re-processing the
     // entry-point anyway.
     //
-    // This way, we avoid the overhed of having to inform the master process about all source files
+    // This way, we avoid the overhead of having to inform the master process about all source files
     // being copied in `copyBundle()`.
 
     // Revert the transformed files.

--- a/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
@@ -45,15 +45,25 @@ export class NewEntryPointFileWriter extends InPlaceFileWriter {
     this.updatePackageJson(entryPoint, formatProperties, ngccFolder);
   }
 
-  revertFile(filePath: AbsoluteFsPath, packagePath: AbsoluteFsPath): void {
-    if (isDtsPath(filePath.replace(/\.map$/, ''))) {
-      // This is either `.d.ts` or `.d.ts.map` file
-      super.revertFile(filePath, packagePath);
-    } else if (this.fs.exists(filePath)) {
-      const relativePath = relative(packagePath, filePath);
-      const newFilePath = join(packagePath, NGCC_DIRECTORY, relativePath);
-      this.fs.removeFile(newFilePath);
+  revertBundle(
+      entryPoint: EntryPoint, transformedFilePaths: AbsoluteFsPath[],
+      formatProperties: EntryPointJsonProperty[]): void {
+    // IMPLEMENTATION NOTE:
+    //
+    // The changes made by `copyBundle()` are not reverted here. The non-transformed copied files
+    // are identical to the original ones and they will be overwritten when re-processing the
+    // entry-point anyway.
+    //
+    // This way, we avoid the overhed of having to inform the master process about all source files
+    // being copied in `copyBundle()`.
+
+    // Revert the transformed files.
+    for (const filePath of transformedFilePaths) {
+      this.revertFile(filePath, entryPoint.package);
     }
+
+    // Revert any changes to `package.json`.
+    this.revertPackageJson(entryPoint, formatProperties);
   }
 
   protected copyBundle(
@@ -79,6 +89,17 @@ export class NewEntryPointFileWriter extends InPlaceFileWriter {
       const newFilePath = join(ngccFolder, relativePath);
       this.fs.ensureDir(dirname(newFilePath));
       this.fs.writeFile(newFilePath, file.contents);
+    }
+  }
+
+  protected revertFile(filePath: AbsoluteFsPath, packagePath: AbsoluteFsPath): void {
+    if (isDtsPath(filePath.replace(/\.map$/, ''))) {
+      // This is either `.d.ts` or `.d.ts.map` file
+      super.revertFileAndBackup(filePath);
+    } else if (this.fs.exists(filePath)) {
+      const relativePath = relative(packagePath, filePath);
+      const newFilePath = join(packagePath, NGCC_DIRECTORY, relativePath);
+      this.fs.removeFile(newFilePath);
     }
   }
 
@@ -112,6 +133,27 @@ export class NewEntryPointFileWriter extends InPlaceFileWriter {
 
       update.addChange(
           [`${formatProperty}${NGCC_PROPERTY_EXTENSION}`], newFormatPath, {before: formatProperty});
+    }
+
+    update.writeChanges(packageJsonPath, packageJson);
+  }
+
+  protected revertPackageJson(entryPoint: EntryPoint, formatProperties: EntryPointJsonProperty[]) {
+    if (formatProperties.length === 0) {
+      // No format properties need reverting.
+      return;
+    }
+
+    const packageJson = entryPoint.packageJson;
+    const packageJsonPath = join(entryPoint.path, 'package.json');
+
+    // Revert all properties in `package.json` (both in memory and on disk).
+    // Since `updatePackageJson()` only adds properties, it is safe to just remove them (if they
+    // exist).
+    const update = this.pkgJsonUpdater.createUpdate();
+
+    for (const formatProperty of formatProperties) {
+      update.addChange([`${formatProperty}${NGCC_PROPERTY_EXTENSION}`], undefined);
     }
 
     update.writeChanges(packageJsonPath, packageJson);

--- a/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
@@ -45,6 +45,17 @@ export class NewEntryPointFileWriter extends InPlaceFileWriter {
     this.updatePackageJson(entryPoint, formatProperties, ngccFolder);
   }
 
+  revertFile(filePath: AbsoluteFsPath, packagePath: AbsoluteFsPath): void {
+    if (isDtsPath(filePath.replace(/\.map$/, ''))) {
+      // This is either `.d.ts` or `.d.ts.map` file
+      super.revertFile(filePath, packagePath);
+    } else if (this.fs.exists(filePath)) {
+      const relativePath = relative(packagePath, filePath);
+      const newFilePath = join(packagePath, NGCC_DIRECTORY, relativePath);
+      this.fs.removeFile(newFilePath);
+    }
+  }
+
   protected copyBundle(
       bundle: EntryPointBundle, packagePath: AbsoluteFsPath, ngccFolder: AbsoluteFsPath) {
     bundle.src.program.getSourceFiles().forEach(sourceFile => {

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
@@ -13,10 +13,10 @@ import {DtsDependencyHost} from '../../src/dependencies/dts_dependency_host';
 import {EsmDependencyHost} from '../../src/dependencies/esm_dependency_host';
 import {ModuleResolver} from '../../src/dependencies/module_resolver';
 import {DirectoryWalkerEntryPointFinder} from '../../src/entry_point_finder/directory_walker_entry_point_finder';
-import {PathMappings} from '../../src/ngcc_options';
 import {NgccConfiguration} from '../../src/packages/configuration';
 import {EntryPoint} from '../../src/packages/entry_point';
 import {EntryPointManifest, EntryPointManifestFile} from '../../src/packages/entry_point_manifest';
+import {PathMappings} from '../../src/path_mappings';
 import {MockLogger} from '../helpers/mock_logger';
 
 runInEachFileSystem(() => {

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
@@ -13,10 +13,10 @@ import {DtsDependencyHost} from '../../src/dependencies/dts_dependency_host';
 import {EsmDependencyHost} from '../../src/dependencies/esm_dependency_host';
 import {ModuleResolver} from '../../src/dependencies/module_resolver';
 import {TargetedEntryPointFinder} from '../../src/entry_point_finder/targeted_entry_point_finder';
-import {PathMappings} from '../../src/ngcc_options';
 import {NGCC_VERSION} from '../../src/packages/build_marker';
 import {NgccConfiguration} from '../../src/packages/configuration';
 import {EntryPoint} from '../../src/packages/entry_point';
+import {PathMappings} from '../../src/path_mappings';
 import {MockLogger} from '../helpers/mock_logger';
 
 runInEachFileSystem(() => {

--- a/packages/compiler-cli/ngcc/test/execution/cluster/executor_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/cluster/executor_spec.ts
@@ -15,6 +15,7 @@ import {MockFileSystemNative, runInEachFileSystem} from '../../../../src/ngtsc/f
 import {ClusterExecutor} from '../../../src/execution/cluster/executor';
 import {ClusterMaster} from '../../../src/execution/cluster/master';
 import {AsyncLocker} from '../../../src/locking/async_locker';
+import {FileWriter} from '../../../src/writing/file_writer';
 import {PackageJsonUpdater} from '../../../src/writing/package_json_updater';
 import {MockLockFile} from '../../helpers/mock_lock_file';
 import {MockLogger} from '../../helpers/mock_logger';
@@ -41,8 +42,8 @@ runInEachFileSystem(() => {
       mockLockFile = new MockLockFile(new MockFileSystemNative(), lockFileLog);
       locker = new AsyncLocker(mockLockFile, mockLogger, 200, 2);
       executor = new ClusterExecutor(
-          42, getFileSystem(), mockLogger, null as unknown as PackageJsonUpdater, locker,
-          createTaskCompletedCallback);
+          42, getFileSystem(), mockLogger, null as unknown as FileWriter,
+          null as unknown as PackageJsonUpdater, locker, createTaskCompletedCallback);
     });
 
     describe('execute()', () => {
@@ -98,8 +99,8 @@ runInEachFileSystem(() => {
         });
 
         executor = new ClusterExecutor(
-            42, getFileSystem(), mockLogger, null as unknown as PackageJsonUpdater, locker,
-            createTaskCompletedCallback);
+            42, getFileSystem(), mockLogger, null as unknown as FileWriter,
+            null as unknown as PackageJsonUpdater, locker, createTaskCompletedCallback);
         let error = '';
         try {
           await executor.execute(anyFn, anyFn);
@@ -118,8 +119,8 @@ runInEachFileSystem(() => {
         });
 
         executor = new ClusterExecutor(
-            42, getFileSystem(), mockLogger, null as unknown as PackageJsonUpdater, locker,
-            createTaskCompletedCallback);
+            42, getFileSystem(), mockLogger, null as unknown as FileWriter,
+            null as unknown as PackageJsonUpdater, locker, createTaskCompletedCallback);
         let error = '';
         try {
           await executor.execute(anyFn, anyFn);

--- a/packages/compiler-cli/ngcc/test/execution/cluster/package_json_updater_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/cluster/package_json_updater_spec.ts
@@ -87,25 +87,34 @@ runInEachFileSystem(() => {
                                          .writeChanges(jsonPath, parsed);
 
         writeToProp(['foo']);
-        expect(processSendSpy).toHaveBeenCalledWith({
-          type: 'update-package-json',
-          packageJsonPath: jsonPath,
-          changes: [[['foo'], 'updated', 'unimportant']],
-        });
+        expect(processSendSpy)
+            .toHaveBeenCalledWith(
+                {
+                  type: 'update-package-json',
+                  packageJsonPath: jsonPath,
+                  changes: [[['foo'], 'updated', 'unimportant']],
+                },
+                jasmine.any(Function));
 
         writeToProp(['bar'], {before: 'foo'});
-        expect(processSendSpy).toHaveBeenCalledWith({
-          type: 'update-package-json',
-          packageJsonPath: jsonPath,
-          changes: [[['bar'], 'updated', {before: 'foo'}]],
-        });
+        expect(processSendSpy)
+            .toHaveBeenCalledWith(
+                {
+                  type: 'update-package-json',
+                  packageJsonPath: jsonPath,
+                  changes: [[['bar'], 'updated', {before: 'foo'}]],
+                },
+                jasmine.any(Function));
 
         writeToProp(['bar', 'baz', 'qux'], 'alphabetic', {});
-        expect(processSendSpy).toHaveBeenCalledWith({
-          type: 'update-package-json',
-          packageJsonPath: jsonPath,
-          changes: [[['bar', 'baz', 'qux'], 'updated', 'alphabetic']],
-        });
+        expect(processSendSpy)
+            .toHaveBeenCalledWith(
+                {
+                  type: 'update-package-json',
+                  packageJsonPath: jsonPath,
+                  changes: [[['bar', 'baz', 'qux'], 'updated', 'alphabetic']],
+                },
+                jasmine.any(Function));
       });
 
       it('should update an in-memory representation (if provided)', () => {

--- a/packages/compiler-cli/ngcc/test/execution/cluster/worker_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/cluster/worker_spec.ts
@@ -57,12 +57,12 @@ describe('startWorker()', () => {
 
     it('should create the `compileFn()`', () => {
       startWorker(mockLogger, createCompileFnSpy);
-      expect(createCompileFnSpy).toHaveBeenCalledWith(jasmine.any(Function));
+      expect(createCompileFnSpy).toHaveBeenCalledWith(jasmine.any(Function), jasmine.any(Function));
     });
 
     it('should set up `compileFn()` to send `task-completed` messages to master', () => {
       startWorker(mockLogger, createCompileFnSpy);
-      const onTaskCompleted: TaskCompletedCallback = createCompileFnSpy.calls.argsFor(0)[0];
+      const onTaskCompleted: TaskCompletedCallback = createCompileFnSpy.calls.argsFor(0)[1];
 
       onTaskCompleted(null as any, TaskProcessingOutcome.Processed, null);
       expect(processSendSpy).toHaveBeenCalledTimes(1);

--- a/packages/compiler-cli/ngcc/test/execution/single_processor_executor_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/single_processor_executor_spec.ts
@@ -44,7 +44,7 @@ describe('SingleProcessExecutor', () => {
         tasksCount--;
         return {};
       },
-      markTaskCompleted(_task: Task) {},
+      markAsCompleted(_task: Task) {},
     };
   };
 

--- a/packages/compiler-cli/ngcc/test/execution/single_processor_executor_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/single_processor_executor_spec.ts
@@ -132,14 +132,15 @@ describe('SingleProcessExecutor', () => {
           {allTasksCompleted: true, getNextTask: jasmine.any(Function)})]);
     });
 
-    it('should pass the created TaskCompletedCallback to the createCompileFn', () => {
+    it('should pass the necessary callbacks to createCompileFn', () => {
+      const beforeWritingFiles = jasmine.any(Function);
+      const onTaskCompleted = () => {};
       const createCompileFn =
           jasmine.createSpy('createCompileFn').and.returnValue(function compileFn() {});
-      function onTaskCompleted() {}
       createTaskCompletedCallback.and.returnValue(onTaskCompleted);
       executor.execute(noTasks, createCompileFn);
       expect(createCompileFn).toHaveBeenCalledTimes(1);
-      expect(createCompileFn).toHaveBeenCalledWith(onTaskCompleted);
+      expect(createCompileFn).toHaveBeenCalledWith(beforeWritingFiles, onTaskCompleted);
     });
   });
 });

--- a/packages/compiler-cli/ngcc/test/execution/tasks/queues/parallel_task_queue_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/tasks/queues/parallel_task_queue_spec.ts
@@ -312,6 +312,57 @@ describe('ParallelTaskQueue', () => {
        });
   });
 
+  describe('markTaskUnprocessed()', () => {
+    it('should mark an in-progress task as unprocessed, so that it can be picked again', () => {
+      const {queue} = createQueue(2);
+
+      const task1 = queue.getNextTask()!;
+      const task2 = queue.getNextTask()!;
+      expect(queue.allTasksCompleted).toBe(false);
+
+      queue.markTaskUnprocessed(task1);
+      queue.markTaskCompleted(task2);
+      expect(queue.allTasksCompleted).toBe(false);
+
+      expect(queue.getNextTask()).toBe(task1);
+      expect(queue.allTasksCompleted).toBe(false);
+
+      queue.markTaskCompleted(task1);
+      expect(queue.allTasksCompleted).toBe(true);
+    });
+
+    it('should throw, if the specified task is not in progress', () => {
+      const {tasks, queue} = createQueue(3);
+      queue.getNextTask();
+
+      expect(() => queue.markTaskUnprocessed(tasks[2]))
+          .toThrowError(
+              `Trying to mark task that was not in progress as unprocessed: ` +
+              `{entryPoint: entry-point-2, formatProperty: prop-0, processDts: true}`);
+    });
+
+    it('should not remove the unprocessed task from the lists of blocking tasks', () => {
+      const {tasks, queue} = createQueue(3, 1, {
+        0: [],      // Entry-point #0 does not depend on anything.
+        1: [0],     // Entry-point #1 depends on #0.
+        2: [0, 1],  // Entry-point #2 depends on #0 and #1.
+      });
+
+      // Pick task #0 first, since it is the only one that is not blocked by other tasks.
+      expect(queue.getNextTask()).toBe(tasks[0]);
+
+      // No task available, until task #0 is completed.
+      expect(queue.getNextTask()).toBe(null);
+
+      // Put task #0 back to the unprocessed tasks.
+      queue.markTaskUnprocessed(tasks[0]);
+      expect(queue.getNextTask()).toBe(tasks[0]);
+
+      // Other tasks are still blocked on task #0.
+      expect(queue.getNextTask()).toBe(null);
+    });
+  });
+
   describe('toString()', () => {
     it('should include the `TaskQueue` constructor\'s name', () => {
       const {queue} = createQueue(0);

--- a/packages/compiler-cli/ngcc/test/execution/tasks/queues/parallel_task_queue_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/tasks/queues/parallel_task_queue_spec.ts
@@ -312,7 +312,7 @@ describe('ParallelTaskQueue', () => {
        });
   });
 
-  describe('markTaskUnprocessed()', () => {
+  describe('markAsUnprocessed()', () => {
     it('should mark an in-progress task as unprocessed, so that it can be picked again', () => {
       const {queue} = createQueue(2);
 
@@ -320,7 +320,7 @@ describe('ParallelTaskQueue', () => {
       const task2 = queue.getNextTask()!;
       expect(queue.allTasksCompleted).toBe(false);
 
-      queue.markTaskUnprocessed(task1);
+      queue.markAsUnprocessed(task1);
       queue.markTaskCompleted(task2);
       expect(queue.allTasksCompleted).toBe(false);
 
@@ -334,8 +334,16 @@ describe('ParallelTaskQueue', () => {
     it('should throw, if the specified task is not in progress', () => {
       const {tasks, queue} = createQueue(3);
       queue.getNextTask();
+      queue.markAsCompleted(tasks[0]);
 
-      expect(() => queue.markTaskUnprocessed(tasks[2]))
+      // Try with a task that is already completed.
+      expect(() => queue.markAsUnprocessed(tasks[0]))
+          .toThrowError(
+              `Trying to mark task that was not in progress as unprocessed: ` +
+              `{entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}`);
+
+      // Try with a task that is not yet started.
+      expect(() => queue.markAsUnprocessed(tasks[2]))
           .toThrowError(
               `Trying to mark task that was not in progress as unprocessed: ` +
               `{entryPoint: entry-point-2, formatProperty: prop-0, processDts: true}`);
@@ -355,7 +363,7 @@ describe('ParallelTaskQueue', () => {
       expect(queue.getNextTask()).toBe(null);
 
       // Put task #0 back to the unprocessed tasks.
-      queue.markTaskUnprocessed(tasks[0]);
+      queue.markAsUnprocessed(tasks[0]);
       expect(queue.getNextTask()).toBe(tasks[0]);
 
       // Other tasks are still blocked on task #0.

--- a/packages/compiler-cli/ngcc/test/execution/tasks/queues/serial_task_queue_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/tasks/queues/serial_task_queue_spec.ts
@@ -51,7 +51,7 @@ describe('SerialTaskQueue', () => {
    */
   const processNextTask = (queue: TaskQueue): ReturnType<TaskQueue['getNextTask']> => {
     const task = queue.getNextTask();
-    if (task !== null) queue.markTaskCompleted(task);
+    if (task !== null) queue.markAsCompleted(task);
     return task;
   };
 
@@ -135,14 +135,14 @@ describe('SerialTaskQueue', () => {
     });
   });
 
-  describe('markTaskCompleted()', () => {
+  describe('markAsCompleted()', () => {
     it('should mark a task as completed, so that the next task can be picked', () => {
       const {queue} = createQueue(3);
       const task = queue.getNextTask()!;
 
       expect(() => queue.getNextTask()).toThrow();
 
-      queue.markTaskCompleted(task);
+      queue.markAsCompleted(task);
       expect(() => queue.getNextTask()).not.toThrow();
     });
 
@@ -150,7 +150,7 @@ describe('SerialTaskQueue', () => {
       const {tasks, queue} = createQueue(3);
       queue.getNextTask();
 
-      expect(() => queue.markTaskCompleted(tasks[2]))
+      expect(() => queue.markAsCompleted(tasks[2]))
           .toThrowError(
               `Trying to mark task that was not in progress as completed: ` +
               `{entryPoint: entry-point-2, formatProperty: prop-2, processDts: true}`);
@@ -206,7 +206,7 @@ describe('SerialTaskQueue', () => {
 
       expect(queue2.toString()).toContain('  All tasks completed: false\n');
 
-      queue2.markTaskCompleted(task);
+      queue2.markAsCompleted(task);
       expect(queue2.toString()).toContain('  All tasks completed: true\n');
     });
 
@@ -226,14 +226,14 @@ describe('SerialTaskQueue', () => {
               '    - {entryPoint: entry-point-1, formatProperty: prop-1, processDts: false}\n' +
               '    - {entryPoint: entry-point-2, formatProperty: prop-2, processDts: true}\n');
 
-      queue.markTaskCompleted(task1);
+      queue.markAsCompleted(task1);
       const task2 = queue.getNextTask()!;
       expect(queue.toString())
           .toContain(
               '  Unprocessed tasks (1): \n' +
               '    - {entryPoint: entry-point-2, formatProperty: prop-2, processDts: true}\n');
 
-      queue.markTaskCompleted(task2);
+      queue.markAsCompleted(task2);
       processNextTask(queue);
       expect(queue.toString()).toContain('  Unprocessed tasks (0): \n');
     });
@@ -248,14 +248,14 @@ describe('SerialTaskQueue', () => {
               '  In-progress tasks (1): \n' +
               '    - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}');
 
-      queue.markTaskCompleted(task1);
+      queue.markAsCompleted(task1);
       const task2 = queue.getNextTask()!;
       expect(queue.toString())
           .toContain(
               '  In-progress tasks (1): \n' +
               '    - {entryPoint: entry-point-1, formatProperty: prop-1, processDts: false}');
 
-      queue.markTaskCompleted(task2);
+      queue.markAsCompleted(task2);
       processNextTask(queue);
       expect(queue.toString()).toContain('  In-progress tasks (0): ');
     });
@@ -291,7 +291,7 @@ describe('SerialTaskQueue', () => {
               '  In-progress tasks (1): \n' +
               '    - {entryPoint: entry-point-1, formatProperty: prop-1, processDts: false}');
 
-      queue2.markTaskCompleted(task);
+      queue2.markAsCompleted(task);
       processNextTask(queue2);
       expect(queue2.toString())
           .toBe(

--- a/packages/compiler-cli/ngcc/test/execution/tasks/queues/serial_task_queue_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/tasks/queues/serial_task_queue_spec.ts
@@ -157,22 +157,30 @@ describe('SerialTaskQueue', () => {
     });
   });
 
-  describe('markTaskUnprocessed()', () => {
+  describe('markAsUnprocessed()', () => {
     it('should mark an in-progress task as unprocessed, so that it can be picked again', () => {
       const {queue} = createQueue(3);
       const task = queue.getNextTask()!;
 
       expect(() => queue.getNextTask()).toThrow();
 
-      queue.markTaskUnprocessed(task);
+      queue.markAsUnprocessed(task);
       expect(queue.getNextTask()).toBe(task);
     });
 
     it('should throw, if the specified task is not in progress', () => {
       const {tasks, queue} = createQueue(3);
       queue.getNextTask();
+      queue.markAsCompleted(tasks[0]);
 
-      expect(() => queue.markTaskUnprocessed(tasks[2]))
+      // Try with a task that is already completed.
+      expect(() => queue.markAsUnprocessed(tasks[0]))
+          .toThrowError(
+              `Trying to mark task that was not in progress as unprocessed: ` +
+              `{entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}`);
+
+      // Try with a task that is not yet started.
+      expect(() => queue.markAsUnprocessed(tasks[2]))
           .toThrowError(
               `Trying to mark task that was not in progress as unprocessed: ` +
               `{entryPoint: entry-point-2, formatProperty: prop-2, processDts: true}`);

--- a/packages/compiler-cli/ngcc/test/execution/tasks/queues/serial_task_queue_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/tasks/queues/serial_task_queue_spec.ts
@@ -157,6 +157,28 @@ describe('SerialTaskQueue', () => {
     });
   });
 
+  describe('markTaskUnprocessed()', () => {
+    it('should mark an in-progress task as unprocessed, so that it can be picked again', () => {
+      const {queue} = createQueue(3);
+      const task = queue.getNextTask()!;
+
+      expect(() => queue.getNextTask()).toThrow();
+
+      queue.markTaskUnprocessed(task);
+      expect(queue.getNextTask()).toBe(task);
+    });
+
+    it('should throw, if the specified task is not in progress', () => {
+      const {tasks, queue} = createQueue(3);
+      queue.getNextTask();
+
+      expect(() => queue.markTaskUnprocessed(tasks[2]))
+          .toThrowError(
+              `Trying to mark task that was not in progress as unprocessed: ` +
+              `{entryPoint: entry-point-2, formatProperty: prop-2, processDts: true}`);
+    });
+  });
+
   describe('toString()', () => {
     it('should include the `TaskQueue` constructor\'s name', () => {
       const {queue} = createQueue(0);

--- a/packages/compiler-cli/ngcc/test/writing/in_place_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/in_place_file_writer_spec.ts
@@ -127,7 +127,7 @@ runInEachFileSystem(() => {
         expect(fs.exists(fileBackupPath)).toBeFalse();
       });
 
-      it('should only revert the written file if there is no backup', () => {
+      it('should just remove the written file if there is no backup', () => {
         const fs = getFileSystem();
         const logger = new MockLogger();
         const fileWriter = new InPlaceFileWriter(fs, logger, /* errorOnFailedEntryPoint */ true);

--- a/packages/compiler-cli/ngcc/test/writing/in_place_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/in_place_file_writer_spec.ts
@@ -9,7 +9,7 @@ import {absoluteFrom, getFileSystem} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadTestFiles} from '../../../test/helpers';
 import {EntryPointBundle} from '../../src/packages/entry_point_bundle';
-import {InPlaceFileWriter} from '../../src/writing/in_place_file_writer';
+import {InPlaceFileWriter, NGCC_BACKUP_EXTENSION} from '../../src/writing/in_place_file_writer';
 import {MockLogger} from '../helpers/mock_logger';
 
 runInEachFileSystem(() => {
@@ -29,77 +29,140 @@ runInEachFileSystem(() => {
       ]);
     });
 
-    it('should write all the FileInfo to the disk', () => {
-      const fs = getFileSystem();
-      const logger = new MockLogger();
-      const fileWriter = new InPlaceFileWriter(fs, logger, /* errorOnFailedEntryPoint */ true);
-      fileWriter.writeBundle({} as EntryPointBundle, [
-        {path: _('/package/path/top-level.js'), contents: 'MODIFIED TOP LEVEL'},
-        {path: _('/package/path/folder-1/file-1.js'), contents: 'MODIFIED FILE 1'},
-        {path: _('/package/path/folder-2/file-4.js'), contents: 'MODIFIED FILE 4'},
-        {path: _('/package/path/folder-3/file-5.js'), contents: 'NEW FILE 5'},
-      ]);
-      expect(fs.readFile(_('/package/path/top-level.js'))).toEqual('MODIFIED TOP LEVEL');
-      expect(fs.readFile(_('/package/path/folder-1/file-1.js'))).toEqual('MODIFIED FILE 1');
-      expect(fs.readFile(_('/package/path/folder-1/file-2.js'))).toEqual('ORIGINAL FILE 2');
-      expect(fs.readFile(_('/package/path/folder-2/file-3.js'))).toEqual('ORIGINAL FILE 3');
-      expect(fs.readFile(_('/package/path/folder-2/file-4.js'))).toEqual('MODIFIED FILE 4');
-      expect(fs.readFile(_('/package/path/folder-3/file-5.js'))).toEqual('NEW FILE 5');
+    describe('writeBundle()', () => {
+      it('should write all the FileInfo to the disk', () => {
+        const fs = getFileSystem();
+        const logger = new MockLogger();
+        const fileWriter = new InPlaceFileWriter(fs, logger, /* errorOnFailedEntryPoint */ true);
+        fileWriter.writeBundle({} as EntryPointBundle, [
+          {path: _('/package/path/top-level.js'), contents: 'MODIFIED TOP LEVEL'},
+          {path: _('/package/path/folder-1/file-1.js'), contents: 'MODIFIED FILE 1'},
+          {path: _('/package/path/folder-2/file-4.js'), contents: 'MODIFIED FILE 4'},
+          {path: _('/package/path/folder-3/file-5.js'), contents: 'NEW FILE 5'},
+        ]);
+        expect(fs.readFile(_('/package/path/top-level.js'))).toEqual('MODIFIED TOP LEVEL');
+        expect(fs.readFile(_('/package/path/folder-1/file-1.js'))).toEqual('MODIFIED FILE 1');
+        expect(fs.readFile(_('/package/path/folder-1/file-2.js'))).toEqual('ORIGINAL FILE 2');
+        expect(fs.readFile(_('/package/path/folder-2/file-3.js'))).toEqual('ORIGINAL FILE 3');
+        expect(fs.readFile(_('/package/path/folder-2/file-4.js'))).toEqual('MODIFIED FILE 4');
+        expect(fs.readFile(_('/package/path/folder-3/file-5.js'))).toEqual('NEW FILE 5');
+      });
+
+      it('should create backups of all files that previously existed', () => {
+        const fs = getFileSystem();
+        const logger = new MockLogger();
+        const fileWriter = new InPlaceFileWriter(fs, logger, /* errorOnFailedEntryPoint */ true);
+        fileWriter.writeBundle({} as EntryPointBundle, [
+          {path: _('/package/path/top-level.js'), contents: 'MODIFIED TOP LEVEL'},
+          {path: _('/package/path/folder-1/file-1.js'), contents: 'MODIFIED FILE 1'},
+          {path: _('/package/path/folder-2/file-4.js'), contents: 'MODIFIED FILE 4'},
+          {path: _('/package/path/folder-3/file-5.js'), contents: 'NEW FILE 5'},
+        ]);
+        expect(fs.readFile(_('/package/path/top-level.js.__ivy_ngcc_bak')))
+            .toEqual('ORIGINAL TOP LEVEL');
+        expect(fs.readFile(_('/package/path/folder-1/file-1.js.__ivy_ngcc_bak')))
+            .toEqual('ORIGINAL FILE 1');
+        expect(fs.exists(_('/package/path/folder-1/file-2.js.__ivy_ngcc_bak'))).toBe(false);
+        expect(fs.exists(_('/package/path/folder-2/file-3.js.__ivy_ngcc_bak'))).toBe(false);
+        expect(fs.readFile(_('/package/path/folder-2/file-4.js.__ivy_ngcc_bak')))
+            .toEqual('ORIGINAL FILE 4');
+        expect(fs.exists(_('/package/path/folder-3/file-5.js.__ivy_ngcc_bak'))).toBe(false);
+      });
+
+      it('should throw an error if the backup file already exists and errorOnFailedEntryPoint is true',
+         () => {
+           const fs = getFileSystem();
+           const logger = new MockLogger();
+           const fileWriter = new InPlaceFileWriter(fs, logger, /* errorOnFailedEntryPoint */ true);
+           const absoluteBackupPath = _('/package/path/already-backed-up.js');
+           expect(
+               () => fileWriter.writeBundle(
+                   {} as EntryPointBundle,
+                   [{path: absoluteBackupPath, contents: 'MODIFIED BACKED UP'}]))
+               .toThrowError(`Tried to overwrite ${
+                   absoluteBackupPath}.__ivy_ngcc_bak with an ngcc back up file, which is disallowed.`);
+         });
+
+      it('should log an error, and skip writing the file, if the backup file already exists and errorOnFailedEntryPoint is false',
+         () => {
+           const fs = getFileSystem();
+           const logger = new MockLogger();
+           const fileWriter =
+               new InPlaceFileWriter(fs, logger, /* errorOnFailedEntryPoint */ false);
+           const absoluteBackupPath = _('/package/path/already-backed-up.js');
+           fileWriter.writeBundle(
+               {} as EntryPointBundle,
+               [{path: absoluteBackupPath, contents: 'MODIFIED BACKED UP'}]);
+           // Should not have written the new file nor overwritten the backup file.
+           expect(fs.readFile(absoluteBackupPath)).toEqual('ORIGINAL ALREADY BACKED UP');
+           expect(fs.readFile(_(absoluteBackupPath + '.__ivy_ngcc_bak'))).toEqual('BACKED UP');
+           expect(logger.logs.error).toEqual([[
+             `Tried to write ${
+                 absoluteBackupPath}.__ivy_ngcc_bak with an ngcc back up file but it already exists so not writing, nor backing up, ${
+                 absoluteBackupPath}.\n` +
+             `This error may be because two or more entry-points overlap and ngcc has been asked to process some files more than once.\n` +
+             `You should check other entry-points in this package and set up a config to ignore any that you are not using.`
+           ]]);
+         });
     });
 
-    it('should create backups of all files that previously existed', () => {
-      const fs = getFileSystem();
-      const logger = new MockLogger();
-      const fileWriter = new InPlaceFileWriter(fs, logger, /* errorOnFailedEntryPoint */ true);
-      fileWriter.writeBundle({} as EntryPointBundle, [
-        {path: _('/package/path/top-level.js'), contents: 'MODIFIED TOP LEVEL'},
-        {path: _('/package/path/folder-1/file-1.js'), contents: 'MODIFIED FILE 1'},
-        {path: _('/package/path/folder-2/file-4.js'), contents: 'MODIFIED FILE 4'},
-        {path: _('/package/path/folder-3/file-5.js'), contents: 'NEW FILE 5'},
-      ]);
-      expect(fs.readFile(_('/package/path/top-level.js.__ivy_ngcc_bak')))
-          .toEqual('ORIGINAL TOP LEVEL');
-      expect(fs.readFile(_('/package/path/folder-1/file-1.js.__ivy_ngcc_bak')))
-          .toEqual('ORIGINAL FILE 1');
-      expect(fs.exists(_('/package/path/folder-1/file-2.js.__ivy_ngcc_bak'))).toBe(false);
-      expect(fs.exists(_('/package/path/folder-2/file-3.js.__ivy_ngcc_bak'))).toBe(false);
-      expect(fs.readFile(_('/package/path/folder-2/file-4.js.__ivy_ngcc_bak')))
-          .toEqual('ORIGINAL FILE 4');
-      expect(fs.exists(_('/package/path/folder-3/file-5.js.__ivy_ngcc_bak'))).toBe(false);
+    describe('revertFile()', () => {
+      it('should revert a written file (and its backup)', () => {
+        const fs = getFileSystem();
+        const logger = new MockLogger();
+        const fileWriter = new InPlaceFileWriter(fs, logger, /* errorOnFailedEntryPoint */ true);
+
+        const packagePath = _('/package/path');
+        const filePath = _('/package/path/top-level.js');
+        const fileBackupPath = _(`/package/path/top-level.js${NGCC_BACKUP_EXTENSION}`);
+
+        fileWriter.writeBundle({} as EntryPointBundle, [
+          {path: filePath, contents: 'MODIFIED TOP LEVEL'},
+        ]);
+        expect(fs.readFile(filePath)).toBe('MODIFIED TOP LEVEL');
+        expect(fs.readFile(fileBackupPath)).toBe('ORIGINAL TOP LEVEL');
+
+        fileWriter.revertFile(filePath, packagePath);
+        expect(fs.readFile(filePath)).toBe('ORIGINAL TOP LEVEL');
+        expect(fs.exists(fileBackupPath)).toBeFalse();
+      });
+
+      it('should only revert the written file if there is no backup', () => {
+        const fs = getFileSystem();
+        const logger = new MockLogger();
+        const fileWriter = new InPlaceFileWriter(fs, logger, /* errorOnFailedEntryPoint */ true);
+
+        const packagePath = _('/package/path');
+        const filePath = _('/package/path/top-level.js');
+        const fileBackupPath = _(`/package/path/top-level.js${NGCC_BACKUP_EXTENSION}`);
+
+        fileWriter.writeBundle({} as EntryPointBundle, [
+          {path: filePath, contents: 'MODIFIED TOP LEVEL'},
+        ]);
+        fs.removeFile(fileBackupPath);
+        expect(fs.readFile(filePath)).toBe('MODIFIED TOP LEVEL');
+        expect(fs.exists(fileBackupPath)).toBeFalse();
+
+        fileWriter.revertFile(filePath, packagePath);
+        expect(fs.exists(filePath)).toBeFalse();
+        expect(fs.exists(fileBackupPath)).toBeFalse();
+      });
+
+      it('should do nothing if the file does not exist', () => {
+        const fs = getFileSystem();
+        const logger = new MockLogger();
+        const fileWriter = new InPlaceFileWriter(fs, logger, /* errorOnFailedEntryPoint */ true);
+
+        const packagePath = _('/package/path');
+        const filePath = _('/package/path/non-existent.js');
+        const fileBackupPath = _(`/package/path/non-existent.js${NGCC_BACKUP_EXTENSION}`);
+
+        fs.writeFile(fileBackupPath, 'BACKUP WITHOUT FILE');
+        fileWriter.revertFile(filePath, packagePath);
+
+        expect(fs.exists(filePath)).toBeFalse();
+        expect(fs.readFile(fileBackupPath)).toBe('BACKUP WITHOUT FILE');
+      });
     });
-
-    it('should throw an error if the backup file already exists and errorOnFailedEntryPoint is true',
-       () => {
-         const fs = getFileSystem();
-         const logger = new MockLogger();
-         const fileWriter = new InPlaceFileWriter(fs, logger, /* errorOnFailedEntryPoint */ true);
-         const absoluteBackupPath = _('/package/path/already-backed-up.js');
-         expect(
-             () => fileWriter.writeBundle(
-                 {} as EntryPointBundle,
-                 [{path: absoluteBackupPath, contents: 'MODIFIED BACKED UP'}]))
-             .toThrowError(`Tried to overwrite ${
-                 absoluteBackupPath}.__ivy_ngcc_bak with an ngcc back up file, which is disallowed.`);
-       });
-
-    it('should log an error, and skip writing the file, if the backup file already exists and errorOnFailedEntryPoint is false',
-       () => {
-         const fs = getFileSystem();
-         const logger = new MockLogger();
-         const fileWriter = new InPlaceFileWriter(fs, logger, /* errorOnFailedEntryPoint */ false);
-         const absoluteBackupPath = _('/package/path/already-backed-up.js');
-         fileWriter.writeBundle(
-             {} as EntryPointBundle, [{path: absoluteBackupPath, contents: 'MODIFIED BACKED UP'}]);
-         // Should not have written the new file nor overwritten the backup file.
-         expect(fs.readFile(absoluteBackupPath)).toEqual('ORIGINAL ALREADY BACKED UP');
-         expect(fs.readFile(_(absoluteBackupPath + '.__ivy_ngcc_bak'))).toEqual('BACKED UP');
-         expect(logger.logs.error).toEqual([[
-           `Tried to write ${
-               absoluteBackupPath}.__ivy_ngcc_bak with an ngcc back up file but it already exists so not writing, nor backing up, ${
-               absoluteBackupPath}.\n` +
-           `This error may be because two or more entry-points overlap and ngcc has been asked to process some files more than once.\n` +
-           `You should check other entry-points in this package and set up a config to ignore any that you are not using.`
-         ]]);
-       });
   });
 });

--- a/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
@@ -508,7 +508,7 @@ runInEachFileSystem(() => {
         esm5bundle = makeTestBundle(fs, entryPoint, 'module', 'esm5');
       });
 
-      it('should revert a written JS file', () => {
+      it('should remove non-typings files', () => {
         const packagePath = _('/node_modules/test');
         fileWriter.writeBundle(
             esm5bundle,


### PR DESCRIPTION
Several small ngcc fixes; the main one being being able to recover when a worker process crashes.
See individual commit messages for more info.

Jira issue: [FW-2008](https://angular-team.atlassian.net/browse/FW-2008)

Fixes #36278.
