### PR TITLE
Rework router guide

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -565,7 +565,6 @@ groups:
           'aio/content/guide/router.md',
           'aio/content/guide/router-techniques.md',
           'aio/content/guide/router-tutorial.md',
-          'aio/content/guide/router-tutorial-2.md',
           'aio/content/examples/router-tutorial/**',
           'aio/content/examples/router/**',
           'aio/content/images/guide/router/**'

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -565,6 +565,7 @@ groups:
           'aio/content/guide/router.md',
           'aio/content/guide/router-techniques.md',
           'aio/content/guide/router-tutorial.md',
+          'aio/content/guide/router-tutorial-toh.md',
           'aio/content/examples/router-tutorial/**',
           'aio/content/examples/router/**',
           'aio/content/images/guide/router/**'

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -563,8 +563,9 @@ groups:
           'packages/router/**',
           'packages/examples/router/**',
           'aio/content/guide/router.md',
+          'aio/content/guide/router-techniques.md',
           'aio/content/guide/router-tutorial.md',
-          'aio/content/guide/router-tutorial-toh.md',
+          'aio/content/guide/router-tutorial-2.md',
           'aio/content/examples/router-tutorial/**',
           'aio/content/examples/router/**',
           'aio/content/images/guide/router/**'

--- a/aio/content/examples/router/src/app/app-routing.module.8.ts
+++ b/aio/content/examples/router/src/app/app-routing.module.8.ts
@@ -2,17 +2,16 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router'; // CLI imports router
 
-// #docregion routes, routes-with-wildcard, redirect
+// #docregion  redirect, routes-with-wildcard
 const routes: Routes = [
   { path: 'first-component', component: FirstComponent },
   { path: 'second-component', component: SecondComponent },
-  // #enddocregion routes, routes-with-wildcard
   { path: '',   redirectTo: '/first-component', pathMatch: 'full' }, // redirect to `first-component`
-  // #docregion routes-with-wildcard
+  // #enddocregion redirect
   { path: '**', component: PageNotFoundComponent },  // Wildcard route for a 404 page
-  // #docregion routes
+  // #docregion redirect
 ];
