### PR TITLE
Correct typos in recent change to doc for template type guards 

### DIFF
--- a/aio/content/guide/aot-compiler.md
+++ b/aio/content/guide/aot-compiler.md
@@ -621,7 +621,6 @@ Using `*ngIf` allows the TypeScript compiler to infer that the `person` used in 
 
 For more information about input type narrowing, see [Input setter coercion](guide/template-typecheck#input-setter-coercion) and [Improving template type checking for custom directives](guide/structural-directives#directive-type-checks).
 
-
 ### Non-null type assertion operator
 
 Use the [non-null type assertion operator](guide/template-syntax#non-null-assertion-operator) to suppress the `Object is possibly 'undefined'` error when it is inconvenient to use `*ngIf` or when some constraint in the component ensures that the expression is always non-null when the binding expression is interpolated.

--- a/aio/content/guide/structural-directives.md
+++ b/aio/content/guide/structural-directives.md
@@ -846,7 +846,7 @@ Use the type-guard properties to inform the template type checker of an expected
 
 This section provides example of both kinds of type-guard property.
 
-<div class="alert is-helpful>
+<div class="alert is-helpful">
 
    For more information, see [Template type checking guide](guide/template-typecheck "Template type-checking guide").
 
@@ -962,7 +962,7 @@ Here is the source from the `src/app/` folder.
 
 
 
-You learned
+You learned:
 
 * that structural directives manipulate HTML layout.
 * to use [`<ng-container>`](guide/structural-directives#ngcontainer) as a grouping element when there is no suitable host element.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Typos cause incorrect rendering of https://angular.io/guide/structural-directives#improving-template-type-checking-for-custom-directives

Issue Number: N/A


## What is the new behavior?

Typos corrected, references and notes display correctly

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No