### PR TITLE
refactor(language-service): move TS utils to separate file

### DIFF
--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -9,13 +9,25 @@ ts_library(
             "*.ts",
             "src/**/*.ts",
         ],
+        exclude = [
+            "src/ts_utils.ts",
+        ],
     ),
     deps = [
+        ":ts_utils",
         "//packages:types",
         "//packages/compiler",
         "//packages/compiler-cli",
         "//packages/core",
         "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)
+
+ts_library(
+    name = "ts_utils",
+    srcs = ["src/ts_utils.ts"],
+    deps = [
         "@npm//typescript",
     ],
 )

--- a/packages/language-service/src/diagnostics.ts
+++ b/packages/language-service/src/diagnostics.ts
@@ -12,9 +12,10 @@ import * as ts from 'typescript';
 
 import {createDiagnostic, Diagnostic} from './diagnostic_messages';
 import {getTemplateExpressionDiagnostics} from './expression_diagnostics';
+import {findPropertyValueOfType, findTightestNode} from './ts_utils';
 import * as ng from './types';
 import {TypeScriptServiceHost} from './typescript_host';
-import {findPropertyValueOfType, findTightestNode, offsetSpan, spanOf} from './utils';
+import {offsetSpan, spanOf} from './utils';
 
 /**
  * Return diagnostic information for the parsed AST of the template.

--- a/packages/language-service/src/ts_utils.ts
+++ b/packages/language-service/src/ts_utils.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript/lib/tsserverlibrary';
+
+/**
+ * Return the node that most tightly encompass the specified `position`.
+ * @param node
+ * @param position
+ */
+export function findTightestNode(node: ts.Node, position: number): ts.Node|undefined {
+  if (node.getStart() <= position && position < node.getEnd()) {
+    return node.forEachChild(c => findTightestNode(c, position)) || node;
+  }
+}
+
+/**
+ * Returns a property assignment from the assignment value if the property name
+ * matches the specified `key`, or `undefined` if there is no match.
+ */
+export function getPropertyAssignmentFromValue(value: ts.Node, key: string): ts.PropertyAssignment|
+    undefined {
+  const propAssignment = value.parent;
+  if (!propAssignment || !ts.isPropertyAssignment(propAssignment) ||
+      propAssignment.name.getText() !== key) {
+    return;
+  }
+  return propAssignment;
+}
+
+/**
+ * Given a decorator property assignment, return the ClassDeclaration node that corresponds to the
+ * directive class the property applies to.
+ * If the property assignment is not on a class decorator, no declaration is returned.
+ *
+ * For example,
+ *
+ * @Component({
+ *   template: '<div></div>'
+ *   ^^^^^^^^^^^^^^^^^^^^^^^---- property assignment
+ * })
+ * class AppComponent {}
+ *           ^---- class declaration node
+ *
+ * @param propAsgn property assignment
+ */
+export function getClassDeclFromDecoratorProp(propAsgnNode: ts.PropertyAssignment):
+    ts.ClassDeclaration|undefined {
+  if (!propAsgnNode.parent || !ts.isObjectLiteralExpression(propAsgnNode.parent)) {
+    return;
+  }
+  const objLitExprNode = propAsgnNode.parent;
+  if (!objLitExprNode.parent || !ts.isCallExpression(objLitExprNode.parent)) {
+    return;
+  }
+  const callExprNode = objLitExprNode.parent;
+  if (!callExprNode.parent || !ts.isDecorator(callExprNode.parent)) {
+    return;
+  }
+  const decorator = callExprNode.parent;
+  if (!decorator.parent || !ts.isClassDeclaration(decorator.parent)) {
+    return;
+  }
+  const classDeclNode = decorator.parent;
+  return classDeclNode;
+}
+
+interface DirectiveClassLike {
+  decoratorId: ts.Identifier;  // decorator identifier, like @Component
+  classId: ts.Identifier;
+}
+
+/**
+ * Return metadata about `node` if it looks like an Angular directive class.
+ * In this case, potential matches are `@NgModule`, `@Component`, `@Directive`,
+ * `@Pipe`, etc.
+ * These class declarations all share some common attributes, namely their
+ * decorator takes exactly one parameter and the parameter must be an object
+ * literal.
+ *
+ * For example,
+ *     v---------- `decoratorId`
+ * @NgModule({           <
+ *   declarations: [],   < classDecl
+ * })                    <
+ * class AppModule {}    <
+ *          ^----- `classId`
+ *
+ * @param node Potential node that represents an Angular directive.
+ */
+export function getDirectiveClassLike(node: ts.Node): DirectiveClassLike|undefined {
+  if (!ts.isClassDeclaration(node) || !node.name || !node.decorators) {
+    return;
+  }
+  for (const d of node.decorators) {
+    const expr = d.expression;
+    if (!ts.isCallExpression(expr) || expr.arguments.length !== 1 ||
+        !ts.isIdentifier(expr.expression)) {
+      continue;
+    }
+    const arg = expr.arguments[0];
+    if (ts.isObjectLiteralExpression(arg)) {
+      return {
+        decoratorId: expr.expression,
+        classId: node.name,
+      };
+    }
+  }
+}
+
+/**
+ * Finds the value of a property assignment that is nested in a TypeScript node and is of a certain
+ * type T.
+ *
+ * @param startNode node to start searching for nested property assignment from
+ * @param propName property assignment name
+ * @param predicate function to verify that a node is of type T.
+ * @return node property assignment value of type T, or undefined if none is found
+ */
+export function findPropertyValueOfType<T extends ts.Node>(
+    startNode: ts.Node, propName: string, predicate: (node: ts.Node) => node is T): T|undefined {
+  if (ts.isPropertyAssignment(startNode) && startNode.name.getText() === propName) {
+    const {initializer} = startNode;
+    if (predicate(initializer)) return initializer;
+  }
+  return startNode.forEachChild(c => findPropertyValueOfType(c, propName, predicate));
+}

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -13,9 +13,8 @@ import * as tss from 'typescript/lib/tsserverlibrary';
 import {createLanguageService} from './language_service';
 import {ReflectorHost} from './reflector_host';
 import {ExternalTemplate, InlineTemplate} from './template';
+import {findTightestNode, getClassDeclFromDecoratorProp, getDirectiveClassLike, getPropertyAssignmentFromValue} from './ts_utils';
 import {AstResult, Declaration, DeclarationError, DiagnosticMessageChain, LanguageService, LanguageServiceHost, Span, TemplateSource} from './types';
-import {findTightestNode, getClassDeclFromDecoratorProp, getDirectiveClassLike, getPropertyAssignmentFromValue} from './utils';
-
 
 /**
  * Create a `LanguageServiceHost`
@@ -370,8 +369,8 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
     if (!tss.isStringLiteralLike(node)) {
       return;
     }
-    const tmplAsgn = getPropertyAssignmentFromValue(node);
-    if (!tmplAsgn || tmplAsgn.name.getText() !== 'template') {
+    const tmplAsgn = getPropertyAssignmentFromValue(node, 'template');
+    if (!tmplAsgn) {
       return;
     }
     const classDecl = getClassDeclFromDecoratorProp(tmplAsgn);

--- a/packages/language-service/src/utils.ts
+++ b/packages/language-service/src/utils.ts
@@ -7,8 +7,6 @@
  */
 
 import {AstPath, BoundEventAst, CompileDirectiveSummary, CompileTypeMetadata, CssSelector, DirectiveAst, ElementAst, EmbeddedTemplateAst, HtmlAstPath, identifierName, Identifiers, Node, ParseSourceSpan, RecursiveTemplateAstVisitor, RecursiveVisitor, TemplateAst, TemplateAstPath, templateVisitAll, visitAll} from '@angular/compiler';
-import * as ts from 'typescript';
-
 import {AstResult, DiagnosticTemplateInfo, SelectorInfo, Span, Symbol, SymbolQuery} from './types';
 
 interface SpanHolder {
@@ -147,78 +145,6 @@ export function findTemplateAstAt(ast: TemplateAst[], position: number): Templat
 }
 
 /**
- * Return the node that most tightly encompass the specified `position`.
- * @param node
- * @param position
- */
-export function findTightestNode(node: ts.Node, position: number): ts.Node|undefined {
-  if (node.getStart() <= position && position < node.getEnd()) {
-    return node.forEachChild(c => findTightestNode(c, position)) || node;
-  }
-}
-
-interface DirectiveClassLike {
-  decoratorId: ts.Identifier;  // decorator identifier, like @Component
-  classId: ts.Identifier;
-}
-
-/**
- * Return metadata about `node` if it looks like an Angular directive class.
- * In this case, potential matches are `@NgModule`, `@Component`, `@Directive`,
- * `@Pipe`, etc.
- * These class declarations all share some common attributes, namely their
- * decorator takes exactly one parameter and the parameter must be an object
- * literal.
- *
- * For example,
- *     v---------- `decoratorId`
- * @NgModule({           <
- *   declarations: [],   < classDecl
- * })                    <
- * class AppModule {}    <
- *          ^----- `classId`
- *
- * @param node Potential node that represents an Angular directive.
- */
-export function getDirectiveClassLike(node: ts.Node): DirectiveClassLike|undefined {
-  if (!ts.isClassDeclaration(node) || !node.name || !node.decorators) {
-    return;
-  }
-  for (const d of node.decorators) {
-    const expr = d.expression;
-    if (!ts.isCallExpression(expr) || expr.arguments.length !== 1 ||
-        !ts.isIdentifier(expr.expression)) {
-      continue;
-    }
-    const arg = expr.arguments[0];
-    if (ts.isObjectLiteralExpression(arg)) {
-      return {
-        decoratorId: expr.expression,
-        classId: node.name,
-      };
-    }
-  }
-}
-
-/**
- * Finds the value of a property assignment that is nested in a TypeScript node and is of a certain
- * type T.
- *
- * @param startNode node to start searching for nested property assignment from
- * @param propName property assignment name
- * @param predicate function to verify that a node is of type T.
- * @return node property assignment value of type T, or undefined if none is found
- */
-export function findPropertyValueOfType<T extends ts.Node>(
-    startNode: ts.Node, propName: string, predicate: (node: ts.Node) => node is T): T|undefined {
-  if (ts.isPropertyAssignment(startNode) && startNode.name.getText() === propName) {
-    const {initializer} = startNode;
-    if (predicate(initializer)) return initializer;
-  }
-  return startNode.forEachChild(c => findPropertyValueOfType(c, propName, predicate));
-}
-
-/**
  * Find the tightest node at the specified `position` from the AST `nodes`, and
  * return the path to the node.
  * @param nodes HTML AST nodes
@@ -276,63 +202,4 @@ export function findOutputBinding(
       }
     }
   }
-}
-
-/**
- * Returns a property assignment from the assignment value, or `undefined` if there is no
- * assignment.
- */
-export function getPropertyAssignmentFromValue(value: ts.Node): ts.PropertyAssignment|undefined {
-  if (!value.parent || !ts.isPropertyAssignment(value.parent)) {
-    return;
-  }
-  return value.parent;
-}
-
-/**
- * Given a decorator property assignment, return the ClassDeclaration node that corresponds to the
- * directive class the property applies to.
- * If the property assignment is not on a class decorator, no declaration is returned.
- *
- * For example,
- *
- * @Component({
- *   template: '<div></div>'
- *   ^^^^^^^^^^^^^^^^^^^^^^^---- property assignment
- * })
- * class AppComponent {}
- *           ^---- class declaration node
- *
- * @param propAsgn property assignment
- */
-export function getClassDeclFromDecoratorProp(propAsgnNode: ts.PropertyAssignment):
-    ts.ClassDeclaration|undefined {
-  if (!propAsgnNode.parent || !ts.isObjectLiteralExpression(propAsgnNode.parent)) {
-    return;
-  }
-  const objLitExprNode = propAsgnNode.parent;
-  if (!objLitExprNode.parent || !ts.isCallExpression(objLitExprNode.parent)) {
-    return;
-  }
-  const callExprNode = objLitExprNode.parent;
-  if (!callExprNode.parent || !ts.isDecorator(callExprNode.parent)) {
-    return;
-  }
-  const decorator = callExprNode.parent;
-  if (!decorator.parent || !ts.isClassDeclaration(decorator.parent)) {
-    return;
-  }
-  const classDeclNode = decorator.parent;
-  return classDeclNode;
-}
-
-/**
- * Determines if a property assignment is on a class decorator.
- * See `getClassDeclFromDecoratorProperty`, which gets the class the decorator is applied to, for
- * more details.
- *
- * @param prop property assignment
- */
-export function isClassDecoratorProperty(propAsgn: ts.PropertyAssignment): boolean {
-  return !!getClassDeclFromDecoratorProp(propAsgn);
 }

--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -56,6 +56,7 @@ ts_library(
         ":test_utils_lib",
         "//packages/compiler",
         "//packages/language-service",
+        "//packages/language-service:ts_utils",
         "@npm//typescript",
     ],
 )

--- a/packages/language-service/test/utils_spec.ts
+++ b/packages/language-service/test/utils_spec.ts
@@ -9,7 +9,8 @@
 import * as ng from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {getClassDeclFromDecoratorProp, getDirectiveClassLike, getPathToNodeAtPosition} from '../src/utils';
+import {getClassDeclFromDecoratorProp, getDirectiveClassLike} from '../src/ts_utils';
+import {getPathToNodeAtPosition} from '../src/utils';
 import {MockTypescriptHost} from './test_utils';
 
 describe('getDirectiveClassLike', () => {


### PR DESCRIPTION
This commit refactors TS-only utility functions to a separate file so
that they could be shared with Ivy language service.
A separate ts_library rule is created so that there is no dependency on
`compiler` and `compiler-cli` to make the compilation fast and
light-weight.
The method `getPropertyAssignmentFromValue` is modified slightly to
improve the ergonomics of the function.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
