### PR TITLE
ngcc: configure and update timeouts

### DIFF
--- a/integration/ngcc/ngcc.config.js
+++ b/integration/ngcc/ngcc.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  locking: {
+    retryAttempts: 5,
+    retryDelay: 100,
+  }
+};

--- a/integration/ngcc/test.sh
+++ b/integration/ngcc/test.sh
@@ -214,6 +214,15 @@ assertFailed "Expected 'ngcc -l error' to not output anything."
 ngcc --formats fesm2015
 assertFailed "Expected 'ngcc --formats fesm2015' to fail (since '--formats' is deprecated)."
 
+# Does it timeout if there is another ngcc process running
+LOCKFILE=node_modules/@angular/compiler-cli/ngcc/__ngcc_lock_file__
+touch $LOCKFILE
+trap "[[ -f $LOCKFILE ]] && rm $LOCKFILE" EXIT
+ngcc
+exitCode=$?
+assertEquals $exitCode 177
+rm $LOCKFILE
+
 # Now try compiling the app using the ngcc compiled libraries
 ngc -p tsconfig-app.json
 assertSucceeded "Expected the app to successfully compile with the ngcc-processed libraries."

--- a/integration/ngcc/yarn.lock
+++ b/integration/ngcc/yarn.lock
@@ -3,7 +3,7 @@
 
 
 "@angular/animations@file:../../dist/packages-dist/animations":
-  version "9.0.0-rc.1"
+  version "10.0.0-next.3"
 
 "@angular/cdk@9.0.0-rc.4":
   version "9.0.0-rc.4"
@@ -13,10 +13,10 @@
     parse5 "^5.0.0"
 
 "@angular/common@file:../../dist/packages-dist/common":
-  version "9.0.0-rc.1"
+  version "10.0.0-next.3"
 
 "@angular/compiler-cli@file:../../dist/packages-dist/compiler-cli":
-  version "9.0.0-rc.1"
+  version "10.0.0-next.3"
   dependencies:
     canonical-path "1.0.0"
     chokidar "^3.0.0"
@@ -28,16 +28,17 @@
     reflect-metadata "^0.1.2"
     semver "^6.3.0"
     source-map "^0.6.1"
-    yargs "13.1.0"
+    sourcemap-codec "^1.4.8"
+    yargs "15.3.0"
 
 "@angular/compiler@file:../../dist/packages-dist/compiler":
-  version "9.0.0-rc.1"
+  version "10.0.0-next.3"
 
 "@angular/core@file:../../dist/packages-dist/core":
-  version "9.0.0-rc.1"
+  version "10.0.0-next.3"
 
 "@angular/forms@file:../../dist/packages-dist/forms":
-  version "9.0.0-rc.1"
+  version "10.0.0-next.3"
 
 "@angular/material@9.0.0-rc.4":
   version "9.0.0-rc.4"
@@ -45,27 +46,30 @@
   integrity sha512-gg/CxwlGuMwXTRkY2DMrRb4GYmL1lksJ5cdnkCVm2locX8kH+ocht8kt6f39E8wBhHmg4jczfLnauRjU+PJ7ug==
 
 "@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
-  version "9.0.0-rc.1"
+  version "10.0.0-next.3"
 
 "@angular/platform-browser@file:../../dist/packages-dist/platform-browser":
-  version "9.0.0-rc.1"
+  version "10.0.0-next.3"
 
 "@angular/platform-server@file:../../dist/packages-dist/platform-server":
-  version "9.0.0-rc.1"
+  version "10.0.0-next.3"
   dependencies:
     domino "^2.1.2"
-    xhr2 "^0.1.4"
+    xhr2 "^0.2.0"
 
 "@angular/router@file:../../dist/packages-dist/router":
-  version "9.0.0-rc.1"
+  version "10.0.0-next.3"
 
