### PR TITLE
feat(language-service): TS references from template items

### DIFF
--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -101,7 +101,7 @@ class LanguageServiceImpl implements ng.LanguageService {
 
   getReferencesAtPosition(fileName: string, position: number): tss.ReferenceEntry[]|undefined {
     const defAndSpan = this.getDefinitionAndBoundSpan(fileName, position);
-    if (!defAndSpan || !defAndSpan.definitions) {
+    if (!defAndSpan?.definitions) {
       return;
     }
     const {definitions} = defAndSpan;
@@ -109,6 +109,6 @@ class LanguageServiceImpl implements ng.LanguageService {
     if (!tsDef) {
       return;
     }
-    return this.host.getReferencesAtPosition(tsDef.fileName, tsDef.textSpan.start);
+    return this.host.tsLS.getReferencesAtPosition(tsDef.fileName, tsDef.textSpan.start);
   }
 }

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -98,4 +98,17 @@ class LanguageServiceImpl implements ng.LanguageService {
     const declarations = this.host.getDeclarations(fileName);
     return getTsHover(position, declarations, analyzedModules);
   }
+
+  getReferencesAtPosition(fileName: string, position: number): tss.ReferenceEntry[]|undefined {
+    const defAndSpan = this.getDefinitionAndBoundSpan(fileName, position);
+    if (!defAndSpan || !defAndSpan.definitions) {
+      return;
+    }
+    const {definitions} = defAndSpan;
+    const tsDef = definitions.find(def => def.fileName.endsWith('.ts'));
+    if (!tsDef) {
+      return;
+    }
+    return this.host.getReferencesAtPosition(tsDef.fileName, tsDef.textSpan.start);
+  }
 }

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -254,7 +254,7 @@ export interface Diagnostic {
 export type LanguageService = Pick<
     ts.LanguageService,
     'getCompletionsAtPosition'|'getDefinitionAndBoundSpan'|'getQuickInfoAtPosition'|
-    'getSemanticDiagnostics'>;
+    'getSemanticDiagnostics'|'getReferencesAtPosition'>;
 
 /** Information about an Angular template AST. */
 export interface AstResult {

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -359,6 +359,10 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
     return program;
   }
 
+  getReferencesAtPosition(fileName: string, position: number): tss.ReferenceEntry[]|undefined {
+    return this.tsLS.getReferencesAtPosition(fileName, position);
+  }
+
   /**
    * Return the TemplateSource if `node` is a template node.
    *

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -72,8 +72,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
     ngModules: [],
   };
 
-  constructor(
-      readonly tsLsHost: tss.LanguageServiceHost, private readonly tsLS: tss.LanguageService) {
+  constructor(readonly tsLsHost: tss.LanguageServiceHost, readonly tsLS: tss.LanguageService) {
     this.summaryResolver = new AotSummaryResolver(
         {
           loadSummary(_filePath: string) {
@@ -357,10 +356,6 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
       throw new Error('No program in language service!');
     }
     return program;
-  }
-
-  getReferencesAtPosition(fileName: string, position: number): tss.ReferenceEntry[]|undefined {
-    return this.tsLS.getReferencesAtPosition(fileName, position);
   }
 
   /**

--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -29,6 +29,7 @@ ts_library(
         "definitions_spec.ts",
         "diagnostics_spec.ts",
         "hover_spec.ts",
+        "references_spec.ts",
     ],
     data = [":project"],
     deps = [

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -71,7 +71,7 @@ describe('definitions', () => {
 
     const fileContent = mockHost.readFile(def.fileName);
     expect(fileContent!.substring(def.textSpan.start, def.textSpan.start + def.textSpan.length))
-        .toEqual(`title = 'Some title';`);
+        .toEqual(`title = 'Tour of Heroes';`);
   });
 
   it('should be able to find a method from a call', () => {

--- a/packages/language-service/test/project/app/app.component.ts
+++ b/packages/language-service/test/project/app/app.component.ts
@@ -31,4 +31,7 @@ export class AppComponent {
   title = 'Tour of Heroes';
   hero: Hero = {id: 1, name: 'Windstorm'};
   private internal: string = 'internal';
+  setTitle(newTitle: string) {
+    this.title = newTitle;
+  }
 }

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -107,4 +107,7 @@ export class TemplateReference {
   constNames = [{name: 'name'}] as const;
   private myField = 'My Field';
   strOrNumber: string|number = '';
+  setTitle(newTitle: string) {
+    this.title = newTitle;
+  }
 }

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -88,7 +88,7 @@ export class TemplateReference {
   /**
    * This is the title of the `TemplateReference` Component.
    */
-  title = 'Some title';
+  title = 'Tour of Heroes';
   hero: Hero = {id: 1, name: 'Windstorm'};
   heroP = Promise.resolve(this.hero);
   heroes: Hero[] = [this.hero];

--- a/packages/language-service/test/references_spec.ts
+++ b/packages/language-service/test/references_spec.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {createLanguageService} from '../src/language_service';
+import {TypeScriptServiceHost} from '../src/typescript_host';
+
+import {MockTypescriptHost} from './test_utils';
+
+describe('references', () => {
+  const mockHost = new MockTypescriptHost(['/app/main.ts']);
+  const tsLS = ts.createLanguageService(mockHost);
+  const ngHost = new TypeScriptServiceHost(mockHost, tsLS);
+  const ngLS = createLanguageService(ngHost);
+
+  beforeEach(() => {
+    mockHost.reset();
+  });
+
+  describe('component members', () => {
+    it('should get TS references for a member in template', () => {
+      const fileName = mockHost.addCode(`
+        @Component({
+          template: '{{«title»}}'
+        })
+        export class MyComponent {
+          /*1*/title: string;
+
+          setTitle(newTitle: string) {
+            this./*2*/title = newTitle;
+          }
+        }`);
+      const content = mockHost.readFile(fileName)!;
+
+      const varName = 'title';
+      const marker = mockHost.getReferenceMarkerFor(fileName, varName);
+
+      const references = ngLS.getReferencesAtPosition(fileName, marker.start)!;
+      expect(references).toBeDefined();
+      expect(references.length).toBe(2);
+
+      for (let i = 0; i < references.length; ++i) {
+        const comment = `/*${i + 1}*/`;
+        const start = content.indexOf(comment) + comment.length;
+        expect(references[i].fileName).toBe(fileName);
+        expect(references[i].textSpan.start).toBe(start);
+        expect(references[i].textSpan.length).toBe(varName.length);
+      }
+    });
+  });
+});

--- a/packages/language-service/test/references_spec.ts
+++ b/packages/language-service/test/references_spec.ts
@@ -37,8 +37,16 @@ describe('references', () => {
           expect(references).toBeDefined();
           expect(references.length).toBe(2);
 
-          for (const reference of references) {
-            expect(getSource(reference)).toBe('title');
+          for (let i = 0; i < references.length; ++i) {
+            // The first reference is declared as a class member.
+            // The second is in `setTitle`.
+            const ref = references[i];
+            expect(getSource(ref)).toBe('title');
+            if (i == 0) {
+              // The first reference is the member declaration, so it should
+              // have a context span pointing to the whole declaration.
+              expect(getSource(ref, 'contextSpan')).toBe('title = \'Tour of Heroes\';');
+            }
           }
         });
       });
@@ -53,11 +61,18 @@ describe('references', () => {
         mockHost.override(TEST_TEMPLATE, template);
         return TEST_TEMPLATE;
       }
-    }
+    };
   }
 
