### PR TITLE
fix(dev-infra): extract commit headers before checking commit message validity

### DIFF
--- a/dev-infra/commit-message/validate-range.ts
+++ b/dev-infra/commit-message/validate-range.ts
@@ -11,6 +11,9 @@ import {parseCommitMessage, validateCommitMessage, ValidateCommitMessageOptions}
 // Whether the provided commit is a fixup commit.
 const isNonFixup = (m: string) => !parseCommitMessage(m).isFixup;
 
+// Extracts commit header (first line of commit message).
+const extractCommitHeader = (m: string) => parseCommitMessage(m).header;
+
 /** Validate all commits in a provided git commit range. */
 export function validateCommitRange(range: string) {
   // A random value is used as a string to allow for a definite split point in the git log result.
@@ -35,7 +38,9 @@ export function validateCommitRange(range: string) {
   const allCommitsInRangeValid = commits.every((m, i) => {
     const options: ValidateCommitMessageOptions = {
       disallowSquash: true,
-      nonFixupCommitHeaders: isNonFixup(m) ? undefined : commits.slice(0, i).filter(isNonFixup)
+      nonFixupCommitHeaders: isNonFixup(m) ?
+          undefined :
+          commits.slice(0, i).filter(isNonFixup).map(extractCommitHeader)
     };
     return validateCommitMessage(m, options);
   });


### PR DESCRIPTION
This commit fixes an issue where adding `fixup` commits was triggering a lint error. The problem was caused by the fact that we used the entire message body while checking whether `fixup` commit has a corresponding "parent" commit in a range. This issue was found after enforcing a check that exits the process if there is an invalid commit message found (https://github.com/angular/angular/commit/4341743b4a6d7e23c6f944aa9e34166b701369a1).


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No