### PR TITLE
[WIP] docs: add docplaster demo for docs team

### DIFF
--- a/aio/content/examples/template-syntax/src/app/app.component.2.ts
+++ b/aio/content/examples/template-syntax/src/app/app.component.2.ts
@@ -1,0 +1,194 @@
+/* tslint:disable:forin member-ordering */
+
+import { AfterViewInit, Component, ElementRef, OnInit, QueryList, ViewChildren } from '@angular/core';
+
+import { Hero } from './hero';
+
+export enum Color {Red, Green, Blue}
+
+/**
+ * Giant grab bag of stuff to drive the chapter
+ */
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: [ './app.component.css' ]
+})
+
+// #docregion no-docplaster
+export class AppComponent implements AfterViewInit, OnInit {
+// #enddocregion no-docplaster
+
+  ngOnInit() {
+    this.resetHeroes();
+    this.setCurrentClasses();
+    this.setCurrentStyles();
+  }
+
+  ngAfterViewInit() {
+    // Detect effects of NgForTrackBy
+    trackChanges(this.heroesNoTrackBy,   () => this.heroesNoTrackByCount++);
+    trackChanges(this.heroesWithTrackBy, () => this.heroesWithTrackByCount++);
+  }
+
+  @ViewChildren('noTrackBy')   heroesNoTrackBy: QueryList<ElementRef>;
+  @ViewChildren('withTrackBy') heroesWithTrackBy: QueryList<ElementRef>;
+
+  actionName = 'Go for it';
+  badCurly = 'bad curly';
+  classes = 'special';
+  help = '';
+
+  alert(msg?: string)      { window.alert(msg); }
+  callFax(value: string)   { this.alert(`Faxing ${value} ...`); }
+  callPhone(value: string) { this.alert(`Calling ${value} ...`); }
+  canSave =  true;
+
+  changeIds() {
+    this.resetHeroes();
+    this.heroes.forEach(h => h.id += 10 * this.heroIdIncrement++);
+    this.heroesWithTrackByCountReset = -1;
+  }
+
+  clearTrackByCounts() {
+    const trackByCountReset = this.heroesWithTrackByCountReset;
+    this.resetHeroes();
+    this.heroesNoTrackByCount = -1;
+    this.heroesWithTrackByCount = trackByCountReset;
+    this.heroIdIncrement = 1;
+  }
+
+  clicked = '';
+  clickMessage = '';
+  clickMessage2 = '';
+
+  Color = Color;
+  color = Color.Red;
+  colorToggle() {this.color = (this.color === Color.Red) ? Color.Blue : Color.Red; }
+
+  currentHero: Hero;
+
+  updateCurrentHeroName(event: Event) {
+    this.currentHero.name = (event.target as any).value;
+  }
+
+  deleteHero(hero?: Hero) {
+    this.alert(`Delete ${hero ? hero.name : 'the hero'}.`);
+  }
+
+  // #docregion evil-title
+  evilTitle = 'Template <script>alert("evil never sleeps")</script>Syntax';
+  // #enddocregion evil-title
+
+  fontSizePx = 16;
+
+  title = 'Template Syntax';
+
+  getVal(): number { return 2; }
+
+  name: string = Hero.heroes[0].name;
+  hero: Hero; // defined to demonstrate template context precedence
+  heroes: Hero[];
+
+  // trackBy change counting
+  heroesNoTrackByCount   = 0;
+  heroesWithTrackByCount = 0;
+  heroesWithTrackByCountReset = 0;
+
+  heroIdIncrement = 1;
+
+  // heroImageUrl = 'http://www.wpclipart.com/cartoon/people/hero/hero_silhoutte_T.png';
+  // Public Domain terms of use: http://www.wpclipart.com/terms.html
+  heroImageUrl = 'assets/images/hero.png';
+  // villainImageUrl = 'http://www.clker.com/cliparts/u/s/y/L/x/9/villain-man-hi.png'
+  // Public Domain terms of use http://www.clker.com/disclaimer.html
+  villainImageUrl = 'assets/images/villain.png';
+
+  iconUrl = 'assets/images/ng-logo.png';
+  isActive = false;
+  isSpecial = true;
+  isUnchanged = true;
+
+  get nullHero(): Hero { return null; }
+
+  onClickMe(event?: MouseEvent) {
+    const evtMsg = event ? ' Event target class is ' + (event.target as HTMLElement).className  : '';
+    this.alert('Click me.' + evtMsg);
+  }
+
+  onSave(event?: MouseEvent) {
+    const evtMsg = event ? ' Event target is ' + (event.target as HTMLElement).textContent : '';
+    this.alert('Saved.' + evtMsg);
+    if (event) { event.stopPropagation(); }
+  }
+
+  onSubmit(data: any) {/* referenced but not used */}
+
+  product = {
+    name: 'frimfram',
+    price: 42
+  };
+
+  // updates with fresh set of cloned heroes
+  resetHeroes() {
+    this.heroes = Hero.heroes.map(hero => hero.clone());
+    this.currentHero = this.heroes[0];
+    this.hero = this.currentHero;
+    this.heroesWithTrackByCountReset = 0;
+  }
+
+  setUppercaseName(name: string) {
+    this.currentHero.name = name.toUpperCase();
+  }
+
+  // #docregion setClasses
+  currentClasses: {};
+  setCurrentClasses() {
+    // CSS classes: added/removed per current state of component properties
+    this.currentClasses =  {
+      saveable: this.canSave,
+      modified: !this.isUnchanged,
+      special:  this.isSpecial
+    };
+  }
+  // #enddocregion setClasses
+
+  // #docregion setStyles
+  currentStyles: {};
+  setCurrentStyles() {
+    // CSS styles: set per current state of component properties
+    this.currentStyles = {
+      'font-style':  this.canSave      ? 'italic' : 'normal',
+      'font-weight': !this.isUnchanged ? 'bold'   : 'normal',
+      'font-size':   this.isSpecial    ? '24px'   : '12px'
+    };
+  }
+  // #enddocregion setStyles
+
+  // #docregion trackByHeroes
+  trackByHeroes(index: number, hero: Hero): number { return hero.id; }
+  // #enddocregion trackByHeroes
+
+  // #docregion trackById
+  trackById(index: number, item: any): number { return item.id; }
+  // #enddocregion trackById
+}
+
+// helper to track changes to viewChildren
+function trackChanges(views: QueryList<ElementRef>, changed: () => void) {
+  let oldRefs = views.toArray();
+  views.changes.subscribe((changes: QueryList<ElementRef>) => {
+      const changedRefs = changes.toArray();
+      // Check if every changed Element is the same as old and in the same position
+      const isSame = oldRefs.every((v, i) => v.nativeElement === changedRefs[i].nativeElement);
+      if (!isSame) {
+        oldRefs = changedRefs;
+        // wait a tick because called after views are constructed
+        setTimeout(changed, 0);
+      }
+  });
+
+// #docregion no-docplaster
+
+}
+// #enddocregion no-docplaster

