### PR TITLE
docs: supply correct manifest.webmanifest filename

### DIFF
--- a/aio/content/guide/service-worker-getting-started.md
+++ b/aio/content/guide/service-worker-getting-started.md
@@ -23,7 +23,7 @@ The above command completes the following actions:
 2. Enables service worker build support in the CLI.
 3. Imports and registers the service worker in the app module.
 4. Updates the `index.html` file:
-    * Includes a link to add the `manifest.json` file.
+    * Includes a link to add the `manifest.webmanifest` file.
     * Adds meta tags for `theme-color`.
 5. Installs icon files to support the installed Progressive Web App (PWA).
 6. Creates the service worker configuration file called [`ngsw-config.json`](/guide/service-worker-config), which specifies the caching behaviors and other settings.


### PR DESCRIPTION
Previously, the docs incorrectly identified the generated manifest file as "manifest.json" when it is actually "manifest.webmanifest".

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Documentation content changes

## What is the current behavior?

Currently the docs incorrectly reference the generated service worker manifest file as "manifest.json" when it is actually named "manifest.webmanifest". 

## What is the new behavior?

Now, the docs correctly reference the generated service worker manifest file as "manifest.webmanifest"

## Does this PR introduce a breaking change?

- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
