### PR TITLE
fix(docs-infra): preconnect to analytics origins

### DIFF
--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -8,6 +8,11 @@
     Join the community of millions of developers who build compelling user interfaces with Angular.">
   <base href="/">
 
+  <link rel="preconnect" href="https://www.google-analytics.com">
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+  <link rel="preconnect" href="https://stats.g.doubleclick.net">
+  <link rel="dns-prefetch" href="https://stats.g.doubleclick.net">
+
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <link rel="search" type="application/opensearchdescription+xml" href="assets/opensearch.xml">


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

No preconnect hints are present for important third-party origins.

## What is the new behavior?

Lighthouse recommends preconnecting to important third-party origins.
See: https://web.dev/uses-rel-preconnect

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
