### PR TITLE
fix(dev-infra): do not require a commit body for release commits

### DIFF
--- a/dev-infra/commit-message/validate.ts
+++ b/dev-infra/commit-message/validate.ts
@@ -136,6 +136,11 @@ export function validateCommitMessage(
     return false;
   }
 
+  // Commits with the type of `release` do not require a commit body.
+  if (commit.type === 'release') {
+    return true;
+  }
+
   //////////////////////////
   // Checking commit body //
   //////////////////////////


### PR DESCRIPTION
Release commits do not require a commit body as the context, usually
provided in commit body, is already available in the process of
releasing.  No additional value is gained from adding a body message
on these commits.
