### PR TITLE
docs(router): get rid of unnecessary line in wildcard route code example and fixing wildcard docregions

### DIFF
--- a/aio/content/examples/router/src/app/app-routing.module.8.ts
+++ b/aio/content/examples/router/src/app/app-routing.module.8.ts
@@ -6,13 +6,11 @@ import { Routes, RouterModule } from '@angular/router'; // CLI imports router
 const routes: Routes = [
   { path: 'first-component', component: FirstComponent },
   { path: 'second-component', component: SecondComponent },
-  // #enddocregion routes
+  // #enddocregion routes, routes-with-wildcard
   { path: '',   redirectTo: '/first-component', pathMatch: 'full' }, // redirect to `first-component`
-  { path: '**', component: FirstComponent },
-  // #enddocregion redirect
+  // #docregion routes-with-wildcard
   { path: '**', component: PageNotFoundComponent },  // Wildcard route for a 404 page
   // #docregion routes
-  // #docregion redirect
 ];
 // #enddocregion routes, routes-with-wildcard, redirect
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The [wildcard example](https://angular.io/guide/router#wildcard-route-how-to) leads to display a 404 page with the `PageNotFoundComponent`. But before, there is a wildcard to redirect to the `FirstComponent` and because of the routes order the `FirstComponent` will be displayed; which it is not the target of the wildcard route example code.