### PR TITLE
feat(elements): add ComponentNgElementStrategy to public API

### DIFF
--- a/goldens/public-api/elements/elements.d.ts
+++ b/goldens/public-api/elements/elements.d.ts
@@ -1,3 +1,25 @@
+export declare class ComponentNgElementStrategy implements NgElementStrategy {
+    events: Observable<NgElementStrategyEvent>;
+    constructor(componentFactory: ComponentFactory<any>, injector: Injector);
+    protected callNgOnChanges(): void;
+    connect(element: HTMLElement): void;
+    protected detectChanges(): void;
+    disconnect(): void;
+    getInputValue(property: string): any;
+    protected initializeComponent(element: HTMLElement): void;
+    protected initializeInputs(): void;
+    protected initializeOutputs(): void;
+    protected recordInputChange(property: string, currentValue: any): void;
+    protected scheduleDetectChanges(): void;
+    setInputValue(property: string, value: any): void;
+}
+
+export declare class ComponentNgElementStrategyFactory implements NgElementStrategyFactory {
+    componentFactory: ComponentFactory<any>;
+    constructor(component: Type<any>, injector: Injector);
+    create(injector: Injector): ComponentNgElementStrategy;
+}
+
 export declare function createCustomElement<P>(component: Type<any>, config: NgElementConfig): NgElementConstructor<P>;
 
 export declare abstract class NgElement extends HTMLElement {

--- a/packages/elements/public_api.ts
+++ b/packages/elements/public_api.ts
@@ -11,6 +11,7 @@
  * @description
  * Entry point for all public APIs of the `elements` package.
  */
+export {ComponentNgElementStrategy, ComponentNgElementStrategyFactory} from './src/component-factory-strategy';
 export {createCustomElement, NgElement, NgElementConfig, NgElementConstructor, WithProperties} from './src/create-custom-element';
 export {NgElementStrategy, NgElementStrategyEvent, NgElementStrategyFactory} from './src/element-strategy';
 export {VERSION} from './src/version';


### PR DESCRIPTION
Adds ComponentNgElementStrategy, ComponentNgElementStrategyFactory to the public API,
allowing third-party libraries to extend the default strategy behavior
(api docs to come in a separate PR)

Fixes #26112, #33490

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [#26112](https://github.com/angular/angular/issues/26112), [#33490](https://github.com/angular/angular/issues/33490)


## What is the new behavior?
ComponentNgElementStrategy, ComponentNgElementStrategyFactory are now public

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
