### PR TITLE
docs: remove redundant web-worker nav

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -585,11 +585,6 @@
           "url": "guide/cli-builder",
           "title": "CLI Builders",
           "tooltip": "Using builders to customize Angular CLI."
-        },
-        {
-          "url": "guide/web-worker",
-          "title": "Web Workers in Angular",
-          "tooltip": "Implement background processing with web workers."
         }
       ]
     },


### PR DESCRIPTION
Web- worker was 2 times in the nav pointing towards the same file, just with different names removed one to remove redundancy

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Redundant web worker nav

Issue Number: N/A


## What is the new behavior?
No redundant web worker nav

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
