### PR TITLE
fix(core): properly move embedded views of dynamic component's projec…

### DIFF
--- a/packages/core/src/render3/assert.ts
+++ b/packages/core/src/render3/assert.ts
@@ -7,6 +7,7 @@
  */
 
 import {assertDefined, assertEqual, assertNumber, throwError} from '../util/assert';
+
 import {getComponentDef, getNgModuleDef} from './definition';
 import {LContainer} from './interfaces/container';
 import {DirectiveDef} from './interfaces/definition';
@@ -14,8 +15,7 @@ import {TIcu} from './interfaces/i18n';
 import {NodeInjectorOffset} from './interfaces/injector';
 import {TNode} from './interfaces/node';
 import {isLContainer, isLView} from './interfaces/type_checks';
-import {HEADER_OFFSET, LView, TVIEW, TView} from './interfaces/view';
-
+import {DECLARATION_COMPONENT_VIEW, HEADER_OFFSET, LView, T_HOST, TVIEW, TView} from './interfaces/view';
 
 // [Assert functions do not constraint type when they are guarded by a truthy
 // expression.](https://github.com/microsoft/TypeScript/issues/37295)
@@ -133,6 +133,20 @@ export function assertBetween(lower: number, upper: number, index: number) {
   if (!(lower <= index && index < upper)) {
     throwError(`Index out of range (expecting ${lower} <= ${index} < ${upper})`);
   }
+}
+
+export function assertProjectionSlots(lView: LView, errMessage?: string) {
+  assertDefined(lView[DECLARATION_COMPONENT_VIEW], 'Component views should exist.');
+  assertDefined(
+      lView[DECLARATION_COMPONENT_VIEW][T_HOST]!.projection,
+      errMessage ||
+          'Components with projection nodes (<ng-content>) must have projection slots defined.');
+}
+
+export function assertParentView(lView: LView|null, errMessage?: string) {
+  assertDefined(
+      lView,
+      errMessage || 'Component views should always have a parent view (component\'s host view)');
 }
 
 

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -1089,6 +1089,9 @@
     "name": "getPreviousIndex"
   },
   {
+    "name": "getProjectionNodes"
+  },
+  {
     "name": "getPromiseCtor"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1404,6 +1404,9 @@
     "name": "getPreviousIndex"
   },
   {
+    "name": "getProjectionNodes"
+  },
+  {
     "name": "getPromiseCtor"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -438,6 +438,9 @@
     "name": "getPreviousIndex"
   },
   {
+    "name": "getProjectionNodes"
+  },
+  {
     "name": "getSelectedIndex"
   },
   {

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule, DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
-import {Compiler, ComponentFactory, ComponentRef, ErrorHandler, EventEmitter, Host, Inject, Injectable, InjectionToken, Injector, NgModule, NgModuleRef, NO_ERRORS_SCHEMA, OnDestroy, SkipSelf, ViewRef, ɵivyEnabled as ivyEnabled} from '@angular/core';
+import {Compiler, ComponentFactory, ComponentRef, ErrorHandler, EventEmitter, Host, Inject, Injectable, InjectionToken, Injector, NgModule, NgModuleRef, NO_ERRORS_SCHEMA, OnDestroy, SkipSelf, ViewChild, ViewRef, ɵivyEnabled as ivyEnabled} from '@angular/core';
 import {ChangeDetectionStrategy, ChangeDetectorRef, PipeTransform} from '@angular/core/src/change_detection/change_detection';
 import {getDebugContext} from '@angular/core/src/errors';
 import {ComponentFactoryResolver} from '@angular/core/src/linker/component_factory_resolver';
@@ -1639,6 +1639,159 @@ function declareTests(config?: {useJit: boolean}) {
       fixture.componentInstance.ctxBoolProp = false;
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('');
+    });
+
+
+    describe('moving embedded views of projectable nodes in a dynamic component', () => {
+      @Component({selector: 'menu-item', template: ''})
+      class DynamicMenuItem {
+        @ViewChild('templateRef', {static: true}) templateRef!: TemplateRef<any>;
+        itemContent!: string;
+      }
+
+      @NgModule({
+        declarations: [DynamicMenuItem],
+        entryComponents: [DynamicMenuItem],
+      })
+      class DynamicMenuItemModule {
+      }
+
+      @Component({selector: 'test', template: `<ng-container #menuItemsContainer></ng-container>`})
+      class TestCmp {
+        constructor(public cfr: ComponentFactoryResolver) {}
+        @ViewChild('menuItemsContainer', {static: true, read: ViewContainerRef})
+        menuItemsContainer!: ViewContainerRef;
+      }
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          declarations: [TestCmp],
+          imports: [DynamicMenuItemModule],
+        });
+      });
+
+      const createElWithContent = (content: string, tagName = 'span') => {
+        const element = document.createElement(tagName);
+        element.textContent = content;
+        return element;
+      };
+
+      it('should support moving embedded views of projectable nodes', () => {
+        TestBed.overrideTemplate(
+            DynamicMenuItem, `<ng-template #templateRef><ng-content></ng-content></ng-template>`);
+
+        const fixture = TestBed.createComponent(TestCmp);
+        const menuItemsContainer = fixture.componentInstance.menuItemsContainer;
+        const dynamicCmptFactory =
+            fixture.componentInstance.cfr.resolveComponentFactory(DynamicMenuItem);
+
+        const cmptRefWithAa =
+            dynamicCmptFactory.create(Injector.NULL, [[createElWithContent('Aa')]]);
+        const cmptRefWithBb =
+            dynamicCmptFactory.create(Injector.NULL, [[createElWithContent('Bb')]]);
+        const cmptRefWithCc =
+            dynamicCmptFactory.create(Injector.NULL, [[createElWithContent('Cc')]]);
+
+        menuItemsContainer.insert(cmptRefWithAa.instance.templateRef.createEmbeddedView({}));
+        menuItemsContainer.insert(cmptRefWithBb.instance.templateRef.createEmbeddedView({}));
+        menuItemsContainer.insert(cmptRefWithCc.instance.templateRef.createEmbeddedView({}));
+
+        menuItemsContainer.move(menuItemsContainer.get(0)!, 1);
+        expect(fixture.nativeElement.textContent).toBe('BbAaCc');
+        menuItemsContainer.move(menuItemsContainer.get(2)!, 1);
+        expect(fixture.nativeElement.textContent).toBe('BbCcAa');
+      });
+
+      it('should support moving embedded views of projectable nodes in multiple slots', () => {
+        TestBed.overrideTemplate(
+            DynamicMenuItem,
+            `<ng-template #templateRef><ng-content select="span"></ng-content><ng-content select="button"></ng-content></ng-template>`);
+
+        const fixture = TestBed.createComponent(TestCmp);
+        const menuItemsContainer = fixture.componentInstance.menuItemsContainer;
+        const dynamicCmptFactory =
+            fixture.componentInstance.cfr.resolveComponentFactory(DynamicMenuItem);
+
+        const cmptRefWithAa = dynamicCmptFactory.create(
+            Injector.NULL, [[createElWithContent('A')], [createElWithContent('a', 'button')]]);
+        const cmptRefWithBb = dynamicCmptFactory.create(
+            Injector.NULL, [[createElWithContent('B')], [createElWithContent('b', 'button')]]);
+        const cmptRefWithCc = dynamicCmptFactory.create(
+            Injector.NULL, [[createElWithContent('C')], [createElWithContent('c', 'button')]]);
+
+        menuItemsContainer.insert(cmptRefWithAa.instance.templateRef.createEmbeddedView({}));
+        menuItemsContainer.insert(cmptRefWithBb.instance.templateRef.createEmbeddedView({}));
+        menuItemsContainer.insert(cmptRefWithCc.instance.templateRef.createEmbeddedView({}));
+
+        menuItemsContainer.move(menuItemsContainer.get(0)!, 1);
+        expect(fixture.nativeElement.textContent).toBe('BbAaCc');
+        menuItemsContainer.move(menuItemsContainer.get(2)!, 1);
+        expect(fixture.nativeElement.textContent).toBe('BbCcAa');
+      });
+
+      it('should support moving embedded views of projectable nodes in multiple slots and interpolations',
+         () => {
+           TestBed.overrideTemplate(
+               DynamicMenuItem,
+               `<ng-template #templateRef><ng-content select="span"></ng-content>{{itemContent}}<ng-content select="button"></ng-content></ng-template>`);
+
+           TestBed.configureTestingModule(
+               {declarations: [TestCmp], imports: [DynamicMenuItemModule]});
+
+           const fixture = TestBed.createComponent(TestCmp);
+           const menuItemsContainer = fixture.componentInstance.menuItemsContainer;
+           const dynamicCmptFactory =
+               fixture.componentInstance.cfr.resolveComponentFactory(DynamicMenuItem);
+
+           const cmptRefWithAa = dynamicCmptFactory.create(
+               Injector.NULL, [[createElWithContent('A')], [createElWithContent('a', 'button')]]);
+           const cmptRefWithBb = dynamicCmptFactory.create(
+               Injector.NULL, [[createElWithContent('B')], [createElWithContent('b', 'button')]]);
+           const cmptRefWithCc = dynamicCmptFactory.create(
+               Injector.NULL, [[createElWithContent('C')], [createElWithContent('c', 'button')]]);
+
+           menuItemsContainer.insert(cmptRefWithAa.instance.templateRef.createEmbeddedView({}));
+           menuItemsContainer.insert(cmptRefWithBb.instance.templateRef.createEmbeddedView({}));
+           menuItemsContainer.insert(cmptRefWithCc.instance.templateRef.createEmbeddedView({}));
+
+           cmptRefWithAa.instance.itemContent = '0';
+           cmptRefWithBb.instance.itemContent = '1';
+           cmptRefWithCc.instance.itemContent = '2';
+
+           fixture.detectChanges();
+
+           menuItemsContainer.move(menuItemsContainer.get(0)!, 1);
+           expect(fixture.nativeElement.textContent).toBe('B1bA0aC2c');
+           menuItemsContainer.move(menuItemsContainer.get(2)!, 1);
+           expect(fixture.nativeElement.textContent).toBe('B1bC2cA0a');
+         });
+
+      it('should support moving embedded views with empty projectable slots', () => {
+        TestBed.overrideTemplate(
+            DynamicMenuItem, `<ng-template #templateRef><ng-content></ng-content></ng-template>`);
+
+        const fixture = TestBed.createComponent(TestCmp);
+        const menuItemsContainer = fixture.componentInstance.menuItemsContainer;
+        const dynamicCmptFactory =
+            fixture.componentInstance.cfr.resolveComponentFactory(DynamicMenuItem);
+
+        const cmptRefWithAa = dynamicCmptFactory.create(Injector.NULL, [[]]);
+        const cmptRefWithBb =
+            dynamicCmptFactory.create(Injector.NULL, [[createElWithContent('Bb')]]);
+        const cmptRefWithCc =
+            dynamicCmptFactory.create(Injector.NULL, [[createElWithContent('Cc')]]);
+
+        menuItemsContainer.insert(cmptRefWithAa.instance.templateRef.createEmbeddedView({}));
+        menuItemsContainer.insert(cmptRefWithBb.instance.templateRef.createEmbeddedView({}));
+        menuItemsContainer.insert(cmptRefWithCc.instance.templateRef.createEmbeddedView({}));
+
+        menuItemsContainer.move(menuItemsContainer.get(0)!, 1);  // [ Bb, NULL, Cc]
+        expect(fixture.nativeElement.textContent).toBe('BbCc');
+        menuItemsContainer.move(menuItemsContainer.get(2)!, 1);  // [ Bb, Cc, NULL]
+        expect(fixture.nativeElement.textContent).toBe('BbCc');
+        menuItemsContainer.move(menuItemsContainer.get(0)!, 1);  // [ Cc, Bb, NULL]
+        expect(fixture.nativeElement.textContent).toBe('CcBb');
+      });
     });
 
     describe('Property bindings', () => {


### PR DESCRIPTION
…table nodes

This commit fixes the issue of the ASSERTION ERROR issue when
a projected node(RNode) inside an array is checked against the types
of TNodeType.Element, TNodeType.Container, TNodeType.ElementContainer,
TNodeType.IcuContainer, TNodeType.Projection. As it's inside an array,
it doesn't fall into any of those types, as a result, it throws
the ASSERTION ERROR.

Fixes #37120

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Moving embedded views created out of dynamic component's projectable nodes causes ASSERTION ERROR.

Issue Number: https://github.com/angular/angular/issues/37120

## What is the new behavior?

Properly moves embedded views created out of dynamic component's projectable nodes causes ASSERTION ERROR.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
