### PR TITLE
fix(localize): ensure `getLocation()` works

### DIFF
--- a/packages/localize/src/tools/src/source_file_utils.ts
+++ b/packages/localize/src/tools/src/source_file_utils.ts
@@ -357,7 +357,7 @@ export function buildCodeFrameError(path: NodePath, e: BabelParseError): string 
 
 export function getLocation(path: NodePath): ɵSourceLocation|undefined {
   const location = path.node.loc;
-  const file = path.hub.file.ops.fileName;
+  const file = path.hub.file.opts.filename;
 
   if (!location || !file) {
     return undefined;


### PR DESCRIPTION
The `getLocation()` method was not working as there were typos in the
properties it was reading. This was not picked up because there were
neither typings for these properties nor unit tests to check it worked.