-  function getSource({fileName, textSpan}: ts.ReferenceEntry): string {
+  /**
+   * Gets the source code of a reference entry. By default the reference
+   * `textSpan` is checked, but this can be overridden by specifying `spanKind`.
+   */
+  function getSource(
+      reference: ts.ReferenceEntry, spanKind: 'textSpan'|'contextSpan' = 'textSpan'): string {
+    const span = reference[spanKind]!;
+    const fileName = reference.fileName;
     const content = mockHost.readFile(fileName)!;
-    return content.substring(textSpan.start, textSpan.start + textSpan.length);
+    return content.substring(span.start, span.start + span.length);
   }
 });

--- a/packages/language-service/test/references_spec.ts
+++ b/packages/language-service/test/references_spec.ts
@@ -13,6 +13,9 @@ import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {MockTypescriptHost} from './test_utils';
 
+const APP_COMPONENT = '/app/app.component.ts';
+const TEST_TEMPLATE = '/app/test.ng';
+
 describe('references', () => {
   const mockHost = new MockTypescriptHost(['/app/main.ts']);
   const tsLS = ts.createLanguageService(mockHost);
@@ -23,35 +26,38 @@ describe('references', () => {
     mockHost.reset();
   });
 
-  describe('component members', () => {
-    it('should get TS references for a member in template', () => {
-      const fileName = mockHost.addCode(`
-        @Component({
-          template: '{{«title»}}'
-        })
-        export class MyComponent {
-          /*1*/title: string;
+  for (const templateStrategy of ['inline', 'external'] as const) {
+    describe(`template: ${templateStrategy}`, () => {
+      describe('component members', () => {
+        it('should get TS references for a member in template', () => {
+          const fileName = overrideTemplate('{{«title»}}');
+          const marker = mockHost.getReferenceMarkerFor(fileName, 'title');
+          const references = ngLS.getReferencesAtPosition(fileName, marker.start)!;
 
-          setTitle(newTitle: string) {
-            this./*2*/title = newTitle;
+          expect(references).toBeDefined();
+          expect(references.length).toBe(2);
+
+          for (const reference of references) {
+            expect(getSource(reference)).toBe('title');
           }
-        }`);
-      const content = mockHost.readFile(fileName)!;
-
-      const varName = 'title';
-      const marker = mockHost.getReferenceMarkerFor(fileName, varName);
-
-      const references = ngLS.getReferencesAtPosition(fileName, marker.start)!;
-      expect(references).toBeDefined();
-      expect(references.length).toBe(2);
-
-      for (let i = 0; i < references.length; ++i) {
-        const comment = `/*${i + 1}*/`;
-        const start = content.indexOf(comment) + comment.length;
-        expect(references[i].fileName).toBe(fileName);
-        expect(references[i].textSpan.start).toBe(start);
-        expect(references[i].textSpan.length).toBe(varName.length);
-      }
+        });
+      });
     });
-  });
+
+    // TODO: override parsing-cases#TemplateReference for inline templates.
+    const overrideTemplate = (template: string): string => {
+      if (templateStrategy === 'inline') {
+        mockHost.overrideInlineTemplate(APP_COMPONENT, template);
+        return APP_COMPONENT;
+      } else {
+        mockHost.override(TEST_TEMPLATE, template);
+        return TEST_TEMPLATE;
+      }
+    }
+  }
+
+  function getSource({fileName, textSpan}: ts.ReferenceEntry): string {
+    const content = mockHost.readFile(fileName)!;
+    return content.substring(textSpan.start, textSpan.start + textSpan.length);
+  }
 });


### PR DESCRIPTION
Keen and I were talking about what it would take to support getting
references at a position in the current language service, since it's
unclear when more investment in the Ivy LS will be available. Getting TS
references from a template is trivial -- we simply need to get the
definition of a symbol, which is already handled by the language
service, and ask the TS language service to give us the references for
that definition.

This doesn't handle references in templates, but that could be done in a
subsequent pass.

Part of https://github.com/angular/vscode-ng-language-service/issues/29

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
