### PR TITLE
fix(forms): typing of NG_VALUE_ACCESSOR

### DIFF
--- a/packages/forms/src/directives/control_value_accessor.ts
+++ b/packages/forms/src/directives/control_value_accessor.ts
@@ -138,4 +138,4 @@ export interface ControlValueAccessor {
  *
  * @publicApi
  */
-export const NG_VALUE_ACCESSOR = new InjectionToken<ControlValueAccessor>('NgValueAccessor');
+export const NG_VALUE_ACCESSOR = new InjectionToken<ControlValueAccessor[]>('NgValueAccessor');


### PR DESCRIPTION
since NG_VALUE_ACCESSOR are provided with `multi = true`, the injector will return an Array of ControlValueAccessor

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using the injection token NG_VALUE_ACCESSOR with the injector.get Method, the
typings suggest that the Type of the return value is `ControlValueAccessor`, when in fact
it is `ControlValueAccessor[]`

## What is the new behavior?
When using the injection token NG_VALUE_ACCESSOR with the injector.get Method, the return
value is correctly typed as `ControlValueAccessor[]`


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
