### PR TITLE
fix(ngcc): mark `@angular/cdk/coercion` as Angular entry-point

### DIFF
--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -125,6 +125,18 @@ export const DEFAULT_NGCC_CONFIG: NgccProjectConfig = {
         './dist': {ignore: true},
       },
     },
+
+    // Enables the `@angular/cdk/coercion` and `@angular/cdk/testing` entry-points as Angular
+    // packages, such that they participate in the dependency graph and ordering computation.
+    // As these entry-points do not have Angular metadata they would otherwise not be considered,
+    // causing the dependency on `@angular/core` not to be included as transitive dependency
+    // of entry-points that depend on these CDK entry-points.
+    '@angular/cdk': {
+      entryPoints: {
+        'coercion': {},
+        'testing': {},
+      },
+    },
   },
 };
 


### PR DESCRIPTION
The `@angular/cdk/coercion` entry-point is compiled using the
`ts_library` Bazel rule and does not have Angular metadata for that
reason. Because no metadata is present, ngcc does not analyze its
dependencies as it doesn't need to know when to schedule the processing
of the entry-point. However, there's an import into `@angular/core`
from this entry-point, so any entry-points that depend on
`@angular/cdk/coercion` also have a transitive dependency on
`@angular/core`.

Because ngcc was unaware of the transitive dependency, it could schedule
an entry-point that depends on `@angular/cdk/coercion` but not on
`@angular/core` to be scheduled before/together with `@angular/core`. If
the processing occurs on a different worker (in a different process)
than where `@angular/core` is processed, this could prime the filesystem
cache with `@angular/core/core.d.ts` before `@angular/core` has been
processed, thereby poisoning the cache with an unprocessed version of
`@angular/core/core.d.ts`. This could then cause compilation failures
on the poisoned worker for entry-points that require Ivy definitions to
be present in `@angular/core/core.d.ts`.

This commit adds entry-points to the default configuration of
`@angular/cdk` which causes ngcc to consider them as Angular
entry-points, even though they do not have metadata.

Resolves FW-2072