### PR TITLE
fix(ngcc): do not inline source-maps for non-inline typings source-maps

### DIFF
--- a/packages/compiler-cli/ngcc/src/rendering/source_maps.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/source_maps.ts
@@ -42,8 +42,11 @@ export function renderSourceAndMap(
 
     const rawMergedMap: RawSourceMap = generatedFile.renderFlattenedSourceMap();
     const mergedMap = fromObject(rawMergedMap);
-    if (generatedFile.sources[0]?.inline) {
-      // The input source-map was inline so make the output one inline too.
+    const firstSource = generatedFile.sources[0];
+    if (firstSource && firstSource.inline &&
+        (firstSource.rawMap !== null || !sourceFile.isDeclarationFile)) {
+      // We render an inline source map if either the input source-map was inline or there was no
+      // input source map and this is not a typings file.
       return [
         {path: generatedPath, contents: `${generatedFile.contents}\n${mergedMap.toComment()}`}
       ];

--- a/packages/compiler-cli/ngcc/src/rendering/source_maps.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/source_maps.ts
@@ -43,10 +43,15 @@ export function renderSourceAndMap(
     const rawMergedMap: RawSourceMap = generatedFile.renderFlattenedSourceMap();
     const mergedMap = fromObject(rawMergedMap);
     const firstSource = generatedFile.sources[0];
-    if (firstSource && firstSource.inline &&
-        (firstSource.rawMap !== null || !sourceFile.isDeclarationFile)) {
-      // We render an inline source map if either the input source-map was inline or there was no
-      // input source map and this is not a typings file.
+    if (firstSource && (firstSource.rawMap !== null || !sourceFile.isDeclarationFile) &&
+        firstSource.inline) {
+      // We render an inline source map if one of:
+      // * there was no input source map and this is not a typings file;
+      // * the input source map exists and was inline.
+      //
+      // We do not generate inline source maps for typings files unless there explicitly was one in
+      // the input file because these inline source maps can be very large and it impacts on the
+      // performance of IDEs that need to read them to provide intellisense etc.
       return [
         {path: generatedPath, contents: `${generatedFile.contents}\n${mergedMap.toComment()}`}
       ];

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -640,6 +640,25 @@ UndecoratedBase.ɵdir = ɵngcc0.ɵɵdefineDirective({ type: UndecoratedBase, vie
              expect(mapFile.path).toEqual(_('/node_modules/test-package/src/file.js.map'));
              expect(JSON.parse(mapFile.contents)).toEqual(MERGED_OUTPUT_PROGRAM_MAP.toObject());
            });
+
+
+        it('should render an internal source map for files whose original file does not have a source map',
+           () => {
+             const sourceFiles: TestFile[] =
+                 [{name: JS_CONTENT.name, contents: JS_CONTENT.contents}];
+             const {
+               decorationAnalyses,
+               renderer,
+               switchMarkerAnalyses,
+               privateDeclarationsAnalyses
+             } = createTestRenderer('test-package', sourceFiles, undefined);
+             const [sourceFile, mapFile] = renderer.renderProgram(
+                 decorationAnalyses, switchMarkerAnalyses, privateDeclarationsAnalyses);
+             expect(sourceFile.path).toEqual(_('/node_modules/test-package/src/file.js'));
+             expect(sourceFile.contents)
+                 .toEqual(RENDERED_CONTENTS + '\n' + OUTPUT_PROGRAM_MAP.toComment());
+             expect(mapFile).toBeUndefined();
+           });
       });
 
       describe('@angular/core support', () => {

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -644,8 +644,7 @@ UndecoratedBase.ɵdir = ɵngcc0.ɵɵdefineDirective({ type: UndecoratedBase, vie
 
         it('should render an internal source map for files whose original file does not have a source map',
            () => {
-             const sourceFiles: TestFile[] =
-                 [{name: JS_CONTENT.name, contents: JS_CONTENT.contents}];
+             const sourceFiles: TestFile[] = [JS_CONTENT];
              const {
                decorationAnalyses,
                renderer,


### PR DESCRIPTION
Inline source-maps in typings files can impact IDE performance
so ngcc should only add such maps if the original typings file
contains inline source-maps.

Fixes #37324

