### PR TITLE
ci: testing folders in compiler-cli should not require `fw-testing`ap…

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -569,7 +569,7 @@ groups:
       - *can-be-global-approved
       - *can-be-global-docs-approved
       - >
-        contains_any_globs(files, [
+        contains_any_globs(files.exclude('packages/compiler-cli/**'), [
           '**/testing/**',
           'aio/content/guide/testing.md',
           'aio/content/examples/testing/**',


### PR DESCRIPTION
…proval

The `fw-testing` PullApprove group is really designed to
capture the top level public testing API groups in packages
like `common` and `router`.

The compiler-cli also has some folders that contain the path
segment `testing` but these should not require `fw-testing`
PullApprove approval.

This commit excludes the whole of `compiler-cli` package from
the `fw-testing` group.
