### PR TITLE
Remove extra semicolons found in the http guide

### DIFF
--- a/aio/content/examples/http/src/app/config/config.service.ts
+++ b/aio/content/examples/http/src/app/config/config.service.ts
@@ -76,15 +76,15 @@ export class ConfigService {
       console.error('An error occurred:', error.error.message);
     } else {
       // The backend returned an unsuccessful response code.
-      // The response body may contain clues as to what went wrong,
+      // The response body may contain clues as to what went wrong.
       console.error(
         `Backend returned code ${error.status}, ` +
         `body was: ${error.error}`);
     }
-    // return an observable with a user-facing error message
+    // Return an observable with a user-facing error message.
     return throwError(
       'Something bad happened; please try again later.');
-  };
+  }
   // #enddocregion handleError
 
   makeIntentionalError() {

--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -277,7 +277,7 @@ searchHeroes(term: string): Observable {
   return this.http.jsonp(heroesUrl, 'callback').pipe(
       catchError(this.handleError('searchHeroes', [])) // then handle the error
     );
-};
+}
 ```
 
 This request passes the `heroesURL` as the first parameter and the callback function name as the second parameter.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

There are some extra semicolons found in some of the code examples in the HTTP [guide](https://angular.io/guide/http), which doesn't match Typescript style guidelines.


## What is the new behavior?

Extra semicolons were removed both for:

- aio/content/guide/http.md 

and for: 

- aio/content/examples/http/src/app/config/config.service.ts

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

In the second commit:

- Replace a comma for a dot in the comment at line 79 to ensure consistency
with the rest of the document.

- Capitalized and added a dot at the end of the comment at line 84 to
ensure consistency with the other comments.