### PR TITLE
fix(router): merge query params from previous url after navigation from a resolver

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -577,6 +577,7 @@ export class Router {
                          rawUrl: rawUrlTree,
                          extras: {skipLocationChange, replaceUrl}
                        } = t;
+                       this.currentUrlTree = t.urlAfterRedirects;
                        return this.hooks.beforePreactivation(targetSnapshot!, {
                          navigationId,
                          appliedUrlTree,
@@ -699,7 +700,6 @@ export class Router {
                         URL and the RouterState, as well as updated the browser URL. All this should
                         happen *before* activating. */
                      tap((t: NavigationTransition) => {
-                       this.currentUrlTree = t.urlAfterRedirects;
                        this.rawUrlTree =
                            this.urlHandlingStrategy.merge(this.currentUrlTree, t.rawUrl);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Router uses old query params after navigation from a resolver.

Issue Number: https://github.com/angular/angular/issues/34675


## What is the new behavior?
Merge query params from previous url after navigation from a resolver.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No