### PR TITLE
refactor(docs-infra): change class to interface where class properties not used

### DIFF
--- a/aio/src/app/custom-elements/resource/resource.model.ts
+++ b/aio/src/app/custom-elements/resource/resource.model.ts
@@ -1,18 +1,18 @@
-export class Category {
+export interface Category {
   id: string;    // "education"
   title: string; // "Education"
   order: number; // 2
   subCategories: SubCategory[];
 }
 
-export class SubCategory {
+export interface SubCategory {
   id: string;    // "books"
   title: string; // "Books"
   order: number; // 1
   resources: Resource[];
 }
 
-export class Resource {
+export interface Resource {
   category: string;    // "Education"
   subCategory: string; // "Books"
   id: string;          // "-KLI8vJ0ZkvWhqPembZ7"


### PR DESCRIPTION
In resource.model.ts the interfaces of the resources were defined as classes, these do not use any class properties and are only used for type checking. So, changed them from class to interface.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
class used for interfaces

Issue Number: N/A


## What is the new behavior?
Interface used for interfaces

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
