### PR TITLE
docs(core): remove v10 mention from @Injectable warning

### DIFF
--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -217,8 +217,8 @@ function getOwnDefinition<T>(type: any, def: ɵɵInjectableDef<T>): ɵɵInjectab
  *
  * @param type A type which may have `ɵprov`, via inheritance.
  *
- * @deprecated Will be removed in v10, where an error will occur in the scenario if we find the
- * `ɵprov` on an ancestor only.
+ * @deprecated Will be removed in a future version of Angular, where an error will occur in the
+ *     scenario if we find the `ɵprov` on an ancestor only.
  */
 export function getInheritedInjectableDef<T>(type: any): ɵɵInjectableDef<T>|null {
   // See `jit/injectable.ts#compileInjectable` for context on NG_PROV_DEF_FALLBACK.
@@ -233,7 +233,8 @@ export function getInheritedInjectableDef<T>(type: any): ɵɵInjectableDef<T>|nu
     console.warn(
         `DEPRECATED: DI is instantiating a token "${
             typeName}" that inherits its @Injectable decorator but does not provide one itself.\n` +
-        `This will become an error in v10. Please add @Injectable() to the "${typeName}" class.`);
+        `This will become an error in a future version of Angular. Please add @Injectable() to the "${
+            typeName}" class.`);
     return def;
   } else {
     return null;

--- a/packages/core/src/di/jit/injectable.ts
+++ b/packages/core/src/di/jit/injectable.ts
@@ -46,7 +46,7 @@ export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
     // undecorated parent class. We work around it by defining a method which should be used
     // as a fallback. This should only be a problem in JIT mode, because in AOT TypeScript
     // seems to have a workaround for static properties. When inheriting from an undecorated
-    // parent is no longer supported in v10, this can safely be removed.
+    // parent is no longer supported (v11 or later), this can safely be removed.
     if (!type.hasOwnProperty(NG_PROV_DEF_FALLBACK)) {
       (type as any)[NG_PROV_DEF_FALLBACK] = () => (type as any)[NG_PROV_DEF];
     }

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -1030,7 +1030,7 @@ describe('di', () => {
       if (ivyEnabled) {
         expect(warnSpy).toHaveBeenCalledWith(
             `DEPRECATED: DI is instantiating a token "SubSubClass" that inherits its @Injectable decorator but does not provide one itself.\n` +
-            `This will become an error in v10. Please add @Injectable() to the "SubSubClass" class.`);
+            `This will become an error in a future version of Angular. Please add @Injectable() to the "SubSubClass" class.`);
       }
     });
 
@@ -1061,7 +1061,7 @@ describe('di', () => {
       if (ivyEnabled) {
         expect(warnSpy).toHaveBeenCalledWith(
             `DEPRECATED: DI is instantiating a token "MyRootService" that inherits its @Injectable decorator but does not provide one itself.\n` +
-            `This will become an error in v10. Please add @Injectable() to the "MyRootService" class.`);
+            `This will become an error in a future version of Angular. Please add @Injectable() to the "MyRootService" class.`);
       }
     });
 


### PR DESCRIPTION
In v9, we started showing a console warning when
instantiating a token that inherited its @Injectable
decorator rather than providing its own. This warning
said that the pattern would become an error in v10.

However, we have decided to wait until at least v11
to throw in this case, so this commit updates the
warning to be less prescriptive about the exact
version when the pattern will no longer be supported.
