### PR TITLE
fix(compiler-cli): add type to ngOptions in NgTscPlugin constructor

### DIFF
--- a/packages/compiler-cli/src/ngtsc/tsc_plugin.ts
+++ b/packages/compiler-cli/src/ngtsc/tsc_plugin.ts
@@ -72,14 +72,14 @@ export class NgTscPlugin implements TscPlugin {
     return this._compiler;
   }
 
-  constructor(private ngOptions: {}) {
+  constructor(private ngOptions: NgCompilerOptions) {
     setFileSystem(new NodeJSFileSystem());
   }
 
   wrapHost(
       host: ts.CompilerHost&UnifiedModulesHost, inputFiles: readonly string[],
       options: ts.CompilerOptions): PluginCompilerHost {
-    this.options = {...this.ngOptions, ...options} as NgCompilerOptions;
+    this.options = {...this.ngOptions, ...options};
     this.host = NgCompilerHost.wrap(host, inputFiles, this.options, /* oldProgram */ null);
     return this.host;
   }


### PR DESCRIPTION


With this change we add a strict type to `ngOptions` in NgTscPlugin constructor compiler cli class.