### PR TITLE
refactor(core): remove ActiveIndexFlag from LContainer

### DIFF
--- a/packages/core/src/render3/instructions/lview_debug.ts
+++ b/packages/core/src/render3/instructions/lview_debug.ts
@@ -13,7 +13,7 @@ import {KeyValueArray} from '../../util/array_utils';
 import {assertDefined} from '../../util/assert';
 import {createNamedArrayType} from '../../util/named_array_type';
 import {initNgDevMode} from '../../util/ng_dev_mode';
-import {ACTIVE_INDEX, ActiveIndexFlag, CONTAINER_HEADER_OFFSET, LContainer, MOVED_VIEWS, NATIVE} from '../interfaces/container';
+import {CONTAINER_HEADER_OFFSET, HAS_TRANSPLANTED_VIEWS, LContainer, MOVED_VIEWS, NATIVE} from '../interfaces/container';
 import {DirectiveDefList, PipeDefList, ViewQueriesFunction} from '../interfaces/definition';
 import {COMMENT_MARKER, ELEMENT_MARKER, I18nMutateOpCode, I18nMutateOpCodes, I18nUpdateOpCode, I18nUpdateOpCodes, TIcu} from '../interfaces/i18n';
 import {PropertyAliases, TConstants, TContainerNode, TElementNode, TNode as ITNode, TNodeFlags, TNodeProviderIndexes, TNodeType, TViewNode} from '../interfaces/node';
@@ -23,7 +23,7 @@ import {RComment, RElement, Renderer3, RendererFactory3, RNode} from '../interfa
 import {getTStylingRangeNext, getTStylingRangeNextDuplicate, getTStylingRangePrev, getTStylingRangePrevDuplicate, TStylingKey, TStylingRange} from '../interfaces/styling';
 import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_VIEW, DestroyHookData, ExpandoInstructions, FLAGS, HEADER_OFFSET, HookData, HOST, INJECTOR, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, SANITIZER, T_HOST, TData, TVIEW, TView as ITView, TView, TViewType} from '../interfaces/view';
 import {attachDebugObject} from '../util/debug_utils';
-import {getLContainerActiveIndex, getTNode, unwrapRNode} from '../util/view_utils';
+import {getTNode, unwrapRNode} from '../util/view_utils';
 
 const NG_DEV_MODE = ((typeof ngDevMode === 'undefined' || !!ngDevMode) && initNgDevMode());
 
