### PR TITLE
feat(common): introduce the `watchCollection` pipe

### DIFF
--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -416,6 +416,12 @@ export declare abstract class ViewportScroller {
     static ɵprov: never;
 }
 
+export declare class WatchCollectionPipe implements PipeTransform {
+    transform(value: {
+        [key: string]: any;
+    } | any[] | null | undefined): unknown;
+}
+
 export declare enum WeekDay {
     Sunday = 0,
     Monday = 1,

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -26,3 +26,4 @@ export {AsyncPipe, DatePipe, I18nPluralPipe, I18nSelectPipe, JsonPipe, LowerCase
 export {PLATFORM_BROWSER_ID as ɵPLATFORM_BROWSER_ID, PLATFORM_SERVER_ID as ɵPLATFORM_SERVER_ID, PLATFORM_WORKER_APP_ID as ɵPLATFORM_WORKER_APP_ID, PLATFORM_WORKER_UI_ID as ɵPLATFORM_WORKER_UI_ID, isPlatformBrowser, isPlatformServer, isPlatformWorkerApp, isPlatformWorkerUi} from './platform_id';
 export {VERSION} from './version';
 export {ViewportScroller, NullViewportScroller as ɵNullViewportScroller} from './viewport_scroller';
+export {WatchCollectionPipe} from './pipes/watch_collection_pipe';

--- a/packages/common/src/directives/ng_for_of_patched.ts
+++ b/packages/common/src/directives/ng_for_of_patched.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license

--- a/packages/common/src/directives/ng_for_of_patched.ts
+++ b/packages/common/src/directives/ng_for_of_patched.ts
@@ -1,0 +1,297 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Directive, DoCheck, EmbeddedViewRef, Input, isDevMode, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDiffers, NgIterable, TemplateRef, TrackByFunction, ViewContainerRef} from '@angular/core';
+
+/**
+ * @publicApi
+ */
+export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
+  constructor(public $implicit: T, public ngForOf: U, public index: number, public count: number) {}
+
+  get first(): boolean {
+    return this.index === 0;
+  }
+
+  get last(): boolean {
+    return this.index === this.count - 1;
+  }
+
+  get even(): boolean {
+    return this.index % 2 === 0;
+  }
+
+  get odd(): boolean {
+    return !this.even;
+  }
+}
+
+/**
+ * A [structural directive](guide/structural-directives) that renders
+ * a template for each item in a collection.
+ * The directive is placed on an element, which becomes the parent
+ * of the cloned templates.
+ *
+ * The `ngForOf` directive is generally used in the
+ * [shorthand form](guide/structural-directives#the-asterisk--prefix) `*ngFor`.
+ * In this form, the template to be rendered for each iteration is the content
+ * of an anchor element containing the directive.
+ *
+ * The following example shows the shorthand syntax with some options,
+ * contained in an `<li>` element.
+ *
+ * ```
+ * <li *ngFor="let item of items; index as i; trackBy: trackByFn">...</li>
+ * ```
+ *
+ * The shorthand form expands into a long form that uses the `ngForOf` selector
+ * on an `<ng-template>` element.
+ * The content of the `<ng-template>` element is the `<li>` element that held the
+ * short-form directive.
+ *
+ * Here is the expanded version of the short-form example.
+ *
+ * ```
+ * <ng-template ngFor let-item [ngForOf]="items" let-i="index" [ngForTrackBy]="trackByFn">
+ *   <li>...</li>
+ * </ng-template>
+ * ```
+ *
+ * Angular automatically expands the shorthand syntax as it compiles the template.
+ * The context for each embedded view is logically merged to the current component
+ * context according to its lexical position.
+ *
+ * When using the shorthand syntax, Angular allows only [one structural directive
+ * on an element](guide/structural-directives#one-structural-directive-per-host-element).
+ * If you want to iterate conditionally, for example,
+ * put the `*ngIf` on a container element that wraps the `*ngFor` element.
+ * For futher discussion, see
+ * [Structural Directives](guide/structural-directives#one-per-element).
+ *
+ * @usageNotes
+ *
+ * ### Local variables
+ *
+ * `NgForOf` provides exported values that can be aliased to local variables.
+ * For example:
+ *
+ *  ```
+ * <li *ngFor="let user of users; index as i; first as isFirst">
+ *    {{i}}/{{users.length}}. {{user}} <span *ngIf="isFirst">default</span>
+ * </li>
+ * ```
+ *
+ * The following exported values can be aliased to local variables:
+ *
+ * - `$implicit: T`: The value of the individual items in the iterable (`ngForOf`).
+ * - `ngForOf: NgIterable<T>`: The value of the iterable expression. Useful when the expression is
+ * more complex then a property access, for example when using the async pipe (`userStreams |
+ * async`).
+ * - `index: number`: The index of the current item in the iterable.
+ * - `count: number`: The length of the iterable.
+ * - `first: boolean`: True when the item is the first item in the iterable.
+ * - `last: boolean`: True when the item is the last item in the iterable.
+ * - `even: boolean`: True when the item has an even index in the iterable.
+ * - `odd: boolean`: True when the item has an odd index in the iterable.
+ *
+ * ### Change propagation
+ *
+ * When the contents of the iterator changes, `NgForOf` makes the corresponding changes to the DOM:
+ *
+ * * When an item is added, a new instance of the template is added to the DOM.
+ * * When an item is removed, its template instance is removed from the DOM.
+ * * When items are reordered, their respective templates are reordered in the DOM.
+ *
+ * Angular uses object identity to track insertions and deletions within the iterator and reproduce
+ * those changes in the DOM. This has important implications for animations and any stateful
+ * controls that are present, such as `<input>` elements that accept user input. Inserted rows can
+ * be animated in, deleted rows can be animated out, and unchanged rows retain any unsaved state
+ * such as user input.
+ * For more on animations, see [Transitions and Triggers](guide/transition-and-triggers).
+ *
+ * The identities of elements in the iterator can change while the data does not.
+ * This can happen, for example, if the iterator is produced from an RPC to the server, and that
+ * RPC is re-run. Even if the data hasn't changed, the second response produces objects with
+ * different identities, and Angular must tear down the entire DOM and rebuild it (as if all old
+ * elements were deleted and all new elements inserted).
+ *
+ * To avoid this expensive operation, you can customize the default tracking algorithm.
+ * by supplying the `trackBy` option to `NgForOf`.
+ * `trackBy` takes a function that has two arguments: `index` and `item`.
+ * If `trackBy` is given, Angular tracks changes by the return value of the function.
+ *
+ * @see [Structural Directives](guide/structural-directives)
+ * @ngModule CommonModule
+ * @publicApi
+ */
+@Directive({selector: '[ngFor][ngForOf]'})
+export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCheck {
+  /**
+   * The value of the iterable expression, which can be used as a
+   * [template input variable](guide/structural-directives#template-input-variable).
+   */
+  @Input()
+  set ngForOf(ngForOf: U&NgIterable<T>|undefined|null) {
+    this._ngForOf = ngForOf;
+    this._ngForOfDirty = true;
+  }
+  /**
+   * A function that defines how to track changes for items in the iterable.
+   *
+   * When items are added, moved, or removed in the iterable,
+   * the directive must re-render the appropriate DOM nodes.
+   * To minimize churn in the DOM, only nodes that have changed
+   * are re-rendered.
+   *
+   * By default, the change detector assumes that
+   * the object instance identifies the node in the iterable.
+   * When this function is supplied, the directive uses
+   * the result of calling this function to identify the item node,
+   * rather than the identity of the object itself.
+   *
+   * The function receives two inputs,
+   * the iteration index and the node object ID.
+   */
+  @Input()
+  set ngForTrackBy(fn: TrackByFunction<T>) {
+    if (isDevMode() && fn != null && typeof fn !== 'function') {
+      // TODO(vicb): use a log service once there is a public one available
+      if (<any>console && <any>console.warn) {
+        console.warn(
+            `trackBy must be a function, but received ${JSON.stringify(fn)}. ` +
+            `See https://angular.io/api/common/NgForOf#change-propagation for more information.`);
+      }
+    }
+    this._trackByFn = fn;
+  }
+
+  get ngForTrackBy(): TrackByFunction<T> {
+    return this._trackByFn;
+  }
+
+  private _ngForOf: U|undefined|null = null;
+  private _ngForOfDirty: boolean = true;
+  private _differ: IterableDiffer<T>|null = null;
+  // TODO(issue/24571): remove '!'.
+  private _trackByFn!: TrackByFunction<T>;
+
+  constructor(
+      private _viewContainer: ViewContainerRef,
+      private _template: TemplateRef<NgForOfContext<T, U>>, private _differs: IterableDiffers) {}
+
+  /**
+   * A reference to the template that is stamped out for each item in the iterable.
+   * @see [template reference variable](guide/template-syntax#template-reference-variables--var-)
+   */
+  @Input()
+  set ngForTemplate(value: TemplateRef<NgForOfContext<T, U>>) {
+    // TODO(TS2.1): make TemplateRef<Partial<NgForRowOf<T>>> once we move to TS v2.1
+    // The current type is too restrictive; a template that just uses index, for example,
+    // should be acceptable.
+    if (value) {
+      this._template = value;
+    }
+  }
+
+  /**
+   * Applies the changes when needed.
+   */
+  ngDoCheck(): void {
+    if (this._ngForOfDirty) {
+      this._diffValues();
+    }
+  }
+
+  private _diffValues(): void {
+    this._ngForOfDirty = false;
+    // React on ngForOf changes only once all inputs have been initialized
+    const value = this._ngForOf;
+    if (!this._differ && value) {
+      try {
+        this._differ = this._differs.find(value).create(this.ngForTrackBy);
+      } catch {
+        throw new Error(`Cannot find a differ supporting object '${value}' of type '${
+            getTypeName(value)}'. NgFor only supports binding to Iterables such as Arrays.`);
+      }
+    }
+
+    if (this._differ) {
+      const changes = this._differ.diff(this._ngForOf);
+      if (changes) this._applyChanges(changes);
+    }
+  }
+
+  private _applyChanges(changes: IterableChanges<T>) {
+    const insertTuples: RecordViewTuple<T, U>[] = [];
+    changes.forEachOperation(
+        (item: IterableChangeRecord<any>, adjustedPreviousIndex: number|null,
+         currentIndex: number|null) => {
+          if (item.previousIndex == null) {
+            // NgForOf is never "null" or "undefined" here because the differ detected
+            // that a new item needs to be inserted from the iterable. This implies that
+            // there is an iterable value for "_ngForOf".
+            const view = this._viewContainer.createEmbeddedView(
+                this._template, new NgForOfContext<T, U>(null!, this._ngForOf!, -1, -1),
+                currentIndex === null ? undefined : currentIndex);
+            const tuple = new RecordViewTuple<T, U>(item, view);
+            insertTuples.push(tuple);
+          } else if (currentIndex == null) {
+            this._viewContainer.remove(
+                adjustedPreviousIndex === null ? undefined : adjustedPreviousIndex);
+          } else if (adjustedPreviousIndex !== null) {
+            const view = this._viewContainer.get(adjustedPreviousIndex)!;
+            this._viewContainer.move(view, currentIndex);
+            const tuple = new RecordViewTuple(item, <EmbeddedViewRef<NgForOfContext<T, U>>>view);
+            insertTuples.push(tuple);
+          }
+        });
+
+    for (let i = 0; i < insertTuples.length; i++) {
+      this._perViewChange(insertTuples[i].view, insertTuples[i].record);
+    }
+
+    for (let i = 0, ilen = this._viewContainer.length; i < ilen; i++) {
+      const viewRef = <EmbeddedViewRef<NgForOfContext<T, U>>>this._viewContainer.get(i);
+      viewRef.context.index = i;
+      viewRef.context.count = ilen;
+      viewRef.context.ngForOf = this._ngForOf!;
+    }
+
+    changes.forEachIdentityChange((record: any) => {
+      const viewRef =
+          <EmbeddedViewRef<NgForOfContext<T, U>>>this._viewContainer.get(record.currentIndex);
+      viewRef.context.$implicit = record.item;
+    });
+  }
+
+  private _perViewChange(
+      view: EmbeddedViewRef<NgForOfContext<T, U>>, record: IterableChangeRecord<any>) {
+    view.context.$implicit = record.item;
+  }
+
+  /**
+   * Asserts the correct type of the context for the template that `NgForOf` will render.
+   *
+   * The presence of this method is a signal to the Ivy template type-check compiler that the
+   * `NgForOf` structural directive renders its template with a specific context type.
+   */
+  static ngTemplateContextGuard<T, U extends NgIterable<T>>(dir: NgForOf<T, U>, ctx: any):
+      ctx is NgForOfContext<T, U> {
+    return true;
+  }
+}
+
+class RecordViewTuple<T, U extends NgIterable<T>> {
+  constructor(public record: any, public view: EmbeddedViewRef<NgForOfContext<T, U>>) {}
+}
+
+function getTypeName(type: any): string {
+  return type['name'] || typeof type;
+}
+////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/common/src/pipes/index.ts
+++ b/packages/common/src/pipes/index.ts
@@ -20,6 +20,7 @@ import {JsonPipe} from './json_pipe';
 import {KeyValue, KeyValuePipe} from './keyvalue_pipe';
 import {CurrencyPipe, DecimalPipe, PercentPipe} from './number_pipe';
 import {SlicePipe} from './slice_pipe';
