### PR TITLE
[9.1.x] fix(elements): fire custom element output events during component initialization

### DIFF
--- a/browser-providers.conf.js
+++ b/browser-providers.conf.js
@@ -30,7 +30,16 @@ var CIconfiguration = {
   'Android7': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
   'Android8': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
   'Android9': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
-  'Android10': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
+  // Disable Android 10 tests due to infrastructure failure.
+  // ex:
+  // Chrome Mobile 74.0.3729 (Android 0.0.0) ERROR:
+  //    Error: XHR error loading
+  //    http://angular-ci.local:9876/base/node_modules/rxjs/internal/operators/zip.js
+  //
+  // Error loading http://angular-ci.local:9876/base/node_modules/rxjs/internal/operators/zip.js as
+  // "../internal/operators/zip" from
+  // http://angular-ci.local:9876/base/node_modules/rxjs/operators/index.js
+  'Android10': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
   'Safari12': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
   'Safari13': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
   'iOS10': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},

--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -187,13 +187,13 @@ export function createCustomElement<P>(
     }
 
     connectedCallback(): void {
-      this.ngElementStrategy.connect(this);
-
       // Listen for events from the strategy and dispatch them as custom events
       this.ngElementEventsSubscription = this.ngElementStrategy.events.subscribe(e => {
         const customEvent = createCustomEvent(this.ownerDocument!, e.name, e.value);
         this.dispatchEvent(customEvent);
       });
+
+      this.ngElementStrategy.connect(this);
     }
 
     disconnectedCallback(): void {

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -41,6 +41,33 @@ describe('ComponentFactoryNgElementStrategy', () => {
     expect(strategyFactory.create(injector)).toBeTruthy();
   });
 
+  describe('before connected', () => {
+    it('should allow subscribing to output events', () => {
+      const events: NgElementStrategyEvent[] = [];
+      strategy.events.subscribe(e => events.push(e));
+
+      // No events before connecting (since `componentRef` is not even on the strategy yet).
+      componentRef.instance.output1.next('output-1a');
+      componentRef.instance.output1.next('output-1b');
+      componentRef.instance.output2.next('output-2a');
+      expect(events).toEqual([]);
+
+      // No events upon connecting (since events are not cached/played back).
+      strategy.connect(document.createElement('div'));
+      expect(events).toEqual([]);
+
+      // Events emitted once connected.
+      componentRef.instance.output1.next('output-1c');
+      componentRef.instance.output1.next('output-1d');
+      componentRef.instance.output2.next('output-2b');
+      expect(events).toEqual([
+        {name: 'templateOutput1', value: 'output-1c'},
+        {name: 'templateOutput1', value: 'output-1d'},
+        {name: 'templateOutput2', value: 'output-2b'},
+      ]);
+    });
+  });
+
   describe('after connected', () => {
     beforeEach(() => {
       // Set up an initial value to make sure it is passed to the component

--- a/packages/elements/test/create-custom-element_spec.ts
+++ b/packages/elements/test/create-custom-element_spec.ts
@@ -117,6 +117,16 @@ if (browserDetection.supportsCustomElements) {
       expect(eventValue).toEqual(null);
     });
 
+    it('should listen to output events during initialization', () => {
+      const events: string[] = [];
+
+      const element = new NgElementCtor(injector);
+      element.addEventListener('strategy-event', evt => events.push((evt as CustomEvent).detail));
+      element.connectedCallback();
+
+      expect(events).toEqual(['connect']);
+    });
+
     it('should properly set getters/setters on the element', () => {
       const element = new NgElementCtor(injector);
       element.fooFoo = 'foo-foo-value';
@@ -255,6 +265,7 @@ if (browserDetection.supportsCustomElements) {
       events = new Subject<NgElementStrategyEvent>();
 
       connect(element: HTMLElement): void {
+        this.events.next({name: 'strategy-event', value: 'connect'});
         this.connectedElement = element;
       }
 


### PR DESCRIPTION
This is a backport of #36161 to the patch branch (9.1.x) ~~with the extra change to payload sizes for 9.1.x: 7db450e452b75133cec9c0ff76b41687e37efd6e~~ _The payload size change is no longer necessary, so I removed it to make this identical to #36161._

Thus the changes have been approved, ~~except for the payload size updates.~~

##
This PR increases the main bundle by ~190B. See the [original PR][1] for details. It happens to push the ViewEngine payload size over the limit (actual increase: 430865B --> 431055B, while the limit is currently at 430383B).

[1]: https://github.com/angular/angular/pull/36161#issue-391545292