### PR TITLE
fix(router): fix navigation ignoring logic to compare to the browser url

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1128,10 +1128,13 @@ export class Router {
       priorPromise?: {resolve: any, reject: any, promise: Promise<boolean>}): Promise<boolean> {
     const lastNavigation = this.getTransition();
     // If the user triggers a navigation imperatively (e.g., by using navigateByUrl),
-    // and that navigation results in 'replaceState' that leads to the same URL,
-    // we should skip those.
+    // and that navigation results in another navigation that leads to the same URL,
+    // we should skip those. Additionally, we compare to `urlAfterRedirects` because
+    // that is the final result of the imperative navigation. If an imperative navigation is
+    // cancelled by a guard and followed by a back/forward button or manual URL change, we should
+    // not skip those navigations so we need to check against `urlAfterRedirects`.
     if (lastNavigation && source !== 'imperative' && lastNavigation.source === 'imperative' &&
-        lastNavigation.rawUrl.toString() === rawUrl.toString()) {
+        lastNavigation.urlAfterRedirects.toString() === rawUrl.toString()) {
       return Promise.resolve(true);  // return value is not used
     }
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1137,8 +1137,10 @@ export class Router {
     //   navigation.
     // Note that imperative navs might only trigger a popstate in tests because the
     // SpyLocation triggers it on replaceState. Real browsers don't; see #27059.
-    if (lastNavigation && source !== 'imperative' && lastNavigation.source === 'imperative' &&
-        lastNavigation.urlAfterRedirects.toString() === rawUrl.toString()) {
+    const navigationToSameUrl = lastNavigation.urlAfterRedirects.toString() === rawUrl.toString();
+    const browserNavPrecededByRouterNav =
+        lastNavigation && source !== 'imperative' && lastNavigation.source === 'imperative';
+    if (browserNavPrecededByRouterNav && navigationToSameUrl) {
       return Promise.resolve(true);  // return value is not used
     }
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1127,12 +1127,16 @@ export class Router {
       extras: NavigationExtras,
       priorPromise?: {resolve: any, reject: any, promise: Promise<boolean>}): Promise<boolean> {
     const lastNavigation = this.getTransition();
-    // If the user triggers a navigation imperatively (e.g., by using navigateByUrl),
-    // and that navigation results in another navigation that leads to the same URL,
-    // we should skip those. Additionally, we compare to `urlAfterRedirects` because
-    // that is the final result of the imperative navigation. If an imperative navigation is
-    // cancelled by a guard and followed by a back/forward button or manual URL change, we should
-    // not skip those navigations so we need to check against `urlAfterRedirects`.
+    // * Imperative navigations (router.navigate) might trigger additional navigations to the same
+    //   URL via a popstate event and the locationChangeListener. We should skip these duplicate
+    //   navs.
+    // * Imperative navigations can be cancelled by router guards, meaning the URL won't change. If
+    //   the user follows that with a navigation using the back/forward button or manual URL change,
+    //   the destination may be the same as the previous imperative attempt. We should not skip
+    //   these navigations because it's a separate case from the one above -- it's not a duplicate
+    //   navigation.
+    // Note that imperative navs might only trigger a popstate in tests because the
+    // SpyLocation triggers it on replaceState. Real browsers don't; see #27059.
     if (lastNavigation && source !== 'imperative' && lastNavigation.source === 'imperative' &&
         lastNavigation.urlAfterRedirects.toString() === rawUrl.toString()) {
       return Promise.resolve(true);  // return value is not used


### PR DESCRIPTION
This PR changes the logic for determining when to skip route processing from
using the URL of the last attempted navigation to the actual resulting URL after
that transition.

Because guards may prevent navigation and reset the browser URL, the raw
URL of the previous transition may not match the actual URL of the
browser at the end of the navigation process. For that reason, we need to use
`urlAfterRedirects` instead.

Other notes:
* These checks in `scheduleNavigation` were added in https://github.com/angular/angular/commit/eb2ceff4ba19a09a5f400f81e371ec176878cd37
The test still passes and, more surprisingly, passes if the checks are removed
completely. There have likely been changes to the navigation handling that
handle the test in a different way. That said, it still appears to be important
to keep the checks there in some capacity because it does affect how many
navigation events occur. 
* This addresses an issue that came up in #16710: https://github.com/angular/angular/issues/16710#issuecomment-634869739
* This also partially addresses #13586 in fixing history for imperative
navigations that are cancelled by guards.

