### PR TITLE
ci: increase AIO payload size limit

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2987,
-        "main-es2015": 454047,
+        "main-es2015": 454665,
         "polyfills-es2015": 52628
       }
     }


### PR DESCRIPTION
This commit updates payload size limit that is triggering errors after merging cda2530. That commit seems to contribute to the payload size increase, but all checks were "green" for the original PR (#35889), so it looks like it's an accumulated payload size increase from multiple changes. The goal of this commit is to bring the patch branch back to "green" state.

Note: master branch is not affected by this problem and the value of the `aio-local.master.uncompressed.main-es2015` field is currently different in master and patch branches (patch is already bigger), so it's a patch-only change.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No