--- a/aio/content/examples/template-syntax/src/app/app.component.3.ts
+++ b/aio/content/examples/template-syntax/src/app/app.component.3.ts
@@ -1,0 +1,194 @@
+/* tslint:disable:forin member-ordering */
+// #docplaster
+import { AfterViewInit, Component, ElementRef, OnInit, QueryList, ViewChildren } from '@angular/core';
+
+import { Hero } from './hero';
+
+export enum Color {Red, Green, Blue}
+
+/**
+ * Giant grab bag of stuff to drive the chapter
+ */
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: [ './app.component.css' ]
+})
+
+// #docregion no-docplaster
+export class AppComponent implements AfterViewInit, OnInit {
+// #enddocregion no-docplaster
+
+  ngOnInit() {
+    this.resetHeroes();
+    this.setCurrentClasses();
+    this.setCurrentStyles();
+  }
+
+  ngAfterViewInit() {
+    // Detect effects of NgForTrackBy
+    trackChanges(this.heroesNoTrackBy,   () => this.heroesNoTrackByCount++);
+    trackChanges(this.heroesWithTrackBy, () => this.heroesWithTrackByCount++);
+  }
+
+  @ViewChildren('noTrackBy')   heroesNoTrackBy: QueryList<ElementRef>;
+  @ViewChildren('withTrackBy') heroesWithTrackBy: QueryList<ElementRef>;
+
+  actionName = 'Go for it';
+  badCurly = 'bad curly';
+  classes = 'special';
+  help = '';
+
+  alert(msg?: string)      { window.alert(msg); }
+  callFax(value: string)   { this.alert(`Faxing ${value} ...`); }
+  callPhone(value: string) { this.alert(`Calling ${value} ...`); }
+  canSave =  true;
+
+  changeIds() {
+    this.resetHeroes();
+    this.heroes.forEach(h => h.id += 10 * this.heroIdIncrement++);
+    this.heroesWithTrackByCountReset = -1;
+  }
+
+  clearTrackByCounts() {
+    const trackByCountReset = this.heroesWithTrackByCountReset;
+    this.resetHeroes();
+    this.heroesNoTrackByCount = -1;
+    this.heroesWithTrackByCount = trackByCountReset;
+    this.heroIdIncrement = 1;
+  }
+
+  clicked = '';
+  clickMessage = '';
+  clickMessage2 = '';
+
+  Color = Color;
+  color = Color.Red;
+  colorToggle() {this.color = (this.color === Color.Red) ? Color.Blue : Color.Red; }
+
+  currentHero: Hero;
+
+  updateCurrentHeroName(event: Event) {
+    this.currentHero.name = (event.target as any).value;
+  }
+
+  deleteHero(hero?: Hero) {
+    this.alert(`Delete ${hero ? hero.name : 'the hero'}.`);
+  }
+
+  // #docregion evil-title
+  evilTitle = 'Template <script>alert("evil never sleeps")</script>Syntax';
+  // #enddocregion evil-title
+
+  fontSizePx = 16;
+
+  title = 'Template Syntax';
+
+  getVal(): number { return 2; }
+
+  name: string = Hero.heroes[0].name;
+  hero: Hero; // defined to demonstrate template context precedence
+  heroes: Hero[];
+
+  // trackBy change counting
+  heroesNoTrackByCount   = 0;
+  heroesWithTrackByCount = 0;
+  heroesWithTrackByCountReset = 0;
+
+  heroIdIncrement = 1;
+
+  // heroImageUrl = 'http://www.wpclipart.com/cartoon/people/hero/hero_silhoutte_T.png';
+  // Public Domain terms of use: http://www.wpclipart.com/terms.html
+  heroImageUrl = 'assets/images/hero.png';
+  // villainImageUrl = 'http://www.clker.com/cliparts/u/s/y/L/x/9/villain-man-hi.png'
+  // Public Domain terms of use http://www.clker.com/disclaimer.html
+  villainImageUrl = 'assets/images/villain.png';
+
+  iconUrl = 'assets/images/ng-logo.png';
+  isActive = false;
+  isSpecial = true;
+  isUnchanged = true;
+
+  get nullHero(): Hero { return null; }
+
+  onClickMe(event?: MouseEvent) {
+    const evtMsg = event ? ' Event target class is ' + (event.target as HTMLElement).className  : '';
+    this.alert('Click me.' + evtMsg);
+  }
+
+  onSave(event?: MouseEvent) {
+    const evtMsg = event ? ' Event target is ' + (event.target as HTMLElement).textContent : '';
+    this.alert('Saved.' + evtMsg);
+    if (event) { event.stopPropagation(); }
+  }
+
+  onSubmit(data: any) {/* referenced but not used */}
+
+  product = {
+    name: 'frimfram',
+    price: 42
+  };
+
+  // updates with fresh set of cloned heroes
+  resetHeroes() {
+    this.heroes = Hero.heroes.map(hero => hero.clone());
+    this.currentHero = this.heroes[0];
+    this.hero = this.currentHero;
+    this.heroesWithTrackByCountReset = 0;
+  }
+
+  setUppercaseName(name: string) {
+    this.currentHero.name = name.toUpperCase();
+  }
+
+  // #docregion setClasses
+  currentClasses: {};
+  setCurrentClasses() {
+    // CSS classes: added/removed per current state of component properties
+    this.currentClasses =  {
+      saveable: this.canSave,
+      modified: !this.isUnchanged,
+      special:  this.isSpecial
+    };
+  }
+  // #enddocregion setClasses
+
+  // #docregion setStyles
+  currentStyles: {};
+  setCurrentStyles() {
+    // CSS styles: set per current state of component properties
+    this.currentStyles = {
+      'font-style':  this.canSave      ? 'italic' : 'normal',
+      'font-weight': !this.isUnchanged ? 'bold'   : 'normal',
+      'font-size':   this.isSpecial    ? '24px'   : '12px'
+    };
+  }
+  // #enddocregion setStyles
+
+  // #docregion trackByHeroes
+  trackByHeroes(index: number, hero: Hero): number { return hero.id; }
+  // #enddocregion trackByHeroes
+
+  // #docregion trackById
+  trackById(index: number, item: any): number { return item.id; }
+  // #enddocregion trackById
+}
+
+// helper to track changes to viewChildren
+function trackChanges(views: QueryList<ElementRef>, changed: () => void) {
+  let oldRefs = views.toArray();
+  views.changes.subscribe((changes: QueryList<ElementRef>) => {
+      const changedRefs = changes.toArray();
+      // Check if every changed Element is the same as old and in the same position
+      const isSame = oldRefs.every((v, i) => v.nativeElement === changedRefs[i].nativeElement);
+      if (!isSame) {
+        oldRefs = changedRefs;
+        // wait a tick because called after views are constructed
+        setTimeout(changed, 0);
+      }
+  });
+
+// #docregion no-docplaster
+
+}
+// #enddocregion no-docplaster

