### PR TITLE
ci: fix a typo in payload size limit config

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -4,7 +4,7 @@
       "uncompressed": {
         "runtime-es2015": 1485,
         "main-es2015": 142794,
-s        "polyfills-es2015": 36657
+        "polyfills-es2015": 36657
       }
     }
   },


### PR DESCRIPTION
This commit fixes a small typo in the payload size limit config introduced in https://github.com/angular/angular/commit/639fab2c146a570dd88052d8df058c71ba5b9480.


## PR Type
What kind of change does this PR introduce?

- [x] CI related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No