-"@types/jasmine@2.5.41":
-  version "2.5.41"
-  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.5.41.tgz#d5e86161a0af80d52062b310a33ed65b051a0713"
-  integrity sha1-1ehhYaCvgNUgYrMQoz7WWwUaBxM=
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/jasmine@file:../../node_modules/@types/jasmine":
+  version "3.5.10"
 
 "@types/node@file:../../node_modules/@types/node":
-  version "12.11.1"
+  version "12.12.34"
 
 "@types/q@^0.0.32":
   version "0.0.32"
@@ -132,10 +136,10 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
 ansi-styles@^1.1.0:
   version "1.1.0"
@@ -146,6 +150,14 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
   integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
+
+ansi-styles@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -615,14 +627,14 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
-cliui@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
-  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
   dependencies:
-    string-width "^2.1.1"
-    strip-ansi "^4.0.0"
-    wrap-ansi "^2.0.0"
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
 
 co@^4.6.0:
   version "4.6.0"
@@ -641,6 +653,18 @@ collection-visit@^1.0.0:
   dependencies:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
+
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.7"
@@ -741,17 +765,6 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
-
-cross-spawn@^6.0.0:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
-  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
-  dependencies:
-    nice-try "^1.0.4"
-    path-key "^2.0.1"
-    semver "^5.5.0"
-    shebang-command "^1.2.0"
-    which "^1.2.9"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -903,22 +916,15 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-emoji-regex@^7.0.1:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
-  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 encodeurl@~1.0.1, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
-
-end-of-stream@^1.1.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
-  integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
-  dependencies:
-    once "^1.4.0"
 
 engine.io-client@~3.2.0:
   version "3.2.1"
@@ -998,19 +1004,6 @@ eventemitter3@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
   integrity sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=
-
-execa@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
-  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
-  dependencies:
-    cross-spawn "^6.0.0"
-    get-stream "^4.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
 
 exit@^0.1.2:
   version "0.1.2"
@@ -1159,12 +1152,13 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-find-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
-  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+find-up@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   dependencies:
-    locate-path "^3.0.0"
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
 
 follow-redirects@^1.2.5:
   version "1.5.9"
@@ -1277,13 +1271,6 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
-
-get-stream@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
-  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
-  dependencies:
-    pump "^3.0.0"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -1535,11 +1522,6 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
-invert-kv@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
-  integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
-
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
@@ -1663,6 +1645,11 @@ is-fullwidth-code-point@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -1758,11 +1745,6 @@ is-primitive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
   integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
-is-stream@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
-
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -1792,11 +1774,6 @@ isarray@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
   integrity sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=
-
-isexe@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -1919,13 +1896,6 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-lcid@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
-  integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
-  dependencies:
-    invert-kv "^2.0.0"
-
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
@@ -1970,13 +1940,12 @@ localtunnel@1.9.1:
     openurl "1.1.1"
     yargs "6.6.0"
 
-locate-path@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
-  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
-    p-locate "^3.0.0"
-    path-exists "^3.0.0"
+    p-locate "^4.1.0"
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -2000,13 +1969,6 @@ magic-string@^0.25.0:
   dependencies:
     sourcemap-codec "^1.4.1"
 
-map-age-cleaner@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
-  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
-  dependencies:
-    p-defer "^1.0.0"
-
 map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
@@ -2023,15 +1985,6 @@ math-random@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
   integrity sha1-izqsWIuKZuSXXjzepn97sylgH6w=
-
-mem@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
-  integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
-  dependencies:
-    map-age-cleaner "^0.1.1"
-    mimic-fn "^2.0.0"
-    p-is-promise "^2.0.0"
 
 micromatch@2.3.11:
   version "2.3.11"
@@ -2087,11 +2040,6 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
-
-mimic-fn@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
-  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
@@ -2201,11 +2149,6 @@ negotiator@0.6.1:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
   integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
 
-nice-try@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
-  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
 node-pre-gyp@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
@@ -2264,13 +2207,6 @@ npm-packlist@^1.1.6:
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
-
-npm-run-path@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
-  integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
-  dependencies:
-    path-key "^2.0.0"
 
 npmlog@^4.0.2:
   version "4.1.2"
