### PR TITLE
build: remove wombot proxy registry from package.jsons for release

### DIFF
--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -18,8 +18,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -52,8 +52,5 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  },
-  "publishConfig": {
-    "registry": "https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -23,8 +23,5 @@
   "sideEffects": [
     "**/global/*.js",
     "**/closure-locale.*"
-  ],
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  ]
 }

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -48,8 +48,5 @@
   "homepage": "https://github.com/angular/angular/tree/master/packages/compiler-cli",
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  },
-  "publishConfig": {
-    "registry": "https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -15,8 +15,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": true,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": true
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,8 +20,5 @@
     "migrations": "./schematics/migrations.json",
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig": {
-    "registry": "https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -21,8 +21,5 @@
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
   "sideEffects": false,
-  "schematics": "./schematics/collection.json",
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "schematics": "./schematics/collection.json"
 }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -21,8 +21,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -14,8 +14,5 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  },
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -31,8 +31,5 @@
   "peerDependencies": {
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "@angular/compiler-cli": "0.0.0-PLACEHOLDER"
-  },
-  "publishConfig": {
-    "registry": "https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/platform-browser-dynamic/package.json
+++ b/packages/platform-browser-dynamic/package.json
@@ -21,8 +21,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -25,8 +25,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -28,8 +28,5 @@
   "sideEffects": false,
   "engines": {
     "node": ">=8.0"
-  },
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/platform-webworker-dynamic/package.json
+++ b/packages/platform-webworker-dynamic/package.json
@@ -22,8 +22,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/platform-webworker/package.json
+++ b/packages/platform-webworker/package.json
@@ -20,8 +20,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -29,8 +29,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -22,8 +22,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -21,8 +21,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -37,9 +37,6 @@
     "url": "git://github.com/angular/angular.git",
     "directory": "packages/zone.js"
   },
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  },
   "author": "Brian Ford",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Due to an outage with the proxy we rely on for publishing, we need
to temporarily directly publish to NPM using our own angular
credentials again.
