### PR TITLE
Revert "refactor(localize): move `source_file_utils.ts` up (#36834)"

### DIFF
--- a/packages/localize/src/tools/src/translate/main.ts
+++ b/packages/localize/src/tools/src/translate/main.ts
@@ -10,17 +10,17 @@ import * as glob from 'glob';
 import {resolve} from 'path';
 import * as yargs from 'yargs';
 
-import {Diagnostics} from '../diagnostics';
-import {MissingTranslationStrategy} from '../source_file_utils';
 import {AssetTranslationHandler} from './asset_files/asset_translation_handler';
 import {getOutputPathFn, OutputPathFn} from './output_path';
 import {SourceFileTranslationHandler} from './source_files/source_file_translation_handler';
+import {MissingTranslationStrategy} from './source_files/source_file_utils';
 import {TranslationLoader} from './translation_files/translation_loader';
 import {SimpleJsonTranslationParser} from './translation_files/translation_parsers/simple_json_translation_parser';
 import {Xliff1TranslationParser} from './translation_files/translation_parsers/xliff1_translation_parser';
 import {Xliff2TranslationParser} from './translation_files/translation_parsers/xliff2_translation_parser';
 import {XtbTranslationParser} from './translation_files/translation_parsers/xtb_translation_parser';
 import {Translator} from './translator';
+import {Diagnostics} from '../diagnostics';
 
 if (require.main === module) {
   const args = process.argv.slice(2);

--- a/packages/localize/src/tools/src/translate/source_files/es2015_translate_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/es2015_translate_plugin.ts
@@ -11,7 +11,7 @@ import {TaggedTemplateExpression} from '@babel/types';
 
 import {Diagnostics} from '../../diagnostics';
 
-import {buildCodeFrameError, buildLocalizeReplacement, isBabelParseError, isLocalize, translate, TranslatePluginOptions, unwrapMessagePartsFromTemplateLiteral} from '../../source_file_utils';
+import {buildCodeFrameError, buildLocalizeReplacement, isBabelParseError, isLocalize, translate, TranslatePluginOptions, unwrapMessagePartsFromTemplateLiteral} from './source_file_utils';
 
 export function makeEs2015TranslatePlugin(
     diagnostics: Diagnostics, translations: Record<string, ɵParsedTranslation>,

--- a/packages/localize/src/tools/src/translate/source_files/es5_translate_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/es5_translate_plugin.ts
@@ -11,7 +11,7 @@ import {CallExpression} from '@babel/types';
 
 import {Diagnostics} from '../../diagnostics';
 
-import {buildCodeFrameError, buildLocalizeReplacement, isBabelParseError, isLocalize, translate, TranslatePluginOptions, unwrapMessagePartsFromLocalizeCall, unwrapSubstitutionsFromLocalizeCall} from '../../source_file_utils';
+import {buildCodeFrameError, buildLocalizeReplacement, isBabelParseError, isLocalize, translate, TranslatePluginOptions, unwrapMessagePartsFromLocalizeCall, unwrapSubstitutionsFromLocalizeCall} from './source_file_utils';
 
 export function makeEs5TranslatePlugin(
     diagnostics: Diagnostics, translations: Record<string, ɵParsedTranslation>,

--- a/packages/localize/src/tools/src/translate/source_files/locale_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/locale_plugin.ts
@@ -8,7 +8,7 @@
 import {NodePath, PluginObj} from '@babel/core';
 import {MemberExpression, stringLiteral} from '@babel/types';
 
-import {isLocalize, TranslatePluginOptions} from '../../source_file_utils';
+import {isLocalize, TranslatePluginOptions} from './source_file_utils';
 
 /**
  * This Babel plugin will replace the following code forms with a string literal containing the

--- a/packages/localize/src/tools/src/translate/source_files/source_file_translation_handler.ts
+++ b/packages/localize/src/tools/src/translate/source_files/source_file_translation_handler.ts
@@ -10,12 +10,12 @@ import {File, Program} from '@babel/types';
 import {extname, join} from 'path';
 import {Diagnostics} from '../../diagnostics';
 import {FileUtils} from '../../file_utils';
-import {TranslatePluginOptions} from '../../source_file_utils';
 import {OutputPathFn} from '../output_path';
 import {TranslationBundle, TranslationHandler} from '../translator';
 import {makeEs2015TranslatePlugin} from './es2015_translate_plugin';
 import {makeEs5TranslatePlugin} from './es5_translate_plugin';
 import {makeLocalePlugin} from './locale_plugin';
+import {TranslatePluginOptions} from './source_file_utils';
 
 /**
  * Translate a file by inlining all messages tagged by `$localize` with the appropriate translated

--- a/packages/localize/src/tools/src/translate/source_files/source_file_utils.ts
+++ b/packages/localize/src/tools/src/translate/source_files/source_file_utils.ts
@@ -8,7 +8,8 @@
 import {ɵisMissingTranslationError, ɵmakeTemplateObject, ɵParsedTranslation, ɵSourceLocation, ɵtranslate} from '@angular/localize';
 import {NodePath} from '@babel/traverse';
 import * as t from '@babel/types';
-import {Diagnostics} from './diagnostics';
+
+import {Diagnostics} from '../../diagnostics';
 
 /**
  * Is the given `expression` the global `$localize` identifier?

--- a/packages/localize/src/tools/test/translate/source_files/source_file_utils_spec.ts
+++ b/packages/localize/src/tools/test/translate/source_files/source_file_utils_spec.ts
@@ -10,7 +10,7 @@ import {NodePath, transformSync} from '@babel/core';
 import generate from '@babel/generator';
 import template from '@babel/template';
 import {Expression, Identifier, TaggedTemplateExpression, ExpressionStatement, FunctionDeclaration, CallExpression, isParenthesizedExpression, numericLiteral, binaryExpression, NumericLiteral} from '@babel/types';
-import {isGlobalIdentifier, isNamedIdentifier, isStringLiteralArray, isArrayOfExpressions, unwrapStringLiteralArray, unwrapMessagePartsFromLocalizeCall, wrapInParensIfNecessary, buildLocalizeReplacement, unwrapSubstitutionsFromLocalizeCall, unwrapMessagePartsFromTemplateLiteral} from '../src/source_file_utils';
+import {isGlobalIdentifier, isNamedIdentifier, isStringLiteralArray, isArrayOfExpressions, unwrapStringLiteralArray, unwrapMessagePartsFromLocalizeCall, wrapInParensIfNecessary, buildLocalizeReplacement, unwrapSubstitutionsFromLocalizeCall, unwrapMessagePartsFromTemplateLiteral} from '../../../src/translate/source_files/source_file_utils';
 
 describe('utils', () => {
   describe('isNamedIdentifier()', () => {


### PR DESCRIPTION
This reverts commit d669429bd26dbd753584c331a6d7aa44a4d1f3ee.

The Angular CLI relies upon deep imports into `@angular/localize`. In this
case it relies upon the `source_file_utils.ts` file being in its previous
position.

In `master` (i.e. v10) the CLI will update its import to cope but we need
to revert for 9.1.x.
