### PR TITLE
docs: add new section for CLI deprecations

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -489,6 +489,56 @@ If you rely on the behavior that the same object instance should cause change de
 - Clone the resulting value so that it has a new identity.
 - Explicitly call [`ChangeDetectorRef.detectChanges()`](api/core/ChangeDetectorRef#detectchanges) to force the update. 
 
+{@ deprecated-cli-flags}
+## Deprecated CLI APIs and Options
+
+This section contains a complete list all of the currently deprecated CLI flags.
+
+### @angular-devkit/build-angular
+
+| API/Option                      | May be removed in | Notes                                                                           |
+| ------------------------------- | ----------------- |-------------------------------------------------------------------------------- |
+| `i18nFile`                      | <!--v9--> v11     | Specified in the project locale configuration in version 9 and later.           |
+| `i18nFormat`                    | <!--v9--> v11     | Format is now automatically detected.                                           |
+| `i18nLocale`                    | <!--v9--> v11     | New [localization option](/guide/i18n#localize-config) in version 9 and later.  |
+| `lazyModules`                   | <!--v9--> v11     | Used with deprecated SystemJsNgModuleLoader.                                    |
+| `rebaseRootRelativeCssUrls`     | <!--v8--> v11     | Intended only to assist with specific migration issues.                         |
+| `scripts[].lazy`                | <!--v8--> v11     | Renamed to `scripts[].inject`.                                                  |
+| `styles[].lazy`                 | <!--v8--> v11     | Renamed to `styles[].inject`.                                                   |
+| `i18nFormat`                    | <!--v9--> v11     | Renamed to `format` to simplify the user experience.                            |
+| `i18nLocale`                    | <!--v9--> v11     | Redundant with project’s source locale.                                         |
+| `scripts[].lazy`                | <!--v8--> v11     | Renamed to `scripts[].inject`.                                                  |
+| `styles[].lazy`                 | <!--v8--> v11     | Renamed to `styles[].inject`.                                                   |
+| `i18nFile`                      | <!--v9--> v11     | Specified in the project locale configuration in version 9 and later.           |
+| `i18nFormat`                    | <!--v9--> v11     | Format is now automatically detected.                                           |
+| `i18nLocale`                    | <!--v9--> v11     | New [localization option](/guide/i18n#localize-config) in version 9 and later.  |
+| `lazyModules`                   | <!--v9--> v11     | Used with deprecated SystemJsNgModuleLoader.                                    |
+
+### @angular-devkit/core
+
+| API/Option                      | May be removed in | Notes                                                                           |
+| ------------------------------- | ----------------- |-------------------------------------------------------------------------------- |
+| `ModuleNotFoundException`       | <!--v8--> v10     | Not used within projects. Used with Tooling API only. Not Yarn PnP compatible and not used in the Angular CLI. Use Node.js [require.resolve](https://nodejs.org/api/modules.html#modules_require_resolve_request_options).|
+| `resolve`                       | <!--v8--> v10     | Not used within projects. Used with Tooling API only. Not Yarn PnP compatible and not used in the Angular CLI. Use Node.js [require.resolve](https://nodejs.org/api/modules.html#modules_require_resolve_request_options).|
+| `setResolveHook`                | <!--v8--> v10     | Not used within projects. Used with Tooling API only. Not Yarn PnP compatible and not used in the Angular CLI. Use Node.js [require.resolve](https://nodejs.org/api/modules.html#modules_require_resolve_request_options).|
+| `ResolveOptions`                | <!--v8--> v10     | Not used within projects. Used with Tooling API only. Not Yarn PnP compatible and not used in the Angular CLI. Use Node.js [require.resolve](https://nodejs.org/api/modules.html#modules_require_resolve_request_options).|
+| `terminal`                      | <!--v8--> v10     | Unused implementation of terminal codes (color).                                |
+| `isObservable`                  | <!--v8--> v10     | Not used within projects. Used with Tooling API only. Use `isObservable` function from the `rxjs` package.|
+
+### @ngtools/webpack
+
+| API/Option                      | May be removed in | Notes                                                                           |
+| ------------------------------- | ----------------- |-------------------------------------------------------------------------------- |
+| `discoverLazyRoutes`            | <!--v9--> TBD     | Used with deprecated SystemJsNgModuleLoader.                                    |
+| `additionalLazyModules`         | <!--v9--> TBD     | Used with deprecated SystemJsNgModuleLoader.                                    |
+| `additionalLazyModuleResources` | <!--v9--> TBD     | Used with deprecated SystemJsNgModuleLoader.                                    |
+
+### @schematics/angular
+
+| API/Option                      | May be removed in | Notes                                                                           |
+| ------------------------------- | ----------------- |-------------------------------------------------------------------------------- |
+| `entryComponent`                | <!--v9--> TBD     | No longer needed with Ivy.                                                      |
+
 {@a removed}
 ## Removed APIs
 


### PR DESCRIPTION
Current documentation does not list CLI flag deprecations. This
change adds it for v10.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Deprecations topic does not list any CLI flag deprecations.

Issue Number: N/A


## What is the new behavior?
New section and table in deprecations topic for CLI flags.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