@@ -2345,7 +2281,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-once@^1.3.0, once@^1.3.1, once@^1.4.0:
+once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -2384,15 +2320,6 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-locale@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
-  integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
-  dependencies:
-    execa "^1.0.0"
-    lcid "^2.0.0"
-    mem "^4.0.0"
-
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -2406,34 +2333,19 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-p-defer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
-  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
-
-p-finally@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
-  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
-
-p-is-promise@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
-  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
-
-p-limit@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
-  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+p-limit@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
   dependencies:
     p-try "^2.0.0"
 
-p-locate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
-  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
-    p-limit "^2.0.0"
+    p-limit "^2.2.0"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -2503,10 +2415,10 @@ path-exists@^2.0.0:
   dependencies:
     pinkie-promise "^2.0.0"
 
-path-exists@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
-  integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -2517,11 +2429,6 @@ path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
-
-path-key@^2.0.0, path-key@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
-  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -2605,14 +2512,6 @@ psl@^1.1.24:
   version "1.1.29"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
   integrity sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
-
-pump@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
-  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -2843,7 +2742,7 @@ rxjs@^5.5.6:
     symbol-observable "1.0.1"
 
 "rxjs@file:../../node_modules/rxjs":
-  version "6.5.3"
+  version "6.5.4"
   dependencies:
     tslib "^1.9.0"
 
@@ -2890,11 +2789,6 @@ selenium-webdriver@3.6.0, selenium-webdriver@^3.0.1:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
-
-semver@^5.5.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
-  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
 semver@^6.3.0:
   version "6.3.0"
@@ -2982,18 +2876,6 @@ setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
   integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
-
-shebang-command@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
-  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
-  dependencies:
-    shebang-regex "^1.0.0"
-
-shebang-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
-  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
 signal-exit@^3.0.0:
   version "3.0.2"
@@ -3114,6 +2996,11 @@ sourcemap-codec@^1.4.1:
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.3.tgz#0ba615b73ec35112f63c2f2d9e7c3f87282b0e33"
   integrity sha512-vFrY/x/NdsD7Yc8mpTJXuao9S8lq08Z/kOITHz6b7YbfI9xL8Spe5EvSQUHOI7SbpY8bRPr0U3kKSsPuqEGSfA==
 
+sourcemap-codec@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+
 spawn-command@^0.0.2-1:
   version "0.0.2-1"
   resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
@@ -3207,7 +3094,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.1.1:
+"string-width@^1.0.2 || 2":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -3215,14 +3102,14 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
-  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
+  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
   dependencies:
-    emoji-regex "^7.0.1"
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^5.1.0"
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -3252,12 +3139,12 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
-    ansi-regex "^4.1.0"
+    ansi-regex "^5.0.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -3265,11 +3152,6 @@ strip-bom@^2.0.0:
   integrity sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=
   dependencies:
     is-utf8 "^0.2.0"
-
-strip-eof@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
-  integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -3394,7 +3276,7 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
 "typescript@file:../../node_modules/typescript":
-  version "3.7.4"
+  version "3.8.3"
 
 ua-parser-js@0.7.17:
   version "0.7.17"
@@ -3516,13 +3398,6 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^1.2.9:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
-  dependencies:
-    isexe "^2.0.0"
-
 wide-align@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
@@ -3548,6 +3423,15 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -3562,10 +3446,10 @@ ws@~3.3.1:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
-xhr2@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/xhr2/-/xhr2-0.1.4.tgz#7f87658847716db5026323812f818cadab387a5f"
-  integrity sha1-f4dliEdxbbUCYyOBL4GMras4el8=
+xhr2@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/xhr2/-/xhr2-0.2.0.tgz#eddeff782f3b7551061b8d75645085269396e521"
+  integrity sha512-BDtiD0i2iKPK/S8OAZfpk6tyzEDnKKSjxWHcMBVmh+LuqJ8A32qXTyOx+TVOg2dKvq6zGBq2sgKPkEeRs1qTRA==
 
 xml2js@^0.4.17:
   version "0.4.19"
