### PR TITLE
fix(common): returnvalues should be readonly

### DIFF
--- a/packages/common/src/i18n/locale_data_api.ts
+++ b/packages/common/src/i18n/locale_data_api.ts
@@ -255,7 +255,7 @@ export function getLocaleDayPeriods(
  * @publicApi
  */
 export function getLocaleDayNames(
-    locale: string, formStyle: FormStyle, width: TranslationWidth): string[] {
+    locale: string, formStyle: FormStyle, width: TranslationWidth): ReadonlyArray<string> {
   const data = ɵfindLocaleData(locale);
   const daysData =
       <string[][][]>[data[ɵLocaleDataIndex.DaysFormat], data[ɵLocaleDataIndex.DaysStandalone]];
@@ -276,7 +276,7 @@ export function getLocaleDayNames(
  * @publicApi
  */
 export function getLocaleMonthNames(
-    locale: string, formStyle: FormStyle, width: TranslationWidth): string[] {
+    locale: string, formStyle: FormStyle, width: TranslationWidth): ReadonlyArray<string> {
   const data = ɵfindLocaleData(locale);
   const monthsData =
       <string[][][]>[data[ɵLocaleDataIndex.MonthsFormat], data[ɵLocaleDataIndex.MonthsStandalone]];


### PR DESCRIPTION
## PR Checklist

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
getLocaleDayNames returns a mutable array which can be modified, when getLocaleDayNames is called again, the mutated array is returned.

A common mistake is this: 
getLocaleDayNames returns an array starting with the American standard, with sunday first.
To change this to our locale standard I would do this:
```
const weekdays = getLocaleDayNames('en', FormStyle.Format, TranslationWidth.Narrow)
weekdays.push(weekdays.shift()); // push Sunday to the back of the array
```
this mutates the array unexpectedly and as a result the weekdays would cycle every time my code was called.

## What is the new behavior?
getLocaleDayNames returns a readonly array.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Mutations to the returnvalue of getLocaleDayNames / getLocaleMonthNames should first be cloned before mutating.

## Other information
