### PR TITLE
fix(compiler-cli): attach incremental driver only in watch mode

### DIFF
--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -169,6 +169,14 @@ export function readNgcCommandLineAndConfiguration(args: string[]): NgcParsedCon
   const config = readCommandLineAndConfiguration(
       args, options, ['i18nFile', 'i18nFormat', 'locale', 'missingTranslation', 'watch']);
   const watch = parsedArgs.w || parsedArgs.watch;
+  if (watch) {
+    // Propagate watch flag to compiler options.
+    // This option instructs the Angular compiler to optimize for a incremental compilations in a
+    // watch-like mode, and does not have to be enabled via the CLI. The
+    // `NgcParsedConfiguration#watch` option tells Angular to explicitly start a watch mode, which
+    // affects more than just the compiler.
+    config.options.watch = true;
+  }
   return {...config, watch};
 }
 

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -143,7 +143,12 @@ export class NgCompiler {
         this.incrementalDriver = IncrementalDriver.fresh(tsProgram);
       }
     }
-    setIncrementalDriver(tsProgram, this.incrementalDriver);
+    if (options.watch) {
+      // Only attach the incremental driver if incremental compilation (watch mode) has been
+      // explicitly been requested. The driver may be large, so we don't want to attach it to a
+      // program not intended for incremental compilation.
+      setIncrementalDriver(tsProgram, this.incrementalDriver);
+    }
 
     this.ignoreForDiagnostics =
         new Set(tsProgram.getSourceFiles().filter(sf => this.host.isShim(sf)));

--- a/packages/compiler-cli/test/ngtsc/incremental_error_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/incremental_error_spec.ts
@@ -21,7 +21,7 @@ runInEachFileSystem(() => {
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);
       env.enableMultipleCompilations();
-      env.tsconfig();
+      env.tsconfig({watch: true});
 
       // This file is part of the program, but not referenced by anything else. It can be used by
       // each test to verify that it isn't re-emitted after incremental builds.


### PR DESCRIPTION
An incremental driver may be very large, and a provider of the program
passed to the Angular compiler may not wish for a driver to be attached
to the provided program. This commit attaches the compiler's incremental
driver to a `ts.Program` iff the compiler is told to run in a watch-like
mode. A watch-like mode is either an Angular watch compilation, invoked
by the `--watch` CLI flag, or a `"watch": true` configuration in the
Angular compiler options. The latter configuration does not start a
watch compilation, but instructs the compiler to optimize the
compilation as if it were in watch mode (i.e. attach an incremental
driver).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] Yes

Previously all compilations would attach an incremental driver by default. Now, only compilations in watch mode attach an incremental driver by default. In practice I don't think this will be impactful since the incremental driver is not useful in 1-pass compilations (i.e. outside watch mode).