### PR TITLE
ngcc: implement a new program-based entry-point finder

### DIFF
--- a/packages/compiler-cli/ngcc/src/command_line_options.ts
+++ b/packages/compiler-cli/ngcc/src/command_line_options.ts
@@ -36,7 +36,14 @@ export function parseCommandLineOptions(args: string[]): NgccOptions {
             alias: 'target',
             describe:
                 'A relative path (from the `source` path) to a single entry-point to process (plus its dependencies).\n' +
-                'If this property is provided then `error-on-failed-entry-point` is forced to true',
+                'If this property is provided then `error-on-failed-entry-point` is forced to true.\n' +
+                'This option overrides the `--use-program-dependencies` option.',
+          })
+          .option('use-program-dependencies', {
+            type: 'boolean',
+            describe:
+                'If this property is provided then the entry-points to process are parsed from the program defined by the loaded tsconfig.json. See `--tsconfig`.\n' +
+                'This option is overridden by the `--target` option.',
           })
           .option('first-only', {
             describe:
@@ -116,6 +123,7 @@ export function parseCommandLineOptions(args: string[]): NgccOptions {
   const enableI18nLegacyMessageIdFormat = options['legacy-message-ids'];
   const invalidateEntryPointManifest = options['invalidate-entry-point-manifest'];
   const errorOnFailedEntryPoint = options['error-on-failed-entry-point'];
+  const findEntryPointsFromTsConfigProgram = options['use-tsconfig'];
   // yargs is not so great at mixed string+boolean types, so we have to test tsconfig against a
   // string "false" to capture the `tsconfig=false` option.
   // And we have to convert the option to a string to handle `no-tsconfig`, which will be `false`.
@@ -134,6 +142,7 @@ export function parseCommandLineOptions(args: string[]): NgccOptions {
     async: options['async'],
     invalidateEntryPointManifest,
     errorOnFailedEntryPoint,
-    tsConfigPath
+    tsConfigPath,
+    findEntryPointsFromTsConfigProgram
   };
 }

--- a/packages/compiler-cli/ngcc/src/command_line_options.ts
+++ b/packages/compiler-cli/ngcc/src/command_line_options.ts
@@ -123,7 +123,7 @@ export function parseCommandLineOptions(args: string[]): NgccOptions {
   const enableI18nLegacyMessageIdFormat = options['legacy-message-ids'];
   const invalidateEntryPointManifest = options['invalidate-entry-point-manifest'];
   const errorOnFailedEntryPoint = options['error-on-failed-entry-point'];
-  const findEntryPointsFromTsConfigProgram = options['use-tsconfig'];
+  const findEntryPointsFromTsConfigProgram = options['use-program-dependencies'];
   // yargs is not so great at mixed string+boolean types, so we have to test tsconfig against a
   // string "false" to capture the `tsconfig=false` option.
   // And we have to convert the option to a string to handle `no-tsconfig`, which will be `false`.
@@ -143,6 +143,6 @@ export function parseCommandLineOptions(args: string[]): NgccOptions {
     invalidateEntryPointManifest,
     errorOnFailedEntryPoint,
     tsConfigPath,
-    findEntryPointsFromTsConfigProgram
+    findEntryPointsFromTsConfigProgram,
   };
 }

--- a/packages/compiler-cli/ngcc/src/dependencies/commonjs_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/commonjs_dependency_host.ts
@@ -9,39 +9,22 @@ import * as ts from 'typescript';
 
 import {AbsoluteFsPath} from '../../../src/ngtsc/file_system';
 import {isRequireCall, isWildcardReexportStatement, RequireCall} from '../host/commonjs_umd_utils';
+import {isAssignment, isAssignmentStatement} from '../host/esm2015_host';
 
 import {DependencyHostBase} from './dependency_host';
-import {ResolvedDeepImport, ResolvedRelativeModule} from './module_resolver';
 
 /**
  * Helper functions for computing dependencies.
  */
 export class CommonJsDependencyHost extends DependencyHostBase {
-  /**
-   * Compute the dependencies of the given file.
-   *
-   * @param file An absolute path to the file whose dependencies we want to get.
-   * @param dependencies A set that will have the absolute paths of resolved entry points added to
-   * it.
-   * @param missing A set that will have the dependencies that could not be found added to it.
-   * @param deepImports A set that will have the import paths that exist but cannot be mapped to
-   * entry-points, i.e. deep-imports.
-   * @param alreadySeen A set that is used to track internal dependencies to prevent getting stuck
-   * in a circular dependency loop.
-   */
-  protected recursivelyCollectDependencies(
-      file: AbsoluteFsPath, dependencies: Set<AbsoluteFsPath>, missing: Set<string>,
-      deepImports: Set<AbsoluteFsPath>, alreadySeen: Set<AbsoluteFsPath>): void {
-    const fromContents = this.fs.readFile(file);
+  protected canSkipFile(fileContents: string): boolean {
+    return !hasRequireCalls(fileContents);
+  }
 
-    if (!this.hasRequireCalls(fromContents)) {
-      // Avoid parsing the source file as there are no imports.
-      return;
-    }
-
+  protected extractImports(file: AbsoluteFsPath, fileContents: string): Set<string> {
     // Parse the source into a TypeScript AST and then walk it looking for imports and re-exports.
     const sf =
-        ts.createSourceFile(file, fromContents, ts.ScriptTarget.ES2015, false, ts.ScriptKind.JS);
+        ts.createSourceFile(file, fileContents, ts.ScriptTarget.ES2015, false, ts.ScriptKind.JS);
     const requireCalls: RequireCall[] = [];
 
     for (const stmt of sf.statements) {
@@ -92,37 +75,20 @@ export class CommonJsDependencyHost extends DependencyHostBase {
       }
     }
 
-    const importPaths = new Set(requireCalls.map(call => call.arguments[0].text));
-    for (const importPath of importPaths) {
-      const resolvedModule = this.moduleResolver.resolveModuleImport(importPath, file);
-      if (resolvedModule === null) {
-        missing.add(importPath);
-      } else if (resolvedModule instanceof ResolvedRelativeModule) {
-        const internalDependency = resolvedModule.modulePath;
-        if (!alreadySeen.has(internalDependency)) {
-          alreadySeen.add(internalDependency);
-          this.recursivelyCollectDependencies(
-              internalDependency, dependencies, missing, deepImports, alreadySeen);
-        }
-      } else if (resolvedModule instanceof ResolvedDeepImport) {
-        deepImports.add(resolvedModule.importPath);
-      } else {
-        dependencies.add(resolvedModule.entryPointPath);
-      }
-    }
+    return new Set(requireCalls.map(call => call.arguments[0].text));
   }
+}
 
-  /**
-   * Check whether a source file needs to be parsed for imports.
-   * This is a performance short-circuit, which saves us from creating
-   * a TypeScript AST unnecessarily.
-   *
-   * @param source The content of the source file to check.
-   *
-   * @returns false if there are definitely no require calls
-   * in this file, true otherwise.
-   */
-  private hasRequireCalls(source: string): boolean {
-    return /require\(['"]/.test(source);
-  }
+/**
+ * Check whether a source file needs to be parsed for imports.
+ * This is a performance short-circuit, which saves us from creating
+ * a TypeScript AST unnecessarily.
+ *
+ * @param source The content of the source file to check.
+ *
+ * @returns false if there are definitely no require calls
+ * in this file, true otherwise.
+ */
+export function hasRequireCalls(source: string): boolean {
+  return /require\(['"]/.test(source);
 }

--- a/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
@@ -8,77 +8,25 @@
 import * as ts from 'typescript';
 import {AbsoluteFsPath} from '../../../src/ngtsc/file_system';
 import {DependencyHostBase} from './dependency_host';
-import {ResolvedDeepImport, ResolvedRelativeModule} from './module_resolver';
 
 /**
  * Helper functions for computing dependencies.
  */
 export class EsmDependencyHost extends DependencyHostBase {
-  /**
-   * Compute the dependencies of the given file.
-   *
-   * @param file An absolute path to the file whose dependencies we want to get.
-   * @param dependencies A set that will have the absolute paths of resolved entry points added to
-   * it.
-   * @param missing A set that will have the dependencies that could not be found added to it.
-   * @param deepImports A set that will have the import paths that exist but cannot be mapped to
-   * entry-points, i.e. deep-imports.
-   * @param alreadySeen A set that is used to track internal dependencies to prevent getting stuck
-   * in a circular dependency loop.
-   */
-  protected recursivelyCollectDependencies(
-      file: AbsoluteFsPath, dependencies: Set<AbsoluteFsPath>, missing: Set<string>,
-      deepImports: Set<string>, alreadySeen: Set<AbsoluteFsPath>): void {
-    const fromContents = this.fs.readFile(file);
-
-    if (!hasImportOrReexportStatements(fromContents)) {
-      // Avoid parsing the source file as there are no imports.
-      return;
-    }
-
-    // Parse the source into a TypeScript AST and then walk it looking for imports and re-exports.
-    const sf =
-        ts.createSourceFile(file, fromContents, ts.ScriptTarget.ES2015, false, ts.ScriptKind.JS);
-    sf.statements
-        // filter out statements that are not imports or reexports
-        .filter(isStringImportOrReexport)
-        // Grab the id of the module that is being imported
-        .map(stmt => stmt.moduleSpecifier.text)
-        .forEach(importPath => {
-          const resolved =
-              this.processImport(importPath, file, dependencies, missing, deepImports, alreadySeen);
-          if (!resolved) {
-            missing.add(importPath);
-          }
-        });
+  protected canSkipFile(fileContents: string): boolean {
+    return !hasImportOrReexportStatements(fileContents);
   }
 
-  /**
-   * Resolve the given `importPath` from `file` and add it to the appropriate set.
-   *
-   * @returns `true` if the import was resolved (to an entry-point, a local import, or a
-   * deep-import).
-   */
-  protected processImport(
-      importPath: string, file: AbsoluteFsPath, dependencies: Set<AbsoluteFsPath>,
-      missing: Set<string>, deepImports: Set<string>, alreadySeen: Set<AbsoluteFsPath>): boolean {
-    const resolvedModule = this.moduleResolver.resolveModuleImport(importPath, file);
-    if (resolvedModule === null) {
-      return false;
-    }
-    if (resolvedModule instanceof ResolvedRelativeModule) {
-      const internalDependency = resolvedModule.modulePath;
-      if (!alreadySeen.has(internalDependency)) {
-        alreadySeen.add(internalDependency);
-        this.recursivelyCollectDependencies(
-            internalDependency, dependencies, missing, deepImports, alreadySeen);
-      }
-    } else if (resolvedModule instanceof ResolvedDeepImport) {
-      deepImports.add(resolvedModule.importPath);
-    } else {
-      dependencies.add(resolvedModule.entryPointPath);
-    }
-    return true;
+  protected extractImports(file: AbsoluteFsPath, fileContents: string): Set<string> {
+    const imports: string[] = [];
+    // Parse the source into a TypeScript AST and then walk it looking for imports and re-exports.
+    const sf =
+        ts.createSourceFile(file, fileContents, ts.ScriptTarget.ES2015, false, ts.ScriptKind.JS);
+    return new Set(sf.statements
+                       // filter out statements that are not imports or reexports
+                       .filter(isStringImportOrReexport)
+                       // Grab the id of the module that is being imported
+                       .map(stmt => stmt.moduleSpecifier.text));
   }
 }
 

--- a/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
@@ -93,7 +93,7 @@ export class EsmDependencyHost extends DependencyHostBase {
  * in this file, true otherwise.
  */
 export function hasImportOrReexportStatements(source: string): boolean {
-  return /(import|export)\s.+from/.test(source);
+  return /(?:import|export)[\s\S]+?(["'])((?:\\\1|.)*?)\1/.test(source);
 }
 
 

--- a/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
@@ -13,20 +13,200 @@ import {DependencyHostBase} from './dependency_host';
  * Helper functions for computing dependencies.
  */
 export class EsmDependencyHost extends DependencyHostBase {
+  // By skipping trivia here we don't have to account for it in the processing below
+  // It has no relevance to capturing imports.
+  private scanner = ts.createScanner(ts.ScriptTarget.Latest, /* skipTrivia */ true);
+
   protected canSkipFile(fileContents: string): boolean {
     return !hasImportOrReexportStatements(fileContents);
   }
 
   protected extractImports(file: AbsoluteFsPath, fileContents: string): Set<string> {
-    const imports: string[] = [];
-    // Parse the source into a TypeScript AST and then walk it looking for imports and re-exports.
-    const sf =
-        ts.createSourceFile(file, fileContents, ts.ScriptTarget.ES2015, false, ts.ScriptKind.JS);
-    return new Set(sf.statements
-                       // filter out statements that are not imports or reexports
-                       .filter(isStringImportOrReexport)
-                       // Grab the id of the module that is being imported
-                       .map(stmt => stmt.moduleSpecifier.text));
+    const imports = new Set<string>();
+    const templateStack: ts.SyntaxKind[] = [];
+    let lastToken: ts.SyntaxKind = ts.SyntaxKind.Unknown;
+    let currentToken: ts.SyntaxKind = ts.SyntaxKind.Unknown;
+
+    this.scanner.setText(fileContents);
+
+    while ((currentToken = this.scanner.scan()) !== ts.SyntaxKind.EndOfFileToken) {
+      switch (currentToken) {
+        case ts.SyntaxKind.TemplateHead:
+          templateStack.push(currentToken);
+          break;
+        case ts.SyntaxKind.OpenBraceToken:
+          if (templateStack.length > 0) {
+            templateStack.push(currentToken);
+          }
+          break;
+        case ts.SyntaxKind.CloseBraceToken:
+          if (templateStack.length > 0) {
+            const templateToken = templateStack[templateStack.length - 1];
+            if (templateToken === ts.SyntaxKind.TemplateHead) {
+              currentToken = this.scanner.reScanTemplateToken(/* isTaggedTemplate */ false);
+              if (currentToken === ts.SyntaxKind.TemplateTail) {
+                templateStack.pop();
+              }
+            } else {
+              templateStack.pop();
+            }
+          }
+          break;
+        case ts.SyntaxKind.SlashToken:
+        case ts.SyntaxKind.SlashEqualsToken:
+          if (canPrecedeARegex(lastToken)) {
+            currentToken = this.scanner.reScanSlashToken();
+          }
+          break;
+        case ts.SyntaxKind.ImportKeyword:
+          const importPath = this.extractImportPath();
+          if (importPath !== null) {
+            imports.add(importPath);
+          }
+          break;
+        case ts.SyntaxKind.ExportKeyword:
+          const reexportPath = this.extractReexportPath();
+          if (reexportPath !== null) {
+            imports.add(reexportPath);
+          }
+          break;
+      }
+      lastToken = currentToken;
+    }
+    return imports;
+  }
+
+
+  /**
+   * We have found an `import` token so now try to identify the import path.
+   *
+   * This method will use the current state of `this.scanner` to extract a string literal module
+   * specifier. It expects that the current state of the scanner is that an `import` token has just
+   * been scanned.
+   *
+   * The following forms of import are matched:
+   *
+   * * `import "module-specifier";`
+   * * `import("module-specifier")`
+   * * `import defaultBinding from "module-specifier";`
+   * * `import defaultBinding, * as identifier from "module-specifier";`
+   * * `import defaultBinding, {...} from "module-specifier";`
+   * * `import * as identifier from "module-specifier";`
+   * * `import {...} from "module-specifier";`
+   *
+   * @returns the import path or null if there is no import or it is not a string literal.
+   */
+  protected extractImportPath(): string|null {
+    // Check for side-effect import
+    let sideEffectImportPath = this.tryStringLiteral();
+    if (sideEffectImportPath !== null) {
+      return sideEffectImportPath;
+    }
+
+    let kind: ts.SyntaxKind|null = this.scanner.getToken();
+
+    // Check for dynamic import expression
+    if (kind === ts.SyntaxKind.OpenParenToken) {
+      return this.tryStringLiteral();
+    }
+
+    // Check for defaultBinding
+    if (kind === ts.SyntaxKind.Identifier) {
+      // Skip default binding
+      kind = this.scanner.scan();
+      if (kind === ts.SyntaxKind.CommaToken) {
+        // Skip comma that indicates additional import bindings
+        kind = this.scanner.scan();
+      }
+    }
+
+    // Check for namespace import clause
+    if (kind === ts.SyntaxKind.AsteriskToken) {
+      kind = this.skipStarClause();
+      if (kind === null) {
+        return null;
+      }
+    }
+    // Check for named imports clause
+    else if (kind === ts.SyntaxKind.OpenBraceToken) {
+      kind = this.skipExplicitClause();
+    }
+
+    // Expect a `from` clause, if not bail out
+    if (kind !== ts.SyntaxKind.FromKeyword) {
+      return null;
+    }
+
+    return this.tryStringLiteral();
+  }
+
+  /**
+   * We have found an `export` token so now try to identify a re-export path.
+   *
+   * This method will use the current state of `this.scanner` to extract a string literal module
+   * specifier. It expects that the current state of the scanner is that an `export` token has
+   * just been scanned.
+   *
+   * There are three forms of re-export that are matched:
+   *
+   * * `export * from '...';
+   * * `export * as alias from '...';
+   * * `export {...} from '...';
+   */
+  protected extractReexportPath(): string|null {
+    // Skip the `export` keyword
+    let token: ts.SyntaxKind|null = this.scanner.scan();
+    if (token === ts.SyntaxKind.AsteriskToken) {
+      token = this.skipStarClause();
+      if (token === null) {
+        return null;
+      }
+    } else if (token === ts.SyntaxKind.OpenBraceToken) {
+      token = this.skipExplicitClause();
+    }
+    // Expect a `from` clause, if not bail out
+    if (token !== ts.SyntaxKind.FromKeyword) {
+      return null;
+    }
+    return this.tryStringLiteral();
+  }
+
+  protected skipStarClause(): ts.SyntaxKind|null {
+    // Skip past the `*`
+    let token = this.scanner.scan();
+    // Check for a `* as identifier` alias clause
+    if (token === ts.SyntaxKind.AsKeyword) {
+      // Skip past the `as` keyword
+      token = this.scanner.scan();
+      // Expect an identifier, if not bail out
+      if (token !== ts.SyntaxKind.Identifier) {
+        return null;
+      }
+      // Skip past the identifier
+      token = this.scanner.scan();
+    }
+    return token;
+  }
+
+  protected skipExplicitClause(): ts.SyntaxKind {
+    let braceCount = 1;
+    // Skip past the initial opening brace `{`
+    let token = this.scanner.scan();
+    // Search for the matching closing brace `}`
+    while (braceCount > 0 && token !== ts.SyntaxKind.EndOfFileToken) {
+      if (token === ts.SyntaxKind.OpenBraceToken) {
+        braceCount++;
+      } else if (token === ts.SyntaxKind.CloseBraceToken) {
+        braceCount--;
+      }
+      token = this.scanner.scan();
+    }
+    return token;
+  }
+
+  protected tryStringLiteral(): string|null {
+    return this.scanner.scan() === ts.SyntaxKind.StringLiteral ? this.scanner.getTokenValue() :
+                                                                 null;
   }
 }
 
@@ -55,4 +235,26 @@ export function isStringImportOrReexport(stmt: ts.Statement): stmt is ts.ImportD
   return ts.isImportDeclaration(stmt) ||
       ts.isExportDeclaration(stmt) && !!stmt.moduleSpecifier &&
       ts.isStringLiteral(stmt.moduleSpecifier);
+}
+
+
+function canPrecedeARegex(kind: ts.SyntaxKind): boolean {
+  switch (kind) {
+    case ts.SyntaxKind.Identifier:
+    case ts.SyntaxKind.StringLiteral:
+    case ts.SyntaxKind.NumericLiteral:
+    case ts.SyntaxKind.BigIntLiteral:
+    case ts.SyntaxKind.RegularExpressionLiteral:
+    case ts.SyntaxKind.ThisKeyword:
+    case ts.SyntaxKind.PlusPlusToken:
+    case ts.SyntaxKind.MinusMinusToken:
+    case ts.SyntaxKind.CloseParenToken:
+    case ts.SyntaxKind.CloseBracketToken:
+    case ts.SyntaxKind.CloseBraceToken:
+    case ts.SyntaxKind.TrueKeyword:
+    case ts.SyntaxKind.FalseKeyword:
+      return false;
+    default:
+      return true;
+  }
 }

--- a/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
@@ -122,14 +122,14 @@ export class EsmDependencyHost extends DependencyHostBase {
 
     // Check for namespace import clause
     if (kind === ts.SyntaxKind.AsteriskToken) {
-      kind = this.skipStarClause();
+      kind = this.skipNamespacedClause();
       if (kind === null) {
         return null;
       }
     }
     // Check for named imports clause
     else if (kind === ts.SyntaxKind.OpenBraceToken) {
-      kind = this.skipExplicitClause();
+      kind = this.skipNamedClause();
     }
 
     // Expect a `from` clause, if not bail out
@@ -157,12 +157,12 @@ export class EsmDependencyHost extends DependencyHostBase {
     // Skip the `export` keyword
     let token: ts.SyntaxKind|null = this.scanner.scan();
     if (token === ts.SyntaxKind.AsteriskToken) {
-      token = this.skipStarClause();
+      token = this.skipNamespacedClause();
       if (token === null) {
         return null;
       }
     } else if (token === ts.SyntaxKind.OpenBraceToken) {
-      token = this.skipExplicitClause();
+      token = this.skipNamedClause();
     }
     // Expect a `from` clause, if not bail out
     if (token !== ts.SyntaxKind.FromKeyword) {
@@ -171,7 +171,7 @@ export class EsmDependencyHost extends DependencyHostBase {
     return this.tryStringLiteral();
   }
 
-  protected skipStarClause(): ts.SyntaxKind|null {
+  protected skipNamespacedClause(): ts.SyntaxKind|null {
     // Skip past the `*`
     let token = this.scanner.scan();
     // Check for a `* as identifier` alias clause
@@ -188,7 +188,7 @@ export class EsmDependencyHost extends DependencyHostBase {
     return token;
   }
 
-  protected skipExplicitClause(): ts.SyntaxKind {
+  protected skipNamedClause(): ts.SyntaxKind {
     let braceCount = 1;
     // Skip past the initial opening brace `{`
     let token = this.scanner.scan();

--- a/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
@@ -93,7 +93,7 @@ export class EsmDependencyHost extends DependencyHostBase {
  * in this file, true otherwise.
  */
 export function hasImportOrReexportStatements(source: string): boolean {
-  return /(?:import|export)[\s\S]+?(["'])((?:\\\1|.)*?)\1/.test(source);
+  return /(?:import|export)[\s\S]+?(["'])(?:(?:\\\1|.)*?)\1/.test(source);
 }
 
 

--- a/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
@@ -73,6 +73,10 @@ export class EsmDependencyHost extends DependencyHostBase {
       }
       lastToken = currentToken;
     }
+
+    // Clear the text from the scanner.
+    this.scanner.setText('');
+
     return imports;
   }
 

--- a/packages/compiler-cli/ngcc/src/dependencies/umd_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/umd_dependency_host.ts
@@ -6,85 +6,36 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
+
 import {AbsoluteFsPath} from '../../../src/ngtsc/file_system';
 import {getImportsOfUmdModule, parseStatementForUmdModule} from '../host/umd_host';
+
+import {hasRequireCalls} from './commonjs_dependency_host';
 import {DependencyHostBase} from './dependency_host';
-import {ResolvedDeepImport, ResolvedRelativeModule} from './module_resolver';
 
 /**
  * Helper functions for computing dependencies.
  */
 export class UmdDependencyHost extends DependencyHostBase {
-  /**
-   * Compute the dependencies of the given file.
-   *
-   * @param file An absolute path to the file whose dependencies we want to get.
-   * @param dependencies A set that will have the absolute paths of resolved entry points added to
-   * it.
-   * @param missing A set that will have the dependencies that could not be found added to it.
-   * @param deepImports A set that will have the import paths that exist but cannot be mapped to
-   * entry-points, i.e. deep-imports.
-   * @param alreadySeen A set that is used to track internal dependencies to prevent getting stuck
-   * in a circular dependency loop.
-   */
-  protected recursivelyCollectDependencies(
-      file: AbsoluteFsPath, dependencies: Set<AbsoluteFsPath>, missing: Set<string>,
-      deepImports: Set<string>, alreadySeen: Set<AbsoluteFsPath>): void {
-    const fromContents = this.fs.readFile(file);
+  protected canSkipFile(fileContents: string): boolean {
+    return !hasRequireCalls(fileContents);
+  }
 
-    if (!this.hasRequireCalls(fromContents)) {
-      // Avoid parsing the source file as there are no imports.
-      return;
-    }
-
+  protected extractImports(file: AbsoluteFsPath, fileContents: string): Set<string> {
     // Parse the source into a TypeScript AST and then walk it looking for imports and re-exports.
     const sf =
-        ts.createSourceFile(file, fromContents, ts.ScriptTarget.ES2015, false, ts.ScriptKind.JS);
+        ts.createSourceFile(file, fileContents, ts.ScriptTarget.ES2015, false, ts.ScriptKind.JS);
 
     if (sf.statements.length !== 1) {
-      return;
+      return new Set();
     }
 
     const umdModule = parseStatementForUmdModule(sf.statements[0]);
     const umdImports = umdModule && getImportsOfUmdModule(umdModule);
     if (umdImports === null) {
-      return;
+      return new Set();
     }
 
-    umdImports.forEach(umdImport => {
-      const resolvedModule = this.moduleResolver.resolveModuleImport(umdImport.path, file);
-      if (resolvedModule) {
-        if (resolvedModule instanceof ResolvedRelativeModule) {
-          const internalDependency = resolvedModule.modulePath;
-          if (!alreadySeen.has(internalDependency)) {
-            alreadySeen.add(internalDependency);
-            this.recursivelyCollectDependencies(
-                internalDependency, dependencies, missing, deepImports, alreadySeen);
-          }
-        } else {
-          if (resolvedModule instanceof ResolvedDeepImport) {
-            deepImports.add(resolvedModule.importPath);
-          } else {
-            dependencies.add(resolvedModule.entryPointPath);
-          }
-        }
-      } else {
-        missing.add(umdImport.path);
-      }
-    });
-  }
-
-  /**
-   * Check whether a source file needs to be parsed for imports.
-   * This is a performance short-circuit, which saves us from creating
-   * a TypeScript AST unnecessarily.
-   *
-   * @param source The content of the source file to check.
-   *
-   * @returns false if there are definitely no require calls
-   * in this file, true otherwise.
-   */
-  private hasRequireCalls(source: string): boolean {
-    return /require\(['"]/.test(source);
+    return new Set(umdImports.map(i => i.path));
   }
 }

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/program_based_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/program_based_entry_point_finder.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
+import {ParsedConfiguration} from '../../../src/perform_compile';
+
+import {createDependencyInfo} from '../dependencies/dependency_host';
+import {DependencyResolver} from '../dependencies/dependency_resolver';
+import {EsmDependencyHost} from '../dependencies/esm_dependency_host';
+import {ModuleResolver} from '../dependencies/module_resolver';
+import {Logger} from '../logging/logger';
+import {NgccConfiguration} from '../packages/configuration';
+import {getPathMappingsFromTsConfig} from '../path_mappings';
+
+import {TracingEntryPointFinder} from './tracing_entry_point_finder';
+
+/**
+ * An EntryPointFinder that starts from the files in the program defined by the given tsconfig.json
+ * and only returns entry-points that are dependencies of these files.
+ *
+ * This is faster than searching the entire file-system for all the entry-points,
+ * and is used primarily by the CLI integration.
+ */
+export class ProgramBasedEntryPointFinder extends TracingEntryPointFinder {
+  constructor(
+      fs: FileSystem, config: NgccConfiguration, logger: Logger, resolver: DependencyResolver,
+      basePath: AbsoluteFsPath, private tsConfig: ParsedConfiguration,
+      projectPath: AbsoluteFsPath) {
+    super(
+        fs, config, logger, resolver, basePath, getPathMappingsFromTsConfig(tsConfig, projectPath));
+  }
+
+  protected getInitialEntryPointPaths(): AbsoluteFsPath[] {
+    const moduleResolver = new ModuleResolver(this.fs, this.pathMappings, ['', '.ts', '/index.ts']);
+    const host = new EsmDependencyHost(this.fs, moduleResolver);
+    const dependencies = createDependencyInfo();
+    this.logger.debug(
+        `Using the program from ${this.tsConfig.project} to seed the entry-point finding.`);
+    this.logger.debug(
+        `Collecting dependencies from the following files:` +
+        this.tsConfig.rootNames.map(file => `\n- ${file}`));
+    this.tsConfig.rootNames.forEach(rootName => {
+      host.collectDependencies(this.fs.resolve(rootName), dependencies);
+    });
+    return Array.from(dependencies.dependencies);
+  }
+}

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/targeted_entry_point_finder.ts
@@ -15,6 +15,7 @@ import {EntryPoint, EntryPointJsonProperty, getEntryPointInfo, INCOMPATIBLE_ENTR
 import {PathMappings} from '../path_mappings';
 
 import {EntryPointFinder} from './interface';
+import {TracingEntryPointFinder} from './tracing_entry_point_finder';
 import {getBasePaths} from './utils';
 
 /**
@@ -24,30 +25,16 @@ import {getBasePaths} from './utils';
  * This is faster than searching the entire file-system for all the entry-points,
  * and is used primarily by the CLI integration.
  */
-export class TargetedEntryPointFinder implements EntryPointFinder {
-  private unprocessedPaths: AbsoluteFsPath[] = [];
-  private unsortedEntryPoints = new Map<AbsoluteFsPath, EntryPointWithDependencies>();
-  private basePaths: AbsoluteFsPath[]|null = null;
-  private getBasePaths() {
-    if (this.basePaths === null) {
-      this.basePaths = getBasePaths(this.logger, this.basePath, this.pathMappings);
-    }
-    return this.basePaths;
+export class TargetedEntryPointFinder extends TracingEntryPointFinder {
+  constructor(
+      fs: FileSystem, config: NgccConfiguration, logger: Logger, resolver: DependencyResolver,
+      basePath: AbsoluteFsPath, pathMappings: PathMappings|undefined,
+      private targetPath: AbsoluteFsPath) {
+    super(fs, config, logger, resolver, basePath, pathMappings);
   }
 
-  constructor(
-      private fs: FileSystem, private config: NgccConfiguration, private logger: Logger,
-      private resolver: DependencyResolver, private basePath: AbsoluteFsPath,
-      private targetPath: AbsoluteFsPath, private pathMappings: PathMappings|undefined) {}
-
   findEntryPoints(): SortedEntryPointsInfo {
-    this.unprocessedPaths = [this.targetPath];
-    while (this.unprocessedPaths.length > 0) {
-      this.processNextPath();
-    }
-    const targetEntryPoint = this.unsortedEntryPoints.get(this.targetPath);
-    const entryPoints = this.resolver.sortEntryPointsByDependency(
-        Array.from(this.unsortedEntryPoints.values()), targetEntryPoint?.entryPoint);
+    const entryPoints = super.findEntryPoints();
 
     const invalidTarget =
         entryPoints.invalidEntryPoints.find(i => i.entryPoint.path === this.targetPath);
@@ -83,149 +70,7 @@ export class TargetedEntryPointFinder implements EntryPointFinder {
     return false;
   }
 
-  private processNextPath(): void {
-    const path = this.unprocessedPaths.shift()!;
-    const entryPoint = this.getEntryPoint(path);
-    if (entryPoint === null || !entryPoint.compiledByAngular) {
-      return;
-    }
-    const entryPointWithDeps = this.resolver.getEntryPointWithDependencies(entryPoint);
-    this.unsortedEntryPoints.set(entryPoint.path, entryPointWithDeps);
-    entryPointWithDeps.depInfo.dependencies.forEach(dep => {
-      if (!this.unsortedEntryPoints.has(dep)) {
-        this.unprocessedPaths.push(dep);
-      }
-    });
-  }
-
-  private getEntryPoint(entryPointPath: AbsoluteFsPath): EntryPoint|null {
-    const packagePath = this.computePackagePath(entryPointPath);
-    const entryPoint =
-        getEntryPointInfo(this.fs, this.config, this.logger, packagePath, entryPointPath);
-    if (entryPoint === NO_ENTRY_POINT || entryPoint === INCOMPATIBLE_ENTRY_POINT) {
-      return null;
-    }
-    return entryPoint;
-  }
-
-  private computePackagePath(entryPointPath: AbsoluteFsPath): AbsoluteFsPath {
-    // First try the main basePath, to avoid having to compute the other basePaths from the paths
-    // mappings, which can be computationally intensive.
-    if (entryPointPath.startsWith(this.basePath)) {
-      const packagePath = this.computePackagePathFromContainingPath(entryPointPath, this.basePath);
-      if (packagePath !== null) {
-        return packagePath;
-      }
-    }
-
-    // The main `basePath` didn't work out so now we try the `basePaths` computed from the paths
-    // mappings in `tsconfig.json`.
-    for (const basePath of this.getBasePaths()) {
-      if (entryPointPath.startsWith(basePath)) {
-        const packagePath = this.computePackagePathFromContainingPath(entryPointPath, basePath);
-        if (packagePath !== null) {
-          return packagePath;
-        }
-        // If we got here then we couldn't find a `packagePath` for the current `basePath`.
-        // Since `basePath`s are guaranteed not to be a sub-directory of each other then no other
-        // `basePath` will match either.
-        break;
-      }
-    }
-
-    // Finally, if we couldn't find a `packagePath` using `basePaths` then try to find the nearest
-    // `node_modules` that contains the `entryPointPath`, if there is one, and use it as a
-    // `basePath`.
-    return this.computePackagePathFromNearestNodeModules(entryPointPath);
-  }
-
-  /**
-   * Search down to the `entryPointPath` from the `containingPath` for the first `package.json` that
-   * we come to. This is the path to the entry-point's containing package. For example if
-   * `containingPath` is `/a/b/c` and `entryPointPath` is `/a/b/c/d/e` and there exists
-   * `/a/b/c/d/package.json` and `/a/b/c/d/e/package.json`, then we will return `/a/b/c/d`.
-   *
-   * To account for nested `node_modules` we actually start the search at the last `node_modules` in
-   * the `entryPointPath` that is below the `containingPath`. E.g. if `containingPath` is `/a/b/c`
-   * and `entryPointPath` is `/a/b/c/d/node_modules/x/y/z`, we start the search at
-   * `/a/b/c/d/node_modules`.
-   */
-  private computePackagePathFromContainingPath(
-      entryPointPath: AbsoluteFsPath, containingPath: AbsoluteFsPath): AbsoluteFsPath|null {
-    let packagePath = containingPath;
-    const segments = this.splitPath(relative(containingPath, entryPointPath));
-    let nodeModulesIndex = segments.lastIndexOf(relativeFrom('node_modules'));
-
-    // If there are no `node_modules` in the relative path between the `basePath` and the
-    // `entryPointPath` then just try the `basePath` as the `packagePath`.
-    // (This can be the case with path-mapped entry-points.)
-    if (nodeModulesIndex === -1) {
-      if (this.fs.exists(join(packagePath, 'package.json'))) {
-        return packagePath;
-      }
-    }
-
-    // Start the search at the deepest nested `node_modules` folder that is below the `basePath`
-    // but above the `entryPointPath`, if there are any.
-    while (nodeModulesIndex >= 0) {
-      packagePath = join(packagePath, segments.shift()!);
-      nodeModulesIndex--;
-    }
-
-    // Note that we start at the folder below the current candidate `packagePath` because the
-    // initial candidate `packagePath` is either a `node_modules` folder or the `basePath` with
-    // no `package.json`.
-    for (const segment of segments) {
-      packagePath = join(packagePath, segment);
-      if (this.fs.exists(join(packagePath, 'package.json'))) {
-        return packagePath;
-      }
-    }
-    return null;
-  }
-
-  /**
-   * Search up the directory tree from the `entryPointPath` looking for a `node_modules` directory
-   * that we can use as a potential starting point for computing the package path.
-   */
-  private computePackagePathFromNearestNodeModules(entryPointPath: AbsoluteFsPath): AbsoluteFsPath {
-    let packagePath = entryPointPath;
-    let scopedPackagePath = packagePath;
-    let containerPath = this.fs.dirname(packagePath);
-    while (!this.fs.isRoot(containerPath) && !containerPath.endsWith('node_modules')) {
-      scopedPackagePath = packagePath;
-      packagePath = containerPath;
-      containerPath = this.fs.dirname(containerPath);
-    }
-
-    if (this.fs.exists(join(packagePath, 'package.json'))) {
-      // The directory directly below `node_modules` is a package - use it
-      return packagePath;
-    } else if (
-        this.fs.basename(packagePath).startsWith('@') &&
-        this.fs.exists(join(scopedPackagePath, 'package.json'))) {
-      // The directory directly below the `node_modules` is a scope and the directory directly
-      // below that is a scoped package - use it
-      return scopedPackagePath;
-    } else {
-      // If we get here then none of the `basePaths` contained the `entryPointPath` and the
-      // `entryPointPath` contains no `node_modules` that contains a package or a scoped
-      // package. All we can do is assume that this entry-point is a primary entry-point to a
-      // package.
-      return entryPointPath;
-    }
-  }
-
-  /**
-   * Split the given `path` into path segments using an FS independent algorithm.
-   * @param path The path to split.
-   */
-  private splitPath(path: PathSegment) {
-    const segments = [];
-    while (path !== '.') {
-      segments.unshift(this.fs.basename(path));
-      path = this.fs.dirname(path);
-    }
-    return segments;
+  protected getInitialEntryPointPaths(): AbsoluteFsPath[] {
+    return [this.targetPath];
   }
 }

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/tracing_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/tracing_entry_point_finder.ts
@@ -1,0 +1,206 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {AbsoluteFsPath, FileSystem, join, PathSegment, relative, relativeFrom} from '../../../src/ngtsc/file_system';
+
+import {EntryPointWithDependencies} from '../dependencies/dependency_host';
+import {DependencyResolver, SortedEntryPointsInfo} from '../dependencies/dependency_resolver';
+import {Logger} from '../logging/logger';
+import {NgccConfiguration} from '../packages/configuration';
+import {EntryPoint, getEntryPointInfo, INCOMPATIBLE_ENTRY_POINT, NO_ENTRY_POINT} from '../packages/entry_point';
+import {PathMappings} from '../path_mappings';
+
+import {EntryPointFinder} from './interface';
+import {getBasePaths} from './utils';
+
+/**
+ * An EntryPointFinder that starts from a set of initial files and only returns entry-points that
+ * are dependencies of these files.
+ *
+ * This is faster than searching the entire file-system for all the entry-points,
+ * and is used primarily by the CLI integration.
+ *
+ * There are two concrete implementation of this class.
+ *
+ * * `TargetEntryPointFinder` - is given a single entry-point as the initial entry-point
+ * * `ProgramBasedEntryPointFinder` - computes the initial entry-points from program files given by
+ * a `tsconfig.json` file.
+ */
+export abstract class TracingEntryPointFinder implements EntryPointFinder {
+  protected unprocessedPaths: AbsoluteFsPath[] = [];
+  protected unsortedEntryPoints = new Map<AbsoluteFsPath, EntryPointWithDependencies>();
+  private basePaths: AbsoluteFsPath[]|null = null;
+
+  constructor(
+      protected fs: FileSystem, protected config: NgccConfiguration, protected logger: Logger,
+      protected resolver: DependencyResolver, protected basePath: AbsoluteFsPath,
+      protected pathMappings: PathMappings|undefined) {}
+
+  protected getBasePaths() {
+    if (this.basePaths === null) {
+      this.basePaths = getBasePaths(this.logger, this.basePath, this.pathMappings);
+    }
+    return this.basePaths;
+  }
+
+  findEntryPoints(): SortedEntryPointsInfo {
+    this.unprocessedPaths = this.getInitialEntryPointPaths();
+    while (this.unprocessedPaths.length > 0) {
+      this.processNextPath();
+    }
+    return this.resolver.sortEntryPointsByDependency(Array.from(this.unsortedEntryPoints.values()));
+  }
+
+  protected abstract getInitialEntryPointPaths(): AbsoluteFsPath[];
+
+  protected getEntryPoint(entryPointPath: AbsoluteFsPath): EntryPoint|null {
+    const packagePath = this.computePackagePath(entryPointPath);
+    const entryPoint =
+        getEntryPointInfo(this.fs, this.config, this.logger, packagePath, entryPointPath);
+    if (entryPoint === NO_ENTRY_POINT || entryPoint === INCOMPATIBLE_ENTRY_POINT) {
+      return null;
+    }
+    return entryPoint;
+  }
+
+  private processNextPath(): void {
+    const path = this.unprocessedPaths.shift()!;
+    const entryPoint = this.getEntryPoint(path);
+    if (entryPoint === null || !entryPoint.compiledByAngular) {
+      return;
+    }
+    const entryPointWithDeps = this.resolver.getEntryPointWithDependencies(entryPoint);
+    this.unsortedEntryPoints.set(entryPoint.path, entryPointWithDeps);
+    entryPointWithDeps.depInfo.dependencies.forEach(dep => {
+      if (!this.unsortedEntryPoints.has(dep)) {
+        this.unprocessedPaths.push(dep);
+      }
+    });
+  }
+
+  private computePackagePath(entryPointPath: AbsoluteFsPath): AbsoluteFsPath {
+    // First try the main basePath, to avoid having to compute the other basePaths from the paths
+    // mappings, which can be computationally intensive.
+    if (entryPointPath.startsWith(this.basePath)) {
+      const packagePath = this.computePackagePathFromContainingPath(entryPointPath, this.basePath);
+      if (packagePath !== null) {
+        return packagePath;
+      }
+    }
+
+    // The main `basePath` didn't work out so now we try the `basePaths` computed from the paths
+    // mappings in `tsconfig.json`.
+    for (const basePath of this.getBasePaths()) {
+      if (entryPointPath.startsWith(basePath)) {
+        const packagePath = this.computePackagePathFromContainingPath(entryPointPath, basePath);
+        if (packagePath !== null) {
+          return packagePath;
+        }
+        // If we got here then we couldn't find a `packagePath` for the current `basePath`.
+        // Since `basePath`s are guaranteed not to be a sub-directory of each other then no other
+        // `basePath` will match either.
+        break;
+      }
+    }
+
+    // Finally, if we couldn't find a `packagePath` using `basePaths` then try to find the nearest
+    // `node_modules` that contains the `entryPointPath`, if there is one, and use it as a
+    // `basePath`.
+    return this.computePackagePathFromNearestNodeModules(entryPointPath);
+  }
+
+
+  /**
+   * Search down to the `entryPointPath` from the `containingPath` for the first `package.json` that
+   * we come to. This is the path to the entry-point's containing package. For example if
+   * `containingPath` is `/a/b/c` and `entryPointPath` is `/a/b/c/d/e` and there exists
+   * `/a/b/c/d/package.json` and `/a/b/c/d/e/package.json`, then we will return `/a/b/c/d`.
+   *
+   * To account for nested `node_modules` we actually start the search at the last `node_modules` in
+   * the `entryPointPath` that is below the `containingPath`. E.g. if `containingPath` is `/a/b/c`
+   * and `entryPointPath` is `/a/b/c/d/node_modules/x/y/z`, we start the search at
+   * `/a/b/c/d/node_modules`.
+   */
+  private computePackagePathFromContainingPath(
+      entryPointPath: AbsoluteFsPath, containingPath: AbsoluteFsPath): AbsoluteFsPath|null {
+    let packagePath = containingPath;
+    const segments = this.splitPath(relative(containingPath, entryPointPath));
+    let nodeModulesIndex = segments.lastIndexOf(relativeFrom('node_modules'));
+
+    // If there are no `node_modules` in the relative path between the `basePath` and the
+    // `entryPointPath` then just try the `basePath` as the `packagePath`.
+    // (This can be the case with path-mapped entry-points.)
+    if (nodeModulesIndex === -1) {
+      if (this.fs.exists(join(packagePath, 'package.json'))) {
+        return packagePath;
+      }
+    }
+
+    // Start the search at the deepest nested `node_modules` folder that is below the `basePath`
+    // but above the `entryPointPath`, if there are any.
+    while (nodeModulesIndex >= 0) {
+      packagePath = join(packagePath, segments.shift()!);
+      nodeModulesIndex--;
+    }
+
+    // Note that we start at the folder below the current candidate `packagePath` because the
+    // initial candidate `packagePath` is either a `node_modules` folder or the `basePath` with
+    // no `package.json`.
+    for (const segment of segments) {
+      packagePath = join(packagePath, segment);
+      if (this.fs.exists(join(packagePath, 'package.json'))) {
+        return packagePath;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Search up the directory tree from the `entryPointPath` looking for a `node_modules` directory
+   * that we can use as a potential starting point for computing the package path.
+   */
+  private computePackagePathFromNearestNodeModules(entryPointPath: AbsoluteFsPath): AbsoluteFsPath {
+    let packagePath = entryPointPath;
+    let scopedPackagePath = packagePath;
+    let containerPath = this.fs.dirname(packagePath);
+    while (!this.fs.isRoot(containerPath) && !containerPath.endsWith('node_modules')) {
+      scopedPackagePath = packagePath;
+      packagePath = containerPath;
+      containerPath = this.fs.dirname(containerPath);
+    }
+
+    if (this.fs.exists(join(packagePath, 'package.json'))) {
+      // The directory directly below `node_modules` is a package - use it
+      return packagePath;
+    } else if (
+        this.fs.basename(packagePath).startsWith('@') &&
+        this.fs.exists(join(scopedPackagePath, 'package.json'))) {
+      // The directory directly below the `node_modules` is a scope and the directory directly
+      // below that is a scoped package - use it
+      return scopedPackagePath;
+    } else {
+      // If we get here then none of the `basePaths` contained the `entryPointPath` and the
+      // `entryPointPath` contains no `node_modules` that contains a package or a scoped
+      // package. All we can do is assume that this entry-point is a primary entry-point to a
+      // package.
+      return entryPointPath;
+    }
+  }
+
+  /**
+   * Split the given `path` into path segments using an FS independent algorithm.
+   * @param path The path to split.
+   */
+  private splitPath(path: PathSegment) {
+    const segments = [];
+    while (path !== '.') {
+      segments.unshift(this.fs.basename(path));
+      path = this.fs.dirname(path);
+    }
+    return segments;
+  }
+}

--- a/packages/compiler-cli/ngcc/src/ngcc_options.ts
+++ b/packages/compiler-cli/ngcc/src/ngcc_options.ts
@@ -124,6 +124,14 @@ export interface SyncNgccOptions {
    * If `null`, ngcc will not attempt to load any TS config file at all.
    */
   tsConfigPath?: string|null;
+
+  /**
+   * Use the program defined in the loaded tsconfig.json (if available - see
+   * `tsConfigPath` option) to identify the entry-points that should be processed.
+   * If this is set to `true` then only the entry-points reachable from the given
+   * program (and their dependencies) will be processed.
+   */
+  findEntryPointsFromTsConfigProgram?: boolean;
 }
 
 /**
@@ -136,7 +144,8 @@ export type AsyncNgccOptions = Omit<SyncNgccOptions, 'async'>&{async: true};
  */
 export type NgccOptions = AsyncNgccOptions|SyncNgccOptions;
 
-export type OptionalNgccOptionKeys = 'targetEntryPointPath'|'tsConfigPath'|'pathMappings';
+export type OptionalNgccOptionKeys =
+    'targetEntryPointPath'|'tsConfigPath'|'pathMappings'|'findEntryPointsFromTsConfigProgram';
 export type RequiredNgccOptions = Required<Omit<NgccOptions, OptionalNgccOptionKeys>>;
 export type OptionalNgccOptions = Pick<NgccOptions, OptionalNgccOptionKeys>;
 export type SharedSetup = {

--- a/packages/compiler-cli/ngcc/test/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/test/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
     ),
     deps = [
         "//packages/compiler",
+        "//packages/compiler-cli",
         "//packages/compiler-cli/ngcc",
         "//packages/compiler-cli/ngcc/test/helpers",
         "//packages/compiler-cli/src/ngtsc/diagnostics",

--- a/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
@@ -27,12 +27,12 @@ runInEachFileSystem(() => {
     });
 
     describe('collectDependencies()', () => {
-      it('should not generate a TS AST if the source does not contain any imports or re-exports',
+      it('should not try to extract import paths if the source does not contain any imports or re-exports',
          () => {
-           spyOn(ts, 'createSourceFile');
+           const extractImportsSpy = spyOn(host as any, 'extractImports');
            host.collectDependencies(
                _('/no/imports/or/re-exports/index.js'), createDependencyInfo());
-           expect(ts.createSourceFile).not.toHaveBeenCalled();
+           expect(extractImportsSpy).not.toHaveBeenCalled();
          });
 
       it('should resolve all the external imports of the source file', () => {

--- a/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
@@ -57,6 +57,17 @@ runInEachFileSystem(() => {
         expect(dependencies.has(_('/node_modules/lib-1/sub-1'))).toBe(true);
       });
 
+      it('should resolve all the external dynamic imports of the source file', () => {
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.collectDependencies(
+            _('/external/dynamic/index.js'), {dependencies, missing, deepImports});
+        expect(dependencies.size).toBe(2);
+        expect(missing.size).toBe(0);
+        expect(deepImports.size).toBe(0);
+        expect(dependencies.has(_('/node_modules/lib-1'))).toBe(true);
+        expect(dependencies.has(_('/node_modules/lib-1/sub-1'))).toBe(true);
+      });
+
       it('should capture missing external imports', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
         host.collectDependencies(
@@ -184,6 +195,13 @@ runInEachFileSystem(() => {
         },
         {name: _('/external/imports/package.json'), contents: '{"esm2015": "./index.js"}'},
         {name: _('/external/imports/index.metadata.json'), contents: 'MOCK METADATA'},
+        {
+          name: _('/external/dynamic/index.js'),
+          contents:
+              `async function foo() { await const x = import('lib-1');\n const promise = import('lib-1/sub-1'); }`
+        },
+        {name: _('/external/dynamic/package.json'), contents: '{"esm2015": "./index.js"}'},
+        {name: _('/external/dynamic/index.metadata.json'), contents: 'MOCK METADATA'},
         {
           name: _('/external/re-exports/index.js'),
           contents: `export {X} from 'lib-1';\nexport {\n   Y,\n   Z\n} from 'lib-1/sub-1';`

--- a/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
@@ -46,6 +46,17 @@ runInEachFileSystem(() => {
         expect(dependencies.has(_('/node_modules/lib-1/sub-1'))).toBe(true);
       });
 
+      it('should resolve all the external dynamic imports of the source file', () => {
+        const {dependencies, missing, deepImports} = createDependencyInfo();
+        host.collectDependencies(
+            _('/external/dynamic/index.js'), {dependencies, missing, deepImports});
+        expect(dependencies.size).toBe(2);
+        expect(missing.size).toBe(0);
+        expect(deepImports.size).toBe(0);
+        expect(dependencies.has(_('/node_modules/lib-1'))).toBe(true);
+        expect(dependencies.has(_('/node_modules/lib-1/sub-1'))).toBe(true);
+      });
+
       it('should resolve all the external re-exports of the source file', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
         host.collectDependencies(
@@ -180,13 +191,20 @@ runInEachFileSystem(() => {
         {name: _('/no/imports/or/re-exports/index.metadata.json'), contents: 'MOCK METADATA'},
         {
           name: _('/external/imports/index.js'),
-          contents: `import {X} from 'lib-1';\nimport {Y} from 'lib-1/sub-1';`
+          contents: `import {\n   X\n} from 'lib-1';\nimport {Y, Z} from 'lib-1/sub-1';`
         },
         {name: _('/external/imports/package.json'), contents: '{"esm2015": "./index.js"}'},
         {name: _('/external/imports/index.metadata.json'), contents: 'MOCK METADATA'},
         {
+          name: _('/external/dynamic/index.js'),
+          contents:
+              `async function foo() { await const x = import 'lib-1';\n const promise = import 'lib-1/sub-1'; }`
+        },
+        {name: _('/external/dynamic/package.json'), contents: '{"esm2015": "./index.js"}'},
+        {name: _('/external/dynamic/index.metadata.json'), contents: 'MOCK METADATA'},
+        {
           name: _('/external/re-exports/index.js'),
-          contents: `export {X} from 'lib-1';\nexport {Y} from 'lib-1/sub-1';`
+          contents: `export {X} from 'lib-1';\nexport {\n   Y,\n   Z\n} from 'lib-1/sub-1';`
         },
         {name: _('/external/re-exports/package.json'), contents: '{"esm2015": "./index.js"}'},
         {name: _('/external/re-exports/index.metadata.json'), contents: 'MOCK METADATA'},
@@ -288,20 +306,44 @@ runInEachFileSystem(() => {
     describe('hasImportOrReexportStatements', () => {
       it('should return true if there is an import statement', () => {
         expect(hasImportOrReexportStatements('import {X} from "some/x";')).toBe(true);
+        expect(hasImportOrReexportStatements('import {X} from \'some/x\';')).toBe(true);
         expect(hasImportOrReexportStatements('import * as X from "some/x";')).toBe(true);
+        expect(hasImportOrReexportStatements('import * as X from \'some/x\';')).toBe(true);
         expect(hasImportOrReexportStatements('blah blah\n\n  import {X} from "some/x";\nblah blah'))
             .toBe(true);
+        expect(
+            hasImportOrReexportStatements('blah blah\n\n  import {X} from \'some/x\';\nblah blah'))
+            .toBe(true);
         expect(hasImportOrReexportStatements('\t\timport {X} from "some/x";')).toBe(true);
+        expect(hasImportOrReexportStatements('\t\timport {X} from \'some/x\';')).toBe(true);
+        expect(hasImportOrReexportStatements('\t\timport {\n  X,\n  Y\n} from "some/x";'))
+            .toBe(true);
+        expect(hasImportOrReexportStatements('\t\timport {\n  X,\n  Y\n} from \'some/x\';'))
+            .toBe(true);
+        expect(hasImportOrReexportStatements('\t\timport "some/x";')).toBe(true);
+        expect(hasImportOrReexportStatements('\t\timport \'some/x\';')).toBe(true);
       });
+
       it('should return true if there is a re-export statement', () => {
         expect(hasImportOrReexportStatements('export {X} from "some/x";')).toBe(true);
+        expect(hasImportOrReexportStatements('export {X} from \'some/x\';')).toBe(true);
         expect(hasImportOrReexportStatements('blah blah\n\n  export {X} from "some/x";\nblah blah'))
             .toBe(true);
+        expect(
+            hasImportOrReexportStatements('blah blah\n\n  export {X} from \'some/x\';\nblah blah'))
+            .toBe(true);
         expect(hasImportOrReexportStatements('\t\texport {X} from "some/x";')).toBe(true);
+        expect(hasImportOrReexportStatements('\t\texport {X} from \'some/x\';')).toBe(true);
+        expect(hasImportOrReexportStatements('export {\n  X,\n  Y\n} from "some/x";')).toBe(true);
+        expect(hasImportOrReexportStatements('export {\n  X,\n  Y\n} from \'some/x\';')).toBe(true);
         expect(hasImportOrReexportStatements(
-                   'blah blah\n\n  export * from "@angular/core;\nblah blah'))
+                   'blah blah\n\n  export * from "@angular/core";\nblah blah'))
+            .toBe(true);
+        expect(hasImportOrReexportStatements(
+                   'blah blah\n\n  export * from \'@angular/core\';\nblah blah'))
             .toBe(true);
       });
+
       it('should return false if there is no import nor re-export statement', () => {
         expect(hasImportOrReexportStatements('blah blah')).toBe(false);
         expect(hasImportOrReexportStatements('export function moo() {}')).toBe(false);

--- a/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/esm_dependency_host_spec.ts
@@ -46,17 +46,6 @@ runInEachFileSystem(() => {
         expect(dependencies.has(_('/node_modules/lib-1/sub-1'))).toBe(true);
       });
 
-      it('should resolve all the external dynamic imports of the source file', () => {
-        const {dependencies, missing, deepImports} = createDependencyInfo();
-        host.collectDependencies(
-            _('/external/dynamic/index.js'), {dependencies, missing, deepImports});
-        expect(dependencies.size).toBe(2);
-        expect(missing.size).toBe(0);
-        expect(deepImports.size).toBe(0);
-        expect(dependencies.has(_('/node_modules/lib-1'))).toBe(true);
-        expect(dependencies.has(_('/node_modules/lib-1/sub-1'))).toBe(true);
-      });
-
       it('should resolve all the external re-exports of the source file', () => {
         const {dependencies, missing, deepImports} = createDependencyInfo();
         host.collectDependencies(
@@ -195,13 +184,6 @@ runInEachFileSystem(() => {
         },
         {name: _('/external/imports/package.json'), contents: '{"esm2015": "./index.js"}'},
         {name: _('/external/imports/index.metadata.json'), contents: 'MOCK METADATA'},
-        {
-          name: _('/external/dynamic/index.js'),
-          contents:
-              `async function foo() { await const x = import 'lib-1';\n const promise = import 'lib-1/sub-1'; }`
-        },
-        {name: _('/external/dynamic/package.json'), contents: '{"esm2015": "./index.js"}'},
-        {name: _('/external/dynamic/index.metadata.json'), contents: 'MOCK METADATA'},
         {
           name: _('/external/re-exports/index.js'),
           contents: `export {X} from 'lib-1';\nexport {\n   Y,\n   Z\n} from 'lib-1/sub-1';`

--- a/packages/compiler-cli/ngcc/test/dependencies/module_resolver_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/module_resolver_spec.ts
@@ -257,6 +257,16 @@ runInEachFileSystem(() => {
                  .toEqual(new ResolvedExternalModule(_('/dist/package-4/secondary-entry-point')));
            });
       });
+
+      describe('with mapped path relative paths', () => {
+        it('should resolve to a relative file if found via a paths mapping', () => {
+          const resolver = new ModuleResolver(
+              getFileSystem(), {baseUrl: '/', paths: {'mapped/*': ['libs/local-package/*']}});
+
+          expect(resolver.resolveModuleImport('mapped/x', _('/libs/local-package/index.js')))
+              .toEqual(new ResolvedRelativeModule(_('/libs/local-package/x.js')));
+        });
+      });
     });
   });
 });

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/program_based_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/program_based_entry_point_finder_spec.ts
@@ -1,0 +1,147 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, relative} from '../../../src/ngtsc/file_system';
+import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
+import {readConfiguration} from '../../../src/perform_compile';
+import {loadTestFiles} from '../../../test/helpers';
+import {DependencyResolver} from '../../src/dependencies/dependency_resolver';
+import {DtsDependencyHost} from '../../src/dependencies/dts_dependency_host';
+import {EsmDependencyHost} from '../../src/dependencies/esm_dependency_host';
+import {ModuleResolver} from '../../src/dependencies/module_resolver';
+import {ProgramBasedEntryPointFinder} from '../../src/entry_point_finder/program_based_entry_point_finder';
+import {NgccConfiguration} from '../../src/packages/configuration';
+import {EntryPoint} from '../../src/packages/entry_point';
+import {EntryPointManifest} from '../../src/packages/entry_point_manifest';
+import {MockLogger} from '../helpers/mock_logger';
+
+runInEachFileSystem(() => {
+  describe('ProgramBasedEntryPointFinder', () => {
+    let fs: FileSystem;
+    let resolver: DependencyResolver;
+    let logger: MockLogger;
+    let config: NgccConfiguration;
+    let manifest: EntryPointManifest;
+    let _Abs: typeof absoluteFrom;
+    let projectPath: AbsoluteFsPath;
+    let basePath: AbsoluteFsPath;
+    let angularNamespacePath: AbsoluteFsPath;
+
+    beforeEach(() => {
+      fs = getFileSystem();
+      _Abs = absoluteFrom;
+      projectPath = _Abs('/sub_entry_points');
+      basePath = _Abs('/sub_entry_points/node_modules');
+      angularNamespacePath = fs.resolve(basePath, '@angular');
+
+      logger = new MockLogger();
+      const srcHost = new EsmDependencyHost(fs, new ModuleResolver(fs));
+      const dtsHost = new DtsDependencyHost(fs);
+      config = new NgccConfiguration(fs, projectPath);
+      resolver = new DependencyResolver(fs, logger, config, {esm2015: srcHost}, dtsHost);
+      manifest = new EntryPointManifest(fs, config, logger);
+    });
+
+    describe('findEntryPoints()', () => {
+      it('should find entry-points imported into the program', () => {
+        loadTestFiles([
+          ...createProgram(projectPath),
+          ...createPackage(angularNamespacePath, 'core'),
+          ...createPackage(angularNamespacePath, 'common'),
+          ...createPackage(fs.resolve(angularNamespacePath, 'common'), 'http', ['@angular/common']),
+          ...createPackage(
+              fs.resolve(angularNamespacePath, 'common/http'), 'testing',
+              ['common/http', 'common/testing']),
+          ...createPackage(
+              fs.resolve(angularNamespacePath, 'common'), 'testing', ['@angular/common']),
+        ]);
+        const tsConfig = readConfiguration(`${projectPath}/tsconfig.json`);
+        const finder = new ProgramBasedEntryPointFinder(
+            fs, config, logger, resolver, basePath, tsConfig, projectPath);
+        const {entryPoints} = finder.findEntryPoints();
+        expect(dumpEntryPointPaths(basePath, entryPoints)).toEqual([
+          ['@angular/core', '@angular/core'],
+          ['@angular/common', '@angular/common'],
+          ['@angular/common', '@angular/common/http'],
+        ]);
+      });
+
+      function createProgram(projectPath: AbsoluteFsPath): TestFile[] {
+        return [
+          {
+            name: _Abs(`${projectPath}/tsconfig.json`),
+            contents: `{
+              "files": [
+                "src/main.ts"
+              ],
+            }`,
+          },
+          {
+            name: _Abs(`${projectPath}/src/main.ts`),
+            contents: `
+            import {AppComponent} from './app.component';
+            import * from './app.module';
+            `,
+          },
+          {
+            name: _Abs(`${projectPath}/src/app.component.ts`),
+            contents: `
+            import * as core from '@angular/core';
+            export class AppComponent {}
+            `,
+          },
+          {
+            name: _Abs(`${projectPath}/src/app.module.ts`),
+            contents: `
+            import {NgModule} from '@angular/core';
+            import * as common from '@angular/common';
+            import * as http from '@angular/common/http';
+            import {AppComponent} from './app.component';
+            export class AppModule {}
+            `,
+          }
+        ];
+      }
+
+      function createPackage(
+          basePath: AbsoluteFsPath, packageName: string, deps: string[] = [],
+          isCompiledByAngular = true): TestFile[] {
+        const files: TestFile[] = [
+          {
+            name: _Abs(`${basePath}/${packageName}/package.json`),
+            contents: JSON.stringify({
+              typings: `./${packageName}.d.ts`,
+              fesm2015: `./fesm2015/${packageName}.js`,
+            })
+          },
+          {
+            name: _Abs(`${basePath}/${packageName}/${packageName}.d.ts`),
+            contents: deps.map((dep, i) => `import * as i${i} from '${dep}';`).join('\n'),
+          },
+          {
+            name: _Abs(`${basePath}/${packageName}/fesm2015/${packageName}.js`),
+            contents: deps.map((dep, i) => `import * as i${i} from '${dep}';`).join('\n'),
+          },
+        ];
+
+        if (isCompiledByAngular) {
+          files.push({
+            name: _Abs(`${basePath}/${packageName}/${packageName}.metadata.json`),
+            contents: 'metadata info'
+          });
+        }
+
+        return files;
+      }
+
+      function dumpEntryPointPaths(
+          basePath: AbsoluteFsPath, entryPoints: EntryPoint[]): [string, string][] {
+        return entryPoints.map(x => [relative(basePath, x.package), relative(basePath, x.path)]);
+      }
+    });
+  });
+});

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
@@ -50,8 +50,8 @@ runInEachFileSystem(() => {
           ...createPackage(fs.resolve(basePath, 'common'), 'testing', ['@angular/common']),
         ]);
         const finder = new TargetedEntryPointFinder(
-            fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
-            undefined);
+            fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), undefined,
+            targetPath);
         const {entryPoints} = finder.findEntryPoints();
         expect(dumpEntryPointPaths(basePath, entryPoints)).toEqual([
           ['common', 'common'],
@@ -69,8 +69,8 @@ runInEachFileSystem(() => {
           ...createPackage(fs.resolve(basePath, 'common'), 'testing', ['common']),
         ]);
         const finder = new TargetedEntryPointFinder(
-            fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), targetPath,
-            undefined);
+            fs, config, logger, resolver, _Abs('/sub_entry_points/node_modules'), undefined,
+            targetPath);
         const {entryPoints} = finder.findEntryPoints();
         expect(dumpEntryPointPaths(basePath, entryPoints)).toEqual([
           ['common', 'common'],
@@ -92,7 +92,7 @@ runInEachFileSystem(() => {
           ...createPackage(fs.resolve(basePath, '@angular/common'), 'testing', ['@angular/common']),
         ]);
         const finder = new TargetedEntryPointFinder(
-            fs, config, logger, resolver, _Abs('/namespaced/node_modules'), targetPath, undefined);
+            fs, config, logger, resolver, _Abs('/namespaced/node_modules'), undefined, targetPath);
         const {entryPoints} = finder.findEntryPoints();
         expect(dumpEntryPointPaths(basePath, entryPoints)).toEqual([
           ['@angular/common', '@angular/common'],
@@ -104,7 +104,7 @@ runInEachFileSystem(() => {
         const targetPath = _Abs('/no_packages/node_modules/should_not_be_found');
         fs.ensureDir(_Abs('/no_packages/node_modules/should_not_be_found'));
         const finder = new TargetedEntryPointFinder(
-            fs, config, logger, resolver, _Abs('/no_packages/node_modules'), targetPath, undefined);
+            fs, config, logger, resolver, _Abs('/no_packages/node_modules'), undefined, targetPath);
         const {entryPoints} = finder.findEntryPoints();
         expect(entryPoints).toEqual([]);
       });
@@ -118,8 +118,8 @@ runInEachFileSystem(() => {
           },
         ]);
         const finder = new TargetedEntryPointFinder(
-            fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'), targetPath,
-            undefined);
+            fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'), undefined,
+            targetPath);
         const {entryPoints} = finder.findEntryPoints();
         expect(entryPoints).toEqual([]);
       });
@@ -143,8 +143,8 @@ runInEachFileSystem(() => {
              },
            ]);
            const finder = new TargetedEntryPointFinder(
-               fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'),
-               targetPath, undefined);
+               fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'), undefined,
+               targetPath);
            const {entryPoints} = finder.findEntryPoints();
            expect(entryPoints).toEqual([]);
          });
@@ -156,8 +156,8 @@ runInEachFileSystem(() => {
           ...createPackage(_Abs('/nested_node_modules/node_modules/outer/node_modules'), 'inner'),
         ]);
         const finder = new TargetedEntryPointFinder(
-            fs, config, logger, resolver, _Abs('/nested_node_modules/node_modules'), targetPath,
-            undefined);
+            fs, config, logger, resolver, _Abs('/nested_node_modules/node_modules'), undefined,
+            targetPath);
         const {entryPoints} = finder.findEntryPoints();
         expect(dumpEntryPointPaths(_Abs('/nested_node_modules/node_modules'), entryPoints))
             .toEqual([
@@ -175,7 +175,7 @@ runInEachFileSystem(() => {
           ...createPackage(_Abs('/nested_node_modules/node_modules/package'), 'entry-point'),
         ]);
         const finder = new TargetedEntryPointFinder(
-            fs, config, logger, resolver, basePath, targetPath, undefined);
+            fs, config, logger, resolver, basePath, undefined, targetPath);
         const {entryPoints} = finder.findEntryPoints();
         expect(dumpEntryPointPaths(_Abs('/nested_node_modules'), entryPoints)).toEqual([
           ['node_modules/package', 'node_modules/package/entry-point'],
@@ -200,7 +200,7 @@ runInEachFileSystem(() => {
            // entry-point info for the `lib3/entry-point` dependency.
            const targetPath = _Abs('/project/node_modules/lib1/node_modules/lib2');
            const finder = new TargetedEntryPointFinder(
-               fs, config, logger, resolver, basePath, targetPath, undefined);
+               fs, config, logger, resolver, basePath, undefined, targetPath);
            const {entryPoints} = finder.findEntryPoints();
            expect(dumpEntryPointPaths(_Abs('/project/node_modules'), entryPoints)).toEqual([
              ['lib3', 'lib3/entry-point'],
@@ -232,7 +232,7 @@ runInEachFileSystem(() => {
            // entry-point info for the `lib3/entry-point` dependency.
            const targetPath = _Abs('/project/node_modules/lib1/node_modules/lib2');
            const finder = new TargetedEntryPointFinder(
-               fs, config, logger, resolver, basePath, targetPath, undefined);
+               fs, config, logger, resolver, basePath, undefined, targetPath);
            const {entryPoints} = finder.findEntryPoints();
            expect(dumpEntryPointPaths(_Abs('/project/node_modules'), entryPoints)).toEqual([
              ['@scope/lib3/node_modules/lib4', '@scope/lib3/node_modules/lib4/entry-point'],
@@ -266,7 +266,7 @@ runInEachFileSystem(() => {
         const dtsHost = new DtsDependencyHost(fs, pathMappings);
         resolver = new DependencyResolver(fs, logger, config, {esm2015: srcHost}, dtsHost);
         const finder = new TargetedEntryPointFinder(
-            fs, config, logger, resolver, basePath, targetPath, pathMappings);
+            fs, config, logger, resolver, basePath, pathMappings, targetPath);
         const {entryPoints} = finder.findEntryPoints();
         expect(dumpEntryPointPaths(basePath, entryPoints)).toEqual([
           ['pkg1', 'pkg1'],
@@ -294,7 +294,7 @@ runInEachFileSystem(() => {
            const dtsHost = new DtsDependencyHost(fs, pathMappings);
            resolver = new DependencyResolver(fs, logger, config, {esm2015: srcHost}, dtsHost);
            const finder = new TargetedEntryPointFinder(
-               fs, config, logger, resolver, basePath, targetPath, pathMappings);
+               fs, config, logger, resolver, basePath, pathMappings, targetPath);
            const {entryPoints} = finder.findEntryPoints();
            expect(entryPoints.length).toEqual(1);
            const entryPoint = entryPoints[0];
@@ -327,7 +327,7 @@ runInEachFileSystem(() => {
            const dtsHost = new DtsDependencyHost(fs, pathMappings);
            resolver = new DependencyResolver(fs, logger, config, {esm2015: srcHost}, dtsHost);
            const finder = new TargetedEntryPointFinder(
-               fs, config, logger, resolver, basePath, targetPath, pathMappings);
+               fs, config, logger, resolver, basePath, pathMappings, targetPath);
            const {entryPoints} = finder.findEntryPoints();
            expect(dumpEntryPointPaths(basePath, entryPoints)).toEqual([
              ['../dist/my-lib/a', '../dist/my-lib/a'],
@@ -354,7 +354,7 @@ runInEachFileSystem(() => {
         const dtsHost = new DtsDependencyHost(fs, pathMappings);
         resolver = new DependencyResolver(fs, logger, config, {esm2015: srcHost}, dtsHost);
         const finder = new TargetedEntryPointFinder(
-            fs, config, logger, resolver, basePath, targetPath, pathMappings);
+            fs, config, logger, resolver, basePath, pathMappings, targetPath);
         const {entryPoints} = finder.findEntryPoints();
         expect(dumpEntryPointPaths(basePath, entryPoints)).toEqual([
           ['test', 'test'],
@@ -372,7 +372,7 @@ runInEachFileSystem(() => {
         const targetPath = _Abs('/no_packages/node_modules/should_not_be_found');
         fs.ensureDir(targetPath);
         const finder = new TargetedEntryPointFinder(
-            fs, config, logger, resolver, _Abs('/no_packages/node_modules'), targetPath, undefined);
+            fs, config, logger, resolver, _Abs('/no_packages/node_modules'), undefined, targetPath);
         expect(finder.targetNeedsProcessingOrCleaning(['fesm2015'], true)).toBe(false);
       });
 
@@ -385,8 +385,8 @@ runInEachFileSystem(() => {
           },
         ]);
         const finder = new TargetedEntryPointFinder(
-            fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'), targetPath,
-            undefined);
+            fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'), undefined,
+            targetPath);
         expect(finder.targetNeedsProcessingOrCleaning(['fesm2015'], true)).toBe(false);
       });
 
@@ -408,8 +408,8 @@ runInEachFileSystem(() => {
           },
         ]);
         const finder = new TargetedEntryPointFinder(
-            fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'), targetPath,
-            undefined);
+            fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'), undefined,
+            targetPath);
         expect(finder.targetNeedsProcessingOrCleaning(['fesm2015'], true)).toBe(false);
       });
 
@@ -431,8 +431,8 @@ runInEachFileSystem(() => {
              },
            ]);
            const finder = new TargetedEntryPointFinder(
-               fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'),
-               targetPath, undefined);
+               fs, config, logger, resolver, _Abs('/no_valid_entry_points/node_modules'), undefined,
+               targetPath);
            expect(finder.targetNeedsProcessingOrCleaning(['fesm2015'], true)).toBe(false);
          });
 
@@ -448,7 +448,7 @@ runInEachFileSystem(() => {
             ...createPackage(fs.resolve(basePath, 'common'), 'testing', ['common']),
           ]);
           const finder = new TargetedEntryPointFinder(
-              fs, config, logger, resolver, basePath, targetPath, undefined);
+              fs, config, logger, resolver, basePath, undefined, targetPath);
           expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], true)).toBe(true);
         });
 
@@ -474,7 +474,7 @@ runInEachFileSystem(() => {
              fs.writeFile(packageJsonPath, JSON.stringify(packageJson));
 
              const finder = new TargetedEntryPointFinder(
-                 fs, config, logger, resolver, basePath, targetPath, undefined);
+                 fs, config, logger, resolver, basePath, undefined, targetPath);
              expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], true)).toBe(true);
            });
 
@@ -500,7 +500,7 @@ runInEachFileSystem(() => {
           fs.writeFile(packageJsonPath, JSON.stringify(packageJson));
 
           const finder = new TargetedEntryPointFinder(
-              fs, config, logger, resolver, basePath, targetPath, undefined);
+              fs, config, logger, resolver, basePath, undefined, targetPath);
           expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], true)).toBe(false);
         });
       });
@@ -518,7 +518,7 @@ runInEachFileSystem(() => {
           ]);
 
           const finder = new TargetedEntryPointFinder(
-              fs, config, logger, resolver, basePath, targetPath, undefined);
+              fs, config, logger, resolver, basePath, undefined, targetPath);
           expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], false)).toBe(true);
         });
 
@@ -544,7 +544,7 @@ runInEachFileSystem(() => {
              fs.writeFile(packageJsonPath, JSON.stringify(packageJson));
 
              const finder = new TargetedEntryPointFinder(
-                 fs, config, logger, resolver, basePath, targetPath, undefined);
+                 fs, config, logger, resolver, basePath, undefined, targetPath);
              expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], false)).toBe(true);
            });
 
@@ -570,7 +570,7 @@ runInEachFileSystem(() => {
              fs.writeFile(packageJsonPath, JSON.stringify(packageJson));
 
              const finder = new TargetedEntryPointFinder(
-                 fs, config, logger, resolver, basePath, targetPath, undefined);
+                 fs, config, logger, resolver, basePath, undefined, targetPath);
              expect(finder.targetNeedsProcessingOrCleaning(['fesm2015', 'esm5'], false))
                  .toBe(false);
            });

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -31,6 +31,14 @@ runInEachFileSystem(() => {
     let _: typeof absoluteFrom;
     let fs: FileSystem;
     let pkgJsonUpdater: PackageJsonUpdater;
+    const STANDARD_MARKERS = {
+      main: '0.0.0-PLACEHOLDER',
+      module: '0.0.0-PLACEHOLDER',
+      es2015: '0.0.0-PLACEHOLDER',
+      esm2015: '0.0.0-PLACEHOLDER',
+      fesm2015: '0.0.0-PLACEHOLDER',
+      typings: '0.0.0-PLACEHOLDER',
+    };
 
     beforeEach(() => {
       _ = absoluteFrom;
@@ -639,15 +647,6 @@ runInEachFileSystem(() => {
 
     describe('with targetEntryPointPath', () => {
       it('should only compile the given package entry-point (and its dependencies).', () => {
-        const STANDARD_MARKERS = {
-          main: '0.0.0-PLACEHOLDER',
-          module: '0.0.0-PLACEHOLDER',
-          es2015: '0.0.0-PLACEHOLDER',
-          esm2015: '0.0.0-PLACEHOLDER',
-          fesm2015: '0.0.0-PLACEHOLDER',
-          typings: '0.0.0-PLACEHOLDER',
-        };
-
         mainNgcc({basePath: '/node_modules', targetEntryPointPath: '@angular/common/http/testing'});
         expect(loadPackage('@angular/common/http/testing').__processed_by_ivy_ngcc__)
             .toEqual(STANDARD_MARKERS);
@@ -812,6 +811,27 @@ runInEachFileSystem(() => {
       markAsProcessed(
           pkgJsonUpdater, targetPackage, targetPackageJsonPath, ['typings', ...properties]);
     }
+
+    describe('with findEntryPointsFromTsConfigProgram', () => {
+      it('should only compile the package entry-points (and their dependencies) reachable from the program in tsconfig.json.',
+         () => {
+           mainNgcc({basePath: '/node_modules', findEntryPointsFromTsConfigProgram: true});
+           // * `common/testing` is a dependency of `./y`, so is compiled.
+           expect(loadPackage('@angular/common/testing').__processed_by_ivy_ngcc__)
+               .toEqual(STANDARD_MARKERS);
+           // * `common/http` is a dependency of `./x`, so is compiled.
+           expect(loadPackage('@angular/common/http').__processed_by_ivy_ngcc__)
+               .toEqual(STANDARD_MARKERS);
+           // * `core` is a dependency of `common/http`, so is compiled.
+           expect(loadPackage('@angular/core').__processed_by_ivy_ngcc__).toEqual(STANDARD_MARKERS);
+           // * `common` is a private (only in .js not .d.ts) dependency so is compiled.
+           expect(loadPackage('@angular/common').__processed_by_ivy_ngcc__)
+               .toEqual(STANDARD_MARKERS);
+           // * `common/http/testing` is not a dependency of the program so is not compiled.
+           expect(loadPackage('@angular/common/http/testing').__processed_by_ivy_ngcc__)
+               .toBeUndefined();
+         });
+    });
 
     it('should clean up outdated artifacts', () => {
       compileIntoFlatEs2015Package('test-package', {
@@ -2107,6 +2127,17 @@ runInEachFileSystem(() => {
           contents: `export declare class AppComponent {}`
         },
         {name: _('/node_modules/invalid-package/index.metadata.json'), contents: 'DUMMY DATA'},
+      ]);
+
+      // A sample application that imports entry-points
+      loadTestFiles([
+        {name: _('/tsconfig.json'), contents: '{"files": ["src/index.ts"]}'},
+        {name: _('/src/index.ts'), contents: `import {X} from './x';\nimport {Y} from './y';`},
+        {name: _('/src/x.ts'), contents: `import '@angular/common/http';\nexport class X {}`},
+        {
+          name: _('/src/y.ts'),
+          contents: `import * as t from '@angular/common/testing';\n export class Y {}`
+        },
       ]);
     }
   });


### PR DESCRIPTION
Add a new `EntryPointFinder` that can be seeded from the imports in the program specified by a tsconfig.json file. This should be much faster than the `DirectoryWalkerEntryPointFinder` when the active program only imports a small proportion of the installed entry-points.

On the AIO project only half the entry-points would be processed by ngcc if the CLI async integration with ngcc made use of the new flag.