### PR TITLE
feat(platform-server): use absolute URLs from Location for HTTP

### DIFF
--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -793,22 +793,53 @@ describe('platform-server integration', () => {
          });
        }));
 
-    it('can make relative HttpClient requests', async(() => {
-         const platform = platformDynamicServer([
-           {provide: INITIAL_CONFIG, useValue: {document: '<app></app>', url: 'http://localhost'}}
-         ]);
-         platform.bootstrapModule(HttpClientExampleModule).then(ref => {
-           const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
-           const http = ref.injector.get(HttpClient);
-           ref.injector.get<NgZone>(NgZone).run(() => {
-             http.get<string>('/testing').subscribe((body: string) => {
-               NgZone.assertInAngularZone();
-               expect(body).toEqual('success!');
-             });
-             mock.expectOne('http://localhost/testing').flush('success!');
-           });
-         });
-       }));
+    it('can make relative HttpClient requests', async () => {
+      const platform = platformDynamicServer([
+        {provide: INITIAL_CONFIG, useValue: {document: '<app></app>', url: 'http://localhost'}}
+      ]);
+      const ref = await platform.bootstrapModule(HttpClientExampleModule);
+      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+      const http = ref.injector.get(HttpClient);
+      ref.injector.get(NgZone).run(() => {
+        http.get<string>('/testing').subscribe((body: string) => {
+          NgZone.assertInAngularZone();
+          expect(body).toEqual('success!');
+        });
+        mock.expectOne('http://localhost/testing').flush('success!');
+      });
+    });
+
+    it('can make relative HttpClient requests two slashes', async () => {
+      const platform = platformDynamicServer([
+        {provide: INITIAL_CONFIG, useValue: {document: '<app></app>', url: 'http://localhost/'}}
+      ]);
+      const ref = await platform.bootstrapModule(HttpClientExampleModule);
+      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+      const http = ref.injector.get(HttpClient);
+      ref.injector.get(NgZone).run(() => {
+        http.get<string>('/testing').subscribe((body: string) => {
+          NgZone.assertInAngularZone();
+          expect(body).toEqual('success!');
+        });
+        mock.expectOne('http://localhost/testing').flush('success!');
+      });
+    });
+
+    it('can make relative HttpClient requests no slashes', async () => {
+      const platform = platformDynamicServer([
+        {provide: INITIAL_CONFIG, useValue: {document: '<app></app>', url: 'http://localhost'}}
+      ]);
+      const ref = await platform.bootstrapModule(HttpClientExampleModule);
+      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+      const http = ref.injector.get(HttpClient);
+      ref.injector.get(NgZone).run(() => {
+        http.get<string>('testing').subscribe((body: string) => {
+          NgZone.assertInAngularZone();
+          expect(body).toEqual('success!');
+        });
+        mock.expectOne('http://localhost/testing').flush('success!');
+      });
+    });
 
     it('requests are macrotasks', async(() => {
          const platform = platformDynamicServer(

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -793,6 +793,23 @@ describe('platform-server integration', () => {
          });
        }));
 
+    it('can make relative HttpClient requests', async(() => {
+         const platform = platformDynamicServer([
+           {provide: INITIAL_CONFIG, useValue: {document: '<app></app>', url: 'http://localhost'}}
+         ]);
+         platform.bootstrapModule(HttpClientExampleModule).then(ref => {
+           const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+           const http = ref.injector.get(HttpClient);
+           ref.injector.get<NgZone>(NgZone).run(() => {
+             http.get<string>('/testing').subscribe((body: string) => {
+               NgZone.assertInAngularZone();
+               expect(body).toEqual('success!');
+             });
+             mock.expectOne('http://localhost/testing').flush('success!');
+           });
+         });
+       }));
+
     it('requests are macrotasks', async(() => {
          const platform = platformDynamicServer(
              [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);


### PR DESCRIPTION
Currently, requests from the server that do not use absolute URLs
fail because the server does not have the same fallback mechanism
that browser XHR does. This adds that mechanism by pulling the
full URL out of the document.location object, if available.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