-// #enddocregion routes, routes-with-wildcard, redirect
+// #enddocregion routes-with-wildcard, redirect
 
 
 @NgModule({
@@ -20,5 +19,3 @@ const routes: Routes = [
   exports: [RouterModule]
 })
 export class AppRoutingModule { }
-
-

--- a/aio/content/examples/router/src/app/heroes/hero-list/hero-list.component.ts
+++ b/aio/content/examples/router/src/app/heroes/hero-list/hero-list.component.ts
@@ -31,8 +31,8 @@ export class HeroListComponent implements OnInit {
   ngOnInit() {
     this.heroes$ = this.route.paramMap.pipe(
       switchMap(params => {
-        // (+) before `params.get()` turns the string into a number
-        this.selectedId = +params.get('id');
+        // turn the string into a number
+        this.selectedId = Number(params.get('id'))
         return this.service.getHeroes();
       })
     );

--- a/aio/content/guide/deployment.md
+++ b/aio/content/guide/deployment.md
@@ -320,8 +320,8 @@ You can dramatically reduce launch time by only loading the application modules 
 absolutely must be present when the app starts.
 
 Configure the Angular Router to defer loading of all other modules (and their associated code), either by
-[waiting until the app has launched](guide/router-tutorial-toh#preloading  "Preloading")
-or by [_lazy loading_](guide/router#lazy-loading "Lazy loading")
+[waiting until the app has launched](guide/lazy-loading-ngmodules#preloading  "Preloading")
+or by [_lazy loading_](guide/lazy-loading-ngmodules "Lazy loading")
 them on demand.
 
 <div class="callout is-helpful">
@@ -413,7 +413,7 @@ Here's the output for the _main_ bundle of an example app called `cli-quickstart
 
 ## The `base` tag
 
-The HTML [_&lt;base href="..."/&gt;_](/guide/router)
+The HTML [_&lt;base href="..."/&gt;_](/guide/router#base-href "Setting a base location")
 specifies a base path for resolving relative URLs to assets such as images, scripts, and style sheets.
 For example, given the `<base href="/my/app/">`, the browser resolves a URL such as `some/place/foo.jpg`
 into a server request for `my/app/some/place/foo.jpg`.

--- a/aio/content/guide/glossary.md
+++ b/aio/content/guide/glossary.md
@@ -210,6 +210,16 @@ An Angular component class is responsible for exposing data and handling most of
 
 Read more about component classes, templates, and views in [Introduction to Angular concepts](guide/architecture).
 
+<<<<<<< HEAD
+=======
+{@a componentless-route}
+
+## componentless route
+
+In configuring the [Angular router](#router), a container `Route` for a set of related child routes that is not itself associated with a component.
+
+Read more about nested routes in the [Routing and Navigation](guide/router) guide.
+>>>>>>> docs: separate router tutorial from router guide
 
 ## configuration
 
@@ -577,8 +587,19 @@ Angular calls these hook methods in the following order:
 * `ngAfterViewChecked`: After every check of a component's views.
 * `ngOnDestroy`: Just before the directive is destroyed.
 
-To learn more, see [Lifecycle Hooks](guide/lifecycle-hooks).
+To learn more, see the [Lifecycle Hooks](guide/lifecycle-hooks) guide.
 
+{@a link-parameters-array}
+
+<<<<<<< HEAD
+=======
+## link parameters array
+
+In the Angular [router service](#router), an array which contains an object that associates a route path string with one or more required or optional query parameters. The router service resolves that array into a complete URL.
+
+To learn more, see the [Routing and Navigation](guide/router#link-parameters-array) guide.
+
+>>>>>>> docs: separate router tutorial from router guide
 {@a M}
 
 {@a module}
@@ -739,6 +760,7 @@ When using reactive forms:
 
 The alternative is a template-driven form. For an introduction and comparison of both forms approaches, see [Introduction to Angular Forms](guide/forms-overview).
 
+<<<<<<< HEAD
 {@a resolver}
 
 ## resolver
@@ -749,28 +771,39 @@ Resolvers run after all [route guards](#route-guard "Definition") for a route tr
 
 See an example of using a [resolve guard](guide/router-tutorial-toh#resolve-guard "Routing techniques tutorial") to retrieve dynamic data.
 
+=======
+>>>>>>> docs: separate router tutorial from router guide
 {@a route-guard}
 
 ## route guard
 
+<<<<<<< HEAD
 A method that controls navigation to a requested route in a routing application.
 Guards determine whether a route can be activated or deactivated, and whether a lazy-loaded module can be loaded.
 
 Learn more in the [Routing and Navigation](guide/router#preventing-unauthorized-access "Examples") guide.
 
+=======
+A function that controls access to a view in a routing application.
+Learn more in the [Routing and Navigation](guide/router#route-guards) guide.
+>>>>>>> docs: separate router tutorial from router guide
 
 {@a router}
 {@a router-module}
 
 ## router
 
-A tool that configures and implements navigation among states and [views](#view) within an Angular app.
-
-The `Router` module is an [NgModule](#ngmodule) that provides the necessary service providers and directives for navigating through application views. A [routing component](#routing-component) is one that imports the `Router` module and whose template contains a `RouterOutlet` element where it can display views produced by the router.
+An Angular service that configures and implements navigation among states and [views](#view) within an Angular app.
 
 The router defines navigation among views on a single page, as opposed to navigation among pages. It interprets URL-like links to determine which views to create or destroy, and which components to load or unload. It allows you to take advantage of [lazy loading](#lazy-load) in your Angular apps.
 
-To learn more, see [Routing and Navigation](guide/router).
+The `RouterModule` provides the necessary service providers and directives for navigating through application views.
+
+* A [routing component](#routing-component) is one that imports the `RouterModule` and whose template contains a `RouterOutlet` element where it can display views produced by the router.
+
+* A [routing module](#routing-module) is a dedicated NgModule that configures routing for an application.
+
+To learn more, see the [Routing and Navigation](guide/router) guide.
 
 {@a router-outlet}
 
@@ -778,13 +811,19 @@ To learn more, see [Routing and Navigation](guide/router).
 
 A [directive](#directive) that acts as a placeholder in a routing component's template. Angular dynamically renders the template based on the current router state.
 
-{@a router-component}
+{@a routing-component}
 
 ## routing component
 
 An Angular [component](#component) with a `RouterOutlet` directive in its template that displays views based on router navigations.
 
 For more information, see [Routing and Navigation](guide/router).
+
+{@a routing-module}
+
+## routing module
+
+An NgModule that contains an application's routing configuration. A dedicated routing module does not declare components, but serves to separate routing concerns from other application concerns. It provides a well-known location for routing service providers such as guards and resolvers. A routing module is also easy to replace or remove when testing the application.
 
 {@a rule}
 

--- a/aio/content/guide/glossary.md
+++ b/aio/content/guide/glossary.md
@@ -211,6 +211,7 @@ An Angular component class is responsible for exposing data and handling most of
 Read more about component classes, templates, and views in [Introduction to Angular concepts](guide/architecture).
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 {@a componentless-route}
 
@@ -221,6 +222,8 @@ In configuring the [Angular router](#router), a container `Route` for a set of r
 Read more about nested routes in the [Routing and Navigation](guide/router) guide.
 >>>>>>> docs: separate router tutorial from router guide
 
+=======
+>>>>>>> fixup! docs: separate router tutorial from router guide
 ## configuration
 
 See  [workspace configuration](#cli-config)
@@ -589,6 +592,7 @@ Angular calls these hook methods in the following order:
 
 To learn more, see the [Lifecycle Hooks](guide/lifecycle-hooks) guide.
 
+<<<<<<< HEAD
 {@a link-parameters-array}
 
 <<<<<<< HEAD
@@ -600,6 +604,8 @@ In the Angular [router service](#router), an array which contains an object that
 To learn more, see the [Routing and Navigation](guide/router#link-parameters-array) guide.
 
 >>>>>>> docs: separate router tutorial from router guide
+=======
+>>>>>>> fixup! docs: separate router tutorial from router guide
 {@a M}
 
 {@a module}
@@ -760,7 +766,6 @@ When using reactive forms:
 
 The alternative is a template-driven form. For an introduction and comparison of both forms approaches, see [Introduction to Angular Forms](guide/forms-overview).
 
-<<<<<<< HEAD
 {@a resolver}
 
 ## resolver
@@ -771,13 +776,10 @@ Resolvers run after all [route guards](#route-guard "Definition") for a route tr
 
 See an example of using a [resolve guard](guide/router-tutorial-toh#resolve-guard "Routing techniques tutorial") to retrieve dynamic data.
 
-=======
->>>>>>> docs: separate router tutorial from router guide
 {@a route-guard}
 
 ## route guard
 
-<<<<<<< HEAD
 A method that controls navigation to a requested route in a routing application.
 Guards determine whether a route can be activated or deactivated, and whether a lazy-loaded module can be loaded.
 
@@ -818,12 +820,6 @@ A [directive](#directive) that acts as a placeholder in a routing component's te
 An Angular [component](#component) with a `RouterOutlet` directive in its template that displays views based on router navigations.
 
 For more information, see [Routing and Navigation](guide/router).
-
-{@a routing-module}
-
-## routing module
-
-An NgModule that contains an application's routing configuration. A dedicated routing module does not declare components, but serves to separate routing concerns from other application concerns. It provides a well-known location for routing service providers such as guards and resolvers. A routing module is also easy to replace or remove when testing the application.
 
 {@a rule}
 

--- a/aio/content/guide/lazy-loading-ngmodules.md
+++ b/aio/content/guide/lazy-loading-ngmodules.md
@@ -311,7 +311,7 @@ ngOnInit() {
 }
 </code-example>
 
-For more information with a working example, see the [routing tutorial section on preloading](guide/router-tutorial-toh#preloading-background-loading-of-feature-areas).
+For more information with a working example, see the section on [preloading](guide/router-techniques#preloading) in the routing tutorial.
 
 
 <hr>

--- a/aio/content/guide/router-techniques.md
+++ b/aio/content/guide/router-techniques.md
@@ -1,0 +1,1789 @@
+# Navigation techniques
+
+The sample application that you create in the [basic routing tutorial](guide/router-tutorial) demonstrates basic navigation setup and configuration, and recommends a modular design that supports complex navigation needs.
+This follow-on tutorial discusses and demonstrates additional navigation capabilities and techniques by extending the sample application.
+
+{@a final-app}
+
+<div class="alert is-helpful">
+
+See the <live-example></live-example> for the source code of the completed sample application.
+
+</div>
+
+## Prerequisites
+
+* Basic navigation and routing concepts: [In-app navigation: routing to views](guide/router)
+* Basic router tutorial: [Using Angular routes in a single-page application](guide/router-tutorial).
+
+The sample app uses the same domain as the [Getting Started: Tour of Heroes](tutorial).
+You might find the original Tour of Heroes tutorial helpful, but it is not required.
+
+---
+
+{@a overview}
+
+## Sample application overview
+
+The sample application for this tutorial helps the Hero Employment Agency find crises for heroes to solve.
+When it is complete, the application has three main feature areas:
+
+* A *Crisis Center* for maintaining the list of crises for assignment to heroes.
+* A *Heroes* area for maintaining the list of heroes employed by the agency.
+* An *Admin* area to manage the list of crises and heroes.
+
+The finished sample application demonstrates the following techniques.
+
+* Using required and optional route parameters to construct route paths.
+* Animating view transitions.
+* Creating child routes.
+* Showing multiple, related views with nested routes.
+* Using route guards to restrict access to views and check whether users can access a route.
+* Controlling whether the application can discard unsaved changes.
+* Requiring specific criteria to load components.
+
+Try it by clicking on this <live-example title="Hero Employment Agency Live Example">live example link</live-example>.
+
+The app renders with a row of navigation buttons and the *Heroes* view with its list of heroes.
+
+<div class="lightbox">
+  <img src='generated/images/guide/router/hero-list.png' alt="Hero List">
+</div>
+
+Select one hero and the app takes you to a hero editing screen.
+
+<div class="lightbox">
+  <img src='generated/images/guide/router/hero-detail.png' alt="Crisis Center Detail">
+</div>
+
+Alter the name.
+Click the "Back" button and the app returns to the heroes list which displays the changed hero name.
+Notice that the name change took effect immediately.
+
+If you click the browser's back button instead of the app's "Back" button, the app still returns you to the heroes list.
+Angular app navigation updates the browser history just like normal web navigation.
+
+Now click the *Crisis Center* link for a list of ongoing crises.
+
+<div class="lightbox">
+  <img src='generated/images/guide/router/crisis-center-list.png' alt="Crisis Center List">
+</div>
+
+Select a crisis and the application takes you to a crisis editing screen.
+The _Crisis Detail_ appears in a child component on the same page, beneath the list.
+
+Alter the name of a crisis.
+Notice that the corresponding name in the crisis list does _not_ change.
+
+<div class="lightbox">
+  <img src='generated/images/guide/router/crisis-center-detail.png' alt="Crisis Center Detail">
+</div>
+
+Unlike *Hero Detail*, which updates as you type, *Crisis Detail* changes are temporary until you either save or discard them by pressing the "Save" or "Cancel" buttons.
+Both buttons navigate back to the *Crisis Center* and its list of crises.
+
+Click the browser back button or the "Heroes" link to activate a dialog.
+
+<div class="lightbox">
+  <img src='generated/images/guide/router/confirm-dialog.png' alt="Confirm Dialog">
+</div>
+
+You can say "OK" and lose your changes or click "Cancel" and continue editing.
+This demonstrates the router's `CanDeactivate` guard.
+The guard function gives you a chance to clean up or ask the user's permission before navigating away from the current view.
+
+The `Admin` and `Login` buttons illustrate the use of *route guards* to control access to parts of an application.
+
+---
+
+{@a route-def-with-parameter}
+{@a route-parameters}
+
+## Part 1: Track navigation states with route parameters
+
+As a user navigates among views, the router keeps track of the current navigation state and navigation history.
+To implement a "back" button, for example, you need to navigate to the previously active route.
+You can identify a previously displayed view by looking at the [route parameters](guide/router#route-parameters "About route parameters") that were passed to the activation operation.
+
+{@a activated-route-in-action}
+
+### Retrieve parameters with `Activated Route`
+
+When the router activates a route, it extracts the route parameter (`id:15`) from the URL and supplies it to
+the `HeroDetailComponent` via the `ActivatedRoute` service.
+Use the following steps to retrieve the parameters used to activate a route.
+
+1. Import the `Router`, `ActivatedRoute`, and `ParamMap` tokens from the router package.
+
+   <code-example path="router/src/app/heroes/hero-detail/hero-detail.component.1.ts" header="src/app/heroes/hero-detail/hero-detail.component.ts (activated route)" region="imports"></code-example>
+
+2. Import the `switchMap` operator because you need it later to process the `Observable` route parameters.
+
+   <code-example path="router/src/app/heroes/hero-detail/hero-detail.component.3.ts" header="src/app/heroes/hero-detail/hero-detail.component.ts (switchMap operator import)" region="rxjs-operator-import"></code-example>
+
+{@a hero-detail-ctor}
+
+3. Add the services as private variables to the constructor so that Angular injects them (makes them visible to the component).
+
+   <code-example path="router/src/app/heroes/hero-detail/hero-detail.component.3.ts" header="src/app/heroes/hero-detail/hero-detail.component.ts (constructor)" region="ctor"></code-example>
+
+4. In the `ngOnInit()` method, use the `ActivatedRoute` service to retrieve the parameters for the route, pull the hero `id` from the parameters, and retrieve the hero to display.
+
+   <code-example path="router/src/app/heroes/hero-detail/hero-detail.component.3.ts" header="src/app/heroes/hero-detail/hero-detail.component.ts (ngOnInit)" region="ngOnInit"></code-example>
+
+   When the map changes, the `paramMap` gets the `id` parameter from the changed parameters.
+   Then you tell the `HeroService` to fetch the hero with that `id` and return the result of the `HeroService` request.
+
+The `switchMap` operator does two things. It flattens the `Observable<Hero>` that `HeroService` returns and cancels previous pending requests.
+
+* If the user re-navigates to this route with a new `id` while the `HeroService` is still retrieving the old `id`, `switchMap` discards that old request and returns the hero for the new `id`.
+
+* `AsyncPipe` handles the observable subscription and the component's `hero` property is reset with the retrieved hero.
+
+<div class="alert is-helpful">
+
+See more about [working with parameter maps](guide/router#param-maps).
+
+</div>
+
+Currently, the `HeroDetailComponent` "Back" button uses the `gotoHeroes()` method that navigates imperatively back to the `HeroListComponent`, using the `navigate()` method.
+This method takes the same single-item [_link parameters array_](guide/router#link-parameters-array) that you can bind to a `[routerLink]` directive.
+So far, the array holds only the path to the `HeroListComponent`:
+
+<code-example path="router/src/app/heroes/hero-detail/hero-detail.component.1.ts" header="src/app/heroes/hero-detail/hero-detail.component.ts (excerpt)" region="gotoHeroes"></code-example>
+
+You can add the required parameter (`id`) to the link parameters array in an explicit route request, in order to display that detail page imperatively.
+
+{@a nav-to-list}
+
+### Preselect previously viewed item in list view
+
+When returning to the `hero-detail.component.ts` list from the hero detail view, it would be nice if the viewed hero were preselected in the list.
+
+<div class="lightbox">
+  <img src='generated/images/guide/router/selected-hero.png' alt="Selected hero">
+</div>
+
+Implement this feature by including the viewed hero's `id` in the URL as an *optional* parameter when returning from the `HeroDetailComponent`.
+
+In the router link that original triggered navigation to the list, the `id` of the hero-to-edit is a required parameter, and is specified as the second item of the link parameters array.
+
+<code-example path="router/src/app/heroes/hero-list/hero-list.component.1.html" header="src/app/heroes/hero-list/hero-list.component.html (link-parameters-array)" region="link-parameters-array"></code-example>
+
+The router embedded the `id` value in the navigation URL because you had defined it as a route parameter with an `:id` placeholder token in the route `path`:
+
+<code-example path="router/src/app/heroes/heroes-routing.module.1.ts" header="src/app/heroes/heroes-routing.module.ts (hero-detail-route)" region="hero-detail-route"></code-example>
+
+When the user clicks the back button, the `HeroDetailComponent` constructs another link parameters array
+which it uses to navigate back to the `HeroListComponent`.
+
+<code-example path="router/src/app/heroes/hero-detail/hero-detail.component.1.ts" header="src/app/heroes/hero-detail/hero-detail.component.ts (gotoHeroes)" region="gotoHeroes"></code-example>
+
+This array lacks a route parameter because you didn't need to send information back to the `HeroListComponent`.
+Now, however, you want to tell the hero-list which hero was previously selected.
+
+To add the selection information in an *optional* parameter, use the following steps.
+
+1. Send the `id` of the current hero with the navigation request so that the
+`HeroListComponent` can highlight that hero in its list.
+   In the link parameters array, include an object that contains an optional `id` parameter.
+
+   For demonstration purposes, there's an extra junk parameter (`foo`) in the object that the `HeroListComponent` should ignore.
+   Here's the revised navigation statement:
+
+   <code-example path="router/src/app/heroes/hero-detail/hero-detail.component.3.ts" header="src/app/heroes/hero-detail/hero-detail.component.ts (go to heroes)" region="gotoHeroes"></code-example>
+
+2. Run the app and click  "back" to show that it returns to the hero list view.
+
+3. Look at the browser address bar. It should look something like this, depending on where you run it:
+
+   <code-example language="bash">
+     localhost:4200/heroes;id=15;foo=foo
+
+   </code-example>
+
+   Notice that the `id` value appears in the URL as (`;id=15;foo=foo`), not in the URL path. The path for the "Heroes" route doesn't have an `:id` token.
+
+   Notice also that the optional route parameters are not separated by "?" and "&" as they would be in the URL query string. They are separated by semicolons (";"), using matrix URL notation.
+
+<div class="alert is-helpful">
+
+Matrix URL notation is an idea first introduced in a
+[1996 proposal](http://www.w3.org/DesignIssues/MatrixURIs.html) by the founder of the web, Tim Berners-Lee.
+
+Although matrix notation is not part of the HTML standard,
+it is legal and it became popular among browser routing systems
+as a way to isolate parameters belonging to parent and child routes.
+The Angular router provides support for the matrix notation across browsers.
+
+</div>
+
+{@a route-parameters-activated-route}
+
+### Access route parameters using `ActivatedRoute` methods
+
+In its current state of development, the list of heroes is unchanged.
+No hero row is highlighted.
+
+The `HeroListComponent` needs code that expects parameters.
+
+Previously, when navigating from the `HeroListComponent` to the `HeroDetailComponent`,
+you subscribed to the route parameter map `Observable` and made it available to the `HeroDetailComponent`
+in the `ActivatedRoute` service.
+You injected that service in the constructor of the `HeroDetailComponent`.
+
+This time you'll be navigating in the opposite direction, from the `HeroDetailComponent` to the `HeroListComponent`.
+
+1. Extend the router import statement to include the `ActivatedRoute` service symbol:
+
+   <code-example path="router/src/app/heroes/hero-list/hero-list.component.ts" header="src/app/heroes/hero-list/hero-list.component.ts (import)" region="import-router"></code-example>
+
+2. Import the `switchMap` operator to perform an operation on the `Observable` of route parameter map.
+
+   <code-example path="router/src/app/heroes/hero-list/hero-list.component.ts" header="src/app/heroes/hero-list/hero-list.component.ts (rxjs imports)" region="rxjs-imports"></code-example>
+
+3. Inject the `ActivatedRoute` in the `HeroListComponent` constructor.
+
+   <code-example path="router/src/app/heroes/hero-list/hero-list.component.ts" header="src/app/heroes/hero-list/hero-list.component.ts (constructor and ngOnInit)" region="ctor"></code-example>
+
+   * The `ActivatedRoute.paramMap` property is an `Observable` map of route parameters.
+   * The `paramMap` emits a new map of values that includes `id` when the user navigates to the component.
+   * In `ngOnInit()` you subscribe to those values, set the `selectedId`, and get the heroes.
+
+4. Update the template with a [class binding](guide/template-syntax#class-binding). The binding adds the `selected` CSS class when the comparison returns `true` and removes it when `false`. Look for it within the repeated `<li>` tag as shown here:
+
+   <code-example path="router/src/app/heroes/hero-list/hero-list.component.html" header="src/app/heroes/hero-list/hero-list.component.html"></code-example>
+
+5. Add some styles to apply when the list item is selected.
+
+   <code-example path="router/src/app/heroes/hero-list/hero-list.component.css" region="selected" header="src/app/heroes/hero-list/hero-list.component.css"></code-example>
+
+When the user navigates from the heroes list to the "Magneta" hero and back, "Magneta" appears selected:
+
+   <div class="lightbox">
+     <img src='generated/images/guide/router/selected-hero.png' alt="Selected List">
+   </div>
+
+The optional `foo` route parameter is harmless and the router continues to ignore it.
+
+{@a route-animation}
+
+### Add routable animations
+
+This section shows you how to add some [animations](guide/animations) to the `HeroDetailComponent`.
+
+1. Import the `BrowserAnimationsModule` and add it to the `imports` array:
+
+   <code-example path="router/src/app/app.module.ts" header="src/app/app.module.ts (animations-module)" region="animations-module"></code-example>
+
+2. Add a `data` object to the routes for `HeroListComponent` and `HeroDetailComponent`. Transitions are based on `states` and you use the `animation` data from the route to provide a named animation `state` for the transitions.
+
+   <code-example path="router/src/app/heroes/heroes-routing.module.2.ts" header="src/app/heroes/heroes-routing.module.ts (animation data)"></code-example>
+
+3. Create an `animations.ts` file in the root `src/app/` folder. The contents look like this:
+
+   <code-example path="router/src/app/animations.ts" header="src/app/animations.ts (excerpt)"></code-example>
+
+   This file does the following:
+
+   * Imports the animation symbols that build the animation triggers, control state, and manage transitions between states.
+
+   * Exports a constant named `slideInAnimation` set to an animation trigger named `routeAnimation`.
+
+   * Defines one transition when switching back and forth from the `heroes` and `hero` routes to ease the component in from the left of the screen as it enters the application view (`:enter`), the other to animate the component to the right as it leaves the application view (`:leave`).
+
+4. In the `AppComponent`, import the `RouterOutlet` token from the `@angular/router` package and the `slideInAnimation` from `'./animations.ts`.
+
+5. Add an `animations` array to the `@Component` metadata that contains the `slideInAnimation`.
+
+   <code-example path="router/src/app/app.component.2.ts" header="src/app/app.component.ts (animations)" region="animation-imports"></code-example>
+
+6. In order to use the routable animations, wrap the `RouterOutlet` inside an element, use the `@routeAnimation` trigger, and bind it to the element.
+
+   * Provide the `data` value from the `ActivatedRoute` so that the `@routeAnimation` transitions can key off route states.
+
+   * The `#routerOutlet` template variable lets you reference the `<router-outlet>` tag elsewhere in the template. The `@routeAnimation` property is bound to the `getAnimationData()` using the `routerOutlet` reference
+
+   <code-example path="router/src/app/app.component.2.html" header="src/app/app.component.html (router outlet)"></code-example>
+
+7. Define the `getAnimationData()` function in the `AppComponent`. This function returns the animation property from the `data` provided through the `ActivatedRoute`. The `animation` property matches the `transition` names you used in the `slideInAnimation` defined in `animations.ts`.
+
+   <code-example path="router/src/app/app.component.2.ts" header="src/app/app.component.ts (router outlet)" region="function-binding"></code-example>
+
+When switching between the two routes, the `HeroDetailComponent` and `HeroListComponent` now ease in from the left when routed to and slide to the right when navigating away.
+
+### Part 1 Summary
+
+The sample app you have built to this point demonstrates the following routing techniques.
+
+* Organizing the app into feature areas.
+* Navigating imperatively from one view to another.
+* Passing information along in route parameters and subscribing to them in the component.
+* Importing the feature area NgModule into the `AppModule`.
+* Applying routable animations based on view transitions.
+
+After these changes, the folder structure is as follows:
+
+<div class='filetree'>
+
+  <div class='file'>
+    angular-router-sample
+  </div>
+
+  <div class='children'>
+
+    <div class='file'>
+      src
+    </div>
+
+    <div class='children'>
+
+      <div class='file'>
+        app
+      </div>
+
+      <div class='children'>
+
+        <div class='file'>
+          crisis-list
+        </div>
+
+          <div class='children'>
+
+            <div class='file'>
+              crisis-list.component.css
+            </div>
+
+            <div class='file'>
+              crisis-list.component.html
+            </div>
+
+            <div class='file'>
+              crisis-list.component.ts
+            </div>
+
+          </div>
+
+        <div class='file'>
+          heroes
+        </div>
+
+        <div class='children'>
+
+          <div class='file'>
+            hero-detail
+          </div>
+
+            <div class='children'>
+
+              <div class='file'>
+                hero-detail.component.css
+              </div>
+
+              <div class='file'>
+                hero-detail.component.html
+              </div>
+
+              <div class='file'>
+                hero-detail.component.ts
+              </div>
+
+            </div>
+
+          <div class='file'>
+            hero-list
+          </div>
+
+            <div class='children'>
+
+              <div class='file'>
+                hero-list.component.css
+              </div>
+
+              <div class='file'>
+                hero-list.component.html
+              </div>
+
+              <div class='file'>
+                hero-list.component.ts
+              </div>
+
+            </div>
+
+          <div class='file'>
+            hero.service.ts
+          </div>
+
+          <div class='file'>
+            hero.ts
+          </div>
+
+          <div class='file'>
+            heroes-routing.module.ts
+          </div>
+
+          <div class='file'>
+            heroes.module.ts
+          </div>
+
+          <div class='file'>
+            mock-heroes.ts
+          </div>
+
+        </div>
+
+        <div class='file'>
+          page-not-found
+        </div>
+
+        <div class='children'>
+
+          <div class='file'>
+
+            page-not-found.component.css
+
+          </div>
+
+          <div class='file'>
+
+            page-not-found.component.html
+
+          </div>
+
+          <div class='file'>
+
+            page-not-found.component.ts
+
+          </div>
+
+        </div>
+
+      </div>
+
+      <div class='file'>
+        animations.ts
+      </div>
+
+      <div class='file'>
+        app.component.css
+      </div>
+
+      <div class='file'>
+        app.component.html
+      </div>
+
+      <div class='file'>
+        app.component.ts
+      </div>
+
+      <div class='file'>
+        app.module.ts
+      </div>
+
+      <div class='file'>
+        app-routing.module.ts
+      </div>
+
+      <div class='file'>
+        main.ts
+      </div>
+
+      <div class='file'>
+        message.service.ts
+      </div>
+
+      <div class='file'>
+        index.html
+      </div>
+
+      <div class='file'>
+        styles.css
+      </div>
+
+      <div class='file'>
+        tsconfig.json
+      </div>
+
+    </div>
+
+    <div class='file'>
+      node_modules ...
+    </div>
+
+    <div class='file'>
+      package.json
+    </div>
+
+  </div>
+
+</div>
+
+Here are the relevant files for this version of the sample application.
+
+<code-tabs>
+
+  <code-pane header="animations.ts" path="router/src/app/animations.ts">
+
+  </code-pane>
+
+  <code-pane header="app.component.html" path="router/src/app/app.component.2.html">
+
+  </code-pane>
+
+  <code-pane header="app.component.ts" path="router/src/app/app.component.2.ts">
+
+  </code-pane>
+
+  <code-pane header="app.module.ts" path="router/src/app/app.module.3.ts">
+
+  </code-pane>
+
+  <code-pane header="app-routing.module.ts" path="router/src/app/app-routing.module.2.ts" region="milestone3">
+
+  </code-pane>
+
+  <code-pane header="hero-list.component.css" path="router/src/app/heroes/hero-list/hero-list.component.css">
+
+  </code-pane>
+
+  <code-pane header="hero-list.component.html" path="router/src/app/heroes/hero-list/hero-list.component.html">
+
+  </code-pane>
+
+  <code-pane header="hero-list.component.ts" path="router/src/app/heroes/hero-list/hero-list.component.ts">
+
+  </code-pane>
+
+  <code-pane header="hero-detail.component.html" path="router/src/app/heroes/hero-detail/hero-detail.component.html">
+
+  </code-pane>
+
+  <code-pane header="hero-detail.component.ts" path="router/src/app/heroes/hero-detail/hero-detail.component.3.ts">
+
+  </code-pane>
+
+  <code-pane header="hero.service.ts" path="router/src/app/heroes/hero.service.ts">
+
+  </code-pane>
+
+  <code-pane header="heroes.module.ts" path="router/src/app/heroes/heroes.module.ts">
+
+  </code-pane>
+
+  <code-pane header="heroes-routing.module.ts" path="router/src/app/heroes/heroes-routing.module.2.ts">
+
+  </code-pane>
+
+  <code-pane header="message.service.ts" path="router/src/app/message.service.ts">
+
+  </code-pane>
+
+</code-tabs>
+
+---
+
+<!--- Possible new page: Complex routes (includes 'Add child routes' and 'Add multiple named outlets') -->
+
+{@a milestone-4}
+{@a relative-routing}
+
+## Part 2: Add child routes and relative paths
+
+In this section, you will create a new Crisis Center feature to learn how to add child routes and use relative routing in your app.
+The Crisis Center stands alone, and changes to it don't affect the `AppModule` or any other feature component.
+
+You will organize the crisis center to conform to the following recommended pattern for Angular applications:
+
+* Each feature area resides in its own folder.
+* Each feature has its own Angular feature module.
+* Each area has its own area root component.
+* Each area root component has its own router outlet and child routes.
+* Feature area routes rarely or never cross with routes of other features.
+
+If your app had many feature areas, the app component trees might look like this:
+
+<div class="lightbox">
+  <img src='generated/images/guide/router/component-tree.png' alt="Component Tree">
+</div>
+
+{@a crisis-child-routes}
+
+### Create a crisis center feature module
+
+To add features to the app's current crisis center, make it an independent module, as you did for the heroes feature.
+
+1. Create a `crisis-center` subfolder in the `src/app` folder.
+
+2. Copy the files and folders from `app/heroes` into the new `crisis-center` folder.
+
+3. In the new files, change every mention of "hero" to "crisis", and "heroes" to "crises".
+
+4. Rename the NgModule files to `crisis-center.module.ts` and `crisis-center-routing.module.ts`.
+
+For this exercise, you use mock crises instead of mock heroes:
+
+<code-example path="router/src/app/crisis-center/mock-crises.ts" header="src/app/crisis-center/mock-crises.ts"></code-example>
+
+The routing style for the new Crisis Center will offer a contrast to the current state of Heroes.
+
+{@a child-routing-component}
+
+### Create a child routing component
+
+The `CrisisCenterComponent` is the root of the crisis center area, just as `AppComponent` is the root of the entire application.
+
+1. Generate a `CrisisCenter` component in the `crisis-center` folder:
+
+   <code-example language="none" class="code-shell">
+     ng generate component crisis-center/crisis-center
+   </code-example>
+
+2. Update the component template with the following markup:
+
+   <code-example path="router/src/app/crisis-center/crisis-center/crisis-center.component.html" header="src/app/crisis-center/crisis-center/crisis-center.component.html"></code-example>
+
+This `CrisisCenterComponent` is a shell for the crisis management feature area, just as the `AppComponent` is a shell to manage the high-level workflow.
+Like most shells, the `CrisisCenterComponent` class is minimal because it has no business logic, and its template has no links, just a title and `<router-outlet>` for the crisis center child component.
+The router displays the components of these routes in the `RouterOutlet` of the `CrisisCenterComponent`, not in the `RouterOutlet` of the `AppComponent` shell.
+
+{@a child-route-config}
+
+### Child route configuration
+
+The Crisis Center feature needs a home page to host its child views.
+Create the home page using the following steps.
+
+1. Generate a `CrisisCenterHome` component in the `crisis-center` folder.
+
+   <code-example language="none" class="code-shell">
+     ng generate component crisis-center/crisis-center-home
+   </code-example>
+
+2. Update the template with a welcome message to the `Crisis Center`.
+
+   <code-example path="router/src/app/crisis-center/crisis-center-home/crisis-center-home.component.html" header="src/app/crisis-center/crisis-center-home/crisis-center-home.component.html"></code-example>
+
+3. Update the `crisis-center-routing.module.ts` you renamed after copying it from `heroes-routing.module.ts` file. This time, you define child routes within the parent `crisis-center` route.
+
+   The parent `crisis-center` route has a `children` property with a single route containing the `CrisisListComponent`.
+   The `CrisisListComponent` route also has a `children` array with two routes, which navigate to the crisis center child components, `CrisisCenterHomeComponent` and `CrisisDetailComponent`, respectively.
+
+   <code-example path="router/src/app/crisis-center/crisis-center-routing.module.1.ts" header="src/app/crisis-center/crisis-center-routing.module.ts (Routes)" region="routes"></code-example>
+
+The `CrisisListComponent` now contains the crisis list and a `RouterOutlet` to display the `Crisis Center Home` and `Crisis Detail` route components. The `Crisis Detail` route is a child of the `Crisis List`.
+
+There are important differences in the way the router treats child routes.
+
+* The router [reuses components](guide/router#reuse) by default, so the `Crisis Detail` component is re-used as you select different crises.
+Compare this to the `Hero Detail` route, where [the component was recreated](guide/router#snapshot) each time you selected a different hero from the list of heroes.
+
+* The path to a child route is [relative](#relative-navigation "More about relative navigation below") to the parent route. Within the crisis center, the parent path is `/crisis-center`. The router constructs the full URL by appending the relative path segment to its parent path.
+
+   * To navigate to the `CrisisCenterHomeComponent`, the full URL is `/crisis-center` (`/crisis-center` + `''` + `''`).
+
+   * To navigate to the `CrisisDetailComponent` for a crisis with `id=2`, the full URL is
+`/crisis-center/2` (`/crisis-center` + `''` +  `'/2'`). The resulting absolute URL, including the `localhost` origin, is as follows:
+
+   <code-example>
+     localhost:4200/crisis-center/2
+
+   </code-example>
+
+Here's the complete `crisis-center-routing.module.ts` file with its imports.
+
+<code-example path="router/src/app/crisis-center/crisis-center-routing.module.1.ts" header="src/app/crisis-center/crisis-center-routing.module.ts (excerpt)"></code-example>
+
+{@a import-crisis-module}
+
+### Import crisis center module into the `AppModule` routes
+
+1. Add the `CrisisCenterModule` to the `imports` array of the `AppModule`
+_before_ the `AppRoutingModule`.
+
+2. Now that the `HeroesModule` and the `CrisisCenter` modules provide the feature routes, remove the initial crisis center route from the `app-routing.module.ts`.
+
+<code-tabs>
+
+  <code-pane path="router/src/app/crisis-center/crisis-center.module.ts"header="src/app/crisis-center/crisis-center.module.ts">
+
+  </code-pane>
+
+  <code-pane path="router/src/app/app.module.4.ts" header="src/app/app.module.ts (import CrisisCenterModule)" region="crisis-center-module">
+
+  </code-pane>
+
+</code-tabs>
+
+3. Make sure that the `app-routing.module.ts` file retains the top-level application routes such as the default and wildcard routes.
+
+   <code-example path="router/src/app/app-routing.module.3.ts" header="src/app/app-routing.module.ts (v3)" region="v3"></code-example>
+
+{@a relative-navigation}
+{@a nav-to-crisis}
+
+While building out the crisis center feature, you navigated to the
+crisis detail route using an absolute path that begins with a slash.
+The router matches such absolute paths to routes starting from the top of the route configuration.
+
+If you change the parent `/crisis-center` path, however, you would have to change the link parameters array.
+You can free the links from this dependency by defining paths that are [relative to the current URL segment](guide/router#using-relative-paths "Using relative paths for routes").
+Navigation within the feature area remains intact even if you change the parent route path to the feature.
+
+4. Update the `gotoCrises()` method of the `CrisisDetailComponent` to navigate back to the Crisis Center list using relative path navigation.
+
+   * You've already injected the `ActivatedRoute` that you need to compose the relative navigation path.
+   * Change the path argument to a relative path specifier. The path goes up a level using the `../` syntax.
+   * The link parameters array still specifies the parameters that you need to append to the path.
+   * Add a third argument, a configuration object that sets the base path to the current active route.
+
+   <code-example path="router/src/app/crisis-center/crisis-detail/crisis-detail.component.ts" header="src/app/crisis-center/crisis-detail/crisis-detail.component.ts (relative navigation)" region="gotoCrises-navigate"></code-example>
+
+   If the current crisis `id` is `3`, the resulting path back to the crisis list is  `/crisis-center/;id=3;foo=foo`.
+
+<div class="alert is-helpful">
+
+When using a `RouterLink` to navigate instead of the `Router` service, you'd use the same link parameters array, but you wouldn't provide the object with the `relativeTo` property.
+The `ActivatedRoute` is implicit in a `RouterLink` directive.
+
+</div>
+
+{@a named-outlets-example}
+{@a secondary-routes}
+
+### Display multiple views in named outlets
+
+So far, there is only a single outlet and you've nested child routes under that outlet to group routes together.
+Suppose you want to give users a way to contact the crisis center.
+When a user clicks a "Contact" button, you want to display a message in a popup view.
+The popup should stay open, even when switching between pages in the application, until the user closes it
+by sending the message or canceling.
+
+To accomplish this, you need to add a [secondary outlet](guide/router#define-secondary-routes "Read about secondary routes and named outlets") to the template.
+While the primary outlet is unnamed, you can have any number of named secondary outlets, with their own route configurations.
+You target a named outlet by adding the outlet name to the route definition.
+
+1. Add an outlet named "popup" in the `AppComponent`, directly below the primary unnamed outlet.
+
+   <code-example path="router/src/app/app.component.4.html" header="src/app/app.component.html (outlets)" region="outlets"></code-example>
+
+   That's where a popup will go when you have routed a popup component to it.
+
+2. Generate a new component to compose the message.
+
+   <code-example language="none" class="code-shell">
+     ng generate component compose-message
+   </code-example>
+
+3. Add the component logic with its template and styles:
+
+<code-tabs>
+
+  <code-pane header="src/app/compose-message/compose-message.component.css" path="router/src/app/compose-message/compose-message.component.css">
+
+  </code-pane>
+
+  <code-pane header="src/app/compose-message/compose-message.component.html" path="router/src/app/compose-message/compose-message.component.html">
+
+  </code-pane>
+
+  <code-pane header="src/app/compose-message/compose-message.component.ts" path="router/src/app/compose-message/compose-message.component.ts">
+
+  </code-pane>
+
+</code-tabs>
+
+   * Note that the `send()` method simulates latency by waiting a second before "sending" the message and closing the popup.
+
+   * The `closePopup()` method closes the popup view by navigating to the popup outlet with a `null`. See [clearing secondary routes](#clear-secondary-routes).
+
+   The view for this component displays a short form with a header, an input box for the message, and two buttons, "Send" and "Cancel".
+
+   <div class="lightbox">
+     <img src='generated/images/guide/router/contact-popup.png' alt="Contact popup">
+   </div>
+
+4. To add a secondary route, open the `AppRoutingModule` and add a new `compose` route to the `appRoutes` array.
+   In addition to the `path` and `component` properties, there's a third property, `outlet`, which is set to `'popup'`.
+
+   <code-example path="router/src/app/app-routing.module.3.ts" header="src/app/app-routing.module.ts (compose route)" region="compose"></code-example>
+
+   This route now targets the `popup` outlet. When it is activated, the `ComposeMessageComponent` view is displayed there.
+
+5. To give users a way to open the popup, add a "Contact" link to the `AppComponent` template.
+
+   Although the `compose` route is configured to the "popup" outlet, that's not sufficient for connecting the route to a `RouterLink` directive.
+   You have to specify the named outlet in a link parameters array and bind it to the `RouterLink` with a property binding.
+
+   <code-example path="router/src/app/app.component.4.html" header="src/app/app.component.html (contact-link)" region="contact-link"></code-example>
+
+   * The link parameters array contains an object with a single `outlets` property whose value is another object keyed by one (or more) outlet names.
+   In this case there is only the "popup" outlet property and its value is another link parameters array that specifies the `compose` route.
+
+When the user clicks the "Contact" link, the router displays the component associated with the `compose` route in the `popup` outlet.
+
+The [URL syntax](guide/router#secondary-route-navigation "Syntax details") for the secondary route appends the secondary outlet and route within parentheses:
+
+<code-example>
+  http://.../crisis-center(popup:compose)
+
+</code-example>
+
+If you click the _Heroes_ link, the primary navigation part changes; the secondary route remains the same.
+
+<code-example>
+  http://.../heroes(popup:compose)
+</code-example>
+
+That's why the popup stays visible as you navigate among the crises and heroes.
+
+{@a clear-secondary-routes}
+
+6. Clicking the "Send" or "Cancel" buttons clears the popup view by calling the `closePopup()` function:
+
+   <code-example path="router/src/app/compose-message/compose-message.component.ts" header="src/app/compose-message/compose-message.component.ts (closePopup)" region="closePopup"></code-example>
+
+   The `closePopup()` function navigates imperatively with the `Router.navigate()` method, passing in a link parameters array.
+
+   * Like the array bound to the _Contact_ `RouterLink` in the `AppComponent`, this one includes an object with an `outlets` property.
+
+   * The `outlets` property value is another object with outlet names for keys. The only named outlet is `'popup'`. This time, the value of `'popup'` is not a route, but the special value `null`.
+
+Setting the "popup" `RouterOutlet` to `null` clears the outlet and removes the secondary popup route from the current URL.
+
+---
+
+<!--- Possible new page: Controlling access to views  -->
+
+{@a guards}
+{@a milestone-5-route-guards}
+
+## Part 3: Control access with route guards
+
+At this point, any user can navigate anywhere in the application anytime.
+To control access, you can use one or more of the pre-defined route-guard functions, or create your own route guards.
+
+The following section provide some examples.
+
+### Add an administrative feature module
+
+This section guides you through extending the crisis center with some new administrative features.
+Start by adding a new feature module named `AdminModule`.
+
+Generate an `admin` folder with a feature module file and a routing configuration file.
+
+<code-example language="none" class="code-shell">
+  ng generate module admin --routing
+</code-example>
+
+Next, generate the supporting components.
+
+<code-example language="none" class="code-shell">
+  ng generate component admin/admin-dashboard
+</code-example>
+
+<code-example language="none" class="code-shell">
+  ng generate component admin/admin
+</code-example>
+
+<code-example language="none" class="code-shell">
+  ng generate component admin/manage-crises
+</code-example>
+
+<code-example language="none" class="code-shell">
+  ng generate component admin/manage-heroes
+</code-example>
+
+The admin feature file structure looks like this:
+
+<div class='filetree'>
+
+  <div class='file'>
+    src/app/admin
+  </div>
+
+  <div class='children'>
+
+    <div class='file'>
+      admin
+    </div>
+
+      <div class='children'>
+
+        <div class='file'>
+          admin.component.css
+        </div>
+
+        <div class='file'>
+          admin.component.html
+        </div>
+
+        <div class='file'>
+          admin.component.ts
+        </div>
+
+      </div>
+
+    <div class='file'>
+      admin-dashboard
+    </div>
+
+      <div class='children'>
+
+        <div class='file'>
+          admin-dashboard.component.css
+        </div>
+
+        <div class='file'>
+          admin-dashboard.component.html
+        </div>
+
+        <div class='file'>
+          admin-dashboard.component.ts
+        </div>
+
+      </div>
+
+    <div class='file'>
+      manage-crises
+    </div>
+
+      <div class='children'>
+
+        <div class='file'>
+          manage-crises.component.css
+        </div>
+
+        <div class='file'>
+          manage-crises.component.html
+        </div>
+
+        <div class='file'>
+          manage-crises.component.ts
+        </div>
+
+      </div>
+
+    <div class='file'>
+      manage-heroes
+    </div>
+
+      <div class='children'>
+
+        <div class='file'>
+          manage-heroes.component.css
+        </div>
+
+        <div class='file'>
+          manage-heroes.component.html
+        </div>
+
+        <div class='file'>
+          manage-heroes.component.ts
+        </div>
+
+      </div>
+
+    <div class='file'>
+      admin.module.ts
+    </div>
+
+    <div class='file'>
+      admin-routing.module.ts
+    </div>
+
+  </div>
+
+</div>
+
+The admin feature module contains the `AdminComponent` used for routing within the
+feature module, a dashboard route and two unfinished components to manage crises and heroes.
+
+<code-tabs>
+
+  <code-pane header="src/app/admin/admin/admin.component.html"  path="router/src/app/admin/admin/admin.component.html">
+
+  </code-pane>
+
+  <code-pane header="src/app/admin/admin-dashboard/admin-dashboard.component.html" path="router/src/app/admin/admin-dashboard/admin-dashboard.component.1.html">
+
+  </code-pane>
+
+  <code-pane header="src/app/admin/admin.module.ts" path="router/src/app/admin/admin.module.ts">
+
+  </code-pane>
+
+  <code-pane header="src/app/admin/manage-crises/manage-crises.component.html" path="router/src/app/admin/manage-crises/manage-crises.component.html">
+
+  </code-pane>
+
+  <code-pane header="src/app/admin/manage-heroes/manage-heroes.component.html"  path="router/src/app/admin/manage-heroes/manage-heroes.component.html">
+
+  </code-pane>
+
+</code-tabs>
+
+<div class="alert is-helpful">
+
+Although the admin dashboard `RouterLink` only contains a relative slash without an additional URL segment, it is a match to any route within the admin feature area.
+You only want the `Dashboard` link to be active when the user visits that route.
+Adding an additional binding to the `Dashboard` routerLink, `[routerLinkActiveOptions]="{ exact: true }"`, marks the `./` link as active when the user navigates to the `/admin` URL and not when navigating to any of the child routes.
+
+</div>
+
+{@a component-less-route}
+
+### Group routes with a componentless parent routes
+
+The initial admin routing configuration:
+
+<code-example path="router/src/app/admin/admin-routing.module.1.ts" header="src/app/admin/admin-routing.module.ts (admin routing)" region="admin-routes"></code-example>
+
+The child route under the `AdminComponent` has a `path` and a `children` property but it's not using a `component`.
+This defines a _component-less_ route.
+
+To group the `Crisis Center` management routes under the `admin` path a component is unnecessary.
+Additionally, a _componentless_ route makes it easier to [guard child routes](#can-activate-child-guard).
+
+Next, import the `AdminModule` into `app.module.ts` and add it to the `imports` array
+to register the admin routes.
+
+<code-example path="router/src/app/app.module.4.ts" header="src/app/app.module.ts (admin module)" region="admin-module"></code-example>
+
+Add an "Admin" link to the `AppComponent` shell so that users can get to this feature.
+
+<code-example path="router/src/app/app.component.5.html" header="src/app/app.component.html (template)"></code-example>
+
+{@a guard-admin-feature}
+{@a can-activate-guard}
+
+### Guard the administration feature
+
+Applications often restrict access to a feature area based on who the user is.
+You could permit access only to authenticated users or to users with a specific role.
+You might block or limit access until the user's account is activated.
+
+The `CanActivate` guard is the tool to manage these navigation business rules.
+
+Currently, every route within the Crisis Center is open to everyone.
+The new admin feature should be accessible only to authenticated users.
+
+In this exercise, you write a `canActivate()` guard method to redirect anonymous users to the
+login page when they try to enter the admin area.
+
+1. Generate an `AuthGuard` in the `auth` folder.
+
+   <code-example language="none" class="code-shell">
+     ng generate guard auth/auth
+   </code-example>
+
+2. Add the following code. To demonstrate the fundamentals, this example just logs to the console, `returns` true immediately, and allows navigation to proceed.
+
+   <code-example path="router/src/app/auth/auth.guard.1.ts" header="src/app/auth/auth.guard.ts (excerpt)"></code-example>
+
+3. Open `admin-routing.module.ts `, import the `AuthGuard` class, and
+update the admin route with a `canActivate` guard property that references it.
+
+   <code-example path="router/src/app/admin/admin-routing.module.2.ts" header="src/app/admin/admin-routing.module.ts (guarded admin route)" region="admin-route"></code-example>
+
+
+
+{@a teach-auth}
+
+### Authenticate with `AuthGuard`
+
+The admin feature is now protected by the guard, but the `AuthGuard` requires more customization to mimic authentication.
+The `AuthGuard` should call an application service that can login a user and retain information about the current user.
+
+1. Generate a new `AuthService` in the `auth` folder.
+
+   <code-example language="none" class="code-shell">
+     ng generate service auth/auth
+   </code-example>
+
+2. Update the `AuthService` to log in the user.
+
+   <code-example path="router/src/app/auth/auth.service.ts" header="src/app/auth/auth.service.ts (excerpt)"></code-example>
+
+   Although it doesn't actually log in, the service has an `isLoggedIn` flag to tell you whether the user is authenticated.
+   * The `login()` method simulates an API call to an external service by returning an observable that resolves successfully after a short pause.
+   * The `redirectUrl` property stores the URL that the user wanted to access so you can navigate to it after authentication.
+   * To keep things minimal, this example redirects unauthenticated users to `/admin`.
+
+3. Revise the `AuthGuard` to call the `AuthService`.
+
+   <code-example path="router/src/app/auth/auth.guard.2.ts" header="src/app/auth/auth.guard.ts (v2)"></code-example>
+
+   * Notice that you inject both the `AuthService` and the `Router` in the constructor.
+   You haven't provided the `AuthService` yet, but this ensures that you will be able to inject helpful services into routing guards.
+
+   * This guard returns a synchronous boolean result.
+   If the user is logged in, it returns true and the navigation continues.
+
+The `ActivatedRouteSnapshot` contains the _future_ route that will be activated and the `RouterStateSnapshot` contains the _future_ `RouterState` of the application, should you pass through the guard check.
+
+If the user is not logged in, you store the attempted URL the user came from using the `RouterStateSnapshot.url` and tell the router to redirect to a login page&mdash;a page you haven't created yet.
+Returning a `UrlTree` tells the `Router` to cancel the current navigation and schedule a new one to redirect the user.
+
+{@a add-login-component}
+
+### Add a `LoginComponent`
+
+You need a `LoginComponent` for the user to log in to the app. After logging in, you'll redirect to the stored URL if available, or use the default URL.
+
+1. Generate a login component.
+
+   <code-example language="none" class="code-shell">
+     ng generate component auth/login
+   </code-example>
+
+   There is nothing new about this component or the way you use it in the router configuration.
+
+2. Register a `/login` route in the `auth/auth-routing.module.ts`.
+
+3. In `app.module.ts`, import and add the `AuthModule` to the `AppModule` imports.
+
+<code-tabs>
+
+  <code-pane header="src/app/app.module.ts" path="router/src/app/app.module.ts" region="auth">
+
+  </code-pane>
+
+  <code-pane header="src/app/auth/login/login.component.html" path="router/src/app/auth/login/login.component.html">
+
+  </code-pane>
+
+  <code-pane header="src/app/auth/login/login.component.ts" path="router/src/app/auth/login/login.component.1.ts">
+
+  </code-pane>
+
+  <code-pane header="src/app/auth/auth.module.ts" path="router/src/app/auth/auth.module.ts">
+
+  </code-pane>
+
+</code-tabs>
+
+
+{@a can-activate-child-guard}
+
+### Protect child routes with `CanActivateChild`
+
+The `CanActivateChild` guard provides an additional way to protect child routes.
+It is similar to the `CanActivate` guard, but it runs before any child route is activated.
+You used `CanActivate` to protect the admin feature module from unauthorized access.
+
+Now you can use  `CanActivateChild` to also protect child routes _within_ the feature module.
+You will extend the `AuthGuard` to protect navigation between the `admin` routes.
+
+1. Open `auth.guard.ts` and add the `CanActivateChild` interface to the imported tokens from the router package.
+
+2. Implement the `canActivateChild()` method.
+
+   * The method takes the same arguments as the `canActivate()` method: an `ActivatedRouteSnapshot` and `RouterStateSnapshot`.
+
+   * The method can return an `Observable<boolean|UrlTree>` or `Promise<boolean|UrlTree>` for async checks and a `boolean` or `UrlTree` for sync checks. This one returns either `true` to allow the user to access the admin feature module or `UrlTree` to redirect the user to the login page instead:
+
+   <code-example path="router/src/app/auth/auth.guard.3.ts" header="src/app/auth/auth.guard.ts (excerpt)" region="can-activate-child"></code-example>
+
+3. Add the same `AuthGuard` to the [componentless admin route](#component-less-route "Remember componentless routes") to protect all other child routes at one time, rather than adding the `AuthGuard` to each route individually.
+
+   <code-example path="router/src/app/admin/admin-routing.module.3.ts" header="src/app/admin/admin-routing.module.ts (excerpt)" region="can-activate-child"></code-example>
+
+{@a can-deactivate-guard}
+
+### Handle unsaved changes with `CanDeactivate`
+
+In the "Heroes" workflow, the app accepts every change to a hero immediately without validation.
+In the real world, you might have to accumulate the users changes, validate across fields, validate on the server, or hold changes in a pending state until the user confirms them as a group or cancels and reverts all changes.
+
+When the user navigates away, you can let the user decide what to do with unsaved changes.
+If the user cancels, you'll stay put and allow more changes.
+If the user approves, the app can save.
+
+You still might delay navigation until the save succeeds.
+If you let the user move to the next screen immediately and saving were to fail (perhaps the data is ruled invalid), you would lose the context of the error.
+
+You need to stop the navigation while you wait, asynchronously, for the server to return with its answer.
+The `CanDeactivate` guard helps you decide what to do with unsaved changes and how to proceed.
+
+{@a cancel-save}
+
+In this exercise, you will implement a "Cancel or Save" dialog that intercepts the update operation. When users update crisis information in the `CrisisDetailComponent`, the app will not update the entity immediately, but will display the dialog.
+
+1. Implement the cancel and save methods.
+
+   * The app will update the entity when the user clicks Save, and discard the changes when the user clicks Cancel.
+   * Both buttons navigate back to the crisis list after save or cancel.
+
+   <code-example path="router/src/app/crisis-center/crisis-detail/crisis-detail.component.ts" header="src/app/crisis-center/crisis-detail/crisis-detail.component.ts (cancel and save methods)" region="cancel-save"></code-example>
+
+2. Generate a `Dialog` service to handle user confirmation.
+
+<code-example language="none" class="code-shell">
+  ng generate service dialog
+</code-example>
+
+3. Add a `confirm()` method to the `DialogService` to prompt the user to confirm their intent.
+
+   <code-example path="router/src/app/dialog.service.ts" header="src/app/dialog.service.ts"></code-example>
+
+   The `window.confirm` is a blocking action that displays a modal dialog and waits for user interaction. It returns an `Observable` that resolves when the user eventually decides what to do: either to discard changes and navigate away (`true`) or to preserve the pending changes and stay in the crisis editor (`false`).
+
+<div class="alert is-helpful">
+
+In this scenario, the user could click the heroes link, cancel, push the browser back button, or navigate away without saving.
+This example app asks the user to be explicit with a confirmation dialog box that waits asynchronously for the user's response.
+You could wait for the user's answer with synchronous, blocking code, but the app is more responsive&mdash;and can do other work&mdash;by waiting for the user's answer asynchronously.
+
+</div>
+
+{@a CanDeactivate}
+
+4. Generate a guard that checks for the presence of a `canDeactivate()` method in a component&mdash;any component.
+
+   <code-example language="none" class="code-shell">
+     ng generate guard can-deactivate
+   </code-example>
+
+5. Paste the following code into your guard.
+
+   <code-example path="router/src/app/can-deactivate.guard.ts" header="src/app/can-deactivate.guard.ts"></code-example>
+
+   While the guard doesn't have to know which component has a deactivate method, it can detect that the `CrisisDetailComponent` component has the `canDeactivate()` method and call it.
+   Insulating the guard from details of any component's deactivation method makes the guard reusable.
+
+<div class="alert is-helpful">
+
+Alternatively, you could make a component-specific `CanDeactivate` guard for the `CrisisDetailComponent`.
+The `canDeactivate()` method provides you with the current instance of the `component`, the current `ActivatedRoute`, and `RouterStateSnapshot` in case you needed to access some external information.
+This would be useful if you only wanted to use this guard for this component and needed to get the component's properties or confirm whether the router should allow navigation away from it.
+
+<code-example path="router/src/app/can-deactivate.guard.1.ts" header="src/app/can-deactivate.guard.ts (component-specific)"></code-example>
+
+</div>
+
+6. In the `CrisisDetailComponent`, implement the confirmation workflow for unsaved changes.
+
+   <code-example path="router/src/app/crisis-center/crisis-detail/crisis-detail.component.ts" header="src/app/crisis-center/crisis-detail/crisis-detail.component.ts (excerpt)" region="canDeactivate"></code-example>
+
+  Notice that the `canDeactivate()` method can return synchronously; it returns `true` immediately if there is no crisis or there are no pending changes. But it can also return a `Promise` or an `Observable` and the router will wait for that to resolve to truthy (navigate) or falsy (stay on the current route).
+
+7. Add the `Guard` to the crisis detail route in `crisis-center-routing.module.ts` using the `canDeactivate` array property.
+
+   <code-example path="router/src/app/crisis-center/crisis-center-routing.module.3.ts" header="src/app/crisis-center/crisis-center-routing.module.ts (can deactivate guard)"></code-example>
+
+Now you have given the user a safeguard against unsaved changes.
+
+
+{@a query-parameters}
+{@a fragment}
+
+## Shared query parameters and URL fragments
+
+In [Part 1](#route-parameters) of this tutorial, you dealt with parameters specific to a route.
+However, you can use query parameters to make optional parameters available to all routes.
+When you require users to log in, for example, you need to identify a login session so that authorized users can remain authorized as they navigate to different views.
+
+<div class="alert is-helpful">
+
+In a route path, a hash mark # introduces an optional [fragment](https://en.wikipedia.org/wiki/Fragment_identifier) near the end of the URL, after any query parameters introduced by a question mark (`?`).
+In Angular route paths, fragments refer to child views of the main or parent view.
+In the example app, the main view is identified with an `id` attribute.
+
+</div>
+
+Use the following steps to add a login session that will remain after navigating to another route.
+
+1. Update the `AuthGuard` to provide a `session_id` query parameter.
+
+2. Add an `anchor` element as a URL fragment, so you can jump to a certain point on the page.
+
+3. Add the `NavigationExtras` object to the `router.navigate()` method that activates the `/login` route.
+
+<code-example path="router/src/app/auth/auth.guard.4.ts" header="src/app/auth/auth.guard.ts (v3)"></code-example>
+
+{@a preserve-params}
+
+### Preserve and share query parameters
+
+You can preserve query parameters and fragments across navigations without having to provide them again when navigating.
+
+1. In the `LoginComponent`,  add a navigation-options object, [NavigationExtras](api/router/NavigationExtras "NavigationExtras API reference"), as the second argument in the `router.navigateUrl()` function.
+
+2. In the object, provide the query and fragment preservation options.
+
+   <code-example path="router/src/app/auth/login/login.component.ts" header="src/app/auth/login/login.component.ts (preserve)" region="preserve"></code-example>
+
+   This configuration allows you to pass along the current query parameters and fragment to the next route.
+
+<div class="alert is-helpful">
+
+The `queryParamsHandling` feature also provides a `merge` option, which preserves and combines the current query parameters with any provided query parameters when navigating.
+
+</div>
+
+3. To navigate to the Admin Dashboard route after logging in, update `admin-dashboard.component.ts` to retrieve the query parameters and fragments through the `ActivatedRoute` service.
+
+   <code-example path="router/src/app/admin/admin-dashboard/admin-dashboard.component.1.ts" header="src/app/admin/admin-dashboard/admin-dashboard.component.ts (v2)"></code-example>
+
+   Like route parameters, the query parameters and fragments are provided as an `Observable`.
+   Feed the `Observable` directly into the template using the `AsyncPipe`.
+
+Now, you can click on the Admin button, which takes you to the Login page with the provided `queryParamMap` and `fragment`.
+After you click the login button, notice that you have been redirected to the `Admin Dashboard` page with the query parameters and fragment still intact in the address bar.
+
+<div class="alert is-helpful">
+
+The `query params` and `fragment` can also be preserved using a `RouterLink` with
+the `queryParamsHandling` and `preserveFragment` bindings respectively.
+
+</div>
+
+{@a resolve}
+{@a resolve-guard}
+
+### Pre-fetch component data with a resolver
+
+In the `Hero Detail` and `Crisis Detail`, the app waited until the route was activated to fetch the respective hero or crisis.
+In a real-world app, there might be some delay before the data to display is returned from the server.
+You don't want to display a blank component while waiting for the data.
+To improve the user experience, you can pre-fetch data from the server using a [resolver function](api/router/Resolve "API reference"), so it's ready the moment the route is activated.
+
+Pre-fetching data also allows you to handle errors before routing to the component.
+There's no point in invoking navigation to a crisis detail for an `id` that doesn't have a record.
+It's better to send the user back to the `Crisis List` that shows only valid crisis centers.
+
+Currently, the route configuration falls back to the default view when the crisis is not found, but the router has already instantiated the `CrisisDetailComponent`. If you prefetch the data you can provide more graceful error handling, and avoid create the component when it is not going to be shown.
+
+In this exercise, you create a `CrisisDetailResolver` service to retrieve a `Crisis`.
+If the requested `Crisis` is not found, this service navigates away before activating the route and creating the `CrisisDetailComponent`.
+
+1. Generate a `CrisisDetailResolver` service file within the `Crisis Center` feature area.
+
+   <code-example language="none" class="code-shell">
+     ng generate service crisis-center/crisis-detail-resolver
+   </code-example>
+
+   This generates the following code file.
+
+   <code-example path="router/src/app/crisis-center/crisis-detail-resolver.service.1.ts" header="src/app/crisis-center/crisis-detail-resolver.service.ts (generated component code)"></code-example>
+
+2. Move the relevant parts of the crisis retrieval logic in `CrisisDetailComponent.ngOnInit()` into the `CrisisDetailResolverService`.
+
+3. Import the `Crisis` model, `CrisisService`, and the `Router` so you can navigate elsewhere if you can't fetch the crisis.
+
+4. Inject the `CrisisService` and `Router` and implement the `resolve()` method, as defined in the [Resolve interface](api/router/Resolve "API reference).
+
+   The `resolve()` method can return a `Promise`, an `Observable`, or a synchronous return value.
+   Implement it to return an `Observable` with a type of `Crisis`.
+
+  * The `CrisisService.getCrisis()` method returns an observable in order to prevent the route from loading until the data is fetched.
+   The `Router` guards require an observable to `complete`, which means it has emitted all
+of its values.
+   Use the `take` operator with an argument of `1` to ensure that the `Observable` completes after retrieving the first value from the Observable returned by the `getCrisis()` method.
+
+   * If the observable doesn't return a valid `Crisis`, then return an empty `Observable`, cancel the previous in-progress navigation to the `CrisisDetailComponent`, and navigate the user back to the `CrisisListComponent`.
+
+   The updated resolver service looks like this:
+
+   <code-example path="router/src/app/crisis-center/crisis-detail-resolver.service.ts" header="src/app/crisis-center/crisis-detail-resolver.service.ts"></code-example>
+
+5. Import this resolver in the `crisis-center-routing.module.ts` and add a `resolve` object to the `CrisisDetailComponent` route configuration.
+
+   <code-example path="router/src/app/crisis-center/crisis-center-routing.module.4.ts" header="src/app/crisis-center/crisis-center-routing.module.ts (resolver)"></code-example>
+
+6. The `CrisisDetailComponent` should no longer fetch the crisis.
+When you re-configured the route, you changed where the crisis is.
+Update the `CrisisDetailComponent` to get the crisis from the  `ActivatedRoute.data.crisis` property instead;
+
+   <code-example path="router/src/app/crisis-center/crisis-detail/crisis-detail.component.ts" header="src/app/crisis-center/crisis-detail/crisis-detail.component.ts (ngOnInit v2)" region="ngOnInit"></code-example>
+
+   Note the following important points:
+
+   * The router's `Resolve` interface is optional. The `CrisisDetailResolverService` doesn't inherit from a base class. The router looks for that method and calls it if found.
+
+   * The router calls the resolver in any case where the the user could navigate away so you don't have to code for each use case.
+
+   * Returning an empty `Observable` in at least one resolver cancels navigation.
+
+### Part 3 Summary
+
+The relevant Crisis Center code for this section follows.
+
+<code-tabs>
+
+  <code-pane header="app.component.html" path="router/src/app/app.component.html">
+
+  </code-pane>
+
+  <code-pane header="crisis-center-home.component.html" path="router/src/app/crisis-center/crisis-center-home/crisis-center-home.component.html">
+
+  </code-pane>
+
+  <code-pane header="crisis-center.component.html" path="router/src/app/crisis-center/crisis-center/crisis-center.component.html">
+
+  </code-pane>
+
+  <code-pane header="crisis-center-routing.module.ts" path="router/src/app/crisis-center/crisis-center-routing.module.4.ts">
+
+  </code-pane>
+
+  <code-pane header="crisis-list.component.html" path="router/src/app/crisis-center/crisis-list/crisis-list.component.html">
+
+  </code-pane>
+
+  <code-pane header="crisis-list.component.ts" path="router/src/app/crisis-center/crisis-list/crisis-list.component.ts">
+
+  </code-pane>
+
+  <code-pane header="crisis-detail.component.html" path="router/src/app/crisis-center/crisis-detail/crisis-detail.component.html">
+
+  </code-pane>
+
+  <code-pane header="crisis-detail.component.ts" path="router/src/app/crisis-center/crisis-detail/crisis-detail.component.ts">
+
+  </code-pane>
+
+  <code-pane header="crisis-detail-resolver.service.ts" path="router/src/app/crisis-center/crisis-detail-resolver.service.ts">
+
+  </code-pane>
+
+  <code-pane header="crisis.service.ts" path="router/src/app/crisis-center/crisis.service.ts">
+
+  </code-pane>
+
+  <code-pane header="dialog.service.ts" path="router/src/app/dialog.service.ts">
+
+  </code-pane>
+
+</code-tabs>
+
+The authorization and deactivation guard code follows.
+
+<code-tabs>
+
+  <code-pane header="auth.guard.ts" path="router/src/app/auth/auth.guard.3.ts">
+
+  </code-pane>
+
+  <code-pane header="can-deactivate.guard.ts" path="router/src/app/can-deactivate.guard.ts">
+
+  </code-pane>
+
+</code-tabs>
+
+---
+
+<!--- Edited to here -->
+
+{@a asynchronous-routing}
+{@a lazy-loaded-routed-modules}
+
+## Part 4: Optimizing a routed application
+
+A fully functional application with many routed modules can take a long time to load.
+You can optimize your application's startup time by loading routed feature modules only on request.
+Asynchronous routing, called [lazy loading](guide/glossary#lazy-loading "Definition of lazy loading"), has multiple benefits.
+
+* For all users, application startup is faster and the intial bundle is smaller.
+* For users who don't ever need a particular feature, the additional load time is never encountered.
+* You can continue expanding lazy-loaded feature areas without increasing the size of the initial load bundle.
+
+In addition to setting up lazy loading, you can improve the user experience by [pre-loading features in the background](#preloading).
+
+When your URLs change as your app develops, you can ease maintenance by setting up [redirects](#redirects-advanced) in the route configuration.
+
+
+{@a lazy-loading-route-config}
+
+### Configure a lazy-loaded route
+
+The sample application, organized into routed modules&mdash;`AppModule`,
+`HeroesModule`, `AdminModule` and `CrisisCenterModule`&mdash;is a natural candidate for lazy loading.
+
+Some modules, like `AppModule`, must be loaded from the start.
+Other feature modules can and should be lazy loaded.
+The `AdminModule` in particular is needed only by a few authorized users,
+so it makes sense to load it only when requested by those users.
+
+To set up lazy loading for the `AdminModule`, use the following steps.
+
+1. Change the `admin` path in the `admin-routing.module.ts` from `'admin'` to an empty string, `''`, creating an empty path.
+
+   Use empty path routes to group routes together without adding any additional path segments to the URL. Users will still visit `/admin` and the `AdminComponent` still serves as the Routing Component containing child routes.
+
+2. Open the `AppRoutingModule` and add a new `admin` route to its `appRoutes` array. Give it a `loadChildren` property instead of a `children` property.
+
+   The `loadChildren` property takes a function that returns a promise using the browser's built-in syntax for lazy loading code using dynamic imports `import('...')`.
+   The path is the location of the `AdminModule` (relative to the app root).
+
+   After the code is requested and loaded, the `Promise` resolves an object that contains the `NgModule`, in this case the `AdminModule`.
+
+   <code-example path="router/src/app/app-routing.module.5.ts" region="admin-1" header="app-routing.module.ts (load children)"></code-example>
+
+<div class="alert is-important">
+
+When using absolute paths, the `NgModule` file location must begin with `src/app` in order to resolve correctly. For custom [path mapping with absolute paths](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping), you must configure the `baseUrl` and `paths` properties in the project's TypeScript configuration file, `tsconfig.json`.
+
+</div>
+
+   When the router navigates to this route, it uses the `loadChildren` string to dynamically load the `AdminModule`.
+   Then it adds the `AdminModule` routes to its current route configuration.
+   Finally, it loads the requested route to the destination admin component.
+
+   The lazy loading and re-configuration happen just once, when the route is first requested; the module and routes are available immediately for subsequent requests.
+
+<div class="alert is-helpful">
+
+Angular provides a built-in module loader that supports SystemJS to load modules asynchronously. If you were
+using another bundling tool, such as Webpack, you would use the Webpack mechanism for asynchronously loading modules.
+
+</div>
+
+3. Finally, detach the admin feature set from the main application. The root `AppModule` must neither load nor reference the `AdminModule` or its files.
+
+   * In `app.module.ts`, remove the `AdminModule` import statement from the top of the file.
+   * Remove the `AdminModule` from the NgModule's `imports` array.
+
+{@a can-load-guard}
+
+### Guard unauthorized loading of feature modules
+
+You're already protecting the `AdminModule` with a `CanActivate` guard that prevents unauthorized users from accessing the admin feature area.
+It redirects to the login page if the user is not authorized.
+
+At this point, however, the router is still loading the `AdminModule` even if the user can't visit any of its components.
+It would be more efficient to only load the `AdminModule` if the user is already logged in.
+To accomplish this, add a `CanLoad` guard that only loads the `AdminModule` once the user is logged in _and_ attempts to access the admin feature area.
+
+The existing `AuthGuard` already has the essential logic in its `checkLogin()` method to support the `CanLoad` guard.
+
+1. Open `auth.guard.ts`.
+
+2. Import the `CanLoad` interface from `@angular/router`.
+
+3. Add it to the `AuthGuard` class's `implements` list.
+
+4. Implement `canLoad()` as follows:
+
+   <code-example path="router/src/app/auth/auth.guard.ts" header="src/app/auth/auth.guard.ts (CanLoad guard)" region="canLoad"></code-example>
+
+   * The router sets the `canLoad()` method's `route` parameter to the intended destination URL.
+   * The `checkLogin()` method redirects to that URL once the user has logged in.
+
+5. Import the `AuthGuard` into the `AppRoutingModule` and add the `AuthGuard` to the `canLoad`
+array property for the `admin` route.
+
+The completed admin route looks like this:
+
+<code-example path="router/src/app/app-routing.module.5.ts" region="admin" header="app-routing.module.ts (lazy admin route)"></code-example>
+
+{@a preloading}
+
+### Preload features in the background
+
+In addition to lazy-loading modules on demand, you can load modules asynchronously with preloading.
+Preloading allows you to load modules in the background so that the data is ready to render when the user activates a particular route.
+
+For example, the Crisis Center is not the first view that a user sees.
+By default, the Heroes are the first view.
+For the smallest initial payload and fastest launch time, you should eagerly load the `AppModule` and the `HeroesModule`.
+
+You could lazy load the Crisis Center, as you have done with the Admin module, but unlike the administrative view, it's likely that the user will visit the Crisis Center within minutes of launching the app.
+For the best performance, you can launch with just the `AppModule` and the `HeroesModule` loaded and then, almost immediately, load the `CrisisCenterModule` in the background.
+By the time the user navigates to the Crisis Center, its module is loaded and ready.
+
+{@a how-preloading}
+
+### How preloading works
+
+After each successful navigation, the router looks in its configuration for an unloaded module that it can preload.
+Whether it preloads a module, and which modules it preloads, depends upon the preload strategy.
+
+The `Router` offers two predefined preloading strategies:
+
+* No preloading, which is the default. Lazy-loaded feature areas are still loaded on-demand.
+* Preloading of all lazy-loaded feature areas.
+
+The following section guides you through updating the `CrisisCenterModule` to load lazily by default and use the `PreloadAllModules` strategy to load all lazy-loaded modules.
+
+The `Router` also supports [custom preloading strategies](#custom-preloading) for fine control over which modules to preload and when.
+
+{@a lazy-load-crisis-center}
+
+### Lazy load the crisis center
+
+Update the route configuration to lazy load the `CrisisCenterModule`.
+Take the same steps you used to configure `AdminModule` for lazy loading.
+
+1. Change the `crisis-center` path in the `CrisisCenterRoutingModule` to an empty string.
+
+1. Add a `crisis-center` route to the `AppRoutingModule`.
+
+1. Set the `loadChildren` string to load the `CrisisCenterModule`.
+
+1. Remove all mention of the `CrisisCenterModule` from `app.module.ts`.
+
+
+Here are the updated modules _before enabling preload_:
+
+
+<code-tabs>
+
+  <code-pane header="app.module.ts" path="router/src/app/app.module.ts" region="preload">
+
+  </code-pane>
+
+  <code-pane header="app-routing.module.ts" path="router/src/app/app-routing.module.6.ts" region="preload-v1">
+
+  </code-pane>
+
+  <code-pane header="crisis-center-routing.module.ts" path="router/src/app/crisis-center/crisis-center-routing.module.ts">
+
+  </code-pane>
+
+</code-tabs>
+
+      You could try this now and confirm that the  `CrisisCenterModule` loads after you click the "Crisis Center" button.
+
+To enable preloading of all lazy loaded modules, use the following steps.
+
+1. Import the `PreloadAllModules` token from the Angular router package.
+
+2. Pass a second argument in the `RouterModule.forRoot()` method, an object for additional configuration options. The `preloadingStrategy` is one of those options.
+
+3. Add the `PreloadAllModules` token to the `forRoot()` call:
+
+<code-example path="router/src/app/app-routing.module.6.ts" header="src/app/app-routing.module.ts (preload all)" region="forRoot"></code-example>
+
+This configures the `Router` preloader to immediately load all lazy loaded routes (routes with a `loadChildren` property).
+
+When you visit `http://localhost:4200`, the `/heroes` route loads immediately upon launch and the router starts loading the `CrisisCenterModule` right after the `HeroesModule` loads.
+
+{@a preload-canload}
+
+#### Blocking pre-load
+
+Currently, the `AdminModule` does not preload because `CanLoad` is blocking it.
+You added a `CanLoad` guard to the route in the `AdminModule` a few steps back to block loading of that module until the user is authorized.
+That `CanLoad` guard takes precedence over the preload strategy.
+The `PreloadAllModules` strategy does not load feature areas protected by a [CanLoad](#can-load-guard) guard.
+
+If you want to preload a module as well as guard against unauthorized access, remove the `canLoad()` guard method and rely on the [canActivate()](#can-activate-guard) guard alone.
+
+{@a custom-preloading}
+
+### Custom preloading strategy
+
+Preloading every lazy loaded module works well in many situations.
+However, in consideration of things such as low bandwidth and user metrics, you can use a custom preloading strategy for specific feature modules.
+
+This section guides you through adding a custom strategy that only preloads routes whose `data.preload` flag is set to `true`.
+Recall that you can add anything to the `data` property of a route.
+
+1. Set the `data.preload` flag in the `crisis-center` route in the `AppRoutingModule`.
+
+   <code-example path="router/src/app/app-routing.module.ts" header="src/app/app-routing.module.ts (route data preload)" region="preload-v2"></code-example>
+
+1. Generate a new `SelectivePreloadingStrategy` service.
+
+   <code-example language="none" class="code-shell">
+     ng generate service selective-preloading-strategy
+   </code-example>
+
+1. Replace the contents of `selective-preloading-strategy.service.ts` with the following:
+
+   <code-example path="router/src/app/selective-preloading-strategy.service.ts" header="src/app/selective-preloading-strategy.service.ts"></code-example>
+
+   `SelectivePreloadingStrategyService` implements the `PreloadingStrategy`, which has one method, `preload()`. The router calls the `preload()` method with two arguments:
+
+   * The route to consider.
+   * A loader function that can load the routed module asynchronously.
+
+   An implementation of `preload` must return an `Observable`.
+
+   * If the route does preload, it returns the observable returned by calling the loader function.
+   * If the route does not preload, it returns an `Observable` of `null`.
+
+   In this sample, the  `preload()` method loads the route if the route's `data.preload` flag is truthy.
+   As a side-effect, `SelectivePreloadingStrategyService` logs the `path` of a selected route in its public `preloadedModules` array.
+
+Before you extend the `AdminDashboardComponent` to inject this service and display its `preloadedModules` array, make a few changes to the `AppRoutingModule`.
+
+1. Import `SelectivePreloadingStrategyService` into `AppRoutingModule`.
+1. Replace the `PreloadAllModules` strategy in the call to `forRoot()` with this `SelectivePreloadingStrategyService`.
+1. Add the `SelectivePreloadingStrategyService` strategy to the `AppRoutingModule` providers array so you can inject it elsewhere in the app.
+
+Now edit the `AdminDashboardComponent` to display the log of preloaded routes.
+
+1. Import the `SelectivePreloadingStrategyService`.
+1. Inject it into the dashboard's constructor.
+1. Update the template to display the strategy service's `preloadedModules` array.
+
+Now the file is as follows:
+
+<code-example path="router/src/app/admin/admin-dashboard/admin-dashboard.component.ts" header="src/app/admin/admin-dashboard/admin-dashboard.component.ts (preloaded modules)"></code-example>
+
+Once the application loads the initial route, the `CrisisCenterModule` is preloaded.
+Verify this by logging in to the `Admin` feature area and noting that the `crisis-center` is listed in the `Preloaded Modules`.
+It also logs to the browser's console.
+
+{@a redirects-advanced}
+{@a url-refactor}
+
+### Migrate URLs with redirects
+
+You've set up the routes for navigating around your application and used navigation imperatively and declaratively.
+You've set up links and navigation to `/heroes` and `/hero/:id` from the `HeroListComponent` and `HeroDetailComponent` components.
+
+In any application, however, requirements change over time. Suppose you need those links to `heroes` become `superheroes`. You would still want the previous URLs to navigate correctly. Refactoring like this is time consuming and error prone.
+
+For easier maintenance, use redirects to update every link in your application.
+The `Router` checks for redirects in your configuration before navigating, so each redirect is triggered when needed.
+
+This section guides you through changing  `/heroes` to `/superheroes`, and migrating the `Hero` routes to new URLs.
+
+1.  To support the changed terminology, add redirects from the old routes to the new routes in the `heroes-routing.module`.
+
+   <code-example path="router/src/app/heroes/heroes-routing.module.ts" header="src/app/heroes/heroes-routing.module.ts (heroes redirects)"></code-example>
+
+   Notice two different types of redirects.
+
+   * The first change is from  `/heroes` to `/superheroes` without any parameters.
+
+   * The second change is from `/hero/:id` to `/superhero/:id`, which includes the `:id` route parameter.
+
+   Router redirects also use powerful pattern-matching, so the `Router` inspects the URL and replaces route parameters in the `path` with their appropriate destination.
+
+<div class="alert is-helpful">
+
+The `Router` also supports [query parameters](#query-parameters) and the [fragment](#fragment) when using redirects.
+
+* When using absolute redirects, the `Router` will use the query parameters and the fragment from the `redirectTo` in the route config.
+* When using relative redirects, the `Router` use the query params and the fragment from the source URL.
+
+</div>
+
+2. Currently, the empty path route redirects to `/heroes`, which redirects to `/superheroes`.
+This won't work because the `Router` handles redirects once at each level of routing configuration.
+This prevents chaining of redirects, which can lead to endless redirect loops.
+
+   Instead, update the empty path route in `app-routing.module.ts` to redirect to `/superheroes`.
+
+   <code-example path="router/src/app/app-routing.module.ts" header="src/app/app-routing.module.ts (superheroes redirect)"></code-example>
+
+3. A `routerLink` isn't tied to route configuration, so update the associated router links to remain active when the new route is active. Update the `app.component.ts` template for the `/heroes` `routerLink`.
+
+   <code-example path="router/src/app/app.component.html" header="src/app/app.component.html (superheroes active routerLink)"></code-example>
+
+4. Update the `goToHeroes()` method in the `hero-detail.component.ts` to navigate back to `/superheroes` with the optional route parameters.
+
+   <code-example path="router/src/app/heroes/hero-detail/hero-detail.component.ts" region="redirect" header="src/app/heroes/hero-detail/hero-detail.component.ts (goToHeroes)"></code-example>
+
+With these redirects in place, all previous routes now point to their new destinations and both URLs still function as intended.
+
+## Next steps
+
+For more information about routing, see the following topics:
+
+* [In-app Routing and Navigation guide](guide/router)
+* [Router API reference](api/router)

--- a/aio/content/guide/router-tutorial.md
+++ b/aio/content/guide/router-tutorial.md
@@ -1,12 +1,11 @@
 # Using Angular routes in a single-page application
 
-This tutorial describes how you can build a single-page application, SPA that uses multiple Angular routes.
-
+This tutorial describes how you can build a [single-page application (SPA)](https://en.wikipedia.org/wiki/Single-page_application) that uses multiple Angular routes.
 
 In an SPA, all of your application's functions exist in a single HTML page.
 As users access your application's features, the browser needs to render only the parts that matter to the user, instead of loading a new page. This pattern can significantly improve your application's user experience.
 
-To define how users navigate through your application, you use routes. You can add routes to define how users navigate from one part of your application to another.
+To enable navigation in your application, you must add *routes* that define how users navigate from one part of your application to another.
 You can also configure routes to guard against unexpected or unauthorized behavior.
 
 To explore a sample app featuring the contents of this tutorial, see the <live-example></live-example>.
@@ -14,13 +13,10 @@ To explore a sample app featuring the contents of this tutorial, see the <live-e
 ## Objectives
 
 * Organize a sample application's features into modules.
-* Define how to navigate to a component.
+* Define how to navigate to a component's view.
 * Pass information to a component using a parameter.
-* Structure routes by nesting several routes.
-* Check whether users can access a route.
-* Control whether the application can discard unsaved changes.
-* Improve performance by pre-fetching route data and lazy loading feature modules.
-* Require specific criteria to load components.
+* Identify the active route and apply CSS styles to show current navigation state.
+* Handle failed navigation attempts with redirects or a "404 not found" page.
 
 ## Prerequisites
 
@@ -86,7 +82,7 @@ Using the Angular CLI, create a new application, _angular-router-sample_. This a
 
    You should see a single web page, consisting of a title and the HTML of your two components.
 
-## Import `RouterModule` from `@angular/router`
+### Import `RouterModule` from `@angular/router`
 
 Routing allows you to display specific views of your application depending on the URL path.
 To add this functionality to your sample application, you need to update the `app.module.ts` file to use the module, `RouterModule`.
@@ -98,7 +94,7 @@ You import this module from `@angular/router`.
 
   <code-example header="src/app/app.module.ts" path="router-tutorial/src/app/app.module.ts" region="router-import"></code-example>
 
-## Define your routes
+### Define your routes
 
 In this section, you'll define two routes:
 
@@ -120,17 +116,23 @@ what component your application should display for that path.
 This code adds the `RouterModule` to the `imports` array. Next, the code uses the `forRoot()` method of the `RouterModule` to
 define your two routes. This method takes an array of JavaScript objects, with each object defining the proprties of a route.
 The `forRoot()` method ensures that your application only instantiates one `RouterModule`. For more information, see
-[Singleton Services](/guide/singleton-services#forroot-and-the-router).
+[Singleton Services](guide/singleton-services#forroot-and-the-router).
 
-## Update your component with `router-outlet`
+## Update the UI to support routing
 
-At this point, you have defined two routes for your application. However, your application
-still has both the `crisis-list` and `heroes-list` components hard-coded in your `app.component.html` template. For your routes to
+At this point, you have defined two routes for your application, and the components have the logic that supports routing. However, your application still has both the `crisis-list` and `heroes-list` components hard-coded in your `app.component.html` template. For your routes to
 work, you need to update your template to dynamically load a component based on the URL path.
 
-To implement this functionality, you add the `router-outlet` directive to your template file.
+To make navigation available to users, the template needs two things:
 
-1. From your code editor, open the `app.component.html` file.
+* A `<router-outlet>` directive as a placeholder for the location where you want a new view to appear.
+* Buttons or other selection elements that let the user initiate navigation to particular views.
+
+### Add a route placeholder to the template
+
+Use the following steps to replace the hard-coded components in the template with the `router-outlet` placeholder directive.
+
+1. From your code editor, open the template file for the root component, `app.component.html`.
 
 1. Delete the following lines.
 
@@ -155,14 +157,11 @@ component. You can load the `heroes-list` component the same way:
 http://localhost:4200/heroes-list
 </code-example>
 
-## Control navigation with UI elements
+### Control navigation with UI elements
 
-Currently, your application supports two routes. However, the only way to use those routes
-is for the user to manually type the path in the browser's address bar. In this section, you'll
-add two links that users can click to navigate between the `heroes-list` and `crisis-list`
-components. You'll also add some CSS styles. While these styles are not required, they make
-it easier to identify the link for the currently-displayed component. You'll add that functionality
-in the next section.
+You can't expect the user to manually type the path in the browser's address bar.
+In this section, you'll add two links that users can click to navigate between the `heroes-list` and `crisis-list` components.
+You'll also add some CSS styles, which will make it easier to identify the link for the currently-displayed component. You'll add that functionality in the next section.
 
 1. Open the `app.component.html` file and add the following HTML below the title.
 
@@ -179,11 +178,13 @@ in the next section.
 If you view your application in the browser, you should see these two links. When you click
 on a link, the corresponding component appears.
 
-## Identify the active route
+### Use styles to identify the active route
 
 While users can navigate your application using the links you added in the previous section,
-they don't have an easy way to identify what the active route is. You can add this functionality
-using Angular's `routerLinkActive` directive.
+they don't have an easy way to identify which view is being displayed&emdash;that is, which route is currently active.
+
+You created a CSS style (`activebutton`) that distinguishes a button for the active route.
+By adding the `routerLinkActive` directive to the anchor, you tell the router to apply that CSS class to the element when the route becomes active.
 
 1. From your code editor, open the `app.component.html` file.
 
@@ -192,11 +193,14 @@ using Angular's `routerLinkActive` directive.
    <code-example header="src/app/app.component.html" path="router-tutorial/src/app/app.component.html" region="routeractivelink"></code-example>
 
 View your application again. As you click one of the buttons, the style for that button updates
-automatically, identifying the active component to the user. By adding the `routerLinkActive`
-directive, you inform your application to apply a specific CSS class to the active route. In this
-tutorial, that CSS class is `activebutton`, but you could use any class that you want.
+automatically, identifying the active component to the user.
 
-## Adding a redirect
+## Configure routes to handle different cases
+
+Your route configuration should take care of common navigation failures or errors.
+You can define a default view and redirect unknown (or partially unknown) URLs to that view, or you can display an error message like the "Page Not Found" page that a browser normally shows in response to the HTTP 404 error.
+
+### Use a redirect route to identify a default view
 
 In this step of the tutorial, you add a route that redirects the user to display the `/heroes-list` component.
 
@@ -213,15 +217,22 @@ In this step of the tutorial, you add a route that redirects the user to display
    * `pathMatch`. This property instructs Angular on how much of the URL to match. For this
       tutorial, you should set this property to `full`. This strategy is recommended when
       you have an empty string for a path. For more information about this property,
-      see the [Route API documentation](/api/router/Route).
+      see the [Route API documentation](api/router/Route).
 
 Now when you open your application, it displays the `heroes-list` component by default.
 
-## Adding a 404 page
+### Handle failed navigation with an error view
 
+<<<<<<< HEAD
 It is possible for a user to try to access a route that you have not defined. To account for
 this behavior, the best practice is to display a 404 page. In this section, you'll create a 404 page and
 update your route configuration to show that page for any unspecified routes.
+=======
+It is possible for a user to try to access a route that you have not defined.
+When this happens, your application should inform the user with a suitable error message.
+In this section, you'll create a component that displays such a message, and
+update your route configuration to show that component for any unspecified routes.
+>>>>>>> docs: separate router tutorial from router guide
 
 1. From the terminal, create a new component, `PageNotFound`.
 
@@ -247,16 +258,238 @@ update your route configuration to show that page for any unspecified routes.
    </div>
 
 Try navigating to a non-existing route on your application, such as `http://localhost:4200/powers`.
-This route doesn't match anything defined in your `app.module.ts` file. However, because you
-defined a wildcard route, the application automatically displays your `PageNotFound` component.
+This route doesn't match anything defined in your `app.module.ts` file.
+However, because you defined a wildcard route, the application automatically displays your `PageNotFound` component.
+
+## Restructure with feature modules
+
+So far, the sample application contains only the single root module, with three components for the crisis view, the hero-list view, and the error message "Page not found" view.
+The navigation buttons are all defined in the root component's template, which contained the one router outlet.
+This design works for introducing the basics of navigation and routing, but a typical application has multiple feature areas, each dedicated to a particular business purpose with its own NgModule.
+This section shows how to refactor the app into different feature modules, import them into the main module and navigate among them.
+
+This section covers the following:
+
+* Organizing the app and routes into feature areas using modules.
+* Navigating imperatively from one component to another.
+* Passing required and optional information in route parameters.
+
+{@a heroes-functionality}
+
+### Add heroes functionality
+
+This section expands the basic app by creating multiple routing modules and importing those routing modules in the correct order.
+
+Take the following steps to restructure the application with multiple feature modules.
+
+1. To manage the heroes, create a `HeroesModule` with routing in the heroes folder and register it with the root `AppModule`.
+
+   <code-example language="none" class="code-shell">
+     ng generate module heroes/heroes --module app --flat --routing
+   </code-example>
+
+2. Move the placeholder `hero-list` folder that's in the `app` folder into the `heroes` folder.
+
+3. Copy the contents of the `heroes/heroes.component.html` from
+the <live-example name="toh-pt4" title="Tour of Heroes: Services example code">"Services" tutorial</live-example> into the `hero-list.component.html` template.
+
+   * Re-label the `<h2>` to `<h2>HEROES</h2>`.
+
+   * Delete the `<app-hero-detail>` component at the bottom of the template.
+
+4. Copy the contents of the `heroes/heroes.component.css` from the live example into the `hero-list.component.css` file.
+
+5. Copy the contents of the `heroes/heroes.component.ts` from the live example into the `hero-list.component.ts` file.
+
+   * Change the component class name to `HeroListComponent`.
+
+   * Change the `selector` to `app-hero-list`.
+
+<div class="alert is-helpful">
+
+   Selectors are not required for routed components because components are dynamically inserted when the page is rendered. However, they are useful for identifying and targeting them in your HTML element tree.
+
+</div>
+
+6. Copy the `hero-detail` folder, the `hero.ts`, `hero.service.ts`,  and `mock-heroes.ts` files into the `heroes` subfolder.
+
+   * Copy the `message.service.ts` into the `src/app` folder.
+
+   * Update the relative path import to the `message.service` in the `hero.service.ts` file.
+
+7. Update the `HeroesModule` metadata.
+
+   * Import and add the `HeroDetailComponent` and `HeroListComponent` to the `declarations` array in the `HeroesModule`.
+
+   <code-example path="router/src/app/heroes/heroes.module.ts" header="src/app/heroes/heroes.module.ts"></code-example>
+
+The hero management file structure is as follows:
+
+<div class='filetree'>
+
+  <div class='file'>
+    src/app/heroes
+  </div>
+
+  <div class='children'>
+
+    <div class='file'>
+      hero-detail
+    </div>
+
+      <div class='children'>
+
+        <div class='file'>
+          hero-detail.component.css
+        </div>
+
+        <div class='file'>
+          hero-detail.component.html
+        </div>
+
+        <div class='file'>
+          hero-detail.component.ts
+        </div>
+
+      </div>
+
+    <div class='file'>
+      hero-list
+    </div>
+
+      <div class='children'>
+
+        <div class='file'>
+          hero-list.component.css
+        </div>
+
+        <div class='file'>
+          hero-list.component.html
+        </div>
+
+        <div class='file'>
+          hero-list.component.ts
+        </div>
+
+      </div>
+
+    <div class='file'>
+      hero.service.ts
+    </div>
+
+    <div class='file'>
+      hero.ts
+    </div>
+
+    <div class='file'>
+      heroes-routing.module.ts
+    </div>
+
+    <div class='file'>
+      heroes.module.ts
+    </div>
+
+    <div class='file'>
+      mock-heroes.ts
+    </div>
+
+    </div>
+
+  </div>
+
+</div>
+
+### Add routes for navigation between features
+
+The component structure supports the two interacting components, the hero list and the hero detail.
+When you navigate to list view, the app fetches a list of heroes and displays them.
+When you click on a hero in the list, the app opens the detail view for that particular hero.
+
+1. To tell the router which hero to display in the detail view, include the selected hero's `id` in the route URL. This is an example of a *route parameter*.
+
+2. Import the hero components from their new locations in the `src/app/heroes/` folder and define the two hero routes.
+
+3. Register the routes for the new `Heroes` module with the `RouterModule`. The new feature module is a child of the root module; to register the routes, use the static `RouterModule.forChild()` method instead of the static `RouterModule.forRoot()` method.
+
+   <div class="alert is-helpful">
+
+      Only call `RouterModule.forRoot()` in the root NgModule.
+      In any other module, you must call the `RouterModule.forChild()` method to register additional routes.
+
+   </div>
+
+   The updated `HeroesRoutingModule` looks like this:
+
+   <code-example path="router/src/app/heroes/heroes-routing.module.1.ts" header="src/app/heroes/heroes-routing.module.ts"></code-example>
+
+<div class="alert is-helpful">
+
+Consider giving each feature module its own route configuration file.
+Though the feature routes are currently minimal, routes have a tendency to grow more complex even in small apps.
+
+</div>
+
+{@a remove-duplicate-hero-routes}
+
+The hero routes are currently defined in two places: in the `HeroesRoutingModule`, by way of the `HeroesModule`, and in the `AppRoutingModule`.
+
+Routes provided by feature modules are combined together into their imported module's routes by the router.
+This allows you to continue defining the feature module routes without modifying the main route configuration.
+
+4. To remove duplicate hero routes, remove the `HeroListComponent` import and the `/heroes` route from the `app-routing.module.ts`. Leave the default and the wildcard routes as these are still in use at the top level of the application.
+
+   <code-example path="router/src/app/app-routing.module.2.ts" header="src/app/app-routing.module.ts (v2)"></code-example>
+
+{@a merge-hero-routes}
+
+5. The `HeroesModule` now provides the `HeroListComponent`, so you can remove it from the `AppModule`'s `declarations` array.
+
+After these steps, the `AppModule` should look like this:
+
+<code-example path="router/src/app/app.module.3.ts" header="src/app/app.module.ts" region="remove-heroes"></code-example>
+
+Now that you have a separate `HeroesModule`, you can evolve the hero feature with more components and different routes.
+
+## Examine the sample app
+
+At this point, you have a basic application that uses Angular's routing feature to change
+what components the user can see based on the URL address. You extended these features
+to include a redirect, as well as a wildcard route to display a custom navigation error page.
+Finally, you expanded the basic application structure to support multiple routing modules and route trees.
+
+{@a routing-module-order}
+
+### Module import order
+
+Notice that in the module `imports` array, the `AppRoutingModule` is last and comes _after_ the `HeroesModule`.
+
+<code-example path="router/src/app/app.module.3.ts" region="module-imports" header="src/app/app.module.ts (module-imports)"></code-example>
+
+The order of route configuration is important because the router accepts the first route that matches a navigation request path.
+
+When all routes were in one `AppRoutingModule`, you put the default and [wildcard](guide/router#wildcard) routes last, after the `/heroes` route, so that the router had a chance to match a URL to the `/heroes` route _before_ hitting the wildcard route and navigating to "Page not found".
+
+Each routing module augments the route configuration in the order of import.
+If you listed `AppRoutingModule` first, the wildcard route would be registered _before_ the hero routes.
+The wildcard route&mdash;which matches _every_ URL&mdash;would intercept the attempt to navigate to a hero route.
+You can reverse the routing modules to see a click of the heroes link resulting in "Page not found".
+
+{@a inspect-config}
+
+### Inspect the router's configuration
+
+To determine if your routes are actually evaluated in the proper order, you can inspect the router's configuration.
+
+Do this by injecting the router and logging its `config` property to the console.
+For example, update the `AppModule` as follows and look in the browser console window
+to see the finished route configuration.
+
+<code-example path="router/src/app/app.module.7.ts" header="src/app/app.module.ts (inspect the router config)" region="inspect-config"></code-example>
+
+</div>
 
 ## Next steps
 
-At this point, you have a basic application that uses Angular's routing feature to change
-what components the user can see based on the URL address. You have extended these features
-to include a redirect, as well as a wildcard route to display a custom 404 page.
-
-For more information about routing, see the following topics:
-
-* [In-app Routing and Navigation](/guide/router)
-* [Router API](/api/router)
+* [Navigation techniques](guide/router-techniques) expands this application further to demonstrate more complex routing hierarchies and navigational control.
+* [In-app Routing and Navigation](guide/router) explains routing concepts.
+* [Router API reference](api/router) provides complete syntax details for the Angular `RouterModule` library.

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -771,9 +771,9 @@ If a guard function returns an observable, the observable must also complete. If
 
 </div>
 
-### Predefined route guards
+### Guard function types
 
-Angular provides the following pre-defined route guard functions:
+Route guard functions implement the following interfaces:
 
 * [`CanActivate`](api/router/CanActivate)
 * [`CanActivateChild`](api/router/CanActivateChild)
@@ -787,7 +787,7 @@ Then it checks the `CanActivate` guards from the top down to the deepest child r
 If the feature module is loaded asynchronously, the `CanLoad` guard is checked before the module is loaded.
 If _any_ guard returns false, pending guards that have not completed are canceled, and the entire navigation is canceled.
 
-Consider using [componentless routes](api/router/Route#componentless-routes) to more easily control access to child routes.
+Consider using [componentless routes](#nesting-routes) to more easily control access to child routes.  A componentless route is a `Route` object that has a base path but no component; it serves as a container for a set of related child routes.
 
 ### Creating a guard service
 

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -1,33 +1,86 @@
 # In-app navigation: routing to views
 
 In a single-page app, you change what the user sees by showing or hiding portions of the display that correspond to particular components, rather than going out to the server to get a new page.
-As users perform application tasks, they need to move between the different [views](guide/glossary#view "Definition of view") that you have defined.
-To implement this kind of navigation within the single page of your app, you use the Angular **`Router`**.
+As users perform application tasks, they need to move between the different [views](guide/glossary#view "Definition of view") defined by your components.
 
-To handle the navigation from one [view](guide/glossary#view) to the next, you use the Angular _router_.
-The router enables navigation by interpreting a browser URL as an instruction to change the view.
+To handle navigation from one view to another, you use the Angular [Router service](api/router/RouterModule). The Router service enables navigation by interpreting a browser URL as an instruction to change the view. A user can initiate a request for navigation interactively from the UI, or you can navigate programmatically.
 
-To explore a sample app featuring the router's primary features, see the <live-example></live-example>.
+To explore a sample app that demonstrates the router's primary features, see the <live-example></live-example>.
+
+<hr />
 
 ## Prerequisites
 
-Before creating a route, you should be familiar with the following:
+Before creating an application capable of view navigation, you should be familiar with the following:
 
 * [Basics of components](guide/architecture-components)
 * [Basics of templates](guide/glossary#template)
 * An Angular app&mdash;you can generate a basic Angular app using the [Angular CLI](cli).
 
-For an introduction to Angular with a ready-made app, see [Getting Started](start).
-For a more in-depth experience of building an Angular app, see the [Tour of Heroes](tutorial) tutorial. Both guide you through using component classes and templates.
+For an introduction to Angular with a ready-made app, see [Getting Started](start "Try it now without setup").
+For a more in-depth experience of building an Angular app, see the [Tour of Heroes](tutorial "Full tutorial") tutorial. Both guide you through using component classes and templates.
+
+**Routing tutorials**: The [Tour of Heroes tutorial](tutorial "Full tutorial") walks you through adding navigation to the sample app.
+Additional tutorials use the same domain to introduce [basic routing](guide/router-tutorial "Using Angular routes in a single-page app") and provide examples of more advanced [navigation techniques](guide/router-techniques "Taking advantage of routing features").
 
 <hr />
 
+## How routing works
+
+The Angular router intercepts the browser's address bar, interpreting a new URL as an instruction to activate a specific component and show its view in the current page, rather than opening a new page.
+Routing is initiated whenever the URL changes, either by entering it directly in the address bar, by the user clicking a page element with a `routerLink` directive, or in a call to a method such as `Router.navigate()` triggered by program logic.
+
+The router selects a component by matching the new URL with a path in the route configuration.
+It instantiates the component if needed, and displays the associated view in a *router outlet*.
+The `[router-outlet]` directive acts as a placeholder for the new component's template within another template.
+
+A template can have more than one router outlet, allowing the router to display secondary, or auxiliary views.
+You can nest related routes, creating a hierarchy of parent and child routes to any depth.
+You pass data between components using *route parameters*.
+
+You can retrieve the current navigation state and respond to routing events to enhance the user experience with styling and animation that helps a user keep track of where they are in your application as the display changes.
+
+You can define *route guard* functions to control access to parts of your application, and *resolver* functions to optimize your application by preloading data needed to resolve routes.
+
+{@a route-parameters}
+
+### Resolving route parameters
+
+The router composes a URL for a particular view by combining a base path with a set of parameters. Parameters in a route definition can be specified as literal values, or can be tokens or expressions that the router resolves.
+For example, in the following route definition, the route to `HeroDetailComponent` has an `:id` token in the path.
+
+<code-example path="router/src/app/heroes/heroes-routing.module.1.ts" header="src/app/heroes/heroes-routing.module.ts (excerpt)" region="hero-detail-route"></code-example>
+
+The `:id` token creates a slot in the path for a route parameter.
+The router resolves the parameter to create a final URL to the component's view by inserting the value of the hero's `id` property into the route path:
+
+<code-example format="nocode">
+  localhost:4200/hero/15
+
+</code-example>
+
+If a user enters that URL into the browser address bar, the router displays the "Magneta" detail view.
+
+The following example navigates to the detail view for a hero by passing a _link parameters array_ to the `router.navigate()` method.
+
+   <code-example path="router/src/app/heroes/hero-list/hero-list.component.1.html" header="src/app/heroes/hero-list/hero-list.component.html (link-parameters-array)" region="link-parameters-array"></code-example>
+
+The link parameters array here contains two items: the routing _path_ and the required _route parameter_ that specifies the `id` of the selected hero.
+The router composes the destination URL from the array: `localhost:4200/hero/15`.
+
+[See more about link parameters arrays and optional parameters](#link-parameters-array).
+
 {@a basics}
 
-## Generate an app with routing enabled
+## Set up an application to use the routing service
 
-The following command uses the Angular CLI to generate a basic Angular app with an app routing module, called `AppRoutingModule`, which is an NgModule where you can configure your routes.
-The app name in the following example is `routing-app`.
+The Angular router is an optional service that presents a particular component view for a given URL.
+It is provided in its own library package, `@angular/router`.
+Import the `RouterModule` and required elements from the package as you would from any other Angular package.
+
+<code-example path="router/src/app/app.module.1.ts" header="src/app/app.module.ts (import)" region="import-router"></code-example>
+
+The following command uses the Angular CLI to generate a basic Angular app that supports navigation with the router service.
 
 <code-example language="none" class="code-shell">
   ng new routing-app --routing
@@ -36,117 +89,278 @@ The app name in the following example is `routing-app`.
 When generating a new app, the CLI prompts you to select CSS or a CSS preprocessor.
 For this example, accept the default of `CSS`.
 
-### Adding components for routing
+A routed Angular application has one singleton instance of the `Router` service.
+When the browser's URL changes, that router looks for a corresponding `Route` from which it can determine the component to display.
 
-To use the Angular router, an app needs to have at least two components so that it can navigate from one to the other. To create a component using the CLI, enter the following at the command line where `first` is the name of your component:
+{@a app-structure}
 
-<code-example language="none" class="code-shell">
-  ng generate component first
-</code-example>
+### Structuring an application for routing
 
-Repeat this step for a second component but give it a different name.
-Here, the new name is `second`.
+An application that supports navigation should have a dedicated [routing module](guide/glossary#routing-module "Definition of routing module") that imports `RouterModule` and `Routes`.
+When you create a new project with the CLI `--routing` option, the application includes a routing module named `AppRoutingModule` and imports it into the root module.
 
-<code-example language="none" class="code-shell">
-  ng generate component second
-</code-example>
-
-The CLI automatically appends `Component`, so if you were to write `first-component`, your component would be `FirstComponentComponent`.
-
-{@a basics-base-href}
+A routing module is an NgModule that contains an application's routing configuration. A dedicated routing module does not declare components, but serves to separate routing concerns from other application concerns. It provides a well-known location for routing service providers such as guards and resolvers. A routing module is also easy to replace or remove when testing the application.
 
 <div class="alert is-helpful">
 
-  #### `<base href>`
+  **Manual Setup**: The examples in this guide work with a CLI-generated Angular app.
+  If you are working manually, you should create your own routing module that imports `RouterModule` and `Routes`, and import it into your root module.
 
-  This guide works with a CLI-generated Angular app.
-  If you are working manually, make sure that you have `<base href="/">` in the `<head>` of your index.html file.
-  This assumes that the `app` folder is the application root, and uses `"/"`.
-
-  </code-example>
+  The CLI also sets a *base URL* for a routing application.
+  If you are working manually, set a base `<base href="/">` in the `<head>` of your `index.html` file   (assuming that the `app` folder is the application root, and uses `"/"`).
 
 </div>
 
+As your application grows more complex, you can generate additional feature modules with the `--routing` flag, and register them with the root module. When you do so, each additional routing module configures a parent of child routes in a [route hierarchy](#route-trees "Read more about nested routes").
 
-### Importing your new components
+{@a lazy-loading}
 
-To use your new components, import them into `AppRoutingModule` at the top of the file, as follows:
+<div class="callout is-helpful">
 
-<code-example header="AppRoutingModule (excerpt)">
+<header>Optimizing performance with lazy-loading and pre-loading</header>
 
-import { FirstComponent } from './first/first.component';
-import { SecondComponent } from './second/second.component';
+In an application that supports navigation, some views are not shown at launch, and might not ever be shown at all unless the user follows a particular path to them. A module that defines such a view might not need to be part of the initial bundle.
+You can configure your routes so that Angular only loads modules as needed, rather than loading all modules when the app launches. This is called [lazy loading](guide/glossary#lazy-loading "Definition of lazy loading").
 
-</code-example>
+You can also improve the user experience by using a [resolve guard](/guide/router-techniques#resolve-guard "See example of `ResolveGuard`") to pre-load data in the background, when you know it will be needed to resolve routes.
+For more information on lazy-loading and pre-loading modules, see the dedicated guide [Lazy loading NgModules](guide/lazy-loading-ngmodules "Lazy-loading guide").
 
+</div>
+
+{@a example-config}
 {@a basic-route}
 
-## Defining a basic route
+### Configuring routes
 
-There are three fundamental building blocks to creating a route.
+To use navigation, you need to configure your application to use the  router service, and define at least two [routing components](guide/glossary#routing-component "Definition of routing component") so that you can navigate between their views.
 
-Import the `AppRoutingModule` into `AppModule` and add it to the `imports` array.
+The router has no routes until you configure it with route definitions.
+The following example creates five route definitions, configures the router via the `RouterModule.forRoot()` method, and adds the result to the root module's `imports` array.
 
-The Angular CLI performs this step for you.
-However, if you are creating an app manually or working with an existing, non-CLI app, verify that the imports and configuration are correct.
-The following is the default `AppModule` using the CLI with the `--routing` flag.
+<code-example path="router/src/app/app.module.0.ts" header="src/app/app.module.ts (excerpt)"></code-example>
 
-  <code-example path="router/src/app/app.module.8.ts" header="Default CLI AppModule with routing">
+The `appRoutes` variable in this example contains an array of routes that describes how to navigate.
+You pass it to the `RouterModule.forRoot()` method in the module `imports` to configure the router.
+The example also shows one of the [additional configuration options](api/router/ExtraOptions "API reference for router config options") that you can pass to the router.
 
-  </code-example>
+Each item in a `Routes` array is a [`Route`](api/router/Route "API reference") object.
 
-  1. Import `RouterModule` and `Routes` into your routing module.
+* Each `Route` maps a URL `path` to a component. There are no leading slashes in the path.
+   The router service parses and builds the final URL for you, which allows you to use both relative and absolute paths when navigating between application views.
 
-  The Angular CLI performs this step automatically.
-  The CLI also sets up a `Routes` array for your routes and configures the `imports` and `exports` arrays for `@NgModule()`.
+* The `:id` in the second route is a token for a *route parameter*. In a URL such as `/hero/42`, "42" is the value of the `id` parameter.
+   The corresponding `HeroDetailComponent` uses that value to find and present the hero whose `id` is 42.
 
-  <code-example path="router/src/app/app-routing.module.7.ts" header="CLI app routing module">
+* The `data` property in the third route is a place to store arbitrary data associated with this specific route. The data property is accessible within each activated route. Use it to store items such as page titles, breadcrumb text, and other read-only, static data.
+   You can use a [resolve guard](/guide/router-techniques#resolve-guard "See example of `ResolveGuard`") to retrieve dynamic data.
 
-  </code-example>
-
-1. Define your routes in your `Routes` array.
-
-  Each route in this array is a JavaScript object that contains two properties.
-  The first property, `path`, defines the URL path for the route.
-  The second property, `component`, defines the component Angular should use for the corresponding path.
-
-  <code-example path="router/src/app/app-routing.module.8.ts" region="routes" header="AppRoutingModule (excerpt)">
-
-  </code-example>
-
-  1. Add your routes to your application.
-
-  Now that you have defined your routes, you can add them to your application.
-  First, add links to the two components.
-  Assign the anchor tag that you want to add the route to the `routerLink` attribute.
-  Set the value of the attribute to the component to show when a user clicks on each link.
-  Next, update your component template to include `<router-outlet>`.
-  This element informs Angular to update the application view with the component for the selected route.
-
-  <code-example path="router/src/app/app.component.7.html" header="Template with routerLink and router-outlet"></code-example>
+The empty path in the fourth route represents the default path for the application&mdash;the place to go when the path in the URL is empty, as it typically is at the start.
+This default route redirects to the route for the `/heroes` URL and, therefore, displays the `HeroesListComponent`.
 
 {@a route-order}
 
-### Route order
+## Prevent navigation failures with route ordering and special syntax
 
-The order of routes is important because the `Router` uses a first-match wins strategy when matching routes, so more specific routes should be placed above less specific routes.
+Your routing configuration, application design, and ordering of routes all affect navigation.
+The order of routes in the configuration is particularly important. The router service activates the first matching route it comes to, so more specific routes should be placed above less specific routes.
+
 List routes with a static path first, followed by an empty path route, which matches the default route.
-The [wildcard route](guide/router#setting-up-wildcard-routes) comes last because it matches every URL and the `Router`  selects it only if no other routes match first.
+The *wildcard* route comes last because it matches every URL and the router selects it only if no other routes match first.
 
+You can [handle navigation errors](#404-page-how-to) by defining a "path not found" view, and avoid navigation errors caused by terminology changes by [defining route redirects](#redirects).
+
+See more examples of routing techniques in the [Route](api/router/Route#usage-notes) reference documentation.
+
+{@a wildcard}
+
+### Using wildcard routes
+
+A well-functioning application should gracefully handle when users attempt to navigate to a part of your application that does not exist.
+To add this functionality to your application, you set up a wildcard route.
+The Angular router selects this route any time the requested URL doesn't match any router paths.
+
+To set up a wildcard route, add the following code to your `routes` definition.
+
+<code-example header="AppRoutingModule (excerpt)">
+
+{ path: '**', component: <component-name> }
+
+</code-example>
+
+The two asterisks, `**`, indicate to Angular that this `routes` definition is a wildcard route.
+For the component property, you can define any component in your application.
+Common choices include an application-specific `PageNotFoundComponent`, which you can define to [display a 404 page](#404-page-how-to) to your users; or a redirect to your application's main component.
+A wildcard route is the last route because it matches any URL.
+For more detail on why order matters for routes, see [Route order](#route-order).
+
+{@a redirects}
+
+### Defining redirects
+
+To set up a redirect, configure a route with the `path` you want to redirect from, the `component` you want to redirect to, and a `pathMatch` value that tells the router how to match the URL.
+
+<code-example path="router/src/app/app-routing.module.8.ts" region="redirect" header="AppRoutingModule (excerpt)">
+
+</code-example>
+
+In this example, the third route is a redirect so that the router defaults to the `first-component` route.
+Notice that this redirect precedes the wildcard route.
+Here, `path: ''` means to use the initial relative URL (the empty string `''`).
+
+{@a pathmatch}
+
+<div class="callout is-helpful">
+
+  <header>Path matching</header>
+
+  Technically, `pathMatch = 'full'` results in a route hit when the *remaining* unmatched  segments of the URL match `''`.
+  If the redirect is in a top level route, the remaining URL is the same as the  *entire* URL. The other possible `pathMatch` value is `'prefix'` which tells the router to match the  redirect route when the remaining URL begins with the redirect route's prefix  path.
+
+  You can share a route prefix between components by making them children of a [componentless route](api/router/Route#componentless-routes "Example of sharing parameters"); that is, a route that has a `path` and `children`, but no `component` value. The parent's path is used as the prefix for the child routes.
+
+  Learn more in Victor Savkin's
+  [post on redirects](http://vsavkin.tumblr.com/post/146722301646/angular-router-empty-paths-componentless-routes "Empty paths, componentless routes, and redirects").
+
+</div>
+
+{@a 404-page-how-to}
+
+### Handling unfound views
+
+To display the equivalent of a "404 Not Found" page, set up a [wildcard route](#wildcard) with the `component` property set to the component you'd like to use for your 404 page as follows.
+
+<code-example path="router/src/app/app-routing.module.8.ts" region="routes-with-wildcard" header="AppRoutingModule (excerpt)">
+
+</code-example>
+
+The last route with the `path` of `**` is a wildcard route.
+The router service selects this route if the requested URL doesn't match any of the paths earlier in the list and sends the user to the `PageNotFoundComponent`.
+
+## Enabling interactive navigation
+
+A template that enables navigation for users needs two things:
+
+* An *outlet*, a placeholder in the page where a component's view is to be inserted.
+* Links to the routing components that allow users to trigger navigation.
+
+{@a basics-router-outlet}
+
+### Placing a view in a template
+
+The `RouterOutlet` is a directive from the router library that is used like a component.
+It acts as a placeholder that marks the spot in the template where the router should
+display the component views for that outlet.
+
+A `<router-outlet>` element in the template for the root component tells Angular to update the application view with the component for the selected route.
+
+<code-example language="html">
+  &lt;router-outlet>&lt;/router-outlet>
+  &lt;!-- Routed components go here -->
+
+</code-example>
+
+Given the configuration above, when the browser URL for this application becomes `/heroes`, the router matches that URL to the route path `/heroes` and displays the `HeroListComponent` as a sibling element to the `RouterOutlet` that you've placed in the host component's template.
+
+{@a basics-router-links}
+{@a router-link}
+
+### Initiating interactive navigation
+
+Your app can initiate navigation programmatically, or a user can trigger a request for navigation by typing a URL in the address bar or clicking a link.
+To navigate as a result of a user action such as a click, include the [`RouterLink` directive](api/router/RouterLink "API reference") in the template.
+
+For example, the following template creates a link to a routing component in a `<nav>` container by using an anchor tag with the `routerLink` attribute.
+
+<code-example path="router/src/app/app.component.1.html" header="src/app/app.component.html"></code-example>
+
+This code assigns the anchor tag to the element that will initiate navigation, and sets the value of that attribute to the component to show when a user clicks on that link.
+
+The `RouterLink` directives on the anchor tags give the router control over those elements.
+The navigation paths are fixed, so you can assign a path string to the `routerLink` (a "one-time" binding).
+
+For a more dynamic navigation path, you can bind the router link to a template expression that returns a [link parameters array](guide/router#link-parameters-array). This array contains an object which associates a route path string with one or more required, optional, or query parameters. The router service resolves that array into a complete URL.
+
+To initiate navigation programmatically, pass a router URL string or link parameters array to the [Router.navigate() method](api/router/Router#navigate).
+
+{@a basics-router-state}
+{@a activated-route}
+{@a router-link-active}
+
+## Tracking navigation state
+
+When the router matches a path and displays a new view, the selected route becomes *active*.
+An active route is represented by an [ActivatedRoute](api/router/ActivatedRoute "API reference") object.
+After the end of each successful navigation cycle, the router builds a tree of `ActivatedRoute` objects that make up the current navigation state.
+Access the navigation state through the [Router.routerState](api/router/Router#routerState "API reference") property.
+
+Each `ActivatedRoute` in the `RouterState` provides the route path and parameters, as well as methods to traverse up and down the route tree to get information from parent, child and sibling routes.
+See the API reference for the many useful properties of an [ActivatedRoute](api/router/ActivatedRoute "API reference documentation") object.
+
+### Style views according to navigation state
+
+You can style views according to the navigation state. For example, you might want to highlight the currently selected tab in a set of tabbed panes, to keep the user oriented.
+
+You can use the [RouterLinkActive](api/router/RouterLinkActive "API reference") directive on an element to toggle CSS classes for active `RouterLink` bindings based on the current `RouterState`.
+
+On each anchor tag, you see a [property binding](guide/template-syntax#property-binding) to the `RouterLinkActive` directive that looks like `routerLinkActive="..."`, as in the following example.
+
+<code-example header="src/app/app.component.html" path="router-tutorial/src/app/app.component.html" region="routeractivelink"></code-example>
+
+You can bind the `routerLinkActive` directive to a space-delimited string of CSS classes such as `[routerLinkActive]="'active fluffy'"`, or bind it to a component property that returns such a string.
+The router automatically adds these classes to the tag when the linked route is activated, and removes them when the route becomes inactive.
+
+When you have [nested routes](#nesting-routes "Complex routing structure"), active routes cascade down through each level of the route tree, so parent and child routes can be active at the same time.
+To distinguish between specific linked routes, you can modify the `RouterLinkActive` directive with the `[routerLinkActiveOptions]={ exact: true }` input binding ([see example](api/router/RouterLinkActive#description "API reference")). This reports the linked route as active only when its URL is an exact match to the current URL.
+
+### Router event order
+
+During each navigation, the router service emits navigation events through the `Router.events` property.
+These events occur when the navigation starts and ends and many points in between.
+
+If you need to see what events are happening during the navigation lifecycle, you can set the `enableTracing` option as part of the router's default configuration.
+This outputs each router event that took place during each navigation lifecycle to the browser console.
+Use `enableTracing` only for debugging purposes.
+Set the `enableTracing: true` option in the object passed as the second argument to the `RouterModule.forRoot()` method.
+
+<!-- this table is moved into API doc in another PR (TBD) - when that lands, replace it with a link -->
+
+The following table lists the router event types in the order in which they can occur. The properties of each event are listed in the [API reference documentation](api/router/Event "Router event types").
+
+| Router Event | Trigger |
+| :----------- | :------- |
+| [NavigationStart](api/router/NavigationStart) | Navigation starts. |
+| [RouteConfigLoadStart](api/router/RouteConfigLoadStart) | Before the router [lazy loads](/guide/router-techniques#asynchronous-routing) a route configuration. |
+| [RouteConfigLoadEnd](api/router/RouteConfigLoadEnd) | After a route has been lazy loaded. |
+| [RoutesRecognized](api/router/RoutesRecognized) | When the router parses the URL and the routes are recognized. |
+| [GuardsCheckStart](api/router/GuardsCheckStart) | When the router begins the *guards* phase of routing. |
+| [ChildActivationStart](api/router/ChildActivationStart) | When the router begins activating a route's children. |
+| [ActivationStart](api/router/ActivationStart)| When the router begins activating a route. |
+| [GuardsCheckEnd](api/router/GuardsCheckEnd) | When the router finishes the *guards* phase of routing successfully. |
+| [ResolveStart](api/router/ResolveStart) | When the router begins the *resolve* phase of routing. |
+| [ResolveEnd](api/router/ResolveEnd) | When the router finishes the *resolve* phase of routing successfuly. |
+| [ChildActivationEnd](api/router/ChildActivationEnd) | When the router finishes activating a route's children. |
+| [ActivationEnd](api/router/ActivationStart) | When the router finishes activating a route. |
+| [NavigationEnd](api/router/NavigationEnd) | When navigation ends successfully. |
+| [NavigationCancel](api/router/NavigationCancel) | When navigation is canceled. This can happen when a [route guard](/guide/router-techniques#guards) returns false during navigation, or redirects by returning a `UrlTree`. |
+| [NavigationError](api/router/NavigationError) | When navigation fails due to an unexpected error. |
+| [Scroll](api/router/Scroll) | When the user scrolls. |
+
+When you set the `enableTracing` option, Angular logs these events to the console.
+For an example of filtering router navigation events, see the [router section](guide/observables-in-angular#router) of the [Observables in Angular](guide/observables-in-angular) guide.
+
+{@a activated-route}
 {@a getting-route-information}
 
-## Getting route information
+## Passing values between components
 
-Often, as a user navigates your application, you want to pass information from one component to another.
+As a user navigates your application, you need to pass route information from one component to another.
 For example, consider an application that displays a shopping list of grocery items.
-Each item in the list has a unique `id`.
 To edit an item, users click an Edit button, which opens an `EditGroceryItem` component.
-You want that component to retrieve the `id` for the grocery item so it can display the right information to the user.
+For the new component to display the right item, it must retrieve the unique identifier of the selected item from the previously displayed shopping-list component.
 
-You can use a route to pass this type of information to your application components.
-To do so, you use the [ActivatedRoute](api/router/ActivatedRoute) interface.
+To pass route parameters between your application components, use the [ActivatedRoute](api/router/ActivatedRoute "API reference") interface together with the [`ngOnInit()` lifecycle hook method](guide/lifecycle-hooks "Hooking into the component lifecycle").
 
-To get information from a route:
+To get parameter information from an active or previously active route, use the following steps.
 
   1. Import `ActivatedRoute` and `ParamMap` to your component.
 
@@ -165,7 +379,8 @@ To get information from a route:
     <code-example path="router/src/app/heroes/hero-detail/hero-detail.component.ts" region="activated-route" header="In the component class (excerpt)">
     </code-example>
 
-  1. Update the `ngOnInit()` method to access the `ActivatedRoute` and track the `id` parameter:
+  1. Update the `ngOnInit()` method to access the `ActivatedRoute` and track it using an identifying parameter.
+  The following example uses a variable, `name`, and assigns it the value based on the `name` parameter.
 
       <code-example header="In the component (excerpt)">
         ngOnInit() {
@@ -175,76 +390,78 @@ To get information from a route:
         }
       </code-example>
 
-    Note: The preceding example uses a variable, `name`, and assigns it the value based on the `name` parameter.
+{@a param-maps}
 
-{@a wildcard-route-how-to}
+### Retrieving parameters from parameter maps
 
-## Setting up wildcard routes
+When you activate a route, the router stores the parameters that were passed to in that activation operation in a *parameter map*. Both route parameters and query parameters are stored in a `ParamMap` object.
+The [ParamMap interface](api/router/ParamMap "ParamMap API reference") is based on the [URLSearchParams interface](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams).
 
-A well-functioning application should gracefully handle when users attempt to navigate to a part of your application that does not exist.
-To add this functionality to your application, you set up a wildcard route.
-The Angular router selects this route any time the requested URL doesn't match any router paths.
+The [ActivatedRoute](api/router/ActivatedRoute "ActivatedRoute API reference") methods give you access to both the route parameters (`paramMap`) and query parameters (`queryParamMap`) with which the route was activated.
+A parameter map provides methods to handle parameter access.
+You can check for the existence of a parameter name, retrieve the value of one or all parameters, and list all parameter names.
 
-To set up a wildcard route, add the following code to your `routes` definition.
+{@a reuse}
 
-<code-example header="AppRoutingModule (excerpt)">
+Notice that the `ActivatedRoute` methods return parameter maps from an `Observable`.
+This is because the parameters can change during the lifetime of an activated component.
+By default, the router re-uses a component instance when it re-navigates to the same component type
+without visiting a different component first. The route parameters could change with each navigation operation.
 
-{ path: '**', component: <component-name> }
+Suppose, for example, a parent component navigation bar has "forward" and "back" buttons
+that scroll through a list of items to retrieve details of a selected item.
+Each click navigates imperatively to the component with the next or previous `id`.
 
-</code-example>
+It would not be efficient to remove the current item-detail instance from the DOM only to re-create it for the next `id`, which would require Angular to re-render the view.
+Instead, the router re-uses the same component instance and updates the parameter.
 
+The `ngOnInit()` method is only called once per component instantiation, so if you use that method to activate a route, the route parameters can change when the same component is reactivated through another means, such as a "back" button. You can detect when the route parameters change from _within the same instance_ using the observable `paramMap` property.
 
-The two asterisks, `**`, indicate to Angular that this `routes` definition is a wildcard route.
-For the component property, you can define any component in your application.
-Common choices include an application-specific `PageNotFoundComponent`, which you can define to [display a 404 page](guide/router#404-page-how-to) to your users; or a redirect to your application's main component.
-A wildcard route is the last route because it matches any URL.
-For more detail on why order matters for routes, see [Route order](guide/router#route-order).
+<!--Bug related to how automatic unsubscribe doesn't actually seem to work: #16261
+removing this note so we aren't recommending something that causes a memory leak.
 
+<div class="alert is-helpful">
 
-{@a 404-page-how-to}
+When subscribing to an observable in a component, you almost always unsubscribe when the component is destroyed.
+However, `ActivatedRoute` observables are among the exceptions because `ActivatedRoute` and its observables are insulated from the `Router` itself.
+The router service is responsible for destroying a routed component when it is no longer needed along with the injected `ActivatedRoute`.
 
-## Displaying a 404 page
+</div> -->
 
-To display a 404 page, set up a [wildcard route](guide/router#wildcard-route-how-to) with the `component` property set to the component you'd like to use for your 404 page as follows:
+{@a snapshot}
 
-<code-example path="router/src/app/app-routing.module.8.ts" region="routes-with-wildcard" header="AppRoutingModule (excerpt)">
+### Use snapshots as an alternative to observables
 
-</code-example>
+You can design an application such that there is only one way to activate a route, so you know that it will create a new component instance on every activation.
 
-The last route with the `path` of `**` is a wildcard route.
-The router selects this route if the requested URL doesn't match any of the paths earlier in the list and sends the user to the `PageNotFoundComponent`.
+In this case, when you know the instance will never be re-used, you can use `activatedRoute.snapshot` to retrieve the initial value of the route parameter map directly from a cached [ActivatedRouteSnapshot](api/router/ActivatedRouteSnapshot "ActivatedRouteSnapshot API reference") object.
+The snapshot gives you direct access the initial parameters, without subscribing or adding observable operators, as in the following example.
 
-## Setting up redirects
+<code-example path="router/src/app/heroes/hero-detail/hero-detail.component.2.ts" header="src/app/heroes/hero-detail/hero-detail.component.ts (ngOnInit snapshot)" region="snapshot"></code-example>
 
-To set up a redirect, configure a route with the `path` you want to redirect from, the `component` you want to redirect to, and a `pathMatch` value that tells the router how to match the URL.
-
-<code-example path="router/src/app/app-routing.module.8.ts" region="redirect" header="AppRoutingModule (excerpt)">
-
-</code-example>
-
-In this example, the third route is a redirect so that the router defaults to the `first-component` route.
-Notice that this redirect precedes the wildcard route.
-Here, `path: ''` means to use the initial relative URL (`''`).
-
-For more details on `pathMatch` see [Spotlight on `pathMatch`](guide/router-tutorial-toh#pathmatch).
 
 {@a nesting-routes}
+{@a route-trees}
+## Creating complex routing structures
 
-## Nesting routes
+As your application grows more complex, you can create routes that are relative to a component other than your root component.
+In addition to the `<router-outlet>` in the root application's template, you can place `<router-outlet>` elements in the templates of other components, resulting in a nested structure of parent and child routes.
+You can [use relative paths to traverse the route tree](#using-relative-paths).
 
-As your application grows more complex, you may want to create routes that are relative to a component other than your root component.
-These types of nested routes are called child routes.
-This means you're adding a second `<router-outlet>` to your app, because it is in addition to the `<router-outlet>` in `AppComponent`.
+The Angular router provides direct access to route path strings.
+You can [access and manipulate query parameters and URL fragments](#access-params), and [set required and optional route parameters](#link-parameters-array) for routing hierarchies of any depth.
 
-In this example, there are two additional child components, `child-a`, and `child-b`.
+
+### Create a navigation tree with nested routes
+
+In the following example, there are two additional child components, `child-a`, and `child-b`.
 Here, `FirstComponent` has its own `<nav>` and a second `<router-outlet>` in addition to the one in `AppComponent`.
 
 <code-example path="router/src/app/app.component.8.html" region="child-routes" header="In the template">
 
 </code-example>
 
-A child route is like any other route, in that it needs both a `path` and a `component`.
-The one difference is that you place child routes in a `children` array within the parent route.
+You place child routes in a `children` array within the parent route. The child route itself, like any other route, needs both a `path` and a `component`.
 
 <code-example path="router/src/app/app-routing.module.9.ts" region="child-routes" header="AppRoutingModule (excerpt)">
 
@@ -252,42 +469,118 @@ The one difference is that you place child routes in a `children` array within t
 
 {@a using-relative-paths}
 
-## Using relative paths
+### Using relative paths to traverse the route tree
 
-Relative paths allow you to define paths that are relative to the current URL segment.
-The following example shows a relative route to another component, `second-component`.
-`FirstComponent` and `SecondComponent` are at the same level in the tree, however, the link to `SecondComponent` is situated within the `FirstComponent`, meaning that the router has to go up a level and then into the second directory to find the `SecondComponent`.
-Rather than writing out the whole path to get to `SecondComponent`, you can use the `../` notation to go up a level.
+Relative paths allow you to define paths in a link parameters list that are relative to the current URL segment.
+Relative route paths use standard path notation: use `../` to specify a route relative to the current level's parent, and use `./` or no leading slash to specify a route relative to the current level.
+
+You can combine relative navigation syntax with an ancestor path.
+To navigate to a sibling route, you can use the `../<sibling>` convention to go up
+one level, then over and down the sibling route path.
+
+Consider a route tree in which `FirstComponent` and `SecondComponent` are at the same level in the route tree, and the `FirstComponent` template contains a link to `SecondComponent`.
+The router has to go up a level and into the second directory to find the `SecondComponent`.
+
+The link in the `FirstComponent` template can provide an absolute path to `SecondComponent`, or it can use relative path notation to go up a level, as in the following example.
 
 <code-example path="router/src/app/app.component.8.html" region="relative-route" header="In the template">
 
 </code-example>
 
-In addition to `../`, you can use `./` or no leading slash to specify the current level.
+The [NavigationExtras configuration object](api/router/NavigationExtras "API reference") allows you to configure specific routing-strategy options for a navigation operation.
+To specify a relative route, pass a configuration object to the `Router.navigate()` call.
+The configuration object sets the `relativeTo` property to a base route.
 
-### Specifying a relative route
+In the following example, the `navigate()` arguments configure the router to use the current route as a base URL upon which to append `items`.
 
-To specify a relative route, use the `NavigationExtras` `relativeTo` property.
-In the component class, import `NavigationExtras` from the `@angular/router`.
+<code-example path="router/src/app/app.component.4.ts" region="relative-to" header="Set a base route"></code-example>
 
-Then use `relativeTo` in your navigation method.
-After the link parameters array, which here contains `items`, add an object with the `relativeTo` property set to the `ActivatedRoute`, which is `this.route`.
 
-<code-example path="router/src/app/app.component.4.ts" region="relative-to" header="RelativeTo">
+* The first argument is a link parameters array, which here contains `items`. The second is a configuration-options object with the `relativeTo` property set to the current `ActivatedRoute`, which is `this.route`.
 
-The `navigate()` arguments configure the router to use the current route as a basis upon which to append `items`.
+* The `goToItems()` method interprets the destination URI as relative to the activated route and navigates from there to the `items` route.
+
+Note that you can only use this configuration with the router's `navigate()` method. You must always specify the complete absolute path when calling router's `navigateByUrl()` method.
+
+<div class="alert is-helpful">
+
+When you initiate navigation from a `RouterLink` directive (rather than calling the `Router.navigate()` method), you use the same link parameters array, but without the configuration object.
+The `ActivatedRoute` is implicit in a `RouterLink` directive.
+
+</div>
+
+{@a define-secondary-routes}
+
+### Define secondary outlets and routes
+
+The router supports only one primary, unnamed outlet per template.
+However, a template can also have any number of named *secondary* outlets.
+Each named outlet has its own set of routes with their own components.
+Multiple outlets can display different content, determined by different routes, all at the same time.
+
+Named outlets are the targets of  _secondary routes_.
+The route configuration for a secondary route has a third property, `outlet: <target_outlet_name>`.
+
+Secondary routes are independent of each other, but work in combination with other routes.
+Using named outlets and secondary routes, you can target multiple outlets with multiple routes in the same `RouterLink` directive.
+
+The router keeps track of separate branches in a navigation tree for each named outlet.
+It generates a representation of that tree in the URL.
+The URL for a secondary route uses the following syntax to specify both the primary and secondary routes at the same time:
+
+<code-example>
+  http://base-path/primary-route-path(outlet-name:route-path)
 
 </code-example>
 
-The `goToItems()` method interprets the destination URI as relative to the activated route and navigates to the `items` route.
+For an example of a named outlet and secondary route configuration, see the [Routing Techniques](guide/router-techniques#named-outlets-example) tutorial.
 
-## Accessing query parameters and fragments
+{@a secondary-route-navigation}
 
-Sometimes, a feature of your application requires accessing a part of a route, such as a query parameter or a fragment. The Tour of Heroes app at this stage in the tutorial uses a list view in which you can click on a hero to see details. The router uses an `id` to show the correct hero's details.
+### Merging routes during navigation
 
-First, import the following members in the component you want to navigate from.
+In the tutorial example, when you navigate to the _Crisis Center_ and click "Contact".
+you should see something like the following URL in the browser address bar.
 
-<code-example header="Component import statements (excerpt)">
+<code-example>
+  http://.../crisis-center(popup:compose)
+
+</code-example>
+
+The relevant part of the URL follows the base path, represented here by `...`.
+The `crisis-center` is the route path for the view displayed in the primary outlet.
+In parentheses, the secondary route consists of an outlet name (`popup`), a `colon` separator, and the secondary route path (`compose`).
+
+Like regular outlets, secondary outlets persists until you navigate away to a new component.
+Each secondary outlet has its own navigation, independent of the navigation driving the primary outlet.
+Changing a current route that displays in the primary outlet has no effect on the popup outlet.
+
+You can add more outlets and routes, at the top level and in nested levels, creating a navigation tree with many branches. The router generates the URLs to go with it.
+You can tell the router to navigate an entire tree at once by filling out the `outlets` object and then pass that object inside a link parameters array to the `router.navigate` method.
+
+
+### Clearing secondary routes
+
+To navigate imperatively to one or more secondary routes, pass the `Router.navigate()` method an array of objects.
+Each object associates an outlet name with a route path.
+
+* To display a view in the outlet, set that outlet's value to the route path for that view.
+
+* To clear the outlet, set the route path for the named outlet to the special value `null`. For example:
+
+   <code-example path="router/src/app/compose-message/compose-message.component.ts" header="src/app/compose-message/compose-message.component.ts (clear the secondary outlet)" region="closePopup"></code-example>
+
+---
+
+{@a access-params}
+
+## Access query parameters and fragments
+
+Sometimes, a feature of your application requires accessing a part of a route, such as a query parameter or a fragment. In the Tour of Heroes sample app, for example, you can click on a hero in a list to see details. The router service depends on the value of the selected hero's `id` property to show the correct hero's details.
+
+Passing the `id` value to the router requires that you import the following members in the component you want to navigate *from*.
+
+<code-example header="Component imports for passing parameters">
 
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
@@ -295,16 +588,16 @@ import { switchMap } from 'rxjs/operators';
 
 </code-example>
 
-Next inject the activated route service:
+The component must inject the activated route service.
 
-<code-example header="Component (excerpt)">
+<code-example header="Component (inject service)">
 constructor(private route: ActivatedRoute) {}
 </code-example>
 
-Configure the class so that you have an observable, `heroes$`, a `selectedId` to hold the `id` number of the hero, and the heroes in the `ngOnInit()`, add the following code to get the `id` of the selected hero.
-This code snippet assumes that you have a heroes list, a hero service, a function to get your heroes, and the HTML to render your list and details, just as in the Tour of Heroes example.
+The following snippet configures the class with an observable `heroes$`, and a `selectedId` variable to hold the `id` number of the hero.
+The `ngOnInit()` method gets the `id` of the selected hero.
 
-<code-example header="Component 1 (excerpt)">
+<code-example header="Component 1 (retrieve Hero ID)">
 heroes$: Observable<Hero[]>;
 selectedId: number;
 heroes = HEROES;
@@ -320,20 +613,18 @@ ngOnInit() {
 
 </code-example>
 
+The component that you want to navigate *to* must import the following members.
 
-Next, in the component that you want to navigate to, import the following members.
-
-<code-example header="Component 2 (excerpt)">
+<code-example header="Component 2 (Component imports for receiving parameters)">
 
 import { Router, ActivatedRoute, ParamMap } from '@angular/router';
 import { Observable } from 'rxjs';
 
 </code-example>
 
-Inject `ActivatedRoute` and `Router` in the constructor of the component class so they are available to this component:
+The following snippet injects `ActivatedRoute` and `Router` in the constructor of the component class so they are available to this component. The `ngOnInit()` method saves a parameter from the currently active route, and the `navigate()` call uses that stored value to activate the next route.
 
-
-<code-example header="Component 2 (excerpt)">
+<code-example header="Component 2 (Retrieving a stored route parameter)">
 
   item$: Observable<Item>;
 
@@ -355,19 +646,134 @@ Inject `ActivatedRoute` and `Router` in the constructor of the component class s
 
 </code-example>
 
-{@a lazy-loading}
+{@a link-parameters-array}
 
-## Lazy loading
+### Passing optional route parameters
 
-You can configure your routes to lazy load modules, which means that Angular only loads modules as needed, rather than loading all modules when the app launches.
-Additionally, you can preload parts of your app in the background to improve the user experience.
+A link parameters array holds the following ingredients for router navigation:
 
-For more information on lazy loading and preloading see the dedicated guide [Lazy loading NgModules](guide/lazy-loading-ngmodules).
+* The path of the route to the destination component.
+* Required and optional route parameters that go into the route URL.
 
-## Preventing unauthorized access
+For interactive links, you can bind the `RouterLink` directive to such an array as in the following example:
 
-Use route guards to prevent users from navigating to parts of an app without authorization.
-The following route guards are available in Angular:
+<code-example path="router/src/app/app.component.3.ts" header="src/app/app.component.ts (Heroes link anchor)" region="h-anchor"></code-example>
+
+When you initiate navigation programmatically, you can pass a link parameters array to the [Router.navigate() method](api/router/Router#navigate "API reference").
+
+The following is a two-element array that specifies a required route parameter:
+
+<code-example path="router/src/app/heroes/hero-list/hero-list.component.1.html" header="src/app/heroes/hero-list/hero-list.component.html (Hero detail link with route parameter)" region="nav-to-detail"></code-example>
+
+The router supports navigation with *optional* parameters, as well as required route parameters.
+You can include optional information in a route request by including expressions in the link parameters array.
+Optional parameters aren't involved in pattern matching and afford flexibility of expression.
+For example:
+
+* Use wildcard formations to create loosely structured search criteria; for example, `name='wind*'`.
+
+* Specify ranges or multiple values, such as `after='12/31/2015' & before='1/1/2017'` or `during='currentYear'`.
+
+Use optional parameters to convey arbitrarily complex information during navigation, when that information doesn't fit easily in a URL path.
+
+In general, use a required route parameter when the value is mandatory (for example, if necessary to distinguish one route path from another); and an optional parameter when the value is optional, complex, and/or multivariate.
+Define optional parameters in a separate object _after_ you define the required route parameters.
+
+You can provide optional route parameters in an object, as in `{ foo: 'foo' }`:
+
+<code-example path="router/src/app/app.component.3.ts" header="src/app/app.component.ts (cc-query-params)" region="cc-query-params"></code-example>
+
+These three examples cover the needs of an app with one level of routing.
+The link parameters array affords the flexibility to represent any routing depth and any legal sequence of route paths, required route parameters, and optional route parameter objects.
+This allows you to write applications with several levels of routing within a navigation hierarchy.
+
+With a child router, such as in the [crisis center in the tutorial example](guide/router-techniques#relative-routing), you create new link array possibilities.
+The following minimal `RouterLink` example builds upon a specified [default child route](/guide/router-techniques#crisis-child-routes) for the crisis center.
+
+<code-example path="router/src/app/app.component.3.ts" header="src/app/app.component.ts (cc-anchor-w-default)" region="cc-anchor-w-default"></code-example>
+
+Note the following:
+
+* The first item in the array identifies the parent route (`/crisis-center`).
+* There are no parameters for this parent route.
+* There is no default for the child route so you need to pick one.
+* You're navigating to the `CrisisListComponent`, whose route path is `/`, but you don't need to explicitly add the slash.
+
+Consider the following router link that navigates from the root of the application down to the Dragon Crisis:
+
+<code-example path="router/src/app/app.component.3.ts" header="src/app/app.component.ts (Dragon-anchor)" region="Dragon-anchor"></code-example>
+
+* The first item in the array identifies the parent route (`/crisis-center`).
+* There are no parameters for this parent route.
+* The second item identifies the child route details about a particular crisis (`/:id`).
+* The details child route requires an `id` route parameter.
+* You added the `id` of the Dragon Crisis as the second item in the array (`1`).
+* The resulting path is `/crisis-center/1`.
+
+You could also redefine the `AppComponent` template with Crisis Center routes exclusively:
+
+<code-example path="router/src/app/app.component.3.ts" header="src/app/app.component.ts (template)" region="template"></code-example>
+
+### Persisting query parameters and fragments
+
+You can preserve query parameters and fragments across navigations without having to provide them again when navigating.
+You can use these persistent bits of information for things that need to be provided across pages like authentication tokens or session ids.
+
+The [`NavigationExtras` configuration object](api/router/NavigationExtras "API reference"), which you can use to configure a navigation request, provides `queryParamsHandling` and `preserveFragment` configuration options.
+For example:
+
+``` ts
+this.router.navigate([redirectUrl], {queryParamsHandling: 'preserve', preserveFragment: 'true'});
+```
+
+See an example in the [Routing techniques tutorial](guide/router-techniques#preserve-params "Preserve and share query parameters").
+
+You can also configure a routing request to both preserve parameters and combine them with new ones (`queryParamsHandling: 'merge'`).
+
+---
+<!---  NEW PAGE?  -->
+
+{@a route-guards}
+{@a guards}
+
+## Controlling view access with route guards
+
+There are times when you need to to control access to different parts of your application.
+For instance:
+
+* A user is not authorized to navigate to the target component.
+* The user must login (authenticate) first.
+* You need to fetch some data before you display the target component.
+* You need to save pending changes before leaving a component.
+* You need to ask the user if it's OK to discard pending changes rather than save them.
+
+You can add *guard functions* to the route configuration to handle these scenarios.
+A guard function's return value controls the router's behavior:
+
+* If it returns `true`, the navigation process continues.
+* If it returns `false`, the navigation process stops and the user stays put.
+* If it returns a `UrlTree`, the current navigation cancels and a new navigation is initiated to the `UrlTree` returned.
+
+<div class="alert is-helpful">
+
+A guard function can also tell the router to navigate elsewhere, effectively canceling the current navigation.
+When doing so inside a guard, the guard should return `false`;
+
+</div>
+
+Guard functions can be asynchronous.
+You can use an ansychronous function to, for example, ask the user a question, save changes to the server, or fetch fresh data.
+If a guard function returns an `Observable<boolean>` or a `Promise<boolean>`, Angular waits for the observable to resolve to `true` or `false`.
+
+<div class="alert is-important">
+
+If a guard function returns an observable, the observable must also complete. If the observable does not complete, the navigation does not continue.
+
+</div>
+
+### Predefined route guards
+
+Angular provides the following pre-defined route guard functions:
 
 * [`CanActivate`](api/router/CanActivate)
 * [`CanActivateChild`](api/router/CanActivateChild)
@@ -375,10 +781,17 @@ The following route guards are available in Angular:
 * [`Resolve`](api/router/Resolve)
 * [`CanLoad`](api/router/CanLoad)
 
-To use route guards, consider using component-less routes as this facilitates guarding child routes.
+You can have multiple guards at every level of a navigation hierarchy.
+The router checks the `CanDeactivate` and `CanActivateChild` guards first, from the deepest child route to the top.
+Then it checks the `CanActivate` guards from the top down to the deepest child route.
+If the feature module is loaded asynchronously, the `CanLoad` guard is checked before the module is loaded.
+If _any_ guard returns false, pending guards that have not completed are canceled, and the entire navigation is canceled.
+
+Consider using [componentless routes](api/router/Route#componentless-routes) to more easily control access to child routes.
+
+### Creating a guard service
 
 Create a service for your guard:
-
 
 <code-example language="none" class="code-shell">
   ng generate guard your-guard
@@ -408,90 +821,43 @@ Here, `canActivate` tells the router to mediate navigation to this particular ro
 }
 </code-example>
 
-For more information with a working example, see the [routing tutorial section on route guards](guide/router-tutorial-toh#milestone-5-route-guards).
+For more about the various types of route guards and their usage, see these [additional route guards examples](/guide/router-techniques#guards "Route guard examples").
 
-## Link parameters array
+---
 
-A link parameters array holds the following ingredients for router navigation:
-
-* The path of the route to the destination component.
-* Required and optional route parameters that go into the route URL.
-
-You can bind the `RouterLink` directive to such an array like this:
-
-<code-example path="router/src/app/app.component.3.ts" header="src/app/app.component.ts (h-anchor)" region="h-anchor"></code-example>
-
-The following is a two-element array when specifying a route parameter:
-
-<code-example path="router/src/app/heroes/hero-list/hero-list.component.1.html" header="src/app/heroes/hero-list/hero-list.component.html (nav-to-detail)" region="nav-to-detail"></code-example>
-
-You can provide optional route parameters in an object, as in `{ foo: 'foo' }`:
-
-<code-example path="router/src/app/app.component.3.ts" header="src/app/app.component.ts (cc-query-params)" region="cc-query-params"></code-example>
-
-These three examples cover the needs of an app with one level of routing.
-However, with a child router, such as in the crisis center, you create new link array possibilities.
-
-The following minimal `RouterLink` example builds upon a specified [default child route](guide/router-tutorial-toh#a-crisis-center-with-child-routes) for the crisis center.
-
-<code-example path="router/src/app/app.component.3.ts" header="src/app/app.component.ts (cc-anchor-w-default)" region="cc-anchor-w-default"></code-example>
-
-Note the following:
-
-* The first item in the array identifies the parent route (`/crisis-center`).
-* There are no parameters for this parent route.
-* There is no default for the child route so you need to pick one.
-* You're navigating to the `CrisisListComponent`, whose route path is `/`, but you don't need to explicitly add the slash.
-
-Consider the following router link that navigates from the root of the application down to the Dragon Crisis:
-
-<code-example path="router/src/app/app.component.3.ts" header="src/app/app.component.ts (Dragon-anchor)" region="Dragon-anchor"></code-example>
-
-* The first item in the array identifies the parent route (`/crisis-center`).
-* There are no parameters for this parent route.
-* The second item identifies the child route details about a particular crisis (`/:id`).
-* The details child route requires an `id` route parameter.
-* You added the `id` of the Dragon Crisis as the second item in the array (`1`).
-* The resulting path is `/crisis-center/1`.
-
-You could also redefine the `AppComponent` template with Crisis Center routes exclusively:
-
-<code-example path="router/src/app/app.component.3.ts" header="src/app/app.component.ts (template)" region="template"></code-example>
-
-In summary, you can write applications with one, two or more levels of routing.
-The link parameters array affords the flexibility to represent any routing depth and any legal sequence of route paths, (required) router parameters, and (optional) route parameter objects.
+<!--- ROuTER CONFIGURATION PAGE?  -->
 
 {@a browser-url-styles}
 
 {@a location-strategy}
 
-## `LocationStrategy` and browser URL styles
+## Browser URL styles and path location strategies
 
 When the router navigates to a new component view, it updates the browser's location and history with a URL for that view.
-As this is a strictly local URL the browser won't send this URL to the server and will not reload the page.
+As this is a strictly local URL the browser does not send this URL to the server and does not reload the page.
 
 Modern HTML5 browsers support <a href="https://developer.mozilla.org/en-US/docs/Web/API/History_API#Adding_and_modifying_history_entries" title="HTML5 browser history push-state">history.pushState</a>, a technique that changes a browser's location and history without triggering a server page request.
-The router can compose a "natural" URL that is indistinguishable from one that would otherwise require a page load.
+The router service can compose a "natural" URL that is indistinguishable from one that would otherwise require a page load.
 
-Here's the Crisis Center URL in this "HTML5 pushState" style:
+For example, the following URL uses the HTML5 "pushState" style for the Crisis Center URL:
 
 <code-example format="nocode">
   localhost:3002/crisis-center/
 
 </code-example>
 
-Older browsers send page requests to the server when the location URL changes unless the change occurs after a "#" (called the "hash").
+Older browsers send page requests to the server when the location URL changes unless the change occurs after a hash mark (#).
 Routers can take advantage of this exception by composing in-application route URLs with hashes.
-Here's a "hash URL" that routes to the Crisis Center.
+For example, the following hash URL routes to the Crisis Center.
 
 <code-example format="nocode">
   localhost:3002/src/#/crisis-center/
 
 </code-example>
 
-The router supports both styles with two `LocationStrategy` providers:
+The `Router` service supports both styles with two `LocationStrategy` providers:
 
-1. `PathLocationStrategy`&mdash;the default "HTML5 pushState" style.
+1. `PathLocationStrategy`&mdash;the default "pushState" or HTML5 URL style.
 1. `HashLocationStrategy`&mdash;the "hash URL" style.
 
 The `RouterModule.forRoot()` function sets the `LocationStrategy` to the `PathLocationStrategy`, which makes it the default strategy.
@@ -499,15 +865,14 @@ You also have the option of switching to the `HashLocationStrategy` with an over
 
 <div class="alert is-helpful">
 
-For more information on providers and the bootstrap process, see [Dependency Injection](guide/dependency-injection#bootstrap).
+For more information on providers and the bootstrap process, see  the [Dependency Injection guide](guide/dependency-injection#bootstrap "Providers and bootstrapping").
 
 </div>
 
-## Choosing a routing strategy
+### Choosing a location strategy
 
-You must choose a routing strategy early in the development of you project because once the application is in production, visitors to your site use and depend on application URL references.
-
-Almost all Angular projects should use the default HTML5 style.
+You must choose a location strategy early in the development of you project because once the application is in production, visitors to your site use and depend on application URL references.
+Almost all Angular projects should use the HTML5 style, which is the default.
 It produces URLs that are easier for users to understand and it preserves the option to do server-side rendering.
 
 Rendering critical pages on the server is a technique that can greatly improve perceived responsiveness when the app first loads.
@@ -515,22 +880,13 @@ An app that would otherwise take ten or more seconds to start could be rendered 
 
 This option is only available if application URLs look like normal web URLs without hashes (#) in the middle.
 
-## `<base href>`
+{@a base-href}
 
-The router uses the browser's <a href="https://developer.mozilla.org/en-US/docs/Web/API/History_API#Adding_and_modifying_history_entries" title="HTML5 browser history push-state">history.pushState</a> for navigation.
-`pushState` allows you to customize in-app URL paths; for example, `localhost:4200/crisis-center`.
-The in-app URLs can be indistinguishable from server URLs.
+### Setting a base location for the push-state strategy
 
-Modern HTML5 browsers were the first to support `pushState` which is why many people refer to these URLs as "HTML5 style" URLs.
+While the router uses the <a href="https://developer.mozilla.org/en-US/docs/Web/API/History_API#Adding_and_modifying_history_entries" title="Browser history push-state">HTML5 pushState</a> style by default, you must configure that strategy by setting a base location.
 
-<div class="alert is-helpful">
-
-HTML5 style navigation is the router default.
-In the [LocationStrategy and browser URL styles](#browser-url-styles) section, learn why HTML5 style is preferable, how to adjust its behavior, and how to switch to the older hash (#) style, if necessary.
-
-</div>
-
-You must add a <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base" title="base href">&lt;base href&gt; element</a> to the app's `index.html` for `pushState` routing to work.
+For `pushState` routing to work, you must add a <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base" title="base href">&lt;base href&gt; element</a> to the app's `index.html`
 The browser uses the `<base href>` value to prefix relative URLs when referencing CSS files, scripts, and images.
 
 Add the `<base>` element just after the  `<head>` tag.
@@ -539,643 +895,37 @@ set the `href` value in `index.html` as shown here.
 
 <code-example path="router/src/index.html" header="src/index.html (base-href)" region="base-href"></code-example>
 
-### HTML5 URLs and the  `<base href>`
-
-While the router uses the <a href="https://developer.mozilla.org/en-US/docs/Web/API/History_API#Adding_and_modifying_history_entries" title="Browser history push-state">HTML5 pushState</a> style by default, you must configure that strategy with a `<base href>`.
-
-The preferred way to configure the strategy is to add a <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base" title="base href">&lt;base href&gt; element</a> tag in the `<head>` of the `index.html`.
-
-<code-example path="router/src/index.html" header="src/index.html (base-href)" region="base-href"></code-example>
-
 Without that tag, the browser may not be able to load resources
 (images, CSS, scripts) when "deep linking" into the app.
 
-Some developers may not be able to add the `<base>` element, perhaps because they don't have access to `<head>` or the `index.html`.
-
-Those developers may still use HTML5 URLs by taking the following two steps:
+You might not be able to add the `<base>` element if, for example, you don't have access to `<head>` or the `index.html`.
+You can still use HTML5 URLs by taking the following steps:
 
 1. Provide the router with an appropriate [APP_BASE_HREF][] value.
 1. Use root URLs for all web resources: CSS, images, scripts, and template HTML files.
 
 {@a hashlocationstrategy}
 
-### `HashLocationStrategy`
+### Using the hash-URL location strategy
 
 You can use `HashLocationStrategy` by providing the `useHash: true` in an object as the second argument of the `RouterModule.forRoot()` in the `AppModule`.
 
 <code-example path="router/src/app/app.module.6.ts" header="src/app/app.module.ts (hash URL strategy)"></code-example>
 
-## Router Reference
 
-The folllowing sections highlight some core router concepts.
-
-{@a basics-router-imports}
-
-### Router imports
-
-The Angular Router is an optional service that presents a particular component view for a given URL.
-It is not part of the Angular core and thus is in its own library package, `@angular/router`.
-
-Import what you need from it as you would from any other Angular package.
-
-<code-example path="router/src/app/app.module.1.ts" header="src/app/app.module.ts (import)" region="import-router"></code-example>
-
-
-<div class="alert is-helpful">
-
-For more on browser URL styles, see [`LocationStrategy` and browser URL styles](#browser-url-styles).
-
-</div>
-
-{@a basics-config}
-
-### Configuration
-
-A routed Angular application has one singleton instance of the `Router` service.
-When the browser's URL changes, that router looks for a corresponding `Route` from which it can determine the component to display.
-
-A router has no routes until you configure it.
-The following example creates five route definitions, configures the router via the `RouterModule.forRoot()` method, and adds the result to the `AppModule`'s `imports` array.
-
-<code-example path="router/src/app/app.module.0.ts" header="src/app/app.module.ts (excerpt)"></code-example>
-
-{@a example-config}
-
-The `appRoutes` array of routes describes how to navigate.
-Pass it to the `RouterModule.forRoot()` method in the module `imports` to configure the router.
-
-Each `Route` maps a URL `path` to a component.
-There are no leading slashes in the path.
-The router parses and builds the final URL for you, which allows you to use both relative and absolute paths when navigating between application views.
-
-The `:id` in the second route is a token for a route parameter.
-In a URL such as `/hero/42`, "42" is the value of the `id` parameter.
-The corresponding `HeroDetailComponent` uses that value to find and present the hero whose `id` is 42.
-
-The `data` property in the third route is a place to store arbitrary data associated with
-this specific route.
-The data property is accessible within each activated route. Use it to store items such as page titles, breadcrumb text, and other read-only, static data.
-You can use the [resolve guard](guide/router-tutorial-toh#resolve-guard) to retrieve dynamic data.
-
-The empty path in the fourth route represents the default path for the application&mdash;the place to go when the path in the URL is empty, as it typically is at the start.
-This default route redirects to the route for the `/heroes` URL and, therefore, displays the `HeroesListComponent`.
-
-If you need to see what events are happening during the navigation lifecycle, there is the `enableTracing` option as part of the router's default configuration.
-This outputs each router event that took place during each navigation lifecycle to the browser console.
-Use `enableTracing` only for debugging purposes.
-You set the `enableTracing: true` option in the object passed as the second argument to the `RouterModule.forRoot()` method.
-
-{@a basics-router-outlet}
-
-### Router outlet
-
-The `RouterOutlet` is a directive from the router library that is used like a component.
-It acts as a placeholder that marks the spot in the template where the router should
-display the components for that outlet.
-
-<code-example language="html">
-  &lt;router-outlet>&lt;/router-outlet>
-  &lt;!-- Routed components go here -->
-
-</code-example>
-
-Given the configuration above, when the browser URL for this application becomes `/heroes`, the router matches that URL to the route path `/heroes` and displays the `HeroListComponent` as a sibling element to the `RouterOutlet` that you've placed in the host component's template.
-
-{@a basics-router-links}
-
-{@a router-link}
-
-### Router links
-
-To navigate as a result of some user action such as the click of an anchor tag, use `RouterLink`.
-
-Consider the following template:
-
-<code-example path="router/src/app/app.component.1.html" header="src/app/app.component.html"></code-example>
-
-The `RouterLink` directives on the anchor tags give the router control over those elements.
-The navigation paths are fixed, so you can assign a string to the `routerLink` (a "one-time" binding).
-
-Had the navigation path been more dynamic, you could have bound to a template expression that returned an array of route link parameters; that is, the [link parameters array](guide/router#link-parameters-array).
-The router resolves that array into a complete URL.
-
-{@a router-link-active}
-
-### Active router links
-
-The `RouterLinkActive` directive toggles CSS classes for active `RouterLink` bindings based on the current `RouterState`.
-
-On each anchor tag, you see a [property binding](guide/property-binding) to the `RouterLinkActive` directive that looks like `routerLinkActive="..."`.
-
-The template expression to the right of the equal sign, `=`, contains a space-delimited string of CSS classes that the Router adds when this link is active (and removes when the link is inactive).
-You set the `RouterLinkActive` directive to a string of classes such as `[routerLinkActive]="'active fluffy'"` or bind it to a component property that returns such a string.
-
-Active route links cascade down through each level of the route tree, so parent and child router links can be active at the same time.
-To override this behavior, you can bind to the `[routerLinkActiveOptions]` input binding with the `{ exact: true }` expression. By using `{ exact: true }`, a given `RouterLink` will only be active if its URL is an exact match to the current URL.
-
-{@a basics-router-state}
-
-### Router state
-
-After the end of each successful navigation lifecycle, the router builds a tree of `ActivatedRoute` objects that make up the current state of the router. You can access the current `RouterState` from anywhere in the application using the `Router` service and the `routerState` property.
-
-Each `ActivatedRoute` in the `RouterState` provides methods to traverse up and down the route tree to get information from parent, child and sibling routes.
-
-{@a activated-route}
-
-### Activated route
-
-The route path and parameters are available through an injected router service called the [ActivatedRoute](api/router/ActivatedRoute).
-It has a great deal of useful information including:
-
-<table>
-  <tr>
-    <th>
-      Property
-    </th>
-
-    <th>
-      Description
-    </th>
-  </tr>
-
-  <tr>
-    <td>
-      <code>url</code>
-    </td>
-    <td>
-
-    An `Observable` of the route path(s), represented as an array of strings for each part of the route path.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>data</code>
-    </td>
-    <td>
-
-    An `Observable` that contains the `data` object provided for the route.
-    Also contains any resolved values from the [resolve guard](guide/router-tutorial-toh#resolve-guard).
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>paramMap</code>
-    </td>
-    <td>
-
-    An `Observable` that contains a [map](api/router/ParamMap) of the required and [optional parameters](guide/router-tutorial-toh#optional-route-parameters) specific to the route.
-    The map supports retrieving single and multiple values from the same parameter.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>queryParamMap</code>
-    </td>
-    <td>
-
-    An `Observable` that contains a [map](api/router/ParamMap) of the [query parameters](guide/router-tutorial-toh#query-parameters) available to all routes.
-    The map supports retrieving single and multiple values from the query parameter.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>fragment</code>
-    </td>
-    <td>
-
-    An `Observable` of the URL [fragment](guide/router-tutorial-toh#fragment) available to all routes.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>outlet</code>
-    </td>
-    <td>
-
-    The name of the `RouterOutlet` used to render the route.
-    For an unnamed outlet, the outlet name is primary.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>routeConfig</code>
-    </td>
-    <td>
-
-    The route configuration used for the route that contains the origin path.
-
-    </td>
-  </tr>
-
-    <tr>
-    <td>
-      <code>parent</code>
-    </td>
-    <td>
-
-    The route's parent `ActivatedRoute` when this route is a [child route](guide/router-tutorial-toh#child-routing-component).
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>firstChild</code>
-    </td>
-    <td>
-
-    Contains the first `ActivatedRoute` in the list of this route's child routes.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>children</code>
-    </td>
-    <td>
-
-    Contains all the [child routes](guide/router-tutorial-toh#child-routing-component) activated under the current route.
-
-    </td>
-  </tr>
-</table>
-
-<div class="alert is-helpful">
-
-Two older properties are still available, however, their replacements are preferable as they may be deprecated in a future Angular version.
-
-* `params`: An `Observable` that contains the required and [optional parameters](guide/router-tutorial-toh#optional-route-parameters) specific to the route. Use `paramMap` instead.
-
-* `queryParams`: An `Observable` that contains the [query parameters](guide/router-tutorial-toh#query-parameters) available to all routes.
-Use `queryParamMap` instead.
-
-</div>
-
-### Router events
-
-During each navigation, the `Router` emits navigation events through the `Router.events` property.
-These events range from when the navigation starts and ends to many points in between. The full list of navigation events is displayed in the table below.
-
-<table>
-  <tr>
-    <th>
-      Router Event
-    </th>
-
-    <th>
-      Description
-    </th>
-  </tr>
-
-  <tr>
-    <td>
-      <code>NavigationStart</code>
-    </td>
-    <td>
-
-      An [event](api/router/NavigationStart) triggered when navigation starts.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>RouteConfigLoadStart</code>
-    </td>
-    <td>
-
-      An [event](api/router/RouteConfigLoadStart) triggered before the `Router`
-      [lazy loads](guide/router-tutorial-toh#asynchronous-routing) a route configuration.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>RouteConfigLoadEnd</code>
-    </td>
-    <td>
-
-      An [event](api/router/RouteConfigLoadEnd) triggered after a route has been lazy loaded.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>RoutesRecognized</code>
-    </td>
-    <td>
-
-      An [event](api/router/RoutesRecognized) triggered when the Router parses the URL and the routes are recognized.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>GuardsCheckStart</code>
-    </td>
-    <td>
-
-      An [event](api/router/GuardsCheckStart) triggered when the Router begins the Guards phase of routing.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>ChildActivationStart</code>
-    </td>
-    <td>
-
-      An [event](api/router/ChildActivationStart) triggered when the Router begins activating a route's children.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>ActivationStart</code>
-    </td>
-    <td>
-
-      An [event](api/router/ActivationStart) triggered when the Router begins activating a route.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>GuardsCheckEnd</code>
-    </td>
-    <td>
-
-      An [event](api/router/GuardsCheckEnd) triggered when the Router finishes the Guards phase of routing successfully.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>ResolveStart</code>
-    </td>
-    <td>
-
-      An [event](api/router/ResolveStart) triggered when the Router begins the Resolve phase of routing.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>ResolveEnd</code>
-    </td>
-    <td>
-
-      An [event](api/router/ResolveEnd) triggered when the Router finishes the Resolve phase of routing successfuly.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>ChildActivationEnd</code>
-    </td>
-    <td>
-
-      An [event](api/router/ChildActivationEnd) triggered when the Router finishes activating a route's children.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>ActivationEnd</code>
-    </td>
-    <td>
-
-      An [event](api/router/ActivationStart) triggered when the Router finishes activating a route.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>NavigationEnd</code>
-    </td>
-    <td>
-
-      An [event](api/router/NavigationEnd) triggered when navigation ends successfully.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>NavigationCancel</code>
-    </td>
-    <td>
-
-      An [event](api/router/NavigationCancel) triggered when navigation is canceled.
-      This can happen when a [Route Guard](guide/router-tutorial-toh#guards) returns false during navigation,
-      or redirects by returning a `UrlTree`.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>NavigationError</code>
-    </td>
-    <td>
-
-      An [event](api/router/NavigationError) triggered when navigation fails due to an unexpected error.
-
-    </td>
-  </tr>
-
-  <tr>
-    <td>
-      <code>Scroll</code>
-    </td>
-    <td>
-
-      An [event](api/router/Scroll) that represents a scrolling event.
-
-    </td>
-  </tr>
-</table>
-
-When you enable the `enableTracing` option, Angular logs these events to the console.
-For an example of filtering router navigation events, see the [router section](guide/observables-in-angular#router) of the [Observables in Angular](guide/observables-in-angular) guide.
-
-### Router terminology
-
-Here are the key `Router` terms and their meanings:
-
-<table>
-
-  <tr>
-
-    <th>
-      Router Part
-    </th>
-
-    <th>
-      Meaning
-    </th>
-
-  </tr>
-
-  <tr>
-
-    <td>
-      <code>Router</code>
-    </td>
-
-    <td>
-      Displays the application component for the active URL.
-      Manages navigation from one component to the next.
-    </td>
-
-  </tr>
-
-  <tr>
-
-    <td>
-      <code>RouterModule</code>
-    </td>
-
-    <td>
-      A separate NgModule that provides the necessary service providers
-      and directives for navigating through application views.
-    </td>
-
-  </tr>
-
-  <tr>
-
-    <td>
-      <code>Routes</code>
-    </td>
-
-    <td>
-      Defines an array of Routes, each mapping a URL path to a component.
-    </td>
-
-  </tr>
-
-  <tr>
-
-    <td>
-      <code>Route</code>
-    </td>
-
-    <td>
-      Defines how the router should navigate to a component based on a URL pattern.
-      Most routes consist of a path and a component type.
-    </td>
-
-  </tr>
-
-  <tr>
-
-    <td>
-      <code>RouterOutlet</code>
-    </td>
-
-    <td>
-      The directive (<code>&lt;router-outlet></code>) that marks where the router displays a view.
-    </td>
-
-  </tr>
-
-  <tr>
-
-    <td>
-      <code>RouterLink</code>
-    </td>
-
-    <td>
-      The directive for binding a clickable HTML element to a route. Clicking an element with a <code>routerLink</code> directive that is bound to a <i>string</i> or a <i>link parameters array</i> triggers a navigation.
-    </td>
-
-  </tr>
-
-  <tr>
-
-    <td>
-      <code>RouterLinkActive</code>
-    </td>
-
-    <td>
-      The directive for adding/removing classes from an HTML element when an associated <code>routerLink</code> contained on or inside the element becomes active/inactive.
-    </td>
-
-  </tr>
-
-  <tr>
-
-    <td>
-      <code>ActivatedRoute</code>
-    </td>
-
-    <td>
-      A service that is provided to each route component that contains route specific information such as route parameters, static data, resolve data, global query params, and the global fragment.
-    </td>
-
-  </tr>
-
-  <tr>
-
-    <td>
-      <code>RouterState</code>
-    </td>
-
-    <td>
-      The current state of the router including a tree of the currently activated routes together with convenience methods for traversing the route tree.
-    </td>
-
-  </tr>
-
-  <tr>
-
-    <td>
-      <b><i>Link parameters array</i></b>
-    </td>
-
-    <td>
-      An array that the router interprets as a routing instruction.
-      You can bind that array to a <code>RouterLink</code> or pass the array as an argument to the <code>Router.navigate</code> method.
-    </td>
-
-  </tr>
-
-  <tr>
-
-    <td>
-      <b><i>Routing component</i></b>
-    </td>
-
-    <td>
-      An Angular component with a <code>RouterOutlet</code> that displays views based on router navigations.
-    </td>
-
-  </tr>
-
-</table>
+## Router API summary
+
+The following table lists and defines key API elements provided by the Angular router service.
+
+| Router term | Meaning |
+| :---------- | :------- |
+| [`RouterModule`](api/router/RouterModule) | A separate NgModule that provides the necessary service providers and directives for navigating through application views. |
+| [`Router`](api/router/Router) | The service class that manages navigation from one component to the next and displays the application component for the active URL. |
+| [`Routes`](api/router/Routes) | An array of `Route` objects, each mapping a URL path to a component. |
+| [`Route`](api/router/Route) | An object that defines how the router should navigate to a component based on a URL pattern. Most routes consist of a *path* and a *component* type. |
+| [`RouterOutlet`](api/router/RouterOutlet) | A directive (<code>&lt;router-outlet></code>) that marks where the router displays a view. A component whose template contains a `routerOutlet` directive is a [routing component](guide/glossary#routing-component "Definition of routing component"). |
+| [`RouterLink`](api/router/RouterLink) | A directive that binds a clickable HTML element to a route. A user triggers navigation by clicking an element with a <code>[routerLink]</code> directive that is bound to a simple route path string, or a [link parameters array](guide/glossary#link-parameters-array "Definition"). You can also initiate navigation programmatically by passing a link parameters array to the [Router.navigate()](api/router/Router#navigate) method. |
+| [`RouterLinkActive`](api/router/RouterLinkActive) | A directive for adding or removing CSS classes on an HTML element when the route for an associated `routerLink` contained on or inside the element becomes active or inactive. |
+| [`ActivatedRoute`](api/router/ActivatedRoute) | A service that is provided to each route component, which contains route-specific information such as route parameters, static data, resolve data, global query parameters, and the global fragment. |
+| [`RouterState`](api/router/RouterState) | Represents the current state of the router, including a tree of the currently activated routes together with convenience methods for traversing the route tree. |
+| [`NavigationExtras`](api/router/NavigationExtras) | A configuration options object that you can pass to a `Router.navigate()` call to control how the URL is constructed for that operation. |

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -778,8 +778,8 @@ Route guard functions implement the following interfaces:
 * [`CanActivate`](api/router/CanActivate)
 * [`CanActivateChild`](api/router/CanActivateChild)
 * [`CanDeactivate`](api/router/CanDeactivate)
-* [`Resolve`](api/router/Resolve)
 * [`CanLoad`](api/router/CanLoad)
+* [`Resolve`](api/router/Resolve)
 
 You can have multiple guards at every level of a navigation hierarchy.
 The router checks the `CanDeactivate` and `CanActivateChild` guards first, from the deepest child route to the top.
@@ -787,7 +787,15 @@ Then it checks the `CanActivate` guards from the top down to the deepest child r
 If the feature module is loaded asynchronously, the `CanLoad` guard is checked before the module is loaded.
 If _any_ guard returns false, pending guards that have not completed are canceled, and the entire navigation is canceled.
 
+If you specify both guards and resolvers for any routes, all guards must run and succeed for a given route hierarchy before the resolvers run.
+For example, consider a route configuration with route A, child of route A, route B, and child of route B.
+The order of execution is: A(guards), A child(guards), A(resolvers), B(guards), B child(guards), B(resolvers).
+
+<div class="alert is-helpful">
+
 Consider using [componentless routes](#nesting-routes) to more easily control access to child routes.  A componentless route is a `Route` object that has a base path but no component; it serves as a container for a set of related child routes.
+
+</div>
 
 ### Creating a guard service
 

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -96,10 +96,10 @@ When the browser's URL changes, that router looks for a corresponding `Route` fr
 
 ### Structuring an application for routing
 
-An application that supports navigation should have a dedicated [routing module](guide/glossary#routing-module "Definition of routing module") that imports `RouterModule` and `Routes`.
-When you create a new project with the CLI `--routing` option, the application includes a routing module named `AppRoutingModule` and imports it into the root module.
+An application that supports navigation can have dedicated NgModules for the routing configuration.
+When you create a new project with the CLI `--routing` option, the application includes a routing module named `AppRoutingModule` and imports it into the root module. The routing module imports `RouterModule` and `Routes`.
 
-A routing module is an NgModule that contains an application's routing configuration. A dedicated routing module does not declare components, but serves to separate routing concerns from other application concerns. It provides a well-known location for routing service providers such as guards and resolvers. A routing module is also easy to replace or remove when testing the application.
+A dedicated routing module does not declare components, but serves to separate routing concerns from other application concerns. It provides a well-known location for routing service providers such as guards and resolvers. A routing module is also easy to replace or remove when testing the application.
 
 <div class="alert is-helpful">
 
@@ -924,7 +924,7 @@ The following table lists and defines key API elements provided by the Angular r
 | [`Routes`](api/router/Routes) | An array of `Route` objects, each mapping a URL path to a component. |
 | [`Route`](api/router/Route) | An object that defines how the router should navigate to a component based on a URL pattern. Most routes consist of a *path* and a *component* type. |
 | [`RouterOutlet`](api/router/RouterOutlet) | A directive (<code>&lt;router-outlet></code>) that marks where the router displays a view. A component whose template contains a `routerOutlet` directive is a [routing component](guide/glossary#routing-component "Definition of routing component"). |
-| [`RouterLink`](api/router/RouterLink) | A directive that binds a clickable HTML element to a route. A user triggers navigation by clicking an element with a <code>[routerLink]</code> directive that is bound to a simple route path string, or a [link parameters array](guide/glossary#link-parameters-array "Definition"). You can also initiate navigation programmatically by passing a link parameters array to the [Router.navigate()](api/router/Router#navigate) method. |
+| [`RouterLink`](api/router/RouterLink) | A directive that binds a clickable HTML element to a route. A user triggers navigation by clicking an element with a <code>[routerLink]</code> directive that is bound to a simple route path string, or a [link parameters array](#link-parameters-array "Definition"). You can also initiate navigation programmatically by passing a link parameters array to the [Router.navigate()](api/router/Router#navigate) method. |
 | [`RouterLinkActive`](api/router/RouterLinkActive) | A directive for adding or removing CSS classes on an HTML element when the route for an associated `routerLink` contained on or inside the element becomes active or inactive. |
 | [`ActivatedRoute`](api/router/ActivatedRoute) | A service that is provided to each route component, which contains route-specific information such as route parameters, static data, resolve data, global query parameters, and the global fragment. |
 | [`RouterState`](api/router/RouterState) | Represents the current state of the router, including a tree of the currently activated routes together with convenience methods for traversing the route tree. |

--- a/aio/content/guide/testing-components-scenarios.md
+++ b/aio/content/guide/testing-components-scenarios.md
@@ -1120,7 +1120,7 @@ for the `id` to change during its lifetime.
 
 <div class="alert is-helpful">
 
-The [ActivatedRoute in action](guide/router-tutorial-toh#activated-route-in-action) section of the [Router tutorial: tour of heroes](guide/router-tutorial-toh) guide covers `ActivatedRoute.paramMap` in more detail.
+The [Routing and Navigation](guide/router) guide covers `ActivatedRoute.paramMap` in more detail. See [Retrieving parameters from parameter maps](guide/router#param-maps).
 
 </div>
 

--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -289,5 +289,3 @@ After you've set up your app for testing, you may find the following testing  gu
 * [Testing pipes](guide/testing-pipes)&mdash;find out how to test attribute directives.
 * [Debugging tests](guide/testing-attribute-directives)&mdash;uncover common testing bugs.
 * [Testing utility APIs](guide/testing-utility-apis)&mdash;get familiar with Angular testing features.
-
-

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -793,9 +793,9 @@
               "tooltip": "A tutorial that covers many patterns associated with Angular routing."
             },
             {
-              "url": "guide/router-tutorial-toh",
-              "title": "Router tutorial: tour of heroes",
-              "tooltip": "Explore how to use Angular's router. Based on the Tour of Heroes example."
+              "url": "guide/router-techniques",
+              "title": "Routing Techniques",
+              "tooltip": "Extend the example to learn more about complex routes and control access to views."
             }
           ]
         },


### PR DESCRIPTION
- Moves the large tutorial from the middle of the router guide to a separate page in the tutorial section. Moves conceptual material from that back into the guide. Organizes the tutorial into major sections of related concepts, and edits content to be more specifically tutorial-style.
- Edits guide content for structure, style, and clarity, removing redundancy. 
- Adds router terms to Glossary.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The current guide, https://angular.io/guide/router, has a very long detailed tutorial in the middle.
Current doc standards call for stand-alone tutorials. 
The guide also uses old styles, has a confused structure, and copies reference information directly from the API doc.

Issue Number: N/A


## What is the new behavior?
* Creates a new page for the tutorial in the Tutorials section
* Updates some (not all) page content for structure and style, replacing redundant API content with appropriate links.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
