### PR TITLE
feat(core):deprecate NgIterable type

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -61,8 +61,9 @@ v9 - v12
 | `@angular/router`             | [`ActivatedRoute` params and `queryParams` properties](#activatedroute-props) | unspecified |
 | template syntax               | [`/deep/`, `>>>`, and `::ng-deep`](#deep-component-style-selector)            | <!--v7--> unspecified |
 | browser support               | [`IE 9 and 10, IE mobile`](#ie-9-10-and-mobile)                               | <!--v10--> v11 |
-
+| `@angular/core`               | [`NgIterable`](api/core/NgIterable)                        | unspecified |
 For information about Angular CDK and Angular Material deprecations, see the [changelog](https://github.com/angular/components/blob/master/CHANGELOG.md).
+
 
 ## Deprecated APIs
 
@@ -97,6 +98,7 @@ Tip: In the [API reference section](api) of this doc site, deprecated APIs are i
 | [`entryComponents`](api/core/NgModule#entryComponents) | none | v9 | See [`entryComponents`](#entryComponents) |
 | [`ANALYZE_FOR_ENTRY_COMPONENTS`](api/core/ANALYZE_FOR_ENTRY_COMPONENTS) | none | v9 | See [`ANALYZE_FOR_ENTRY_COMPONENTS`](#entryComponents) |
 | [`WrappedValue`](api/core/WrappedValue) | none | v10 | See [removing `WrappedValue`](#wrapped-value) |
+| [`NgIterable`](api/core/NgIterable) | Iterabe | unspecified | Use the default Iterable type instead of NgIterable |
 
 
 

--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -215,17 +215,17 @@ export declare class NgComponentOutlet implements OnChanges, OnDestroy {
     ngOnDestroy(): void;
 }
 
-export declare class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCheck {
-    set ngForOf(ngForOf: (U & NgIterable<T>) | undefined | null);
+export declare class NgForOf<T, U extends Iterable<T> = Iterable<T>> implements DoCheck {
+    set ngForOf(ngForOf: (U & Iterable<T>) | undefined | null);
     set ngForTemplate(value: TemplateRef<NgForOfContext<T, U>>);
     set ngForTrackBy(fn: TrackByFunction<T>);
     get ngForTrackBy(): TrackByFunction<T>;
     constructor(_viewContainer: ViewContainerRef, _template: TemplateRef<NgForOfContext<T, U>>, _differs: IterableDiffers);
     ngDoCheck(): void;
-    static ngTemplateContextGuard<T, U extends NgIterable<T>>(dir: NgForOf<T, U>, ctx: any): ctx is NgForOfContext<T, U>;
+    static ngTemplateContextGuard<T, U extends Iterable<T>>(dir: NgForOf<T, U>, ctx: any): ctx is NgForOfContext<T, U>;
 }
 
-export declare class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
+export declare class NgForOfContext<T, U extends Iterable<T> = Iterable<T>> {
     $implicit: T;
     count: number;
     get even(): boolean;

--- a/goldens/public-api/core/core.d.ts
+++ b/goldens/public-api/core/core.d.ts
@@ -570,6 +570,9 @@ export declare interface ModuleWithProviders<T> {
     providers?: Provider[];
 }
 
+/** @deprecated */
+export declare type NgIterable<T> = Iterable<T>;
+
 export declare interface NgModule {
     bootstrap?: Array<Type<any> | any[]>;
     declarations?: Array<Type<any> | any[]>;

--- a/goldens/public-api/core/core.d.ts
+++ b/goldens/public-api/core/core.d.ts
@@ -250,8 +250,8 @@ export declare class DefaultIterableDiffer<V> implements IterableDiffer<V>, Iter
     get isDirty(): boolean;
     readonly length: number;
     constructor(trackByFn?: TrackByFunction<V>);
-    check(collection: NgIterable<V>): boolean;
-    diff(collection: NgIterable<V> | null | undefined): DefaultIterableDiffer<V> | null;
+    check(collection: Iterable<V>): boolean;
+    diff(collection: Iterable<V> | null | undefined): DefaultIterableDiffer<V> | null;
     forEachAddedItem(fn: (record: IterableChangeRecord_<V>) => void): void;
     forEachIdentityChange(fn: (record: IterableChangeRecord_<V>) => void): void;
     forEachItem(fn: (record: IterableChangeRecord_<V>) => void): void;
@@ -499,7 +499,7 @@ export declare interface IterableChanges<V> {
 }
 
 export declare interface IterableDiffer<V> {
-    diff(object: NgIterable<V> | undefined | null): IterableChanges<V> | null;
+    diff(object: Iterable<V> | undefined | null): IterableChanges<V> | null;
 }
 
 export declare interface IterableDifferFactory {
@@ -569,8 +569,6 @@ export declare interface ModuleWithProviders<T> {
     ngModule: Type<T>;
     providers?: Provider[];
 }
-
-export declare type NgIterable<T> = Array<T> | Iterable<T>;
 
 export declare interface NgModule {
     bootstrap?: Array<Type<any> | any[]>;

--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, DoCheck, EmbeddedViewRef, Input, isDevMode, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDiffers, NgIterable, TemplateRef, TrackByFunction, ViewContainerRef} from '@angular/core';
+import {Directive, DoCheck, EmbeddedViewRef, Input, isDevMode, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDiffers, TemplateRef, TrackByFunction, ViewContainerRef} from '@angular/core';
 
 /**
  * @publicApi
  */
-export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
+export class NgForOfContext<T, U extends Iterable<T> = Iterable<T>> {
   constructor(public $implicit: T, public ngForOf: U, public index: number, public count: number) {}
 
   get first(): boolean {
@@ -89,7 +89,7 @@ export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
  * The following exported values can be aliased to local variables:
  *
  * - `$implicit: T`: The value of the individual items in the iterable (`ngForOf`).
- * - `ngForOf: NgIterable<T>`: The value of the iterable expression. Useful when the expression is
+ * - `ngForOf: Iterable<T>`: The value of the iterable expression. Useful when the expression is
  * more complex then a property access, for example when using the async pipe (`userStreams |
  * async`).
  * - `index: number`: The index of the current item in the iterable.
@@ -130,13 +130,13 @@ export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
  * @publicApi
  */
 @Directive({selector: '[ngFor][ngForOf]'})
-export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCheck {
+export class NgForOf<T, U extends Iterable<T> = Iterable<T>> implements DoCheck {
   /**
    * The value of the iterable expression, which can be used as a
    * [template input variable](guide/structural-directives#template-input-variable).
    */
   @Input()
-  set ngForOf(ngForOf: U&NgIterable<T>|undefined|null) {
+  set ngForOf(ngForOf: U&Iterable<T>|undefined|null) {
     this._ngForOf = ngForOf;
     this._ngForOfDirty = true;
   }
@@ -275,13 +275,13 @@ export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCh
    * The presence of this method is a signal to the Ivy template type-check compiler that the
    * `NgForOf` structural directive renders its template with a specific context type.
    */
-  static ngTemplateContextGuard<T, U extends NgIterable<T>>(dir: NgForOf<T, U>, ctx: any):
+  static ngTemplateContextGuard<T, U extends Iterable<T>>(dir: NgForOf<T, U>, ctx: any):
       ctx is NgForOfContext<T, U> {
     return true;
   }
 }
 
-class RecordViewTuple<T, U extends NgIterable<T>> {
+class RecordViewTuple<T, U extends Iterable<T>> {
   constructor(public record: any, public view: EmbeddedViewRef<NgForOfContext<T, U>>) {}
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_emitter.ts
@@ -67,26 +67,24 @@ export function canEmitType(type: ts.TypeNode, resolver: TypeReferenceResolver):
  * For example, consider the following code:
  *
  * ```
- * import {NgIterable} from '@angular/core';
- *
- * class NgForOf<T, U extends NgIterable<T>> {}
+ * class NgForOf<T, U extends Iterable<T>> {}
  * ```
  *
  * Here, the generic type parameters `T` and `U` can be emitted into a different context, as the
- * type reference to `NgIterable` originates from an absolute module import so that it can be
+ * type reference to `Iterable` originates from an absolute module import so that it can be
  * emitted anywhere, using that same module import. The process of emitting translates the
- * `NgIterable` type reference to a type reference that is valid in the context in which it is
+ * `Iterable` type reference to a type reference that is valid in the context in which it is
  * emitted, for example:
  *
  * ```
  * import * as i0 from '@angular/core';
  * import * as i1 from '@angular/common';
  *
- * const _ctor1: <T, U extends i0.NgIterable<T>>(o: Pick<i1.NgForOf<T, U>, 'ngForOf'>):
+ * const _ctor1: <T, U extends Iterable<T>>(o: Pick<i1.NgForOf<T, U>, 'ngForOf'>):
  * i1.NgForOf<T, U>;
  * ```
  *
- * Notice how the type reference for `NgIterable` has been translated into a qualified name,
+ * Notice how the type reference for `Iterable` has been translated into a qualified name,
  * referring to the namespace import that was created.
  */
 export class TypeEmitter {

--- a/packages/compiler-cli/test/ngtsc/fake_core/index.ts
+++ b/packages/compiler-cli/test/ngtsc/fake_core/index.ts
@@ -100,6 +100,4 @@ export interface QueryList<T>/* implements Iterable<T> */ {
   [Symbol.iterator]: () => Iterator<T>;
 }
 
-export type NgIterable<T> = Array<T>|Iterable<T>;
-
 export class NgZone {}

--- a/packages/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/packages/core/src/change_detection/differs/default_iterable_differ.ts
@@ -9,7 +9,7 @@
 import {stringify} from '../../util/stringify';
 import {isListLikeIterable, iterateListLike} from '../change_detection_util';
 
-import {IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, NgIterable, TrackByFunction} from './iterable_differs';
+import {IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, TrackByFunction} from './iterable_differs';
 
 
 export class DefaultIterableDifferFactory implements IterableDifferFactory {
@@ -149,7 +149,7 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
     }
   }
 
-  diff(collection: NgIterable<V>|null|undefined): DefaultIterableDiffer<V>|null {
+  diff(collection: Iterable<V>|null|undefined): DefaultIterableDiffer<V>|null {
     if (collection == null) collection = [];
     if (!isListLikeIterable(collection)) {
       throw new Error(
@@ -165,7 +165,7 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
 
   onDestroy() {}
 
-  check(collection: NgIterable<V>): boolean {
+  check(collection: Iterable<V>): boolean {
     this._reset();
 
     let record: IterableChangeRecord_<V>|null = this._itHead;

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -15,10 +15,11 @@ import {DefaultIterableDifferFactory} from '../differs/default_iterable_differ';
 
 /**
  * A type describing supported iterable types.
- *
+ * @deprecated Use `Iterable` from the standard TypeScript library instead of `NgIterable`. The two
+ *     are equivalent.
  * @publicApi
  */
-export type NgIterable<T> = Array<T>|Iterable<T>;
+export type NgIterable<T> = Iterable<T>;
 
 /**
  * A strategy for tracking changes over time to an iterable. Used by {@link NgForOf} to
@@ -34,7 +35,7 @@ export interface IterableDiffer<V> {
    * @returns an object describing the difference. The return value is only valid until the next
    * `diff()` invocation.
    */
-  diff(object: NgIterable<V>|undefined|null): IterableChanges<V>|null;
+  diff(object: Iterable<V>|undefined|null): IterableChanges<V>|null;
 }
 
 /**

--- a/packages/core/src/linker/query_list.ts
+++ b/packages/core/src/linker/query_list.ts
@@ -159,6 +159,6 @@ export class QueryList<T> implements Iterable<T> {
   // tree-shaking issues with `QueryList. So instead, it's added in the constructor (see comments
   // there) and this declaration is left here to ensure that TypeScript considers QueryList to
   // implement the Iterable interface. This is required for template type-checking of NgFor loops
-  // over QueryLists to work correctly, since QueryList must be assignable to NgIterable.
+  // over QueryLists to work correctly, since QueryList must be assignable to Iterable.
   [Symbol.iterator]!: () => Iterator<T>;
 }

--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -7,11 +7,11 @@
  */
 
 import {NgForOf as NgForOfDef, NgIf as NgIfDef, NgTemplateOutlet as NgTemplateOutletDef} from '@angular/common';
-import {IterableDiffers, NgIterable, TemplateRef, ViewContainerRef} from '@angular/core';
+import {IterableDiffers, TemplateRef, ViewContainerRef} from '@angular/core';
 
 import {DirectiveType, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵNgOnChangesFeature} from '../../src/render3/index';
 
-export const NgForOf: DirectiveType<NgForOfDef<any, NgIterable<any>>> = NgForOfDef as any;
+export const NgForOf: DirectiveType<NgForOfDef<any, Iterable<any>>> = NgForOfDef as any;
 export const NgIf: DirectiveType<NgIfDef<any>> = NgIfDef as any;
 export const NgTemplateOutlet: DirectiveType<NgTemplateOutletDef> = NgTemplateOutletDef as any;
 


### PR DESCRIPTION
typescript contains Array of type ReadonlyArray earlier we only used to support Array type added support for ReadonlyArray too in the core.js file

Fixes #36854

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Added readonlyArray type not in iterable


Issue Number: #36854


## What is the new behavior?
Added readonlyArray type in iterable

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
