### PR TITLE
refactor(router): remove duplicate type from the LoadChildrenCallback

### DIFF
--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -153,7 +153,8 @@ export declare type InitialNavigation = true | false | 'enabled' | 'disabled' | 
 
 export declare type LoadChildren = LoadChildrenCallback | DeprecatedLoadChildren;
 
-export declare type LoadChildrenCallback = () => Type<any> | NgModuleFactory<any> | Observable<Type<any>> | Promise<NgModuleFactory<any> | Type<any> | any>;
+export declare type LoadChildrenCallback = () =>
+    Type<any> | NgModuleFactory<any> | Observable<Type<any>> | Promise<NgModuleFactory<any> | any>;
 
 export declare type Navigation = {
     id: number;

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -110,8 +110,8 @@ export type ResolveData = {
  * @see `Route#loadChildren`.
  * @publicApi
  */
-export type LoadChildrenCallback = () => Type<any>|NgModuleFactory<any>|Observable<Type<any>>|
-    Promise<NgModuleFactory<any>|Type<any>|any>;
+export type LoadChildrenCallback = () =>
+    Type<any>|NgModuleFactory<any>|Observable<Type<any>>|Promise<NgModuleFactory<any>|any>;
 
 /**
  *


### PR DESCRIPTION
This removes the duplicated `Type<any>` from the `LoadChildrenCallback` type literal used in Route#loadChildren.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe:


## What is the current behavior?
The _type_ `LoadChildrenCallback` has a duplicate `Type<any>`.


## What is the new behavior?
The _type_ `LoadChildrenCallback` has no duplicate `Type<any>`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No