### PR TITLE
build: complete removal of bazel format yarn commands

### DIFF
--- a/dev-infra/format/cli.ts
+++ b/dev-infra/format/cli.ts
@@ -34,35 +34,9 @@ export function buildFormatParser(localYargs: yargs.Argv) {
             const executionCmd = check ? checkFiles : formatFiles;
             executionCmd(allChangedFilesSince(sha));
           })
-      .command(
-          'files <files..>', 'Run the formatter on provided files', {},
-          ({check, files}) => {
-            const executionCmd = check ? checkFiles : formatFiles;
-            executionCmd(files);
-          })
-      // TODO(josephperrott): remove this hidden command after deprecation period.
-      .command('deprecation-warning [originalCommand]', false, {}, ({originalCommand}) => {
-        console.warn(`\`yarn ${
-            originalCommand}\` is deprecated in favor of running the formatter via ng-dev`);
-        console.warn();
-        console.warn(`As a replacement of \`yarn ${originalCommand}\`, run:`);
-        switch (originalCommand) {
-          case 'bazel:format':
-          case 'bazel:lint-fix':
-            console.warn(`  yarn ng-dev format all`);
-            break;
-          case 'bazel:lint':
-            console.warn(`  yarn ng-dev format all --check`);
-            break;
-          default:
-            console.warn(`Error: Unrecognized previous command.`);
-        }
-        console.warn();
-        console.warn(`You can find more usage information by running:`);
-        console.warn(`  yarn ng-dev format --help`);
-        console.warn();
-        console.warn(`For more on the rationale and effects of this deprecation visit:`);
-        console.warn(`  https://github.com/angular/angular/pull/36842#issue-410321447`);
+      .command('files <files..>', 'Run the formatter on provided files', {}, ({check, files}) => {
+        const executionCmd = check ? checkFiles : formatFiles;
+        executionCmd(files);
       });
 }
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "url": "https://github.com/angular/angular.git"
   },
   "scripts": {
+    "/": "",
+    "// 1": "Many developer of our checks/scripts/tools have moved to our ng-dev tool",
+    "// 2": "Find the usage you are looking for with:",
+    "// 3": "yarn ng-dev --help",
+    "/ ": "",
     "preinstall": "node tools/yarn/check-yarn.js",
     "postinstall": "node scripts/webdriver-manager-update.js && node --preserve-symlinks --preserve-symlinks-main ./tools/postinstall-patches.js",
     "check-env": "gulp check-env",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "url": "https://github.com/angular/angular.git"
   },
   "scripts": {
-    "bazel:format": "yarn -s ng-dev format deprecation-warning bazel:format",
-    "bazel:lint": "yarn -s ng-dev format deprecation-warning bazel:lint",
-    "bazel:lint-fix": "yarn -s ng-dev format deprecation-warning bazel:lint-fix",
     "preinstall": "node tools/yarn/check-yarn.js",
     "postinstall": "node scripts/webdriver-manager-update.js && node --preserve-symlinks --preserve-symlinks-main ./tools/postinstall-patches.js",
     "check-env": "gulp check-env",


### PR DESCRIPTION
Remove bazel yarn format deprecation message to complete the removal of
formatting bazel related files via yarn command command.
