### PR TITLE
fix(service-worker): Don't stay locked in EXISTING_CLIENTS_ONLY if corrupted data

### DIFF
--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -490,6 +490,15 @@ export class Driver implements Debuggable, UpdateSource {
         table.read<LatestEntry>('latest'),
       ]);
 
+      // Make sure latest manifest is correctly installed. If not (e.g. corrupted data),
+      // it could stay locked in EXISTING_CLIENTS_ONLY or SAFE_MODE state.
+      if (!this.versions.has(latest.latest) && !manifests.hasOwnProperty(latest.latest)) {
+        this.debugger.log(
+            `Missing manifest for latest version hash ${latest.latest}`,
+            'initialize: read from DB');
+        throw new Error(`Missing manifest for latest hash ${latest.latest}`);
+      }
+
       // Successfully loaded from saved state. This implies a manifest exists, so
       // the update check needs to happen in the background.
       this.idle.schedule('init post-load (update, cleanup)', async () => {


### PR DESCRIPTION
**Problem**

After #31109 and #31865, it's still possible to get locked in state
`EXISTING_CLIENTS_ONLY`, without any possibility to get out (even by
pushing new updates on the server).
More specifically, if control doc `/latest` of `ngsw:/:db:control` once
gets a bad value, then the service worker will fail early, and won't be
able to overwrite `/latest` with new, valid values (the ones from future
updates).

For example, once in this state, URL `/ngsw/state` will show:

    NGSW Debug Info:
    Driver state: EXISTING_CLIENTS_ONLY (Degraded due to failed initialization: Invariant violated (initialize): latest hash 8b75… has no known manifest
    Error: Invariant violated (initialize): latest hash 8b75… has no known manifest
        at Driver.<anonymous> (https://my.app/ngsw-worker.js:2302:27)
        at Generator.next (<anonymous>)
        at fulfilled (https://my.app/ngsw-worker.js:175:62))
    Latest manifest hash: 8b75…
    Last update check: 22s971u

... with hash `8b75…` corresponding to no installed version.

**Solution**

Currently, when such a case happens, the service worker [simply fails
with an assertion][1]. Because this failure happens early, and is not
handled, the service worker is not able to update `/latest` to new
installed app versions.

I propose to detect this corrupted case (a `latest` hash that doesn't
match any installed version) a few lines above, so that the service
worker can correctly call its [already existing cleaning code][2].

[1]: https://github.com/angular/angular/blob/3569fdf/packages/service-worker/worker/src/driver.ts#L559-L563
[2]: https://github.com/angular/angular/blob/3569fdf/packages/service-worker/worker/src/driver.ts#L505-L519

This change successfully fixes the problem described above.

~I tried to add unit tests, but the mock fixture in https://github.com/angular/angular/blob/d1ea1f4/packages/service-worker/worker/test/happy_spec.ts is too simple to include access to *cache storage* / `ngsw:/:db:control` / `/latest`. Spontaneously I'm not sure unit tests are needed for this locked-state-recovery fix. However if unit tests can be written, could you guide me on what to do?~

Unit test written with the help of George Kalpakas. Thank you!