### PR TITLE
fix(router): remove parentheses for primary outlet segment

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -341,6 +341,11 @@ function serializeSegment(segment: UrlSegmentGroup, root: boolean): string {
       return [`${k}:${serializeSegment(v, false)}`];
     });
 
+    // use no parenthesis if the only child is a primary outlet route
+    if (Object.keys(segment.children).length === 1 && segment.children[PRIMARY_OUTLET] != null) {
+      return `${serializePaths(segment)}/${children[0]}`;
+    }
+
     return `${serializePaths(segment)}/(${children.join('//')})`;
   }
 }

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -128,6 +128,12 @@ describe('createUrlTree', () => {
     expect(serializer.serialize(t)).toEqual('/a');
   });
 
+  it('should support removing parenthesis for primary segment on second path element', () => {
+    const p = serializer.parse('/a/(b//right:c)');
+    const t = createRoot(p, ['a', {outlets: {right: null}}]);
+    expect(serializer.serialize(t)).toEqual('/a/b');
+  });
+
   it('should update matrix parameters', () => {
     const p = serializer.parse('/a;pp=11');
     const t = createRoot(p, ['/a', {pp: 22, dd: 33}]);

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -3351,7 +3351,7 @@ describe('Integration', () => {
              advance(fixture);
 
              expect(log.map((a: any) => a.path)).toEqual(['b']);
-             expect(location.path()).toEqual('/two-outlets/(a)');
+             expect(location.path()).toEqual('/two-outlets/a');
            })));
 
         it('works with a nested route',


### PR DESCRIPTION
For URLs that use auxiliary route outlets in the second or following path elements,
when removing the auxiliary route segment, parentheses remain for the primary outlet segment.
This causes the following error when trying to reload the URL: "Cannot match any route".
The commit adds a check for this scenario, serializing the URL as "a/b" instead of "a/(b)".

PR Close #24656

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## What is the current behavior?
For the following URL:
`a/(b//right:c)`

When removing the auxiliary outlet with:
`this.router.navigate( ['a', { outlets: { right: null } }]);`

Parentheses remain in the URL:
`a/(b)`

Issue Number: #24656


## What is the new behavior?
Parentheses are not added if the only child is a primary outlet segment:
`a/b`

## Does this PR introduce a breaking change?

- [x] No

