### PR TITLE
docs(router): fix a typo in example code for RouterTestingModule

### DIFF
--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -155,7 +155,7 @@ export function setupTestingRouter(
  *
  * ```
  * beforeEach(() => {
- *   TestBed.configureTestModule({
+ *   TestBed.configureTestingModule({
  *     imports: [
  *       RouterTestingModule.withRoutes(
  *         [{path: '', component: BlankCmp}, {path: 'simple', component: SimpleCmp}]


### PR DESCRIPTION
Fix RouterTestingModule example

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The example code in the RouterTestingModule documentation uses a non-existent method of TestBed (`TestBed.configureTestModule`). 

Issue Number: N/A


## What is the new behavior?

Changed `TestBed.configureTestModule` to `TestBed.configureTestingModule`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
