### PR TITLE
feat(language-service): [ivy] Parse Angular compiler options

### DIFF
--- a/packages/language-service/ivy/BUILD.bazel
+++ b/packages/language-service/ivy/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
     name = "ivy",
     srcs = glob(["*.ts"]),
     deps = [
+        "//packages/compiler-cli",
         "@npm//typescript",
     ],
 )

--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -6,12 +6,50 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {CompilerOptions, createNgCompilerOptions} from '@angular/compiler-cli';
 import * as ts from 'typescript/lib/tsserverlibrary';
 
 export class LanguageService {
-  constructor(private readonly tsLS: ts.LanguageService) {}
+  private options: CompilerOptions;
+
+  constructor(project: ts.server.Project, private readonly tsLS: ts.LanguageService) {
+    this.options = parseNgCompilerOptions(project);
+    this.watchConfigFile(project);
+  }
 
   getSemanticDiagnostics(fileName: string): ts.Diagnostic[] {
     return [];
   }
+
+  private watchConfigFile(project: ts.server.Project) {
+    // TODO: Check the case when the project is disposed. An InferredProject
+    // could be disposed when a tsconfig.json is added to the workspace,
+    // in which case it becomes a ConfiguredProject (or vice-versa).
+    // We need to make sure that the FileWatcher is closed.
+    if (!(project instanceof ts.server.ConfiguredProject)) {
+      return;
+    }
+    const {host} = project.projectService;
+    host.watchFile(
+        project.getConfigFilePath(), (fileName: string, eventKind: ts.FileWatcherEventKind) => {
+          project.log(`Config file changed: ${fileName}`);
+          if (eventKind === ts.FileWatcherEventKind.Changed) {
+            this.options = parseNgCompilerOptions(project);
+          }
+        });
+  }
+}
+
+export function parseNgCompilerOptions(project: ts.server.Project): CompilerOptions {
+  let config = {};
+  if (project instanceof ts.server.ConfiguredProject) {
+    const configPath = project.getConfigFilePath();
+    const result = ts.readConfigFile(configPath, path => project.readFile(path));
+    if (result.error) {
+      project.error(ts.flattenDiagnosticMessageText(result.error.messageText, '\n'));
+    }
+    config = result.config || config;
+  }
+  const basePath = project.getCurrentDirectory();
+  return createNgCompilerOptions(basePath, config, project.getCompilationSettings());
 }

--- a/packages/language-service/ivy/test/BUILD.bazel
+++ b/packages/language-service/ivy/test/BUILD.bazel
@@ -5,6 +5,7 @@ ts_library(
     testonly = True,
     srcs = glob(["*.ts"]),
     deps = [
+        "//packages/language-service/ivy",
         "@npm//typescript",
     ],
 )

--- a/packages/language-service/ivy/test/language_service_spec.ts
+++ b/packages/language-service/ivy/test/language_service_spec.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {parseNgCompilerOptions} from '../language_service';
+
+import {setup} from './mock_host';
+
+const {project} = setup();
+
+describe('parseNgCompilerOptions', () => {
+  it('should read angularCompilerOptions in tsconfig.json', () => {
+    const options = parseNgCompilerOptions(project);
+    expect(options).toEqual(jasmine.objectContaining({
+      enableIvy: true,  // default for ivy is true
+      fullTemplateTypeCheck: true,
+      strictInjectionParameters: true,
+    }));
+  });
+});

--- a/packages/language-service/ivy/ts_plugin.ts
+++ b/packages/language-service/ivy/ts_plugin.ts
@@ -10,10 +10,10 @@ import * as ts from 'typescript/lib/tsserverlibrary';
 import {LanguageService} from './language_service';
 
 export function create(info: ts.server.PluginCreateInfo): ts.LanguageService {
-  const {languageService: tsLS, config} = info;
+  const {project, languageService: tsLS, config} = info;
   const angularOnly = config?.angularOnly === true;
 
-  const ngLS = new LanguageService(tsLS);
+  const ngLS = new LanguageService(project, tsLS);
 
   function getSemanticDiagnostics(fileName: string): ts.Diagnostic[] {
     const diagnostics: ts.Diagnostic[] = [];


### PR DESCRIPTION
Parse Angular compiler options in Angular language service.

In View Engine, only TypeScript compiler options are read, Angular
compiler options are not. With Ivy, there could be different modes of
compilation, most notably how strict the templates should be checked.
This commit makes the behavior of language service consistent with the
Ivy compiler.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
