### PR TITLE
fix/refactor(common): prevent duplicate URL change notifications from `SpyLocation` and use `TestBed.inject` in the `Location` test suite

### DIFF
--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -64,7 +64,8 @@ export class Location {
   _platformLocation: PlatformLocation;
   /** @internal */
   _urlChangeListeners: ((url: string, state: unknown) => void)[] = [];
-  private _urlChangeSubscription?: SubscriptionLike;
+  /** @internal */
+  _urlChangeSubscription?: SubscriptionLike;
 
   constructor(platformStrategy: LocationStrategy, platformLocation: PlatformLocation) {
     this._platformStrategy = platformStrategy;

--- a/packages/common/test/location/location_spec.ts
+++ b/packages/common/test/location/location_spec.ts
@@ -8,7 +8,7 @@
 
 import {CommonModule, Location, LocationStrategy, PathLocationStrategy, PlatformLocation} from '@angular/common';
 import {MockLocationStrategy, MockPlatformLocation} from '@angular/common/testing';
-import {inject, TestBed} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 
 const baseUrl = '/base';
 
@@ -41,6 +41,8 @@ describe('Location Class', () => {
   });
 
   describe('location.getState()', () => {
+    let location: Location;
+
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [CommonModule],
@@ -55,31 +57,36 @@ describe('Location Class', () => {
           {provide: Location, useClass: Location, deps: [LocationStrategy, PlatformLocation]},
         ]
       });
+
+      location = TestBed.inject(Location);
     });
 
-    it('should get the state object', inject([Location], (location: Location) => {
-         expect(location.getState()).toBe(null);
+    it('should get the state object', () => {
+      expect(location.getState()).toBe(null);
 
-         location.go('/test', '', {foo: 'bar'});
+      location.go('/test', '', {foo: 'bar'});
 
-         expect(location.getState()).toEqual({foo: 'bar'});
-       }));
+      expect(location.getState()).toEqual({foo: 'bar'});
+    });
 
-    it('should work after using back button', inject([Location], (location: Location) => {
-         expect(location.getState()).toBe(null);
+    it('should work after using back button', () => {
+      expect(location.getState()).toBe(null);
 
-         location.go('/test1', '', {url: 'test1'});
-         location.go('/test2', '', {url: 'test2'});
+      location.go('/test1', '', {url: 'test1'});
+      location.go('/test2', '', {url: 'test2'});
 
-         expect(location.getState()).toEqual({url: 'test2'});
+      expect(location.getState()).toEqual({url: 'test2'});
 
-         location.back();
+      location.back();
 
-         expect(location.getState()).toEqual({url: 'test1'});
-       }));
+      expect(location.getState()).toEqual({url: 'test1'});
+    });
   });
 
   describe('location.onUrlChange()', () => {
+    let location: Location;
+    let locationStrategy: MockLocationStrategy;
+
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [CommonModule],
@@ -94,29 +101,29 @@ describe('Location Class', () => {
           {provide: Location, useClass: Location, deps: [LocationStrategy, PlatformLocation]},
         ]
       });
+
+      location = TestBed.inject(Location);
+      locationStrategy = TestBed.inject(LocationStrategy) as MockLocationStrategy;
     });
 
-    it('should have onUrlChange method', inject([Location], (location: Location) => {
-         expect(typeof location.onUrlChange).toBe('function');
-       }));
+    it('should have onUrlChange method', () => {
+      expect(typeof location.onUrlChange).toBe('function');
+    });
 
-    it('should add registered functions to urlChangeListeners',
-       inject([Location], (location: Location) => {
-         function changeListener(url: string, state: unknown) {
-           return undefined;
-         }
+    it('should add registered functions to urlChangeListeners', () => {
+      function changeListener(url: string, state: unknown) {
+        return undefined;
+      }
 
-         expect((location as any)._urlChangeListeners.length).toBe(0);
+      expect((location as any)._urlChangeListeners.length).toBe(0);
 
-         location.onUrlChange(changeListener);
+      location.onUrlChange(changeListener);
 
-         expect((location as any)._urlChangeListeners.length).toBe(1);
-         expect((location as any)._urlChangeListeners[0]).toEqual(changeListener);
-       }));
+      expect((location as any)._urlChangeListeners.length).toBe(1);
+      expect((location as any)._urlChangeListeners[0]).toEqual(changeListener);
+    });
 
     it('should only notify listeners once when multiple listeners are registered', () => {
-      const location = TestBed.inject(Location);
-      const locationStrategy = TestBed.inject(LocationStrategy) as MockLocationStrategy;
       let notificationCount = 0;
 
       function incrementChangeListener(url: string, state: unknown) {

--- a/packages/common/testing/src/location_mock.ts
+++ b/packages/common/testing/src/location_mock.ts
@@ -30,6 +30,8 @@ export class SpyLocation implements Location {
   _platformLocation: PlatformLocation = null!;
   /** @internal */
   _urlChangeListeners: ((url: string, state: unknown) => void)[] = [];
+  /** @internal */
+  _urlChangeSubscription?: SubscriptionLike;
 
   setInitialPath(url: string) {
     this._history[this._historyIndex].path = url;
@@ -123,9 +125,12 @@ export class SpyLocation implements Location {
   }
   onUrlChange(fn: (url: string, state: unknown) => void) {
     this._urlChangeListeners.push(fn);
-    this.subscribe(v => {
-      this._notifyUrlChangeListeners(v.url, v.state);
-    });
+
+    if (!this._urlChangeSubscription) {
+      this._urlChangeSubscription = this.subscribe(v => {
+        this._notifyUrlChangeListeners(v.url, v.state);
+      });
+    }
   }
 
   /** @internal */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
1. `SpyLocation` emits duplicate notifications to URL change listeners when multiple are registered.
1. `Location` uses the `private` acces modifier for the private `_urlChangeSubscription` member.
1. `location_spec.ts` uses the weakly typed `inject` to resolve dependencies.

Issue Number: As discussed in #37404

## What is the new behavior?
1. `SpyLocation` only emits one URL change notification to all listeners.
1. `Location` use `@internal` JSDoc annotations for all private members.
1. `location_spec.ts` uses the strongly typed `TestBed.inject` to resolve dependencies.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Cc @atscott