### PR TITLE
docs(forms): remove of alias

### DIFF
--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -81,7 +81,7 @@ export interface Validator {
  * async validator directive with a custom error key.
  *
  * ```typescript
- * import { of as observableOf } from 'rxjs';
+ * import { of } from 'rxjs';
  *
  * @Directive({
  *   selector: '[customAsyncValidator]',
@@ -90,7 +90,7 @@ export interface Validator {
  * })
  * class CustomAsyncValidatorDirective implements AsyncValidator {
  *   validate(control: AbstractControl): Observable<ValidationErrors|null> {
- *     return observableOf({'custom': true});
+ *     return of({'custom': true});
  *   }
  * }
  * ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Documentation content changes


## What is the current behavior?
One example in the docs for AsyncValidators makes use of an alias import for the rxjs creation function of. I don't know about the background behind this, but it doesn't seem to be intuitive to me. To align with the RxJS docs, I think it would make sense to don't use an alias here. I can check the whole repo and fix other occasions(in case there are some) if there is a general agreement on this.

## What is the new behavior?
Just use `of` instead of the alias

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
