### PR TITLE
fix(http): provide alternative to broken HttpUrlEncodingCodec

### DIFF
--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -546,6 +546,16 @@ You can also create HTTP parameters directly from a query string by using the `f
 const params = new HttpParams({fromString: 'name=foo'});
 </code-example>
 
+<div class="alert is-important">
+By default, `HttpParams` are encoded incorrectly (see [Issue #11058](https://github.com/angular/angular/issues/11058) for more details). This bug will be fixed in a future major version of Angular.
+
+To opt in to correct encoding, configure `HttpClientModule` when importing it:
+<code-example hideCopy language="typescript">
+imports: [
+  HttpClientModule.withOptions({useCanonicalParamEncoding: true}),
+]
+</div>
+
 
 {@a intercepting-requests-and-responses}
 ## Intercepting requests and responses

--- a/packages/common/http/src/module.ts
+++ b/packages/common/http/src/module.ts
@@ -6,17 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, Injector, ModuleWithProviders, NgModule} from '@angular/core';
+import {Inject, Injectable, InjectionToken, Injector, ModuleWithProviders, NgModule, Optional} from '@angular/core';
 import {Observable} from 'rxjs';
 
 import {HttpBackend, HttpHandler} from './backend';
 import {HttpClient} from './client';
 import {HTTP_INTERCEPTORS, HttpInterceptor, HttpInterceptorHandler, NoopInterceptor} from './interceptor';
 import {JsonpCallbackContext, JsonpClientBackend, JsonpInterceptor} from './jsonp';
+import {HttpParams, HttpUrlComponentCodec as HttpCanonicalParamCodec} from './params';
 import {HttpRequest} from './request';
 import {HttpEvent} from './response';
 import {BrowserXhr, HttpXhrBackend, XhrFactory} from './xhr';
 import {HttpXsrfCookieExtractor, HttpXsrfInterceptor, HttpXsrfTokenExtractor, XSRF_COOKIE_NAME, XSRF_HEADER_NAME} from './xsrf';
+
+export const USE_CANONICAL_PARAM_ENCODING =
+    new InjectionToken<boolean>('USE_CANONICAL_PARAM_ENCODING');
 
 /**
  * An injectable `HttpHandler` that applies multiple interceptors
@@ -164,6 +168,25 @@ export class HttpClientXsrfModule {
   ],
 })
 export class HttpClientModule {
+  constructor(@Inject(USE_CANONICAL_PARAM_ENCODING) @Optional() useCanonicalParamEncoding: boolean|
+              null) {
+    if (useCanonicalParamEncoding === true) {
+      HttpParams.setDefaultParameterCodec(HttpCanonicalParamCodec);
+    }
+  }
+
+  static withOptions(options: {useCanonicalParamEncoding?: boolean}):
+      ModuleWithProviders<HttpClientModule> {
+    return {
+      ngModule: HttpClientModule,
+      providers: [
+        {
+          provide: USE_CANONICAL_PARAM_ENCODING,
+          useValue: options.useCanonicalParamEncoding || false,
+        },
+      ],
+    };
+  }
 }
 
 /**

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpParams} from '@angular/common/http/src/params';
+import {HttpParams, HttpUrlComponentCodec, HttpUrlEncodingCodec} from '@angular/common/http/src/params';
 
 {
   describe('HttpUrlEncodedParams', () => {
@@ -89,6 +89,31 @@ import {HttpParams} from '@angular/common/http/src/params';
       it('should stringify empty array params', () => {
         const body = new HttpParams({fromObject: {a: '', b: [], c: '3'}});
         expect(body.toString()).toBe('a=&c=3');
+      });
+    });
+
+    describe('HttpUrlEncodingCodec', () => {
+      beforeEach(() => {
+        HttpParams.setDefaultParameterCodec(HttpUrlComponentCodec);
+      });
+
+      afterEach(() => {
+        HttpParams.setDefaultParameterCodec(HttpUrlEncodingCodec);
+      });
+
+      it('should encode + characters correctly', () => {
+        const body = new HttpParams({fromObject: {param: '1+2'}});
+        expect(body.toString()).toBe('param=1%2B2');
+      });
+
+      it('should encode = characters correctly', () => {
+        const body = new HttpParams({fromObject: {'a=b': 'c=d'}});
+        expect(body.toString()).toBe('a%3Db=c%3Dd');
+      });
+
+      it('should encode : characters correctly', () => {
+        const body = new HttpParams({fromObject: {param: '1:2'}});
+        expect(body.toString()).toBe('param=1%3A2');
       });
     });
   });


### PR DESCRIPTION
Currently in Angular, by default `HttpParam` instances are encoded with the
`HttpUrlEncodingCodec`. This is an implementation of `HttpParameterCodec`
which uses `encodeURIComponent` plus a number of manual post-processing
substitutions to encode keys and values for x-www-form-urlencoded contexts.

Unfortunately, the logic of `HttpUrlEncodingCodec` is fatally flawed. Among
other problems, the character '+' is left unencoded. In such contexts, '+'
is interpeted as a space by any correct decoder, meaning that this
implementation actually changes values. This logic is indefensible, and
appears to be the result of a copy/paste bug from angular.js encoding meant
for a different context.

Fixing this bug directly is challenging since existing backends may be
relying on Angular's broken behavior, so changing the default is a breaking
change and will need to be done in an Angular major version. This commit
begins that process by introducing a new codec, `HttpUrlComponentCodec`,
which implements a corrected encoding algorithm. In a future commit for v11,
this corrected codec can be made the default.

In the meantime, this commit introduces a static method which can change the
built-in default codec, for convenience.

```typescript
HttpParams.setDefaultParameterCodec(HttpUrlComponentCodec);
```

See #11058 for more details.