### PR TITLE
fix(platform-server): correctly handle absolute relative URLs

### DIFF
--- a/packages/platform-server/src/http.ts
+++ b/packages/platform-server/src/http.ts
@@ -10,13 +10,12 @@
 const xhr2: any = require('xhr2');
 
 import {Injectable, Injector, Provider} from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+import {PlatformLocation} from '@angular/common';
 import {HttpEvent, HttpRequest, HttpHandler, HttpBackend, XhrFactory, ɵHttpInterceptingHandler as HttpInterceptingHandler} from '@angular/common/http';
 import {Observable, Observer, Subscription} from 'rxjs';
 
 // @see https://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01#URI-syntax
 const isAbsoluteUrl = /^[a-zA-Z\-\+.]+:\/\//;
-const FORWARD_SLASH = '/';
 
 @Injectable()
 export class ServerXhr implements XhrFactory {
@@ -105,20 +104,18 @@ export abstract class ZoneMacroTaskWrapper<S, R> {
 
 export class ZoneClientBackend extends
     ZoneMacroTaskWrapper<HttpRequest<any>, HttpEvent<any>> implements HttpBackend {
-  constructor(private backend: HttpBackend, private doc: Document) {
+  constructor(private backend: HttpBackend, private platformLocation: PlatformLocation) {
     super();
   }
 
   handle(request: HttpRequest<any>): Observable<HttpEvent<any>> {
-    const href = this.doc.location.href;
-    if (!isAbsoluteUrl.test(request.url) && href) {
-      const urlParts = Array.from(request.url);
-      if (request.url[0] === FORWARD_SLASH && href[href.length - 1] === FORWARD_SLASH) {
-        urlParts.shift();
-      } else if (request.url[0] !== FORWARD_SLASH && href[href.length - 1] !== FORWARD_SLASH) {
-        urlParts.splice(0, 0, FORWARD_SLASH);
-      }
-      return this.wrap(request.clone({url: href + urlParts.join('')}));
+    const {href, protocol, hostname} = this.platformLocation;
+    if (!isAbsoluteUrl.test(request.url) && href !== '/') {
+      const baseHref = this.platformLocation.getBaseHrefFromDOM() || href;
+      const urlPrefix = `${protocol}//${hostname}`;
+      const baseUrl = new URL(baseHref, urlPrefix);
+      const url = new URL(request.url, baseUrl);
+      return this.wrap(request.clone({url: url.toString()}));
     }
     return this.wrap(request);
   }
@@ -129,15 +126,15 @@ export class ZoneClientBackend extends
 }
 
 export function zoneWrappedInterceptingHandler(
-    backend: HttpBackend, injector: Injector, doc: Document) {
+    backend: HttpBackend, injector: Injector, platformLocation: PlatformLocation) {
   const realBackend: HttpBackend = new HttpInterceptingHandler(backend, injector);
-  return new ZoneClientBackend(realBackend, doc);
+  return new ZoneClientBackend(realBackend, platformLocation);
 }
 
 export const SERVER_HTTP_PROVIDERS: Provider[] = [
   {provide: XhrFactory, useClass: ServerXhr}, {
     provide: HttpHandler,
     useFactory: zoneWrappedInterceptingHandler,
-    deps: [HttpBackend, Injector, DOCUMENT]
+    deps: [HttpBackend, Injector, PlatformLocation]
   }
 ];

--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -51,6 +51,7 @@ export class ServerPlatformLocation implements PlatformLocation {
       this.pathname = parsedUrl.pathname;
       this.search = parsedUrl.search;
       this.hash = parsedUrl.hash;
+      this.href = _doc.location.href;
     }
   }
 

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -841,6 +841,58 @@ describe('platform-server integration', () => {
       });
     });
 
+    it('can make relative HttpClient requests no slashes longer url', async () => {
+      const platform = platformDynamicServer([{
+        provide: INITIAL_CONFIG,
+        useValue: {document: '<app></app>', url: 'http://localhost/path/page'}
+      }]);
+      const ref = await platform.bootstrapModule(HttpClientExampleModule);
+      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+      const http = ref.injector.get(HttpClient);
+      ref.injector.get(NgZone).run(() => {
+        http.get<string>('testing').subscribe((body: string) => {
+          NgZone.assertInAngularZone();
+          expect(body).toEqual('success!');
+        });
+        mock.expectOne('http://localhost/path/testing').flush('success!');
+      });
+    });
+
+    it('can make relative HttpClient requests slashes longer url', async () => {
+      const platform = platformDynamicServer([{
+        provide: INITIAL_CONFIG,
+        useValue: {document: '<app></app>', url: 'http://localhost/path/page'}
+      }]);
+      const ref = await platform.bootstrapModule(HttpClientExampleModule);
+      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+      const http = ref.injector.get(HttpClient);
+      ref.injector.get(NgZone).run(() => {
+        http.get<string>('/testing').subscribe((body: string) => {
+          NgZone.assertInAngularZone();
+          expect(body).toEqual('success!');
+        });
+        mock.expectOne('http://localhost/testing').flush('success!');
+      });
+    });
+
+    it('can make relative HttpClient requests slashes longer url with base href', async () => {
+      const platform = platformDynamicServer([{
+        provide: INITIAL_CONFIG,
+        useValue:
+            {document: '<base href="http://other"><app></app>', url: 'http://localhost/path/page'}
+      }]);
+      const ref = await platform.bootstrapModule(HttpClientExampleModule);
+      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+      const http = ref.injector.get(HttpClient);
+      ref.injector.get(NgZone).run(() => {
+        http.get<string>('/testing').subscribe((body: string) => {
+          NgZone.assertInAngularZone();
+          expect(body).toEqual('success!');
+        });
+        mock.expectOne('http://other/testing').flush('success!');
+      });
+    });
+
     it('requests are macrotasks', async(() => {
          const platform = platformDynamicServer(
              [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);


### PR DESCRIPTION
Previously, we would simply prepend any relative URL with the HREF
for the current route (pulled from document.location). However,
this does not correctly account for the leading slash URLs that
would otherwise be parsed correctly in the browser, or the
presence of a base HREF in the DOM.

Therefore, we use the built-in URL implementation for NodeJS,
which implements the WHATWG standard that's used in the browser.
We also pull the base HREF from the DOM, falling back on the full
HREF as the browser would, to form the correct request URL.

Fixes #37314

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 37314


## What is the new behavior?

Add support for base HREF and absolute relative URLs on SSR HTTP requests.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
