### PR TITLE
build(language-service): make test project a filegroup

### DIFF
--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -30,7 +30,7 @@ ts_library(
         "diagnostics_spec.ts",
         "hover_spec.ts",
     ],
-    data = glob(["project/**/*"]),
+    data = [":project"],
     deps = [
         ":test_utils_lib",
         "//packages/language-service",
@@ -51,13 +51,19 @@ ts_library(
         "typescript_host_spec.ts",
         "utils_spec.ts",
     ],
-    data = glob(["project/**/*"]),
+    data = [":project"],
     deps = [
         ":test_utils_lib",
         "//packages/compiler",
         "//packages/language-service",
         "@npm//typescript",
     ],
+)
+
+filegroup(
+    name = "project",
+    srcs = glob(["project/**/*"]),
+    visibility = ["//packages/language-service:__subpackages__"],
 )
 
 jasmine_node_test(

--- a/packages/language-service/test/project/foo.ts
+++ b/packages/language-service/test/project/foo.ts
@@ -1,9 +1,0 @@
-/**
- * @license
- * Copyright Google Inc. All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
-
-export * from './app/app.component';


### PR DESCRIPTION
This commit makes the test project a filegroup so that it could be
shared with the Ivy tests.
Also removed `project/foo.ts` since it's no longer used.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
