### PR TITLE
build: fix the compare master and patch script output

### DIFF
--- a/scripts/compare-master-to-patch.js
+++ b/scripts/compare-master-to-patch.js
@@ -88,7 +88,7 @@ function collectCommitsAsMap(rawGitCommits) {
   return commitsMap;
 }
 
-function getCommitInfoAsString(commitInfo, version) {
+function getCommitInfoAsString(version, commitInfo) {
   return `[${version}+] ${commitInfo}`;
 }
 


### PR DESCRIPTION
Currently the commit message and corresponding version are flipped, which makes it hard to review the changes. This commit updates the script to properly recognize the order of arguments.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No