### PR TITLE
build: fix deprecation notice in scripts/github/merge-pr script

### DIFF
--- a/scripts/github/merge-pr
+++ b/scripts/github/merge-pr
@@ -22,7 +22,7 @@ favor of using ng-dev.
 
 To merge a pr using the new tooling run:
 
-$ yarn -s ng dev pr merge <pr-number>
+$ yarn -s ng-dev pr merge <pr-number>
 
 ################################################"
 # Sleep a short time to highlight deprecate notice.


### PR DESCRIPTION
The deprecation notice for the merge-pr script errantly referenced
'ng dev' rather than 'ng-dev', this PR corrects this.