@@ -3600,10 +3484,10 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
   integrity sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=
 
-yargs-parser@^13.0.0:
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.0.tgz#7016b6dd03e28e1418a510e258be4bff5a31138f"
-  integrity sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==
+yargs-parser@^18.1.0:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
@@ -3615,22 +3499,22 @@ yargs-parser@^4.1.0, yargs-parser@^4.2.0:
   dependencies:
     camelcase "^3.0.0"
 
-yargs@13.1.0:
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.1.0.tgz#b2729ce4bfc0c584939719514099d8a916ad2301"
-  integrity sha512-1UhJbXfzHiPqkfXNHYhiz79qM/kZqjTE8yGlEjZa85Q+3+OwcV6NRkV7XOV1W2Eom2bzILeUn55pQYffjVOLAg==
+yargs@15.3.0:
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.0.tgz#403af6edc75b3ae04bf66c94202228ba119f0976"
+  integrity sha512-g/QCnmjgOl1YJjGsnUg2SatC7NUYEiLXJqxNOQU9qSpjzGtGXda9b+OKccr1kLTy8BN9yqEyqfq5lxlwdc13TA==
   dependencies:
-    cliui "^4.0.0"
-    find-up "^3.0.0"
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
     get-caller-file "^2.0.1"
-    os-locale "^3.1.0"
     require-directory "^2.1.1"
     require-main-filename "^2.0.0"
     set-blocking "^2.0.0"
-    string-width "^3.0.0"
+    string-width "^4.2.0"
     which-module "^2.0.0"
     y18n "^4.0.0"
-    yargs-parser "^13.0.0"
+    yargs-parser "^18.1.0"
 
 yargs@6.4.0:
   version "6.4.0"

--- a/packages/compiler-cli/ngcc/main-ngcc.ts
+++ b/packages/compiler-cli/ngcc/main-ngcc.ts
@@ -24,7 +24,7 @@ if (require.main === module) {
       process.exitCode = 0;
     } catch (e) {
       console.error(e.stack || e.message);
-      process.exit(1);
+      process.exit(typeof e.code === 'number' ? e.code : 1);
     }
   })();
 }

--- a/packages/compiler-cli/ngcc/src/constants.ts
+++ b/packages/compiler-cli/ngcc/src/constants.ts
@@ -7,3 +7,4 @@
  */
 
 export const IMPORT_PREFIX = 'ɵngcc';
