### PR TITLE
refactor(compiler-cli): Remove any cast for CompilerHost

### DIFF
--- a/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
@@ -125,10 +125,11 @@ export function resolveModuleName(
     compilerHost: ts.ModuleResolutionHost&Pick<ts.CompilerHost, 'resolveModuleNames'>,
     moduleResolutionCache: ts.ModuleResolutionCache|null): ts.ResolvedModule|undefined {
   if (compilerHost.resolveModuleNames) {
-    // FIXME: Additional parameters are required in TS3.6, but ignored in 3.5.
-    // Remove the any cast once google3 is fully on TS3.6.
-    return (compilerHost as any)
-        .resolveModuleNames([moduleName], containingFile, undefined, undefined, compilerOptions)[0];
+    return compilerHost.resolveModuleNames(
+        [moduleName], containingFile,
+        undefined,  // reusedNames
+        undefined,  // redirectedReference
+        compilerOptions)[0];
   } else {
     return ts
         .resolveModuleName(


### PR DESCRIPTION
This commit removes the FIXME for casting CompilerHost to any since
google3 is now already on TS 3.8.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
