### PR TITLE
fix(dev-infra): exit non-zero if commit message validation failed

### DIFF
--- a/dev-infra/commit-message/validate-range.ts
+++ b/dev-infra/commit-message/validate-range.ts
@@ -39,7 +39,12 @@ export function validateCommitRange(range: string) {
     };
     return validateCommitMessage(m, options);
   });
+
   if (allCommitsInRangeValid) {
     console.info('√  All commit messages in range valid.');
+  } else {
+    // Exit with a non-zero exit code if invalid commit messages have
+    // been discovered.
+    process.exit(1);
   }
 }


### PR DESCRIPTION
Currently the `commit-message` validation script does not exit
with a non-zero exit code if the commit message validation failed.

This means that invalid commit messages are currently not
causing CI to be red. See: https://circleci.com/gh/angular/angular/686008

@josephperrott I think we _could_ update the required base sha in the merge script one this PR lands. Not sure if we want to do that though (as it introduces slow-down due to rebasing I guess)