### PR TITLE
build: add AndrewKushnir to the `fw-testing` group

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -566,6 +566,7 @@ groups:
           ])
     reviewers:
       users:
+        - AndrewKushnir
         - IgorMinar
         - kara
         - pkozlowski-opensource


### PR DESCRIPTION
This commit update the PullApprove config to add AndrewKushnir to the `fw-testing` group. The reason for this change is that I was involved into TestBed rewrite (for Ivy) and it belongs to the `fw-testing` group ownership.


## PR Type
What kind of change does this PR introduce?

- [x] Build related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No