### PR TITLE
feat(common): add ReadonlyMap in place of Map in keyValuePipe

### DIFF
--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -138,18 +138,18 @@ export declare class KeyValuePipe implements PipeTransform {
     transform<K, V>(input: null, compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): null;
     transform<V>(input: {
         [key: string]: V;
-    } | Map<string, V>, compareFn?: (a: KeyValue<string, V>, b: KeyValue<string, V>) => number): Array<KeyValue<string, V>>;
+    } | ReadonlyMap<string, V>, compareFn?: (a: KeyValue<string, V>, b: KeyValue<string, V>) => number): Array<KeyValue<string, V>>;
     transform<V>(input: {
         [key: string]: V;
-    } | Map<string, V> | null, compareFn?: (a: KeyValue<string, V>, b: KeyValue<string, V>) => number): Array<KeyValue<string, V>> | null;
+    } | ReadonlyMap<string, V> | null, compareFn?: (a: KeyValue<string, V>, b: KeyValue<string, V>) => number): Array<KeyValue<string, V>> | null;
     transform<V>(input: {
         [key: number]: V;
-    } | Map<number, V>, compareFn?: (a: KeyValue<number, V>, b: KeyValue<number, V>) => number): Array<KeyValue<number, V>>;
+    } | ReadonlyMap<number, V>, compareFn?: (a: KeyValue<number, V>, b: KeyValue<number, V>) => number): Array<KeyValue<number, V>>;
     transform<V>(input: {
         [key: number]: V;
-    } | Map<number, V> | null, compareFn?: (a: KeyValue<number, V>, b: KeyValue<number, V>) => number): Array<KeyValue<number, V>> | null;
-    transform<K, V>(input: Map<K, V>, compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): Array<KeyValue<K, V>>;
-    transform<K, V>(input: Map<K, V> | null, compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): Array<KeyValue<K, V>> | null;
+    } | ReadonlyMap<number, V> | null, compareFn?: (a: KeyValue<number, V>, b: KeyValue<number, V>) => number): Array<KeyValue<number, V>> | null;
+    transform<K, V>(input: ReadonlyMap<K, V>, compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): Array<KeyValue<K, V>>;
+    transform<K, V>(input: ReadonlyMap<K, V> | null, compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): Array<KeyValue<K, V>> | null;
 }
 
 export declare class Location {

--- a/packages/common/src/pipes/keyvalue_pipe.ts
+++ b/packages/common/src/pipes/keyvalue_pipe.ts
@@ -36,8 +36,8 @@ export interface KeyValue<K, V> {
  * @usageNotes
  * ### Examples
  *
- * This examples show how an Object or a Map can be iterated by ngFor with the use of this keyvalue
- * pipe.
+ * This examples show how an Object or a Map can be iterated by ngFor with the use of this
+ * keyvalue pipe.
  *
  * {@example common/pipes/ts/keyvalue_pipe.ts region='KeyValuePipe'}
  *
@@ -52,28 +52,29 @@ export class KeyValuePipe implements PipeTransform {
 
   transform<K, V>(input: null, compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): null;
   transform<V>(
-      input: {[key: string]: V}|Map<string, V>,
+      input: {[key: string]: V}|ReadonlyMap<string, V>,
       compareFn?: (a: KeyValue<string, V>, b: KeyValue<string, V>) => number):
       Array<KeyValue<string, V>>;
   transform<V>(
-      input: {[key: string]: V}|Map<string, V>|null,
+      input: {[key: string]: V}|ReadonlyMap<string, V>|null,
       compareFn?: (a: KeyValue<string, V>, b: KeyValue<string, V>) => number):
       Array<KeyValue<string, V>>|null;
   transform<V>(
-      input: {[key: number]: V}|Map<number, V>,
+      input: {[key: number]: V}|ReadonlyMap<number, V>,
       compareFn?: (a: KeyValue<number, V>, b: KeyValue<number, V>) => number):
       Array<KeyValue<number, V>>;
   transform<V>(
-      input: {[key: number]: V}|Map<number, V>|null,
+      input: {[key: number]: V}|ReadonlyMap<number, V>|null,
       compareFn?: (a: KeyValue<number, V>, b: KeyValue<number, V>) => number):
       Array<KeyValue<number, V>>|null;
-  transform<K, V>(input: Map<K, V>, compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number):
-      Array<KeyValue<K, V>>;
   transform<K, V>(
-      input: Map<K, V>|null,
+      input: ReadonlyMap<K, V>,
+      compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): Array<KeyValue<K, V>>;
+  transform<K, V>(
+      input: ReadonlyMap<K, V>|null,
       compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): Array<KeyValue<K, V>>|null;
   transform<K, V>(
-      input: null|{[key: string]: V, [key: number]: V}|Map<K, V>,
+      input: null|{[key: string]: V, [key: number]: V}|ReadonlyMap<K, V>,
       compareFn: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number = defaultComparator):
       Array<KeyValue<K, V>>|null {
     if (!input || (!(input instanceof Map) && typeof input !== 'object')) {


### PR DESCRIPTION
ReadonlyMap is a superset of Map, in keyValuePipe we do not change the value of the object so ReadonlyPipe Works right in this case and we can accomodate more types. To accomodate more types added ReadonlyMap in Key Value pipe.

Fixes #37308

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Only map support in keyValue pipe

Issue Number: #37308 


## What is the new behavior?
ReadonlyMap support in keyValue pipe

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
