### PR TITLE
build: complete removal of gulp format

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,29 +33,3 @@ gulp.task('changelog:zonejs', loadTask('changelog-zonejs'));
 gulp.task('check-env', () => {/* this is a noop because the env test ran already above */});
 gulp.task('cldr:extract', loadTask('cldr', 'extract'));
 gulp.task('cldr:gen-closure-locale', loadTask('cldr', 'closure'));
-
-
-// TODO(josephperrott): Remove old task entries and deprecation notice after deprecation period.
-/** Notify regarding `gulp format:*` deprecation. */
-function gulpFormatDeprecationNotice() {
-  console.info(`######################################################################`)
-  console.info(`gulp format is deprecated in favor of running the formatter via ng-dev`);
-  console.info();
-  console.info(`You can find more usage information by running:`);
-  console.info(`  yarn ng-dev format --help`);
-  console.info();
-  console.info(`For more on the rationale and effects of this deprecation visit:`);
-  console.info(`  https://github.com/angular/angular/pull/36726#issue-406278018`);
-  console.info(`######################################################################`)
-  process.exit(1);
-}
-gulp.task('format:all', gulpFormatDeprecationNotice);
-gulp.task('format:all:enforce', gulpFormatDeprecationNotice);
-gulp.task('format:untracked', gulpFormatDeprecationNotice);
-gulp.task('format:untracked:enforce', gulpFormatDeprecationNotice);
-gulp.task('format:diff', gulpFormatDeprecationNotice);
-gulp.task('format:diff:enforce', gulpFormatDeprecationNotice);
-gulp.task('format:changed', gulpFormatDeprecationNotice);
-gulp.task('format:changed:enforce', gulpFormatDeprecationNotice);
-gulp.task('format', gulpFormatDeprecationNotice);
-gulp.task('lint', gulpFormatDeprecationNotice);


### PR DESCRIPTION
Remove gulp format deprecation message to complete the removal of
formatting Typescript and Javascript files via gulp command.
