### PR TITLE
docs(platform-webworker): remove mention of version 10

### DIFF
--- a/packages/platform-webworker-dynamic/src/platform-webworker-dynamic.ts
+++ b/packages/platform-webworker-dynamic/src/platform-webworker-dynamic.ts
@@ -16,7 +16,8 @@ export {VERSION} from './version';
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export const platformWorkerAppDynamic =
     createPlatformFactory(platformCoreDynamic, 'workerAppDynamic', [

--- a/packages/platform-webworker-dynamic/src/version.ts
+++ b/packages/platform-webworker-dynamic/src/version.ts
@@ -16,6 +16,7 @@ import {Version} from '@angular/core';
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export const VERSION = new Version('0.0.0-PLACEHOLDER');

--- a/packages/platform-webworker/PACKAGE.md
+++ b/packages/platform-webworker/PACKAGE.md
@@ -1,2 +1,2 @@
-**Deprecated** This package is deprecated and will be removed in version 10.
+**Deprecated** This package is deprecated and will be removed in a future version of Angular.
 See [Angular deprecations policy](guide/deprecations).

--- a/packages/platform-webworker/src/platform-webworker.ts
+++ b/packages/platform-webworker/src/platform-webworker.ts
@@ -24,7 +24,8 @@ export {platformWorkerUi} from './worker_render';
  * Bootstraps the worker ui.
  *
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export function bootstrapWorkerUi(
     workerScriptUri: string, customProviders: StaticProvider[] = []): Promise<PlatformRef> {

--- a/packages/platform-webworker/src/version.ts
+++ b/packages/platform-webworker/src/version.ts
@@ -16,6 +16,7 @@ import {Version} from '@angular/core';
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export const VERSION = new Version('0.0.0-PLACEHOLDER');

--- a/packages/platform-webworker/src/web_workers/shared/client_message_broker.ts
+++ b/packages/platform-webworker/src/web_workers/shared/client_message_broker.ts
@@ -12,7 +12,8 @@ import {Serializer, SerializerTypes} from './serializer';
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 @Injectable()
 export class ClientMessageBrokerFactory {
@@ -40,7 +41,8 @@ interface PromiseCompleter {
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export class ClientMessageBroker {
   private _pending = new Map<string, PromiseCompleter>();
@@ -146,7 +148,8 @@ interface ResponseMessageData {
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export class FnArg {
   constructor(
@@ -155,7 +158,8 @@ export class FnArg {
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export class UiArguments {
   constructor(public method: string, public args?: FnArg[]) {}

--- a/packages/platform-webworker/src/web_workers/shared/message_bus.ts
+++ b/packages/platform-webworker/src/web_workers/shared/message_bus.ts
@@ -17,7 +17,8 @@ import {EventEmitter, NgZone} from '@angular/core';
  * by the corresponding MessageBusSource.
  *
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export abstract class MessageBus implements MessageBusSource, MessageBusSink {
   /**
@@ -53,7 +54,8 @@ export abstract class MessageBus implements MessageBusSource, MessageBusSink {
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export interface MessageBusSource {
   /**
@@ -80,7 +82,8 @@ export interface MessageBusSource {
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export interface MessageBusSink {
   /**

--- a/packages/platform-webworker/src/web_workers/shared/serializer.ts
+++ b/packages/platform-webworker/src/web_workers/shared/serializer.ts
@@ -12,7 +12,8 @@ import {RenderStore} from './render_store';
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export const enum SerializerTypes {
   // RendererType2

--- a/packages/platform-webworker/src/web_workers/shared/service_message_broker.ts
+++ b/packages/platform-webworker/src/web_workers/shared/service_message_broker.ts
@@ -13,7 +13,8 @@ import {Serializer, SerializerTypes} from '../shared/serializer';
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 @Injectable()
 export class ServiceMessageBrokerFactory {
@@ -41,7 +42,8 @@ export class ServiceMessageBrokerFactory {
  * If that method returns a promise, the UIMessageBroker returns the result to the worker.
  *
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export class ServiceMessageBroker {
   private _sink: EventEmitter<any>;
@@ -93,7 +95,8 @@ export class ServiceMessageBroker {
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export interface ReceivedMessage {
   method: string;

--- a/packages/platform-webworker/src/web_workers/ui/location_providers.ts
+++ b/packages/platform-webworker/src/web_workers/ui/location_providers.ts
@@ -21,7 +21,8 @@ import {MessageBasedPlatformLocation} from './platform_location';
  * A list of {@link Provider}s. To use the router in a Worker enabled application you must
  * include these providers when setting up the render thread.
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export const WORKER_UI_LOCATION_PROVIDERS = <StaticProvider[]>[
   {

--- a/packages/platform-webworker/src/web_workers/worker/location_providers.ts
+++ b/packages/platform-webworker/src/web_workers/worker/location_providers.ts
@@ -17,7 +17,8 @@ import {WebWorkerPlatformLocation} from './platform_location';
  * a worker context.
  *
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export const WORKER_APP_LOCATION_PROVIDERS: StaticProvider[] = [
   {provide: PlatformLocation, useClass: WebWorkerPlatformLocation} as any as StaticProvider, {

--- a/packages/platform-webworker/src/worker_app.ts
+++ b/packages/platform-webworker/src/worker_app.ts
@@ -22,7 +22,8 @@ import {WorkerDomAdapter} from './web_workers/worker/worker_adapter';
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export const platformWorkerApp: (extraProviders?: StaticProvider[]|undefined) => PlatformRef =
     createPlatformFactory(
@@ -56,7 +57,8 @@ export function setupWebWorker(): void {
  * The ng module for the worker app side.
  *
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 @NgModule({
   providers: [

--- a/packages/platform-webworker/src/worker_render.ts
+++ b/packages/platform-webworker/src/worker_render.ts
@@ -26,7 +26,8 @@ import {MessageBasedRenderer2} from './web_workers/ui/renderer';
  * and underlying {@link MessageBus} for lower level message passing.
  *
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 @Injectable()
 export class WebWorkerInstance {
@@ -44,7 +45,8 @@ export class WebWorkerInstance {
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export const WORKER_SCRIPT = new InjectionToken<string>('WebWorkerScript');
 
@@ -53,7 +55,8 @@ export const WORKER_SCRIPT = new InjectionToken<string>('WebWorkerScript');
  * created.
  *
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export const WORKER_UI_STARTABLE_MESSAGING_SERVICE =
     new InjectionToken<({start: () => void})[]>('WorkerRenderStartableMsgService');
@@ -154,7 +157,8 @@ function initWebWorkerRenderPlatform(injector: Injector): () => void {
 
 /**
  * @publicApi
- * @deprecated platform-webworker is deprecated in Angular and will be removed in version 10
+ * @deprecated platform-webworker is deprecated in Angular and will be removed in a future version
+ *     of Angular
  */
 export const platformWorkerUi =
     createPlatformFactory(platformCore, 'workerUi', _WORKER_UI_PLATFORM_PROVIDERS);


### PR DESCRIPTION
The deprecation notice for platform-webworker
APIs is too prescriptive and notes that we will
remove the package in version 10. Since we are
not planning to do this for version 10, this
commit updates the notice to read "a future
version of Angular".
