### PR TITLE
ci: fix bad reference to `head` property in rebase-pr script

### DIFF
--- a/tools/rebase-pr.js
+++ b/tools/rebase-pr.js
@@ -86,7 +86,7 @@ async function _main() {
         Rebase instructions for PR Author, please run the following commands:
 
           git fetch upstream ${refs.base.ref};
-          git checkout ${refs.head.ref};
+          git checkout ${refs.target.ref};
           git rebase upstream/${refs.base.ref};
           git push --force-with-lease;
         `);


### PR DESCRIPTION
Update rebase-pr script to properly reference a property on
the refs object using `target` rather than the previously
named `head`.
