### PR TITLE
fix(dev-infra): properly determine oauth scopes for git client token

### DIFF
--- a/dev-infra/utils/git.ts
+++ b/dev-infra/utils/git.ts
@@ -60,7 +60,7 @@ export class GitClient {
   /** The file path of project's root directory. */
   private _projectRoot = getRepoBaseDir();
   /** The OAuth scopes available for the provided Github token. */
-  private _oauthScopes = Promise.resolve<string[]>([]);
+  private _oauthScopes: Promise<string[]>|null = null;
   /** Regular expression that matches the provided Github token. */
   private _tokenRegex = new RegExp(this._githubToken, 'g');
 


### PR DESCRIPTION
Resubmit of b2bd38699b0595d0a35b501f20251f8715a9fd1c since
85b6c94cc6d4dd1cfae68fc14575d0efa57574b3 accidentally reverted
the fix due to rebasing most likely.