### PR TITLE
feat(dev-infra): register ts-node when reading configuration

### DIFF
--- a/dev-infra/tmpl-package.json
+++ b/dev-infra/tmpl-package.json
@@ -24,7 +24,13 @@
   "peerDependencies": {
     "@bazel/buildifier": "<from-root>",
     "clang-format": "<from-root>",
+    "ts-node": "<from-root>",
     "tslib": "<from-root>",
     "typescript": "<from-root>"
+  },
+  "peerDependenciesMeta": {
+    "ts-node": {
+      "optional": true
+    }
   }
 }

--- a/dev-infra/utils/ts-node.ts
+++ b/dev-infra/utils/ts-node.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/** Whether ts-node has been installed and is available to ng-dev. */
+export function isTsNodeAvailable(): boolean {
+  try {
+    require.resolve('ts-node');
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
`ts-node` is now an optional peer dependency of the shared dev-infra
package. Whenever a `ng-dev` command runs, and a TypeScript-based
configuration file exists, `ts-node` is set up if available.

That allows consumers of the package (as the components repo) to more
conveniently use a TypeScript-based configuration for dev-infra. Currently,
commands would need to be proxied through `ts-node` which rather
complicates the setup:

```bash
NG_DEV_COMMAND="ts-node ./node_modules/@angular/dev-infra-private/cli.js"
```

I'm thinking that it should be best-practice to use TypeScript for writing
the configuration files. Given that the tool is used primarily in Angular
projects (for which most sources are TypeScript), this should be acceptable.

Additional changes in this PR:

* Fixes common config errors not reported
* Small code change to avoid unnecessary config clone.