### PR TITLE
refactor(core): make generic mandatory for ModuleWithProviders

### DIFF
--- a/aio/content/examples/ngmodules/src/app/greeting/greeting.module.ts
+++ b/aio/content/examples/ngmodules/src/app/greeting/greeting.module.ts
@@ -23,7 +23,7 @@ export class GreetingModule {
   // #enddocregion ctor
 
   // #docregion for-root
-  static forRoot(config: UserServiceConfig): ModuleWithProviders {
+  static forRoot(config: UserServiceConfig): ModuleWithProviders<GreetingModule> {
     return {
       ngModule: GreetingModule,
       providers: [

--- a/aio/tools/examples/shared/boilerplate/testing/tsconfig.app.json
+++ b/aio/tools/examples/shared/boilerplate/testing/tsconfig.app.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../out-tsc/app",
-    "types": []
+    "types": [],
+    // TODO(FW-2145): turn lib checks back on after fixing in-memory-api and investigating impact of ModuleWithProviders
+    "skipLibCheck": true
   },
   "files": [
     "src/main.ts",

--- a/aio/tools/examples/shared/boilerplate/viewengine/cli/tsconfig.json
+++ b/aio/tools/examples/shared/boilerplate/viewengine/cli/tsconfig.json
@@ -17,7 +17,9 @@
     "lib": [
       "es2018",
       "dom"
-    ]
+    ],
+    // TODO(FW-2145): turn lib checks back on after fixing in-memory-api and investigating impact of ModuleWithProviders
+    "skipLibCheck": true
   },
   "angularCompilerOptions": {
     "enableIvy": false,

--- a/aio/tools/examples/shared/tsconfig.json
+++ b/aio/tools/examples/shared/tsconfig.json
@@ -13,7 +13,9 @@
     "suppressImplicitAnyIndexErrors": true,
     "typeRoots": [
       "node_modules/@types"
-    ]
+    ],
+    // TODO(FW-2145): turn lib checks back on after fixing in-memory-api and investigating impact of ModuleWithProviders
+    "skipLibCheck": true
   },
   "include": [
     "../../../content/examples/*/e2e-spec.ts"

--- a/goldens/public-api/core/core.d.ts
+++ b/goldens/public-api/core/core.d.ts
@@ -559,7 +559,7 @@ export declare class ModuleWithComponentFactories<T> {
     constructor(ngModuleFactory: NgModuleFactory<T>, componentFactories: ComponentFactory<any>[]);
 }
 
-export declare interface ModuleWithProviders<T = any /** TODO(alxhub): remove default when callers pass explicit type param */> {
+export declare interface ModuleWithProviders<T> {
     ngModule: Type<T>;
     providers?: Provider[];
 }

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -82,16 +82,14 @@ export interface NgModuleDef<T> {
 /**
  * A wrapper around an NgModule that associates it with the providers.
  *
- * @param T the module type. In Ivy applications, this must be explicitly
- * provided.
+ * @param T the module type.
  *
  * Note that using ModuleWithProviders without a generic type is deprecated.
  * The generic will become required in a future version of Angular.
  *
  * @publicApi
  */
-export interface ModuleWithProviders<
-    T = any /** TODO(alxhub): remove default when callers pass explicit type param */> {
+export interface ModuleWithProviders<T> {
   ngModule: Type<T>;
   providers?: Provider[];
 }


### PR DESCRIPTION
In v9, we deprecated the use of ModuleWithProviders
without a generic. In v10, we will be requiring the
generic when using ModuleWithProviders. You can read
more about the reasoning behind this change in the
migration guide:
http://v9.angular.io/guide/migration-module-with-providers