@@ -510,12 +510,8 @@ export function buildDebugNode(tNode: ITNode, lView: LView, nodeIndex: number): 
 export class LContainerDebug {
   constructor(private readonly _raw_lContainer: LContainer) {}
 
-  get activeIndex(): number {
-    return getLContainerActiveIndex(this._raw_lContainer);
-  }
   get hasTransplantedViews(): boolean {
-    return (this._raw_lContainer[ACTIVE_INDEX] & ActiveIndexFlag.HAS_TRANSPLANTED_VIEWS) ===
-        ActiveIndexFlag.HAS_TRANSPLANTED_VIEWS;
+    return this._raw_lContainer[HAS_TRANSPLANTED_VIEWS];
   }
   get views(): LViewDebug[] {
     return this._raw_lContainer.slice(CONTAINER_HEADER_OFFSET)

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -26,7 +26,16 @@ export const TYPE = 1;
  * without having to remember the specific indices.
  * Uglify will inline these when minifying so there shouldn't be a cost.
  */
-export const ACTIVE_INDEX = 2;
+
+/**
+ * Flag to signify that this `LContainer` may have transplanted views which need to be change
+ * detected. (see: `LView[DECLARATION_COMPONENT_VIEW])`.
+ *
+ * This flag, once set, is never unset for the `LContainer`. This means that when unset we can skip
+ * a lot of work in `refreshDynamicEmbeddedViews`. But when set we still need to verify
+ * that the `MOVED_VIEWS` are transplanted and on-push.
+ */
+export const HAS_TRANSPLANTED_VIEWS = 2;
 
 // PARENT, NEXT, TRANSPLANTED_VIEWS_TO_REFRESH are indices 3, 4, and 5
 // As we already have these constants in LView, we don't need to re-create them.
@@ -46,32 +55,6 @@ export const MOVED_VIEWS = 9;
  * remove views from the DOM when they are no longer required.
  */
 export const CONTAINER_HEADER_OFFSET = 10;
-
-
-/**
- * Used to track Transplanted `LView`s (see: `LView[DECLARATION_COMPONENT_VIEW])`
- */
-export const enum ActiveIndexFlag {
-  /**
-   * Flag which signifies that the `LContainer` does not have any inline embedded views.
-   */
-  DYNAMIC_EMBEDDED_VIEWS_ONLY = -1,
-
-  /**
-   * Flag to signify that this `LContainer` may have transplanted views which need to be change
-   * detected. (see: `LView[DECLARATION_COMPONENT_VIEW])`.
-   *
-   * This flag once set is never unset for the `LContainer`. This means that when unset we can skip
-   * a lot of work in `refreshDynamicEmbeddedViews`. But when set we still need to verify
-   * that the `MOVED_VIEWS` are transplanted and on-push.
-   */
-  HAS_TRANSPLANTED_VIEWS = 1,
-
-  /**
-   * Number of bits to shift inline embedded views counter to make space for other flags.
-   */
-  SHIFT = 1,
-}
 
 /**
  * The state associated with a container.
@@ -97,16 +80,12 @@ export interface LContainer extends Array<any> {
   [TYPE]: true;
 
   /**
-   * The next active index in the views array to read or write to. This helps us
-   * keep track of where we are in the views array.
-   * In the case the LContainer is created for a ViewContainerRef,
-   * it is set to null to identify this scenario, as indices are "absolute" in that case,
-   * i.e. provided directly by the user of the ViewContainerRef API.
+   * Flag to signify that this `LContainer` may have transplanted views which need to be change
+   * detected. (see: `LView[DECLARATION_COMPONENT_VIEW])`.
    *
-   * The lowest bit signals that this `LContainer` has transplanted views which need to be change
-   * detected as part of the declaration CD. (See `LView[DECLARATION_COMPONENT_VIEW]`)
+   * This flag, once set, is never unset for the `LContainer`.
    */
-  [ACTIVE_INDEX]: ActiveIndexFlag;
+  [HAS_TRANSPLANTED_VIEWS]: boolean;
 
   /**
    * Access to the parent view is necessary so we can propagate back

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -262,7 +262,7 @@ export interface LView extends Array<any> {
    *
    * see also:
    *   - https://hackmd.io/@mhevery/rJUJsvv9H write up of the problem
-   *   - `LContainer[ACTIVE_INDEX]` for flag which marks which `LContainer` has transplanted views.
+   *   - `LContainer[HAS_TRANSPLANTED_VIEWS]` which marks which `LContainer` has transplanted views.
    *   - `LContainer[TRANSPLANT_HEAD]` and `LContainer[TRANSPLANT_TAIL]` storage for transplanted
    *   - `LView[DECLARATION_LCONTAINER]` similar problem for queries
    *   - `LContainer[MOVED_VIEWS]` similar problem for queries

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -13,7 +13,7 @@ import {assertDefined, assertDomNode, assertEqual, assertString} from '../util/a
 
 import {assertLContainer, assertLView, assertTNodeForLView} from './assert';
 import {attachPatchData} from './context_discovery';
-import {ACTIVE_INDEX, ActiveIndexFlag, CONTAINER_HEADER_OFFSET, LContainer, MOVED_VIEWS, NATIVE, unusedValueExportToPlacateAjd as unused1} from './interfaces/container';
+import {CONTAINER_HEADER_OFFSET, HAS_TRANSPLANTED_VIEWS, LContainer, MOVED_VIEWS, NATIVE, unusedValueExportToPlacateAjd as unused1} from './interfaces/container';
 import {ComponentDef} from './interfaces/definition';
 import {NodeInjectorFactory} from './interfaces/injector';
 import {TElementNode, TNode, TNodeFlags, TNodeType, TProjectionNode, TViewNode, unusedValueExportToPlacateAjd as unused2} from './interfaces/node';
@@ -276,7 +276,7 @@ function trackMovedView(declarationContainer: LContainer, lView: LView) {
     // At this point the declaration-component is not same as insertion-component; this means that
     // this is a transplanted view. Mark the declared lView as having transplanted views so that
     // those views can participate in CD.
-    declarationContainer[ACTIVE_INDEX] |= ActiveIndexFlag.HAS_TRANSPLANTED_VIEWS;
+    declarationContainer[HAS_TRANSPLANTED_VIEWS] = true;
   }
   if (movedViews === null) {
     declarationContainer[MOVED_VIEWS] = [lView];

--- a/packages/core/src/render3/util/view_traversal_utils.ts
+++ b/packages/core/src/render3/util/view_traversal_utils.ts
@@ -61,18 +61,17 @@ export function getRootContext(viewOrComponent: LView|{}): RootContext {
  * Gets the first `LContainer` in the LView or `null` if none exists.
  */
 export function getFirstLContainer(lView: LView): LContainer|null {
-  let viewOrContainer = lView[CHILD_HEAD];
-  while (viewOrContainer !== null && !isLContainer(viewOrContainer)) {
-    viewOrContainer = viewOrContainer[NEXT];
-  }
-  return viewOrContainer;
+  return getNearestLContainer(lView[CHILD_HEAD]);
 }
 
 /**
  * Gets the next `LContainer` that is a sibling of the given container.
  */
 export function getNextLContainer(container: LContainer): LContainer|null {
-  let viewOrContainer = container[NEXT];
+  return getNearestLContainer(container[NEXT]);
+}
+
+function getNearestLContainer(viewOrContainer: LContainer|LView|null) {
   while (viewOrContainer !== null && !isLContainer(viewOrContainer)) {
     viewOrContainer = viewOrContainer[NEXT];
   }

--- a/packages/core/src/render3/util/view_traversal_utils.ts
+++ b/packages/core/src/render3/util/view_traversal_utils.ts
@@ -8,8 +8,10 @@
 
 import {assertDefined} from '../../util/assert';
 import {assertLView} from '../assert';
+import {LContainer} from '../interfaces/container';
 import {isLContainer, isLView} from '../interfaces/type_checks';
-import {CONTEXT, FLAGS, LView, LViewFlags, PARENT, RootContext} from '../interfaces/view';
+import {CHILD_HEAD, CONTEXT, FLAGS, LView, LViewFlags, NEXT, PARENT, RootContext} from '../interfaces/view';
+
 import {readPatchedLView} from './view_utils';
 
 
@@ -52,4 +54,27 @@ export function getRootContext(viewOrComponent: LView|{}): RootContext {
   ngDevMode &&
       assertDefined(rootView[CONTEXT], 'RootView has no context. Perhaps it is disconnected?');
   return rootView[CONTEXT] as RootContext;
+}
+
+
+/**
+ * Gets the first `LContainer` in the LView or `null` if none exists.
+ */
+export function getFirstLContainer(lView: LView): LContainer|null {
+  let viewOrContainer = lView[CHILD_HEAD];
+  while (viewOrContainer !== null && !isLContainer(viewOrContainer)) {
+    viewOrContainer = viewOrContainer[NEXT];
+  }
+  return viewOrContainer;
+}
+
+/**
+ * Gets the next `LContainer` that is a sibling of the given container.
+ */
+export function getNextLContainer(container: LContainer): LContainer|null {
+  let viewOrContainer = container[NEXT];
+  while (viewOrContainer !== null && !isLContainer(viewOrContainer)) {
+    viewOrContainer = viewOrContainer[NEXT];
+  }
+  return viewOrContainer;
 }

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -8,7 +8,7 @@
 
 import {assertDataInRange, assertDefined, assertDomNode, assertGreaterThan, assertLessThan} from '../../util/assert';
 import {assertTNodeForLView} from '../assert';
-import {ACTIVE_INDEX, ActiveIndexFlag, LContainer, TYPE} from '../interfaces/container';
+import {LContainer, TYPE} from '../interfaces/container';
 import {LContext, MONKEY_PATCH_KEY_NAME} from '../interfaces/context';
 import {TConstants, TNode} from '../interfaces/node';
 import {isProceduralRenderer, RNode} from '../interfaces/renderer';
@@ -186,14 +186,6 @@ export function getConstant<T>(consts: TConstants|null, index: number|null|undef
  */
 export function resetPreOrderHookFlags(lView: LView) {
   lView[PREORDER_HOOK_FLAGS] = 0;
-}
-
-export function getLContainerActiveIndex(lContainer: LContainer) {
-  return lContainer[ACTIVE_INDEX] >> ActiveIndexFlag.SHIFT;
-}
-
-export function setLContainerActiveIndex(lContainer: LContainer, index: number) {
-  lContainer[ACTIVE_INDEX] = index << ActiveIndexFlag.SHIFT;
 }
 
 /**

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -21,7 +21,7 @@ import {assertDefined, assertEqual, assertGreaterThan, assertLessThan} from '../
 import {assertLContainer} from './assert';
 import {getParentInjectorLocation, NodeInjector} from './di';
 import {addToViewTree, createLContainer, createLView, renderView} from './instructions/shared';
-import {ActiveIndexFlag, CONTAINER_HEADER_OFFSET, LContainer, VIEW_REFS} from './interfaces/container';
+import {CONTAINER_HEADER_OFFSET, LContainer, VIEW_REFS} from './interfaces/container';
 import {TContainerNode, TDirectiveHostNode, TElementContainerNode, TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
 import {isProceduralRenderer, RComment, RElement} from './interfaces/renderer';
 import {isComponentHost, isLContainer, isLView, isRootView} from './interfaces/type_checks';
@@ -31,7 +31,7 @@ import {addRemoveViewFromContainer, appendChild, detachView, getBeforeNodeForVie
 import {getParentInjectorTNode} from './node_util';
 import {getLView, getPreviousOrParentTNode} from './state';
 import {getParentInjectorView, hasParentInjector} from './util/injector_utils';
-import {getComponentLViewByIndex, getNativeByTNode, setLContainerActiveIndex, unwrapRNode, viewAttachedToContainer} from './util/view_utils';
+import {getComponentLViewByIndex, getNativeByTNode, unwrapRNode, viewAttachedToContainer} from './util/view_utils';
 import {ViewRef} from './view_ref';
 
 
@@ -349,7 +349,6 @@ export function createContainerRef(
   if (isLContainer(slotValue)) {
     // If the host is a container, we don't need to create a new LContainer
     lContainer = slotValue;
-    setLContainerActiveIndex(lContainer, ActiveIndexFlag.DYNAMIC_EMBEDDED_VIEWS_ONLY);
   } else {
     let commentNode: RComment;
     // If the host is an element container, the native host element is guaranteed to be a

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -1,8 +1,5 @@
 [
   {
-    "name": "ACTIVE_INDEX"
-  },
-  {
     "name": "BLOOM_MASK"
   },
   {
@@ -43,6 +40,9 @@
   },
   {
     "name": "FLAGS"
+  },
+  {
+    "name": "HAS_TRANSPLANTED_VIEWS"
   },
   {
     "name": "HEADER_OFFSET"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -363,6 +363,9 @@
     "name": "getNativeByTNode"
   },
   {
+    "name": "getNearestLContainer"
+  },
+  {
     "name": "getNextLContainer"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -1,8 +1,5 @@
 [
   {
-    "name": "ACTIVE_INDEX"
-  },
-  {
     "name": "BLOOM_MASK"
   },
   {
@@ -40,6 +37,9 @@
   },
   {
     "name": "FLAGS"
+  },
+  {
+    "name": "HAS_TRANSPLANTED_VIEWS"
   },
   {
     "name": "HEADER_OFFSET"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -294,6 +294,9 @@
     "name": "getNativeByTNode"
   },
   {
+    "name": "getNearestLContainer"
+  },
+  {
     "name": "getNextLContainer"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -660,6 +660,9 @@
     "name": "getNativeByTNode"
   },
   {
+    "name": "getNearestLContainer"
+  },
+  {
     "name": "getNextLContainer"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1,8 +1,5 @@
 [
   {
-    "name": "ACTIVE_INDEX"
-  },
-  {
     "name": "BLOOM_MASK"
   },
   {
@@ -70,6 +67,9 @@
   },
   {
     "name": "FLAGS"
+  },
+  {
+    "name": "HAS_TRANSPLANTED_VIEWS"
   },
   {
     "name": "HEADER_OFFSET"
@@ -1138,9 +1138,6 @@
   },
   {
     "name": "setIsNotParent"
-  },
-  {
-    "name": "setLContainerActiveIndex"
   },
   {
     "name": "setPreviousOrParentTNode"


### PR DESCRIPTION
The `ActiveIndexFlag` is no longer needed because we no longer have "inline embedded views".
There is only one type of embedded view so we do not need complex tracking for
inline embedded views.

`HAS_TRANSPLANTED_VIEWS` now takes the place of the `ACTIVE_INDEX` slot as a
simple boolean rather than being a shifted flag inside the `ACTIVE_INDEX` bits.

This is a follow-up of https://github.com/angular/angular/pull/34715