### PR TITLE
feat(dev-infra): Add oauth scope check to ensure necessary permissions for merge tooling

### DIFF
--- a/dev-infra/pr/merge/failures.ts
+++ b/dev-infra/pr/merge/failures.ts
@@ -71,9 +71,9 @@ export class PullRequestFailure {
     return new this(`Pull request could not be found upstream.`);
   }
 
-  static insufficientPermissionsToMerge() {
-    return new this(
-        `Insufficient Github API permissions to merge pull request. Please ` +
-        `ensure that your auth token has write access.`);
+  static insufficientPermissionsToMerge(
+      message = `Insufficient Github API permissions to merge pull request. Please ensure that ` +
+          `your auth token has write access.`) {
+    return new this(message);
   }
 }

--- a/dev-infra/pr/merge/git.ts
+++ b/dev-infra/pr/merge/git.ts
@@ -49,7 +49,7 @@ export class GitClient {
   api: Octokit;
 
   /** The OAuth scopes available for the provided Github token. */
-  private _oauthScopes: Promise<string[]>;
+  private _oauthScopes = Promise.resolve<string[]>([]);
   /** Regular expression that matches the provided Github token. */
   private _tokenRegex = new RegExp(this._githubToken, 'g');
 

--- a/dev-infra/pr/merge/index.ts
+++ b/dev-infra/pr/merge/index.ts
@@ -110,6 +110,10 @@ export async function mergePullRequest(
             red('An unknown Git error has been thrown. Please check the output ' +
                 'above for details.'));
         return false;
+      case MergeStatus.GITHUB_ERROR:
+        error(red('An error related to interacting with Github has been discovered.'));
+        error(failure!.message);
+        return false;
       case MergeStatus.FAILED:
         error(yellow(`Could not merge the specified pull request.`));
         error(red(failure!.message));

--- a/dev-infra/pr/merge/task.ts
+++ b/dev-infra/pr/merge/task.ts
@@ -13,6 +13,9 @@ import {isPullRequest, loadAndValidatePullRequest,} from './pull-request';
 import {GithubApiMergeStrategy} from './strategies/api-merge';
 import {AutosquashMergeStrategy} from './strategies/autosquash-merge';
 
+/** Github OAuth scopes required for the merge task. */
+const REQUIRED_SCOPES = ['repo'];
+
 /** Describes the status of a pull request merge. */
 export const enum MergeStatus {
   UNKNOWN_GIT_ERROR,
@@ -48,6 +51,9 @@ export class PullRequestMergeTask {
    * @param force Whether non-critical pull request failures should be ignored.
    */
   async merge(prNumber: number, force = false): Promise<MergeResult> {
+    // Assert the authenticated GitClient has access on the required scopes.
+    await this.git.assertOauthScopes(...REQUIRED_SCOPES);
+
     if (this.git.hasUncommittedChanges()) {
       return {status: MergeStatus.DIRTY_WORKING_DIR};
     }


### PR DESCRIPTION
Adds an assertion that the provided TOKEN has OAuth scope permissions for `repo`
as this is required for all merge attempts.

On failure, provides detailed error message with remediation steps for the user.


Addresses DEV-108