### PR TITLE
docs: update file header to be correct

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/api/src/adapter.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/adapter.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license


### PR DESCRIPTION
The file header should be Google LLC rather than Google Inc. because it is now an LLC after Alphabet Holdings was formed.
