### PR TITLE
fix(compiler-cli): don't try to tag non-ts files as shims

### DIFF
--- a/packages/compiler-cli/src/ngtsc/shims/src/reference_tagger.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/reference_tagger.ts
@@ -9,6 +9,7 @@
 import * as ts from 'typescript';
 
 import {absoluteFrom, absoluteFromSourceFile} from '../../file_system';
+import {isNonDeclarationTsPath} from '../../util/src/typescript';
 
 import {isExtended as isExtendedSf, isShim, NgExtension, sfExtensionData} from './expando';
 import {makeShimFileName} from './util';
@@ -42,7 +43,8 @@ export class ShimReferenceTagger {
    * Tag `sf` with any needed references if it's not a shim itself.
    */
   tag(sf: ts.SourceFile): void {
-    if (!this.enabled || sf.isDeclarationFile || isShim(sf) || this.tagged.has(sf)) {
+    if (!this.enabled || sf.isDeclarationFile || isShim(sf) || this.tagged.has(sf) ||
+        !isNonDeclarationTsPath(sf.fileName)) {
       return;
     }
 

--- a/packages/compiler-cli/src/ngtsc/shims/test/reference_tagger_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/test/reference_tagger_spec.ts
@@ -40,6 +40,17 @@ runInEachFileSystem(() => {
       expectReferencedFiles(sf, []);
     });
 
+    it('should not tag .js files', () => {
+      const tagger = new ShimReferenceTagger(['test1', 'test2']);
+
+      const fileName = _('/file.js');
+      const sf = makeArbitrarySf(fileName);
+
+      expectReferencedFiles(sf, []);
+      tagger.tag(sf);
+      expectReferencedFiles(sf, []);
+    });
+
     it('should not tag shim files', () => {
       const tagger = new ShimReferenceTagger(['test1', 'test2']);
       const fileName = _('/file.ts');

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -59,6 +59,7 @@ export class NgtscTestEnvironment {
         "outDir": "built",
         "rootDir": ".",
         "baseUrl": ".",
+        "allowJs": true,
         "declaration": true,
         "target": "es5",
         "newLine": "lf",

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -3540,6 +3540,33 @@ runInEachFileSystem(os => {
         env.tsconfig({'generateNgFactoryShims': true});
       });
 
+      it('should not be generated for .js files', () => {
+        // This test verifies that the compiler does not attempt to generate shim files for non-TS
+        // input files (in this case, other.js).
+        env.write('test.ts', `
+          import {Component, NgModule} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: 'This is a template',
+          })
+          export class TestCmp {}
+
+          @NgModule({
+            declarations: [TestCmp],
+            exports: [TestCmp],
+          })
+          export class TestModule {}
+        `);
+        env.write('other.js', `
+          export class TestJs {}
+        `);
+
+        expect(env.driveDiagnostics()).toEqual([]);
+        env.assertExists('test.ngfactory.js');
+        env.assertDoesNotExist('other.ngfactory.js');
+      });
+
       it('should be able to depend on an existing factory shim', () => {
         // This test verifies that ngfactory files from the compilations of dependencies are
         // available to import in a fresh compilation. It is derived from a bug observed in g3 where


### PR DESCRIPTION
Some projects include .js source files (via the TypeScript allowJs option).
Previously, the compiler would attempt to tag these files for shims, which
caused errors as the regex used to create shim filenames assumes a .ts file.
This commit fixes the bug by filtering out non-ts files during tagging.
