### PR TITLE
build: Add entry point for Ivy language service

### DIFF
--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -35,5 +35,6 @@ pkg_npm(
         ":language-service",
         # min bundle is not used at the moment; omit from package to speed up build
         "//packages/language-service/bundles:language-service.umd.js",
+        "//packages/language-service/bundles:ivy.umd.js",
     ],
 )

--- a/packages/language-service/bundles/BUILD.bazel
+++ b/packages/language-service/bundles/BUILD.bazel
@@ -18,6 +18,21 @@ ls_rollup_bundle(
     ],
 )
 
+ls_rollup_bundle(
+    name = "ivy",
+    entry_point = "//packages/language-service/ivy:ts_plugin.ts",
+    globals = {
+        "fs": "fs",
+        "path": "path",
+        "typescript/lib/tsserverlibrary": "ts",
+    },
+    license_banner = ":banner",
+    visibility = ["//packages/language-service:__pkg__"],
+    deps = [
+        "//packages/language-service/ivy",
+    ],
+)
+
 genrule(
     name = "banner",
     srcs = ["banner.js"],

--- a/packages/language-service/ivy/BUILD.bazel
+++ b/packages/language-service/ivy/BUILD.bazel
@@ -1,0 +1,11 @@
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "ivy",
+    srcs = glob(["*.ts"]),
+    deps = [
+        "@npm//typescript",
+    ],
+)

--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript/lib/tsserverlibrary';
+
+export class LanguageService {
+  constructor(private readonly tsLS: ts.LanguageService) {}
+
+  getSemanticDiagnostics(fileName: string): ts.Diagnostic[] {
+    return [];
+  }
+}

--- a/packages/language-service/ivy/ts_plugin.ts
+++ b/packages/language-service/ivy/ts_plugin.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript/lib/tsserverlibrary';
+import {LanguageService} from './language_service';
+
+export function create(info: ts.server.PluginCreateInfo): ts.LanguageService {
+  const {languageService: tsLS, config} = info;
+  const angularOnly = config?.angularOnly === true;
+
+  const ngLS = new LanguageService(tsLS);
+
+  function getSemanticDiagnostics(fileName: string): ts.Diagnostic[] {
+    const diagnostics: ts.Diagnostic[] = [];
+    if (!angularOnly) {
+      diagnostics.push(...tsLS.getSemanticDiagnostics(fileName));
+    }
+    diagnostics.push(...ngLS.getSemanticDiagnostics(fileName));
+    return diagnostics;
+  }
+
+  return {
+    ...tsLS,
+    getSemanticDiagnostics,
+  };
+}


### PR DESCRIPTION
This commit adds a new entry point for the Ivy version of language
service. The entry point is just a shell for now, implementation will be
added in subsequent PRs.

The Ivy version of language service could be loaded from the NPM package
via `require(@angular/language-service/bundles/ivy.umd.js)`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
