### PR TITLE
fix(localize): include legacy ids when describing messages

### DIFF
--- a/packages/localize/src/utils/src/translations.ts
+++ b/packages/localize/src/utils/src/translations.ts
@@ -123,5 +123,7 @@ export function makeTemplateObject(cooked: string[], raw: string[]): TemplateStr
 
 function describeMessage(message: ParsedMessage): string {
   const meaningString = message.meaning && ` - "${message.meaning}"`;
-  return `"${message.messageId}" ("${message.messageString}"${meaningString})`;
+  const legacy =
+      message.legacyIds.length > 0 ? ` [${message.legacyIds.map(l => `"${l}"`).join(', ')}]` : '';
+  return `"${message.messageId}"${legacy} ("${message.messageString}"${meaningString})`;
 }

--- a/packages/localize/src/utils/test/translations_spec.ts
+++ b/packages/localize/src/utils/test/translations_spec.ts
@@ -82,6 +82,13 @@ describe('utils', () => {
     it('should throw an error if there is no matching translation', () => {
       expect(() => doTranslate({}, parts`abc`))
           .toThrowError('No translation found for "2674653928643152084" ("abc").');
+      expect(() => doTranslate({}, parts`:@@customId:abc`))
+          .toThrowError('No translation found for "customId" ("abc").');
+      expect(
+          () => doTranslate(
+              {}, parts`:␟d42e3c2d3aa340581d42f53c46eb49ecb3d3beb4␟3896949568605777881:abc`))
+          .toThrowError(
+              'No translation found for "2674653928643152084" ["d42e3c2d3aa340581d42f53c46eb49ecb3d3beb4", "3896949568605777881"] ("abc").');
       expect(() => doTranslate({}, parts`:meaning|:abc`))
           .toThrowError('No translation found for "1071947593002928768" ("abc" - "meaning").');
     });


### PR DESCRIPTION
Previously, we only displayed the new `$localize` id, which is not
currently what most people have in their translation files.
Until people migrate to the new message id system it is confusing
not to display the legacy ids.
