### PR TITLE
refactor(localize): use the new workspaces API for ng-add schematic

### DIFF
--- a/packages/localize/schematics/ng-add/README.md
+++ b/packages/localize/schematics/ng-add/README.md
@@ -1,6 +1,6 @@
 # @angular/localize schematic for `ng add`
 
-This schematic will be executed when a Angular CLI user runs `ng add @angular/localize`.
+This schematic will be executed when an Angular CLI user runs `ng add @angular/localize`.
 
 It will search their `angular.json` file, and find polyfills and main files for server builders.
 Then it will add the `@angular/localize/init` polyfill that `@angular/localize` needs to work.

--- a/packages/localize/schematics/ng-add/index_spec.ts
+++ b/packages/localize/schematics/ng-add/index_spec.ts
@@ -42,6 +42,7 @@ export { renderModule, renderModuleFactory } from '@angular/platform-server';`;
     host.create('src/unrelated-main.server.ts', mainServerContent);
     host.create('src/another-unrelated-main.server.ts', mainServerContent);
     host.create('angular.json', JSON.stringify({
+      version: 1,
       projects: {
         'demo': {
           architect: {
@@ -155,6 +156,7 @@ export { renderModule, renderModuleFactory } from '@angular/platform-server';`;
 
   it('should not break when there are no polyfills', async () => {
     host.overwrite('angular.json', JSON.stringify({
+      version: 1,
       projects: {
         'demo': {
           architect: {},


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Updates the `ng add @angular/localize` to use the new Workspaces API.

Issue Number: N/A

Related to PR https://github.com/angular/angular-cli/pull/17597 and https://github.com/angular/components/pull/19229


## What is the new behavior?

As the title describes, this PR updates the schematic to use the new workspaces API.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This PR is a followup for https://github.com/angular/angular-cli/pull/17597 where I've discovered that there are some unused methods in `@schematics/angular` and removed them.

cc: @alan-agius4 