+import {WatchCollectionPipe} from './watch_collection_pipe';
 
 export {
   AsyncPipe,
@@ -36,6 +37,7 @@ export {
   SlicePipe,
   TitleCasePipe,
   UpperCasePipe,
+  WatchCollectionPipe,
 };
 
 
@@ -56,4 +58,5 @@ export const COMMON_PIPES = [
   I18nPluralPipe,
   I18nSelectPipe,
   KeyValuePipe,
+  WatchCollectionPipe,
 ];

--- a/packages/common/src/pipes/value_harness.ts
+++ b/packages/common/src/pipes/value_harness.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license

--- a/packages/common/src/pipes/value_harness.ts
+++ b/packages/common/src/pipes/value_harness.ts
@@ -1,0 +1,243 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * An interface that updates the `value` member whenever `update()` is called.
+ *
+ * This interface allows for an abstraction to create a new value
+ * each time the `update()` method is called. It is up to the
+ * abstraction to decide whether or not to update its value when
+ * this occurs.
+ *
+ * Value harnesses are useful for collection-based values. A collection-based
+ * harness can be used to make a local copy of a collection and then only
+ * change the underlying collection instance whenever the contents change.
+ *
+ * ```typescript
+ * const h = new MyCollectionValueHarness([1,2,3]);
+ * const v1 = h.value; // [1,2,3]
+ *
+ * h.update([1,2,3])
+ * const v2 = h.value; // same identity as v1 => [1,2,3]
+ *
+ * h.update([1,2])
+ * const v3 = h.value; // new collection => [1,2]
+ * ```
+ */
+export interface ValueHarness<T> {
+  update(value: T): void;
+  readonly value: T;
+}
+
+/**
+ * A value harness specific to arrays.
+ *
+ * This harness is used to track whenever contents of an array
+ * change compared to the previous array that is current stored.
+ *
+ * Each time the `update()` method is called, then the local array
+ * copy will be updated with the new contents of the new array that
+ * was provided. If and when the new array contents do not match with
+ * the old array then the local array value will be updated.
+ */
+export class ArrayHarness implements ValueHarness<unknown[]> {
+  private _array!: unknown[];
+
+  constructor(value: unknown[]) {
+    this._updateValue(value);
+  }
+
+  private _updateValue(value: unknown[]) {
+    this._array = [...value];
+  }
+
+  update(value: unknown[]): void {
+    if (!arraysAreEqual(value, this._array)) {
+      this._updateValue(value);
+    }
+  }
+
+  get value() {
+    return this._array;
+  }
+}
+
+/**
+ * An array representation of a key/value map.
+ *
+ * A `KeyValueArray` is used as a substitute data structure
+ * to avoid having to constantly fetch all key strings from
+ * a map (this avoids megamorphic property reads).
+ *
+ * All even-indexed keys are used to store the key values
+ * within a key/value map and all odd-based store the
+ * values within a key/value map.
+ */
+interface KeyValueArray extends Array<string|unknown> {}
+
+/**
+ * A collection of constants used for accessing entries within a `KeyValueArray` data-structure
+ */
+const enum KeyValueArrayIndex {
+  TupleLength = 2,
+  KeyOffset = 0,
+  ValueOffset = 1,
+}
+
+/**
+ * A value harness specific to key/value maps.
+ *
+ * This harness is used to track whenever contents of a key/value map
+ * change compared to the previous key/value map that is current stored.
+ *
+ * Each time the `update()` method is called, then the local key/value map
+ * copy will be updated with the new contents of the new key/value map that
+ * was provided. If and when the new key/value map contents do not match with
+ * the key/value map then the local key/value map value will be updated.
+ */
+export class MapHarness implements ValueHarness<{[key: string]: unknown}> {
+  private _keyValueArray!: KeyValueArray;
+  private _value!: {[key: string]: any};
+
+  constructor(value: {[key: string]: unknown}) {
+    this._updateValue(value);
+    this._value = value;
+  }
+
+  private _updateValue(value: {[key: string]: unknown}) {
+    this._keyValueArray = toKeyValueArray(value);
+  }
+
+  update(value: {[key: string]: unknown}): void {
+    if (hasMapChanged(value, this._keyValueArray)) {
+      this._updateValue(value);
+      this._value = {...value};
+    }
+  }
+
+  get value() {
+    return this._value;
+  }
+}
+
+/**
+ * A value harness specific to non-collection values.
+ *
+ * This harness is used to track whenever or not the a new value
+ * value has changed compared to the previous value that is stored
+ * within the class. Each time there is a change the new value is
+ * stored within the class.
+ */
+export class DefaultValueHarness implements ValueHarness<unknown> {
+  constructor(private _value: unknown) {}
+
+  update(value: unknown): void {
+    if (this._value !== value) {
+      this._value = value;
+    }
+  }
+
+  get value() {
+    return this._value;
+  }
+}
+
+/**
+ * Converts a key/value map to an instance of `KeyValueArray`
+ *
+ * Examples include:
+ *
+ * `{}` => []
+ * `{one:1}` => ['one', 1]
+ * `{one:1, two:2}` => ['one', 1, 'two', 2]
+ */
+function toKeyValueArray(map: {[key: string]: unknown}): KeyValueArray {
+  const keys = Object.keys(map);
+  const keyValueArray: KeyValueArray = new Array(keys.length * KeyValueArrayIndex.TupleLength);
+  for (let i = 0, j = 0; i < keys.length; i++, j += KeyValueArrayIndex.TupleLength) {
+    const key = keys[i];
+    setKey(keyValueArray, j, key);
+    setValue(keyValueArray, j, map[key]);
+  }
+  return keyValueArray;
+}
+
+/**
+ * Whether or not the provided `map` value is different in terms of entries.
+ */
+function hasMapChanged(
+    map: {[key: string]: unknown}, previousValue: KeyValueArray|{[key: string]: unknown}): boolean {
+  let hasChanged = false;
+
+  const keyValueArray =
+      Array.isArray(previousValue) ? previousValue : toKeyValueArray(previousValue);
+  const keys = Object.keys(map);
+
+  if (keyValueArray.length !== (keys.length * KeyValueArrayIndex.TupleLength)) {
+    // check #1: check to see if the sizing of the map has changed
+    hasChanged = true;
+  } else {
+    // check #2: check to see if all the values match up
+    //           Because we know that the key sizes are the same,
+    //           we do not need to run another for loop.
+    for (let i = 0; i < keyValueArray.length; i += KeyValueArrayIndex.TupleLength) {
+      const key = getKey(keyValueArray, i);
+      if (!map.hasOwnProperty(key) || getValue(keyValueArray, i) !== map[key]) {
+        hasChanged = true;
+        break;
+      }
+    }
+  }
+
+  return hasChanged;
+}
+
+/**
+ * Returns the `key` string value at the provided `index` location within a `KeyValueArray`
+ */
+function getKey(kvArray: KeyValueArray, index: number): string {
+  return kvArray[index + KeyValueArrayIndex.KeyOffset] as string;
+}
+
+/**
+ * Sets the `key` string value at the provided `index` location within a `KeyValueArray`
+ */
+function setKey(kvArray: KeyValueArray, index: number, key: string): void {
+  kvArray[index + KeyValueArrayIndex.KeyOffset] = key;
+}
+
+/**
+ * Gets the value at the provided `index` location within a `KeyValueArray`
+ */
+function getValue(kvArray: KeyValueArray, index: number): unknown {
+  return kvArray[index + KeyValueArrayIndex.ValueOffset];
+}
+
+/**
+ * Sets the value at the provided `index` location within a `KeyValueArray`
+ */
+function setValue(kvArray: KeyValueArray, index: number, value: unknown): void {
+  kvArray[index + KeyValueArrayIndex.ValueOffset] = value;
+}
+
+/**
+ * Whether or not the arrays have the same entries.
+ */
+function arraysAreEqual(arrayA: unknown[], arrayB: unknown[]): boolean {
+  if (arrayA.length !== arrayB.length) {
+    return false;
+  }
+
+  for (let i = 0; i < arrayA.length; i++) {
+    if (arrayA[i] !== arrayB[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/common/src/pipes/watch_collection_pipe.ts
+++ b/packages/common/src/pipes/watch_collection_pipe.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license

--- a/packages/common/src/pipes/watch_collection_pipe.ts
+++ b/packages/common/src/pipes/watch_collection_pipe.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Pipe, PipeTransform} from '@angular/core';
+
+import {ArrayHarness, DefaultValueHarness, MapHarness, ValueHarness} from './value_harness';
+
+/**
+ * @ngModule CommonModule
+ * @description
+ *
+ * Watches and creates a new instance of a collection each time the contents change.
+ *
+ * This pipe is designed to be used when collection-based values are assigned to template
+ * bindings. Template bindings only update when the reference of the binding changes (i.e.
+ * when a new variable value is assigned to the binding). This behavior works fine for
+ * scalar values (e.g. `null`, `string`, `number`, etc...), however, it will not detect if
+ * the inner contents of a variable change. This means that if an array or key/value object
+ * is assigned to a template binding then the binding setter will only execute if a new array
+ * or key/value object is created.
+ *
+ * The `watchCollection` pipe fills this hole by shallow-watching the entries within an array
+ * or key/value map. If and when those entries change within the collection then the pipe will
+ * create a new instance of the collection and pass that on to the binding.
+ *
+ * This pipe supports both arrays and map values. When assigned, it will examine and
+ * compare the contents of the collection to the previous value of the collection
+ *
+ * The example below shows how to use the `watchCollection` pipe within a component template:
+ *
+ * @usageNotes
+ *
+ * ```html
+ * <!-- the [values] binding will only update when the
+ *      `myValues` binding value changes in reference (when the
+ *      value identity changes) -->
+ * <inner-comp [values]="myValues"></inner-comp>
+ *
+ * <!-- the [values] binding will now update each time the contents
+ *      of the `myValues` collection will change in entries -->
+ * <inner-comp [values]="myValues | watchCollection"></inner-comp>
+ * ```
+ *
+ * @publicApi
+ */
+@Pipe({name: 'watchCollection', pure: false})
+export class WatchCollectionPipe implements PipeTransform {
+  private _previousValue: unknown = undefined;
+  private _valueHarness: ValueHarness<unknown> = new DefaultValueHarness(undefined);
+
+  /**
+   * Returns a new instance of a collection value if an when the contents of the provided `value`
+   * collection differ from the previous collection.
+   */
+  transform<T extends {[key: string]: any}|any[]|null|undefined>(value: T): T {
+    if (value === this._previousValue) {
+      // Case #1: the collection reference hasn't changed (therefore just update the contents)
+      this._valueHarness.update(value);
+    } else {
+      // Case #2: the reference has changed (therefore create a new harness on that collection)
+      this._previousValue = value;
+
+      // if an identity change has occurs this means that the value type could have
+      // also changed. For this reason a new watcher instance needs to be created.
+      this._valueHarness = createValueHarness(value);
+    }
+
+    // if the value harness changes or the contents of the collection have
+    // changed then the `.value` identity will have changed. Otherwise the
+    // old `value` is returned.
+    return this._valueHarness.value as T;
+  }
+}
+
+/**
+ * Returns type-specific instance of `ValueHarness` based on the provided `value`.
+ *
+ * Depending on the typeof provided `value` param, this function will return one of the following:
+ * Case #1: `ArrayHarness` when `value` is array-like
+ * Case #2: `MapHarness` when `value` is a key/value map
+ * Case #3: `DefaultValueHarness` when `value` is non-collection type
+ */
+function createValueHarness(value: unknown): ValueHarness<unknown> {
+  // Case #1: array
+  if (Array.isArray(value)) {
+    return new ArrayHarness(value);
+  }
+
+  // Case #2: map
+  if (value !== null && typeof value === 'object') {
+    return new MapHarness(value as {});
+  }
+
+  // Case #3: non-collection value
+  return new DefaultValueHarness(value);
+}

--- a/packages/common/test/pipes/value_harness_spec.ts
+++ b/packages/common/test/pipes/value_harness_spec.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {ArrayHarness, DefaultValueHarness, MapHarness} from '@angular/common/src/pipes/value_harness';
+
+fdescribe('ValueHarness', () => {
+  describe('ArrayHarness', () => {
+    it('should produce a new array whenever the contents differ', () => {
+      const a = [1, 2, 3];
+      const h = new ArrayHarness(a);
+
+      const v1 = h.value;
+      expect(v1).toEqual([1, 2, 3]);
+
+      h.update([1, 2, 3]);
+
+      const v2 = h.value;
+      expect(v2).toBe(v1);
+      expect(v2).toEqual([1, 2, 3]);
+
+      h.update([1, 2, 3, 4]);
+
+      const v3 = h.value;
+      expect(v3).not.toBe(v2);
+      expect(v3).not.toBe(v1);
+      expect(v3).toEqual([1, 2, 3, 4]);
+    });
+
+    it('should produce a new array whenever it is mutated', () => {
+      const a: {[key: string]: any} = {one: 1, two: 2};
+      const h = new MapHarness(a);
+
+      expect(h.value).toEqual({one: 1, two: 2});
+
+      delete a['one'];
+      h.update(a);
+      expect(h.value).toEqual({two: 2});
+
+      a['two'] = 4;
+      h.update(a);
+      expect(h.value).toEqual({two: 4});
+
+      a['five'] = 5;
+      h.update(a);
+      expect(h.value).toEqual({two: 4, five: 5});
+    });
+
+    it('should update the array contents when called', () => {
+      const h = new ArrayHarness([]);
+
+      h.update([1]);
+      expect(h.value).toEqual([1]);
+
+      h.update([1, 2]);
+      expect(h.value).toEqual([1, 2]);
+
+      h.update([3]);
+      expect(h.value).toEqual([3]);
+    });
+  });
+
+  describe('MapHarness', () => {
+    it('should produce a new map whenever the contents differ', () => {
+      const a = {one: 1, two: 2};
+      const h = new MapHarness(a);
+
+      const v1 = h.value;
+      expect(v1).toEqual({one: 1, two: 2});
+
+      h.update({one: 1, two: 2});
+
+      const v2 = h.value;
+      expect(v2).toBe(v1);
+      expect(v2).toEqual({one: 1, two: 2});
+
+      h.update({one: 1, two: 2, three: 3});
+
+      const v3 = h.value;
+      expect(v3).not.toBe(v2);
+      expect(v3).not.toBe(v1);
+      expect(v3).toEqual({one: 1, two: 2, three: 3});
+    });
+
+    it('should produce a new map whenever map is mutated', () => {
+      const a: {[key: string]: any} = {one: 1, two: 2};
+      const h = new MapHarness(a);
+
+      expect(h.value).toEqual({one: 1, two: 2});
+
+      delete a['one'];
+      h.update(a);
+      expect(h.value).toEqual({two: 2});
+
+      a['two'] = 4;
+      h.update(a);
+      expect(h.value).toEqual({two: 4});
+
+      a['five'] = 5;
+      h.update(a);
+      expect(h.value).toEqual({two: 4, five: 5});
+    });
+
+    it('should update the map contents when called', () => {
+      const h = new MapHarness({});
+
+      expect(h.value).toEqual({});
+
+      h.update({one: 1});
+      expect(h.value).toEqual({one: 1});
+
+      h.update({one: 1, two: 2});
+      expect(h.value).toEqual({one: 1, two: 2});
+
+      h.update({three: 3});
+      expect(h.value).toEqual({three: 3});
+    });
+  });
+
+  describe('DefaultValueHarness', () => {
+    it('should update the value when update() is called', () => {
+      const h = new DefaultValueHarness(null);
+      expect(h.value).toEqual(null);
+
+      h.update(undefined);
+      expect(h.value).toEqual(undefined);
+
+      h.update(1);
+      expect(h.value).toEqual(1);
+
+      h.update('one');
+      expect(h.value).toEqual('one');
+
+      h.update(true);
+      expect(h.value).toEqual(true);
+
+      h.update({});
+      expect(h.value).toEqual({});
+    });
+  });
+});

--- a/packages/common/test/pipes/value_harness_spec.ts
+++ b/packages/common/test/pipes/value_harness_spec.ts
@@ -1,13 +1,13 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
 import {ArrayHarness, DefaultValueHarness, MapHarness} from '@angular/common/src/pipes/value_harness';
 
-fdescribe('ValueHarness', () => {
+describe('ValueHarness', () => {
   describe('ArrayHarness', () => {
     it('should produce a new array whenever the contents differ', () => {
       const a = [1, 2, 3];

--- a/packages/common/test/pipes/watch_collection_pipe_spec.ts
+++ b/packages/common/test/pipes/watch_collection_pipe_spec.ts
@@ -330,7 +330,7 @@ fdescribe('WatchCollectionPipe', () => {
   });
 
   describe('using ngFor', () => {
-    it('should signal to ngFor when a collection changes', () => {
+    fit('should signal to ngFor when a collection changes', () => {
       @Component({
         template: `
         <div *ngFor="let item of items | watchCollection"> {{ item }} </div>

--- a/packages/common/test/pipes/watch_collection_pipe_spec.ts
+++ b/packages/common/test/pipes/watch_collection_pipe_spec.ts
@@ -1,0 +1,370 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {WatchCollectionPipe} from '@angular/common';
+import {Component, Input, ViewChild} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+fdescribe('WatchCollectionPipe', () => {
+  describe('using arrays', () => {
+    @Component({selector: 'inner-comp', template: '...'})
+    class InnerComp {
+      public counter = 0;
+      private _value: string[]|null = null;
+
+      @Input('value')
+      set value(val: string[]|null) {
+        this.counter++;
+        this._value = val;
+      }
+
+      get value(): string[]|null {
+        return this._value;
+      }
+    }
+
+    @Component({template: '<inner-comp #inner [value]="value | watchCollection"></inner-comp>'})
+    class App {
+      value: string[]|null = null;
+
+      @ViewChild('inner') public inner!: InnerComp;
+    }
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [App, InnerComp, WatchCollectionPipe],
+      });
+    });
+
+    it('should watch arrays and provide a new array each time the collection changes', () => {
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const component = fixture.componentInstance;
+      const innerComponent = component.inner;
+
+      expect(innerComponent.value).toEqual(null);
+      component.value = ['1', '2', '3'];
+
+      fixture.detectChanges();
+      expect(innerComponent.value).not.toBe(component.value);
+      expect(innerComponent.value).toEqual(['1', '2', '3']);
+
+      component.value.pop();
+      fixture.detectChanges();
+      expect(innerComponent.value).not.toBe(component.value);
+      expect(innerComponent.value).toEqual(['1', '2']);
+
+      component.value.push('3');
+      fixture.detectChanges();
+      expect(innerComponent.value).not.toBe(component.value);
+      expect(innerComponent.value).toEqual(['1', '2', '3']);
+
+      component.value.unshift('0');
+      fixture.detectChanges();
+      expect(innerComponent.value).not.toBe(component.value);
+      expect(innerComponent.value).toEqual(['0', '1', '2', '3']);
+    });
+
+    it('should not emit a collection change if the contents do not change', () => {
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const component = fixture.componentInstance;
+      const innerComponent = component.inner;
+
+      component.value = ['a', 'b', 'c'];
+      innerComponent.counter = 0;
+      fixture.detectChanges();
+
+      expect(innerComponent.counter).toEqual(1);
+      fixture.detectChanges();
+
+      expect(innerComponent.counter).toEqual(1);
+      component.value.push('d');
+      fixture.detectChanges();
+
+      expect(innerComponent.counter).toEqual(2);
+    });
+
+    it('should emit a collection change if the order of entries within the array change', () => {
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const component = fixture.componentInstance;
+      const innerComponent = component.inner;
+      component.value = ['a', 'b', 'c'];
+
+      fixture.detectChanges();
+      expect(innerComponent.value).toEqual(['a', 'b', 'c']);
+
+      swapValues(component.value, 0, 2);
+      expect(component.value).toEqual(['c', 'b', 'a']);
+      expect(innerComponent.value).toEqual(['a', 'b', 'c']);
+      fixture.detectChanges();
+
+      expect(innerComponent.value).toEqual(['c', 'b', 'a']);
+    });
+  });
+
+  describe('using maps', () => {
+    @Component({selector: 'inner-comp', template: '...'})
+    class InnerComp {
+      private _value: {[key: string]: any}|null = null;
+
+      public counter = 0;
+
+      @Input('value')
+      set value(val: {[key: string]: any}|null) {
+        this.counter++;
+        this._value = val;
+      }
+
+      get value(): {[key: string]: any}|null {
+        return this._value;
+      }
+    }
+
+    @Component({template: '<inner-comp #inner [value]="value | watchCollection"></inner-comp>'})
+    class App {
+      value: {[key: string]: any}|null = null;
+
+      @ViewChild('inner') public inner!: InnerComp;
+    }
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [App, InnerComp, WatchCollectionPipe],
+      });
+    });
+
+    it('should watch maps and provide a new map each time the collection changes', () => {
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const component = fixture.componentInstance;
+      const innerComponent = component.inner;
+
+      expect(innerComponent.value).toEqual(null);
+      component.value = {one: 1, two: 2};
+
+      fixture.detectChanges();
+      expect(innerComponent.value).toBe(component.value);
+      expect(innerComponent.value).toEqual({one: 1, two: 2});
+
+      delete component.value['one'];
+      fixture.detectChanges();
+      expect(innerComponent.value).not.toBe(component.value);
+      expect(innerComponent.value).toEqual({two: 2});
+
+      component.value['one'] = 1;
+      fixture.detectChanges();
+      expect(innerComponent.value).not.toBe(component.value);
+      expect(innerComponent.value).toEqual({one: 1, two: 2});
+
+      component.value['three'] = 3;
+      fixture.detectChanges();
+      expect(innerComponent.value).not.toBe(component.value);
+      expect(innerComponent.value).toEqual({one: 1, two: 2, three: 3});
+    });
+
+    it('should not emit a collection change if the contents do not change', () => {
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const component = fixture.componentInstance;
+      const innerComponent = component.inner;
+
+      component.value = {one: 1, two: 2};
+      innerComponent.counter = 0;
+      fixture.detectChanges();
+
+      expect(innerComponent.counter).toEqual(1);
+      fixture.detectChanges();
+
+      expect(innerComponent.counter).toEqual(1);
+      component.value['three'] = 3;
+      fixture.detectChanges();
+
+      expect(innerComponent.counter).toEqual(2);
+    });
+  });
+
+  describe('using non collection values', () => {
+    @Component({selector: 'inner-comp', template: '...'})
+    class InnerComp {
+      private _value: string|number|null = null;
+
+      public counter = 0;
+
+      @Input('value')
+      set value(val: string|number|null) {
+        this.counter++;
+        this._value = val;
+      }
+
+      get value() {
+        return this._value;
+      }
+    }
+
+    @Component({template: '<inner-comp #inner [value]="value | watchCollection"></inner-comp>'})
+    class App {
+      value: string|number|null = null;
+
+      @ViewChild('inner') public inner!: InnerComp;
+    }
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [App, InnerComp, WatchCollectionPipe],
+      });
+    });
+
+    it('should watch non collection values for changes', () => {
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const component = fixture.componentInstance;
+      const innerComponent = component.inner;
+
+      expect(innerComponent.value).toEqual(null);
+      component.value = 1;
+
+      fixture.detectChanges();
+      expect(innerComponent.value).toEqual(1);
+
+      component.value = 2;
+
+      fixture.detectChanges();
+      expect(innerComponent.value).toEqual(2);
+
+      component.value = '3';
+
+      fixture.detectChanges();
+      expect(innerComponent.value).toEqual('3');
+
+      component.value = null;
+
+      fixture.detectChanges();
+      expect(innerComponent.value).toEqual(null);
+    });
+
+    it('should not emit an input change if the value has not changed', () => {
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const component = fixture.componentInstance;
+      const innerComponent = component.inner;
+
+      component.value = 1;
+      innerComponent.counter = 0;
+      fixture.detectChanges();
+
+      expect(innerComponent.counter).toEqual(1);
+      fixture.detectChanges();
+
+      expect(innerComponent.counter).toEqual(1);
+      component.value = 3;
+      fixture.detectChanges();
+
+      expect(innerComponent.counter).toEqual(2);
+    });
+  });
+
+  describe('using a mix of arrays and maps', () => {
+    @Component({selector: 'inner-comp', template: '...'})
+    class InnerComp {
+      private _value: {[key: string]: any}|string[]|null = null;
+
+      @Input('value')
+      set value(val: {[key: string]: any}|string[]|null) {
+        this._value = val;
+      }
+
+      get value() {
+        return this._value;
+      }
+    }
+
+    @Component({template: '<inner-comp #inner [value]="value | watchCollection"></inner-comp>'})
+    class App {
+      value: {[key: string]: any}|string[]|null = null;
+
+      @ViewChild('inner') public inner!: InnerComp;
+    }
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [App, InnerComp, WatchCollectionPipe],
+      });
+    });
+
+    it('should switch watching from a map to an array', () => {
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const component = fixture.componentInstance;
+      const innerComponent = component.inner;
+
+      component.value = {one: 1, two: 2};
+      fixture.detectChanges();
+      expect(innerComponent.value).toEqual({one: 1, two: 2});
+
+      component.value['three'] = 3;
+      fixture.detectChanges();
+      expect(innerComponent.value).toEqual({one: 1, two: 2, three: 3});
+
+      component.value = ['one', 'two'];
+      fixture.detectChanges();
+      expect(innerComponent.value).toEqual(['one', 'two']);
+
+      component.value.push('three');
+      fixture.detectChanges();
+      expect(innerComponent.value).toEqual(['one', 'two', 'three']);
+    });
+  });
+
+  describe('using ngFor', () => {
+    it('should signal to ngFor when a collection changes', () => {
+      @Component({
+        template: `
+        <div *ngFor="let item of items | watchCollection"> {{ item }} </div>
+      `
+      })
+      class App {
+        items: any[] = [
+          'one',
+          'two',
+          'three',
+        ];
+      }
+
+      TestBed.configureTestingModule({
+        declarations: [App, WatchCollectionPipe],
+      });
+
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const component = fixture.componentInstance;
+      const element = fixture.nativeElement;
+      expect(element.textContent.trim().replace(/\s+/g, ',')).toEqual('one,two,three');
+
+      component.items.push('four');
+      fixture.detectChanges();
+
+      expect(element.textContent.trim().replace(/\s+/g, ',')).toEqual('one,two,three,four');
+    });
+  });
+});
+
+function swapValues(arr: any[], indexA: number, indexB: number) {
+  const tmp = arr[indexA];
+  arr[indexA] = arr[indexB];
+  arr[indexB] = tmp;
+}

--- a/packages/common/test/pipes/watch_collection_pipe_spec.ts
+++ b/packages/common/test/pipes/watch_collection_pipe_spec.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
@@ -9,7 +9,7 @@ import {WatchCollectionPipe} from '@angular/common';
 import {Component, Input, ViewChild} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
-fdescribe('WatchCollectionPipe', () => {
+describe('WatchCollectionPipe', () => {
   describe('using arrays', () => {
     @Component({selector: 'inner-comp', template: '...'})
     class InnerComp {

--- a/packages/core/test/render3/perf/BUILD.bazel
+++ b/packages/core/test/render3/perf/BUILD.bazel
@@ -8,6 +8,7 @@ ts_library(
         ["**/*.ts"],
     ),
     deps = [
+        "//packages/common",
         "//packages/core",
         "//packages/core/src/util",
         "@npm//@types/jasmine",
@@ -241,4 +242,18 @@ ng_rollup_bundle(
 ng_benchmark(
     name = "view_destroy_hook",
     bundle = ":view_destroy_hook_lib",
+)
+
+ng_rollup_bundle(
+    name = "ng_for_lib",
+    entry_point = ":ng_for/index.ts",
+    deps = [
+        ":perf_lib",
+        "//packages/common",
+    ],
+)
+
+ng_benchmark(
+    name = "ng_for",
+    bundle = ":ng_for_lib",
 )

--- a/packages/core/test/render3/perf/micro_bench.ts
+++ b/packages/core/test/render3/perf/micro_bench.ts
@@ -28,7 +28,7 @@ export interface Profile {
   noImprovementCount: number;
 }
 
-export function createBenchmark(benchmarkName: string): Benchmark {
+export function createBenchmark(benchmarkName: string, testSetup?: Function): Benchmark {
   const profiles: Profile[] = [];
 
   const benchmark = function Benchmark(profileName: string): Profile {
@@ -69,9 +69,17 @@ export function createBenchmark(benchmarkName: string): Benchmark {
           }
         }
         iterationCounter = profile.iterationCount;
+        if (testSetup) testSetup();
         timestamp = performance.now();
         return runAgain;
       } else {
+        if (testSetup) {
+          const start = performance.now();
+          testSetup();
+          const testSetupTime = performance.now() - start;
+          timestamp += testSetupTime;  // add time to run test setup to timestamp so it's not
+                                       // included in calculations
+        }
         // this is the common path and it needs te be quick!
         iterationCounter--;
         return true;

--- a/packages/core/test/render3/perf/ng_for/benchmark_suite.ts
+++ b/packages/core/test/render3/perf/ng_for/benchmark_suite.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license

--- a/packages/core/test/render3/perf/ng_for/benchmark_suite.ts
+++ b/packages/core/test/render3/perf/ng_for/benchmark_suite.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {createBenchmark, Profile} from '../micro_bench';
+
+/**
+ * Benchmarking suite used to track benchmark tests for each suite that it is created with.
+ *
+ * The benchmarking suite is designed to be used in the following way.
+ *
+ * ```ts
+ * const suite = new BenchmarkSuite([
+ *   'my default test suite'
+ * ])
+ *
+ * // first create a new benchmark
+ * const index = suite.registerBenchmark('my benchmark');
+ *
+ * // then run tests
+ * suite.benchmarkStart(0, index, null);
+ * while (suite.benchmarkIsStillTracking()) {
+ *    // do whatever needs to be done that will
+ *    // be tracked by the benchmark
+ * }
+ * suite.benchmarkEnd();
+ * ```
+ */
+export class BenchmarkSuite {
+  public readonly entries: number[][] = [];
+  public readonly benchmarks: string[] = [];
+
+  private _currentProfile: Profile|null = null;
+  private _currentScenarioIndex = -1;
+  private _currentBenchmarkIndex = -1;
+
+  constructor(public readonly scenarios: string[]) {}
+
+  registerBenchmark(name: string) {
+    const index = this.benchmarks.length;
+    this.benchmarks.push(name);
+    this.entries.push(new Array(this.scenarios.length))
+    return index;
+  }
+
+  benchmarkStart(scenarioIndex: number, benchmarkIndex: number, testSetup: Function|null) {
+    const scenarioName = this.scenarios[scenarioIndex];
+    const benchmarkName = this.benchmarks[benchmarkIndex];
+    this._currentProfile = createBenchmark(scenarioName, testSetup || undefined)('');
+    this._currentBenchmarkIndex = benchmarkIndex;
+    this._currentScenarioIndex = scenarioIndex;
+    console.profile(`${scenarioName} ${benchmarkName}`);
+  }
+
+  benchmarkIsStillTracking() {
+    return this._currentProfile!();
+  }
+
+  benchmarkEnd() {
+    console.profileEnd();
+    const value = this._currentProfile!.bestTime;
+    const benchmarkIndex = this._currentBenchmarkIndex;
+    const row = this.entries[benchmarkIndex]!;
+    row[this._currentScenarioIndex] = value;
+    this._currentBenchmarkIndex = -1;
+    this._currentScenarioIndex = -1;
+    this._currentProfile = null;
+  }
+}

--- a/packages/core/test/render3/perf/ng_for/benchmarks.ts
+++ b/packages/core/test/render3/perf/ng_for/benchmarks.ts
@@ -1,0 +1,537 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {NgForOf} from '@angular/common';
+import {NgForOf as NgForOfPatched} from '@angular/common/src/directives/ng_for_of_patched';
+import {WatchCollectionPipe} from '@angular/common/src/pipes/watch_collection_pipe';
+
+import {BenchmarkSuite} from './benchmark_suite';
+import {createFakeNgFor} from './fake_ng_for';
+import {makeNumberArray, makeObjectArray, ObjectEntry, printHeading, trackByObjects, untilLessBusy} from './util';
+
+/**
+ * Creates a new benchmarking suite with three test scenarios:
+ * 1. NgFor normally
+ * 2. NgFor without deep watching
+ * 3. NgFor without deep watching and using WatchCollection
+ */
+export function createTripleNgForBenchmarkSuite() {
+  return new BenchmarkSuite([
+    'Master',
+    'No Deep Watching',
+    'WatchCollection',
+  ]);
+}
+
+/**
+ * Runs the provided benchmark function in following suites:
+ * 1. NgFor normally
+ * 2. NgFor without deep watching
+ * 3. NgFor without deep watching and using WatchCollection
+ */
+export async function run(
+    suite: BenchmarkSuite, benchmarkName: string, fn: BenchmarkRunFn, flags: SuiteOptions = 0) {
+  const benchmarkIndex = suite.registerBenchmark(benchmarkName);
+  printHeading(`Benchmark #${benchmarkIndex}: ${suite.benchmarks[benchmarkIndex]}`);
+
+  // Test for ngFor as it currently is in master
+  if (!optionIsSet(flags, SuiteOptions.SkipScenario1)) {
+    fn(suite, benchmarkIndex, 0, BenchmarkFeatures.UseStandardNgFor);
+    await untilLessBusy();
+  }
+
+  // Test for ngFor without any deep watching behavior (ngForPatched allows for this)
+  if (!optionIsSet(flags, SuiteOptions.SkipScenario2)) {
+    fn(suite, benchmarkIndex, 1, BenchmarkFeatures.UsePatchedNgFor);
+    await untilLessBusy();
+  }
+
+  // Test for ngFor without any deep watching behavior (ngForPatched)
+  // and also use the WatchCollectionPipe to enable deep watching
+  // behavior
+  if (!optionIsSet(flags, SuiteOptions.SkipScenario3)) {
+    fn(suite, benchmarkIndex, 2, BenchmarkFeatures.UseWatchCollection);
+    await untilLessBusy();
+  }
+}
+
+/**
+ * Options passed in when a benchmark is run across any of the scenarios attached to the suite
+ */
+export enum SuiteOptions {
+  SkipScenario1 = 0b001,
+  SkipScenario2 = 0b010,
+  SkipScenario3 = 0b100,
+}
+
+/**
+ * Feature flags used for instruct what structures to load for benchmark tests
+ */
+enum BenchmarkFeatures {
+  UseStandardNgFor    = 0b000,
+  UsePatchedNgFor     = 0b01,
+  UseWatchCollection  = 0b10,
+}
+
+/**
+ * The benchmark function that is run for each scenario within a benchmark suite
+ */
+interface BenchmarkRunFn {
+  (suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+   options: BenchmarkFeatures): void;
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function numberListNoChanges(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor = createFakeNgFor<number>(options & BenchmarkFeatures.UsePatchedNgFor, null);
+  const array = makeNumberArray();
+  const wc = (options & BenchmarkFeatures.UseWatchCollection) === BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  function testSetup() {
+    updateNgForValue(ngFor, wc, array);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    updateNgForValue(ngFor, wc, array);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function objectListNoChanges(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor = createFakeNgFor<number>(options & BenchmarkFeatures.UsePatchedNgFor, null);
+  const array = makeObjectArray();
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  function testSetup() {
+    updateNgForValue(ngFor, wc, array);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    updateNgForValue(ngFor, wc, array);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function numberListRefChange(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor = createFakeNgFor<number>(options & BenchmarkFeatures.UsePatchedNgFor, null);
+  const arr1 = makeNumberArray();
+  const arr2 = makeNumberArray();
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  function testSetup() {
+    updateNgForValue(ngFor, wc, arr1);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    updateNgForValue(ngFor, wc, arr2);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function objectListRefChange(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor = createFakeNgFor<number>(options & BenchmarkFeatures.UsePatchedNgFor, null);
+  const arr1 = makeObjectArray();
+  const arr2 = makeObjectArray();
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  function testSetup() {
+    updateNgForValue(ngFor, wc, arr1);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    updateNgForValue(ngFor, wc, arr2);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function objectListRefChangeWithTrackBy(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor =
+      createFakeNgFor<ObjectEntry>(options & BenchmarkFeatures.UsePatchedNgFor, trackByObjects);
+  const arr1 = makeObjectArray();
+  const arr2 = makeObjectArray();
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  function testSetup() {
+    updateNgForValue(ngFor, wc, arr1);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    updateNgForValue(ngFor, wc, arr2);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function numberListToEmpty(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor = createFakeNgFor<number>(options & BenchmarkFeatures.UsePatchedNgFor, null);
+  const arr1 = makeNumberArray();
+  const arr2: any[] = [];
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  function testSetup() {
+    updateNgForValue(ngFor, wc, arr1);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    updateNgForValue(ngFor, wc, arr2);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function objectListToEmpty(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor = createFakeNgFor<number>(options & BenchmarkFeatures.UsePatchedNgFor, null);
+  const arr1 = makeObjectArray();
+  const arr2: any[] = [];
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  function testSetup() {
+    updateNgForValue(ngFor, wc, arr1);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    updateNgForValue(ngFor, wc, arr2);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function objectListToEmptyTrackBy(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor =
+      createFakeNgFor<ObjectEntry>(options & BenchmarkFeatures.UsePatchedNgFor, trackByObjects);
+  const arr1 = makeObjectArray();
+  const arr2: any[] = [];
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  function testSetup() {
+    updateNgForValue(ngFor, wc, arr1);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    updateNgForValue(ngFor, wc, arr2);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function addRemoveNumberItems(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor = createFakeNgFor<number>(options & BenchmarkFeatures.UsePatchedNgFor, null);
+  const original = makeNumberArray();
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  let arrayForTest = [];
+  function testSetup() {
+    arrayForTest = [...original];
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    arrayForTest.push('a', 'b', 'c');
+    updateNgForValue(ngFor, wc, arrayForTest);
+    arrayForTest.pop();
+    arrayForTest.pop();
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function addRemoveObjectItems(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor = createFakeNgFor<number>(options & BenchmarkFeatures.UsePatchedNgFor, null);
+  const original = makeObjectArray();
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  let arrayForTest: ObjectEntry[] = [];
+  function testSetup() {
+    arrayForTest = [...original];
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    arrayForTest.push({value: 1}, {value: 2}, {value: 3});
+    updateNgForValue(ngFor, wc, arrayForTest);
+    arrayForTest.pop();
+    arrayForTest.pop();
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function addRemoveObjectItemsTrackBy(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor =
+      createFakeNgFor<ObjectEntry>(options & BenchmarkFeatures.UsePatchedNgFor, trackByObjects);
+  const original = makeObjectArray();
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  let arrayForTest: ObjectEntry[] = [];
+  function testSetup() {
+    arrayForTest = [...original];
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    arrayForTest.push({value: 1}, {value: 2}, {value: 3});
+    updateNgForValue(ngFor, wc, arrayForTest);
+    arrayForTest.pop();
+    arrayForTest.pop();
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function benchmark5dot1(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor = createFakeNgFor<number>(options & BenchmarkFeatures.UsePatchedNgFor, null);
+  const original = makeNumberArray();
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  let arrayForTest: any[] = [];
+  function testSetup() {
+    arrayForTest = [...original];
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    arrayForTest = [...arrayForTest, 'a', 'b', 'c'];
+    updateNgForValue(ngFor, wc, arrayForTest);
+    arrayForTest = arrayForTest.slice(0, arrayForTest.length - 1);
+    arrayForTest = arrayForTest.slice(0, arrayForTest.length - 1);
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function sortNumberItems(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor = createFakeNgFor<number>(options & BenchmarkFeatures.UsePatchedNgFor, null);
+  const original = makeNumberArray();
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  let arrayForTest: number[] = [];
+  function testSetup() {
+    arrayForTest = [...original];
+    updateNgForValue(ngFor, wc, arrayForTest);
+    arrayForTest.reverse();
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function sortObjectItems(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor = createFakeNgFor<number>(options & BenchmarkFeatures.UsePatchedNgFor, null);
+  const original = makeObjectArray();
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  let arrayForTest: ObjectEntry[] = [];
+  function testSetup() {
+    arrayForTest = [...original];
+    updateNgForValue(ngFor, wc, arrayForTest);
+    arrayForTest.reverse();
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function sortObjectItemsTrackBy(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor =
+      createFakeNgFor<ObjectEntry>(options & BenchmarkFeatures.UsePatchedNgFor, trackByObjects);
+  const original = makeObjectArray();
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  let arrayForTest: ObjectEntry[] = [];
+  function testSetup() {
+    arrayForTest = [...original];
+    updateNgForValue(ngFor, wc, arrayForTest);
+    arrayForTest.reverse();
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function truncateListOfNumbers(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor = createFakeNgFor<number>(options & BenchmarkFeatures.UsePatchedNgFor, null);
+  const original = makeNumberArray();
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  let arrayForTest: number[] = [];
+  function testSetup() {
+    arrayForTest = [...original];
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    arrayForTest.length = 0;
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function truncateListOfObjects(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor = createFakeNgFor<number>(options & BenchmarkFeatures.UsePatchedNgFor, null);
+  const original = makeObjectArray();
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  let arrayForTest: ObjectEntry[] = [];
+  function testSetup() {
+    arrayForTest = [...original];
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    arrayForTest.length = 0;
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Benchmark used with NgFor, NgFor patched and WatchCollection
+ */
+export function truncateListOfObjectsTrackBy(
+    suite: BenchmarkSuite, benchmarkIndex: number, scenarioIndex: number,
+    options: BenchmarkFeatures) {
+  const ngFor =
+      createFakeNgFor<ObjectEntry>(options & BenchmarkFeatures.UsePatchedNgFor, trackByObjects);
+  const original = makeObjectArray();
+  const wc = options & BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+
+  let arrayForTest: ObjectEntry[] = [];
+  function testSetup() {
+    arrayForTest = [...original];
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+
+  suite.benchmarkStart(scenarioIndex, benchmarkIndex, testSetup);
+  while (suite.benchmarkIsStillTracking()) {
+    arrayForTest.length = 0;
+    updateNgForValue(ngFor, wc, arrayForTest);
+  }
+  suite.benchmarkEnd();
+}
+
+/**
+ * Updates the provided ngFor param with the provided collection.
+ *
+ * If `wc` is passed in then the provided `array` value will be transformed before
+ * being assigned to `ngFor`.
+ */
+function updateNgForValue(
+    ngFor: NgForOf<any>|NgForOfPatched<any>, wc: WatchCollectionPipe|null, array: any[]) {
+  const oldValue = (ngFor as any)._ngForOf;
+  const newValue = wc !== null ? wc.transform(array) : array;
+  if (oldValue !== newValue) {
+    ngFor.ngForOf = newValue;
+  }
+  ngFor.ngDoCheck();
+}
+
+function optionIsSet(value: number, option: SuiteOptions) {
+  return (value & option) !== 0;
+}

--- a/packages/core/test/render3/perf/ng_for/benchmarks.ts
+++ b/packages/core/test/render3/perf/ng_for/benchmarks.ts
@@ -33,7 +33,7 @@ export function createTripleNgForBenchmarkSuite() {
  * 2. NgFor without deep watching
  * 3. NgFor without deep watching and using WatchCollection
  */
-export async function run(
+export function run(
     suite: BenchmarkSuite, benchmarkName: string, fn: BenchmarkRunFn, flags: SuiteOptions = 0) {
   const benchmarkIndex = suite.registerBenchmark(benchmarkName);
   printHeading(`Benchmark #${benchmarkIndex}: ${suite.benchmarks[benchmarkIndex]}`);
@@ -41,13 +41,11 @@ export async function run(
   // Test for ngFor as it currently is in master
   if (!optionIsSet(flags, SuiteOptions.SkipScenario1)) {
     fn(suite, benchmarkIndex, 0, BenchmarkFeatures.UseStandardNgFor);
-    await untilLessBusy();
   }
 
   // Test for ngFor without any deep watching behavior (ngForPatched allows for this)
   if (!optionIsSet(flags, SuiteOptions.SkipScenario2)) {
     fn(suite, benchmarkIndex, 1, BenchmarkFeatures.UsePatchedNgFor);
-    await untilLessBusy();
   }
 
   // Test for ngFor without any deep watching behavior (ngForPatched)
@@ -55,7 +53,6 @@ export async function run(
   // behavior
   if (!optionIsSet(flags, SuiteOptions.SkipScenario3)) {
     fn(suite, benchmarkIndex, 2, BenchmarkFeatures.UseWatchCollection);
-    await untilLessBusy();
   }
 }
 
@@ -72,9 +69,9 @@ export enum SuiteOptions {
  * Feature flags used for instruct what structures to load for benchmark tests
  */
 enum BenchmarkFeatures {
-  UseStandardNgFor    = 0b000,
-  UsePatchedNgFor     = 0b01,
-  UseWatchCollection  = 0b10,
+  UseStandardNgFor = 0b000,
+  UsePatchedNgFor = 0b01,
+  UseWatchCollection = 0b10,
 }
 
 /**
@@ -93,7 +90,10 @@ export function numberListNoChanges(
     options: BenchmarkFeatures) {
   const ngFor = createFakeNgFor<number>(options & BenchmarkFeatures.UsePatchedNgFor, null);
   const array = makeNumberArray();
-  const wc = (options & BenchmarkFeatures.UseWatchCollection) === BenchmarkFeatures.UseWatchCollection ? new WatchCollectionPipe() : null;
+  const wc =
+      (options & BenchmarkFeatures.UseWatchCollection) === BenchmarkFeatures.UseWatchCollection ?
+      new WatchCollectionPipe() :
+      null;
 
   function testSetup() {
     updateNgForValue(ngFor, wc, array);

--- a/packages/core/test/render3/perf/ng_for/benchmarks.ts
+++ b/packages/core/test/render3/perf/ng_for/benchmarks.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
@@ -11,7 +11,7 @@ import {WatchCollectionPipe} from '@angular/common/src/pipes/watch_collection_pi
 
 import {BenchmarkSuite} from './benchmark_suite';
 import {createFakeNgFor} from './fake_ng_for';
-import {makeNumberArray, makeObjectArray, ObjectEntry, printHeading, trackByObjects, untilLessBusy} from './util';
+import {makeNumberArray, makeObjectArray, ObjectEntry, printHeading, trackByObjects} from './util';
 
 /**
  * Creates a new benchmarking suite with three test scenarios:

--- a/packages/core/test/render3/perf/ng_for/fake_ng_for.ts
+++ b/packages/core/test/render3/perf/ng_for/fake_ng_for.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license

--- a/packages/core/test/render3/perf/ng_for/fake_ng_for.ts
+++ b/packages/core/test/render3/perf/ng_for/fake_ng_for.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {NgForOf} from '@angular/common';
+import {NgForOf as NgForOfPatched} from '@angular/common/src/directives/ng_for_of_patched';
+import {ElementRef, EmbeddedViewRef, Injector, NgModuleRef, TemplateRef, ViewContainerRef, ViewRef} from '@angular/core/src/core';
+import {ComponentFactory, ComponentRef} from '@angular/core/src/render3';
+
+import {DefaultIterableDifferFactory, DefaultKeyValueDifferFactory, TrackByFunction} from '../../../../src/change_detection/change_detection';
+
+const KV_DIFFER_FACTORY = new DefaultKeyValueDifferFactory();
+const ITERABLE_DIFFER_FACTORY = new DefaultIterableDifferFactory();
+
+export function createFakeNgFor<T>(usePatched: any, trackByFn: TrackByFunction<T>|null) {
+  const container = new FakeContainerRef();
+  const template = new FakeTemplateRef();
+  const differs: any = {
+    find: (iterable: any) => {
+      return ITERABLE_DIFFER_FACTORY.supports(iterable) ? ITERABLE_DIFFER_FACTORY :
+                                                          KV_DIFFER_FACTORY;
+    }
+  };
+
+  const ngFor = usePatched ? new NgForOfPatched<T>(container, template, differs) :
+                             new NgForOf<T>(container, template, differs)
+  if (trackByFn !== null) {
+    ngFor.ngForTrackBy = trackByFn;
+  }
+  return ngFor;
+}
+
+class FakeContainerRef extends ViewContainerRef {
+  get element(): ElementRef<any> {
+    throw new Error('Method not implemented.');
+  }
+  get injector(): Injector {
+    return {} as any;
+  }
+  get parentInjector(): Injector {
+    return {} as any;
+  }
+  clear(): void {}
+  get(index: number): ViewRef|null {
+    return {context: {}} as any;
+  }
+  get length(): number {
+    return 0;
+  }
+  createEmbeddedView<C>(
+      templateRef: TemplateRef<C>, context?: C|undefined,
+      index?: number|undefined): EmbeddedViewRef<C> {
+    return {context: {}} as any;
+  }
+  createComponent<C>(
+      componentFactory: ComponentFactory<C>, index?: number|undefined,
+      injector?: Injector|undefined, projectableNodes?: any[][]|undefined,
+      ngModule?: NgModuleRef<any>|undefined): ComponentRef<C> {
+    return {} as any;
+  }
+  insert(viewRef: ViewRef, index?: number|undefined): ViewRef {
+    return {} as any;
+  }
+  move(viewRef: ViewRef, currentIndex: number): ViewRef {
+    return {} as any;
+  }
+  indexOf(viewRef: ViewRef): number {
+    return {} as any;
+  }
+  remove(index?: number|undefined): void {
+    return {} as any;
+  }
+  detach(index?: number|undefined): ViewRef|null {
+    return {} as any;
+  }
+}
+
+class FakeTemplateRef extends TemplateRef<any> {
+  get elementRef(): ElementRef<any> {
+    return {} as any;
+  }
+  createEmbeddedView(context: any): EmbeddedViewRef<any> {
+    return {} as any;
+  }
+}

--- a/packages/core/test/render3/perf/ng_for/index.ts
+++ b/packages/core/test/render3/perf/ng_for/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license

--- a/packages/core/test/render3/perf/ng_for/index.ts
+++ b/packages/core/test/render3/perf/ng_for/index.ts
@@ -6,33 +6,32 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as b from './benchmarks';
-import {printHeading, printBenchmarkResultsTable} from './util';
+import {printBenchmarkResultsTable, printHeading} from './util';
 
-async function main() {
+function main() {
   const suite = b.createTripleNgForBenchmarkSuite();
 
-  await b.run(suite, 'numbers (no changes)', b.numberListNoChanges);
-  await b.run(suite, 'objects (no changes)', b.objectListNoChanges);
-  await b.run(suite, 'numbers (ref change)', b.numberListRefChange);
-  await b.run(suite, 'objects (ref change)', b.objectListRefChange);
-  await b.run(suite, 'track objects (ref change)', b.objectListRefChangeWithTrackBy);
-  await b.run(suite, 'numbers (ref to [])', b.numberListToEmpty);
-  await b.run(suite, 'objects (ref to [])', b.objectListToEmpty);
-  await b.run(suite, 'track objects (ref to [])', b.objectListToEmptyTrackBy);
+  b.run(suite, 'numbers (no changes)', b.numberListNoChanges);
+  b.run(suite, 'objects (no changes)', b.objectListNoChanges);
+  b.run(suite, 'numbers (ref change)', b.numberListRefChange);
+  b.run(suite, 'objects (ref change)', b.objectListRefChange);
+  b.run(suite, 'track objects (ref change)', b.objectListRefChangeWithTrackBy);
+  b.run(suite, 'numbers (ref to [])', b.numberListToEmpty);
+  b.run(suite, 'objects (ref to [])', b.objectListToEmpty);
+  b.run(suite, 'track objects (ref to [])', b.objectListToEmptyTrackBy);
 
   // mutation benchmarks do not need to run scenario #2 (which is the `No Deep Watching` case)
   const skipDeepWatching = b.SuiteOptions.SkipScenario2;
-  await b.run(suite, 'numbers (mutate add/remove)', b.addRemoveNumberItems, skipDeepWatching);
-  await b.run(suite, 'objects (mutate add/remove)', b.addRemoveObjectItems, skipDeepWatching);
-  await b.run(
+  b.run(suite, 'numbers (mutate add/remove)', b.addRemoveNumberItems, skipDeepWatching);
+  b.run(suite, 'objects (mutate add/remove)', b.addRemoveObjectItems, skipDeepWatching);
+  b.run(
       suite, 'track objects (mutate add/remove)', b.addRemoveObjectItemsTrackBy, skipDeepWatching);
-  await b.run(suite, 'numbers (sort in place)', b.sortNumberItems, skipDeepWatching);
-  await b.run(suite, 'objects (sort in place)', b.sortObjectItems, skipDeepWatching);
-  await b.run(suite, 'track objects (sort in place)', b.sortObjectItemsTrackBy, skipDeepWatching);
-  await b.run(suite, 'numbers (set length => 0)', b.truncateListOfNumbers, skipDeepWatching);
-  await b.run(suite, 'objects (set length => 0)', b.truncateListOfObjects, skipDeepWatching);
-  await b.run(
-      suite, 'track objects (set length => 0)', b.truncateListOfObjectsTrackBy, skipDeepWatching);
+  b.run(suite, 'numbers (sort in place)', b.sortNumberItems, skipDeepWatching);
+  b.run(suite, 'objects (sort in place)', b.sortObjectItems, skipDeepWatching);
+  b.run(suite, 'track objects (sort in place)', b.sortObjectItemsTrackBy, skipDeepWatching);
+  b.run(suite, 'numbers (set length => 0)', b.truncateListOfNumbers, skipDeepWatching);
+  b.run(suite, 'objects (set length => 0)', b.truncateListOfObjects, skipDeepWatching);
+  b.run(suite, 'track objects (set length => 0)', b.truncateListOfObjectsTrackBy, skipDeepWatching);
 
   printHeading('Results');
   printBenchmarkResultsTable(suite.scenarios, suite.benchmarks, suite.entries);

--- a/packages/core/test/render3/perf/ng_for/index.ts
+++ b/packages/core/test/render3/perf/ng_for/index.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as b from './benchmarks';
+import {printHeading, printBenchmarkResultsTable} from './util';
+
+async function main() {
+  const suite = b.createTripleNgForBenchmarkSuite();
+
+  await b.run(suite, 'numbers (no changes)', b.numberListNoChanges);
+  await b.run(suite, 'objects (no changes)', b.objectListNoChanges);
+  await b.run(suite, 'numbers (ref change)', b.numberListRefChange);
+  await b.run(suite, 'objects (ref change)', b.objectListRefChange);
+  await b.run(suite, 'track objects (ref change)', b.objectListRefChangeWithTrackBy);
+  await b.run(suite, 'numbers (ref to [])', b.numberListToEmpty);
+  await b.run(suite, 'objects (ref to [])', b.objectListToEmpty);
+  await b.run(suite, 'track objects (ref to [])', b.objectListToEmptyTrackBy);
+
+  // mutation benchmarks do not need to run scenario #2 (which is the `No Deep Watching` case)
+  const skipDeepWatching = b.SuiteOptions.SkipScenario2;
+  await b.run(suite, 'numbers (mutate add/remove)', b.addRemoveNumberItems, skipDeepWatching);
+  await b.run(suite, 'objects (mutate add/remove)', b.addRemoveObjectItems, skipDeepWatching);
+  await b.run(
+      suite, 'track objects (mutate add/remove)', b.addRemoveObjectItemsTrackBy, skipDeepWatching);
+  await b.run(suite, 'numbers (sort in place)', b.sortNumberItems, skipDeepWatching);
+  await b.run(suite, 'objects (sort in place)', b.sortObjectItems, skipDeepWatching);
+  await b.run(suite, 'track objects (sort in place)', b.sortObjectItemsTrackBy, skipDeepWatching);
+  await b.run(suite, 'numbers (set length => 0)', b.truncateListOfNumbers, skipDeepWatching);
+  await b.run(suite, 'objects (set length => 0)', b.truncateListOfObjects, skipDeepWatching);
+  await b.run(
+      suite, 'track objects (set length => 0)', b.truncateListOfObjectsTrackBy, skipDeepWatching);
+
+  printHeading('Results');
+  printBenchmarkResultsTable(suite.scenarios, suite.benchmarks, suite.entries);
+}
+
+main();

--- a/packages/core/test/render3/perf/ng_for/util.ts
+++ b/packages/core/test/render3/perf/ng_for/util.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Interface used with listing object entries in this benchmark
+ */
+export interface ObjectEntry {
+  value: number;
+}
+
+/**
+ * Prints out a table in the following format
+ *
+ * index | scenario1 | scenario2 | scenario2and1Diff% | scenario3 | scenario3and1Diff%
+ * -----------------------------------------------------------------------------------
+ * ...values...
+ */
+export function printBenchmarkResultsTable(scenarios: string[], benchmarks: string[], entries: number[][]): void {
+  const rowTpl: {[scenario: string]: any} = {benchmark: ''};
+  for (let i = 0; i < scenarios.length; i++) {
+    const scenario = scenarios[i];
+    const scenarioName = timeColumn(scenario);
+    rowTpl[scenarioName] = null;
+    if (i !== 0) {
+      const diffName = diffColumn(scenario);
+      rowTpl[diffName] = null;
+    }
+  }
+
+  const rows: any[] = [];
+  for (let i = 0; i < benchmarks.length; i++) {
+    const entry = entries[i];
+    if (!entry) continue;
+    const row: {[scenario: string]: string|number|null} = {...rowTpl, benchmark: benchmarks[i]};
+    const masterValue = entry[0] || 0;
+    for (let j = 0; j < scenarios.length; j++) {
+      const scenario = scenarios[j];
+      const scenarioName = timeColumn(scenario);
+      const value = entry[j] || 0 as number;
+      row[scenarioName] = formatTime(value);
+      if (j !== 0) {
+        const diffName = diffColumn(scenario);
+        row[diffName] = value === 0 ? 'n/a' : formatDiff(masterValue / value);
+      }
+    }
+    rows.push(row);
+  }
+
+  console.table(rows);
+}
+
+function diffColumn(name: string) {
+  return `${name} (diff)`;
+}
+
+function timeColumn(name: string) {
+  return `${name} (ms)`;
+}
+
+// e.g. `1.02 x 10^-2ms`
+const TIME_DECIMAL_PLACES = 2;
+
+// e.g. `0.05x`
+const DIFF_DECIMAL_PLACES = 2;
+
+/**
+ * Formats the provided number into millisecond form (using scientific notation to help reduce characters).
+ *
+ * Example:
+ * ```ts
+ * formatTime(0) // 0ms
+ * formatTime(1) // 1ms
+ * formatTime(0.1) // 1 * 10^-1ms
+ * formatTime(0.01) // 1 * 10^-2ms
+ * formatTime(0.001) // 1 * 10^-3ms
+ * // ...
+ * ```
+ *
+ * @param value a number in millisecond form
+ */
+function formatTime(value: number): string {
+  let exponentValue;
+  for (exponentValue = 0; value !== 0 && value < 1; exponentValue++) {
+    value *= 10;
+  }
+
+  let displayValue: string;
+  if (value === 0) {
+    displayValue = 'n/a';
+  } else {
+    displayValue = value.toFixed(TIME_DECIMAL_PLACES);
+    displayValue = exponentValue === 0
+      ? displayValue
+      : `${displayValue} * 10^-${exponentValue}`;
+  }
+
+  return displayValue;
+}
+
+/**
+ * Returns a diff value representing the change in value in the form of `valueX`.
+ *
+ * There are three cases of the value is formatted:
+ * Case 1: If greater than 1 then round down
+ * Case 2: If greater than 1 but less than 2 then still use a floating point diff
+ * Case 3: Otherwise show a negative difference
+ */
+function formatDiff(value: number) {
+  let slower = false;
+  if (value > 2) {
+    // Case 1: bigger than 100%
+    value = Math.floor(value);
+  } else if (value > 1) {
+    // Case 2: less than 2x, but greater than 1x
+    value--;
+  } else {
+    // Case 3: less than 1x
+    value = 1 - value;
+    slower = true;
+  }
+
+  const displayValue = value < 1
+    ? formatToDecimalPlaces(value, DIFF_DECIMAL_PLACES)
+    : value.toString();
+
+  return displayValue === '0'
+    ? 'no difference'
+    : `${displayValue}x ${slower ? 'slower' : 'faster'}`;
+}
+
+/**
+ * Formats the value nicely to the given decimal places amount, but returns `0` when the value is beyond the provided decimal places
+ */
+function formatToDecimalPlaces(value: number, decimalPlaces: number): string {
+  const maxNumber = Math.pow(10,-decimalPlaces);
+  return value < maxNumber
+    ? '0'
+    : value.toFixed(decimalPlaces);
+}
+
+export function printHeading(name: string) {
+  console.log(
+      '-----------------------------------------------\n' + name + '\n' +
+      '-----------------------------------------------');
+}
+
+/**
+ * Returns and resolves a promise once the program is less busy.
+ *
+ * See `setImmediate`
+ */
+export function untilLessBusy() {
+  return new Promise(r => {
+    setImmediate(() => r());
+  });
+}
+
+/**
+ * Returns a list of 1000 numbers
+ */
+export function makeNumberArray(): number[] {
+  const array: number[] = [];
+  for (let i = 0; i < 1000; i++) {
+    array.push(i);
+  }
+  return array;
+}
+
+/**
+ * Returns a list of 1000 objects each having an incremented value
+ */
+export function makeObjectArray(): ObjectEntry[] {
+  return makeNumberArray().map(value => ({value}));
+}
+
+/**
+ * The trackBy function used for tracking `ObjectEntry` entries.
+ *
+ * This function is designed to be used with NgFor.
+ */
+export function trackByObjects(index: number, item: ObjectEntry) {
+  return item.value;
+}

--- a/packages/core/test/render3/perf/ng_for/util.ts
+++ b/packages/core/test/render3/perf/ng_for/util.ts
@@ -20,7 +20,8 @@ export interface ObjectEntry {
  * -----------------------------------------------------------------------------------
  * ...values...
  */
-export function printBenchmarkResultsTable(scenarios: string[], benchmarks: string[], entries: number[][]): void {
+export function printBenchmarkResultsTable(
+    scenarios: string[], benchmarks: string[], entries: number[][]): void {
   const rowTpl: {[scenario: string]: any} = {benchmark: ''};
   for (let i = 0; i < scenarios.length; i++) {
     const scenario = scenarios[i];
@@ -69,7 +70,8 @@ const TIME_DECIMAL_PLACES = 2;
 const DIFF_DECIMAL_PLACES = 2;
 
 /**
- * Formats the provided number into millisecond form (using scientific notation to help reduce characters).
+ * Formats the provided number into millisecond form (using scientific notation to help reduce
+ * characters).
  *
  * Example:
  * ```ts
@@ -94,9 +96,7 @@ function formatTime(value: number): string {
     displayValue = 'n/a';
   } else {
     displayValue = value.toFixed(TIME_DECIMAL_PLACES);
-    displayValue = exponentValue === 0
-      ? displayValue
-      : `${displayValue} * 10^-${exponentValue}`;
+    displayValue = exponentValue === 0 ? displayValue : `${displayValue} * 10^-${exponentValue}`;
   }
 
   return displayValue;
@@ -124,23 +124,20 @@ function formatDiff(value: number) {
     slower = true;
   }
 
-  const displayValue = value < 1
-    ? formatToDecimalPlaces(value, DIFF_DECIMAL_PLACES)
-    : value.toString();
+  const displayValue =
+      value < 1 ? formatToDecimalPlaces(value, DIFF_DECIMAL_PLACES) : value.toString();
 
-  return displayValue === '0'
-    ? 'no difference'
-    : `${displayValue}x ${slower ? 'slower' : 'faster'}`;
+  return displayValue === '0' ? 'no difference' :
+                                `${displayValue}x ${slower ? 'slower' : 'faster'}`;
 }
 
 /**
- * Formats the value nicely to the given decimal places amount, but returns `0` when the value is beyond the provided decimal places
+ * Formats the value nicely to the given decimal places amount, but returns `0` when the value is
+ * beyond the provided decimal places
  */
 function formatToDecimalPlaces(value: number, decimalPlaces: number): string {
-  const maxNumber = Math.pow(10,-decimalPlaces);
-  return value < maxNumber
-    ? '0'
-    : value.toFixed(decimalPlaces);
+  const maxNumber = Math.pow(10, -decimalPlaces);
+  return value < maxNumber ? '0' : value.toFixed(decimalPlaces);
 }
 
 export function printHeading(name: string) {

--- a/packages/core/test/render3/perf/ng_for/util.ts
+++ b/packages/core/test/render3/perf/ng_for/util.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
@@ -52,6 +52,7 @@ export function printBenchmarkResultsTable(
     rows.push(row);
   }
 
+  // tslint:disable-next-line
   console.table(rows);
 }
 
@@ -141,20 +142,10 @@ function formatToDecimalPlaces(value: number, decimalPlaces: number): string {
 }
 
 export function printHeading(name: string) {
+  // tslint:disable-next-line
   console.log(
       '-----------------------------------------------\n' + name + '\n' +
       '-----------------------------------------------');
-}
-
-/**
- * Returns and resolves a promise once the program is less busy.
- *
- * See `setImmediate`
- */
-export function untilLessBusy() {
-  return new Promise(r => {
-    setImmediate(() => r());
-  });
 }
 
 /**


### PR DESCRIPTION
The `watchCollection` pipe is used to track the contents of an array or key/value map and then create a new copy once a change is detected.

This pipe can be used to signal input bindings whenever the contents of a collection change.

```html
<!-- [values] only gets fired when the `myValues` input
     value changes in identity (when the value is rewritten) -->
<my-comp [values]="myValues"></my-comp>

<!-- [values] will now get updated whenever the `myValues`
     collection changes in identity or content -->
<my-comp [values]="myValues | watchCollection"></my-comp>
```