+export const NGCC_TIMED_OUT_EXIT_CODE = 177;

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
@@ -225,7 +225,7 @@ export class DependencyResolver {
   private filterIgnorableDeepImports(entryPoint: EntryPoint, deepImports: Set<AbsoluteFsPath>):
       AbsoluteFsPath[] {
     const version = (entryPoint.packageJson.version || null) as string | null;
-    const packageConfig = this.config.getConfig(entryPoint.package, version);
+    const packageConfig = this.config.getPackageConfig(entryPoint.package, version);
     const matchers = packageConfig.ignorableDeepImportMatchers || [];
     return Array.from(deepImports)
         .filter(deepImport => !matchers.some(matcher => matcher.test(deepImport)));

--- a/packages/compiler-cli/ngcc/src/locking/async_locker.ts
+++ b/packages/compiler-cli/ngcc/src/locking/async_locker.ts
@@ -5,8 +5,14 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {NGCC_TIMED_OUT_EXIT_CODE} from '../constants';
 import {Logger} from '../logging/logger';
+
 import {LockFile} from './lock_file';
+
+class TimeoutError extends Error {
+  code = NGCC_TIMED_OUT_EXIT_CODE;
+}
 
 /**
  * AsyncLocker is used to prevent more than one instance of ngcc executing at the same time,
@@ -61,7 +67,7 @@ export class AsyncLocker {
       }
     }
     // If we fall out of the loop then we ran out of rety attempts
-    throw new Error(
+    throw new TimeoutError(
         `Timed out waiting ${
             this.retryAttempts * this.retryDelay /
             1000}s for another ngcc process, with id ${pid}, to complete.\n` +

--- a/packages/compiler-cli/ngcc/src/locking/async_locker.ts
+++ b/packages/compiler-cli/ngcc/src/locking/async_locker.ts
@@ -52,7 +52,9 @@ export class AsyncLocker {
         if (attempts === 0) {
           this.logger.info(
               `Another process, with id ${pid}, is currently running ngcc.\n` +
-              `Waiting up to ${this.retryDelay * this.retryAttempts / 1000}s for it to finish.`);
+              `Waiting up to ${this.retryDelay * this.retryAttempts / 1000}s for it to finish.\n` +
+              `(If you are sure no ngcc process is running then you should delete the lock-file at ${
+                  this.lockFile.path}.)`);
         }
         // The file is still locked by another process so wait for a bit and retry
         await new Promise(resolve => setTimeout(resolve, this.retryDelay));

--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -33,7 +33,7 @@ export interface NgccProjectConfig<T = NgccPackageConfig> {
 export interface ProcessLockingConfiguration {
   /**
    * The number of times the AsyncLocker will attempt to lock the process before failing.
-   * Defaults to 50.
+   * Defaults to 500.
    */
   retryAttempts?: number;
   /**
@@ -148,7 +148,7 @@ export const DEFAULT_NGCC_CONFIG: NgccProjectConfig = {
   },
   locking: {
     retryDelay: 500,
-    retryAttempts: 50,
+    retryAttempts: 500,
   }
 };
 

--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -177,7 +177,7 @@ export class NgccConfiguration {
    * @param version The version of the package whose config we want, or `null` if the package's
    * package.json did not exist or was invalid.
    */
-  getConfig(packagePath: AbsoluteFsPath, version: string|null): VersionedPackageConfig {
+  getPackageConfig(packagePath: AbsoluteFsPath, version: string|null): VersionedPackageConfig {
     const cacheKey = packagePath + (version !== null ? `@${version}` : '');
     if (this.cache.has(cacheKey)) {
       return this.cache.get(cacheKey)!;

--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -121,7 +121,7 @@ export function getEntryPointInfo(
   const packageJsonPath = resolve(entryPointPath, 'package.json');
   const packageVersion = getPackageVersion(fs, packageJsonPath);
   const entryPointConfig =
-      config.getConfig(packagePath, packageVersion).entryPoints[entryPointPath];
+      config.getPackageConfig(packagePath, packageVersion).entryPoints[entryPointPath];
   const hasConfig = entryPointConfig !== undefined;
 
   if (!hasConfig && !fs.exists(packageJsonPath)) {

--- a/packages/compiler-cli/ngcc/test/locking/async_locker_spec.ts
+++ b/packages/compiler-cli/ngcc/test/locking/async_locker_spec.ts
@@ -76,7 +76,9 @@ runInEachFileSystem(() => {
         // The lock is now waiting on the lock-file becoming free, so no `fn()` in the log.
         expect(log).toEqual(['write()', 'read() => 188']);
         expect(logger.logs.info).toEqual([[
-          'Another process, with id 188, is currently running ngcc.\nWaiting up to 1s for it to finish.'
+          'Another process, with id 188, is currently running ngcc.\nWaiting up to 1s for it to finish.\n' +
+          `(If you are sure no ngcc process is running then you should delete the lock-file at ${
+              lockFile.path}.)`
         ]]);
 
         lockFileContents = null;
@@ -112,7 +114,9 @@ runInEachFileSystem(() => {
         // The lock is now waiting on the lock-file becoming free, so no `fn()` in the log.
         expect(log).toEqual(['write()', 'read() => 188']);
         expect(logger.logs.info).toEqual([[
-          'Another process, with id 188, is currently running ngcc.\nWaiting up to 1s for it to finish.'
+          'Another process, with id 188, is currently running ngcc.\nWaiting up to 1s for it to finish.\n' +
+          `(If you are sure no ngcc process is running then you should delete the lock-file at ${
+              lockFile.path}.)`
         ]]);
 
         lockFileContents = '444';
@@ -120,12 +124,12 @@ runInEachFileSystem(() => {
         await new Promise(resolve => setTimeout(resolve, 250));
         expect(log).toEqual(['write()', 'read() => 188', 'write()', 'read() => 444']);
         expect(logger.logs.info).toEqual([
-          [
-            'Another process, with id 188, is currently running ngcc.\nWaiting up to 1s for it to finish.'
-          ],
-          [
-            'Another process, with id 444, is currently running ngcc.\nWaiting up to 1s for it to finish.'
-          ]
+          ['Another process, with id 188, is currently running ngcc.\nWaiting up to 1s for it to finish.\n' +
+           `(If you are sure no ngcc process is running then you should delete the lock-file at ${
+               lockFile.path}.)`],
+          ['Another process, with id 444, is currently running ngcc.\nWaiting up to 1s for it to finish.\n' +
+           `(If you are sure no ngcc process is running then you should delete the lock-file at ${
+               lockFile.path}.)`]
         ]);
 
         lockFileContents = null;

--- a/packages/compiler-cli/ngcc/test/packages/configuration_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/configuration_spec.ts
@@ -167,32 +167,6 @@ runInEachFileSystem(() => {
                     entryPoints: {
                       './entry-point-1': {}
                     },
-                  },
-                },
-              };`
-          }]);
-          const readFileSpy = spyOn(fs, 'readFile').and.callThrough();
-          const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
-          expect(readFileSpy).toHaveBeenCalledWith(_Abs('/project-1/ngcc.config.js'));
-
-          const config =
-              configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
-          expect(config).toEqual({
-            versionRange: '*',
-            entryPoints: {[_Abs('/project-1/node_modules/package-1/entry-point-1')]: {}}
-          });
-        });
-
-        it('should return configuration for a package found in a project level file', () => {
-          loadTestFiles([{
-            name: _Abs('/project-1/ngcc.config.js'),
-            contents: `
-              module.exports = {
-                packages: {
-                  'package-1': {
-                    entryPoints: {
-                      './entry-point-1': {}
-                    },
                     ignorableDeepImportMatchers: [ /xxx/ ],
                   },
                 },

--- a/packages/compiler-cli/ngcc/test/packages/configuration_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/configuration_spec.ts
@@ -84,7 +84,7 @@ runInEachFileSystem(() => {
       });
     });
 
-    describe('getConfig()', () => {
+    describe('getPackageConfig()', () => {
       describe('at the package level', () => {
         it('should return configuration for a package found in a package level file, with a matching version',
            () => {
@@ -92,7 +92,7 @@ runInEachFileSystem(() => {
              const readFileSpy = spyOn(fs, 'readFile').and.callThrough();
              const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
              const config =
-                 configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
+                 configuration.getPackageConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
 
              expect(config).toEqual({
                versionRange: '1.0.0',
@@ -107,7 +107,7 @@ runInEachFileSystem(() => {
               'package-1', 'entry-point-1', '1.0.0', 'ignorableDeepImportMatchers: [ /xxx/ ]'));
           const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
           const config =
-              configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
+              configuration.getPackageConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
 
           expect(config).toEqual({
             versionRange: '1.0.0',
@@ -121,11 +121,11 @@ runInEachFileSystem(() => {
           const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
 
           // Populate the cache
-          configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
+          configuration.getPackageConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
 
           const readFileSpy = spyOn(fs, 'readFile').and.callThrough();
           const config =
-              configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
+              configuration.getPackageConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
 
           expect(config).toEqual({
             versionRange: '1.0.0',
@@ -139,7 +139,7 @@ runInEachFileSystem(() => {
              loadTestFiles(packageWithConfigFiles('package-2', 'entry-point-1', '1.0.0'));
              const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
              const config =
-                 configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
+                 configuration.getPackageConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
              expect(config).toEqual({versionRange: '*', entryPoints: {}});
            });
 
@@ -149,7 +149,9 @@ runInEachFileSystem(() => {
             contents: `bad js code`
           }]);
           const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
-          expect(() => configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0'))
+          expect(
+              () => configuration.getPackageConfig(
+                  _Abs('/project-1/node_modules/package-1'), '1.0.0'))
               .toThrowError(`Invalid package configuration file at "${
                   _Abs(
                       '/project-1/node_modules/package-1/ngcc.config.js')}": Unexpected identifier`);
@@ -174,7 +176,7 @@ runInEachFileSystem(() => {
           }]);
           const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
           const config =
-              configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
+              configuration.getPackageConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
           expect(config).toEqual({
             versionRange: '*',
             entryPoints: {[_Abs('/project-1/node_modules/package-1/entry-point-1')]: {}},
@@ -209,22 +211,26 @@ runInEachFileSystem(() => {
              }]);
              const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
 
-             expect(configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0'))
+             expect(
+                 configuration.getPackageConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0'))
                  .toEqual({
                    versionRange: '1.0.0',
                    entryPoints: {[_Abs('/project-1/node_modules/package-1/entry-point-1')]: {}}
                  });
-             expect(configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '2.5.0'))
+             expect(
+                 configuration.getPackageConfig(_Abs('/project-1/node_modules/package-1'), '2.5.0'))
                  .toEqual({
                    versionRange: '2.*',
                    entryPoints: {[_Abs('/project-1/node_modules/package-1/entry-point-2')]: {}}
                  });
-             expect(configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '3.2.5'))
+             expect(
+                 configuration.getPackageConfig(_Abs('/project-1/node_modules/package-1'), '3.2.5'))
                  .toEqual({
                    versionRange: '^3.2.0',
                    entryPoints: {[_Abs('/project-1/node_modules/package-1/entry-point-3')]: {}}
                  });
-             expect(configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '4.0.0'))
+             expect(
+                 configuration.getPackageConfig(_Abs('/project-1/node_modules/package-1'), '4.0.0'))
                  .toEqual({versionRange: '*', entryPoints: {}});
            });
 
@@ -258,7 +264,8 @@ runInEachFileSystem(() => {
 
           const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
           const getConfig = (packageName: string, version: string|null) =>
-              configuration.getConfig(_Abs(`/project-1/node_modules/${packageName}`), version);
+              configuration.getPackageConfig(
+                  _Abs(`/project-1/node_modules/${packageName}`), version);
 
           // Default version range: *
           expect(getConfig('package-1', '1.0.0-beta.2'))
@@ -352,7 +359,8 @@ runInEachFileSystem(() => {
           }]);
           const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
 
-          expect(configuration.getConfig(_Abs('/project-1/node_modules/@angular/common'), '1.0.0'))
+          expect(configuration.getPackageConfig(
+                     _Abs('/project-1/node_modules/@angular/common'), '1.0.0'))
               .toEqual({
                 versionRange: '*',
                 entryPoints: {[_Abs('/project-1/node_modules/@angular/common')]: {}}
@@ -383,7 +391,7 @@ runInEachFileSystem(() => {
           expect(readFileSpy).toHaveBeenCalledWith(_Abs('/project-1/ngcc.config.js'));
 
           const package1Config =
-              configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
+              configuration.getPackageConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
           expect(package1Config).toEqual({
             versionRange: '1.0.0',
             entryPoints:
@@ -396,7 +404,7 @@ runInEachFileSystem(() => {
           // This is because overriding happens for packages as a whole and there is no attempt to
           // merge entry-points.
           const package2Config =
-              configuration.getConfig(_Abs('/project-1/node_modules/package-2'), '1.0.0');
+              configuration.getPackageConfig(_Abs('/project-1/node_modules/package-2'), '1.0.0');
           expect(package2Config).toEqual({
             versionRange: '*',
             entryPoints:
@@ -410,7 +418,7 @@ runInEachFileSystem(() => {
       describe('at the default level', () => {
         const originalDefaultConfig = JSON.stringify(DEFAULT_NGCC_CONFIG.packages);
         beforeEach(() => {
-          DEFAULT_NGCC_CONFIG.packages['package-1'] = {
+          DEFAULT_NGCC_CONFIG.packages!['package-1'] = {
             entryPoints: {'./default-level-entry-point': {}},
           };
         });
@@ -422,7 +430,7 @@ runInEachFileSystem(() => {
           expect(readFileSpy).not.toHaveBeenCalled();
 
           const config =
-              configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
+              configuration.getPackageConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
           expect(config).toEqual({
             versionRange: '*',
             entryPoints: {[_Abs('/project-1/node_modules/package-1/default-level-entry-point')]: {}}
@@ -433,7 +441,7 @@ runInEachFileSystem(() => {
           loadTestFiles(packageWithConfigFiles('package-1', 'package-level-entry-point', '1.0.0'));
           const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
           const config =
-              configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
+              configuration.getPackageConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
           // Note that only the package-level-entry-point is left.
           // This is because overriding happens for packages as a whole and there is no attempt to
           // merge entry-points.
@@ -470,7 +478,7 @@ runInEachFileSystem(() => {
 
           const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
           const config =
-              configuration.getConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
+              configuration.getPackageConfig(_Abs('/project-1/node_modules/package-1'), '1.0.0');
           // Note that only the project-level-entry-point is left.
           // This is because overriding happens for packages as a whole and there is no attempt to
           // merge entry-points.
@@ -501,7 +509,8 @@ runInEachFileSystem(() => {
 
           const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
           const getConfig = (packageName: string, version: string|null) =>
-              configuration.getConfig(_Abs(`/project-1/node_modules/${packageName}`), version);
+              configuration.getPackageConfig(
+                  _Abs(`/project-1/node_modules/${packageName}`), version);
 
           // Default version range: *
           expect(getConfig('package-1', '1.0.0-beta.2'))

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
@@ -68,7 +68,7 @@ runInEachFileSystem(() => {
         },
       ]);
       const config = new NgccConfiguration(fs, _('/project'));
-      spyOn(config, 'getConfig').and.returnValue({
+      spyOn(config, 'getPackageConfig').and.returnValue({
         entryPoints: {[_('/project/node_modules/some_package/valid_entry_point')]: {ignore: true}}
       } as any);
       const entryPoint = getEntryPointInfo(
@@ -94,7 +94,7 @@ runInEachFileSystem(() => {
         typings: './some_other.d.ts',
         esm2015: './some_other.js',
       };
-      spyOn(config, 'getConfig').and.returnValue({
+      spyOn(config, 'getPackageConfig').and.returnValue({
         entryPoints: {[_('/project/node_modules/some_package/valid_entry_point')]: {override}},
         versionRange: '*'
       });
@@ -145,7 +145,7 @@ runInEachFileSystem(() => {
          const config = new NgccConfiguration(fs, _('/project'));
          const override =
              JSON.parse(createPackageJson('missing_package_json', {excludes: ['name']}));
-         spyOn(config, 'getConfig').and.returnValue({
+         spyOn(config, 'getPackageConfig').and.returnValue({
            entryPoints:
                {[_('/project/node_modules/some_package/missing_package_json')]: {override}},
            versionRange: '*'
@@ -281,7 +281,7 @@ runInEachFileSystem(() => {
            // no metadata.json!
          ]);
          const config = new NgccConfiguration(fs, _('/project'));
-         spyOn(config, 'getConfig').and.returnValue({
+         spyOn(config, 'getPackageConfig').and.returnValue({
            entryPoints: {[_('/project/node_modules/some_package/missing_metadata')]: {}},
            versionRange: '*'
          });


### PR DESCRIPTION
Discussions on https://github.com/angular/angular/issues/36796 highlighted that we ought to make the ngcc async locker timeouts longer (and more configurable). This should sort that out.

--- 
Note that there is a bit of tidying up of the codebase along the way. Some of these refactoring/fix commits should be cherry-picked to the patch branch...
