### PR TITLE
build: add github config for ng-dev configuration

### DIFF
--- a/.ng-dev-config.ts
+++ b/.ng-dev-config.ts
@@ -72,8 +72,15 @@ const format = {
   'buildifier': true
 };
 
+// Github metadata information for `ng-dev` commands.
+const github = {
+  owner: 'angular',
+  name: 'angular',
+};
+
 // Export function to build ng-dev configuration object.
 module.exports = {
   commitMessage,
   format,
+  github,
 };

--- a/dev-infra/utils/config.ts
+++ b/dev-infra/utils/config.ts
@@ -12,8 +12,8 @@ import {exec} from 'shelljs';
 /** The common configuration for ng-dev. */
 type CommonConfig = {
   github: {
-    owner: string;
-    name: string;
+    owner: string,
+    name: string,
   }
 };
 

--- a/dev-infra/utils/config.ts
+++ b/dev-infra/utils/config.ts
@@ -11,7 +11,7 @@ import {exec} from 'shelljs';
 
 /** The common configuration for ng-dev. */
 type CommonConfig = {
-  // Github repository configuration used for API Requests, determining upstream remote, etc.
+  /* Github repository configuration used for API Requests, determining upstream remote, etc. */
   github: {
     owner: string,
     name: string,
@@ -24,8 +24,10 @@ type CommonConfig = {
  */
 export type NgDevConfig<T = {}> = CommonConfig&T;
 
-// The filename expected for creating the ng-dev config, without the file
-// extension to allow either a typescript or javascript file to be used.
+/**
+ * The filename expected for creating the ng-dev config, without the file
+ * extension to allow either a typescript or javascript file to be used.
+ */
 const CONFIG_FILE_NAME = '.ng-dev-config';
 
 /** The configuration for ng-dev. */

--- a/dev-infra/utils/config.ts
+++ b/dev-infra/utils/config.ts
@@ -11,7 +11,10 @@ import {exec} from 'shelljs';
 
 /** The common configuration for ng-dev. */
 type CommonConfig = {
-    // TODO: add common configuration
+  github: {
+    owner: string;
+    name: string;
+  }
 };
 
 /**
@@ -46,9 +49,21 @@ export function getConfig(): NgDevConfig {
 }
 
 /** Validate the common configuration has been met for the ng-dev command. */
-function validateCommonConfig(config: NgDevConfig<CommonConfig>) {
-  // TODO: add validation for the common configuration
-  return config;
+function validateCommonConfig(config: Partial<NgDevConfig<CommonConfig>>) {
+  const errors: string[] = [];
+  // Validate the github configuration.
+  if (config.github === undefined) {
+    errors.push(`No configuration defined for "format"`);
+  } else {
+    if (config.github.name === undefined) {
+      errors.push(`"github.name" is not defined`);
+    }
+    if (config.github.owner === undefined) {
+      errors.push(`"github.org"  is not defined`);
+    }
+  }
+
+  return config as NgDevConfig<CommonConfig>;
 }
 
 /**

--- a/dev-infra/utils/config.ts
+++ b/dev-infra/utils/config.ts
@@ -11,6 +11,7 @@ import {exec} from 'shelljs';
 
 /** The common configuration for ng-dev. */
 type CommonConfig = {
+  // Github repository configuration used for API Requests, determining upstream remote, etc.
   github: {
     owner: string,
     name: string,
@@ -49,21 +50,21 @@ export function getConfig(): NgDevConfig {
 }
 
 /** Validate the common configuration has been met for the ng-dev command. */
-function validateCommonConfig(config: Partial<NgDevConfig<CommonConfig>>) {
+function validateCommonConfig(config: Partial<NgDevConfig>) {
   const errors: string[] = [];
   // Validate the github configuration.
   if (config.github === undefined) {
-    errors.push(`No configuration defined for "format"`);
+    errors.push(`Github repository not configured. Set the "github" option.`);
   } else {
     if (config.github.name === undefined) {
       errors.push(`"github.name" is not defined`);
     }
     if (config.github.owner === undefined) {
-      errors.push(`"github.org"  is not defined`);
+      errors.push(`"github.owner" is not defined`);
     }
   }
 
-  return config as NgDevConfig<CommonConfig>;
+  return config as NgDevConfig;
 }
 
 /**


### PR DESCRIPTION
Adds the gitub configuration to the ng-dev configuration. This github
configuration provides information needed for making API requests to
github.  Upcoming tooling related PRs will require these API requests
being possible.