### PR TITLE
fix(language-service): show element selectors only in element autocomplete

### DIFF
--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -181,6 +181,7 @@ export enum CompletionKind {
   ANGULAR_ELEMENT = 'angular element',
   ATTRIBUTE = 'attribute',
   COMPONENT = 'component',
+  DIRECTIVE = 'directive',
   ELEMENT = 'element',
   ENTITY = 'entity',
   HTML_ATTRIBUTE = 'html attribute',
@@ -267,12 +268,6 @@ export interface AstResult {
   expressionParser: Parser;
   template: TemplateSource;
 }
-
-/** Information about a directive's selectors. */
-export type SelectorInfo = {
-  selectors: CssSelector[],
-  map: Map<CssSelector, CompileDirectiveSummary>
-};
 
 export interface SymbolInfo {
   symbol: Symbol;

--- a/packages/language-service/src/utils.ts
+++ b/packages/language-service/src/utils.ts
@@ -7,7 +7,7 @@
  */
 
 import {AstPath, BoundEventAst, CompileDirectiveSummary, CompileTypeMetadata, CssSelector, DirectiveAst, ElementAst, EmbeddedTemplateAst, HtmlAstPath, identifierName, Identifiers, Node, ParseSourceSpan, RecursiveTemplateAstVisitor, RecursiveVisitor, TemplateAst, TemplateAstPath, templateVisitAll, visitAll} from '@angular/compiler';
-import {AstResult, DiagnosticTemplateInfo, SelectorInfo, Span, Symbol, SymbolQuery} from './types';
+import {AstResult, DiagnosticTemplateInfo, Span, Symbol, SymbolQuery} from './types';
 
 interface SpanHolder {
   sourceSpan: ParseSourceSpan;
@@ -64,17 +64,23 @@ export function isStructuralDirective(type: CompileTypeMetadata): boolean {
   return false;
 }
 
-export function getSelectors(info: AstResult): SelectorInfo {
-  const map = new Map<CssSelector, CompileDirectiveSummary>();
-  const results: CssSelector[] = [];
-  for (const directive of info.directives) {
+/**
+ * Extract all selectors from the specified `directives`.
+ * @param directives a list of directives (including components)
+ * @param isElementSelector if true, retain element selectors only
+ */
+export function getSelectorMap(directives: CompileDirectiveSummary[], isElementSelector: boolean) {
+  const selectorMap = new Map<CssSelector, CompileDirectiveSummary>();
+  for (const directive of directives) {
     const selectors: CssSelector[] = CssSelector.parse(directive.selector!);
     for (const selector of selectors) {
-      results.push(selector);
-      map.set(selector, directive);
+      if (selector.isElementSelector() !== isElementSelector) {
+        continue;
+      }
+      selectorMap.set(selector, directive);
     }
   }
-  return {selectors: results, map};
+  return selectorMap;
 }
 
 export function diagnosticInfoFromTemplateInfo(info: AstResult): DiagnosticTemplateInfo {

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -15,9 +15,7 @@ import {TypeScriptServiceHost} from '../src/typescript_host';
 import {MockTypescriptHost} from './test_utils';
 
 const APP_COMPONENT = '/app/app.component.ts';
-const PARSING_CASES = '/app/parsing-cases.ts';
 const TEST_TEMPLATE = '/app/test.ng';
-const EXPRESSION_CASES = '/app/expression-cases.ts';
 
 describe('completions', () => {
   const mockHost = new MockTypescriptHost(['/app/main.ts']);
@@ -45,12 +43,15 @@ describe('completions', () => {
   });
 
   it('should be able to return component directives', () => {
-    const marker = mockHost.getLocationMarkerFor(APP_COMPONENT, 'empty');
+    mockHost.overrideInlineTemplate(APP_COMPONENT, '<~{cursor}');
+    const marker = mockHost.getLocationMarkerFor(APP_COMPONENT, 'cursor');
     const completions = ngLS.getCompletionsAtPosition(APP_COMPONENT, marker.start);
+    expectContain(completions, CompletionKind.DIRECTIVE, [
+      'ng-form',  // from directive NgForm in ng_form.ts
+    ]);
     expectContain(completions, CompletionKind.COMPONENT, [
-      'ng-form',
       'my-app',
-      'ng-component',
+      'my-comp',
       'test-comp',
     ]);
   });
@@ -255,12 +256,22 @@ describe('completions', () => {
     });
 
     it('should be able to return element directives', () => {
-      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'empty');
+      mockHost.override(TEST_TEMPLATE, '<~{cursor}');
+      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
       const completions = ngLS.getCompletionsAtPosition(TEST_TEMPLATE, marker.start);
+      expect(completions?.entries.length).toBe(8);
+      expectContain(completions, CompletionKind.ANGULAR_ELEMENT, [
+        'ng-container',
+        'ng-content',
+        'ng-template',
+      ]);
+      expectContain(completions, CompletionKind.DIRECTIVE, [
+        'ng-form',  // from directive NgForm in ng_form.ts
+        'option',   // from directive NgSelectOption in select_control_value_accessor.ts
+      ]);
       expectContain(completions, CompletionKind.COMPONENT, [
-        'ng-form',
         'my-app',
-        'ng-component',
+        'my-comp',
         'test-comp',
       ]);
     });

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -82,6 +82,7 @@ export class TestComponent {
 } /*EndTestComponent*/
 
 @Component({
+  selector: 'my-comp',
   templateUrl: 'test.ng',
 })
 export class TemplateReference {


### PR DESCRIPTION
This commit fixes a bug whereby element in CSS selectors like `form` in
the selector of the `NgForm` directive

```ts
@Directive({
  selector: 'form:not([ngNoForm]):not([formGroup]),ng-form,[ngForm]',
  // ...
})
export class NgForm extends ControlContainer implements Form, AfterViewInit {
```

are inadvertently included in the autocomplete results for a HTML
element. Only component selectors and element selectors in directives
should be included in the results.

In addition, this commit assigns a selector to the `TemplateReference`
class. Without an explicit `selector`, Angular assigns the generic
name `ng-component`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
