### PR TITLE
refactor(core): rename refreshDynamicEmbeddedViews to refreshEmbedded…

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -435,7 +435,7 @@ export function refreshView<T>(
     // insertion points. This is needed to avoid the situation where the template is defined in this
     // `LView` but its declaration appears after the insertion component.
     markTransplantedViewsForRefresh(lView);
-    refreshDynamicEmbeddedViews(lView);
+    refreshEmbeddedViews(lView);
 
     // Content query results must be refreshed before content hooks are called.
     if (tView.contentQueries !== null) {
@@ -1623,10 +1623,10 @@ export function createLContainer(
 }
 
 /**
- * Goes over dynamic embedded views (ones created through ViewContainerRef APIs) and refreshes
+ * Goes over embedded views (ones created through ViewContainerRef APIs) and refreshes
  * them by executing an associated template function.
  */
-function refreshDynamicEmbeddedViews(lView: LView) {
+function refreshEmbeddedViews(lView: LView) {
   for (let lContainer = getFirstLContainer(lView); lContainer !== null;
        lContainer = getNextLContainer(lContainer)) {
     for (let i = CONTAINER_HEADER_OFFSET; i < lContainer.length; i++) {
@@ -1664,7 +1664,7 @@ function markTransplantedViewsForRefresh(lView: LView) {
       // Note, it is possible that the `movedViews` is tracking views that are transplanted *and*
       // those that aren't (declaration component === insertion component). In the latter case,
       // it's fine to add the flag, as we will clear it immediately in
-      // `refreshDynamicEmbeddedViews` for the view currently being refreshed.
+      // `refreshEmbeddedViews` for the view currently being refreshed.
       movedLView[FLAGS] |= LViewFlags.RefreshTransplantedView;
     }
   }

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -32,7 +32,7 @@ export const TYPE = 1;
  * detected. (see: `LView[DECLARATION_COMPONENT_VIEW])`.
  *
  * This flag, once set, is never unset for the `LContainer`. This means that when unset we can skip
- * a lot of work in `refreshDynamicEmbeddedViews`. But when set we still need to verify
+ * a lot of work in `refreshEmbeddedViews`. But when set we still need to verify
  * that the `MOVED_VIEWS` are transplanted and on-push.
  */
 export const HAS_TRANSPLANTED_VIEWS = 2;

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -558,7 +558,7 @@
     "name": "refreshContentQueries"
   },
   {
-    "name": "refreshDynamicEmbeddedViews"
+    "name": "refreshEmbeddedViews"
   },
   {
     "name": "refreshView"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -435,7 +435,7 @@
     "name": "refreshContentQueries"
   },
   {
-    "name": "refreshDynamicEmbeddedViews"
+    "name": "refreshEmbeddedViews"
   },
   {
     "name": "refreshView"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1038,7 +1038,7 @@
     "name": "refreshContentQueries"
   },
   {
-    "name": "refreshDynamicEmbeddedViews"
+    "name": "refreshEmbeddedViews"
   },
   {
     "name": "refreshView"


### PR DESCRIPTION
…Views

Dynamic embedded views were conceptually different from inline embedded views, but we have since
removed the inline embedded views so we now only have "embedded views".
See related refactoring work to remove inline embedded views in #34715
and #37073.
