### PR TITLE
build: use static patch value for targetting branches in merge config

### DIFF
--- a/.ng-dev-config.ts
+++ b/.ng-dev-config.ts
@@ -1,5 +1,4 @@
 import {MergeConfig} from './dev-infra/pr/merge/config';
-import {determineMergeBranches} from './dev-infra/pr/merge/determine-merge-branches';
 
 // The configuration for `ng-dev commit-message` commands.
 const commitMessage = {
@@ -84,7 +83,8 @@ const github = {
 // Configuration for the `ng-dev pr merge` command. The command can be used
 // for merging upstream pull requests into branches based on a PR target label.
 const merge = () => {
-  const {patch} = determineMergeBranches(require('./package.json').version, '@angular/core');
+  // TODO: resume dynamically determining patch branch
+  const patch = '10.0.x';
   const config: MergeConfig = {
     githubApiMerge: false,
     claSignedLabel: 'cla: yes',


### PR DESCRIPTION
Due to the desired patch branch (10.0.x) being on a semver version
that is unreleased as stable (there is no 10.0.0 on latest, it is on
next) our logic for determining target patch branches does not work.

This change is a workaround to unblock merging in the repo while a
longer term answer is discovered.
