### PR TITLE
build: move CHANGELOG to public-api approval group

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1030,6 +1030,7 @@ groups:
     reviewers:
       users:
         - IgorMinar
+        - kara
 
 
   # ================================================

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -948,7 +948,7 @@ groups:
     conditions:
       - *can-be-global-approved
       - >
-        contains_any_globs(files, [
+        contains_any_globs(files.exclude("CHANGELOG.md"), [
           '*',
           '.circleci/**',
           '.devcontainer/**',

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1020,6 +1020,7 @@ groups:
       - >
         contains_any_globs(files, [
           'goldens/public-api/**',
+          'CHANGELOG.md',
           'docs/NAMING.md',
           'aio/content/guide/glossary.md',
           'aio/content/guide/styleguide.md',


### PR DESCRIPTION
Previously, the CHANGELOG file was caught under the general
"*" glob, which meant that it fell under the dev-infra
approval group. This does not really make sense since it
has more to do with public-facing changes. As such, this
commit moves the CHANGELOG file specifically to the
public-api approval group.
