### PR TITLE
revert: fix(common): format day-periods that cross midnight (#36611)

### DIFF
--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -202,30 +202,12 @@ describe('Format date', () => {
         BBBBB: 'mi',
       };
 
-      const midnightCrossingPeriods: any = {
-        b: 'night',
-        bb: 'night',
-        bbb: 'night',
-        bbbb: 'night',
-        bbbbb: 'night',
-        B: 'at night',
-        BB: 'at night',
-        BBB: 'at night',
-        BBBB: 'at night',
-        BBBBB: 'at night',
-      };
-
       Object.keys(dateFixtures).forEach((pattern: string) => {
         expectDateFormatAs(date, pattern, dateFixtures[pattern]);
       });
 
       Object.keys(isoStringWithoutTimeFixtures).forEach((pattern: string) => {
         expectDateFormatAs(isoStringWithoutTime, pattern, isoStringWithoutTimeFixtures[pattern]);
-      });
-
-      const nightTime = new Date(2015, 5, 15, 2, 3, 1, 550);
-      Object.keys(midnightCrossingPeriods).forEach(pattern => {
-        expectDateFormatAs(nightTime, pattern, midnightCrossingPeriods[pattern]);
       });
     });
 


### PR DESCRIPTION
This reverts commit 1756cced4a59bc1185653c6c9b8f661636fd6116.

The reason for this revert is because of the change being too risky for
a patch release of Angular. Changing date formatting proves to be a
breaking change and can only be apart of the next release.