### PR TITLE
fix(compiler-cli): ensure FS case-sensitivity is correct

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -75,7 +75,8 @@ export class DecorationAnalyzer {
     // TODO(alxhub): there's no reason why ngcc needs the "logical file system" logic here, as ngcc
     // projects only ever have one rootDir. Instead, ngcc should just switch its emitted import
     // based on whether a bestGuessOwningModule is present in the Reference.
-    new LogicalProjectStrategy(this.reflectionHost, new LogicalFileSystem(this.rootDirs)),
+    new LogicalProjectStrategy(
+        this.reflectionHost, new LogicalFileSystem(this.rootDirs, this.host)),
   ]);
   aliasingHost = this.bundle.entryPoint.generateDeepReexports ?
       new PrivateExportAliasingHost(this.reflectionHost) :

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -612,8 +612,8 @@ export class NgCompiler {
           (this.options.rootDirs !== undefined && this.options.rootDirs.length > 0)) {
         // rootDirs logic is in effect - use the `LogicalProjectStrategy` for in-project relative
         // imports.
-        localImportStrategy =
-            new LogicalProjectStrategy(reflector, new LogicalFileSystem([...this.host.rootDirs]));
+        localImportStrategy = new LogicalProjectStrategy(
+            reflector, new LogicalFileSystem([...this.host.rootDirs], this.host));
       } else {
         // Plain relative imports are all that's needed.
         localImportStrategy = new RelativePathStrategy(reflector);

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -727,7 +727,7 @@ export class NgCompiler {
 
     const templateTypeChecker = new TemplateTypeChecker(
         this.tsProgram, this.typeCheckingProgramStrategy, traitCompiler,
-        this.getTypeCheckingConfig(), refEmitter, reflector, this.incrementalDriver);
+        this.getTypeCheckingConfig(), refEmitter, reflector, this.host, this.incrementalDriver);
 
     return {
       isCore,

--- a/packages/compiler-cli/src/ngtsc/file_system/src/compiler_host.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/compiler_host.ts
@@ -44,7 +44,7 @@ export class NgtscCompilerHost implements ts.CompilerHost {
   }
 
   getCanonicalFileName(fileName: string): string {
-    return this.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase();
+    return this.useCaseSensitiveFileNames() ? fileName : fileName.toLowerCase();
   }
 
   useCaseSensitiveFileNames(): boolean {

--- a/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
@@ -68,7 +68,9 @@ export class NodeJSFileSystem implements FileSystem {
   }
   isCaseSensitive(): boolean {
     if (this._caseSensitive === undefined) {
-      this._caseSensitive = this.exists(togglePathCase(__filename));
+      // Note the use of the real file-system is intentional:
+      // `this.exists()` relies upon `isCaseSensitive()` so that would cause an infinite recursion.
+      this._caseSensitive = !fs.existsSync(togglePathCase(__filename));
     }
     return this._caseSensitive;
   }

--- a/packages/compiler-cli/src/ngtsc/file_system/test/compiler_host_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/test/compiler_host_spec.ts
@@ -41,5 +41,27 @@ runInEachFileSystem(() => {
         expect(host.getSourceFile(directory, ts.ScriptTarget.ES2015)).toBe(undefined);
       });
     });
+
+    describe('useCaseSensitiveFileNames()', () => {
+      it('should return the same as `FileSystem.isCaseSensitive()', () => {
+        const directory = absoluteFrom('/a/b/c');
+        const fs = getFileSystem();
+        fs.ensureDir(directory);
+        const host = new NgtscCompilerHost(fs);
+        expect(host.useCaseSensitiveFileNames()).toEqual(fs.isCaseSensitive());
+      });
+    });
+
+    describe('getCanonicalFileName()', () => {
+      it('should return the original filename if FS is case-sensitive or lower case otherwise',
+         () => {
+           const directory = absoluteFrom('/a/b/c');
+           const fs = getFileSystem();
+           fs.ensureDir(directory);
+           const host = new NgtscCompilerHost(fs);
+           expect(host.getCanonicalFileName(('AbCd.ts')))
+               .toEqual(fs.isCaseSensitive() ? 'AbCd.ts' : 'abcd.ts');
+         });
+    });
   });
 });

