### PR TITLE
refactor(localize): da time format change

### DIFF
--- a/packages/common/locales/da-GL.ts
+++ b/packages/common/locales/da-GL.ts
@@ -45,7 +45,7 @@ export default [
   1,
   [6, 0],
   ['dd.MM.y', 'd. MMM y', 'd. MMMM y', 'EEEE \'den\' d. MMMM y'],
-  ['HH.mm', 'HH.mm.ss', 'HH.mm.ss z', 'HH.mm.ss zzzz'],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
   ['{1} {0}', u, '{1} \'kl\'. {0}', u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', '.'],
   ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],

--- a/packages/common/locales/da.ts
+++ b/packages/common/locales/da.ts
@@ -45,7 +45,7 @@ export default [
   1,
   [6, 0],
   ['dd.MM.y', 'd. MMM y', 'd. MMMM y', 'EEEE \'den\' d. MMMM y'],
-  ['HH.mm', 'HH.mm.ss', 'HH.mm.ss z', 'HH.mm.ss zzzz'],
+  ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
   ['{1} {0}', u, '{1} \'kl\'. {0}', u],
   [',', '.', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', '.'],
   ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],


### PR DESCRIPTION
refactor(localize): da time format change

Change separator in time format to colon instead of dot. Change made for both da and da-GL.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
i18n time format for danish and danish-greenlandic use a dot as a separator 

Issue Number: N/A


## What is the new behavior?
i18n time format for danish and danish-greenlandic now use a colon as a separator

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


## Other information
