### PR TITLE
perf(ngcc): only compute basePaths in TargetedEntryPointFinder when n…

### DIFF
--- a/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
@@ -27,12 +27,12 @@ import {getBasePaths} from './utils';
 export class TargetedEntryPointFinder implements EntryPointFinder {
   private unprocessedPaths: AbsoluteFsPath[] = [];
   private unsortedEntryPoints = new Map<AbsoluteFsPath, EntryPointWithDependencies>();
-  private _basePaths: AbsoluteFsPath[]|null = null;
-  private get basePaths() {
-    if (this._basePaths === null) {
-      this._basePaths = getBasePaths(this.logger, this.basePath, this.pathMappings);
+  private basePaths: AbsoluteFsPath[]|null = null;
+  private getBasePaths() {
+    if (this.basePaths === null) {
+      this.basePaths = getBasePaths(this.logger, this.basePath, this.pathMappings);
     }
-    return this._basePaths;
+    return this.basePaths;
   }
 
   constructor(
@@ -108,50 +108,24 @@ export class TargetedEntryPointFinder implements EntryPointFinder {
     return entryPoint;
   }
 
-  /**
-   * Search down to the `entryPointPath` from each `basePath` for the first `package.json` that we
-   * come to. This is the path to the entry-point's containing package. For example if `basePath` is
-   * `/a/b/c` and `entryPointPath` is `/a/b/c/d/e` and there exists `/a/b/c/d/package.json` and
-   * `/a/b/c/d/e/package.json`, then we will return `/a/b/c/d`.
-   *
-   * To account for nested `node_modules` we actually start the search at the last `node_modules` in
-   * the `entryPointPath` that is below the `basePath`. E.g. if `basePath` is `/a/b/c` and
-   * `entryPointPath` is `/a/b/c/d/node_modules/x/y/z`, we start the search at
-   * `/a/b/c/d/node_modules`.
-   */
   private computePackagePath(entryPointPath: AbsoluteFsPath): AbsoluteFsPath {
-    for (const basePath of this.basePaths) {
+    // First try the main basePath, to avoid having to compute the other basePaths from the paths
+    // mappings, which can be computationally intensive.
+    if (entryPointPath.startsWith(this.basePath)) {
+      const packagePath = this.computePackagePathFromContainingPath(entryPointPath, this.basePath);
+      if (packagePath !== null) {
+        return packagePath;
+      }
+    }
+
+    // The main `basePath` didn't work out so now we try the `basePaths` computed from the paths
+    // mappings in `tsconfig.json`.
+    for (const basePath of this.getBasePaths()) {
       if (entryPointPath.startsWith(basePath)) {
-        let packagePath = basePath;
-        const segments = this.splitPath(relative(basePath, entryPointPath));
-        let nodeModulesIndex = segments.lastIndexOf(relativeFrom('node_modules'));
-
-        // If there are no `node_modules` in the relative path between the `basePath` and the
-        // `entryPointPath` then just try the `basePath` as the `packagePath`.
-        // (This can be the case with path-mapped entry-points.)
-        if (nodeModulesIndex === -1) {
-          if (this.fs.exists(join(packagePath, 'package.json'))) {
-            return packagePath;
-          }
+        const packagePath = this.computePackagePathFromContainingPath(entryPointPath, basePath);
+        if (packagePath !== null) {
+          return packagePath;
         }
-
-        // Start the search at the deepest nested `node_modules` folder that is below the `basePath`
-        // but above the `entryPointPath`, if there are any.
-        while (nodeModulesIndex >= 0) {
-          packagePath = join(packagePath, segments.shift()!);
-          nodeModulesIndex--;
-        }
-
-        // Note that we start at the folder below the current candidate `packagePath` because the
-        // initial candidate `packagePath` is either a `node_modules` folder or the `basePath` with
-        // no `package.json`.
-        for (const segment of segments) {
-          packagePath = join(packagePath, segment);
-          if (this.fs.exists(join(packagePath, 'package.json'))) {
-            return packagePath;
-          }
-        }
-
         // If we got here then we couldn't find a `packagePath` for the current `basePath`.
         // Since `basePath`s are guaranteed not to be a sub-directory of each other then no other
         // `basePath` will match either.
@@ -159,8 +133,62 @@ export class TargetedEntryPointFinder implements EntryPointFinder {
       }
     }
 
-    // We couldn't find a `packagePath` using `basePaths` so try to find the nearest `node_modules`
-    // that contains the `entryPointPath`, if there is one, and use it as a `basePath`.
+    // Finally, if we couldn't find a `packagePath` using `basePaths` then try to find the nearest
+    // `node_modules` that contains the `entryPointPath`, if there is one, and use it as a
+    // `basePath`.
+    return this.computePackagePathFromNearestNodeModules(entryPointPath);
+  }
+
+  /**
+   * Search down to the `entryPointPath` from the `containingPath` for the first `package.json` that
+   * we come to. This is the path to the entry-point's containing package. For example if
+   * `containingPath` is `/a/b/c` and `entryPointPath` is `/a/b/c/d/e` and there exists
+   * `/a/b/c/d/package.json` and `/a/b/c/d/e/package.json`, then we will return `/a/b/c/d`.
+   *
+   * To account for nested `node_modules` we actually start the search at the last `node_modules` in
+   * the `entryPointPath` that is below the `containingPath`. E.g. if `containingPath` is `/a/b/c`
+   * and `entryPointPath` is `/a/b/c/d/node_modules/x/y/z`, we start the search at
+   * `/a/b/c/d/node_modules`.
+   */
+  private computePackagePathFromContainingPath(
+      entryPointPath: AbsoluteFsPath, containingPath: AbsoluteFsPath): AbsoluteFsPath|null {
+    let packagePath = containingPath;
+    const segments = this.splitPath(relative(containingPath, entryPointPath));
+    let nodeModulesIndex = segments.lastIndexOf(relativeFrom('node_modules'));
+
+    // If there are no `node_modules` in the relative path between the `basePath` and the
+    // `entryPointPath` then just try the `basePath` as the `packagePath`.
+    // (This can be the case with path-mapped entry-points.)
+    if (nodeModulesIndex === -1) {
+      if (this.fs.exists(join(packagePath, 'package.json'))) {
+        return packagePath;
+      }
+    }
+
+    // Start the search at the deepest nested `node_modules` folder that is below the `basePath`
+    // but above the `entryPointPath`, if there are any.
+    while (nodeModulesIndex >= 0) {
+      packagePath = join(packagePath, segments.shift()!);
+      nodeModulesIndex--;
+    }
+
+    // Note that we start at the folder below the current candidate `packagePath` because the
+    // initial candidate `packagePath` is either a `node_modules` folder or the `basePath` with
+    // no `package.json`.
+    for (const segment of segments) {
+      packagePath = join(packagePath, segment);
+      if (this.fs.exists(join(packagePath, 'package.json'))) {
+        return packagePath;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Search up the directory tree from the `entryPointPath` looking for a `node_modules` directory
+   * that we can use as a potential starting point for computing the package path.
+   */
+  private computePackagePathFromNearestNodeModules(entryPointPath: AbsoluteFsPath): AbsoluteFsPath {
     let packagePath = entryPointPath;
     let scopedPackagePath = packagePath;
     let containerPath = this.fs.dirname(packagePath);

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
@@ -27,7 +27,13 @@ import {getBasePaths} from './utils';
 export class TargetedEntryPointFinder implements EntryPointFinder {
   private unprocessedPaths: AbsoluteFsPath[] = [];
   private unsortedEntryPoints = new Map<AbsoluteFsPath, EntryPointWithDependencies>();
-  private basePaths = getBasePaths(this.logger, this.basePath, this.pathMappings);
+  private _basePaths: AbsoluteFsPath[]|null = null;
+  private get basePaths() {
+    if (this._basePaths === null) {
+      this._basePaths = getBasePaths(this.logger, this.basePath, this.pathMappings);
+    }
+    return this._basePaths;
+  }
 
   constructor(
       private fs: FileSystem, private config: NgccConfiguration, private logger: Logger,

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/utils.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/utils.ts
@@ -108,7 +108,7 @@ export function dedupePaths(paths: AbsoluteFsPath[]): AbsoluteFsPath[] {
   for (const path of paths) {
     addPath(root, path);
   }
-  return flattenTree(root).sort().reverse();
+  return flattenTree(root);
 }
 
 /**

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/utils_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/utils_spec.ts
@@ -48,6 +48,23 @@ runInEachFileSystem(() => {
       ]);
     });
 
+    it('should not be confused by folders that have the same starting string', () => {
+      const projectDirectory = _('/path/to/project');
+      const fs = getFileSystem();
+      fs.ensureDir(fs.resolve(projectDirectory, 'a/b'));
+      fs.ensureDir(fs.resolve(projectDirectory, 'a/b-2'));
+      fs.ensureDir(fs.resolve(projectDirectory, 'a/b/c'));
+
+      const sourceDirectory = _('/path/to/project/node_modules');
+      const pathMappings = {baseUrl: projectDirectory, paths: {'@dist': ['a/b', 'a/b-2', 'a/b/c']}};
+      const basePaths = getBasePaths(logger, sourceDirectory, pathMappings);
+      expect(basePaths).toEqual([
+        sourceDirectory,
+        fs.resolve(projectDirectory, 'a/b-2'),
+        fs.resolve(projectDirectory, 'a/b'),
+      ]);
+    });
+
     it('should discard paths that are already contained by another path', () => {
       const projectDirectory = _('/path/to/project');
       const fs = getFileSystem();

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/utils_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/utils_spec.ts
@@ -27,7 +27,7 @@ runInEachFileSystem(() => {
       expect(basePaths).toEqual([sourceDirectory]);
     });
 
-    it('should use each path mapping prefix and sort in descending order', () => {
+    it('should use each path mapping prefix', () => {
       const projectDirectory = _('/path/to/project');
       const fs = getFileSystem();
       fs.ensureDir(fs.resolve(projectDirectory, 'dist-1'));
@@ -41,10 +41,10 @@ runInEachFileSystem(() => {
       };
       const basePaths = getBasePaths(logger, sourceDirectory, pathMappings);
       expect(basePaths).toEqual([
-        fs.resolve(projectDirectory, 'sub-folder/dist-2'),
         sourceDirectory,
-        fs.resolve(projectDirectory, 'libs'),
         fs.resolve(projectDirectory, 'dist-1'),
+        fs.resolve(projectDirectory, 'libs'),
+        fs.resolve(projectDirectory, 'sub-folder/dist-2'),
       ]);
     });
 
@@ -60,8 +60,8 @@ runInEachFileSystem(() => {
       const basePaths = getBasePaths(logger, sourceDirectory, pathMappings);
       expect(basePaths).toEqual([
         sourceDirectory,
-        fs.resolve(projectDirectory, 'a/b-2'),
         fs.resolve(projectDirectory, 'a/b'),
+        fs.resolve(projectDirectory, 'a/b-2'),
       ]);
     });
 
@@ -122,8 +122,8 @@ runInEachFileSystem(() => {
       const pathMappings = {baseUrl: _('/'), paths: {'@dist': ['dist']}};
       const basePaths = getBasePaths(logger, sourceDirectory, pathMappings);
       expect(basePaths).toEqual([
-        sourceDirectory,
         fs.resolve('/dist'),
+        sourceDirectory,
       ]);
       expect(logger.logs.warn).toEqual([
         [`The provided pathMappings baseUrl is the root path ${_('/')}.\n` +


### PR DESCRIPTION
…eeded

Previously the `basePaths` were computed when the finder was instantiated.
This was a waste of effort in the case that the targeted entry-point is already
processed.

This change makes the computation of `basePaths` lazy, so that the work is
only done if they are actually needed.

Fixes #36874
