### PR TITLE
fix(ngcc): correctly get config for packages in nested `node_modules/`

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -58,7 +58,7 @@ export class DecorationAnalyzer {
   private host = this.bundle.src.host;
   private typeChecker = this.bundle.src.program.getTypeChecker();
   private rootDirs = this.bundle.rootDirs;
-  private packagePath = this.bundle.entryPoint.package;
+  private packagePath = this.bundle.entryPoint.packagePath;
   private isCore = this.bundle.isCore;
   private compilerOptions = this.tsConfig !== null ? this.tsConfig.options : {};
 

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
@@ -225,7 +225,7 @@ export class DependencyResolver {
   private filterIgnorableDeepImports(entryPoint: EntryPoint, deepImports: Set<AbsoluteFsPath>):
       AbsoluteFsPath[] {
     const version = (entryPoint.packageJson.version || null) as string | null;
-    const packageConfig = this.config.getPackageConfig(entryPoint.package, version);
+    const packageConfig = this.config.getPackageConfig(entryPoint.packagePath, version);
     const matchers = packageConfig.ignorableDeepImportMatchers || [];
     return Array.from(deepImports)
         .filter(deepImport => !matchers.some(matcher => matcher.test(deepImport)));

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
@@ -225,8 +225,9 @@ export class DependencyResolver {
   private filterIgnorableDeepImports(entryPoint: EntryPoint, deepImports: Set<AbsoluteFsPath>):
       AbsoluteFsPath[] {
     const version = (entryPoint.packageJson.version || null) as string | null;
-    const packageConfig = this.config.getPackageConfig(entryPoint.packagePath, version);
-    const matchers = packageConfig.ignorableDeepImportMatchers || [];
+    const packageConfig =
+        this.config.getPackageConfig(entryPoint.packageName, entryPoint.packagePath, version);
+    const matchers = packageConfig.ignorableDeepImportMatchers;
     return Array.from(deepImports)
         .filter(deepImport => !matchers.some(matcher => matcher.test(deepImport)));
   }

--- a/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
@@ -258,7 +258,7 @@ export class EsmDependencyHost extends DependencyHostBase {
  * in this file, true otherwise.
  */
 export function hasImportOrReexportStatements(source: string): boolean {
-  return /(?:import|export)[\s\S]+?(["'])(?:(?:\\\1|.)*?)\1/.test(source);
+  return /(?:import|export)[\s\S]+?(["'])(?:\\\1|.)+?\1/.test(source);
 }
 
 

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
@@ -5,18 +5,15 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem, join, PathSegment, relative, relativeFrom} from '../../../src/ngtsc/file_system';
-import {EntryPointWithDependencies} from '../dependencies/dependency_host';
+import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
 import {DependencyResolver, SortedEntryPointsInfo} from '../dependencies/dependency_resolver';
 import {Logger} from '../logging/logger';
 import {hasBeenProcessed} from '../packages/build_marker';
 import {NgccConfiguration} from '../packages/configuration';
-import {EntryPoint, EntryPointJsonProperty, getEntryPointInfo, INCOMPATIBLE_ENTRY_POINT, NO_ENTRY_POINT} from '../packages/entry_point';
+import {EntryPointJsonProperty} from '../packages/entry_point';
 import {PathMappings} from '../path_mappings';
 
-import {EntryPointFinder} from './interface';
 import {TracingEntryPointFinder} from './tracing_entry_point_finder';
-import {getBasePaths} from './utils';
 
 /**
  * An EntryPointFinder that starts from a target entry-point and only finds

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/tracing_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/tracing_entry_point_finder.ts
@@ -11,7 +11,7 @@ import {EntryPointWithDependencies} from '../dependencies/dependency_host';
 import {DependencyResolver, SortedEntryPointsInfo} from '../dependencies/dependency_resolver';
 import {Logger} from '../logging/logger';
 import {NgccConfiguration} from '../packages/configuration';
-import {EntryPoint, getEntryPointInfo, INCOMPATIBLE_ENTRY_POINT, NO_ENTRY_POINT} from '../packages/entry_point';
+import {EntryPoint, getEntryPointInfo, isEntryPoint} from '../packages/entry_point';
 import {PathMappings} from '../path_mappings';
 
 import {EntryPointFinder} from './interface';
@@ -61,10 +61,8 @@ export abstract class TracingEntryPointFinder implements EntryPointFinder {
     const packagePath = this.computePackagePath(entryPointPath);
     const entryPoint =
         getEntryPointInfo(this.fs, this.config, this.logger, packagePath, entryPointPath);
-    if (entryPoint === NO_ENTRY_POINT || entryPoint === INCOMPATIBLE_ENTRY_POINT) {
-      return null;
-    }
-    return entryPoint;
+
+    return isEntryPoint(entryPoint) ? entryPoint : null;
   }
 
   private processNextPath(): void {

--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -24,14 +24,14 @@ export type EntryPointFormat = 'esm5'|'esm2015'|'umd'|'commonjs';
  * to each of the possible entry-point formats.
  */
 export interface EntryPoint extends JsonObject {
-  /** The name of the package (e.g. `@angular/core`). */
+  /** The name of the entry-point (e.g. `@angular/core` or `@angular/common/http`). */
   name: string;
-  /** The parsed package.json file for this entry-point. */
-  packageJson: EntryPointPackageJson;
-  /** The path to the package that contains this entry-point. */
-  package: AbsoluteFsPath;
   /** The path to this entry point. */
   path: AbsoluteFsPath;
+  /** The path to the package that contains this entry-point. */
+  packagePath: AbsoluteFsPath;
+  /** The parsed package.json file for this entry-point. */
+  packageJson: EntryPointPackageJson;
   /** The path to a typings (.d.ts) file for this entry-point. */
   typings: AbsoluteFsPath;
   /** Is this EntryPoint compiled with the Angular View Engine compiler? */
@@ -166,9 +166,9 @@ export function getEntryPointInfo(
 
   const entryPointInfo: EntryPoint = {
     name: entryPointPackageJson.name,
-    packageJson: entryPointPackageJson,
-    package: packagePath,
     path: entryPointPath,
+    packagePath,
+    packageJson: entryPointPackageJson,
     typings: resolve(entryPointPath, typings),
     compiledByAngular,
     ignoreMissingDependencies:

--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -138,8 +138,9 @@ export function getEntryPointInfo(
       loadPackageJson(fs, entryPointPackageJsonPath);
   const {packageName, packageVersion} = getPackageNameAndVersion(
       fs, packagePath, loadedPackagePackageJson, loadedEntryPointPackageJson);
-  const entryPointConfig =
-      config.getPackageConfig(packagePath, packageVersion).entryPoints[entryPointPath];
+
+  const packageConfig = config.getPackageConfig(packageName, packagePath, packageVersion);
+  const entryPointConfig = packageConfig.entryPoints.get(entryPointPath);
   let entryPointPackageJson: EntryPointPackageJson;
 
   if (entryPointConfig === undefined) {

--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -131,7 +131,7 @@ export function getEntryPointInfo(
   const loadedEntryPointPackageJson = (packagePackageJsonPath === entryPointPackageJsonPath) ?
       loadedPackagePackageJson :
       loadPackageJson(fs, entryPointPackageJsonPath);
-  const packageVersion = getPackageVersion(loadedPackagePackageJson, loadedEntryPointPackageJson);
+  const packageVersion = getPackageVersion(loadedPackagePackageJson);
   const entryPointConfig =
       config.getPackageConfig(packagePath, packageVersion).entryPoints[entryPointPath];
   let entryPointPackageJson: EntryPointPackageJson;
@@ -306,16 +306,13 @@ function guessTypingsFromPackageJson(
 /**
  * Find the version of the package at `packageJsonPath`.
  *
- * The version is read off of the `version` property of the package's or the entry-point's
- * `package.json` file (if available).
+ * The version is read off of the `version` property of the package's `package.json` file (if
+ * available).
  *
- * @param packagePackageJson the parsed `package.json` of the package (if available).
- * @param entryPointPackageJson the parsed `package.json` of an entry-point (if available).
- * @returns the version string or `null` if the `pckage.json` files are missing or don't contain a
+ * @param packageJson the parsed `package.json` of the package (if available).
+ * @returns the version string or `null` if the `pckage.json` file is missing or doesn't contain a
  *     version.
  */
-function getPackageVersion(
-    packagePackageJson: EntryPointPackageJson|null,
-    entryPointPackageJson: EntryPointPackageJson|null): string|null {
-  return packagePackageJson?.version ?? entryPointPackageJson?.version ?? null;
+function getPackageVersion(packageJson: EntryPointPackageJson|null): string|null {
+  return packageJson?.version ?? null;
 }

--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -125,21 +125,25 @@ export type GetEntryPointResult =
 export function getEntryPointInfo(
     fs: FileSystem, config: NgccConfiguration, logger: Logger, packagePath: AbsoluteFsPath,
     entryPointPath: AbsoluteFsPath): GetEntryPointResult {
-  const packageJsonPath = resolve(entryPointPath, 'package.json');
-  const loadedEntryPointPackageJson = loadPackageJson(fs, packageJsonPath);
-  const packageVersion = getPackageVersion(loadedEntryPointPackageJson);
+  const packagePackageJsonPath = resolve(packagePath, 'package.json');
+  const entryPointPackageJsonPath = resolve(entryPointPath, 'package.json');
+  const loadedPackagePackageJson = loadPackageJson(fs, packagePackageJsonPath);
+  const loadedEntryPointPackageJson = (packagePackageJsonPath === entryPointPackageJsonPath) ?
+      loadedPackagePackageJson :
+      loadPackageJson(fs, entryPointPackageJsonPath);
+  const packageVersion = getPackageVersion(loadedPackagePackageJson, loadedEntryPointPackageJson);
   const entryPointConfig =
       config.getPackageConfig(packagePath, packageVersion).entryPoints[entryPointPath];
   let entryPointPackageJson: EntryPointPackageJson;
 
   if (entryPointConfig === undefined) {
-    if (!fs.exists(packageJsonPath)) {
+    if (!fs.exists(entryPointPackageJsonPath)) {
       // No `package.json` and no config.
       return NO_ENTRY_POINT;
     } else if (loadedEntryPointPackageJson === null) {
       // `package.json` exists but could not be parsed and there is no redeeming config.
-      logger.warn(
-          `Failed to read entry point info from invalid 'package.json' file: ${packageJsonPath}`);
+      logger.warn(`Failed to read entry point info from invalid 'package.json' file: ${
+          entryPointPackageJsonPath}`);
 
       return INCOMPATIBLE_ENTRY_POINT;
     } else {
@@ -302,14 +306,16 @@ function guessTypingsFromPackageJson(
 /**
  * Find the version of the package at `packageJsonPath`.
  *
- * The version is read off of the `version` property of `packageJson`. It is assumed that even if
- * `packageJson` corresponds to a secondary entry-point (e.g. `@angular/common/http`) it will still
- * contain the same version as the main package (e.g. `@angular/common`).
+ * The version is read off of the `version` property of the package's or the entry-point's
+ * `package.json` file (if available).
  *
- * @param packageJson the parsed `package.json` of the package or one of its entry-points (if
- *     available).
- * @returns the version string or `null` if the `package.json` is not available.
+ * @param packagePackageJson the parsed `package.json` of the package (if available).
+ * @param entryPointPackageJson the parsed `package.json` of an entry-point (if available).
+ * @returns the version string or `null` if the `pckage.json` files are missing or don't contain a
+ *     version.
  */
-function getPackageVersion(packageJson: EntryPointPackageJson|null): string|null {
-  return packageJson?.version ?? null;
+function getPackageVersion(
+    packagePackageJson: EntryPointPackageJson|null,
+    entryPointPackageJson: EntryPointPackageJson|null): string|null {
+  return packagePackageJson?.version ?? entryPointPackageJson?.version ?? null;
 }

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
@@ -47,7 +47,7 @@ export function makeEntryPointBundle(
     mirrorDtsFromSrc: boolean = false,
     enableI18nLegacyMessageIdFormat: boolean = true): EntryPointBundle {
   // Create the TS program and necessary helpers.
-  const rootDir = entryPoint.package;
+  const rootDir = entryPoint.packagePath;
   const options: ts
       .CompilerOptions = {allowJs: true, maxNodeModuleJsDepth: Infinity, rootDir, ...pathMappings};
   const srcHost = new NgccSourcesCompilerHost(fs, options, entryPoint.path);
@@ -57,12 +57,12 @@ export function makeEntryPointBundle(
   const absFormatPath = fs.resolve(entryPoint.path, formatPath);
   const typingsPath = fs.resolve(entryPoint.path, entryPoint.typings);
   const src = makeBundleProgram(
-      fs, isCore, entryPoint.package, absFormatPath, 'r3_symbols.js', options, srcHost);
+      fs, isCore, entryPoint.packagePath, absFormatPath, 'r3_symbols.js', options, srcHost);
   const additionalDtsFiles = transformDts && mirrorDtsFromSrc ?
       computePotentialDtsFilesFromJsFiles(fs, src.program, absFormatPath, typingsPath) :
       [];
   const dts = transformDts ? makeBundleProgram(
-                                 fs, isCore, entryPoint.package, typingsPath, 'r3_symbols.d.ts',
+                                 fs, isCore, entryPoint.packagePath, typingsPath, 'r3_symbols.d.ts',
                                  options, dtsHost, additionalDtsFiles) :
                              null;
   const isFlatCore = isCore && src.r3SymbolsFile === null;

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
@@ -126,7 +126,7 @@ export class EntryPointManifest {
       lockFileHash: lockFileHash,
       entryPointPaths: entryPoints.map(e => {
         const entryPointPaths: EntryPointPaths = [
-          this.fs.relative(basePath, e.entryPoint.package),
+          this.fs.relative(basePath, e.entryPoint.packagePath),
           this.fs.relative(basePath, e.entryPoint.path),
         ];
         // Only add depInfo arrays if needed.

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
@@ -13,7 +13,7 @@ import {Logger} from '../logging/logger';
 
 import {NGCC_VERSION} from './build_marker';
 import {NgccConfiguration} from './configuration';
-import {getEntryPointInfo, INCOMPATIBLE_ENTRY_POINT, NO_ENTRY_POINT} from './entry_point';
+import {getEntryPointInfo, isEntryPoint} from './entry_point';
 
 /**
  * Manages reading and writing a manifest file that contains a list of all the entry-points that
@@ -75,7 +75,7 @@ export class EntryPointManifest {
         const result = getEntryPointInfo(
             this.fs, this.config, this.logger, this.fs.resolve(basePath, packagePath),
             this.fs.resolve(basePath, entryPointPath));
-        if (result === NO_ENTRY_POINT || result === INCOMPATIBLE_ENTRY_POINT) {
+        if (!isEntryPoint(result)) {
           throw new Error(`The entry-point manifest at ${
               manifestPath} contained an invalid pair of package paths: [${packagePath}, ${
               entryPointPath}]`);

--- a/packages/compiler-cli/ngcc/src/packages/transformer.ts
+++ b/packages/compiler-cli/ngcc/src/packages/transformer.ts
@@ -147,7 +147,7 @@ export class Transformer {
     const referencesRegistry = new NgccReferencesRegistry(reflectionHost);
 
     const switchMarkerAnalyzer =
-        new SwitchMarkerAnalyzer(reflectionHost, bundle.entryPoint.package);
+        new SwitchMarkerAnalyzer(reflectionHost, bundle.entryPoint.packagePath);
     const switchMarkerAnalyses = switchMarkerAnalyzer.analyzeProgram(bundle.src.program);
 
     const diagnostics: ts.Diagnostic[] = [];

--- a/packages/compiler-cli/ngcc/src/writing/cleaning/package_cleaner.ts
+++ b/packages/compiler-cli/ngcc/src/writing/cleaning/package_cleaner.ts
@@ -63,7 +63,7 @@ export function cleanOutdatedPackages(fileSystem: FileSystem, entryPoints: Entry
   const packagesToClean = new Set<AbsoluteFsPath>();
   for (const entryPoint of entryPoints) {
     if (needsCleaning(entryPoint.packageJson)) {
-      packagesToClean.add(entryPoint.package);
+      packagesToClean.add(entryPoint.packagePath);
     }
   }
 

--- a/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
@@ -39,9 +39,9 @@ export class NewEntryPointFileWriter extends InPlaceFileWriter {
       formatProperties: EntryPointJsonProperty[]) {
     // The new folder is at the root of the overall package
     const entryPoint = bundle.entryPoint;
-    const ngccFolder = join(entryPoint.package, NGCC_DIRECTORY);
-    this.copyBundle(bundle, entryPoint.package, ngccFolder);
-    transformedFiles.forEach(file => this.writeFile(file, entryPoint.package, ngccFolder));
+    const ngccFolder = join(entryPoint.packagePath, NGCC_DIRECTORY);
+    this.copyBundle(bundle, entryPoint.packagePath, ngccFolder);
+    transformedFiles.forEach(file => this.writeFile(file, entryPoint.packagePath, ngccFolder));
     this.updatePackageJson(entryPoint, formatProperties, ngccFolder);
   }
 
@@ -59,7 +59,7 @@ export class NewEntryPointFileWriter extends InPlaceFileWriter {
 
     // Revert the transformed files.
     for (const filePath of transformedFilePaths) {
-      this.revertFile(filePath, entryPoint.package);
+      this.revertFile(filePath, entryPoint.packagePath);
     }
 
     // Revert any changes to `package.json`.
@@ -118,7 +118,7 @@ export class NewEntryPointFileWriter extends InPlaceFileWriter {
     const oldFormatProp = formatProperties[0]!;
     const oldFormatPath = packageJson[oldFormatProp]!;
     const oldAbsFormatPath = join(entryPoint.path, oldFormatPath);
-    const newAbsFormatPath = join(ngccFolder, relative(entryPoint.package, oldAbsFormatPath));
+    const newAbsFormatPath = join(ngccFolder, relative(entryPoint.packagePath, oldAbsFormatPath));
     const newFormatPath = relative(entryPoint.path, newAbsFormatPath);
 
     // Update all properties in `package.json` (both in memory and on disk).

--- a/packages/compiler-cli/ngcc/test/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/test/BUILD.bazel
@@ -64,13 +64,14 @@ ts_library(
     ],
 )
 
-# As of version 10, the release packages do not contain esm2015 output anymore. The ngcc
-# integration tests intend to test ES5 features though, so we downlevel the flat esm2015
-# file to ES5 using Babel. We can then link that into the mock file system as if the Angular
-# core package is still built with previous APF versions where esm5 output was shipped. This
-# allows us to ensure that ngcc properly processes libraries with esm5 output. **Note**: We are
-# using Babel instead of `tsc` as TypeScript does not allow us to downlevel the file without
-# setting the module resolution to either `amd` or `system`. We want to preserve ES modules.
+# As of version 10, the release packages do not contain esm5 output anymore. The ngcc integration
+# tests intend to test ES5 features though, so we downlevel the flat esm2015 file to ES5 using
+# Babel. We can then link that into the mock file system as if the Angular core package is still
+# built with previous APF versions where esm5 output was shipped. This allows us to ensure that ngcc
+# properly processes libraries with esm5 output.
+# **Note**: We are using Babel instead of `tsc` as TypeScript does not allow us to downlevel the
+# file without setting the module resolution to either `amd` or `system`. We want to preserve ES
+# modules.
 babel(
     name = "fesm5_angular_core",
     outs = ["fesm5_angular_core.js"],

--- a/packages/compiler-cli/ngcc/test/analysis/switch_marker_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/switch_marker_analyzer_spec.ts
@@ -82,7 +82,7 @@ runInEachFileSystem(() => {
             'test', 'esm2015', false, [_('/node_modules/test/entrypoint.js')]);
         const program = bundle.src.program;
         const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle.src);
-        const analyzer = new SwitchMarkerAnalyzer(host, bundle.entryPoint.package);
+        const analyzer = new SwitchMarkerAnalyzer(host, bundle.entryPoint.packagePath);
         const analysis = analyzer.analyzeProgram(program);
 
         const entrypoint = getSourceFileOrError(program, _('/node_modules/test/entrypoint.js'));
@@ -113,7 +113,7 @@ runInEachFileSystem(() => {
             'test', 'esm2015', false, [_('/node_modules/test/entrypoint.js')]);
         const program = bundle.src.program;
         const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle.src);
-        const analyzer = new SwitchMarkerAnalyzer(host, bundle.entryPoint.package);
+        const analyzer = new SwitchMarkerAnalyzer(host, bundle.entryPoint.packagePath);
         const analysis = analyzer.analyzeProgram(program);
 
         const x = getSourceFileOrError(program, _('/node_modules/other/x.js'));
@@ -126,7 +126,7 @@ runInEachFileSystem(() => {
             'test', 'esm2015', false, [_('/node_modules/test/entrypoint.js')]);
         const program = bundle.src.program;
         const host = new Esm2015ReflectionHost(new MockLogger(), false, bundle.src);
-        const analyzer = new SwitchMarkerAnalyzer(host, bundle.entryPoint.package);
+        const analyzer = new SwitchMarkerAnalyzer(host, bundle.entryPoint.packagePath);
         const analysis = analyzer.analyzeProgram(program);
 
         const x = getSourceFileOrError(program, _('/node_modules/test/node_modules/nested/e.js'));

--- a/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
@@ -280,7 +280,7 @@ runInEachFileSystem(() => {
 
       it('should not log a warning for ignored deep imports', () => {
         spyOn(host, 'collectDependencies').and.callFake(createFakeComputeDependencies({
-          [_('/project/node_modules/test-package/index.js')]: {
+          [_('/project/node_modules/test-package/test-entry-point/index.js')]: {
             resolved: [],
             missing: [],
             deepImports: [
@@ -290,7 +290,10 @@ runInEachFileSystem(() => {
           },
         }));
         spyOn(dtsHost, 'collectDependencies').and.callFake(createFakeComputeDependencies({
-          [_('/project/node_modules/test-package/index.d.ts')]: {resolved: [], missing: []},
+          [_('/project/node_modules/test-package/test-entry-point/index.d.ts')]: {
+            resolved: [],
+            missing: [],
+          },
         }));
         // Setup the configuration to ignore deep imports that contain either "deep/" or "two".
         fs.ensureDir(_('/project'));
@@ -300,12 +303,12 @@ runInEachFileSystem(() => {
         config = new NgccConfiguration(fs, _('/project'));
         resolver = new DependencyResolver(fs, logger, config, {esm5: host, esm2015: host}, dtsHost);
         const testEntryPoint = {
-          name: 'test-package',
-          path: _('/project/node_modules/test-package'),
+          name: 'test-package/test-entry-point',
+          path: _('/project/node_modules/test-package/test-entry-point'),
           packageName: 'test-package',
           packagePath: _('/project/node_modules/test-package'),
           packageJson: {esm5: './index.js'},
-          typings: _('/project/node_modules/test-package/index.d.ts'),
+          typings: _('/project/node_modules/test-package/test-entry-point/index.d.ts'),
           compiledByAngular: true,
           ignoreMissingDependencies: false,
         } as EntryPoint;
@@ -314,7 +317,7 @@ runInEachFileSystem(() => {
             getEntryPointsWithDeps(resolver, [testEntryPoint]));
         expect(result.entryPoints).toEqual([testEntryPoint]);
         expect(logger.logs.warn).toEqual([[
-          `Entry point 'test-package' contains deep imports into '${
+          `Entry point 'test-package/test-entry-point' contains deep imports into '${
               _('/project/node_modules/deeper/one')}'. This is probably not a problem, but may cause the compilation of entry points to be out of order.`
         ]]);
       });

--- a/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
@@ -60,6 +60,7 @@ runInEachFileSystem(() => {
         first = {
           name: 'first',
           path: _('/first'),
+          packageName: 'first',
           packagePath: _('/first'),
           packageJson: {esm5: './index.js'},
           typings: _('/first/index.d.ts'),
@@ -67,7 +68,9 @@ runInEachFileSystem(() => {
           ignoreMissingDependencies: false,
         } as EntryPoint;
         second = {
+          name: 'second',
           path: _('/second'),
+          packageName: 'second',
           packagePath: _('/second'),
           packageJson: {esm2015: './sub/index.js'},
           typings: _('/second/sub/index.d.ts'),
@@ -75,7 +78,9 @@ runInEachFileSystem(() => {
           ignoreMissingDependencies: false,
         } as EntryPoint;
         third = {
+          name: 'third',
           path: _('/third'),
+          packageName: 'third',
           packagePath: _('/third'),
           packageJson: {fesm5: './index.js'},
           typings: _('/third/index.d.ts'),
@@ -83,7 +88,9 @@ runInEachFileSystem(() => {
           ignoreMissingDependencies: false,
         } as EntryPoint;
         fourth = {
+          name: 'fourth',
           path: _('/fourth'),
+          packageName: 'fourth',
           packagePath: _('/fourth'),
           packageJson: {fesm2015: './sub2/index.js'},
           typings: _('/fourth/sub2/index.d.ts'),
@@ -91,7 +98,9 @@ runInEachFileSystem(() => {
           ignoreMissingDependencies: false,
         } as EntryPoint;
         fifth = {
+          name: 'fifth',
           path: _('/fifth'),
+          packageName: 'fifth',
           packagePath: _('/fifth'),
           packageJson: {module: './index.js'},
           typings: _('/fifth/index.d.ts'),
@@ -100,7 +109,9 @@ runInEachFileSystem(() => {
         } as EntryPoint;
 
         sixthIgnoreMissing = {
+          name: 'sixth',
           path: _('/sixth'),
+          packageName: 'sixth',
           packagePath: _('/sixth'),
           packageJson: {module: './index.js'},
           typings: _('/sixth/index.d.ts'),
@@ -291,6 +302,7 @@ runInEachFileSystem(() => {
         const testEntryPoint = {
           name: 'test-package',
           path: _('/project/node_modules/test-package'),
+          packageName: 'test-package',
           packagePath: _('/project/node_modules/test-package'),
           packageJson: {esm5: './index.js'},
           typings: _('/project/node_modules/test-package/index.d.ts'),

--- a/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/dependency_resolver_spec.ts
@@ -60,52 +60,52 @@ runInEachFileSystem(() => {
         first = {
           name: 'first',
           path: _('/first'),
-          package: _('/first'),
+          packagePath: _('/first'),
           packageJson: {esm5: './index.js'},
+          typings: _('/first/index.d.ts'),
           compiledByAngular: true,
           ignoreMissingDependencies: false,
-          typings: _('/first/index.d.ts'),
         } as EntryPoint;
         second = {
           path: _('/second'),
-          package: _('/second'),
+          packagePath: _('/second'),
           packageJson: {esm2015: './sub/index.js'},
+          typings: _('/second/sub/index.d.ts'),
           compiledByAngular: true,
           ignoreMissingDependencies: false,
-          typings: _('/second/sub/index.d.ts'),
         } as EntryPoint;
         third = {
           path: _('/third'),
-          package: _('/third'),
+          packagePath: _('/third'),
           packageJson: {fesm5: './index.js'},
+          typings: _('/third/index.d.ts'),
           compiledByAngular: true,
           ignoreMissingDependencies: false,
-          typings: _('/third/index.d.ts'),
         } as EntryPoint;
         fourth = {
           path: _('/fourth'),
-          package: _('/fourth'),
+          packagePath: _('/fourth'),
           packageJson: {fesm2015: './sub2/index.js'},
+          typings: _('/fourth/sub2/index.d.ts'),
           compiledByAngular: true,
           ignoreMissingDependencies: false,
-          typings: _('/fourth/sub2/index.d.ts'),
         } as EntryPoint;
         fifth = {
           path: _('/fifth'),
-          package: _('/fifth'),
+          packagePath: _('/fifth'),
           packageJson: {module: './index.js'},
+          typings: _('/fifth/index.d.ts'),
           compiledByAngular: true,
           ignoreMissingDependencies: false,
-          typings: _('/fifth/index.d.ts'),
         } as EntryPoint;
 
         sixthIgnoreMissing = {
           path: _('/sixth'),
-          package: _('/sixth'),
+          packagePath: _('/sixth'),
           packageJson: {module: './index.js'},
+          typings: _('/sixth/index.d.ts'),
           compiledByAngular: true,
           ignoreMissingDependencies: true,
-          typings: _('/sixth/index.d.ts'),
         } as EntryPoint;
 
         dependencies = {
@@ -291,11 +291,11 @@ runInEachFileSystem(() => {
         const testEntryPoint = {
           name: 'test-package',
           path: _('/project/node_modules/test-package'),
-          package: _('/project/node_modules/test-package'),
+          packagePath: _('/project/node_modules/test-package'),
           packageJson: {esm5: './index.js'},
+          typings: _('/project/node_modules/test-package/index.d.ts'),
           compiledByAngular: true,
           ignoreMissingDependencies: false,
-          typings: _('/project/node_modules/test-package/index.d.ts'),
         } as EntryPoint;
 
         const result = resolver.sortEntryPointsByDependency(

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
@@ -451,7 +451,8 @@ runInEachFileSystem(() => {
 
       function dumpEntryPointPaths(
           basePath: AbsoluteFsPath, entryPoints: EntryPoint[]): [string, string][] {
-        return entryPoints.map(x => [relative(basePath, x.package), relative(basePath, x.path)]);
+        return entryPoints.map(
+            x => [relative(basePath, x.packagePath), relative(basePath, x.path)]);
       }
     });
   });

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
@@ -13,7 +13,7 @@ import {DtsDependencyHost} from '../../src/dependencies/dts_dependency_host';
 import {EsmDependencyHost} from '../../src/dependencies/esm_dependency_host';
 import {ModuleResolver} from '../../src/dependencies/module_resolver';
 import {DirectoryWalkerEntryPointFinder} from '../../src/entry_point_finder/directory_walker_entry_point_finder';
-import {NgccConfiguration} from '../../src/packages/configuration';
+import {NgccConfiguration, ProcessedNgccPackageConfig} from '../../src/packages/configuration';
 import {EntryPoint} from '../../src/packages/entry_point';
 import {EntryPointManifest, EntryPointManifestFile} from '../../src/packages/entry_point_manifest';
 import {PathMappings} from '../../src/path_mappings';
@@ -109,12 +109,13 @@ runInEachFileSystem(() => {
             fs, config, logger, resolver, manifest, basePath, undefined);
 
         loadTestFiles(createPackage(basePath, 'some-package'));
-        spyOn(config, 'getPackageConfig').and.returnValue({
-          versionRange: '*',
-          entryPoints: {
-            [_Abs('/project/node_modules/some-package')]: {ignore: true},
-          },
-        });
+        spyOn(config, 'getPackageConfig')
+            .and.returnValue(
+                new ProcessedNgccPackageConfig(_Abs('/project/node_modules/some-package'), {
+                  entryPoints: {
+                    '.': {ignore: true},
+                  },
+                }));
 
         const {entryPoints} = finder.findEntryPoints();
         expect(entryPoints).toEqual([]);
@@ -131,12 +132,13 @@ runInEachFileSystem(() => {
           ...createPackage(
               fs.resolve(basePath, 'some-package/sub-entry-point-1'), 'sub-entry-point-2'),
         ]);
-        spyOn(config, 'getPackageConfig').and.returnValue({
-          versionRange: '*',
-          entryPoints: {
-            [_Abs('/project/node_modules/some-package/sub-entry-point-1')]: {ignore: true},
-          },
-        });
+        spyOn(config, 'getPackageConfig')
+            .and.returnValue(
+                new ProcessedNgccPackageConfig(_Abs('/project/node_modules/some-package'), {
+                  entryPoints: {
+                    './sub-entry-point-1': {ignore: true},
+                  },
+                }));
 
         const {entryPoints} = finder.findEntryPoints();
         expect(dumpEntryPointPaths(basePath, entryPoints)).toEqual([

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/program_based_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/program_based_entry_point_finder_spec.ts
@@ -159,7 +159,8 @@ runInEachFileSystem(() => {
 
       function dumpEntryPointPaths(
           basePath: AbsoluteFsPath, entryPoints: EntryPoint[]): [string, string][] {
-        return entryPoints.map(x => [relative(basePath, x.package), relative(basePath, x.path)]);
+        return entryPoints.map(
+            x => [relative(basePath, x.packagePath), relative(basePath, x.path)]);
       }
     });
   });

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
@@ -318,7 +318,7 @@ runInEachFileSystem(() => {
            const entryPoint = entryPoints[0];
            expect(entryPoint.name).toEqual('secondary');
            expect(entryPoint.path).toEqual(_Abs('/path_mapped/dist/primary/secondary'));
-           expect(entryPoint.package).toEqual(_Abs('/path_mapped/dist/primary'));
+           expect(entryPoint.packagePath).toEqual(_Abs('/path_mapped/dist/primary'));
          });
 
       it('should correctly compute an entry-point whose path starts with the same string as another entry-point, via pathMappings',
@@ -381,7 +381,8 @@ runInEachFileSystem(() => {
 
       function dumpEntryPointPaths(
           basePath: AbsoluteFsPath, entryPoints: EntryPoint[]): [string, string][] {
-        return entryPoints.map(x => [relative(basePath, x.package), relative(basePath, x.path)]);
+        return entryPoints.map(
+            x => [relative(basePath, x.packagePath), relative(basePath, x.path)]);
       }
     });
 

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
@@ -14,7 +14,7 @@ import {EsmDependencyHost} from '../../src/dependencies/esm_dependency_host';
 import {ModuleResolver} from '../../src/dependencies/module_resolver';
 import {TargetedEntryPointFinder} from '../../src/entry_point_finder/targeted_entry_point_finder';
 import {NGCC_VERSION} from '../../src/packages/build_marker';
-import {NgccConfiguration} from '../../src/packages/configuration';
+import {NgccConfiguration, ProcessedNgccPackageConfig} from '../../src/packages/configuration';
 import {EntryPoint} from '../../src/packages/entry_point';
 import {PathMappings} from '../../src/path_mappings';
 import {MockLogger} from '../helpers/mock_logger';
@@ -116,12 +116,13 @@ runInEachFileSystem(() => {
             fs, config, logger, resolver, basePath, undefined, targetPath);
 
         loadTestFiles(createPackage(basePath, 'some-package'));
-        spyOn(config, 'getPackageConfig').and.returnValue({
-          versionRange: '*',
-          entryPoints: {
-            [_Abs('/project/node_modules/some-package')]: {ignore: true},
-          },
-        });
+        spyOn(config, 'getPackageConfig')
+            .and.returnValue(
+                new ProcessedNgccPackageConfig(_Abs('/project/node_modules/some-package'), {
+                  entryPoints: {
+                    '.': {ignore: true},
+                  },
+                }));
 
         const {entryPoints} = finder.findEntryPoints();
         expect(entryPoints).toEqual([]);
@@ -416,12 +417,13 @@ runInEachFileSystem(() => {
             fs, config, logger, resolver, basePath, undefined, targetPath);
 
         loadTestFiles(createPackage(basePath, 'some-package'));
-        spyOn(config, 'getPackageConfig').and.returnValue({
-          versionRange: '*',
-          entryPoints: {
-            [_Abs('/project/node_modules/some-package')]: {ignore: true},
-          },
-        });
+        spyOn(config, 'getPackageConfig')
+            .and.returnValue(
+                new ProcessedNgccPackageConfig(_Abs('/project/node_modules/some-package'), {
+                  entryPoints: {
+                    '.': {ignore: true},
+                  },
+                }));
 
         expect(finder.targetNeedsProcessingOrCleaning(['fesm2015'], true)).toBe(false);
       });

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
@@ -109,6 +109,24 @@ runInEachFileSystem(() => {
         expect(entryPoints).toEqual([]);
       });
 
+      it('should return an empty array if the target path is an ignored entry-point', () => {
+        const basePath = _Abs('/project/node_modules');
+        const targetPath = _Abs('/project/node_modules/some-package');
+        const finder = new TargetedEntryPointFinder(
+            fs, config, logger, resolver, basePath, undefined, targetPath);
+
+        loadTestFiles(createPackage(basePath, 'some-package'));
+        spyOn(config, 'getPackageConfig').and.returnValue({
+          versionRange: '*',
+          entryPoints: {
+            [_Abs('/project/node_modules/some-package')]: {ignore: true},
+          },
+        });
+
+        const {entryPoints} = finder.findEntryPoints();
+        expect(entryPoints).toEqual([]);
+      });
+
       it('should return an empty array if the target path is not an Angular entry-point', () => {
         const targetPath = _Abs('/no_valid_entry_points/node_modules/some_package');
         loadTestFiles([
@@ -387,6 +405,23 @@ runInEachFileSystem(() => {
         const finder = new TargetedEntryPointFinder(
             fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'), undefined,
             targetPath);
+        expect(finder.targetNeedsProcessingOrCleaning(['fesm2015'], true)).toBe(false);
+      });
+
+      it('should return false if the target path is ignored by the config', () => {
+        const basePath = _Abs('/project/node_modules');
+        const targetPath = _Abs('/project/node_modules/some-package');
+        const finder = new TargetedEntryPointFinder(
+            fs, config, logger, resolver, basePath, undefined, targetPath);
+
+        loadTestFiles(createPackage(basePath, 'some-package'));
+        spyOn(config, 'getPackageConfig').and.returnValue({
+          versionRange: '*',
+          entryPoints: {
+            [_Abs('/project/node_modules/some-package')]: {ignore: true},
+          },
+        });
+
         expect(finder.targetNeedsProcessingOrCleaning(['fesm2015'], true)).toBe(false);
       });
 

--- a/packages/compiler-cli/ngcc/test/helpers/utils.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/utils.ts
@@ -21,9 +21,9 @@ export function makeTestEntryPoint(
     entryPointName: string, packageName: string = entryPointName, config?: TestConfig): EntryPoint {
   return {
     name: entryPointName,
-    packageJson: {name: entryPointName},
-    package: absoluteFrom(`/node_modules/${packageName}`),
     path: absoluteFrom(`/node_modules/${entryPointName}`),
+    packagePath: absoluteFrom(`/node_modules/${packageName}`),
+    packageJson: {name: entryPointName},
     typings: absoluteFrom(`/node_modules/${entryPointName}/index.d.ts`),
     compiledByAngular: true,
     ignoreMissingDependencies: false,
@@ -43,8 +43,9 @@ export function makeTestEntryPointBundle(
     enableI18nLegacyMessageIdFormat = false): EntryPointBundle {
   const entryPoint = makeTestEntryPoint(packageName, packageName, config);
   const src = makeTestBundleProgram(srcRootNames[0], isCore);
-  const dts =
-      dtsRootNames ? makeTestDtsBundleProgram(dtsRootNames[0], entryPoint.package, isCore) : null;
+  const dts = dtsRootNames ?
+      makeTestDtsBundleProgram(dtsRootNames[0], entryPoint.packagePath, isCore) :
+      null;
   const isFlatCore = isCore && src.r3SymbolsFile === null;
   return {
     entryPoint,

--- a/packages/compiler-cli/ngcc/test/helpers/utils.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/utils.ts
@@ -22,6 +22,7 @@ export function makeTestEntryPoint(
   return {
     name: entryPointName,
     path: absoluteFrom(`/node_modules/${entryPointName}`),
+    packageName,
     packagePath: absoluteFrom(`/node_modules/${packageName}`),
     packageJson: {name: entryPointName},
     typings: absoluteFrom(`/node_modules/${entryPointName}/index.d.ts`),

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -1599,21 +1599,28 @@ runInEachFileSystem(() => {
         loadTestFiles([
           {
             name: _('/ngcc.config.js'),
-            contents: `module.exports = { packages: {
-            '@angular/core': {
-              entryPoints: {
-                './testing': {ignore: true}
-              },
-            },
-            '@angular/common': {
-              entryPoints: {
-                '.': {ignore: true}
-              },
-            }
-          }};`,
+            contents: `
+              module.exports = {
+                packages: {
+                  '@angular/core': {
+                    entryPoints: {
+                      './testing': {ignore: true},
+                    },
+                  },
+                  '@angular/common': {
+                    entryPoints: {
+                      '.': {ignore: true},
+                      './http': {override: {fesm2015: undefined}},
+                    },
+                  },
+                },
+              };
+            `,
           },
         ]);
+
         mainNgcc({basePath: '/node_modules', propertiesToConsider: ['es2015']});
+
         // We process core but not core/testing.
         expect(loadPackage('@angular/core').__processed_by_ivy_ngcc__).toEqual({
           module: '0.0.0-PLACEHOLDER',
@@ -1622,12 +1629,14 @@ runInEachFileSystem(() => {
           typings: '0.0.0-PLACEHOLDER',
         });
         expect(loadPackage('@angular/core/testing').__processed_by_ivy_ngcc__).toBeUndefined();
+
         // We do not compile common but we do compile its sub-entry-points.
         expect(loadPackage('@angular/common').__processed_by_ivy_ngcc__).toBeUndefined();
         expect(loadPackage('@angular/common/http').__processed_by_ivy_ngcc__).toEqual({
+          // `fesm2015` is not processed, because the ngcc config removes it.
+          // fesm2015: '0.0.0-PLACEHOLDER',
           module: '0.0.0-PLACEHOLDER',
           es2015: '0.0.0-PLACEHOLDER',
-          fesm2015: '0.0.0-PLACEHOLDER',
           typings: '0.0.0-PLACEHOLDER',
         });
       });

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -1556,7 +1556,7 @@ runInEachFileSystem(() => {
           },
           {
             name: _('/node_modules/deep_import/package.json'),
-            contents: '{"name": "deep-import", "es2015": "./index.js", "typings": "./index.d.ts"}',
+            contents: '{"name": "deep_import", "es2015": "./index.js", "typings": "./index.d.ts"}',
           },
           {
             name: _('/node_modules/deep_import/entry_point.js'),

--- a/packages/compiler-cli/ngcc/test/integration/util.ts
+++ b/packages/compiler-cli/ngcc/test/integration/util.ts
@@ -20,8 +20,8 @@ export type PackageSources = {
 /**
  * Instead of writing packaged code by hand, and manually describing the layout of the package, this
  * function transpiles the TypeScript sources into a flat file structure using the ES5 format. In
- * this package layout, all compiled sources are at the root of the package, with .d.ts files next
- * to the .js files. Each .js also has a corresponding .metadata.js file alongside with it.
+ * this package layout, all compiled sources are at the root of the package, with `.d.ts` files next
+ * to the `.js` files. Each `.js` also has a corresponding `.metadata.json` file alongside with it.
  *
  * All generated code is written into the `node_modules` in the top-level filesystem, ready for use
  * in testing ngcc.
@@ -41,7 +41,7 @@ export function compileIntoFlatEs5Package(pkgName: string, sources: PackageSourc
  * Instead of writing packaged code by hand, and manually describing the layout of the package,
  * this function transpiles the TypeScript sources into a flat file structure using the ES2015
  * format. In this package layout, all compiled sources are at the root of the package, with
- * `.d.ts` files next to the `.js` files. Each `.js` also has a corresponding `.metadata.js`
+ * `.d.ts` files next to the `.js` files. Each `.js` also has a corresponding `.metadata.json`
  * file alongside with it.
  *
  * All generated code is written into the `node_modules` in the top-level filesystem, ready for use
@@ -78,8 +78,8 @@ export interface FlatLayoutOptions {
 /**
  * Instead of writing packaged code by hand, and manually describing the layout of the package, this
  * function transpiles the TypeScript sources into a flat file structure using a single format. In
- * this package layout, all compiled sources are at the root of the package, with .d.ts files next
- * to the .js files. Each .js also has a corresponding .metadata.js file alongside with it.
+ * this package layout, all compiled sources are at the root of the package, with `.d.ts` files next
+ * to the `.js` files. Each `.js` also has a corresponding `.metadata.json` file alongside with it.
  *
  * All generated code is written into the `node_modules` in the top-level filesystem, ready for use
  * in testing ngcc.

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
@@ -168,6 +168,7 @@ runInEachFileSystem(() => {
          const entryPoint: EntryPoint = {
            name: 'test',
            path: absoluteFrom('/node_modules/test'),
+           packageName: 'test',
            packagePath: absoluteFrom('/node_modules/test'),
            packageJson: {name: 'test'},
            typings: absoluteFrom('/node_modules/test/index.d.ts'),
@@ -218,6 +219,7 @@ runInEachFileSystem(() => {
             const entryPoint: EntryPoint = {
               name: 'test',
               path: absoluteFrom('/node_modules/test'),
+              packageName: 'test',
               packagePath: absoluteFrom('/node_modules/test'),
               packageJson: {name: 'test'},
               typings: absoluteFrom('/node_modules/test/index.d.ts'),
@@ -240,6 +242,7 @@ runInEachFileSystem(() => {
             const entryPoint: EntryPoint = {
               name: 'internal',
               path: absoluteFrom('/node_modules/internal'),
+              packageName: 'internal',
               packagePath: absoluteFrom('/node_modules/internal'),
               packageJson: {name: 'internal'},
               typings: absoluteFrom('/node_modules/internal/index.d.ts'),
@@ -262,6 +265,7 @@ runInEachFileSystem(() => {
             const entryPoint: EntryPoint = {
               name: 'test',
               path: absoluteFrom('/node_modules/test'),
+              packageName: 'test',
               packagePath: absoluteFrom('/node_modules/test'),
               packageJson: {name: 'test'},
               typings: absoluteFrom('/node_modules/test/index.d.ts'),
@@ -285,6 +289,7 @@ runInEachFileSystem(() => {
       const entryPoint: EntryPoint = {
         name: 'secondary',
         path: absoluteFrom('/node_modules/primary/secondary'),
+        packageName: 'primary',
         packagePath: absoluteFrom('/node_modules/primary'),
         packageJson: {name: 'secondary'},
         typings: absoluteFrom('/node_modules/primary/secondary/index.d.ts'),

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
@@ -167,9 +167,9 @@ runInEachFileSystem(() => {
          const fs = getFileSystem();
          const entryPoint: EntryPoint = {
            name: 'test',
-           packageJson: {name: 'test'},
-           package: absoluteFrom('/node_modules/test'),
            path: absoluteFrom('/node_modules/test'),
+           packagePath: absoluteFrom('/node_modules/test'),
+           packageJson: {name: 'test'},
            typings: absoluteFrom('/node_modules/test/index.d.ts'),
            compiledByAngular: true,
            ignoreMissingDependencies: false,
@@ -217,9 +217,9 @@ runInEachFileSystem(() => {
             const fs = getFileSystem();
             const entryPoint: EntryPoint = {
               name: 'test',
-              packageJson: {name: 'test'},
-              package: absoluteFrom('/node_modules/test'),
               path: absoluteFrom('/node_modules/test'),
+              packagePath: absoluteFrom('/node_modules/test'),
+              packageJson: {name: 'test'},
               typings: absoluteFrom('/node_modules/test/index.d.ts'),
               compiledByAngular: true,
               ignoreMissingDependencies: false,
@@ -239,9 +239,9 @@ runInEachFileSystem(() => {
             const fs = getFileSystem();
             const entryPoint: EntryPoint = {
               name: 'internal',
-              packageJson: {name: 'internal'},
-              package: absoluteFrom('/node_modules/internal'),
               path: absoluteFrom('/node_modules/internal'),
+              packagePath: absoluteFrom('/node_modules/internal'),
+              packageJson: {name: 'internal'},
               typings: absoluteFrom('/node_modules/internal/index.d.ts'),
               compiledByAngular: true,
               ignoreMissingDependencies: false,
@@ -261,9 +261,9 @@ runInEachFileSystem(() => {
             const fs = getFileSystem();
             const entryPoint: EntryPoint = {
               name: 'test',
-              packageJson: {name: 'test'},
-              package: absoluteFrom('/node_modules/test'),
               path: absoluteFrom('/node_modules/test'),
+              packagePath: absoluteFrom('/node_modules/test'),
+              packageJson: {name: 'test'},
               typings: absoluteFrom('/node_modules/test/index.d.ts'),
               compiledByAngular: true,
               ignoreMissingDependencies: false,
@@ -284,9 +284,9 @@ runInEachFileSystem(() => {
       const fs = getFileSystem();
       const entryPoint: EntryPoint = {
         name: 'secondary',
-        packageJson: {name: 'secondary'},
-        package: absoluteFrom('/node_modules/primary'),
         path: absoluteFrom('/node_modules/primary/secondary'),
+        packagePath: absoluteFrom('/node_modules/primary'),
+        packageJson: {name: 'secondary'},
         typings: absoluteFrom('/node_modules/primary/secondary/index.d.ts'),
         compiledByAngular: true,
         ignoreMissingDependencies: false,

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_manifest_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_manifest_spec.ts
@@ -12,7 +12,7 @@ import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadTestFiles} from '../../../test/helpers';
 import {EntryPointWithDependencies} from '../../src/dependencies/dependency_host';
 import {NGCC_VERSION} from '../../src/packages/build_marker';
-import {NgccConfiguration} from '../../src/packages/configuration';
+import {NgccConfiguration, ProcessedNgccPackageConfig} from '../../src/packages/configuration';
 import {EntryPointManifest, EntryPointManifestFile} from '../../src/packages/entry_point_manifest';
 import {MockLogger} from '../helpers/mock_logger';
 
@@ -223,12 +223,13 @@ runInEachFileSystem(() => {
         fs.writeFile(
             _Abs('/project/node_modules/__ngcc_entry_points__.json'), JSON.stringify(manifestFile));
 
-        spyOn(config, 'getPackageConfig').and.returnValue({
-          versionRange: '*',
-          entryPoints: {
-            [_Abs('/project/node_modules/some_package/ignored_entry_point')]: {ignore: true},
-          },
-        });
+        spyOn(config, 'getPackageConfig')
+            .and.returnValue(
+                new ProcessedNgccPackageConfig(_Abs('/project/node_modules/some_package'), {
+                  entryPoints: {
+                    './ignored_entry_point': {ignore: true},
+                  },
+                }));
 
         const entryPoints = manifest.readEntryPointsUsingManifest(_Abs('/project/node_modules'));
         expect(entryPoints).toEqual(null);

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_manifest_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_manifest_spec.ts
@@ -149,6 +149,7 @@ runInEachFileSystem(() => {
           entryPoint: {
             name: 'some_package/valid_entry_point',
             path: _Abs('/project/node_modules/some_package/valid_entry_point'),
+            packageName: 'some_package',
             packagePath: _Abs('/project/node_modules/some_package'),
             packageJson: jasmine.any(Object),
             typings:

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_manifest_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_manifest_spec.ts
@@ -148,9 +148,9 @@ runInEachFileSystem(() => {
         expect(entryPoints).toEqual([{
           entryPoint: {
             name: 'some_package/valid_entry_point',
-            packageJson: jasmine.any(Object),
-            package: _Abs('/project/node_modules/some_package'),
             path: _Abs('/project/node_modules/some_package/valid_entry_point'),
+            packagePath: _Abs('/project/node_modules/some_package'),
+            packageJson: jasmine.any(Object),
             typings:
                 _Abs('/project/node_modules/some_package/valid_entry_point/valid_entry_point.d.ts'),
             compiledByAngular: true,
@@ -298,8 +298,8 @@ runInEachFileSystem(() => {
         fs.writeFile(_Abs('/project/package-lock.json'), 'LOCK FILE CONTENTS');
         const entryPoint1: EntryPointWithDependencies = {
           entryPoint: {
-            package: _Abs('/project/node_modules/package-1/'),
             path: _Abs('/project/node_modules/package-1/'),
+            packagePath: _Abs('/project/node_modules/package-1/'),
           } as any,
           depInfo: {
             dependencies: new Set([
@@ -312,8 +312,8 @@ runInEachFileSystem(() => {
         };
         const entryPoint2: EntryPointWithDependencies = {
           entryPoint: {
-            package: _Abs('/project/node_modules/package-2/'),
             path: _Abs('/project/node_modules/package-2/entry-point'),
+            packagePath: _Abs('/project/node_modules/package-2/'),
           } as any,
           depInfo: {
             dependencies: new Set(),

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
@@ -44,11 +44,11 @@ runInEachFileSystem(() => {
              _('/project/node_modules/some_package/valid_entry_point'));
          expect(entryPoint).toEqual({
            name: 'some_package/valid_entry_point',
-           package: SOME_PACKAGE,
            path: _('/project/node_modules/some_package/valid_entry_point'),
+           packagePath: SOME_PACKAGE,
+           packageJson: loadPackageJson(fs, '/project/node_modules/some_package/valid_entry_point'),
            typings:
                _(`/project/node_modules/some_package/valid_entry_point/valid_entry_point.d.ts`),
-           packageJson: loadPackageJson(fs, '/project/node_modules/some_package/valid_entry_point'),
            compiledByAngular: true,
            ignoreMissingDependencies: false,
            generateDeepReexports: false,
@@ -107,10 +107,10 @@ runInEachFileSystem(() => {
       };
       expect(entryPoint).toEqual({
         name: 'some_package/valid_entry_point',
-        package: SOME_PACKAGE,
         path: _('/project/node_modules/some_package/valid_entry_point'),
-        typings: _('/project/node_modules/some_package/valid_entry_point/some_other.d.ts'),
+        packagePath: SOME_PACKAGE,
         packageJson: overriddenPackageJson,
+        typings: _('/project/node_modules/some_package/valid_entry_point/some_other.d.ts'),
         compiledByAngular: true,
         ignoreMissingDependencies: false,
         generateDeepReexports: false,
@@ -155,11 +155,11 @@ runInEachFileSystem(() => {
              _('/project/node_modules/some_package/missing_package_json'));
          expect(entryPoint).toEqual({
            name: 'some_package/missing_package_json',
-           package: SOME_PACKAGE,
            path: _('/project/node_modules/some_package/missing_package_json'),
+           packagePath: SOME_PACKAGE,
+           packageJson: {name: 'some_package/missing_package_json', ...override},
            typings: _(
                '/project/node_modules/some_package/missing_package_json/missing_package_json.d.ts'),
-           packageJson: {name: 'some_package/missing_package_json', ...override},
            compiledByAngular: true,
            ignoreMissingDependencies: false,
            generateDeepReexports: false,
@@ -236,10 +236,10 @@ runInEachFileSystem(() => {
                _('/project/node_modules/some_package/missing_typings'));
            expect(entryPoint).toEqual({
              name: 'some_package/missing_typings',
-             package: SOME_PACKAGE,
              path: _('/project/node_modules/some_package/missing_typings'),
-             typings: _(`/project/node_modules/some_package/missing_typings/${typingsPath}.d.ts`),
+             packagePath: SOME_PACKAGE,
              packageJson: loadPackageJson(fs, '/project/node_modules/some_package/missing_typings'),
+             typings: _(`/project/node_modules/some_package/missing_typings/${typingsPath}.d.ts`),
              compiledByAngular: true,
              ignoreMissingDependencies: false,
              generateDeepReexports: false,
@@ -261,10 +261,10 @@ runInEachFileSystem(() => {
              _('/project/node_modules/some_package/missing_metadata'));
          expect(entryPoint).toEqual({
            name: 'some_package/missing_metadata',
-           package: SOME_PACKAGE,
            path: _('/project/node_modules/some_package/missing_metadata'),
-           typings: _(`/project/node_modules/some_package/missing_metadata/missing_metadata.d.ts`),
+           packagePath: SOME_PACKAGE,
            packageJson: loadPackageJson(fs, '/project/node_modules/some_package/missing_metadata'),
+           typings: _(`/project/node_modules/some_package/missing_metadata/missing_metadata.d.ts`),
            compiledByAngular: false,
            ignoreMissingDependencies: false,
            generateDeepReexports: false,
@@ -290,10 +290,10 @@ runInEachFileSystem(() => {
              _('/project/node_modules/some_package/missing_metadata'));
          expect(entryPoint).toEqual({
            name: 'some_package/missing_metadata',
-           package: SOME_PACKAGE,
            path: _('/project/node_modules/some_package/missing_metadata'),
-           typings: _('/project/node_modules/some_package/missing_metadata/missing_metadata.d.ts'),
+           packagePath: SOME_PACKAGE,
            packageJson: loadPackageJson(fs, '/project/node_modules/some_package/missing_metadata'),
+           typings: _('/project/node_modules/some_package/missing_metadata/missing_metadata.d.ts'),
            compiledByAngular: true,
            ignoreMissingDependencies: false,
            generateDeepReexports: false,
@@ -318,12 +318,12 @@ runInEachFileSystem(() => {
           _('/project/node_modules/some_package/types_rather_than_typings'));
       expect(entryPoint).toEqual({
         name: 'some_package/types_rather_than_typings',
-        package: SOME_PACKAGE,
         path: _('/project/node_modules/some_package/types_rather_than_typings'),
-        typings: _(
-            `/project/node_modules/some_package/types_rather_than_typings/types_rather_than_typings.d.ts`),
+        packagePath: SOME_PACKAGE,
         packageJson:
             loadPackageJson(fs, '/project/node_modules/some_package/types_rather_than_typings'),
+        typings: _(
+            `/project/node_modules/some_package/types_rather_than_typings/types_rather_than_typings.d.ts`),
         compiledByAngular: true,
         ignoreMissingDependencies: false,
         generateDeepReexports: false,
@@ -353,10 +353,10 @@ runInEachFileSystem(() => {
           _('/project/node_modules/some_package/material_style'));
       expect(entryPoint).toEqual({
         name: 'some_package/material_style',
-        package: SOME_PACKAGE,
         path: _('/project/node_modules/some_package/material_style'),
-        typings: _(`/project/node_modules/some_package/material_style/material_style.d.ts`),
+        packagePath: SOME_PACKAGE,
         packageJson: loadPackageJson(fs, '/project/node_modules/some_package/material_style'),
+        typings: _(`/project/node_modules/some_package/material_style/material_style.d.ts`),
         compiledByAngular: true,
         ignoreMissingDependencies: false,
         generateDeepReexports: false,

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
@@ -10,7 +10,7 @@ import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem} from '../../../
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadTestFiles} from '../../../test/helpers';
 import {NgccConfiguration} from '../../src/packages/configuration';
-import {EntryPoint, EntryPointJsonProperty, getEntryPointFormat, getEntryPointInfo, INCOMPATIBLE_ENTRY_POINT, NO_ENTRY_POINT, SUPPORTED_FORMAT_PROPERTIES} from '../../src/packages/entry_point';
+import {EntryPoint, EntryPointJsonProperty, getEntryPointFormat, getEntryPointInfo, IGNORED_ENTRY_POINT, INCOMPATIBLE_ENTRY_POINT, isEntryPoint, NO_ENTRY_POINT, SUPPORTED_FORMAT_PROPERTIES} from '../../src/packages/entry_point';
 import {MockLogger} from '../helpers/mock_logger';
 
 runInEachFileSystem(() => {
@@ -55,7 +55,7 @@ runInEachFileSystem(() => {
          });
        });
 
-    it('should return `NO_ENTRY_POINT` if configured to ignore the specified entry-point', () => {
+    it('should return `IGNORED_ENTRY_POINT` if configured to ignore the specified entry-point', () => {
       loadTestFiles([
         {
           name: _('/project/node_modules/some_package/valid_entry_point/package.json'),
@@ -74,7 +74,7 @@ runInEachFileSystem(() => {
       const entryPoint = getEntryPointInfo(
           fs, config, new MockLogger(), SOME_PACKAGE,
           _('/project/node_modules/some_package/valid_entry_point'));
-      expect(entryPoint).toBe(NO_ENTRY_POINT);
+      expect(entryPoint).toBe(IGNORED_ENTRY_POINT);
     });
 
     it('should override the properties on package.json if the entry-point is configured', () => {
@@ -381,7 +381,7 @@ runInEachFileSystem(() => {
     });
   });
 
-  describe('getEntryPointFormat', () => {
+  describe('getEntryPointFormat()', () => {
     let SOME_PACKAGE: AbsoluteFsPath;
     let _: typeof absoluteFrom;
     let fs: FileSystem;
@@ -399,10 +399,10 @@ runInEachFileSystem(() => {
       const result = getEntryPointInfo(
           fs, config, new MockLogger(), SOME_PACKAGE,
           _('/project/node_modules/some_package/valid_entry_point'));
-      if (result === NO_ENTRY_POINT || result === INCOMPATIBLE_ENTRY_POINT) {
+      if (!isEntryPoint(result)) {
         return fail(`Expected an entry point but got ${result}`);
       }
-      entryPoint = result as any;
+      entryPoint = result;
     });
 
     it('should return `esm2015` format for `fesm2015` property', () => {

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
@@ -9,7 +9,7 @@
 import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, join, relative} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadTestFiles} from '../../../test/helpers';
-import {NgccConfiguration} from '../../src/packages/configuration';
+import {NgccConfiguration, ProcessedNgccPackageConfig} from '../../src/packages/configuration';
 import {EntryPoint, EntryPointJsonProperty, getEntryPointFormat, getEntryPointInfo, IGNORED_ENTRY_POINT, INCOMPATIBLE_ENTRY_POINT, isEntryPoint, NO_ENTRY_POINT, SUPPORTED_FORMAT_PROPERTIES} from '../../src/packages/entry_point';
 import {MockLogger} from '../helpers/mock_logger';
 
@@ -69,9 +69,10 @@ runInEachFileSystem(() => {
         },
       ]);
       const config = new NgccConfiguration(fs, _('/project'));
-      spyOn(config, 'getPackageConfig').and.returnValue({
-        entryPoints: {[_('/project/node_modules/some_package/valid_entry_point')]: {ignore: true}}
-      } as any);
+      spyOn(config, 'getPackageConfig')
+          .and.returnValue(new ProcessedNgccPackageConfig(
+              _('/project/node_modules/some_package'),
+              {entryPoints: {'./valid_entry_point': {ignore: true}}}));
       const entryPoint = getEntryPointInfo(
           fs, config, new MockLogger(), SOME_PACKAGE,
           _('/project/node_modules/some_package/valid_entry_point'));
@@ -181,10 +182,10 @@ runInEachFileSystem(() => {
         typings: './some_other.d.ts',
         esm2015: './some_other.js',
       };
-      spyOn(config, 'getPackageConfig').and.returnValue({
-        entryPoints: {[_('/project/node_modules/some_package/valid_entry_point')]: {override}},
-        versionRange: '*'
-      });
+      spyOn(config, 'getPackageConfig')
+          .and.returnValue(new ProcessedNgccPackageConfig(
+              _('/project/node_modules/some_package'),
+              {entryPoints: {'./valid_entry_point': {override}}}));
       const entryPoint = getEntryPointInfo(
           fs, config, new MockLogger(), SOME_PACKAGE,
           _('/project/node_modules/some_package/valid_entry_point'));
@@ -233,11 +234,10 @@ runInEachFileSystem(() => {
          const config = new NgccConfiguration(fs, _('/project'));
          const override =
              JSON.parse(createPackageJson('missing_package_json', {excludes: ['name']}));
-         spyOn(config, 'getPackageConfig').and.returnValue({
-           entryPoints:
-               {[_('/project/node_modules/some_package/missing_package_json')]: {override}},
-           versionRange: '*'
-         });
+         spyOn(config, 'getPackageConfig')
+             .and.returnValue(new ProcessedNgccPackageConfig(
+                 _('/project/node_modules/some_package/'),
+                 {entryPoints: {'./missing_package_json': {override}}}));
          const entryPoint = getEntryPointInfo(
              fs, config, new MockLogger(), SOME_PACKAGE,
              _('/project/node_modules/some_package/missing_package_json'));
@@ -520,10 +520,10 @@ runInEachFileSystem(() => {
            // no metadata.json!
          ]);
          const config = new NgccConfiguration(fs, _('/project'));
-         spyOn(config, 'getPackageConfig').and.returnValue({
-           entryPoints: {[_('/project/node_modules/some_package/missing_metadata')]: {}},
-           versionRange: '*'
-         });
+         spyOn(config, 'getPackageConfig')
+             .and.returnValue(new ProcessedNgccPackageConfig(
+                 _('/project/node_modules/some_package'),
+                 {entryPoints: {'./missing_metadata': {}}}));
          const entryPoint = getEntryPointInfo(
              fs, config, new MockLogger(), SOME_PACKAGE,
              _('/project/node_modules/some_package/missing_metadata'));

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
@@ -78,64 +78,115 @@ runInEachFileSystem(() => {
     });
 
     it('should retrieve the entry-point\'s version from the package\'s `package.json`', () => {
-      const packagePath = _('/project/node_modules/some_package');
-      const entryPointPath = join(packagePath, 'valid_entry_point');
-      const config = new NgccConfiguration(fs, _('/project'));
-      const getPackageConfigSpy = spyOn(config, 'getPackageConfig').and.callThrough();
+      const entryPointPath = join(SOME_PACKAGE, 'valid_entry_point');
 
       loadTestFiles([
         {
-          name: join(packagePath, 'package.json'),
-          contents: createPackageJson('', {version: '1.0'}),
+          name: _('/project/ngcc.config.js'),
+          contents: `
+            module.exports = {
+              packages: {
+                'some_package@3': {
+                  entryPoints: {valid_entry_point: {override: {packageVersion: '3'}}},
+                },
+                'some_package@2': {
+                  entryPoints: {valid_entry_point: {override: {packageVersion: '2'}}},
+                },
+                'some_package@1': {
+                  entryPoints: {valid_entry_point: {override: {packageVersion: '1'}}},
+                },
+              },
+            };
+          `,
+        },
+        {
+          name: join(SOME_PACKAGE, 'package.json'),
+          contents: createPackageJson('', {version: '1.0.0'}),
         },
         {
           name: join(entryPointPath, 'package.json'),
-          contents: createPackageJson('valid_entry_point', {version: '2.0'}),
+          contents: createPackageJson('valid_entry_point', {version: '2.0.0'}),
         },
         {
           name: join(entryPointPath, 'valid_entry_point.metadata.json'),
           contents: 'some meta data',
         },
       ]);
-      getEntryPointInfo(fs, config, new MockLogger(), SOME_PACKAGE, entryPointPath);
 
-      expect(getPackageConfigSpy).toHaveBeenCalledWith(packagePath, '1.0');
+      const config = new NgccConfiguration(fs, _('/project'));
+      const info: EntryPoint =
+          getEntryPointInfo(fs, config, new MockLogger(), SOME_PACKAGE, entryPointPath) as any;
+
+      expect(info.packageJson).toEqual(jasmine.objectContaining({packageVersion: '1'}));
     });
 
     it('should retrieve the entry-point\'s version from the entry-point\'s `package.json`', () => {
-      const packagePath = _('/project/node_modules/some_package');
-      const entryPointPath = join(packagePath, 'valid_entry_point');
-      const config = new NgccConfiguration(fs, _('/project'));
-      const getPackageConfigSpy = spyOn(config, 'getPackageConfig').and.callThrough();
+      const entryPointPath = join(SOME_PACKAGE, 'valid_entry_point');
 
       loadTestFiles([
         {
-          name: join(packagePath, 'package.json'),
+          name: _('/project/ngcc.config.js'),
+          contents: `
+            module.exports = {
+              packages: {
+                'some_package@3': {
+                  entryPoints: {valid_entry_point: {override: {packageVersion: '3'}}},
+                },
+                'some_package@2': {
+                  entryPoints: {valid_entry_point: {override: {packageVersion: '2'}}},
+                },
+                'some_package@1': {
+                  entryPoints: {valid_entry_point: {override: {packageVersion: '1'}}},
+                },
+              },
+            };
+          `,
+        },
+        {
+          name: join(SOME_PACKAGE, 'package.json'),
           contents: createPackageJson(''),
         },
         {
           name: join(entryPointPath, 'package.json'),
-          contents: createPackageJson('valid_entry_point', {version: '2.0'}),
+          contents: createPackageJson('valid_entry_point', {version: '2.0.0'}),
         },
         {
           name: join(entryPointPath, 'valid_entry_point.metadata.json'),
           contents: 'some meta data',
         },
       ]);
-      getEntryPointInfo(fs, config, new MockLogger(), SOME_PACKAGE, entryPointPath);
 
-      expect(getPackageConfigSpy).toHaveBeenCalledWith(packagePath, '2.0');
+      const config = new NgccConfiguration(fs, _('/project'));
+      const info: EntryPoint =
+          getEntryPointInfo(fs, config, new MockLogger(), SOME_PACKAGE, entryPointPath) as any;
+
+      expect(info.packageJson).toEqual(jasmine.objectContaining({packageVersion: '2'}));
     });
 
     it('should use `null` for version if it cannot be retrieved from a `package.json`', () => {
-      const packagePath = _('/project/node_modules/some_package');
-      const entryPointPath = join(packagePath, 'valid_entry_point');
-      const config = new NgccConfiguration(fs, _('/project'));
-      const getPackageConfigSpy = spyOn(config, 'getPackageConfig').and.callThrough();
+      const entryPointPath = join(SOME_PACKAGE, 'valid_entry_point');
 
       loadTestFiles([
         {
-          name: join(packagePath, 'package.json'),
+          name: _('/project/ngcc.config.js'),
+          contents: `
+            module.exports = {
+              packages: {
+                'some_package@3': {
+                  entryPoints: {valid_entry_point: {override: {packageVersion: '3'}}},
+                },
+                'some_package@2': {
+                  entryPoints: {valid_entry_point: {override: {packageVersion: '2'}}},
+                },
+                'some_package@1': {
+                  entryPoints: {valid_entry_point: {override: {packageVersion: '1'}}},
+                },
+              },
+            };
+          `,
+        },
+        {
+          name: join(SOME_PACKAGE, 'package.json'),
           contents: createPackageJson(''),
         },
         {
@@ -147,9 +198,12 @@ runInEachFileSystem(() => {
           contents: 'some meta data',
         },
       ]);
-      getEntryPointInfo(fs, config, new MockLogger(), SOME_PACKAGE, entryPointPath);
 
-      expect(getPackageConfigSpy).toHaveBeenCalledWith(packagePath, null);
+      const config = new NgccConfiguration(fs, _('/project'));
+      const info: EntryPoint =
+          getEntryPointInfo(fs, config, new MockLogger(), SOME_PACKAGE, entryPointPath) as any;
+
+      expect(info.packageJson).toEqual(jasmine.objectContaining({packageVersion: '3'}));
     });
 
     it('should override the properties on package.json if the entry-point is configured', () => {

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_spec.ts
@@ -120,49 +120,6 @@ runInEachFileSystem(() => {
       expect(info.packageJson).toEqual(jasmine.objectContaining({packageVersion: '1'}));
     });
 
-    it('should retrieve the entry-point\'s version from the entry-point\'s `package.json`', () => {
-      const entryPointPath = join(SOME_PACKAGE, 'valid_entry_point');
-
-      loadTestFiles([
-        {
-          name: _('/project/ngcc.config.js'),
-          contents: `
-            module.exports = {
-              packages: {
-                'some_package@3': {
-                  entryPoints: {valid_entry_point: {override: {packageVersion: '3'}}},
-                },
-                'some_package@2': {
-                  entryPoints: {valid_entry_point: {override: {packageVersion: '2'}}},
-                },
-                'some_package@1': {
-                  entryPoints: {valid_entry_point: {override: {packageVersion: '1'}}},
-                },
-              },
-            };
-          `,
-        },
-        {
-          name: join(SOME_PACKAGE, 'package.json'),
-          contents: createPackageJson(''),
-        },
-        {
-          name: join(entryPointPath, 'package.json'),
-          contents: createPackageJson('valid_entry_point', {version: '2.0.0'}),
-        },
-        {
-          name: join(entryPointPath, 'valid_entry_point.metadata.json'),
-          contents: 'some meta data',
-        },
-      ]);
-
-      const config = new NgccConfiguration(fs, _('/project'));
-      const info: EntryPoint =
-          getEntryPointInfo(fs, config, new MockLogger(), SOME_PACKAGE, entryPointPath) as any;
-
-      expect(info.packageJson).toEqual(jasmine.objectContaining({packageVersion: '2'}));
-    });
-
     it('should use `null` for version if it cannot be retrieved from a `package.json`', () => {
       const entryPointPath = join(SOME_PACKAGE, 'valid_entry_point');
 

--- a/packages/compiler-cli/ngcc/test/rendering/commonjs_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/commonjs_rendering_formatter_spec.ts
@@ -156,7 +156,7 @@ exports.D = D;
       const referencesRegistry = new NgccReferencesRegistry(host);
       const decorationAnalyses =
           new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();
-      const switchMarkerAnalyses = new SwitchMarkerAnalyzer(host, bundle.entryPoint.package)
+      const switchMarkerAnalyses = new SwitchMarkerAnalyzer(host, bundle.entryPoint.packagePath)
                                        .analyzeProgram(bundle.src.program);
       const renderer = new CommonJsRenderingFormatter(host, false);
       const importManager = new ImportManager(new NoopImportRewriter(), 'i');

--- a/packages/compiler-cli/ngcc/test/rendering/esm5_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm5_rendering_formatter_spec.ts
@@ -33,8 +33,8 @@ function setup(file: {name: AbsoluteFsPath, contents: string}) {
   const referencesRegistry = new NgccReferencesRegistry(host);
   const decorationAnalyses =
       new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();
-  const switchMarkerAnalyses =
-      new SwitchMarkerAnalyzer(host, bundle.entryPoint.package).analyzeProgram(bundle.src.program);
+  const switchMarkerAnalyses = new SwitchMarkerAnalyzer(host, bundle.entryPoint.packagePath)
+                                   .analyzeProgram(bundle.src.program);
   const renderer = new Esm5RenderingFormatter(host, false);
   const importManager = new ImportManager(new NoopImportRewriter(), IMPORT_PREFIX);
   return {

--- a/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
@@ -38,8 +38,8 @@ function setup(files: TestFile[], dtsFiles?: TestFile[]) {
   const referencesRegistry = new NgccReferencesRegistry(host);
   const decorationAnalyses =
       new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();
-  const switchMarkerAnalyses =
-      new SwitchMarkerAnalyzer(host, bundle.entryPoint.package).analyzeProgram(bundle.src.program);
+  const switchMarkerAnalyses = new SwitchMarkerAnalyzer(host, bundle.entryPoint.packagePath)
+                                   .analyzeProgram(bundle.src.program);
   const renderer = new EsmRenderingFormatter(host, false);
   const importManager = new ImportManager(new NoopImportRewriter(), IMPORT_PREFIX);
   return {

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -90,8 +90,8 @@ function createTestRenderer(
   const referencesRegistry = new NgccReferencesRegistry(host);
   const decorationAnalyses =
       new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();
-  const switchMarkerAnalyses =
-      new SwitchMarkerAnalyzer(host, bundle.entryPoint.package).analyzeProgram(bundle.src.program);
+  const switchMarkerAnalyses = new SwitchMarkerAnalyzer(host, bundle.entryPoint.packagePath)
+                                   .analyzeProgram(bundle.src.program);
   const privateDeclarationsAnalyses =
       new PrivateDeclarationsAnalyzer(host, referencesRegistry).analyzeProgram(bundle.src.program);
   const testFormatter = new TestRenderingFormatter();

--- a/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
@@ -34,7 +34,7 @@ function setup(file: TestFile) {
   const decorationAnalyses =
       new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();
   const switchMarkerAnalyses =
-      new SwitchMarkerAnalyzer(host, bundle.entryPoint.package).analyzeProgram(src.program);
+      new SwitchMarkerAnalyzer(host, bundle.entryPoint.packagePath).analyzeProgram(src.program);
   const renderer = new UmdRenderingFormatter(host, false);
   const importManager = new ImportManager(new NoopImportRewriter(), 'i');
   return {

--- a/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
@@ -9,7 +9,7 @@ import {absoluteFrom, FileSystem, getFileSystem, join} from '../../../src/ngtsc/
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadTestFiles} from '../../../test/helpers';
 import {NgccConfiguration} from '../../src/packages/configuration';
-import {EntryPoint, EntryPointFormat, EntryPointJsonProperty, getEntryPointInfo, INCOMPATIBLE_ENTRY_POINT, NO_ENTRY_POINT} from '../../src/packages/entry_point';
+import {EntryPoint, EntryPointFormat, EntryPointJsonProperty, getEntryPointInfo, isEntryPoint} from '../../src/packages/entry_point';
 import {EntryPointBundle, makeEntryPointBundle} from '../../src/packages/entry_point_bundle';
 import {FileWriter} from '../../src/writing/file_writer';
 import {NewEntryPointFileWriter} from '../../src/writing/new_entry_point_file_writer';
@@ -106,7 +106,7 @@ runInEachFileSystem(() => {
         const config = new NgccConfiguration(fs, _('/'));
         const result = getEntryPointInfo(
             fs, config, logger, _('/node_modules/test'), _('/node_modules/test'))!;
-        if (result === NO_ENTRY_POINT || result === INCOMPATIBLE_ENTRY_POINT) {
+        if (!isEntryPoint(result)) {
           return fail(`Expected an entry point but got ${result}`);
         }
         entryPoint = result;
@@ -246,7 +246,7 @@ runInEachFileSystem(() => {
         const config = new NgccConfiguration(fs, _('/'));
         const result = getEntryPointInfo(
             fs, config, logger, _('/node_modules/test'), _('/node_modules/test/a'))!;
-        if (result === NO_ENTRY_POINT || result === INCOMPATIBLE_ENTRY_POINT) {
+        if (!isEntryPoint(result)) {
           return fail(`Expected an entry point but got ${result}`);
         }
         entryPoint = result;
@@ -375,7 +375,7 @@ runInEachFileSystem(() => {
         const config = new NgccConfiguration(fs, _('/'));
         const result = getEntryPointInfo(
             fs, config, new MockLogger(), _('/node_modules/test'), _('/node_modules/test/b'))!;
-        if (result === NO_ENTRY_POINT || result === INCOMPATIBLE_ENTRY_POINT) {
+        if (!isEntryPoint(result)) {
           return fail(`Expected an entry point but got ${result}`);
         }
         entryPoint = result;
@@ -501,7 +501,7 @@ runInEachFileSystem(() => {
         const config = new NgccConfiguration(fs, _('/'));
         const result = getEntryPointInfo(
             fs, config, logger, _('/node_modules/test'), _('/node_modules/test'))!;
-        if (result === NO_ENTRY_POINT || result === INCOMPATIBLE_ENTRY_POINT) {
+        if (!isEntryPoint(result)) {
           return fail(`Expected an entry point but got ${result}`);
         }
         entryPoint = result;

--- a/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
@@ -577,7 +577,7 @@ runInEachFileSystem(() => {
 
       it('should revert changes to `package.json`', () => {
         const entryPoint = esm5bundle.entryPoint;
-        const packageJsonPath = join(entryPoint.package, 'package.json');
+        const packageJsonPath = join(entryPoint.packagePath, 'package.json');
 
         fileWriter.writeBundle(
             esm5bundle,

--- a/packages/compiler-cli/test/helpers/src/mock_file_loading.ts
+++ b/packages/compiler-cli/test/helpers/src/mock_file_loading.ts
@@ -37,7 +37,7 @@ export function loadStandardTestFiles(
     loadFakeCore(tmpFs, basePath);
   } else {
     getAngularPackagesFromRunfiles().forEach(({name, pkgPath}) => {
-      loadTestDirectory(tmpFs, pkgPath, tmpFs.resolve('/node_modules/@angular', name));
+      loadTestDirectory(tmpFs, pkgPath, tmpFs.resolve(basePath, 'node_modules/@angular', name));
     });
   }
 


### PR DESCRIPTION
Previously, ngcc would only be able to match an ngcc configuration to packages that were located inside the project's top-level `node_modules/`. However, if there are multiple versions of a package in a project (e.g. as a transitive dependency of other packages), multiple copies of a package (at different versions) may exist in nested `node_modules/` directories. For example, one at `<project-root>/node_modules/some-package/` and one at `<project-root>/node_modules/other-package/node_modules/some-package/`. In such cases, ngcc was only able to detect the config for the first copy but not for the second.

This commit fixes this by returning a new instance of `ProcessedNgccPackageConfig` for each different package path (even if they refer to the same package name). In these `ProcessedNgccPackageConfig`, the `entryPoints` paths have been processed to take the package path into account.