### PR TITLE
test(router): fix router test failing on IE

### DIFF
--- a/packages/router/test/BUILD.bazel
+++ b/packages/router/test/BUILD.bazel
@@ -44,21 +44,6 @@ jasmine_node_test(
 
 karma_web_test_suite(
     name = "test_web",
-    tags = [
-        # disabled on 2020-04-14 due to failure on saucelabs monitor job
-        # https://app.circleci.com/pipelines/github/angular/angular/13320/workflows/9ca3527a-d448-4a64-880a-fb4de9d1fece/jobs/680645
-        # ```
-        # Chrome 73.0.3683 (Windows 7.0.0) ERROR: 'ERROR', Error: Uncaught (in promise): Error: Cannot match any routes. URL Segment: 'aa'
-        # Error: Cannot match any routes. URL Segment: 'aa'
-        # IE 11.0.0 (Windows 8.1.0.0) ERROR: 'ERROR', Error: Uncaught (in promise): Error: Cannot match any routes. URL Segment: 'aa'
-        # Error: Cannot match any routes. URL Segment: 'aa'
-        # Firefox 65.0.0 (Windows 7.0.0) ERROR: 'ERROR', Error: Uncaught (in promise): Error: Cannot match any routes. URL Segment: 'aa'
-        # IE 10.0.0 (Windows 8.0.0) ERROR: 'ERROR', Error: Uncaught (in promise): Error: Cannot match any routes. URL Segment: 'aa'
-        # Error: Cannot match any routes. URL Segment: 'aa'
-        # ```
-        "fixme-saucelabs-ve",
-        "fixme-saucelabs-ivy",
-    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -297,7 +297,6 @@ describe('bootstrap', () => {
 
     const res = await platformBrowserDynamic([]).bootstrapModule(TestModule);
     const router = res.injector.get(Router);
-    const location: Location = res.injector.get(Location);
 
     await router.navigateByUrl('/aa');
     window.scrollTo(0, 5000);
@@ -317,12 +316,12 @@ describe('bootstrap', () => {
     expect(getScrollY()).toEqual(0);
 
     await router.navigateByUrl('/aa#marker2');
-    expect(getScrollY() >= 5900).toBe(true);
-    expect(window.scrollY < 6000).toBe(true);  // offset
+    expect(getScrollY()).toBeGreaterThanOrEqual(5900);
+    expect(getScrollY()).toBeLessThan(6000);  // offset
 
     await router.navigateByUrl('/aa#marker3');
-    expect(getScrollY() >= 8900).toBe(true);
-    expect(getScrollY() < 9000).toBe(true);
+    expect(getScrollY()).toBeGreaterThanOrEqual(8900);
+    expect(getScrollY()).toBeLessThan(9000);
     done();
   });
 


### PR DESCRIPTION
This was originally fixed in #35976, but one of the `window.scrollY`
assertions was missed. Also updated tests to use toBeGreater/LessThan
to improve failure messages.
