### PR TITLE
docs: fix typo in committer.md

### DIFF
--- a/docs/COMMITTER.md
+++ b/docs/COMMITTER.md
@@ -7,7 +7,7 @@ As a contributor, see the instructions in [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 # Change approvals
 
-Change approvals in our monorepo are managed via [PullApprove](https://https://docs.pullapprove.com/) and are configured via the [`.pullapprove`](../.pullapprove) file.
+Change approvals in our monorepo are managed via [PullApprove](https://docs.pullapprove.com/) and are configured via the [`.pullapprove`](../.pullapprove) file.
 
 # Merging
 


### PR DESCRIPTION
Fix a type of COMMITTER.md, the url of the pullapprove service should be https://docs.pullapprove.com/,
now the document has an additional `https` prefix.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

