### PR TITLE
build: fix and re-enable elements tests on saucelabs

### DIFF
--- a/packages/elements/test/BUILD.bazel
+++ b/packages/elements/test/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//tools:defaults.bzl", "karma_web_test_suite", "ts_library")
 load("//tools/circular_dependency_test:index.bzl", "circular_dependency_test")
+load("//tools:utils.bzl", "transpile_js_to_es5")
 
 circular_dependency_test(
     name = "circular_deps_test",
@@ -25,13 +26,20 @@ ts_library(
     ],
 )
 
+# This file is shipped as es2015 to npm. We have to transpile
+# it to es5 in order to run the tests against older browsers.
+transpile_js_to_es5(
+    name = "custom_elements_native_shim",
+    js_file = "@npm//:node_modules/@webcomponents/custom-elements/src/native-shim.js",
+)
+
 filegroup(
     name = "elements_test_bootstrap_scripts",
     testonly = True,
     # do not sort
     srcs = [
         "@npm//:node_modules/core-js/client/core.js",
-        "@npm//:node_modules/@webcomponents/custom-elements/src/native-shim.js",
+        ":custom_elements_native_shim",
         "@npm//:node_modules/reflect-metadata/Reflect.js",
         "//packages/zone.js/dist:zone.js",
         "//packages/zone.js/dist:zone-testing.js",
@@ -42,17 +50,6 @@ karma_web_test_suite(
     name = "test",
     bootstrap = [
         ":elements_test_bootstrap_scripts",
-    ],
-    tags = [
-        # disabled on 2020-04-14 due to failure on saucelabs monitor job
-        # https://app.circleci.com/pipelines/github/angular/angular/13320/workflows/9ca3527a-d448-4a64-880a-fb4de9d1fece/jobs/680645
-        # ```
-        # IE 10.0.0 (Windows 8.0.0) ERROR
-        #   An error was thrown in afterAll
-        #   Syntax error
-        # ```
-        "fixme-saucelabs-ve",
-        "fixme-saucelabs-ivy",
     ],
     deps = [
         ":test_lib",


### PR DESCRIPTION
The `elements` tests were disabled on Saucelabs, because they were failing on IE10. The problem was that we were loading an es2015 file from npm directly, causing a syntax error. These changes transpile the file to es5.
