### PR TITLE
build: update release precheck to rely on ng-dev for bazel stamping

### DIFF
--- a/scripts/release/pre-check
+++ b/scripts/release/pre-check
@@ -3,7 +3,7 @@
 # Runs the Bazel workspace status command in order to ensure that the version placeholder
 # will be replaced with the proper version name when building the release output.
 
-versionName=$(node tools/bazel_stamp_vars.js | grep -e "BUILD_SCM_VERSION" | cut -d " " -f2)
+versionName=$(yarn -s ng-dev release build-env-stamp | grep -e "BUILD_SCM_VERSION" | cut -d " " -f2)
 
 if [[ ! ${versionName} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(rc|next).[0-9]+)?$ ]]; then
   echo "ERROR: The release will currently have the following version: ${versionName}"


### PR DESCRIPTION
Migrate from using tools/bazel_stamp_vars.js to ng-dev to obtain
the current version name in the pre-check script.
