### PR TITLE
ci: increase payload size limits for integration tests

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 142812,
+        "main-es2015": 143315,
         "polyfills-es2015": 36657
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 148933,
+        "main-es2015": 149436,
         "polyfills-es2015": 36657
       }
     }


### PR DESCRIPTION
This commit updates payload size limits that are triggering errors after merging cda2530. That commit seems to contribute to the payload size increase, but all checks were "green" for the original PR (#35889), so it looks like it's an accumulated payload size increase from multiple changes. The goal of this commit is to bring the master branch back to "green" state.

Note: for some reasons patch branch is not affected (which indicates that there might be some discrepancies between branches), but I think we should update both master and patch to keep these limits consistent.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No