### PR TITLE
feat(core): update TestModuleMetadata typings

### DIFF
--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AbstractType, Component, Directive, InjectFlags, InjectionToken, NgModule, Pipe, PlatformRef, SchemaMetadata, Type} from '@angular/core';
+import {AbstractType, Component, Directive, InjectFlags, InjectionToken, ModuleWithProviders, NgModule, Pipe, PlatformRef, Provider, SchemaMetadata, Type} from '@angular/core';
 
 import {ComponentFixture} from './component_fixture';
 import {MetadataOverride} from './metadata_override';
@@ -36,9 +36,9 @@ export const ComponentFixtureNoNgZone = new InjectionToken<boolean[]>('Component
  * @publicApi
  */
 export type TestModuleMetadata = {
-  providers?: any[],
-  declarations?: any[],
-  imports?: any[],
+  providers?: Provider[],
+  declarations?: Array<Type<any>|any[]>,
+  imports?: Array<Type<any>|ModuleWithProviders<{}>|any[]>,
   schemas?: Array<SchemaMetadata|any[]>,
   aotSummaries?: () => any[],
 };


### PR DESCRIPTION
Update TestModuleMetadata typings to be stricter and in-line with
NgModule interface typings.

Issue Close #37178

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Current `TestModuleMetadata` were loose which could lead to hard-to-pin-down issues in tests.


## What is the new behavior?
`TestModuleMetadata` has been update to be stricter and in-line with `NgModule` interface.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

This should not be a breaking change. It is a breaking change only if some tests used incorrect TestModuleMetadata configuration.


## Other information
Related issue: https://github.com/angular/angular/issues/37178