### PR TITLE
ci: temporarily disable Android 10 browser unit tests on Saucelabs

### DIFF
--- a/browser-providers.conf.js
+++ b/browser-providers.conf.js
@@ -31,7 +31,16 @@ var CIconfiguration = {
   'Android7': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
   'Android8': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
   'Android9': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
-  'Android10': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
+  // Disable Android 10 tests due to infrastructure failure.
+  // ex:
+  // Chrome Mobile 74.0.3729 (Android 0.0.0) ERROR:
+  //    Error: XHR error loading
+  //    http://angular-ci.local:9876/base/node_modules/rxjs/internal/operators/zip.js
+  //
+  // Error loading http://angular-ci.local:9876/base/node_modules/rxjs/internal/operators/zip.js as
+  // "../internal/operators/zip" from
+  // http://angular-ci.local:9876/base/node_modules/rxjs/operators/index.js
+  'Android10': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
   // Disable all Safari and iOS tests because of incorrect results
   // ex:
   // Mobile Safari 13.0.0 (iOS 13.0.0) styling static template only should capture static values in


### PR DESCRIPTION
Disabling Android 10 browser unit tests on Saucelabs due to errors:

Example of failures seen:

```
02 06 2020 14:03:05.048:INFO [SaucelabsLauncher]: Chrome 10.0 (Android) session at https://saucelabs.com/tests/54f5fb181db644a3b4779187c2309000

02 06 2020 14:03:06.869:INFO [Chrome Mobile 74.0.3729 (Android 0.0.0)]: Disconnected browser returned on socket E-bi0p0NKtghk-HcAAAO with id 85563367.

Chrome Mobile 74.0.3729 (Android 0.0.0) ERROR: Error: XHR error loading http://angular-ci.local:9876/base/node_modules/rxjs/internal/operators/zip.js

	Error loading http://angular-ci.local:9876/base/node_modules/rxjs/internal/operators/zip.js as "../internal/operators/zip" from http://angular-ci.local:9876/base/node_modules/rxjs/operators/index.js

Error: XHR error loading http://angular-ci.local:9876/base/node_modules/rxjs/internal/operators/zip.js

    at error (http://angular-ci.local:9876/base/node_modules/systemjs/dist/system.src.js?1c6a6c12fec50a8db7aeebe8e06e2b70135c0615:1028:16)

    at XMLHttpRequest.xhr.onreadystatechange [as __zone_symbol__ON_PROPERTYreadystatechange] (http://angular-ci.local:9876/base/node_modules/systemjs/dist/system.src.js?1c6a6c12fec50a8db7aeebe8e06e2b70135c0615:1036:13)

    at XMLHttpRequest.wrapFn (http://angular-ci.local:9876/base/dist/bin/packages/zone.js/npm_package/dist/zone.js?942d01da94828e1c75e8527fa8d06f363d6379ce:809:43)

    at ZoneDelegate.invokeTask (http://angular-ci.local:9876/base/dist/bin/packages/zone.js/npm_package/dist/zone.js?942d01da94828e1c75e8527fa8d06f363d6379ce:432:35)

    at Zone.runTask (http://angular-ci.local:9876/base/dist/bin/packages/zone.js/npm_package/dist/zone.js?942d01da94828e1c75e8527fa8d06f363d6379ce:201:55)

    at ZoneTask.invokeTask [as invoke] (http://angular-ci.local:9876/base/dist/bin/packages/zone.js/npm_package/dist/zone.js?942d01da94828e1c75e8527fa8d06f363d6379ce:514:38)

    at invokeTask (http://angular-ci.local:9876/base/dist/bin/packages/zone.js/npm_package/dist/zone.js?942d01da94828e1c75e8527fa8d06f363d6379ce:1722:18)

    at XMLHttpRequest.globalZoneAwareCallback (http://angular-ci.local:9876/base/dist/bin/packages/zone.js/npm_package/dist/zone.js?942d01da94828e1c75e8527fa8d06f363d6379ce:1748:21)
```


Fixes being tracked in DEV-111 and FW-2204