### PR TITLE
fix(core): delegate ctor regex updated to work on minified code

### DIFF
--- a/packages/core/src/reflection/reflection_capabilities.ts
+++ b/packages/core/src/reflection/reflection_capabilities.ts
@@ -25,7 +25,7 @@ export const INHERITED_CLASS = /^class\s+[A-Za-z\d$_]*\s*extends\s+[^{]+{/;
 export const INHERITED_CLASS_WITH_CTOR =
     /^class\s+[A-Za-z\d$_]*\s*extends\s+[^{]+{[\s\S]*constructor\s*\(/;
 export const INHERITED_CLASS_WITH_DELEGATE_CTOR =
-    /^class\s+[A-Za-z\d$_]*\s*extends\s+[^{]+{[\s\S]*constructor\s*\(\)\s*{\s+super\(\.\.\.arguments\)/;
+    /^class\s+[A-Za-z\d$_]*\s*extends\s+[^{]+{[\s\S]*constructor\s*\(\)\s*{\s*super\(\.\.\.arguments\)/;
 
 /**
  * Determine whether a stringified type is a class which delegates its constructor

--- a/packages/core/test/reflection/reflector_spec.ts
+++ b/packages/core/test/reflection/reflector_spec.ts
@@ -201,6 +201,18 @@ class TestObj {
         expect(isDelegateCtor(ChildWithCtor.toString())).toBe(false);
       });
 
+      it('should support ES2015 classes when minified', () => {
+        // These classes are ES2015 in minified form
+        const ChildNoCtorMinified = 'class ChildNoCtor extends Parent{}';
+        const ChildWithCtorMinified = 'class ChildWithCtor extends Parent{constructor(){super()}}';
+        const ChildNoCtorPrivatePropsMinified =
+            'class ChildNoCtorPrivateProps extends Parent{constructor(){super(...arguments);this.x=10}}';
+
+        expect(isDelegateCtor(ChildNoCtorMinified)).toBe(true);
+        expect(isDelegateCtor(ChildNoCtorPrivatePropsMinified)).toBe(true);
+        expect(isDelegateCtor(ChildWithCtorMinified)).toBe(false);
+      });
+
       it('should not throw when no prototype on type', () => {
         // Cannot test arrow function here due to the compilation
         const dummyArrowFn = function() {};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

If one component Parent inherit another component Base like the following:

```
@Component(...)
class Base {
  constructor(@Inject(INJECTOR) injector: Injector) { }
}

@Component(...)
class Parent extends Base {
    // no constructor
}
```

When creating Component Parent, the dependency injection should work on delegating ctors like above.

The Parent code above will be compiled into something like:

```
class Parent extends Base {
  constructor() {
    super(...arguments);
  }
}
```

The angular core isDelegateCtor function will identify the delegation ctor to the base class.

But when the code above is minified (using Terser), the minified code will compress the spaces, resulting in something like:

`class Parent extends Base{constructor(){super(...arguments)}}`

The regex will stop working, since it wasn't aware of this case. So this fix will allow this to work in minified code cases.

## What is the new behavior?
The new behavior will identify delegating ctors on minified code as well, as written above.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No