### PR TITLE
docs: fix the code sample displayed in the "reusable animations" guide

### DIFF
--- a/aio/content/examples/animations/src/app/open-close.component.3.ts
+++ b/aio/content/examples/animations/src/app/open-close.component.3.ts
@@ -1,29 +1,12 @@
 // #docplaster
 // #docregion reusable
 import { Component } from '@angular/core';
-import { useAnimation, transition, trigger, style, animate } from '@angular/animations';
+import { transition, trigger, useAnimation } from '@angular/animations';
 import { transAnimation } from './animations';
 
 @Component({
-// #enddocregion reusable
   selector: 'app-open-close-reusable',
-// #docregion runtime
   animations: [
-    transition('open => closed', [
-      style({
-        height: '200 px',
-        opacity: '{{ opacity }}',
-        backgroundcolor: 'yelow'
-      }),
-      animate('{{ time }}'),
-    ], {
-        params: {
-          time: '1s',
-          opacity: '1'
-        }
-      }),
-// #enddocregion runtime
-// #docregion reusable
     trigger('openClose', [
       transition('open => closed', [
         useAnimation(transAnimation, {
@@ -36,10 +19,9 @@ import { transAnimation } from './animations';
         })
       ])
     ])
-// #enddocregion reusable
+  ],
   templateUrl: 'open-close.component.html',
   styleUrls: ['open-close.component.css']
-// #docregion reusable
 })
 // #enddocregion reusable
 export class OpenCloseReusableComponent { }


### PR DESCRIPTION
Currently the code sample displayed in this guide is not a valid.
The `trigger` is directly used in the `@Component` decorator.
It should instead be in the `animations` array of the `@Component` decorator.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the code sample displayed in this guide is not a valid.
The `trigger` is directly used in the `@Component` decorator.
```
@Component({
    trigger('openClose', [
      transition('open => closed', [
        useAnimation(transAnimation, {
          params: {
            height: 0,
            opacity: 1,
            backgroundColor: 'red',
            time: '1s'
          }
        })
      ])
    ])
})
```
Issue Number: N/A


## What is the new behavior?
It should instead be in the `animations` array of the `@Component` decorator.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
