### PR TITLE
refactor(dev-infra): use the `exec()` helper from `utils/shelljs` whenever possible

### DIFF
--- a/dev-infra/commit-message/validate-range.ts
+++ b/dev-infra/commit-message/validate-range.ts
@@ -5,9 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {exec} from 'shelljs';
-
 import {info} from '../utils/console';
+import {exec} from '../utils/shelljs';
 
 import {parseCommitMessage, validateCommitMessage, ValidateCommitMessageOptions} from './validate';
 
@@ -26,7 +25,7 @@ export function validateCommitRange(range: string) {
   const gitLogFormat = `%s%n%n%b${randomValueSeparator}`;
 
   // Retrieve the commits in the provided range.
-  const result = exec(`git log --reverse --format=${gitLogFormat} ${range}`, {silent: true});
+  const result = exec(`git log --reverse --format=${gitLogFormat} ${range}`);
   if (result.code) {
     throw new Error(`Failed to get all commits in the range: \n  ${result.stderr}`);
   }

--- a/dev-infra/release/env-stamp.ts
+++ b/dev-infra/release/env-stamp.ts
@@ -6,9 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {exec as _exec} from 'shelljs';
-
-import {info} from '../utils/console';
+import {exec as _exec} from '../utils/shelljs';
 
 /**
  * Log the environment variables expected by bazel for stamping.
@@ -32,7 +30,7 @@ export function buildEnvStamp() {
 
 /** Run the exec command and return the stdout as a trimmed string. */
 function exec(cmd: string) {
-  return _exec(cmd, {silent: true}).toString().trim();
+  return _exec(cmd).trim();
 }
 
 /** Whether the repo has local changes. */

--- a/dev-infra/utils/config.ts
+++ b/dev-infra/utils/config.ts
@@ -8,9 +8,9 @@
 
 import {existsSync} from 'fs';
 import {dirname, join} from 'path';
-import {exec} from 'shelljs';
 
 import {error} from './console';
+import {exec} from './shelljs';
 import {isTsNodeAvailable} from './ts-node';
 
 /**
@@ -119,7 +119,7 @@ export function assertNoErrors(errors: string[]) {
 
 /** Gets the path of the directory for the repository base. */
 export function getRepoBaseDir() {
-  const baseRepoDir = exec(`git rev-parse --show-toplevel`, {silent: true});
+  const baseRepoDir = exec(`git rev-parse --show-toplevel`);
   if (baseRepoDir.code) {
     throw Error(
         `Unable to find the path to the base directory of the repository.\n` +

--- a/dev-infra/utils/git.ts
+++ b/dev-infra/utils/git.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {exec} from '../utils/shelljs';
+import {exec} from './shelljs';
 
 
 /** Whether the repo has any local changes. */

--- a/dev-infra/utils/repo-files.ts
+++ b/dev-infra/utils/repo-files.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {exec} from 'shelljs';
 import {getRepoBaseDir} from './config';
+import {exec} from './shelljs';
 
 /**
  * A list of all files currently in the repo which have been modified since the provided sha.
@@ -33,8 +33,5 @@ export function allFiles() {
 
 
 function gitOutputAsArray(cmd: string) {
-  return exec(cmd, {cwd: getRepoBaseDir(), silent: true})
-      .split('\n')
-      .map(x => x.trim())
-      .filter(x => !!x);
+  return exec(cmd, {cwd: getRepoBaseDir()}).split('\n').map(x => x.trim()).filter(x => !!x);
 }

--- a/dev-infra/utils/shelljs.ts
+++ b/dev-infra/utils/shelljs.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {exec as _exec, ShellString} from 'shelljs';
+import {exec as _exec, ExecOptions, ShellString} from 'shelljs';
 
 /* Run an exec command as silent. */
-export function exec(cmd: string): ShellString {
-  return _exec(cmd, {silent: true});
+export function exec(cmd: string, opts?: ExecOptions&{async?: false}): ShellString {
+  return _exec(cmd, {silent: true, ...opts});
 }


### PR DESCRIPTION
There is an `exec()` helper provided by `utils/shelljs.ts`, which is a wrapper around ShellJS' `exec()` with some default options (currently `silent: true`). The intention is to avoid having to pass these options to every invocation of the `exec()` function.

This commit updates all code inside `dev-infra/` to use this helper whenever possible).

NOTE: For simplicity, the `utils/shelljs` helper does not support some of the less common call signatures of the original `exec()` helper, so in some cases we still need to use the original.
