### PR TITLE
fix(common): canceled JSONP requests won't throw error with missing callback function

### DIFF
--- a/packages/common/http/src/jsonp.ts
+++ b/packages/common/http/src/jsonp.ts
@@ -125,15 +125,17 @@ export class JsonpClientBackend implements HttpBackend {
       // cleanup() is a utility closure that removes the <script> from the page and
       // the response callback from the window. This logic is used in both the
       // success, error, and cancellation paths, so it's extracted out for convenience.
-      const cleanup = () => {
+      const cleanup = (removeCallback = true) => {
         // Remove the <script> tag if it's still on the page.
         if (node.parentNode) {
           node.parentNode.removeChild(node);
         }
 
-        // Remove the response callback from the callbackMap (window object in the
-        // browser).
-        delete this.callbackMap[callback];
+        if (removeCallback) {
+          // Remove the response callback from the callbackMap (window object in the
+          // browser).
+          delete this.callbackMap[callback];
+        }
       };
 
       // onLoad() is the success callback which runs after the response callback
@@ -218,7 +220,9 @@ export class JsonpClientBackend implements HttpBackend {
         node.removeEventListener('error', onError);
 
         // And finally, clean up the page.
-        cleanup();
+        // Unsubscription won't remove the callback handler because there's no way to stop
+        // loading <script> once it has been added to DOM.
+        cleanup(false);
       };
     });
   }

--- a/packages/common/http/test/jsonp_spec.ts
+++ b/packages/common/http/test/jsonp_spec.ts
@@ -17,7 +17,6 @@ function runOnlyCallback(home: any, data: Object) {
   const keys = Object.keys(home);
   expect(keys.length).toBe(1);
   const callback = home[keys[0]];
-  delete home[keys[0]];
   callback(data);
 }
 
@@ -62,6 +61,11 @@ const SAMPLE_REQ = new HttpRequest<never>('JSONP', '/test');
         done();
       });
       document.mockError(error);
+    });
+    it('allows the callback to be invoked when the request is cancelled', () => {
+      backend.handle(SAMPLE_REQ).subscribe().unsubscribe();
+      runOnlyCallback(home, {data: 'This is a test'});
+      expect(Object.keys(home).length).toBe(0);
     });
     describe('throws an error', () => {
       it('when request method is not JSONP',


### PR DESCRIPTION
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes #34818

Unsubscribing from a JSONP request will throw console errors such as `Uncaught ReferenceError: ng_jsonp_callback_41 is not defined`. This is happening because the callback function is removed right on unsubscription but this doesn't stop the JSONP script from loading.

https://stackblitz.com/edit/angular-4zmfjr?file=src/app/app.component.ts

## What is the new behavior?

Unsubscribing from JSONP request won't remove callback handler. Handler is then removed by the handler itself:

https://github.com/angular/angular/blob/2365bb89d7a37089f596705db19b1ee5d0366b42/packages/common/http/src/jsonp.ts#L107

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
