### PR TITLE
fix(ngcc): find decorated constructor params on IIFE wrapped classes

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -866,10 +866,10 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
   /**
    * Try to retrieve the symbol of a static property on a class.
    *
-   * In some cases, a static property can either be set on the inner declaration inside the class'
-   * IIFE, or it can be set on the outer variable declaration. Therefore, the host checks both
-   * places, first looking up the property on the inner symbol, and if the property is not found it
-   * will fall back to looking up the property on the outer symbol.
+   * In some cases, a static property can either be set on the inner (implementation or adjacent)
+   * declaration inside the class' IIFE, or it can be set on the outer variable declaration.
+   * Therefore, the host checks all places, first looking up the property on the inner symbols, and
+   * if the property is not found it will fall back to looking up the property on the outer symbol.
    *
    * @param symbol the class whose property we are interested in.
    * @param propertyName the name of static property.
@@ -877,8 +877,9 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
    */
   protected getStaticProperty(symbol: NgccClassSymbol, propertyName: ts.__String): ts.Symbol
       |undefined {
-    return symbol.implementation.exports && symbol.implementation.exports.get(propertyName) ||
-        symbol.declaration.exports && symbol.declaration.exports.get(propertyName);
+    return symbol.implementation.exports?.get(propertyName) ||
+        symbol.adjacent?.exports?.get(propertyName) ||
+        symbol.declaration.exports?.get(propertyName);
   }
 
   /**


### PR DESCRIPTION
Now in TS 3.9, classes in ES2015 can be wrapped in an IIFE.
This commit ensures that we still find the static properties that contain
decorator information, even if they are attached to the adjacent node
of the class, rather than the implementation or declaration.

Fixes #37330

I have checked locally and this allows the reproduction in #37330 to build without error.