### PR TITLE
docs: template ref variables new behaviour documented

### DIFF
--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -1815,9 +1815,27 @@ The scope of a reference variable is the entire template. So, don't define the s
 You can use the `ref-` prefix alternative to `#`.
 This example declares the `fax` variable as `ref-fax` instead of `#fax`.
 
-
 <code-example path="template-reference-variables/src/app/app.component.html" region="ref-fax" header="src/app/app.component.html"></code-example>
 
+#### Breaking Change (Ivy)
+
+In the View Engine compiler when a template reference variable is declared it can be used any where in the template ie scope of these variables was the entire template.
+
+In Ivy the binding evaluation order is changed to have a simpler / more predictable evaluation order. In this new implementation template reference variables cannot be used before its declaration. For example
+
+```html
+  <h1>Greetings, {{hello.name}}</h1>
+  <hello-comp #hello [name]="'John'"></hello-comp>
+```
+
+In Ivy this does not work.
+
+The correct sequence for using template reference variable in Ivy is
+
+```html
+  <hello-comp #hello [name]="'John'"></hello-comp>
+  <h1>Greetings, {{hello.name}}</h1>
+```
 
 <hr/>
 


### PR DESCRIPTION
Template ref variable's scope used to be the whole template but in Ivy it changed now template reference variables cannot be used before its declaration in template . Documented this behaviour  in template-sytax.md file.

Fixes #34821, #35826

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No documentation of new behaviour for template ref variables.

Issue Number: #34821, #35826


## What is the new behavior?
Documented new behavior for template ref variables.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
