### PR TITLE
refactor(docs-infra): refactors `extractDecoratedClasses`

### DIFF
--- a/aio/tools/transforms/angular-api-package/processors/extractDecoratedClasses.js
+++ b/aio/tools/transforms/angular-api-package/processors/extractDecoratedClasses.js
@@ -1,5 +1,3 @@
-var _ = require('lodash');
-
 module.exports = function extractDecoratedClassesProcessor(EXPORT_DOC_TYPES) {
 
   // Add the "directive" docType into those that can be exported from a module
@@ -10,12 +8,9 @@ module.exports = function extractDecoratedClassesProcessor(EXPORT_DOC_TYPES) {
     $runBefore: ['docs-processed'],
     decoratorTypes: ['Directive', 'Component', 'Pipe', 'NgModule'],
     $process: function(docs) {
-      var decoratorTypes = this.decoratorTypes;
-
-      _.forEach(docs, function(doc) {
-
-        _.forEach(doc.decorators, function(decorator) {
-
+      const decoratorTypes = this.decoratorTypes;
+      docs.forEach(doc => {
+        (doc.decorators || []).forEach(decorator => {
           if (decoratorTypes.indexOf(decorator.name) !== -1) {
             doc.docType = decorator.name.toLowerCase();
             // Directives do not always have an argument (i.e. abstract directives).


### PR DESCRIPTION
This commit removes the dependency on the `lodash` module and refactors
the `extractDecoratedClasses` method.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
