### PR TITLE
build: use sh instead of exec for release scripts

### DIFF
--- a/scripts/release/publish-latest
+++ b/scripts/release/publish-latest
@@ -4,7 +4,7 @@ set -u -e -o pipefail
 
 # Runs the pre-check before performing the publish to ensure
 # the version is valid for release.
-exec "$(dirname "$0")/pre-check";
+sh "$(dirname "$0")/pre-check";
 
 # Use for production releases
 # Query Bazel for npm_package and ng_package rules with tags=["release-with-framework"]

--- a/scripts/release/publish-next
+++ b/scripts/release/publish-next
@@ -4,7 +4,7 @@ set -u -e -o pipefail
 
 # Runs the pre-check before performing the publish to ensure
 # the version is valid for release.
-exec "$(dirname "$0")/pre-check";
+sh "$(dirname "$0")/pre-check";
 
 # Use for BETA and RC releases
 # Query Bazel for npm_package and ng_package rules with tags=["release-with-framework"]


### PR DESCRIPTION
Previously the exec command was used, however the exec command would
exit the original calling script regardless of the whether exit was
called.  This caused the release script to always exit after the
pre-check phase.
