### PR TITLE
docs: remove the note about @angular/http from the deprecations guide

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -547,18 +547,6 @@ In practical terms, the `package.json` of all `@angular` packages has changed in
 
 For more information about the npm package format, see the [Angular Package Format spec](https://goo.gl/jB3GVv).
 
-{@a ie-9-10}
-### IE 9 and 10 support
-
-Support for IE 9 and 10 has been deprecated and will be removed in a future version.
-Supporting outdated browsers like these increases bundle size, code complexity, and test load, and also requires time and effort that could be spent on improvements to the framework.
-For example, fixing issues can be more difficult, as a straightforward fix for modern browsers could break old ones that have quirks due to not receiving updates from vendors. 
-
-The final decision was made on three key points:
-* __Vendor support__: Microsoft dropped support of IE 9 and 10 on 1/12/16, meaning they no longer provide security updates or technical support.
-* __Usage statistics__: We looked at usage trends for IE 9 and 10 from various sources and all indicated that usage percentages were extremely small (fractions of 1%).
-* __Feedback from partners__: We also reached out to some of our Angular customers and none expressed concern about dropping IE 9 and 10 support.
-
 {@a removed}
 ## Removed APIs
 
@@ -570,68 +558,6 @@ The following APIs have been removed starting with version 10.0.0*:
 | `@angular/core`  | `ModuleWithProviders` without a generic             | `ModuleWithProviders` with a generic | See [migration guide](guide/migration-module-with-providers) for more info |
 
 *To see APIs removed in version 9, check out this guide on the [version 9 docs site](https://v9.angular.io/guide/deprecations#removed).
-
-
-<!-- The following anchor is used by redirects from the removed API pages. Do not change or remove. -->
-{@a http}
-### @angular/http
-
-<!--
-Deprecation announced in version 5
-https://blog.angular.io/version-5-0-0-of-angular-now-available-37e414935ced)
--->
-
-
-The entire [`@angular/http`](http://v7.angular.io/api/http) package has been removed. Use [`@angular/common/http`](api/common/http) instead.
-
-The new API is a smaller, easier, and more powerful way to make HTTP requests in Angular.
-The new API simplifies the default ergonomics: There is no need to map by invoking the `.json()` method.
-It also supports typed return values and interceptors.
-
-To update your apps:
-* Replace `HttpModule` with [`HttpClientModule`](api/common/http/HttpClientModule) (from [`@angular/common/http`](api/common/http)) in each of your modules.
-* Replace the `Http` service with the [`HttpClient`](api/common/http/HttpClient) service.
-* Remove any `map(res => res.json())` calls. They are no longer needed.
-
-For more information about using `@angular/common/http`, see the [HttpClient guide](guide/http "HTTP Client guide").
-
-
-| `@angular/http` | Closest replacement in `@angular/common/http` |
-| ------------- | ------------------------------------------- |
-| `BaseRequestOptions` |  [`HttpRequest`](/api/common/http/HttpRequest) |
-| `BaseResponseOptions` | [`HttpResponse`](/api/common/http/HttpResponse) |
-| `BrowserXhr` |  |
-| `Connection` | [`HttpBackend`](/api/common/http/HttpBackend) |
-| `ConnectionBackend` | [`HttpBackend`](/api/common/http/HttpBackend) |
-| `CookieXSRFStrategy` | [`HttpClientXsrfModule`](/api/common/http/HttpClientXsrfModule) |
-| `Headers` | [`HttpHeaders`](/api/common/http/HttpHeaders) |
-| `Http` | [`HttpClient`](/api/common/http/HttpClient) |
-| `HttpModule` | [`HttpClientModule`](/api/common/http/HttpClientModule) |
-| `Jsonp` | [`HttpClient`](/api/common/http/HttpClient) |
-| `JSONPBackend` | [`JsonpClientBackend`](/api/common/http/JsonpClientBackend) |
-| `JSONPConnection` | [`JsonpClientBackend`](/api/common/http/JsonpClientBackend) |
-| `JsonpModule` | [`HttpClientJsonpModule`](/api/common/http/HttpClientJsonpModule) |
-| `QueryEncoder` | [`HttpUrlEncodingCodec`](/api/common/http/HttpUrlEncodingCodec) |
-| `ReadyState` | [`HttpBackend`](/api/common/http/HttpBackend) |
-| `Request` | [`HttpRequest`](/api/common/http/HttpRequest) |
-| `RequestMethod` | [`HttpClient`](/api/common/http/HttpClient) |
-| `RequestOptions` | [`HttpRequest`](/api/common/http/HttpRequest) |
-| `RequestOptionsArgs` | [`HttpRequest`](/api/common/http/HttpRequest) |
-| `Response` | [`HttpResponse`](/api/common/http/HttpResponse) |
-| `ResponseContentType` | [`HttpClient`](/api/common/http/HttpClient) |
-| `ResponseOptions` | [`HttpResponse`](/api/common/http/HttpResponse) |
-| `ResponseOptionsArgs` | [`HttpResponse`](/api/common/http/HttpResponse) |
-| `ResponseType` | [`HttpClient`](/api/common/http/HttpClient) |
-| `URLSearchParams` | [`HttpParams`](/api/common/http/HttpParams) |
-| `XHRBackend` | [`HttpXhrBackend`](/api/common/http/HttpXhrBackend) |
-| `XHRConnection` | [`HttpXhrBackend`](/api/common/http/HttpXhrBackend) |
-| `XSRFStrategy` | [`HttpClientXsrfModule`](/api/common/http/HttpClientXsrfModule) |
-
-
-| `@angular/http/testing` | Closest replacement in `@angular/common/http/testing` |
-| --------------------- | ------------------------------------------- |
-| `MockBackend` | [`HttpTestingController`](/api/common/http/testing/HttpTestingController) |
-| `MockConnection` | [`HttpTestingController`](/api/common/http/testing/HttpTestingController) |
 
 {@a style-sanitization}
 ### Style Sanitization for `[style]` and `[style.prop]` bindings


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

This was originally pushed by @igorminar in #36944, but later reverted in #35621

## What is the new behavior?

This re-deletes the `@angular/http` section, as done in #36944

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No