### PR TITLE
refactor(core): remove _tViewNode field from ViewRef

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 143350,
+        "main-es2015": 142812,
         "polyfills-es2015": 36657
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 149471,
+        "main-es2015": 148933,
         "polyfills-es2015": 36657
       }
     }

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -26,10 +26,11 @@ import {getComponentDef} from './definition';
 import {NodeInjector} from './di';
 import {assignTViewNodeToLView, createLView, createTView, elementCreate, locateHostElement, renderView} from './instructions/shared';
 import {ComponentDef} from './interfaces/definition';
-import {TContainerNode, TElementContainerNode, TElementNode, TNode} from './interfaces/node';
+import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType} from './interfaces/node';
 import {domRendererFactory3, RendererFactory3, RNode} from './interfaces/renderer';
 import {LView, LViewFlags, TVIEW, TViewType} from './interfaces/view';
 import {MATH_ML_NAMESPACE, SVG_NAMESPACE} from './namespaces';
+import {assertNodeOfPossibleTypes} from './node_assert';
 import {writeDirectClass} from './node_manipulation';
 import {extractAttrsAndClassesFromSelector, stringifyCSSSelectorList} from './node_selector_matcher';
 import {enterView, leaveView} from './state';
@@ -234,7 +235,8 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
     if (!rootSelectorOrNode || isIsolated) {
       // The host element of the internal or isolated root view is attached to the component's host
       // view node.
-      componentRef.hostView._tViewNode!.child = tElementNode;
+      ngDevMode && assertNodeOfPossibleTypes(rootTView.node, TNodeType.View);
+      rootTView.node!.child = tElementNode;
     }
     return componentRef;
   }
@@ -275,7 +277,7 @@ export class ComponentRef<T> extends viewEngine_ComponentRef<T> {
     super();
     this.instance = instance;
     this.hostView = this.changeDetectorRef = new RootViewRef<T>(_rootLView);
-    this.hostView._tViewNode = assignTViewNodeToLView(_rootLView[TVIEW], null, -1, _rootLView);
+    assignTViewNodeToLView(_rootLView[TVIEW], null, -1, _rootLView);
     this.componentType = componentType;
   }
 

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -266,7 +266,7 @@ function createTNodeAtIndex(
 }
 
 export function assignTViewNodeToLView(
-    tView: TView, tParentNode: TNode|null, index: number, lView: LView): TViewNode {
+    tView: TView, tParentNode: TNode|null, index: number, lView: LView): void {
   // View nodes are not stored in data because they can be added / removed at runtime (which
   // would cause indices to change). Their TNodes are instead stored in tView.node.
   let tNode = tView.node;
@@ -279,7 +279,7 @@ export function assignTViewNodeToLView(
                              TNodeType.View, index, null, null) as TViewNode;
   }
 
-  return lView[T_HOST] = tNode as TViewNode;
+  lView[T_HOST] = tNode as TViewNode;
 }
 
 

--- a/packages/core/src/render3/node_assert.ts
+++ b/packages/core/src/render3/node_assert.ts
@@ -26,7 +26,7 @@ export function assertNodeType(tNode: TNode, type: TNodeType): asserts tNode is 
   assertEqual(tNode.type, type, `should be a ${typeName(type)}`);
 }
 
-export function assertNodeOfPossibleTypes(tNode: TNode, ...types: TNodeType[]): void {
+export function assertNodeOfPossibleTypes(tNode: TNode|null, ...types: TNodeType[]): void {
   assertDefined(tNode, 'should be called with a TNode');
   const found = types.some(type => tNode.type === type);
   assertEqual(

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -119,9 +119,7 @@ export function createTemplateRef<T>(
 
         renderView(embeddedTView, embeddedLView, context);
 
-        const viewRef = new ViewRef<T>(embeddedLView);
-        viewRef._tViewNode = embeddedLView[T_HOST] as TViewNode;
-        return viewRef;
+        return new ViewRef<T>(embeddedLView);
       }
     };
   }

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -33,11 +33,6 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
   private _appRef: ApplicationRef|null = null;
   private _viewContainerRef: viewEngine_ViewContainerRef|null = null;
 
-  /**
-   * @internal
-   */
-  public _tViewNode: TViewNode|null = null;
-
   get rootNodes(): any[] {
     const lView = this._lView;
     if (lView[HOST] == null) {

--- a/packages/core/src/util/assert.ts
+++ b/packages/core/src/util/assert.ts
@@ -86,7 +86,7 @@ export function assertNotDefined<T>(actual: T, msg: string) {
   }
 }
 
-export function assertDefined<T>(actual: T, msg: string) {
+export function assertDefined<T>(actual: T|null|undefined, msg: string): asserts actual is T {
   if (actual == null) {
     throwError(msg, actual, null, '!=');
   }


### PR DESCRIPTION
The _tViewNode field (that was marked as internal) on the ViewRef is not
necessary as a reference to a relevant TView is available as a local
variable.
