### PR TITLE
fix(router): fragment must be a string

### DIFF
--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -79,7 +79,7 @@ class ApplyRedirects {
         this.expandSegmentGroup(this.ngModule, this.config, this.urlTree.root, PRIMARY_OUTLET);
     const urlTrees$ = expanded$.pipe(
         map((rootSegmentGroup: UrlSegmentGroup) => this.createUrlTree(
-                rootSegmentGroup, this.urlTree.queryParams, this.urlTree.fragment!)));
+                rootSegmentGroup, this.urlTree.queryParams, this.urlTree.fragment)));
     return urlTrees$.pipe(catchError((e: any) => {
       if (e instanceof AbsoluteRedirect) {
         // after an absolute redirect we do not apply any more redirects!
@@ -101,7 +101,7 @@ class ApplyRedirects {
         this.expandSegmentGroup(this.ngModule, this.config, tree.root, PRIMARY_OUTLET);
     const mapped$ = expanded$.pipe(
         map((rootSegmentGroup: UrlSegmentGroup) =>
-                this.createUrlTree(rootSegmentGroup, tree.queryParams, tree.fragment!)));
+                this.createUrlTree(rootSegmentGroup, tree.queryParams, tree.fragment)));
     return mapped$.pipe(catchError((e: any): Observable<UrlTree> => {
       if (e instanceof NoMatch) {
         throw this.noMatchError(e);
@@ -115,8 +115,8 @@ class ApplyRedirects {
     return new Error(`Cannot match any routes. URL Segment: '${e.segmentGroup}'`);
   }
 
-  private createUrlTree(rootCandidate: UrlSegmentGroup, queryParams: Params, fragment: string):
-      UrlTree {
+  private createUrlTree(
+      rootCandidate: UrlSegmentGroup, queryParams: Params, fragment?: string|null): UrlTree {
     const root = rootCandidate.segments.length > 0 ?
         new UrlSegmentGroup([], {[PRIMARY_OUTLET]: rootCandidate}) :
         rootCandidate;

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -12,8 +12,8 @@ import {UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
 import {forEach, last, shallowEqual} from './utils/collection';
 
 export function createUrlTree(
-    route: ActivatedRoute, urlTree: UrlTree, commands: any[], queryParams: Params,
-    fragment: string): UrlTree {
+    route: ActivatedRoute, urlTree: UrlTree, commands: any[], queryParams?: Params|null,
+    fragment?: string|null): UrlTree {
   if (commands.length === 0) {
     return tree(urlTree.root, urlTree.root, urlTree, queryParams, fragment);
   }
@@ -39,7 +39,7 @@ function isMatrixParams(command: any): boolean {
 
 function tree(
     oldSegmentGroup: UrlSegmentGroup, newSegmentGroup: UrlSegmentGroup, urlTree: UrlTree,
-    queryParams: Params, fragment: string): UrlTree {
+    queryParams?: Params|null, fragment?: string|null): UrlTree {
   let qp: any = {};
   if (queryParams) {
     forEach(queryParams, (value: any, name: any) => {

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -43,7 +43,7 @@ class Recognizer {
 
       const root = new ActivatedRouteSnapshot(
           [], Object.freeze({}), Object.freeze({...this.urlTree.queryParams}),
-          this.urlTree.fragment!, {}, PRIMARY_OUTLET, this.rootComponentType, null,
+          this.urlTree.fragment, {}, PRIMARY_OUTLET, this.rootComponentType, null,
           this.urlTree.root, -1, {});
 
       const rootNode = new TreeNode<ActivatedRouteSnapshot>(root, children);
@@ -121,7 +121,7 @@ class Recognizer {
     if (route.path === '**') {
       const params = segments.length > 0 ? last(segments)!.parameters : {};
       snapshot = new ActivatedRouteSnapshot(
-          segments, params, Object.freeze({...this.urlTree.queryParams}), this.urlTree.fragment!,
+          segments, params, Object.freeze({...this.urlTree.queryParams}), this.urlTree.fragment,
           getData(route), outlet, route.component!, route, getSourceSegmentGroup(rawSegment),
           getPathIndexShift(rawSegment) + segments.length, getResolve(route));
     } else {
@@ -131,7 +131,7 @@ class Recognizer {
 
       snapshot = new ActivatedRouteSnapshot(
           consumedSegments, result.parameters, Object.freeze({...this.urlTree.queryParams}),
-          this.urlTree.fragment!, getData(route), outlet, route.component!, route,
+          this.urlTree.fragment, getData(route), outlet, route.component!, route,
           getSourceSegmentGroup(rawSegment),
           getPathIndexShift(rawSegment) + consumedSegments.length, getResolve(route));
     }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -999,7 +999,7 @@ export class Router {
     if (q !== null) {
       q = this.removeEmptyProps(q);
     }
-    return createUrlTree(a, this.currentUrlTree, commands, q!, f!);
+    return createUrlTree(a, this.currentUrlTree, commands, q, f);
   }
 
   /**

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -284,6 +284,9 @@ export class ActivatedRouteSnapshot {
   // TODO(issue/24571): remove '!'.
   _queryParamMap!: ParamMap;
 
+  /** The URL fragment shared by all the routes */
+  fragment: string;
+
   /** @internal */
   constructor(
       /** The URL segments matched by this route */
@@ -291,9 +294,7 @@ export class ActivatedRouteSnapshot {
       /** The matrix parameters scoped to this route */
       public params: Params,
       /** The query parameters shared by all the routes */
-      public queryParams: Params,
-      /** The URL fragment shared by all the routes */
-      public fragment: string,
+      public queryParams: Params, fragment: string|null|undefined,
       /** The static and resolved data of this route */
       public data: Data,
       /** The outlet name of the route */
@@ -305,6 +306,7 @@ export class ActivatedRouteSnapshot {
     this._urlSegment = urlSegment;
     this._lastPathIndex = lastPathIndex;
     this._resolve = resolve;
+    this.fragment = fragment ?? '';
   }
 
   /** The root of the router state */

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -108,6 +108,9 @@ export class UrlTree {
   // TODO(issue/24571): remove '!'.
   _queryParamMap!: ParamMap;
 
+  /** The fragment of the URL */
+  fragment: string|null;
+
   /** @internal */
   constructor(
       /** The root segment group of the URL tree */
@@ -115,7 +118,9 @@ export class UrlTree {
       /** The query params of the URL */
       public queryParams: Params,
       /** The fragment of the URL */
-      public fragment: string|null) {}
+      fragment?: string|null) {
+    this.fragment = fragment ?? null;
+  }
 
   get queryParamMap(): ParamMap {
     if (!this._queryParamMap) {
@@ -301,7 +306,7 @@ export class DefaultUrlSerializer implements UrlSerializer {
     const segment = `/${serializeSegment(tree.root, true)}`;
     const query = serializeQueryParams(tree.queryParams);
     const fragment =
-        typeof tree.fragment === `string` ? `#${encodeUriFragment(tree.fragment!)}` : '';
+        typeof tree.fragment === `string` ? `#${encodeUriFragment(tree.fragment)}` : '';
 
     return `${segment}${query}${fragment}`;
   }

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -250,7 +250,7 @@ function createRoot(tree: UrlTree, commands: any[], queryParams?: Params, fragme
       new BehaviorSubject(null!), new BehaviorSubject(null!), new BehaviorSubject(null!),
       new BehaviorSubject(null!), new BehaviorSubject(null!), PRIMARY_OUTLET, 'someComponent', s);
   advanceActivatedRoute(a);
-  return createUrlTree(a, tree, commands, queryParams!, fragment!);
+  return createUrlTree(a, tree, commands, queryParams, fragment);
 }
 
 function create(
@@ -266,5 +266,5 @@ function create(
       new BehaviorSubject(null!), new BehaviorSubject(null!), new BehaviorSubject(null!),
       new BehaviorSubject(null!), new BehaviorSubject(null!), PRIMARY_OUTLET, 'someComponent', s);
   advanceActivatedRoute(a);
-  return createUrlTree(a, tree, commands, queryParams!, fragment!);
+  return createUrlTree(a, tree, commands, queryParams, fragment);
 }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1044,6 +1044,21 @@ describe('Integration', () => {
        expect(fixture.nativeElement).toHaveText('query: 2 fragment: fragment2');
      })));
 
+  it('should not have undefined or null as fragment value',
+     fakeAsync(inject([Router], (router: Router) => {
+       const fixture = createRoot(router, RootCmp);
+
+       router.resetConfig([{path: 'query', component: QueryParamsAndFragmentCmp}]);
+
+       router.navigateByUrl('/query#');
+       advance(fixture);
+       expect(fixture.nativeElement).toHaveText('query:  fragment: ');
+
+       router.navigateByUrl('/query');
+       advance(fixture);
+       expect(fixture.nativeElement).toHaveText('query:  fragment: ');
+     })));
+
   it('should ignore null and undefined query params',
      fakeAsync(inject([Router], (router: Router) => {
        const fixture = createRoot(router, RootCmp);
@@ -5339,7 +5354,15 @@ class QueryParamsAndFragmentCmp {
 
   constructor(route: ActivatedRoute) {
     this.name = route.queryParamMap.pipe(map((p: ParamMap) => p.get('name')));
-    this.fragment = route.fragment;
+    this.fragment = route.fragment.pipe(map((p: string|null|undefined) => {
+      if (p === undefined) {
+        return 'undefined';
+      } else if (p === null) {
+        return 'null';
+      } else {
+        return p;
+      }
+    }));
   }
 }
 

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -186,6 +186,12 @@ describe('url serializer', () => {
     expect(url.serialize(tree)).toEqual('/one#');
   });
 
+  it('should parse no fragment', () => {
+    const tree = url.parse('/one');
+    expect(tree.fragment).toEqual(null);
+    expect(url.serialize(tree)).toEqual('/one');
+  });
+
   describe('encoding/decoding', () => {
     it('should encode/decode path segments and parameters', () => {
       const u = `/${encodeUriSegment('one two')};${encodeUriSegment('p 1')}=${


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`ActivatedRoute.fragment` is typed as `Observable<string>` but can emit both `null` and `undefined` due to incorrect non-null assertion. 


Issue Number: Fixes #23894


## What is the new behavior?
The non-null assertions have been removed and fragment will now be an empty string instead of null. This behavior is consistent with [window.location.hash](https://html.spec.whatwg.org/multipage/history.html#dom-location-hash).

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

ActivatedRoute.fragment will no longer be null when the URL does not have a fragment. Difference for fragment values:
    
|              | Old  | New |
|--------------|------|-----|
| https://e.g  | `null` | `''`  |
| https://e.g# | `''`   | `''`  |

Applications should check for an empty string instead of `null` in order to determine that no fragment is set.