### PR TITLE
ci(docs-infra): skip deploying RC version when lexicographically smaller than stable

### DIFF
--- a/aio/scripts/deploy-to-firebase.sh
+++ b/aio/scripts/deploy-to-firebase.sh
@@ -33,7 +33,7 @@ else
   readonly majorVersionStable=${CI_STABLE_BRANCH%%.*}
 
   # Do not deploy if the major version is not less than the stable branch major version
-  if [[ !( "$majorVersion" < "$majorVersionStable" ) ]]; then
+  if [[ !( "$majorVersion" -lt "$majorVersionStable" ) ]]; then
     echo "Skipping deploy of branch \"$CI_BRANCH\" to firebase."
     echo "We only deploy archive branches with the major version less than the stable branch: \"$CI_STABLE_BRANCH\""
     exit 0


### PR DESCRIPTION
The angular.io production deployment script (`deploy-to-firebase.sh`) compares the major version corresponding to the current branch (e.g. `8` for branch `8.1.x`) against the major stable version (e.g. `9` if the current stable version is `9.1.0`). It then uses the result of that comparison to determine whether the current branch corresponds to a newer version than stable (i.e. an RC version) and thus should not be deployed or to an older version and thus may need to be deployed to an archive vX.angular.io project.

Previously, the script was using string comparison (`<`) to compare the two major versions. This could produce incorrect results for an RC major version that is numerically greater than the stable but lexicographically smaller. For example, 10 vs 9 (10 is numerically greater but lexicographically smaller than 9).
Example of a CI job that incorrectly tried to deploy an RC branch to production: https://circleci.com/gh/angular/angular/726414

This commit fixes it by switching to an integer comparison (i.e. using the `-lt` operator).
