### PR TITLE
Fix module loading to handle interaction between route preload strategy  and route navigation  

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -486,6 +486,11 @@ export interface Route {
    * @internal
    */
   _loadedConfig?: LoadedRouterConfig;
+  /**
+   * Filled for routes with `loadChildren` during load
+   * @internal
+   */
+  _loader$?: Observable<LoadedRouterConfig>;
 }
 
 export class LoadedRouterConfig {

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -8,7 +8,7 @@
 
 import {Compiler, InjectionToken, Injector, NgModuleFactory, NgModuleFactoryLoader} from '@angular/core';
 import {from, Observable, of} from 'rxjs';
-import {map, mergeMap, share, tap} from 'rxjs/operators';
+import {catchError, map, mergeMap, share} from 'rxjs/operators';
 
 import {LoadChildren, LoadedRouterConfig, Route, standardizeConfig} from './config';
 import {flatten, wrapIntoObservable} from './utils/collection';
@@ -35,6 +35,10 @@ export class RouterConfigLoader {
       const moduleFactory$ = this.loadModuleFactory(route.loadChildren!);
 
       route._loader$ = moduleFactory$.pipe(
+          catchError((err) => {
+            route._loader$ = undefined;
+            throw err;
+          }),
           map((factory: NgModuleFactory<any>) => {
             if (this.onLoadEndListener) {
               this.onLoadEndListener(route);

--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -127,7 +127,8 @@ export class RouterPreloader implements OnDestroy {
 
   private preloadConfig(ngModule: NgModuleRef<any>, route: Route): Observable<void> {
     return this.preloadingStrategy.preload(route, () => {
-      const loaded$ = this.loader.load(ngModule.injector, route);
+      const loaded$ = route._loadedConfig ? of(route._loadedConfig) :
+                                            this.loader.load(ngModule.injector, route);
       return loaded$.pipe(mergeMap((config: LoadedRouterConfig) => {
         route._loadedConfig = config;
         return this.processRoutes(config.module, config.routes);

--- a/packages/router/test/spy_ng_module_factory_loader.spec.ts
+++ b/packages/router/test/spy_ng_module_factory_loader.spec.ts
@@ -93,8 +93,7 @@ describe('SpyNgModuleFactoryLoader', () => {
        r.load('one').then((r: any) => error = r).catch((e: any) => error = e);
        tick();
        expect(error).toEqual(expected);
-
-    }));
+     }));
 
   it('should return a rejected promise when given an invalid path', fakeAsync(() => {
        const r = new SpyNgModuleFactoryLoader(<any>null);


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature

## What is the current behaviour?

This PR addresses the issues found in the issues  #22842, and pr #26557

It also replaces the PR for #26557 which has a number of issues
 * By forcing the subscription to close if a module has a lazy sub-module then the these are passed to the PreloadingStrategy class as the observable has already terminated.
 * It doesn't actually prevent the load as the fetch may overlap with the preload fetch. Ie both the pre-loader and navigation can start a load both will finish .

Issue Number:  #26557, #22842

## What is the new behaviour?

By Prevent loading a route module twice, we prevent the sending of multiple  RouteConfigLoadEnd events, and the duplicate console log as show in the stackbiz example on #26557 

We also add a new feature to SpyNgModuleFactoryLoader to enable us to emulate slow loading modules, this is required for testing.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information / Questions

* I have a version of this based on #36654
* I need to add test to enable the and support error in loading the module. Ie if the initial load request fails, the stored load-observable need to be removed so a new one is created.
* I need suggestions for the name of the private var attached to the route to store the loading observable currently named '_loader'. It attached to the route as both the preloader and router create the own instance of the RouterConfigLoader

