### PR TITLE
chore(dev-infra): cleanup package dependencies for shared package

### DIFF
--- a/dev-infra/commit-message/BUILD.bazel
+++ b/dev-infra/commit-message/BUILD.bazel
@@ -18,7 +18,6 @@ ts_library(
         "@npm//@types/shelljs",
         "@npm//@types/yargs",
         "@npm//shelljs",
-        "@npm//tslib",
         "@npm//yargs",
     ],
 )

--- a/dev-infra/format/BUILD.bazel
+++ b/dev-infra/format/BUILD.bazel
@@ -18,7 +18,6 @@ ts_library(
         "@npm//inquirer",
         "@npm//multimatch",
         "@npm//shelljs",
-        "@npm//tslib",
         "@npm//yargs",
     ],
 )

--- a/dev-infra/pullapprove/BUILD.bazel
+++ b/dev-infra/pullapprove/BUILD.bazel
@@ -21,7 +21,6 @@ ts_library(
         "@npm//@types/yargs",
         "@npm//minimatch",
         "@npm//shelljs",
-        "@npm//tslib",
         "@npm//yaml",
         "@npm//yargs",
     ],

--- a/dev-infra/tmpl-package.json
+++ b/dev-infra/tmpl-package.json
@@ -8,19 +8,21 @@
     "ng-dev": "./cli.js",
     "ts-circular-deps": "./ts-circular-dependencies/index.js"
   },
-  "peerDependencies": {
-    "@bazel/buildifier": "<from-root>",
+  "dependencies": {
     "chalk": "<from-root>",
-    "clang-format": "<from-root>",
     "cli-progress": "<from-root>",
     "glob": "<from-root>",
     "inquirer": "<from-root>",
     "minimatch": "<from-root>",
     "multimatch": "<from-root>",
     "shelljs": "<from-root>",
-    "typescript": "<from-root>",
     "yaml": "<from-root>",
-    "yargs": "<from-root>",
-    "tslib": "<from-root>"
+    "yargs": "<from-root>"
+  },
+  "peerDependencies": {
+    "@bazel/buildifier": "<from-root>",
+    "clang-format": "<from-root>",
+    "tslib": "<from-root>",
+    "typescript": "<from-root>"
   }
 }

--- a/dev-infra/ts-circular-dependencies/BUILD.bazel
+++ b/dev-infra/ts-circular-dependencies/BUILD.bazel
@@ -11,7 +11,6 @@ ts_library(
         "@npm//@types/node",
         "@npm//@types/yargs",
         "@npm//chalk",
-        "@npm//tslib",
         "@npm//typescript",
     ],
 )


### PR DESCRIPTION
As per our discussion in the dev-infra sync meeting, we don't want to
have all dependencies show up as peer dependencies. Instead, we only
want to have larger dependencies such as `typescript` or buildifier as
peer dependencies. Tslib is also included for the sake of it being generally
a peer dependency of all Angular framework packages.

The rationale is that Yarn is smart enough to collapse packages if all
satisfy a given range. This means that we don't necessarily need to have
all dependencies as peer dependencies. The initial idea was to keep
all dependencies as peer dependencies so that we have control over
duplication of packages as downloading multiple packages w/ different
versions impacts local dev, CI and caches.

At the same time though, we don't want to bother with setting up peer
dependencies all the time. Not every consumer of the shared dev-infra
package would like to manually specify `yaml` or `multimatch` etc. in the
project `package.json`. Hence we decided to go with a hybrid approach
where only more impactful dependencies are peer dependencies, and
other smaller ones can be standard dependencies that are usually collapsed
by Yarn anyway.

Also this commit removes tslib from build targets that don't rely on it.