### PR TITLE
build(docs-infra): upgrade cli command docs sources to 15edb0231

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -23,7 +23,7 @@
     "build-local-with-viewengine": "yarn ~~build",
     "prebuild-local-with-viewengine-ci": "node scripts/switch-to-viewengine && yarn setup-local-ci",
     "build-local-with-viewengine-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js b7d7ee9bd",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 15edb0231",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#master](https://github.com/angular/angular/tree/master) from [cli-builds#master](https://github.com/angular/cli-builds/tree/master).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/b7d7ee9bd...15edb0231):

**Modified**
- help/generate.json
- help/new.json

**Removed**
- help/get.json
- help/set.json

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/440275c34...15edb0231) since PR #36981:

**Removed**
- help/get.json
- help/set.json

##
Closes #36950
Closes #36981