### PR TITLE
Revert "fix(router): pass correct component to canDeactivate checks when using two or more sibling router-outlets (#36302)"

### DIFF
--- a/packages/router/src/utils/preactivation.ts
+++ b/packages/router/src/utils/preactivation.ts
@@ -83,7 +83,7 @@ function getChildRouteGuards(
   forEach(
       prevChildren,
       (v: TreeNode<ActivatedRouteSnapshot>, k: string) =>
-          deactivateRouteAndItsChildren(v, contexts!.getContext(k), contexts, checks));
+          deactivateRouteAndItsChildren(v, contexts!.getContext(k), checks));
 
   return checks;
 }
@@ -127,7 +127,7 @@ function getRouteGuards(
     }
   } else {
     if (curr) {
-      deactivateRouteAndItsChildren(currNode, context, parentContexts, checks);
+      deactivateRouteAndItsChildren(currNode, context, checks);
     }
 
     checks.canActivateChecks.push(new CanActivate(futurePath));
@@ -172,21 +172,17 @@ function shouldRunGuardsAndResolvers(
 }
 
 function deactivateRouteAndItsChildren(
-    route: TreeNode<ActivatedRouteSnapshot>, context: OutletContext|null,
-    parentContexts: ChildrenOutletContexts|null, checks: Checks): void {
+    route: TreeNode<ActivatedRouteSnapshot>, context: OutletContext|null, checks: Checks): void {
   const children = nodeChildrenAsMap(route);
   const r = route.value;
 
   forEach(children, (node: TreeNode<ActivatedRouteSnapshot>, childName: string) => {
     if (!r.component) {
-      deactivateRouteAndItsChildren(
-          node, parentContexts ? parentContexts.getContext(childName) : context, parentContexts,
-          checks);
+      deactivateRouteAndItsChildren(node, context, checks);
     } else if (context) {
-      deactivateRouteAndItsChildren(
-          node, context.children.getContext(childName), parentContexts, checks);
+      deactivateRouteAndItsChildren(node, context.children.getContext(childName), checks);
     } else {
-      deactivateRouteAndItsChildren(node, null, parentContexts, checks);
+      deactivateRouteAndItsChildren(node, null, checks);
     }
   });
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -3046,44 +3046,6 @@ describe('Integration', () => {
              expect(location.path()).toEqual('/two-outlets/(a)');
            })));
 
-        it('should call canDeactivate handler with each deactivated component',
-           fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, TwoOutletsCmp);
-
-             router.resetConfig([
-               {
-                 path: 'a',
-                 children: [
-                   {
-                     path: 'b1',
-                     component: BlankCmp,
-                     canDeactivate: ['RecordingDeactivate'],
-                   },
-                   {
-                     path: 'b2',
-                     canDeactivate: ['RecordingDeactivate'],
-                     component: SimpleCmp,
-                     outlet: 'aux',
-                   },
-                 ],
-               },
-               {
-                 path: 'c',
-                 component: BlankCmp,
-               },
-             ]);
-
-             router.navigate(['/a', {outlets: {primary: ['b1'], aux: ['b2']}}]);
-             advance(fixture);
-             expect(location.path()).toEqual('/a/(b1//aux:b2)');
-
-             router.navigate(['/c']);
-             advance(fixture);
-
-             expect(log[0].component).toBeAnInstanceOf(BlankCmp);
-             expect(log[1].component).toBeAnInstanceOf(SimpleCmp);
-           })));
-
         it('works with a nested route',
            fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
              const fixture = createRoot(router, RootCmp);


### PR DESCRIPTION
This reverts commit 80e6c07d89d74d71956fb1299c54f5353e255370.