### PR TITLE
fix(compiler): Expression converter typo

### DIFF
--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -467,7 +467,7 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
     // For literal values of null, undefined, true, or false allow type interference
     // to infer the type.
     const type =
-        ast.value === null || ast.value === undefined || ast.value === true || ast.value === true ?
+        ast.value === null || ast.value === undefined || ast.value === true || ast.value === false ?
         o.INFERRED_TYPE :
         undefined;
     return convertToStatementIfNeeded(


### PR DESCRIPTION
In expression converter for literal values of null, undefined, true, or false type interference was to be done but it was not done for value false. Added false also to the check.

Fixes #21233

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
a typo
Issue Number: #21233


## What is the new behavior?
typo removed

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
