### PR TITLE
fix(docs-infra): better detect failed attempts to update the preview server Docker container

### DIFF
--- a/aio/aio-builds-setup/docs/vm-setup--create-docker-image.md
+++ b/aio/aio-builds-setup/docs/vm-setup--create-docker-image.md
@@ -4,9 +4,8 @@
 ## Install git, Node.js and yarn
 - `sudo apt-get update`
 - `sudo apt-get install -y git`
-- Install [nvm](https://github.com/nvm-sh/nvm#installing-and-updating).
-- Install Node.js: `nvm install 12`
-- Install yarn: `npm install --global yarn`
+- Install the latest stable version of [Node.js](https://nodejs.org/en/download).
+- Install the latest stable version of [yarn](https://classic.yarnpkg.com/en/docs/install).
 
 
 ## Checkout repository
@@ -18,7 +17,11 @@
 - You can overwrite the default environment variables inside the image, by passing new values using
   `--build-arg`.
 
-**Note:** The script has to execute docker commands with `sudo`.
+**Note 1:** The script has to execute docker commands with `sudo`.
+
+**Note 2:**
+The script has to execute `yarn` commands, so make sure `yarn` is on the `PATH` when invoking the
+script.
 
 
 ## Example

--- a/aio/aio-builds-setup/docs/vm-setup--update-docker-container.md
+++ b/aio/aio-builds-setup/docs/vm-setup--update-docker-container.md
@@ -8,7 +8,7 @@ VM host to update the preview server based on changes in the source code.
 
 The script will pull the latest changes from the origin's master branch and examine if there have
 been any changes in files inside the preview server source code directory (see below). If there are,
-it will create a new image and verify that is works as expected. Finally, it will stop and remove
+it will create a new image and verify that it works as expected. Finally, it will stop and remove
 the old docker container and image, create a new container based on the new image and start it.
 
 The script assumes that the preview server source code is in the repository's
@@ -25,7 +25,11 @@ used for.
 
 **Note 1:** The script has to execute docker commands with `sudo`.
 
-**Note 2:** Make sure the user that executes the script has access to update the repository
+**Note 2:**
+The script has to execute `yarn` commands, so make sure `yarn` is on the `PATH` when invoking the
+script.
+
+**Note 3:** Make sure the user that executes the script has access to update the repository.
 
 
 ## Run the script manually
@@ -50,3 +54,9 @@ log its output to `update-preview-server.log` (assuming the user has the necessa
 # Periodically check for changes and update the preview server (if necessary)
 */30 *  * * *   /path/to/update-preview-server.sh /path/to/repo /path/to/secrets /path/to/builds /path/to/localcerts /path/to/logs >> /path/to/update-preview-server.log 2>&1
 ```
+
+**Note:**
+Keep in mind that cron jobs run in non-interactive, non-login shells. This means that the execution
+context might be different compared to when running the same commands from an interactive, login
+shell. For example, `.bashrc` files are normally _not_ sourced automatically in cron jobs. See
+[here](http://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html) for more info.

--- a/aio/aio-builds-setup/scripts/update-preview-server.sh
+++ b/aio/aio-builds-setup/scripts/update-preview-server.sh
@@ -13,7 +13,8 @@ readonly HOST_LOCALCERTS_DIR=$4
 readonly HOST_LOGS_DIR=$5
 
 # Constants
-readonly PROVISIONAL_IMAGE_NAME=aio-builds:provisional
+readonly PROVISIONAL_TAG=provisional
+readonly PROVISIONAL_IMAGE_NAME=aio-builds:$PROVISIONAL_TAG
 readonly LATEST_IMAGE_NAME=aio-builds:latest
 readonly CONTAINER_NAME=aio
 
@@ -30,7 +31,7 @@ readonly CONTAINER_NAME=aio
   # Do not update the server unless files inside `aio-builds-setup/` have changed
   # or the last attempt failed (identified by the provisional image still being around).
   readonly relevantChangedFilesCount=$(git diff --name-only $lastDeployedCommit...HEAD | grep -P "^aio/aio-builds-setup/" | wc -l)
-  readonly lastAttemptFailed=$(sudo docker rmi "$PROVISIONAL_IMAGE_NAME" >> /dev/fd/3 && echo "true" || echo "false")
+  readonly lastAttemptFailed=$(sudo docker image ls | grep "$PROVISIONAL_TAG" >> /dev/fd/3 && echo "true" || echo "false")
   if [[ $relevantChangedFilesCount -eq 0 ]] && [[ "$lastAttemptFailed" != "true" ]]; then
     echo "Skipping update because no relevant files have been touched."
     exit 0


### PR DESCRIPTION
In order to avoid unnecessary operations, the `update-preview-server.sh` script, that is used to update the PR preview server Docker container, will only try to update the Docker container if either any files in the `aio/aio-builds-setup/` directory have changed since the last update or if a previous update failed. A failed previous update is detected by checking whether the temporary `aio-builds:provisional` Docker image still exists. This temporary image is created during the update operation and is renamed to `aio-builds:latest` if the update goes well.

Previously, the update script was not able to detect a previous failed attempt if the operation failed before creating the `aio-builds:provisional` Docker image, such as if the `create-image.sh` script failed. This could lead to a situation where the preview server Docker container would not be updated after a failed attempt.

This commit improves the logic for detecting failed attempts to account for this type of failures. It does this by not removing an older `aio-builds:provisional` Docker image until a new one is successfully created.

NOTE: While this is not full-proof, it is an improvement as it eliminates a certain kind of failures.

##
This PR also includes some docs improvements. See the rspective commit for more details.