### PR TITLE
refactor(ngcc): change async locker timeout to 250 secs

### DIFF
--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -155,7 +155,7 @@ function getExecutor(
   const lockFile = new LockFileWithChildProcess(fileSystem, logger);
   if (async) {
     // Execute asynchronously (either serially or in parallel)
-    const locker = new AsyncLocker(lockFile, logger, 500, 50);
+    const locker = new AsyncLocker(lockFile, logger, 500, 500);
     if (inParallel) {
       // Execute in parallel. Use up to 8 CPU cores for workers, always reserving one for master.
       const workerCount = Math.min(8, os.cpus().length - 1);


### PR DESCRIPTION
As it is the default with 10.x anyways

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Parallel builds fail due to too low timeout.

Issue Number: https://github.com/angular/angular/issues/36796


## What is the new behavior?

Raised retries and thus a longer timeout at all, as it is the default with 10.x branch


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No