### PR TITLE
feat(docs-infra): refactor use of media queries

### DIFF
--- a/aio/src/styles/_constants.scss
+++ b/aio/src/styles/_constants.scss
@@ -123,6 +123,22 @@ $api-symbols: (
 );
 
 // OTHER
+
+// |0px                             |320px           |480px       |600px   |650px          |800px              |993px
+// |--------------------------------|----------------|------------|--------|---------------|-------------------|------- -  -   -
+// |             xxsmall            |     xsmall     |    teeny   |  tiny  |     small     |       medium      |   big
+// |________________________________|________________|____________|________|_______________|___________________|_______ _  _   _
+//
+// pattern:
+// $breakpoint-<size>: <minimum value that is inside that size>;
+$breakpoint-xxsmall: 0;
+$breakpoint-xsmall: 320px;
+$breakpoint-teeny: 480px;
+$breakpoint-tiny: 600px;
+$breakpoint-small: 650px;
+$breakpoint-medium: 800px;
+$breakpoint-big: 993px;
+
 $small-breakpoint-width: 840px;
-$phone-breakpoint: 480px;
-$tablet-breakpoint: 800px;
+$phone-breakpoint: $breakpoint-teeny;
+$tablet-breakpoint: $breakpoint-medium;

--- a/aio/src/styles/_mixins.scss
+++ b/aio/src/styles/_mixins.scss
@@ -9,7 +9,123 @@
      }
 
      Replace "tiny" with "medium" or "big" as necessary.
+      @include bp-starting-at(tiny) {
+        background-color: purple;
+      }
+
+  or
+
+      @include bp-up-to(tiny) {
+        background-color: purple;
+      }
+
+  Replace "tiny" one of (xxsmall, xsmall, teeny, tiny, small, medium, big) as necessary.
+
+  bp-starting-at(<size>) => creates a Media Query including <size> and any breakpoint bigger than <size>
+  bp-up-to(<size>) => creates a Media Query including <size> and any breakpoint smaller than <size>
+
 *************************************/
+
+@mixin bp-starting-at($point, $mediatype:null) {
+  // Makes no sense to call this mixin with 'xxsmall' as parameter
+  // $breakpoint-xxsmall-min: $breakpoint-xxsmall;
+  $breakpoint-xsmall-min: $breakpoint-xsmall;
+  $breakpoint-teeny-min:  $breakpoint-teeny;
+  $breakpoint-tiny-min:   $breakpoint-tiny;
+  $breakpoint-small-min:  $breakpoint-small;
+  $breakpoint-medium-min: $breakpoint-medium;
+  $breakpoint-big-min:    $breakpoint-big;
+
+  $map: (
+    // xxsmall: $breakpoint-xxsmall-min,
+    xsmall: $breakpoint-xsmall-min,
+    teeny: $breakpoint-teeny-min,
+    tiny: $breakpoint-tiny-min,
+    small: $breakpoint-small-min,
+    medium: $breakpoint-medium-min,
+    big: $breakpoint-big-min,
+  );
+
+  @if not map-has-key($map, $point) {
+    @error "Invalid breakpoint key `#{$point}` for mixin `bp-starting-at`"
+  }
+
+  $breakpoint-size: "(min-width: #{map-get($map, $point)})";
+
+  @if $mediatype {
+    $breakpoint-size: "#{$mediatype} and #{$breakpoint-size}";
+  }
+
+  @media #{$breakpoint-size} { @content; }
+}
+
+@mixin bp-up-to($point, $mediatype:null) {
+  // Makes no sense to call this mixin with 'big' as parameter
+  $breakpoint-xxsmall-max: $breakpoint-xsmall - 1px;
+  $breakpoint-xsmall-max:  $breakpoint-teeny  - 1px;
+  $breakpoint-teeny-max:   $breakpoint-tiny   - 1px;
+  $breakpoint-tiny-max:    $breakpoint-small  - 1px;
+  $breakpoint-small-max:   $breakpoint-medium - 1px;
+  $breakpoint-medium-max:  $breakpoint-big    - 1px;
+  // $breakpoint-big-max:  infinite;
+
+  $map: (
+    xxsmall: $breakpoint-xxsmall-max,
+    xsmall: $breakpoint-xsmall-max,
+    teeny: $breakpoint-teeny-max,
+    tiny: $breakpoint-tiny-max,
+    small: $breakpoint-small-max,
+    medium: $breakpoint-medium-max,
+    // big: $breakpoint-big-max,
+  );
+
+  @if not map-has-key($map, $point) {
+    @error "Invalid breakpoint key `#{$point}` for mixin `bp-up-to`"
+  }
+
+  $breakpoint-size: "(max-width: #{map-get($map, $point)})";
+
+  @if $mediatype {
+    $breakpoint-size: "#{$mediatype} and #{$breakpoint-size}";
+  }
+
+  @media #{$breakpoint-size} { @content; }
+}
+
+// @mixin bp-handheld {
+//   @media handheld and (max-width: 480px),
+//          screen and (max-width: 480px),
+//          screen and (max-width: 900px) {
+//            @content;
+//          }
+// }
+
+@mixin bp-handheld($handheld: default, $screen1: default, $screen2: default) {
+
+  @if $handheld == default {
+    $handheld: #{$breakpoint-teeny - 1px};
+  }
+  @if $screen1 == default {
+    $screen1: #{$breakpoint-teeny - 1px};
+  }
+  @if $screen2 == default {
+    $screen2: 900px;
+  }
+
+  $val: ();
+
+  @if $handheld {
+    $val: append($val, "handheld and (max-width: #{$handheld})", comma);
+  }
+  @if $screen1 {
+    $val: append($val, "screen and (max-width: #{$screen1})", comma);
+  }
+  @if $screen2 {
+    $val: append($val, "screen and (max-width: #{$screen2})", comma);
+  }
+
+  @media #{$val} { @content; }
+}
 
 @mixin bp($point) {
 


### PR DESCRIPTION
Building on the work done by @carlosasj. #26428

Change the use of media queries from inline values to a mixin with constants.
The motivation was to add consistency between media queries and avoid
gaps of 1px where the layout presented have mixed styles from two breakpoints.
Also, remove redundant CSS attributes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Media queries inlined using constants

Issue Number: N/A


## What is the new behavior?
Use mixins for media queries

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
