### PR TITLE
feat(router): Add RouteConfigReady

### DIFF
--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -322,6 +322,15 @@ export declare class RouteConfigLoadStart {
     toString(): string;
 }
 
+export declare class RouteConfigReady {
+    route: Route;
+    routes: Routes;
+    constructor(
+    route: Route,
+    routes: Routes);
+    toString(): string;
+}
+
 export declare class Router {
     config: Routes;
     errorHandler: ErrorHandler;

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -248,7 +248,6 @@ class ApplyRedirects {
       if (route.loadChildren) {
         return this.configLoader.load(ngModule.injector, route)
             .pipe(map((cfg: LoadedRouterConfig) => {
-              route._loadedConfig = cfg;
               return new UrlSegmentGroup(segments, {});
             }));
       }
@@ -303,11 +302,7 @@ class ApplyRedirects {
       return runCanLoadGuard(ngModule.injector, route, segments)
           .pipe(mergeMap((shouldLoad: boolean) => {
             if (shouldLoad) {
-              return this.configLoader.load(ngModule.injector, route)
-                  .pipe(map((cfg: LoadedRouterConfig) => {
-                    route._loadedConfig = cfg;
-                    return cfg;
-                  }));
+              return this.configLoader.load(ngModule.injector, route);
             }
             return canLoadFails(route);
           }));

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Route} from './config';
+import {Route, Routes} from './config';
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
 
 /**
@@ -323,6 +323,22 @@ export class RouteConfigLoadEnd {
       public route: Route) {}
   toString(): string {
     return `RouteConfigLoadEnd(path: ${this.route.path})`;
+  }
+}
+
+/**
+ * An event triggered when a route has been loaded and ready.
+ *
+ * @publicApi
+ */
+export class RouteConfigReady {
+  constructor(
+      /** @docsNotRequired */
+      public route: Route,
+      /** @docsNotRequired */
+      public routes: Routes) {}
+  toString(): string {
+    return `RouteConfigReady(path: ${this.route.path})`;
   }
 }
 

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -11,7 +11,7 @@ export {Data, DeprecatedLoadChildren, LoadChildren, LoadChildrenCallback, QueryP
 export {RouterLink, RouterLinkWithHref} from './directives/router_link';
 export {RouterLinkActive} from './directives/router_link_active';
 export {RouterOutlet} from './directives/router_outlet';
-export {ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized, Scroll} from './events';
+export {ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteConfigReady, RouterEvent, RoutesRecognized, Scroll} from './events';
 export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, Resolve} from './interfaces';
 export {DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
 export {Navigation, NavigationExtras, Router} from './router';

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -14,7 +14,7 @@ import {catchError, filter, finalize, map, switchMap, tap} from 'rxjs/operators'
 import {QueryParamsHandling, Route, Routes, standardizeConfig, validateConfig} from './config';
 import {createRouterState} from './create_router_state';
 import {createUrlTree} from './create_url_tree';
-import {Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, NavigationTrigger, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RoutesRecognized} from './events';
+import {Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, NavigationTrigger, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteConfigReady, RoutesRecognized} from './events';
 import {activateRoutes} from './operators/activate_routes';
 import {applyRedirects} from './operators/apply_redirects';
 import {checkGuards} from './operators/check_guards';
@@ -402,6 +402,8 @@ export class Router {
       loader: NgModuleFactoryLoader, compiler: Compiler, public config: Routes) {
     const onLoadStart = (r: Route) => this.triggerEvent(new RouteConfigLoadStart(r));
     const onLoadEnd = (r: Route) => this.triggerEvent(new RouteConfigLoadEnd(r));
+    const onReady = (r: Route, routes: Routes) =>
+        this.triggerEvent(new RouteConfigReady(r, routes));
 
     this.ngModule = injector.get(NgModuleRef);
     this.console = injector.get(Console);
@@ -413,7 +415,7 @@ export class Router {
     this.rawUrlTree = this.currentUrlTree;
     this.browserUrlTree = this.currentUrlTree;
 
-    this.configLoader = new RouterConfigLoader(loader, compiler, onLoadStart, onLoadEnd);
+    this.configLoader = new RouterConfigLoader(loader, compiler, onLoadStart, onLoadEnd, onReady);
     this.routerState = createEmptyState(this.currentUrlTree, this.rootComponentType);
 
     this.transitions = new BehaviorSubject<NavigationTransition>({

--- a/packages/router/test/apply_redirects.spec.ts
+++ b/packages/router/test/apply_redirects.spec.ts
@@ -193,6 +193,7 @@ describe('applyRedirects', () => {
       const loader = {
         load: (injector: any, p: any) => {
           if (injector !== testModule.injector) throw 'Invalid Injector';
+          (p as any)._loadedConfig = loadedConfig;
           return of(loadedConfig);
         }
       };
@@ -383,7 +384,12 @@ describe('applyRedirects', () => {
     it('should work with absolute redirects', () => {
       const loadedConfig = new LoadedRouterConfig([{path: '', component: ComponentB}], testModule);
 
-      const loader = {load: (injector: any, p: any) => of(loadedConfig)};
+      const loader = {
+        load: (injector: any, p: any) => {
+          (p as any)._loadedConfig = loadedConfig;
+          return of(loadedConfig);
+        }
+      };
 
       const config: Routes =
           [{path: '', pathMatch: 'full', redirectTo: '/a'}, {path: 'a', loadChildren: 'children'}];
@@ -402,6 +408,7 @@ describe('applyRedirects', () => {
         load: (injector: any, p: any) => {
           if (called) throw new Error('Should not be called twice');
           called = true;
+          (p as any)._loadedConfig = loadedConfig;
           return of(loadedConfig);
         }
       };
@@ -416,6 +423,7 @@ describe('applyRedirects', () => {
               r => {
                 expectTreeToBe(r, 'a?k2');
                 expect((config[0] as any)._loadedConfig).toBe(loadedConfig);
+                expect(called).toBeTruthy();
               },
               (e) => {
                 throw 'Should not reach';
@@ -425,7 +433,12 @@ describe('applyRedirects', () => {
     it('should load the configuration of a wildcard route', () => {
       const loadedConfig = new LoadedRouterConfig([{path: '', component: ComponentB}], testModule);
 
-      const loader = {load: (injector: any, p: any) => of(loadedConfig)};
+      const loader = {
+        load: (injector: any, p: any) => {
+          (p as any)._loadedConfig = loadedConfig;
+          return of(loadedConfig);
+        }
+      };
 
       const config: Routes = [{path: '**', loadChildren: 'children'}];
 
@@ -438,7 +451,12 @@ describe('applyRedirects', () => {
     it('should load the configuration after a local redirect from a wildcard route', () => {
       const loadedConfig = new LoadedRouterConfig([{path: '', component: ComponentB}], testModule);
 
-      const loader = {load: (injector: any, p: any) => of(loadedConfig)};
+      const loader = {
+        load: (injector: any, p: Route) => {
+          (p as any)._loadedConfig = loadedConfig;
+          return of(loadedConfig);
+        }
+      };
 
       const config: Routes =
           [{path: 'not-found', loadChildren: 'children'}, {path: '**', redirectTo: 'not-found'}];
@@ -452,7 +470,12 @@ describe('applyRedirects', () => {
     it('should load the configuration after an absolute redirect from a wildcard route', () => {
       const loadedConfig = new LoadedRouterConfig([{path: '', component: ComponentB}], testModule);
 
-      const loader = {load: (injector: any, p: any) => of(loadedConfig)};
+      const loader = {
+        load: (injector: any, p: any) => {
+          (p as any)._loadedConfig = loadedConfig;
+          return of(loadedConfig);
+        }
+      };
 
       const config: Routes =
           [{path: 'not-found', loadChildren: 'children'}, {path: '**', redirectTo: '/not-found'}];

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -12,7 +12,7 @@ import {ChangeDetectionStrategy, Component, Injectable, NgModule, NgModuleFactor
 import {ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DefaultUrlSerializer, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, Navigation, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ParamMap, Params, PreloadAllModules, PreloadingStrategy, PRIMARY_OUTLET, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, Router, RouteReuseStrategy, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
+import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DefaultUrlSerializer, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, Navigation, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ParamMap, Params, PreloadAllModules, PreloadingStrategy, PRIMARY_OUTLET, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteConfigReady, Router, RouteReuseStrategy, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
 import {Observable, Observer, of, Subscription} from 'rxjs';
 import {filter, first, map, tap} from 'rxjs/operators';
 
@@ -3433,6 +3433,7 @@ describe('Integration', () => {
                  [NavigationStart, '/lazyTrue/loaded'],
                  [RouteConfigLoadStart],
                  [RouteConfigLoadEnd],
+                 [RouteConfigReady],
                  [RoutesRecognized, '/lazyTrue/loaded'],
                  [GuardsCheckStart, '/lazyTrue/loaded'],
                  [ChildActivationStart],
@@ -4085,7 +4086,7 @@ describe('Integration', () => {
            })));
 
 
-    it('should emit RouteConfigLoadStart and RouteConfigLoadEnd event when route is lazy loaded',
+    it('should emit RouteConfig[LoadStart|LoadEnd|Ready] event when route is lazy loaded',
        fakeAsync(inject(
            [Router, Location, NgModuleFactoryLoader],
            (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
@@ -4111,10 +4112,11 @@ describe('Integration', () => {
              class LoadedModule {
              }
 
-             const events: Array<RouteConfigLoadStart|RouteConfigLoadEnd> = [];
+             const events: Array<RouteConfigLoadStart|RouteConfigLoadEnd|RouteConfigReady> = [];
 
              router.events.subscribe(e => {
-               if (e instanceof RouteConfigLoadStart || e instanceof RouteConfigLoadEnd) {
+               if (e instanceof RouteConfigLoadStart || e instanceof RouteConfigLoadEnd ||
+                   e instanceof RouteConfigReady) {
                  events.push(e);
                }
              });
@@ -4126,9 +4128,10 @@ describe('Integration', () => {
              router.navigateByUrl('/lazy/loaded/child');
              advance(fixture);
 
-             expect(events.length).toEqual(2);
+             expect(events.length).toEqual(3);
              expect(events[0].toString()).toEqual('RouteConfigLoadStart(path: lazy)');
              expect(events[1].toString()).toEqual('RouteConfigLoadEnd(path: lazy)');
+             expect(events[2].toString()).toEqual('RouteConfigReady(path: lazy)');
            })));
 
     it('throws an error when forRoot() is used in a lazy context',

--- a/packages/router/test/router_preloader.spec.ts
+++ b/packages/router/test/router_preloader.spec.ts
@@ -10,7 +10,7 @@ import {Compiler, Component, NgModule, NgModuleFactoryLoader, NgModuleRef} from 
 import {fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {PreloadAllModules, PreloadingStrategy, RouterPreloader} from '@angular/router';
 
-import {Route, RouteConfigLoadEnd, RouteConfigLoadStart, Router, RouterModule} from '../index';
+import {Route, RouteConfigLoadEnd, RouteConfigLoadStart, RouteConfigReady, Router, RouterModule} from '../index';
 import {LoadedRouterConfig} from '../src/config';
 import {RouterTestingModule, SpyNgModuleFactoryLoader} from '../testing';
 
@@ -64,7 +64,7 @@ describe('RouterPreloader', () => {
            [NgModuleFactoryLoader, RouterPreloader, Router, NgModuleRef],
            (loader: SpyNgModuleFactoryLoader, preloader: RouterPreloader, router: Router,
             testModule: NgModuleRef<any>) => {
-             const events: Array<RouteConfigLoadStart|RouteConfigLoadEnd> = [];
+             const events: Array<RouteConfigLoadStart|RouteConfigLoadEnd|RouteConfigReady> = [];
              @NgModule({
                declarations: [LazyLoadedCmp],
                imports: [RouterModule.forChild([{path: 'LoadedModule2', component: LazyLoadedCmp}])]
@@ -80,7 +80,8 @@ describe('RouterPreloader', () => {
              }
 
              router.events.subscribe(e => {
-               if (e instanceof RouteConfigLoadEnd || e instanceof RouteConfigLoadStart) {
+               if (e instanceof RouteConfigLoadEnd || e instanceof RouteConfigLoadStart ||
+                   e instanceof RouteConfigReady) {
                  events.push(e);
                }
              });
@@ -109,10 +110,9 @@ describe('RouterPreloader', () => {
              expect(module2._parent).toBe(module);
 
              expect(events.map(e => e.toString())).toEqual([
-               'RouteConfigLoadStart(path: lazy)',
-               'RouteConfigLoadEnd(path: lazy)',
-               'RouteConfigLoadStart(path: LoadedModule1)',
-               'RouteConfigLoadEnd(path: LoadedModule1)',
+               'RouteConfigLoadStart(path: lazy)', 'RouteConfigLoadEnd(path: lazy)',
+               'RouteConfigReady(path: lazy)', 'RouteConfigLoadStart(path: LoadedModule1)',
+               'RouteConfigLoadEnd(path: LoadedModule1)', 'RouteConfigReady(path: LoadedModule1)'
              ]);
            })));
   });


### PR DESCRIPTION
* Add new event to provide notification of a route being added and  ready for use.
* Improve DRY-ness of setting of _loadedConfig

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
When routes are loaded a RouteConfigLoadStart/End get fired. The RouteConfigLoadEnd event occur at the end of loading not when the route is fully added to the router and 

This has been discussed in #16282,  #14036


Issue Number:  <N/A>


## What is the new behavior?

This now add a new Event as per @jasonaden  request on #16308 but also moves the setting of the internal _loadedConfig to inside the loader so the event can be sent from one place.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
