### PR TITLE
fix(router): update type for routerLink to include null and undefined

### DIFF
--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -380,7 +380,7 @@ export declare class RouterLink {
     };
     queryParamsHandling: QueryParamsHandling;
     replaceUrl: boolean;
-    set routerLink(commands: any[] | string);
+    set routerLink(commands: any[] | string | null | undefined);
     skipLocationChange: boolean;
     state?: {
         [k: string]: any;
@@ -414,7 +414,7 @@ export declare class RouterLinkWithHref implements OnChanges, OnDestroy {
     };
     queryParamsHandling: QueryParamsHandling;
     replaceUrl: boolean;
-    set routerLink(commands: any[] | string);
+    set routerLink(commands: any[] | string | null | undefined);
     skipLocationChange: boolean;
     state?: {
         [k: string]: any;

--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -408,7 +408,7 @@ export declare class RouterLinkWithHref implements OnChanges, OnDestroy {
     fragment: string;
     href: string;
     preserveFragment: boolean;
-    set preserveQueryParams(value: boolean);
+    /** @deprecated */ set preserveQueryParams(value: boolean);
     queryParams: {
         [k: string]: any;
     };

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -139,7 +139,7 @@ export class RouterLink {
   }
 
   @Input()
-  set routerLink(commands: any[]|string) {
+  set routerLink(commands: any[]|string|null|undefined) {
     if (commands != null) {
       this.commands = Array.isArray(commands) ? commands : [commands];
     } else {
@@ -229,7 +229,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   }
 
   @Input()
-  set routerLink(commands: any[]|string) {
+  set routerLink(commands: any[]|string|null|undefined) {
     if (commands != null) {
       this.commands = Array.isArray(commands) ? commands : [commands];
     } else {

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -115,19 +115,49 @@ import {UrlTree} from '../url_tree';
 export class RouterLink {
   // TODO(issue/24571): remove '!'.
   @Input() queryParams!: {[k: string]: any};
+  /**
+   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
+   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   // TODO(issue/24571): remove '!'.
   @Input() fragment!: string;
+  /**
+   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
+   * @see [QueryParamsHandling](https://angular.io/api/router/QueryParamsHandling#queryparamshandling)
+   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   // TODO(issue/24571): remove '!'.
   @Input() queryParamsHandling!: QueryParamsHandling;
+  /**
+   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
+   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   // TODO(issue/24571): remove '!'.
   @Input() preserveFragment!: boolean;
+  /**
+   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
+   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   // TODO(issue/24571): remove '!'.
   @Input() skipLocationChange!: boolean;
+  /**
+   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
+   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   // TODO(issue/24571): remove '!'.
   @Input() replaceUrl!: boolean;
+  /**
+   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
+   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   @Input() state?: {[k: string]: any};
   private commands: any[] = [];
-  // TODO(issue/24571): remove '!'.
   private preserve!: boolean;
 
   constructor(
@@ -138,6 +168,13 @@ export class RouterLink {
     }
   }
 
+  /**
+   * @param commands An array of commands to pass to `Router.createUrlTree`.
+   *   - **array**: commands to pass to `Router.createUrlTree`.
+   *   - **string**: shorthand for array of commands with just the string, i.e. `['/route']`
+   *   - **null|undefined**: shorthand for an empty array of commands, i.e. `[]`
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   @Input()
   set routerLink(commands: any[]|string|null|undefined) {
     if (commands != null) {
@@ -196,18 +233,53 @@ export class RouterLink {
 export class RouterLinkWithHref implements OnChanges, OnDestroy {
   // TODO(issue/24571): remove '!'.
   @HostBinding('attr.target') @Input() target!: string;
+  /**
+   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
+   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   // TODO(issue/24571): remove '!'.
   @Input() queryParams!: {[k: string]: any};
+  /**
+   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
+   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   // TODO(issue/24571): remove '!'.
   @Input() fragment!: string;
+  /**
+   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
+   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   // TODO(issue/24571): remove '!'.
   @Input() queryParamsHandling!: QueryParamsHandling;
+  /**
+   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
+   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   // TODO(issue/24571): remove '!'.
   @Input() preserveFragment!: boolean;
+  /**
+   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
+   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   // TODO(issue/24571): remove '!'.
   @Input() skipLocationChange!: boolean;
+  /**
+   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
+   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   // TODO(issue/24571): remove '!'.
   @Input() replaceUrl!: boolean;
+  /**
+   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
+   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   @Input() state?: {[k: string]: any};
   private commands: any[] = [];
   private subscription: Subscription;
@@ -228,6 +300,13 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
     });
   }
 
+  /**
+   * @param commands An array of commands to pass to `Router.createUrlTree`.
+   *   - **array**: commands to pass to `Router.createUrlTree`.
+   *   - **string**: shorthand for array of commands with just the string, i.e. `['/route']`
+   *   - **null|undefined**: shorthand for an empty array of commands, i.e. `[]`
+   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   */
   @Input()
   set routerLink(commands: any[]|string|null|undefined) {
     if (commands != null) {
@@ -237,6 +316,9 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
     }
   }
 
+  /**
+   * @deprecated 4.0.0 use `queryParamsHandling` instead.
+   */
   @Input()
   set preserveQueryParams(value: boolean) {
     if (isDevMode() && <any>console && <any>console.warn) {

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -113,48 +113,52 @@ import {UrlTree} from '../url_tree';
  */
 @Directive({selector: ':not(a):not(area)[routerLink]'})
 export class RouterLink {
+  /**
+   * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
+   * @see {@link NavigationExtras#queryParams NavigationExtras#queryParams}
+   * @see {@link Router#createUrlTree Router#createUrlTree}
+   */
   // TODO(issue/24571): remove '!'.
   @Input() queryParams!: {[k: string]: any};
   /**
-   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
-   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
+   * @see {@link NavigationExtras#fragment NavigationExtras#fragment}
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   // TODO(issue/24571): remove '!'.
   @Input() fragment!: string;
   /**
-   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
-   * @see [QueryParamsHandling](https://angular.io/api/router/QueryParamsHandling#queryparamshandling)
-   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
+   * @see {@link NavigationExtras#queryParamsHandling NavigationExtras#queryParamsHandling}
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   // TODO(issue/24571): remove '!'.
   @Input() queryParamsHandling!: QueryParamsHandling;
   /**
-   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
-   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
+   * @see {@link NavigationExtras#preserveFragment NavigationExtras#preserveFragment}
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   // TODO(issue/24571): remove '!'.
   @Input() preserveFragment!: boolean;
   /**
-   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
-   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
+   * @see {@link NavigationExtras#skipLocationChange NavigationExtras#skipLocationChange}
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   // TODO(issue/24571): remove '!'.
   @Input() skipLocationChange!: boolean;
   /**
-   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
-   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
+   * @see {@link NavigationExtras#replaceUrl NavigationExtras#replaceUrl}
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   // TODO(issue/24571): remove '!'.
   @Input() replaceUrl!: boolean;
   /**
-   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
-   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
+   * @see {@link NavigationExtras#state NavigationExtras#state}
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   @Input() state?: {[k: string]: any};
   private commands: any[] = [];
@@ -169,11 +173,12 @@ export class RouterLink {
   }
 
   /**
-   * @param commands An array of commands to pass to `Router.createUrlTree`.
-   *   - **array**: commands to pass to `Router.createUrlTree`.
+   * @param commands An array of commands to pass to {@link Router#createUrlTree
+   *     Router#createUrlTree}.
+   *   - **array**: commands to pass to {@link Router#createUrlTree Router#createUrlTree}.
    *   - **string**: shorthand for array of commands with just the string, i.e. `['/route']`
    *   - **null|undefined**: shorthand for an empty array of commands, i.e. `[]`
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   @Input()
   set routerLink(commands: any[]|string|null|undefined) {
@@ -185,7 +190,7 @@ export class RouterLink {
   }
 
   /**
-   * @deprecated 4.0.0 use `queryParamsHandling` instead.
+   * @deprecated As of Angular v4.0 use `queryParamsHandling` instead.
    */
   @Input()
   set preserveQueryParams(value: boolean) {
@@ -234,51 +239,51 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   // TODO(issue/24571): remove '!'.
   @HostBinding('attr.target') @Input() target!: string;
   /**
-   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
-   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
+   * @see {@link NavigationExtras#queryParams NavigationExtras#queryParams}
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   // TODO(issue/24571): remove '!'.
   @Input() queryParams!: {[k: string]: any};
   /**
-   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
-   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
+   * @see {@link NavigationExtras#fragment NavigationExtras#fragment}
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   // TODO(issue/24571): remove '!'.
   @Input() fragment!: string;
   /**
-   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
-   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
+   * @see {@link NavigationExtras#queryParamsHandling NavigationExtras#queryParamsHandling}
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   // TODO(issue/24571): remove '!'.
   @Input() queryParamsHandling!: QueryParamsHandling;
   /**
-   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
-   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
+   * @see {@link NavigationExtras#preserveFragment NavigationExtras#preserveFragment}
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   // TODO(issue/24571): remove '!'.
   @Input() preserveFragment!: boolean;
   /**
-   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
-   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
+   * @see {@link NavigationExtras#skipLocationChange NavigationExtras#skipLocationChange}
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   // TODO(issue/24571): remove '!'.
   @Input() skipLocationChange!: boolean;
   /**
-   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
-   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
+   * @see {@link NavigationExtras#replaceUrl NavigationExtras#replaceUrl}
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   // TODO(issue/24571): remove '!'.
   @Input() replaceUrl!: boolean;
   /**
-   * Passed to `Router.createUrlTree` as part of the `NavigationExtras`.
-   * @see [NavigationExtras](https://angular.io/api/router/NavigationExtras#navigationextras)
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
+   * @see {@link NavigationExtras#state NavigationExtras#state}
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   @Input() state?: {[k: string]: any};
   private commands: any[] = [];
@@ -301,11 +306,12 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   }
 
   /**
-   * @param commands An array of commands to pass to `Router.createUrlTree`.
-   *   - **array**: commands to pass to `Router.createUrlTree`.
+   * @param commands An array of commands to pass to {@link Router#createUrlTree
+   *     Router#createUrlTree}.
+   *   - **array**: commands to pass to {@link Router#createUrlTree Router#createUrlTree}.
    *   - **string**: shorthand for array of commands with just the string, i.e. `['/route']`
    *   - **null|undefined**: shorthand for an empty array of commands, i.e. `[]`
-   * @see [Router.createUrlTree](https://angular.io/api/router/Router#createurltree)
+   * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   @Input()
   set routerLink(commands: any[]|string|null|undefined) {
@@ -317,7 +323,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   }
 
   /**
-   * @deprecated 4.0.0 use `queryParamsHandling` instead.
+   * @deprecated As of Angular v4.0 use `queryParamsHandling` instead.
    */
   @Input()
   set preserveQueryParams(value: boolean) {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1968,11 +1968,15 @@ describe('Integration', () => {
          expect(native.getAttribute('href')).toEqual('/home');
        }));
 
-    it('should not throw when commands is null', fakeAsync(() => {
+    it('should not throw when commands is null or undefined', fakeAsync(() => {
          @Component({
            selector: 'someCmp',
-           template:
-               `<router-outlet></router-outlet><a [routerLink]="null">Link</a><button [routerLink]="null">Button</button>`
+           template: `<router-outlet></router-outlet>
+               <a [routerLink]="null">Link</a>
+               <button [routerLink]="null">Button</button>
+               <a [routerLink]="undefined">Link</a>
+               <button [routerLink]="undefined">Button</button>
+               `
          })
          class CmpWithLink {
          }
@@ -1982,10 +1986,12 @@ describe('Integration', () => {
 
          let fixture: ComponentFixture<CmpWithLink> = createRoot(router, CmpWithLink);
          router.resetConfig([{path: 'home', component: SimpleCmp}]);
-         const anchor = fixture.nativeElement.querySelector('a');
-         const button = fixture.nativeElement.querySelector('button');
-         expect(() => anchor.click()).not.toThrow();
-         expect(() => button.click()).not.toThrow();
+         const anchors = fixture.nativeElement.querySelectorAll('a');
+         const buttons = fixture.nativeElement.querySelectorAll('button');
+         expect(() => anchors[0].click()).not.toThrow();
+         expect(() => anchors[1].click()).not.toThrow();
+         expect(() => buttons[0].click()).not.toThrow();
+         expect(() => buttons[1].click()).not.toThrow();
        }));
 
     it('should update hrefs when query params or fragment change', fakeAsync(() => {


### PR DESCRIPTION
PR #13380 added support for `null` and `undefined` but the type on the parameter was not updated. This would result in a compilation error if `fullTemplateTypeCheck` is enabled.

Fixes #36544