### PR TITLE
fix(zone.js): zone patch rxjs should return null _unsubscribe correctly.

### DIFF
--- a/packages/zone.js/test/rxjs/rxjs.retry.spec.ts
+++ b/packages/zone.js/test/rxjs/rxjs.retry.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Observable, of, throwError, timer} from 'rxjs';
+import {catchError, finalize, mergeMap, retryWhen} from 'rxjs/operators';
+
+describe('retryWhen', () => {
+  let log: any[];
+  const genericRetryStrategy = (finalizer: () => void) => (attempts: Observable<any>) =>
+      attempts.pipe(
+          mergeMap((error, i) => {
+            const retryAttempt = i + 1;
+            if (retryAttempt > 3) {
+              return throwError(error);
+            }
+            log.push(error);
+            return timer(retryAttempt * 1);
+          }),
+          finalize(() => finalizer()));
+
+  const errorGenerator = () => {
+    return throwError(new Error('error emit'));
+  };
+  beforeEach(() => {
+    log = [];
+  });
+
+  it('should retry max 3 times',
+     (done: DoneFn) => {errorGenerator()
+                            .pipe(
+                                retryWhen(genericRetryStrategy(() => {
+                                  expect(log.length).toBe(3);
+                                  done();
+                                })),
+                                catchError(error => of(error)))
+                            .subscribe()});
+});

--- a/packages/zone.js/test/rxjs/rxjs.spec.ts
+++ b/packages/zone.js/test/rxjs/rxjs.spec.ts
@@ -27,6 +27,7 @@ import './rxjs.merge.spec';
 import './rxjs.never.spec';
 import './rxjs.of.spec';
 import './rxjs.range.spec';
+import './rxjs.retry.spec';
 import './rxjs.throw.spec';
 import './rxjs.timer.spec';
 import './rxjs.zip.spec';


### PR DESCRIPTION
Close #31684.

In some rxjs operator, such as `retryWhen`, rxjs internally will set
`Subscription._unsubscribe` method to null, and the current zone.js monkey patch
didn't handle this case correctly, even rxjs set _unsubscribe to null, zone.js
still return a function by finding the prototype chain.

This PR fix this issue and the following test will pass.

```
const errorGenerator = () => {
  return throwError(new Error('error emit'));
};

const genericRetryStrategy = (finalizer: () => void) => (attempts: Observable<any>) =>
    attempts.pipe(
      mergeMap((error, i) => {
        const retryAttempt = i + 1;
        if (retryAttempt > 3) {
          return throwError(error);
        }
        return timer(retryAttempt * 1);
      }),
      finalize(() => finalizer()));

errorGenerator()
  .pipe(
    retryWhen(genericRetryStrategy(() => {
      expect(log.length).toBe(3);
      done();
    })),
    catchError(error => of(error)))
  .subscribe()
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:
