### PR TITLE
docs: update package names

### DIFF
--- a/aio/content/guide/ngmodules.md
+++ b/aio/content/guide/ngmodules.md
@@ -18,9 +18,9 @@ Modules are a great way to organize an application and extend it with capabiliti
 
 Angular libraries are NgModules, such as `FormsModule`, `HttpClientModule`, and `RouterModule`.
 Many third-party libraries are available as NgModules such as
-<a href="https://material.angular.io/">Material Design</a>,
+<a href="https://material.angular.io/">@angular/material</a>,
 <a href="http://ionicframework.com/">Ionic</a>, and
-<a href="https://github.com/angular/angularfire2">AngularFire2</a>.
+<a href="https://github.com/angular/angularfire">@angular/fire</a>.
 
 NgModules consolidate components, directives, and pipes into
 cohesive blocks of functionality, each focused on a


### PR DESCRIPTION
This PR updates the names and urls of packages like Material Design and AngularFire.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The docs were referring to some packages with their old names like Material Design and AngularFire2.

Issue Number: N/A

## What is the new behavior?

The docs will now refer to the package with @angular/material and @angular/fire.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N.A.