### PR TITLE
docs: missing quotes on class on architecture docs

### DIFF
--- a/aio/content/guide/architecture.md
+++ b/aio/content/guide/architecture.md
@@ -19,7 +19,7 @@ Both components and services are simply classes, with *decorators* that mark the
 
 An app's components typically define many views, arranged hierarchically. Angular provides the `Router` service to help you define navigation paths among views. The router provides sophisticated in-browser navigational capabilities.
 
-<div class="alert is-helpful>
+<div class="alert is-helpful">
 
   See the [Angular Glossary](guide/glossary) for basic definitions of important Angular terms and usage.
 


### PR DESCRIPTION
In the Architecture document, the Introduction to Angular concepts section has a div element which is missing a closing double quotes. This missing quote is causing styling issues. This is a production issue https://angular.io/guide/architecture

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

On the [architecture page](https://angular.io/guide/architecture), in the section **Introduction to Angular concepts**, there is a div at the end of the section which says "Angular Glossary for basic definitions of important Angular terms and usage." However, this div is not styled properly. It should say "See the [Angular Glossary](https://angular.io/guide/glossary) for basic definitions of important Angular terms and usage." The styling and the link are both missing.

Issue Number: N/A


## What is the new behavior?
Adding in the missing quote fixes this styling issue.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