--- a/packages/compiler-cli/src/ngtsc/file_system/test/logical_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/test/logical_spec.ts
@@ -6,18 +6,24 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {absoluteFrom} from '../src/helpers';
+import {NgtscCompilerHost} from '../src/compiler_host';
+import {absoluteFrom, getFileSystem} from '../src/helpers';
 import {LogicalFileSystem, LogicalProjectPath} from '../src/logical';
 import {runInEachFileSystem} from '../testing';
 
 runInEachFileSystem(() => {
   describe('logical paths', () => {
     let _: typeof absoluteFrom;
-    beforeEach(() => _ = absoluteFrom);
+    let host: NgtscCompilerHost;
+
+    beforeEach(() => {
+      _ = absoluteFrom;
+      host = new NgtscCompilerHost(getFileSystem());
+    });
 
     describe('LogicalFileSystem', () => {
       it('should determine logical paths in a single root file system', () => {
-        const fs = new LogicalFileSystem([_('/test')]);
+        const fs = new LogicalFileSystem([_('/test')], host);
         expect(fs.logicalPathOfFile(_('/test/foo/foo.ts')))
             .toEqual('/foo/foo' as LogicalProjectPath);
         expect(fs.logicalPathOfFile(_('/test/bar/bar.ts')))
@@ -26,23 +32,23 @@ runInEachFileSystem(() => {
       });
 
       it('should determine logical paths in a multi-root file system', () => {
-        const fs = new LogicalFileSystem([_('/test/foo'), _('/test/bar')]);
+        const fs = new LogicalFileSystem([_('/test/foo'), _('/test/bar')], host);
         expect(fs.logicalPathOfFile(_('/test/foo/foo.ts'))).toEqual('/foo' as LogicalProjectPath);
         expect(fs.logicalPathOfFile(_('/test/bar/bar.ts'))).toEqual('/bar' as LogicalProjectPath);
       });
 
       it('should continue to work when one root is a child of another', () => {
-        const fs = new LogicalFileSystem([_('/test'), _('/test/dist')]);
+        const fs = new LogicalFileSystem([_('/test'), _('/test/dist')], host);
         expect(fs.logicalPathOfFile(_('/test/foo.ts'))).toEqual('/foo' as LogicalProjectPath);
         expect(fs.logicalPathOfFile(_('/test/dist/foo.ts'))).toEqual('/foo' as LogicalProjectPath);
       });
 
       it('should always return `/` prefixed logical paths', () => {
-        const rootFs = new LogicalFileSystem([_('/')]);
+        const rootFs = new LogicalFileSystem([_('/')], host);
         expect(rootFs.logicalPathOfFile(_('/foo/foo.ts')))
             .toEqual('/foo/foo' as LogicalProjectPath);
 
-        const nonRootFs = new LogicalFileSystem([_('/test/')]);
+        const nonRootFs = new LogicalFileSystem([_('/test/')], host);
         expect(nonRootFs.logicalPathOfFile(_('/test/foo/foo.ts')))
             .toEqual('/foo/foo' as LogicalProjectPath);
       });

--- a/packages/compiler-cli/src/ngtsc/file_system/test/node_js_file_system_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/test/node_js_file_system_spec.ts
@@ -153,14 +153,6 @@ describe('NodeJSFileSystem', () => {
       expect(mkdirCalls).toEqual([xPath, xyPath, xyzPath]);
     });
 
-    describe('removeDeep()', () => {
-      it('should delegate to fsExtra.remove()', () => {
-        const spy = spyOn(fsExtra, 'removeSync');
-        fs.removeDeep(abcPath);
-        expect(spy).toHaveBeenCalledWith(abcPath);
-      });
-    });
-
     it('should not fail if a directory (that did not exist before) does exist when trying to create it',
        () => {
          let abcPathExists = false;
@@ -226,6 +218,21 @@ describe('NodeJSFileSystem', () => {
 
       expect(() => fs.ensureDir(abcPath)).toThrowError('It exists already. Supposedly.');
       expect(isDirectorySpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('removeDeep()', () => {
+    it('should delegate to fsExtra.remove()', () => {
+      const spy = spyOn(fsExtra, 'removeSync');
+      fs.removeDeep(abcPath);
+      expect(spy).toHaveBeenCalledWith(abcPath);
+    });
+  });
+
+  describe('isCaseSensitive()', () => {
+    it('should return true if the FS is case-sensitive', () => {
+      const isCaseSensitive = !realFs.existsSync(__filename.toUpperCase());
+      expect(fs.isCaseSensitive()).toEqual(isCaseSensitive);
     });
   });
 });

--- a/packages/compiler-cli/src/ngtsc/file_system/testing/src/mock_file_system_windows.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/testing/src/mock_file_system_windows.ts
@@ -42,6 +42,6 @@ export class MockFileSystemWindows extends MockFileSystem {
   }
 
   normalize<T extends PathString>(path: T): T {
-    return path.replace(/^[\/\\]/i, 'C:/').replace(/\\/g, '/') as T;
+    return path.replace(/^[\/\\]/i, 'c:/').replace(/\\/g, '/') as T;
   }
 }

--- a/packages/compiler-cli/src/ngtsc/imports/test/emitter_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/test/emitter_spec.ts
@@ -146,7 +146,7 @@ runInEachFileSystem(() => {
         }
       }
 
-      const {program} = makeProgram([
+      const {program, host} = makeProgram([
         {
           name: _('/index.ts'),
           contents: `export class Foo {}`,
@@ -157,7 +157,7 @@ runInEachFileSystem(() => {
         }
       ]);
       const checker = program.getTypeChecker();
-      const logicalFs = new LogicalFileSystem([_('/')]);
+      const logicalFs = new LogicalFileSystem([_('/')], host);
       const strategy = new LogicalProjectStrategy(new TestHost(checker), logicalFs);
       const decl = getDeclaration(program, _('/index.ts'), 'Foo', ts.isClassDeclaration);
       const context = program.getSourceFile(_('/context.ts'))!;

--- a/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/context_spec.ts
@@ -23,7 +23,7 @@ runInEachFileSystem(() => {
         boundTemplate,
         templateMeta: {
           isInline: false,
-          file: new ParseSourceFile('<div></div>', util.getTestFilePath()),
+          file: new ParseSourceFile('<div></div>', declaration.getSourceFile().fileName),
         },
       });
 
@@ -34,7 +34,7 @@ runInEachFileSystem(() => {
           boundTemplate,
           templateMeta: {
             isInline: false,
-            file: new ParseSourceFile('<div></div>', util.getTestFilePath()),
+            file: new ParseSourceFile('<div></div>', declaration.getSourceFile().fileName),
           },
         },
       ]));

--- a/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
@@ -25,7 +25,7 @@ function populateContext(
     boundTemplate,
     templateMeta: {
       isInline,
-      file: new ParseSourceFile(template, util.getTestFilePath()),
+      file: new ParseSourceFile(template, component.getSourceFile().fileName),
     },
   });
 }
@@ -45,12 +45,12 @@ runInEachFileSystem(() => {
       expect(info).toEqual({
         name: 'C',
         selector: 'c-selector',
-        file: new ParseSourceFile('class C {}', util.getTestFilePath()),
+        file: new ParseSourceFile('class C {}', decl.getSourceFile().fileName),
         template: {
           identifiers: getTemplateIdentifiers(util.getBoundTemplate('<div>{{foo}}</div>')),
           usedComponents: new Set(),
           isInline: false,
-          file: new ParseSourceFile('<div>{{foo}}</div>', util.getTestFilePath()),
+          file: new ParseSourceFile('<div>{{foo}}</div>', decl.getSourceFile().fileName),
         }
       });
     });
@@ -69,7 +69,7 @@ runInEachFileSystem(() => {
       const info = analysis.get(decl);
       expect(info).toBeDefined();
       expect(info!.template.file)
-          .toEqual(new ParseSourceFile('class C {}', util.getTestFilePath()));
+          .toEqual(new ParseSourceFile('class C {}', decl.getSourceFile().fileName));
     });
 
     it('should give external templates their own source file', () => {
@@ -84,7 +84,7 @@ runInEachFileSystem(() => {
       const info = analysis.get(decl);
       expect(info).toBeDefined();
       expect(info!.template.file)
-          .toEqual(new ParseSourceFile('<div>{{foo}}</div>', util.getTestFilePath()));
+          .toEqual(new ParseSourceFile('<div>{{foo}}</div>', decl.getSourceFile().fileName));
     });
 
     it('should emit used components', () => {

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -16,7 +16,7 @@ import {getDeclaration, makeProgram} from '../../testing';
 import {ComponentMeta} from '../src/context';
 
 /** Dummy file URL */
-export function getTestFilePath(): AbsoluteFsPath {
+function getTestFilePath(): AbsoluteFsPath {
   return absoluteFrom('/TEST_FILE.ts');
 }
 

--- a/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
-import {absoluteFrom} from '../../file_system';
+import {absoluteFrom, getSourceFileOrError} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {getDeclaration, makeProgram} from '../../testing';
 import {CtorParameter} from '../src/host';
@@ -329,8 +329,8 @@ runInEachFileSystem(() => {
         } else if (directTargetDecl === null) {
           return fail('No declaration found for DirectTarget');
         }
-        expect(targetDecl.node!.getSourceFile().fileName)
-            .toBe(_('/node_modules/absolute/index.ts'));
+        expect(targetDecl.node!.getSourceFile())
+            .toBe(getSourceFileOrError(program, _('/node_modules/absolute/index.ts')));
         expect(ts.isClassDeclaration(targetDecl.node!)).toBe(true);
         expect(directTargetDecl.viaModule).toBe('absolute');
         expect(directTargetDecl.node).toBe(targetDecl.node);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -39,6 +39,7 @@ export class TemplateTypeChecker {
       private typeCheckingStrategy: TypeCheckingProgramStrategy,
       private typeCheckAdapter: ProgramTypeCheckAdapter, private config: TypeCheckingConfig,
       private refEmitter: ReferenceEmitter, private reflector: ReflectionHost,
+      private compilerHost: ts.CompilerHost,
       private priorBuild: IncrementalBuild<unknown, FileTypeCheckingData>) {}
 
   /**
@@ -49,7 +50,7 @@ export class TemplateTypeChecker {
     this.files.clear();
 
     const ctx =
-        new TypeCheckContext(this.config, this.originalProgram, this.refEmitter, this.reflector);
+        new TypeCheckContext(this.config, this.compilerHost, this.refEmitter, this.reflector);
 
     // Typecheck all the files.
     for (const sf of this.originalProgram.getSourceFiles()) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -113,7 +113,7 @@ export class TypeCheckContext {
   private fileMap = new Map<AbsoluteFsPath, PendingFileTypeCheckingData>();
 
   constructor(
-      private config: TypeCheckingConfig, private program: ts.Program,
+      private config: TypeCheckingConfig, private compilerHost: ts.CompilerHost,
       private refEmitter: ReferenceEmitter, private reflector: ReflectionHost) {}
 
   /**
@@ -320,7 +320,8 @@ export class TypeCheckContext {
         domSchemaChecker: new RegistryDomSchemaChecker(sourceManager),
         oobRecorder: new OutOfBandDiagnosticRecorderImpl(sourceManager),
         typeCheckFile: new TypeCheckFile(
-            TypeCheckShimGenerator.shimFor(sfPath), this.config, this.refEmitter, this.reflector),
+            TypeCheckShimGenerator.shimFor(sfPath), this.config, this.refEmitter, this.reflector,
+            this.compilerHost),
         hasInlines: false,
         sourceManager,
       };

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
@@ -34,10 +34,11 @@ export class TypeCheckFile extends Environment {
 
   constructor(
       readonly fileName: AbsoluteFsPath, config: TypeCheckingConfig, refEmitter: ReferenceEmitter,
-      reflector: ReflectionHost) {
+      reflector: ReflectionHost, compilerHost: ts.CompilerHost) {
     super(
         config, new ImportManager(new NoopImportRewriter(), 'i'), refEmitter, reflector,
-        ts.createSourceFile(fileName, '', ts.ScriptTarget.Latest, true));
+        ts.createSourceFile(
+            compilerHost.getCanonicalFileName(fileName), '', ts.ScriptTarget.Latest, true));
   }
 
   addTypeCheckBlock(
@@ -49,7 +50,7 @@ export class TypeCheckFile extends Environment {
   }
 
   render(): string {
-    let source: string = this.importManager.getAllImports(this.fileName)
+    let source: string = this.importManager.getAllImports(this.contextFile.fileName)
                              .map(i => `import * as ${i.qualifier} from '${i.specifier}';`)
                              .join('\n') +
         '\n\n';

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -95,7 +95,7 @@ export function angularCoreDts(): TestFile {
     export declare class EventEmitter<T> {
       subscribe(generatorOrNext?: any, error?: any, complete?: any): unknown;
     }
-    
+
     export declare type NgIterable<T> = Array<T> | Iterable<T>;
   `
   };
@@ -254,7 +254,7 @@ export function typecheck(
       makeProgram(files, {strictNullChecks: true, noImplicitAny: true, ...opts}, undefined, false);
   const sf = program.getSourceFile(absoluteFrom('/main.ts'))!;
   const checker = program.getTypeChecker();
-  const logicalFs = new LogicalFileSystem(getRootDirs(host, options));
+  const logicalFs = new LogicalFileSystem(getRootDirs(host, options), host);
   const reflectionHost = new TypeScriptReflectionHost(checker);
   const moduleResolver =
       new ModuleResolver(program, options, host, /* moduleResolutionCache */ null);

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -302,7 +302,7 @@ export function typecheck(
 
   const programStrategy = new ReusedProgramStrategy(program, host, options, []);
   const templateTypeChecker = new TemplateTypeChecker(
-      program, programStrategy, checkAdapter, fullConfig, emitter, reflectionHost,
+      program, programStrategy, checkAdapter, fullConfig, emitter, reflectionHost, host,
       NOOP_INCREMENTAL_BUILD);
   templateTypeChecker.refresh();
   return templateTypeChecker.getDiagnosticsForFile(sf);

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
@@ -43,7 +43,7 @@ runInEachFileSystem(() => {
       const host = new NgtscCompilerHost(getFileSystem());
       const file = new TypeCheckFile(
           _('/_typecheck_.ts'), ALL_ENABLED_CONFIG, new ReferenceEmitter([]),
-          /* reflector */ null!);
+          /* reflector */ null!, host);
       const sf = file.render();
       expect(sf).toContain('export const IS_A_MODULE = true;');
     });
@@ -73,10 +73,10 @@ TestClass.ngTypeCtor({value: 'test'});
           new AbsoluteModuleStrategy(program, checker, moduleResolver, reflectionHost),
           new LogicalProjectStrategy(reflectionHost, logicalFs),
         ]);
-        const ctx = new TypeCheckContext(ALL_ENABLED_CONFIG, program, emitter, reflectionHost);
+        const ctx = new TypeCheckContext(ALL_ENABLED_CONFIG, host, emitter, reflectionHost);
         const TestClass =
             getDeclaration(program, _('/main.ts'), 'TestClass', isNamedClassDeclaration);
-        const pendingFile = makePendingFile(reflectionHost);
+        const pendingFile = makePendingFile(reflectionHost, host);
         ctx.addInlineTypeCtor(
             pendingFile, getSourceFileOrError(program, _('/main.ts')), new Reference(TestClass), {
               fnName: 'ngTypeCtor',
@@ -109,8 +109,8 @@ TestClass.ngTypeCtor({value: 'test'});
           new AbsoluteModuleStrategy(program, checker, moduleResolver, reflectionHost),
           new LogicalProjectStrategy(reflectionHost, logicalFs),
         ]);
-        const pendingFile = makePendingFile(reflectionHost);
-        const ctx = new TypeCheckContext(ALL_ENABLED_CONFIG, program, emitter, reflectionHost);
+        const pendingFile = makePendingFile(reflectionHost, host);
+        const ctx = new TypeCheckContext(ALL_ENABLED_CONFIG, host, emitter, reflectionHost);
         const TestClass =
             getDeclaration(program, _('/main.ts'), 'TestClass', isNamedClassDeclaration);
         ctx.addInlineTypeCtor(
@@ -152,8 +152,8 @@ TestClass.ngTypeCtor({value: 'test'});
           new AbsoluteModuleStrategy(program, checker, moduleResolver, reflectionHost),
           new LogicalProjectStrategy(reflectionHost, logicalFs),
         ]);
-        const pendingFile = makePendingFile(reflectionHost);
-        const ctx = new TypeCheckContext(ALL_ENABLED_CONFIG, program, emitter, reflectionHost);
+        const pendingFile = makePendingFile(reflectionHost, host);
+        const ctx = new TypeCheckContext(ALL_ENABLED_CONFIG, host, emitter, reflectionHost);
         const TestClass =
             getDeclaration(program, _('/main.ts'), 'TestClass', isNamedClassDeclaration);
         ctx.addInlineTypeCtor(
@@ -184,7 +184,8 @@ TestClass.ngTypeCtor({value: 'test'});
   }
 });
 
-function makePendingFile(reflector: ReflectionHost): PendingFileTypeCheckingData {
+function makePendingFile(
+    reflector: ReflectionHost, compilerHost: ts.CompilerHost): PendingFileTypeCheckingData {
   const manager = new TemplateSourceManager();
   return {
     domSchemaChecker: new RegistryDomSchemaChecker(manager),
@@ -192,6 +193,7 @@ function makePendingFile(reflector: ReflectionHost): PendingFileTypeCheckingData
     oobRecorder: new NoopOobRecorder(),
     sourceManager: manager,
     typeCheckFile: new TypeCheckFile(
-        absoluteFrom('/typecheck.ts'), ALL_ENABLED_CONFIG, new ReferenceEmitter([]), reflector)
+        absoluteFrom('/typecheck.ts'), ALL_ENABLED_CONFIG, new ReferenceEmitter([]), reflector,
+        compilerHost)
   };
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
@@ -7,7 +7,7 @@
  */
 import * as ts from 'typescript';
 
-import {absoluteFrom, getSourceFileOrError, LogicalFileSystem} from '../../file_system';
+import {absoluteFrom, getFileSystem, getSourceFileOrError, LogicalFileSystem, NgtscCompilerHost} from '../../file_system';
 import {runInEachFileSystem, TestFile} from '../../file_system/testing';
 import {AbsoluteModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, Reference, ReferenceEmitter} from '../../imports';
 import {isNamedClassDeclaration, ReflectionHost, TypeScriptReflectionHost} from '../../reflection';
@@ -40,6 +40,7 @@ runInEachFileSystem(() => {
     });
 
     it('should not produce an empty SourceFile when there is nothing to typecheck', () => {
+      const host = new NgtscCompilerHost(getFileSystem());
       const file = new TypeCheckFile(
           _('/_typecheck_.ts'), ALL_ENABLED_CONFIG, new ReferenceEmitter([]),
           /* reflector */ null!);
@@ -64,7 +65,7 @@ TestClass.ngTypeCtor({value: 'test'});
         const {program, host, options} = makeProgram(files, undefined, undefined, false);
         const checker = program.getTypeChecker();
         const reflectionHost = new TypeScriptReflectionHost(checker);
-        const logicalFs = new LogicalFileSystem(getRootDirs(host, options));
+        const logicalFs = new LogicalFileSystem(getRootDirs(host, options), host);
         const moduleResolver =
             new ModuleResolver(program, options, host, /* moduleResolutionCache */ null);
         const emitter = new ReferenceEmitter([
@@ -100,7 +101,7 @@ TestClass.ngTypeCtor({value: 'test'});
         const {program, host, options} = makeProgram(files, undefined, undefined, false);
         const checker = program.getTypeChecker();
         const reflectionHost = new TypeScriptReflectionHost(checker);
-        const logicalFs = new LogicalFileSystem(getRootDirs(host, options));
+        const logicalFs = new LogicalFileSystem(getRootDirs(host, options), host);
         const moduleResolver =
             new ModuleResolver(program, options, host, /* moduleResolutionCache */ null);
         const emitter = new ReferenceEmitter([
@@ -143,7 +144,7 @@ TestClass.ngTypeCtor({value: 'test'});
         const {program, host, options} = makeProgram(files, undefined, undefined, false);
         const checker = program.getTypeChecker();
         const reflectionHost = new TypeScriptReflectionHost(checker);
-        const logicalFs = new LogicalFileSystem(getRootDirs(host, options));
+        const logicalFs = new LogicalFileSystem(getRootDirs(host, options), host);
         const moduleResolver =
             new ModuleResolver(program, options, host, /* moduleResolutionCache */ null);
         const emitter = new ReferenceEmitter([

--- a/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
@@ -105,7 +105,7 @@ export function getRootDirs(host: ts.CompilerHost, options: ts.CompilerOptions):
   // See:
   // https://github.com/Microsoft/TypeScript/blob/3f7357d37f66c842d70d835bc925ec2a873ecfec/src/compiler/sys.ts#L650
   // Also compiler options might be set via an API which doesn't normalize paths
-  return rootDirs.map(rootDir => absoluteFrom(rootDir));
+  return rootDirs.map(rootDir => absoluteFrom(host.getCanonicalFileName(rootDir)));
 }
 
 export function nodeDebugInfo(node: ts.Node): string {


### PR DESCRIPTION
The `NodeJSFileSystem.isCaseSensitive()` method was computing
completely the opposite value for its result.

Also the `NgtscCompilerHost.getCanonicalFileName()` method was
not actually calling `useCaseSensitiveFileNames()` so it was always
assuming that the filenames were case sensitive and not actually
canonicalizing them. Instead just returning the original.

Once these two bugs were fixed, a number of issues with the rest of the
handling of case-insensitive files in compiler-cli and tests were uncovered.

This commit also fixes these issues. Here are some further notes:

The TS compiler canonicalizes filenames internally for lookups etc. So
if we are also doing file lookups we need to use the same canonicalized
forms. This is achieved by injecting the `ts.CompilerHost` where needed
and calling `getCanonicalFileName()`. For example, when computing the
`rootDirs` in the `LogicalFileSystem`.

Some tests were checking that particular source files were being exposed
by comparing the `ts.SourceFile.fileName` property with some non-canonical
filename. In some cases this would fail. Instead these comparisons are
achieved by directly comparing the SourceFile objects, if known, or getting
the SourceFile object from a non-canonical filename from the program, by
calling `program.getSourceFile(nonCanonicalFileName)`.

The `MockFileSystemWindows` class was not considering lower case drive names
when computing if a path is rooted (i.e. absolute).

The `NodeJSFileSystem.isCaseSensitive()` method was relying upon its `exists()`
method. But this itself relies upon the `isCaseSensitive()` to determine
if a file exists. So there was an infinite recursion. This is solved by
actually using the underlying real `fs.existsSync` to compute whether the
file system is case sensitive.

---

This was tested to work on Windows via #36873. See https://app.circleci.com/pipelines/github/angular/angular/14310/workflows/b347d457-f0ce-4d54-afbe-413a1c481003
