### PR TITLE
build(docs-infra): remove `{@searchKeywords}` from content when rende…

### DIFF
--- a/aio/tools/transforms/angular-base-package/inline-tag-defs/custom-search-defs/index.js
+++ b/aio/tools/transforms/angular-base-package/inline-tag-defs/custom-search-defs/index.js
@@ -1,9 +1,9 @@
 module.exports = {
   name: 'searchKeywords',
-  description: 'A shorthand for creating elements with search terms. Usage: `{@searchKeywords term1 term2 termN }`',
+  description:
+      'A shorthand for creating elements with search terms. Usage: `{@searchKeywords term1 term2 termN }`',
   handler: function(doc, tagName, tagDescription) {
     doc.searchKeywords = tagDescription;
-    return doc;
+    return '';
   }
 };
-  


### PR DESCRIPTION
…ring

Previously this inline-tag-def was returning the `doc` which is rendered
to the output as `[Object Object]` - obviously not what is intended.

Now it returns `''` which effectively strips the tag handler from the
rendered output.
