### PR TITLE
build: remove skipLibCheck from AIO examples

### DIFF
--- a/aio/tools/examples/shared/boilerplate/cli-ajs/package.json
+++ b/aio/tools/examples/shared/boilerplate/cli-ajs/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser-dynamic": "~9.1.4",
     "@angular/router": "~9.1.4",
     "angular": "1.7.9",
-    "angular-in-memory-web-api": "~0.9.0",
+    "angular-in-memory-web-api": "~0.11.0",
     "angular-route": "1.7.9",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",

--- a/aio/tools/examples/shared/boilerplate/cli/package.json
+++ b/aio/tools/examples/shared/boilerplate/cli/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~9.1.4",
     "@angular/platform-browser-dynamic": "~9.1.4",
     "@angular/router": "~9.1.4",
-    "angular-in-memory-web-api": "~0.9.0",
+    "angular-in-memory-web-api": "~0.11.0",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",
     "zone.js": "~0.10.3"

--- a/aio/tools/examples/shared/boilerplate/elements/package.json
+++ b/aio/tools/examples/shared/boilerplate/elements/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser-dynamic": "~9.1.4",
     "@angular/router": "~9.1.4",
     "@webcomponents/custom-elements": "^1.4.1",
-    "angular-in-memory-web-api": "~0.9.0",
+    "angular-in-memory-web-api": "~0.11.0",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",
     "zone.js": "~0.10.3"

--- a/aio/tools/examples/shared/boilerplate/i18n/package.json
+++ b/aio/tools/examples/shared/boilerplate/i18n/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser": "~9.1.4",
     "@angular/platform-browser-dynamic": "~9.1.4",
     "@angular/router": "~9.1.4",
-    "angular-in-memory-web-api": "~0.9.0",
+    "angular-in-memory-web-api": "~0.11.0",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",
     "zone.js": "~0.10.3"

--- a/aio/tools/examples/shared/boilerplate/service-worker/package.json
+++ b/aio/tools/examples/shared/boilerplate/service-worker/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser-dynamic": "~9.1.4",
     "@angular/router": "~9.1.4",
     "@angular/service-worker": "~9.1.4",
-    "angular-in-memory-web-api": "~0.9.0",
+    "angular-in-memory-web-api": "~0.11.0",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",
     "zone.js": "~0.10.3"

--- a/aio/tools/examples/shared/boilerplate/testing/tsconfig.app.json
+++ b/aio/tools/examples/shared/boilerplate/testing/tsconfig.app.json
@@ -2,9 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../out-tsc/app",
-    "types": [],
-    // TODO(FW-2145): turn lib checks back on after fixing in-memory-api and investigating impact of ModuleWithProviders
-    "skipLibCheck": true
+    "types": []
   },
   "files": [
     "src/main.ts",

--- a/aio/tools/examples/shared/boilerplate/universal/package.json
+++ b/aio/tools/examples/shared/boilerplate/universal/package.json
@@ -26,7 +26,7 @@
     "@angular/platform-server": "~9.1.4",
     "@angular/router": "~9.1.4",
     "@nguniversal/express-engine": "~9.0.1",
-    "angular-in-memory-web-api": "~0.9.0",
+    "angular-in-memory-web-api": "~0.11.0",
     "express": "^4.15.2",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",

--- a/aio/tools/examples/shared/boilerplate/viewengine/cli/tsconfig.json
+++ b/aio/tools/examples/shared/boilerplate/viewengine/cli/tsconfig.json
@@ -17,9 +17,7 @@
     "lib": [
       "es2018",
       "dom"
-    ],
-    // TODO(FW-2145): turn lib checks back on after fixing in-memory-api and investigating impact of ModuleWithProviders
-    "skipLibCheck": true
+    ]
   },
   "angularCompilerOptions": {
     "enableIvy": false,

--- a/aio/tools/examples/shared/package.json
+++ b/aio/tools/examples/shared/package.json
@@ -35,7 +35,7 @@
     "@nguniversal/express-engine": "~9.0.1",
     "@webcomponents/custom-elements": "^1.4.1",
     "angular": "1.7.9",
-    "angular-in-memory-web-api": "~0.9.0",
+    "angular-in-memory-web-api": "~0.11.0",
     "angular-route": "1.7.9",
     "core-js": "^2.5.4",
     "express": "^4.15.2",

--- a/aio/tools/examples/shared/tsconfig.json
+++ b/aio/tools/examples/shared/tsconfig.json
@@ -13,9 +13,7 @@
     "suppressImplicitAnyIndexErrors": true,
     "typeRoots": [
       "node_modules/@types"
-    ],
-    // TODO(FW-2145): turn lib checks back on after fixing in-memory-api and investigating impact of ModuleWithProviders
-    "skipLibCheck": true
+    ]
   },
   "include": [
     "../../../content/examples/*/e2e-spec.ts"

--- a/aio/tools/examples/shared/yarn.lock
+++ b/aio/tools/examples/shared/yarn.lock
@@ -1891,10 +1891,10 @@ alphanum-sort@^1.0.0:
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
-angular-in-memory-web-api@~0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/angular-in-memory-web-api/-/angular-in-memory-web-api-0.9.0.tgz#6c98d9494fadc6b98f54e68376a1998ccfff04bc"
-  integrity sha512-//PiJ5qb1+Yf/N7270ioQqR2laf4/Irjavg+M+WEn8y4At9LUoYgbQ5HVwvM5xUTlVlL0XkbJRLxREcGGNdIEw==
+angular-in-memory-web-api@~0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/angular-in-memory-web-api/-/angular-in-memory-web-api-0.11.0.tgz#46e4ad896b36d669f36801fc8cafa7db8278d078"
+  integrity sha512-QV1qYHm+Zd+wrvlcPLnAcqqGpOmCN1EUj4rRuYHpek8+QqFFdxBNuPZOJCKvU7I97z5QSKHsdc6PNKlpUQr3UA==
 
 angular-route@1.7.9:
   version "1.7.9"


### PR DESCRIPTION
`skipLibCheck` had to be added to a few AIO examples, because of a breaking change in master. These changes update to a newer version of `angular-in-memory-web-api` that accounts for the breaking change.
