### PR TITLE
docs: list IE 9 and 10 as deprecated

### DIFF
--- a/aio/content/guide/browser-support.md
+++ b/aio/content/guide/browser-support.md
@@ -54,7 +54,7 @@ Angular supports most recent browsers. This includes the following specific vers
     </td>
     <td>
       <div> 11, 10*, 9* ("compatibility view" mode not supported) </div>
-      <div>* deprecated in v10, see <a href="/guide/deprecations#ie-9-10">deprecations</a></div>
+      <div>*deprecated in v10, see the <a href="/guide/deprecations#ie-9-10">deprecations guide</a>.</div>
     </td>
   </tr>
  <tr>

--- a/aio/content/guide/browser-support.md
+++ b/aio/content/guide/browser-support.md
@@ -53,7 +53,8 @@ Angular supports most recent browsers. This includes the following specific vers
       IE
     </td>
     <td>
-      11, 10, 9 ("compatibility view" mode not supported)
+      <div> 11, 10*, 9* ("compatibility view" mode not supported) </div>
+      <div>* deprecated in v10, see <a href="/guide/deprecations#ie-9-10">deprecations</a></div>
     </td>
   </tr>
  <tr>

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -60,6 +60,7 @@ v9 - v12
 | `@angular/core/testing`       | [`TestBed.get`](#testing)                                                     | <!--v9--> v12 |
 | `@angular/router`             | [`ActivatedRoute` params and `queryParams` properties](#activatedroute-props) | unspecified |
 | template syntax               | [`/deep/`, `>>>`, and `::ng-deep`](#deep-component-style-selector)            | <!--v7--> unspecified |
+| browser support               | [`IE 9 and 10`](#ie-9-10)                                                     | <!--v10--> unspecified |
 
 
 
@@ -651,3 +652,18 @@ For more information about using `@angular/common/http`, see the [HttpClient gui
 | --------------------- | ------------------------------------------- |
 | `MockBackend` | [`HttpTestingController`](/api/common/http/testing/HttpTestingController) |
 | `MockConnection` | [`HttpTestingController`](/api/common/http/testing/HttpTestingController) |
+
+{a browser-support}
+## Browser support
+
+{a ie-9-10}
+### IE 9 and 10
+
+We’ve been evaluating the cost of maintaining support for IE 9 and 10 and have determined that dropping them is the best way forward.
+Supporting outdated browsers like these increases bundle size, code complexity, and test load, and also requires time and effort that could be spent on improvements to the framework.
+For example, fixing issues can be more difficult, as a straightforward fix for modern browsers could break old ones that have quirks due to not receiving updates from vendors. 
+
+The final decision was made on three key points:
+* __Vendor support__: Microsoft dropped support of IE 9 and 10 on 1/12/16, meaning they no longer provide security updates or technical support.
+* __Usage statistics__: We looked at usage trends for IE 9 and 10 from various sources and all indicated that usage percentages were extremely small (fractions of 1%).
+* __Feedback from partners__: We also reached out to some of our Angular customers and none expressed concern about dropping IE 9 and 10 support.

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -563,7 +563,17 @@ In practical terms, the `package.json` of all `@angular` packages will change in
 
 For more information about the npm package format, see the [Angular Package Format spec](https://goo.gl/jB3GVv).
 
+{@a ie-9-10}
+### IE 9 and 10
 
+Support for IE 9 and 10 has been deprecated and will be removed in a future version.
+Supporting outdated browsers like these increases bundle size, code complexity, and test load, and also requires time and effort that could be spent on improvements to the framework.
+For example, fixing issues can be more difficult, as a straightforward fix for modern browsers could break old ones that have quirks due to not receiving updates from vendors. 
+
+The final decision was made on three key points:
+* __Vendor support__: Microsoft dropped support of IE 9 and 10 on 1/12/16, meaning they no longer provide security updates or technical support.
+* __Usage statistics__: We looked at usage trends for IE 9 and 10 from various sources and all indicated that usage percentages were extremely small (fractions of 1%).
+* __Feedback from partners__: We also reached out to some of our Angular customers and none expressed concern about dropping IE 9 and 10 support.
 
 {@a removed}
 ## Removed APIs
@@ -652,18 +662,3 @@ For more information about using `@angular/common/http`, see the [HttpClient gui
 | --------------------- | ------------------------------------------- |
 | `MockBackend` | [`HttpTestingController`](/api/common/http/testing/HttpTestingController) |
 | `MockConnection` | [`HttpTestingController`](/api/common/http/testing/HttpTestingController) |
-
-{@a browser-support}
-## Browser support
-
-{@a ie-9-10}
-### IE 9 and 10
-
-We’ve been evaluating the cost of maintaining support for IE 9 and 10 and have determined that dropping them is the best way forward.
-Supporting outdated browsers like these increases bundle size, code complexity, and test load, and also requires time and effort that could be spent on improvements to the framework.
-For example, fixing issues can be more difficult, as a straightforward fix for modern browsers could break old ones that have quirks due to not receiving updates from vendors. 
-
-The final decision was made on three key points:
-* __Vendor support__: Microsoft dropped support of IE 9 and 10 on 1/12/16, meaning they no longer provide security updates or technical support.
-* __Usage statistics__: We looked at usage trends for IE 9 and 10 from various sources and all indicated that usage percentages were extremely small (fractions of 1%).
-* __Feedback from partners__: We also reached out to some of our Angular customers and none expressed concern about dropping IE 9 and 10 support.

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -653,10 +653,10 @@ For more information about using `@angular/common/http`, see the [HttpClient gui
 | `MockBackend` | [`HttpTestingController`](/api/common/http/testing/HttpTestingController) |
 | `MockConnection` | [`HttpTestingController`](/api/common/http/testing/HttpTestingController) |
 
-{a browser-support}
+{@a browser-support}
 ## Browser support
 
-{a ie-9-10}
+{@a ie-9-10}
 ### IE 9 and 10
 
 We’ve been evaluating the cost of maintaining support for IE 9 and 10 and have determined that dropping them is the best way forward.

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -564,7 +564,7 @@ In practical terms, the `package.json` of all `@angular` packages will change in
 For more information about the npm package format, see the [Angular Package Format spec](https://goo.gl/jB3GVv).
 
 {@a ie-9-10}
-### IE 9 and 10
+### IE 9 and 10 support
 
 Support for IE 9 and 10 has been deprecated and will be removed in a future version.
 Supporting outdated browsers like these increases bundle size, code complexity, and test load, and also requires time and effort that could be spent on improvements to the framework.

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -60,7 +60,7 @@ v9 - v12
 | `@angular/core/testing`       | [`TestBed.get`](#testing)                                                     | <!--v9--> v12 |
 | `@angular/router`             | [`ActivatedRoute` params and `queryParams` properties](#activatedroute-props) | unspecified |
 | template syntax               | [`/deep/`, `>>>`, and `::ng-deep`](#deep-component-style-selector)            | <!--v7--> unspecified |
-| browser support               | [`IE 9 and 10`](#ie-9-10)                                                     | <!--v10--> unspecified |
+| browser support               | [`IE 9 and 10`](#ie-9-10)                                                     | <!--v10--> v11 |
 
 
 


### PR DESCRIPTION
Add documentation in the deprecations markdown file about the deprecation of IE 9 and 10.