--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -6,6 +6,12 @@
   h4 .syntax { font-size: 100%; }
 </style>
 
+<code-example path="template-syntax/src/app/app.component.ts" header="src/app/app.component.html with docplaster"></code-example>
+
+
+<code-example path="template-syntax/src/app/app.component.2.ts" region="no-docplaster" header="src/app/app.component.2.html without docplaster"></code-example>
+
+
 The Angular application manages what the user sees and can do, achieving this through the interaction of a component class instance (the *component*) and its user-facing template.
 
 You may be familiar with the component/template duality from your experience with model-view-controller (MVC) or model-view-viewmodel (MVVM).
@@ -900,12 +906,12 @@ Here's how to set the `class` attribute without a binding in plain HTML:
 
 You can also add and remove CSS class names from an element's `class` attribute with a **class binding**.
 
-To create a single class binding, start with the prefix `class` followed by a dot (`.`) and the name of the CSS class (for example, `[class.foo]="hasFoo"`). 
+To create a single class binding, start with the prefix `class` followed by a dot (`.`) and the name of the CSS class (for example, `[class.foo]="hasFoo"`).
 Angular adds the class when the bound expression is truthy, and it removes the class when the expression is falsy (with the exception of `undefined`, see [styling delegation](#styling-delegation)).
 
 To create a binding to multiple classes, use a generic `[class]` binding without the dot (for example, `[class]="classExpr"`).
-The expression can be a space-delimited string of class names, or you can format it as an object with class names as the keys and truthy/falsy expressions as the values. 
-With object format, Angular will add a class only if its associated value is truthy. 
+The expression can be a space-delimited string of class names, or you can format it as an object with class names as the keys and truthy/falsy expressions as the values.
+With object format, Angular will add a class only if its associated value is truthy.
 
 It's important to note that with any object-like expression (`object`, `Array`, `Map`, `Set`, etc), the identity of the object must change for the class list to be updated.
 Updating the property without changing object identity will have no effect.
@@ -962,7 +968,7 @@ If there are multiple bindings to the same class name, conflicts are resolved us
 </table>
 
 
-The [NgClass](#ngclass) directive can be used as an alternative to direct `[class]` bindings. 
+The [NgClass](#ngclass) directive can be used as an alternative to direct `[class]` bindings.
 However, using the above class binding syntax without `NgClass` is preferred because due to improvements in class binding in Angular, `NgClass` no longer provides significant value, and might eventually be removed in the future.
 
 
@@ -979,7 +985,7 @@ Here's how to set the `style` attribute without a binding in plain HTML:
 
 You can also set styles dynamically with a **style binding**.
 
-To create a single style binding, start with the prefix `style` followed by a dot (`.`) and the name of the CSS style property (for example, `[style.width]="width"`). 
+To create a single style binding, start with the prefix `style` followed by a dot (`.`) and the name of the CSS style property (for example, `[style.width]="width"`).
 The property will be set to the value of the bound expression, which is normally a string.
 Optionally, you can add a unit extension like `em` or `%`, which requires a number type.
 
@@ -992,9 +998,9 @@ Note that a _style property_ name can be written in either
 </div>
 
 If there are multiple styles you'd like to toggle, you can bind to the `[style]` property directly without the dot (for example, `[style]="styleExpr"`).
-The expression attached to the `[style]` binding is most often a string list of styles like `"width: 100px; height: 100px;"`. 
+The expression attached to the `[style]` binding is most often a string list of styles like `"width: 100px; height: 100px;"`.
 
-You can also format the expression as an object with style names as the keys and style values as the values, like `{width: '100px', height: '100px'}`. 
+You can also format the expression as an object with style names as the keys and style values as the values, like `{width: '100px', height: '100px'}`.
 It's important to note that with any object-like expression (`object`, `Array`, `Map`, `Set`, etc), the identity of the object must change for the class list to be updated.
 Updating the property without changing object identity will have no effect.
 
@@ -1056,7 +1062,7 @@ If there are multiple bindings to the same style property, conflicts are resolve
   </tr>
 </table>
 
-The [NgStyle](#ngstyle) directive can be used as an alternative to direct `[style]` bindings. 
+The [NgStyle](#ngstyle) directive can be used as an alternative to direct `[style]` bindings.
 However, using the above style binding syntax without `NgStyle` is preferred because due to improvements in style binding in Angular, `NgStyle` no longer provides significant value, and might eventually be removed in the future.
 
 
@@ -1075,15 +1081,15 @@ When there are multiple bindings to the same class name or style property, Angul
 1. Template bindings
     1. Property binding (for example, `<div [class.foo]="hasFoo">` or `<div [style.color]="color">`)
     1. Map binding (for example, `<div [class]="classExpr">` or `<div [style]="styleExpr">`)
-    1. Static value (for example, `<div class="foo">` or `<div style="color: blue">`) 
+    1. Static value (for example, `<div class="foo">` or `<div style="color: blue">`)
 1. Directive host bindings
     1. Property binding (for example, `host: {'[class.foo]': 'hasFoo'}` or `host: {'[style.color]': 'color'}`)
     1. Map binding (for example, `host: {'[class]': 'classExpr'}` or `host: {'[style]': 'styleExpr'}`)
-    1. Static value (for example, `host: {'class': 'foo'}` or `host: {'style': 'color: blue'}`)    
+    1. Static value (for example, `host: {'class': 'foo'}` or `host: {'style': 'color: blue'}`)
 1. Component host bindings
     1. Property binding (for example, `host: {'[class.foo]': 'hasFoo'}` or `host: {'[style.color]': 'color'}`)
     1. Map binding (for example, `host: {'[class]': 'classExpr'}` or `host: {'[style]': 'styleExpr'}`)
-    1. Static value (for example, `host: {'class': 'foo'}` or `host: {'style': 'color: blue'}`)    
+    1. Static value (for example, `host: {'class': 'foo'}` or `host: {'style': 'color: blue'}`)
 
 </div>
 
@@ -1093,18 +1099,18 @@ A binding to a specific class (for example, `[class.foo]`) will take precedence 
 
 <code-example path="attribute-binding/src/app/app.component.html" region="basic-specificity" header="src/app/app.component.html"></code-example>
 
-Specificity rules also apply when it comes to bindings that originate from different sources. 
+Specificity rules also apply when it comes to bindings that originate from different sources.
 It's possible for an element to have bindings in the template where it's declared, from host bindings on matched directives, and from host bindings on matched components.
 
 Template bindings are the most specific because they apply to the element directly and exclusively, so they have the highest precedence.
 
 Directive host bindings are considered less specific because directives can be used in multiple locations, so they have a lower precedence than template bindings.
 
-Directives often augment component behavior, so host bindings from components have the lowest precedence. 
+Directives often augment component behavior, so host bindings from components have the lowest precedence.
 
 <code-example path="attribute-binding/src/app/app.component.html" region="source-specificity" header="src/app/app.component.html"></code-example>
 
-In addition, bindings take precedence over static attributes. 
+In addition, bindings take precedence over static attributes.
 
 In the following case, `class` and `[class]` have similar specificity, but the `[class]` binding will take precedence because it is dynamic.
 
@@ -1116,7 +1122,7 @@ In the following case, `class` and `[class]` have similar specificity, but the `
 It is possible for higher precedence styles to "delegate" to lower precedence styles using `undefined` values.
 Whereas setting a style property to `null` ensures the style is removed, setting it to `undefined` will cause Angular to fall back to the next-highest precedence binding to that style.
 
-For example, consider the following template: 
+For example, consider the following template:
 
 <code-example path="attribute-binding/src/app/app.component.html" region="style-delegation" header="src/app/app.component.html"></code-example>
 

--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -6,10 +6,12 @@
   h4 .syntax { font-size: 100%; }
 </style>
 
-<code-example path="template-syntax/src/app/app.component.ts" header="src/app/app.component.html with docplaster"></code-example>
+<code-example path="template-syntax/src/app/app.component.ts" header="src/app/app.component.html normal and long"></code-example>
 
 
-<code-example path="template-syntax/src/app/app.component.2.ts" region="no-docplaster" header="src/app/app.component.2.html without docplaster"></code-example>
+<code-example path="template-syntax/src/app/app.component.2.ts" region="no-docplaster" header="src/app/app.component.2.ts without docplaster"></code-example>
+
+<code-example path="template-syntax/src/app/app.component.3.ts" region="no-docplaster" header="src/app/app.component.2.ts with docplaster"></code-example>
 
 
 The Angular application manages what the user sees and can do, achieving this through the interaction of a component class instance (the *component*) and its user-facing template.


### PR DESCRIPTION
### Demo. Not for merge.


An example of docplaster in use. The first code-example uses the whole long file (keeeeeep scrolling). It is unchanged in the PR. 

The second example doesn’t use docplaster, but only a docregion to cut out all that extra code and show /* … */ in its place. 

The third example is identical to the second file, but has docplaster so the  /* ... */ won’t show.

https://pr36645-ea9a364.ngbuilds.io/guide/template-syntax