### PR TITLE
ngcc: fix NgModuleWithProviders issue for aliased IIFE wrapped es2015 classes

### DIFF
--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
@@ -174,12 +174,13 @@ runInEachFileSystem(() => {
       ];
       return AliasedWrappedClass;
     })();
-    let DecoratedWrappedClass = /** @class */ (() => {
-      let DecoratedWrappedClass = class DecoratedWrappedClass {}
-      // ... add decorations ...
-      return DecoratedWrappedClass;
-    })();
     let usageOfWrappedClass = AliasedWrappedClass_1;
+    let DecoratedWrappedClass = /** @class */ (() => {
+      let DecoratedWrappedClass_1 = class DecoratedWrappedClass {}
+      // ... add decorations ...
+      return DecoratedWrappedClass_1;
+    })();
+    let usageOfDecorated = DecoratedWrappedClass_1;
   `,
       };
 
@@ -1970,7 +1971,7 @@ runInEachFileSystem(() => {
                !isNamedVariableDeclaration(classSymbol.adjacent.valueDeclaration)) {
              return fail('Expected a named variable declaration for the adjacent symbol');
            }
-           expect(classSymbol.adjacent.valueDeclaration.name.text).toBe('DecoratedWrappedClass');
+           expect(classSymbol.adjacent.valueDeclaration.name.text).toBe('DecoratedWrappedClass_1');
          });
 
       it('should return the class symbol for a decorated wrapped class expression (inner class expression)',
@@ -2000,7 +2001,7 @@ runInEachFileSystem(() => {
                !isNamedVariableDeclaration(classSymbol.adjacent.valueDeclaration)) {
              return fail('Expected a named variable declaration for the adjacent symbol');
            }
-           expect(classSymbol.adjacent.valueDeclaration.name.text).toBe('DecoratedWrappedClass');
+           expect(classSymbol.adjacent.valueDeclaration.name.text).toBe('DecoratedWrappedClass_1');
          });
 
       it('should return the same class symbol (of the outer declaration) for decorated wrapped outer and inner declarations',

--- a/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
@@ -54,7 +54,7 @@ export function getDeclaration<T extends ts.Declaration>(
     program: ts.Program, fileName: AbsoluteFsPath, name: string,
     assert: (value: any) => value is T): T {
   const sf = getSourceFileOrError(program, fileName);
-  const chosenDecl = walkForDeclaration(sf);
+  const chosenDecl = walkForDeclaration(name, sf);
 
   if (chosenDecl === null) {
     throw new Error(`No such symbol: ${name} in ${fileName}`);
@@ -63,37 +63,40 @@ export function getDeclaration<T extends ts.Declaration>(
     throw new Error(`Symbol ${name} from ${fileName} is a ${ts.SyntaxKind[chosenDecl.kind]}`);
   }
   return chosenDecl;
-
-  // We walk the AST tree looking for a declaration that matches
-  function walkForDeclaration(rootNode: ts.Node): ts.Declaration|null {
-    let chosenDecl: ts.Declaration|null = null;
-    rootNode.forEachChild(node => {
-      if (chosenDecl !== null) {
-        return;
-      }
-      if (ts.isVariableStatement(node)) {
-        node.declarationList.declarations.forEach(decl => {
-          if (bindingNameEquals(decl.name, name)) {
-            chosenDecl = decl;
-          }
-        });
-      } else if (
-          ts.isClassDeclaration(node) || ts.isFunctionDeclaration(node) ||
-          ts.isInterfaceDeclaration(node)) {
-        if (node.name !== undefined && node.name.text === name) {
-          chosenDecl = node;
-        }
-      } else if (
-          ts.isImportDeclaration(node) && node.importClause !== undefined &&
-          node.importClause.name !== undefined && node.importClause.name.text === name) {
-        chosenDecl = node.importClause;
-      } else {
-        chosenDecl = walkForDeclaration(node);
-      }
-    });
-    return chosenDecl;
-  }
 }
+
+// We walk the AST tree looking for a declaration that matches
+export function walkForDeclaration(name: string, rootNode: ts.Node): ts.Declaration|null {
+  let chosenDecl: ts.Declaration|null = null;
+  rootNode.forEachChild(node => {
+    if (chosenDecl !== null) {
+      return;
+    }
+    if (ts.isVariableStatement(node)) {
+      node.declarationList.declarations.forEach(decl => {
+        if (bindingNameEquals(decl.name, name)) {
+          chosenDecl = decl;
+        } else {
+          chosenDecl = walkForDeclaration(name, node);
+        }
+      });
+    } else if (
+        ts.isClassDeclaration(node) || ts.isFunctionDeclaration(node) ||
+        ts.isInterfaceDeclaration(node) || ts.isClassExpression(node)) {
+      if (node.name !== undefined && node.name.text === name) {
+        chosenDecl = node;
+      }
+    } else if (
+        ts.isImportDeclaration(node) && node.importClause !== undefined &&
+        node.importClause.name !== undefined && node.importClause.name.text === name) {
+      chosenDecl = node.importClause;
+    } else {
+      chosenDecl = walkForDeclaration(name, node);
+    }
+  });
+  return chosenDecl;
+}
+
 
 function bindingNameEquals(node: ts.BindingName, name: string): boolean {
   if (ts.isIdentifier(node)) {


### PR DESCRIPTION
In ES2015 IIFE wrapped classes, the identifier that would reference the class
of the NgModule may be an alias variable. Previously the `Esm2015ReflectionHost`
was not able to match this alias to the original class declaration. This resulted
in failing to identify some `ModuleWithProviders` functions in such case.

These IIFE wrapped classes were introduced in TypeScript 3.9, which is why
this issue is only recently appearing. Since 9.1.x does not support TS 3.9
there is no reason to backport this commit to that branch.

Fixes #37189