### PR TITLE
docs: add blank line before header

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -91,6 +91,7 @@ merged if the code is formatted properly and all tests are passing.
 
 <a name="formatting-your-source-code">
 <a name="clang-format"></a>
+
 ## Formatting your source code
 
 Angular uses [clang-format](http://clang.llvm.org/docs/ClangFormat.html) to format the source code.


### PR DESCRIPTION
Currently, `Formatting your source code` is not being formatted as a header because of a missing empty line.
