### PR TITLE
fix(compiler-cli): ensure LogicalFileSystem maintains case in paths (PATCH_VERSION)

### DIFF
--- a/packages/compiler-cli/src/ngtsc/file_system/test/logical_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/test/logical_spec.ts
@@ -52,6 +52,24 @@ runInEachFileSystem(() => {
         expect(nonRootFs.logicalPathOfFile(_('/test/foo/foo.ts')))
             .toEqual('/foo/foo' as LogicalProjectPath);
       });
+
+      it('should maintain casing of logical paths', () => {
+        const fs = new LogicalFileSystem([_('/Test')], host);
+        expect(fs.logicalPathOfFile(_('/Test/foo/Foo.ts')))
+            .toEqual('/foo/Foo' as LogicalProjectPath);
+        expect(fs.logicalPathOfFile(_('/Test/bar/bAR.ts')))
+            .toEqual('/bar/bAR' as LogicalProjectPath);
+      });
+
+      it('should use case-sensitivity when matching rootDirs', () => {
+        const fs = new LogicalFileSystem([_('/Test')], host);
+        if (host.useCaseSensitiveFileNames()) {
+          expect(fs.logicalPathOfFile(_('/test/car/CAR.ts'))).toBe(null);
+        } else {
+          expect(fs.logicalPathOfFile(_('/test/car/CAR.ts')))
+              .toEqual('/car/CAR' as LogicalProjectPath);
+        }
+      });
     });
 
     describe('utilities', () => {
@@ -65,6 +83,12 @@ runInEachFileSystem(() => {
         const res = LogicalProjectPath.relativePathBetween(
             '/foo/index' as LogicalProjectPath, '/bar/index' as LogicalProjectPath);
         expect(res).toEqual('../bar/index');
+      });
+
+      it('should maintain casing in relative path between logical files', () => {
+        const res = LogicalProjectPath.relativePathBetween(
+            '/fOO' as LogicalProjectPath, '/bAR' as LogicalProjectPath);
+        expect(res).toEqual('./bAR');
       });
     });
   });


### PR DESCRIPTION
The work to support case-sensitivity in the `FileSystem` went too far
with the `LogicalFileSystem`, which is used to compute import paths
that will be added to files processed by ngtsc and ngcc.

Previously all logical paths were canonicalised, which meant that on
case-insensitive file-systems, the paths were all set to lower case.
This resulted in incorrect imports being added to files. For example:

```
import { Apollo } from './Apollo';
import { SelectPipe } from './SelectPipe';
import * as ɵngcc0 from '@angular/core';
import * as ɵngcc1 from './selectpipe';
```

The import from `./SelectPipe` is from the original file, while the
import from `./selectpipe` is added by ngcc. This causes the
TypeScript compiler to complain, or worse for paths not to be
matched correctly.

Now, when computing logical paths, the original absolute paths
are matched against rootDirs in a canonical manner, but the actual
logical path that is returned maintains it original casing.

Fixes #36992, #36993, #37000
