### PR TITLE
build: fix circular deps failure

### DIFF
--- a/goldens/packages-circular-deps.json
+++ b/goldens/packages-circular-deps.json
@@ -1807,9 +1807,10 @@
     "packages/core/src/render3/interfaces/view.ts"
   ],
   [
-    "packages/core/testing/src/r3_test_bed.ts",
+    "packages/core/testing/src/r3_test_bed_compiler.ts",
     "packages/core/testing/src/test_bed_common.ts",
-    "packages/core/testing/src/test_bed.ts"
+    "packages/core/testing/src/test_bed.ts",
+    "packages/core/testing/src/r3_test_bed.ts"
   ],
   [
     "packages/core/testing/src/r3_test_bed.ts",


### PR DESCRIPTION
With the large scale refactoring of the repo to the new version of `clang-format`, some import orders were changed.

Specifically the imports found in [this range](https://github.com/angular/angular/blob/b01084910266deaa7d8e4424398062e6905199e8/packages/core/testing/src/r3_test_bed.ts#L37-L38).

The file previously read: 
```ts
import {TestBed} from './test_bed';
import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, TestBedStatic, TestComponentRenderer, TestModuleMetadata} from './test_bed_common';
import {R3TestBedCompiler} from './r3_test_bed_compiler';
```

and now reads:
```ts
import {R3TestBedCompiler} from './r3_test_bed_compiler';
import {TestBed} from './test_bed';
import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, TestBedStatic, TestComponentRenderer, TestModuleMetadata} from './test_bed_common';
```

This change in order cause the circular dependency to be entered earlier and changed the golden file for our circular deps discovery.