### PR TITLE
ci: removing CI environment variable caching setup

### DIFF
--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -5,87 +5,76 @@ readonly projectDir=$(realpath "$(dirname ${BASH_SOURCE[0]})/..")
 readonly envHelpersPath="$projectDir/.circleci/env-helpers.inc.sh";
 readonly bashEnvCachePath="$projectDir/.circleci/bash_env_cache";
 
-if [ -f $bashEnvCachePath ]; then
-  # Since a bash env cache is present, load this into the $BASH_ENV
-  cat "$bashEnvCachePath" >> $BASH_ENV;
-  echo "BASH environment loaded from cached value at $bashEnvCachePath";
-else
-  # Since no bash env cache is present, build out $BASH_ENV values.
-
-  # Load helpers and make them available everywhere (through `$BASH_ENV`).
-  source $envHelpersPath;
-  echo "source $envHelpersPath;" >> $BASH_ENV;
+# Load helpers and make them available everywhere (through `$BASH_ENV`).
+source $envHelpersPath;
+echo "source $envHelpersPath;" >> $BASH_ENV;
 
 
-  ####################################################################################################
-  # Define PUBLIC environment variables for CircleCI.
-  ####################################################################################################
-  # See https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables for more info.
-  ####################################################################################################
-  setPublicVar CI "$CI"
-  setPublicVar PROJECT_ROOT "$projectDir";
-  setPublicVar CI_AIO_MIN_PWA_SCORE "95";
-  # This is the branch being built; e.g. `pull/12345` for PR builds.
-  setPublicVar CI_BRANCH "$CIRCLE_BRANCH";
-  setPublicVar CI_BUILD_URL "$CIRCLE_BUILD_URL";
-  setPublicVar CI_COMMIT "$CIRCLE_SHA1";
-  # `CI_COMMIT_RANGE` is only used on push builds (a.k.a. non-PR, non-scheduled builds and rerun
-  # workflows of such builds).
-  setPublicVar CI_GIT_BASE_REVISION "${CIRCLE_GIT_BASE_REVISION}";
-  setPublicVar CI_GIT_REVISION "${CIRCLE_GIT_REVISION}";
-  setPublicVar CI_COMMIT_RANGE "$CIRCLE_GIT_BASE_REVISION..$CIRCLE_GIT_REVISION";
-  setPublicVar CI_PULL_REQUEST "${CIRCLE_PR_NUMBER:-false}";
-  setPublicVar CI_REPO_NAME "$CIRCLE_PROJECT_REPONAME";
-  setPublicVar CI_REPO_OWNER "$CIRCLE_PROJECT_USERNAME";
-  setPublicVar CI_PR_REPONAME "$CIRCLE_PR_REPONAME";
-  setPublicVar CI_PR_USERNAME "$CIRCLE_PR_USERNAME";
+####################################################################################################
+# Define PUBLIC environment variables for CircleCI.
+####################################################################################################
+# See https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables for more info.
+####################################################################################################
+setPublicVar CI "$CI"
+setPublicVar PROJECT_ROOT "$projectDir";
+setPublicVar CI_AIO_MIN_PWA_SCORE "95";
+# This is the branch being built; e.g. `pull/12345` for PR builds.
+setPublicVar CI_BRANCH "$CIRCLE_BRANCH";
+setPublicVar CI_BUILD_URL "$CIRCLE_BUILD_URL";
+setPublicVar CI_COMMIT "$CIRCLE_SHA1";
+# `CI_COMMIT_RANGE` is only used on push builds (a.k.a. non-PR, non-scheduled builds and rerun
+# workflows of such builds).
+setPublicVar CI_GIT_BASE_REVISION "${CIRCLE_GIT_BASE_REVISION}";
+setPublicVar CI_GIT_REVISION "${CIRCLE_GIT_REVISION}";
+setPublicVar CI_COMMIT_RANGE "$CIRCLE_GIT_BASE_REVISION..$CIRCLE_GIT_REVISION";
+setPublicVar CI_PULL_REQUEST "${CIRCLE_PR_NUMBER:-false}";
+setPublicVar CI_REPO_NAME "$CIRCLE_PROJECT_REPONAME";
+setPublicVar CI_REPO_OWNER "$CIRCLE_PROJECT_USERNAME";
+setPublicVar CI_PR_REPONAME "$CIRCLE_PR_REPONAME";
+setPublicVar CI_PR_USERNAME "$CIRCLE_PR_USERNAME";
 
 
-  ####################################################################################################
-  # Define "lazy" PUBLIC environment variables for CircleCI.
-  # (I.e. functions to set an environment variable when called.)
-  ####################################################################################################
-  createPublicVarSetter CI_STABLE_BRANCH "\$(npm info @angular/core dist-tags.latest | sed -r 's/^\\s*([0-9]+\\.[0-9]+)\\.[0-9]+.*$/\\1.x/')";
+####################################################################################################
+# Define "lazy" PUBLIC environment variables for CircleCI.
+# (I.e. functions to set an environment variable when called.)
+####################################################################################################
+createPublicVarSetter CI_STABLE_BRANCH "\$(npm info @angular/core dist-tags.latest | sed -r 's/^\\s*([0-9]+\\.[0-9]+)\\.[0-9]+.*$/\\1.x/')";
 
 
-  ####################################################################################################
-  # Define SECRET environment variables for CircleCI.
-  ####################################################################################################
-  setSecretVar CI_SECRET_AIO_DEPLOY_FIREBASE_TOKEN "$AIO_DEPLOY_TOKEN";
-  setSecretVar CI_SECRET_PAYLOAD_FIREBASE_TOKEN "$ANGULAR_PAYLOAD_TOKEN";
+####################################################################################################
+# Define SECRET environment variables for CircleCI.
+####################################################################################################
+setSecretVar CI_SECRET_AIO_DEPLOY_FIREBASE_TOKEN "$AIO_DEPLOY_TOKEN";
+setSecretVar CI_SECRET_PAYLOAD_FIREBASE_TOKEN "$ANGULAR_PAYLOAD_TOKEN";
 
 
-  ####################################################################################################
-  # Define SauceLabs environment variables for CircleCI.
-  ####################################################################################################
-  setPublicVar SAUCE_USERNAME "angular-framework";
-  setSecretVar SAUCE_ACCESS_KEY "0c731274ed5f-cbc9-16f4-021a-9835e39f";
-  # TODO(josephperrott): Remove environment variables once all saucelabs tests are via bazel method.
-  setPublicVar SAUCE_LOG_FILE /tmp/angular/sauce-connect.log
-  setPublicVar SAUCE_READY_FILE /tmp/angular/sauce-connect-ready-file.lock
-  setPublicVar SAUCE_PID_FILE /tmp/angular/sauce-connect-pid-file.lock
-  setPublicVar SAUCE_TUNNEL_IDENTIFIER "angular-framework-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}"
-  # Amount of seconds we wait for sauceconnect to establish a tunnel instance. In order to not
-  # acquire CircleCI instances for too long if sauceconnect failed, we need a connect timeout.
-  setPublicVar SAUCE_READY_FILE_TIMEOUT 120
+####################################################################################################
+# Define SauceLabs environment variables for CircleCI.
+####################################################################################################
+setPublicVar SAUCE_USERNAME "angular-framework";
+setSecretVar SAUCE_ACCESS_KEY "0c731274ed5f-cbc9-16f4-021a-9835e39f";
+# TODO(josephperrott): Remove environment variables once all saucelabs tests are via bazel method.
+setPublicVar SAUCE_LOG_FILE /tmp/angular/sauce-connect.log
+setPublicVar SAUCE_READY_FILE /tmp/angular/sauce-connect-ready-file.lock
+setPublicVar SAUCE_PID_FILE /tmp/angular/sauce-connect-pid-file.lock
+setPublicVar SAUCE_TUNNEL_IDENTIFIER "angular-framework-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}"
+# Amount of seconds we wait for sauceconnect to establish a tunnel instance. In order to not
+# acquire CircleCI instances for too long if sauceconnect failed, we need a connect timeout.
+setPublicVar SAUCE_READY_FILE_TIMEOUT 120
 
 
-  ####################################################################################################
-  # Define environment variables for the `angular/components` repo unit tests job.
-  ####################################################################################################
-  # We specifically use a directory within "/tmp" here because we want the cloned repo to be
-  # completely isolated from angular/angular in order to avoid any bad interactions between
-  # their separate build setups. **NOTE**: When updating the temporary directory, also update
-  # the `save_cache` path configuration in `config.yml`
-  setPublicVar COMPONENTS_REPO_TMP_DIR "/tmp/angular-components-repo"
-  setPublicVar COMPONENTS_REPO_URL "https://github.com/angular/components.git"
-  setPublicVar COMPONENTS_REPO_BRANCH "master"
-  # **NOTE**: When updating the commit SHA, also update the cache key in the CircleCI `config.yml`.
-  setPublicVar COMPONENTS_REPO_COMMIT "598db096e668aa7e9debd56eedfd127b7a55e371"
-
-  # Save the created BASH_ENV into the bash env cache file.
-  cat "$BASH_ENV" >> $bashEnvCachePath;
-fi
+####################################################################################################
+# Define environment variables for the `angular/components` repo unit tests job.
+####################################################################################################
+# We specifically use a directory within "/tmp" here because we want the cloned repo to be
+# completely isolated from angular/angular in order to avoid any bad interactions between
+# their separate build setups. **NOTE**: When updating the temporary directory, also update
+# the `save_cache` path configuration in `config.yml`
+setPublicVar COMPONENTS_REPO_TMP_DIR "/tmp/angular-components-repo"
+setPublicVar COMPONENTS_REPO_URL "https://github.com/angular/components.git"
+setPublicVar COMPONENTS_REPO_BRANCH "master"
+# **NOTE**: When updating the commit SHA, also update the cache key in the CircleCI `config.yml`.
+setPublicVar COMPONENTS_REPO_COMMIT "598db096e668aa7e9debd56eedfd127b7a55e371"
 
 
 ####################################################################################################


### PR DESCRIPTION
A caching mechanism was put in place to prevent repeated calls to
the Github API.  As the CI setup no longer relies on calls to the
Github API, this caching is no longer necessary.

It was discovered that this caching was causing a contention issue
for saucelabs testing as the same tunnel was being reused for
multiple jobs simultaneously.  With this caching mechanism removed
the jobs will once again run via separate tunnels.

