### PR TITLE
fix(http): avoid abort a request when fetch operation is completed

### DIFF
--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -339,7 +339,9 @@ export class HttpXhrBackend implements HttpBackend {
         }
 
         // Finally, abort the in-flight request.
-        xhr.abort();
+        if (xhr.readyState !== xhr.DONE) {
+          xhr.abort();
+        }
       };
     });
   }

--- a/packages/common/http/test/xhr_spec.ts
+++ b/packages/common/http/test/xhr_spec.ts
@@ -147,6 +147,17 @@ const XSSI_PREFIX = ')]}\'\n';
       });
       factory.mock.mockErrorEvent(new Error('blah'));
     });
+    it('avoids abort a request when fetch operation is completed', done => {
+      const abort = jasmine.createSpy('abort');
+
+      backend.handle(TEST_POST).toPromise().then(() => {
+        expect(abort).not.toHaveBeenCalled();
+        done();
+      });
+
+      factory.mock.abort = abort;
+      factory.mock.mockFlush(200, 'OK', 'Done');
+    });
     describe('progress events', () => {
       it('are emitted for download progress', done => {
         backend.handle(TEST_POST.clone({reportProgress: true}))


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`abort` method is calling, even if fetch operation is completed.

Issue Number: https://github.com/angular/angular/issues/36537


## What is the new behavior?
Avoid abort a request when fetch operation is completed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
