### PR TITLE
docs(core): fix typo in decorators.ts relating to the use of Object.defineProperty

### DIFF
--- a/packages/core/src/util/decorators.ts
+++ b/packages/core/src/util/decorators.ts
@@ -153,8 +153,8 @@ export function makePropDecorator(
 
       function PropDecorator(target: any, name: string) {
         const constructor = target.constructor;
-        // Use of Object.defineProperty is important since it creates non-enumerable property which
-        // prevents the property is copied during subclassing.
+        // Use of Object.defineProperty is important because it creates a non-enumerable property
+        // which prevents the property from being copied during subclassing.
         const meta = constructor.hasOwnProperty(PROP_METADATA) ?
             (constructor as any)[PROP_METADATA] :
             Object.defineProperty(constructor, PROP_METADATA, {value: {}})[PROP_METADATA];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Fixes comment in `decorators.ts` relating to the use of `Object.defineProperty`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
