### PR TITLE
fix(bazel): ng_module rule does not expose flat module information in Ivy

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -354,8 +354,11 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
         "angularCompilerOptions": angular_compiler_options,
     })
 
+def _has_target_angular_summaries(target):
+    return hasattr(target, "angular") and hasattr(target.angular, "summaries")
+
 def _collect_summaries_aspect_impl(target, ctx):
-    results = depset(target.angular.summaries if hasattr(target, "angular") else [])
+    results = depset(target.angular.summaries if _has_target_angular_summaries(target) else [])
 
     # If we are visiting empty-srcs ts_library, this is a re-export
     srcs = ctx.rule.attr.srcs if hasattr(ctx.rule.attr, "srcs") else []
@@ -363,7 +366,7 @@ def _collect_summaries_aspect_impl(target, ctx):
     # "re-export" rules should expose all the files of their deps
     if not srcs and hasattr(ctx.rule.attr, "deps"):
         for dep in ctx.rule.attr.deps:
-            if (hasattr(dep, "angular")):
+            if (_has_target_angular_summaries(dep)):
                 results = depset(dep.angular.summaries, transitive = [results])
 
     return struct(collect_summaries_aspect_result = results)
@@ -608,20 +611,23 @@ def ng_module_impl(ctx, ts_compile_actions):
 
     outs = _expected_outs(ctx)
 
+    providers["angular"] = {}
+
     if is_legacy_ngc:
-        providers["angular"] = {
-            "summaries": outs.summaries,
-            "metadata": outs.metadata,
-        }
+        providers["angular"]["summaries"] = outs.summaries
+        providers["angular"]["metadata"] = outs.metadata
         providers["ngc_messages"] = outs.i18n_messages
 
-    if is_legacy_ngc and _should_produce_flat_module_outs(ctx):
-        if len(outs.metadata) > 1:
+    if _should_produce_flat_module_outs(ctx):
+        # Sanity error if more than one metadata file has been created in the
+        # legacy ngc compiler while a flat module should be produced.
+        if is_legacy_ngc and len(outs.metadata) > 1:
             fail("expecting exactly one metadata output for " + str(ctx.label))
 
         providers["angular"]["flat_module_metadata"] = struct(
             module_name = ctx.attr.module_name,
-            metadata_file = outs.metadata[0],
+            # Metadata files are only generated in the legacy ngc compiler.
+            metadata_file = outs.metadata[0] if is_legacy_ngc else None,
             typings_file = outs.bundle_index_typings,
             flat_module_out_file = _flat_module_out_file(ctx),
         )

--- a/packages/bazel/src/ng_package/packager.ts
+++ b/packages/bazel/src/ng_package/packager.ts
@@ -180,8 +180,8 @@ function main(args: string[]): number {
 
     moduleFiles['esm2015_index'] = path.join(binDir, 'esm2015', relative);
 
-    // Metadata file is optional as entry-points can be also built
-    // with the "ts_library" rule.
+    // Metadata file is optional as entry-points can be built with the `ts_library`
+    // rule or `ng_module` rule in Ivy mode.
     const metadataFile = moduleFiles['metadata'];
     if (!metadataFile) {
       return;

--- a/packages/bazel/test/ng_package/BUILD.bazel
+++ b/packages/bazel/test/ng_package/BUILD.bazel
@@ -25,10 +25,6 @@ jasmine_node_test(
         "@npm//@types/shelljs",
         "@npm//shelljs",
     ],
-    # The "ng_package" rule currently does not properly handle flat module
-    # bundles which the common package tests rely on. We temporarily disable
-    # this test until we fix `ng_package` for Ivy. Tracked with: FW-2144.
-    tags = ["fixme-ivy-aot"],
 )
 
 ts_library(
@@ -49,10 +45,6 @@ jasmine_node_test(
         "//packages/common:npm_package",
         "@npm//shelljs",
     ],
-    # The "ng_package" rule currently does not properly handle flat module
-    # bundles which the common package tests rely on. We temporarily disable
-    # this test until we fix `ng_package` for Ivy. Tracked with: FW-2144.
-    tags = ["fixme-ivy-aot"],
 )
 
 ts_library(

--- a/packages/compiler-cli/integrationtest/bazel/ng_module/extract_flat_module_index.bzl
+++ b/packages/compiler-cli/integrationtest/bazel/ng_module/extract_flat_module_index.bzl
@@ -8,9 +8,14 @@
 def _extract_flat_module_index(ctx):
     files = []
     for dep in ctx.attr.deps:
-        if hasattr(dep, "angular"):
-            metadata = dep.angular.flat_module_metadata
-            files.extend([metadata.metadata_file, metadata.typings_file])
+        if hasattr(dep, "angular") and hasattr(dep.angular, "flat_module_metadata"):
+            flat_module = dep.angular.flat_module_metadata
+            files.append(flat_module.typings_file)
+
+            # The flat module metadata file could be `None` for targets
+            # built with Ivy. No metadata files are generated in ngtsc.
+            if flat_module.metadata_file != None:
+                files.append(flat_module.metadata_file)
     return [DefaultInfo(files = depset(files))]
 
 extract_flat_module_index = rule(


### PR DESCRIPTION
The `ng_module` rule supports the generation of flat module bundles. In
View Engine, information about this flat module bundle is exposed
as a Bazel provider. This is helpful as other rules like `ng_package`
could rely on this information to determine entry-points for the APF.

With Ivy this currently does not work because the flat module
information is not exposed in the provider. The reason for this is
unclear. We should also provide this information in Ivy so that rules
like `ng_package` can also determine the correct entry-points when a
package is built specifically with `--config=ivy`.

This allows us re-enable the tests we previously had to disable when switching to APF. The tests started failing because previously the entry-points were hardcoded, but now we rely on the automatic resolution of those. And apparently tests highlighted that the resolution is incorrect in Ivy.