### PR TITLE
fix(forms): do not update group with "submit" update strategy on child controls input

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -660,7 +660,8 @@ export abstract class AbstractControl {
       (this.statusChanges as EventEmitter<string>).emit(this.status);
     }
 
-    if (this._parent && !opts.onlySelf) {
+    if (this._parent && !opts.onlySelf &&
+        (this._parent.updateOn === 'change' || this._parent.updateOn === this.updateOn)) {
       this._parent.updateValueAndValidity(opts);
     }
   }

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -1481,6 +1481,28 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           expect(groupValidatorSpy).not.toHaveBeenCalled();
         });
 
+        it('should not run validation for group with "submit" update strategy on child controls input',
+           () => {
+             const validatorSpy = jasmine.createSpy('validator');
+
+             const fixture = initTest(FormGroupComp);
+             const formGroup = new FormGroup(
+                 {
+                   login: new FormControl('', {updateOn: 'change'}),
+                 },
+                 {updateOn: 'submit'});
+             fixture.componentInstance.form = formGroup;
+             fixture.detectChanges();
+
+             formGroup!.setValidators(validatorSpy);
+
+             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             dispatchEvent(input, 'input');
+             fixture.detectChanges();
+
+             expect(validatorSpy).not.toHaveBeenCalled();
+           });
+
         it('should mark as untouched properly if pending touched', () => {
           const fixture = initTest(FormGroupComp);
           const formGroup = new FormGroup({login: new FormControl('', {updateOn: 'submit'})});

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -704,6 +704,26 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              expect(groupValidatorSpy).not.toHaveBeenCalled();
            }));
 
+        it('should not run validation for form with "submit" update strategy on child controls input',
+           fakeAsync(() => {
+             const validatorSpy = jasmine.createSpy('validator');
+
+             const fixture = initTest(NgModelOptionsStandalone);
+             fixture.componentInstance.options = {updateOn: 'change', name: 'two'};
+             fixture.componentInstance.formOptions = {updateOn: 'submit'};
+             fixture.detectChanges();
+             tick();
+
+             const form = fixture.debugElement.children[0].injector.get(NgForm);
+             form.control!.setValidators(validatorSpy);
+
+             const inputTwo = fixture.debugElement.queryAll(By.css('input'))[1].nativeElement;
+             dispatchEvent(inputTwo, 'input');
+             fixture.detectChanges();
+
+             expect(validatorSpy).not.toHaveBeenCalled();
+           }));
+
         it('should not update dirtiness until submit', fakeAsync(() => {
              const fixture = initTest(NgModelForm);
              fixture.componentInstance.name = '';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Previously, group was updating on child controls input, even if updateOn was set to "submit".

Issue Number: https://github.com/angular/angular/issues/36998


## What is the new behavior?
Do not update group with "submit" update strategy on child controls input.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

