### PR TITLE
docs: fix purpose description of "builders.json"

### DIFF
--- a/aio/content/guide/cli-builder.md
+++ b/aio/content/guide/cli-builder.md
@@ -42,7 +42,7 @@ For example, your `myBuilder` folder could contain the following files.
 | `src/my-builder.ts`      | Main source file for the builder definition. |
 | `src/my-builder.spec.ts` | Source file for tests. |
 | `src/schema.json`        | Definition of builder input options. |
-| `builders.json`          | Testing configuration. |
+| `builders.json`          | Builders definition. |
 | `package.json`           | Dependencies. See https://docs.npmjs.com/files/package.json. |
 | `tsconfig.json`          | [TypeScript configuration](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html). |
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the CLI Builders documentation, the file "builders.json" is described as "Testing configuration", which is wrong.

Issue Number: N/A


## What is the new behavior?
Fixed the description to "Builders definition".

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
