### PR TITLE
ci: extend and update the reviewer groups

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -844,6 +844,32 @@ groups:
 
 
   # =========================================================
+  #  Tooling: Compiler API shared with Angular CLI
+  #
+  #  Changing this API might break Angular CLI, so we require
+  #  the CLI team to approve changes here.
+  # =========================================================
+  tooling-cli-shared-api:
+    conditions:
+      - *can-be-global-approved
+      - *can-be-global-docs-approved
+      - >
+        contains_any_globs(files, [
+          'packages/compiler-cli/src/tooling.ts'
+        ])
+    reviewers:
+      users:
+        - alan-agius4
+        - clydin
+        - kyliau
+        - IgorMinar
+    reviews:
+      request: -1   # request reviews from everyone
+      required: 2   # require at least 2 approvals
+      reviewed_for: required
+
+
+  # =========================================================
   #  Docs: CLI
   # =========================================================
   docs-cli:

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -80,8 +80,8 @@
 #  Used for approving minor changes, large-scale refactorings, and in emergency situations.
 #
 # IgorMinar
+# jelbourn
 # josephperrott
-# kara
 # mhevery
 #
 # =========================================================
@@ -203,7 +203,6 @@ groups:
         - alxhub
         - AndrewKushnir
         - JoostK
-        - kara
 
 
   # =========================================================
@@ -235,7 +234,6 @@ groups:
         - alxhub
         - crisbeto
         - devversion
-        - kara
 
 
   # =========================================================
@@ -352,7 +350,7 @@ groups:
         - alxhub
         - AndrewKushnir
         - atscott
-        - kara
+        - ~kara  # do not request reviews from Kara, but allow her to approve PRs
         - mhevery
         - pkozlowski-opensource
 
@@ -579,7 +577,6 @@ groups:
       users:
         - AndrewKushnir
         - IgorMinar
-        - kara
         - pkozlowski-opensource
 
 
@@ -596,7 +593,6 @@ groups:
     reviewers:
       users:
         - IgorMinar
-        - kara
         - pkozlowski-opensource
 
 
@@ -613,7 +609,8 @@ groups:
     reviewers:
       users:
         - IgorMinar
-        - kara
+        - jelbourn
+        - pkozlowski-opensource
 
 
   # =========================================================
@@ -637,6 +634,13 @@ groups:
       users:
         - IgorMinar
         - mhevery
+        - jelbourn
+        - pkozlowski-opensource
+    reviews:
+      request: -1   # request reviews from everyone
+      required: 2   # require at least 2 approvals
+      reviewed_for: required
+
 
   # =========================================================
   #  Bazel
@@ -707,6 +711,7 @@ groups:
     reviewers:
       users:
         - alxhub
+        - josephperrott
 
 
   # =========================================================
@@ -723,7 +728,6 @@ groups:
       users:
         - IgorMinar
         - josephperrott
-        - kara
         - mhevery
 
 
@@ -836,7 +840,7 @@ groups:
     reviewers:
       users:
         - IgorMinar
-        - kara
+        - jelbourn
 
 
   # =========================================================
@@ -1023,8 +1027,14 @@ groups:
           ])
     reviewers:
       users:
+        - alxhub
         - IgorMinar
-        - kara
+        - jelbourn
+        - pkozlowski-opensource
+    reviews:
+      request: -1   # request reviews from everyone
+      required: 3   # require at least 3 approvals
+      reviewed_for: required
 
 
   # ================================================
@@ -1039,8 +1049,14 @@ groups:
           ])
     reviewers:
       users:
+        - alxhub
         - IgorMinar
-        - kara
+        - jelbourn
+        - pkozlowski-opensource
+    reviews:
+      request: -1   # request reviews from everyone
+      required: 2   # require at least 2 approvals
+      reviewed_for: required
 
 
   # ================================================
@@ -1056,8 +1072,9 @@ groups:
     reviewers:
       users:
         - IgorMinar
+        - jelbourn
         - josephperrott
-        - kara
+        - pkozlowski-opensource
 
 
 ####################################################################################

--- a/packages/compiler-cli/src/tooling.ts
+++ b/packages/compiler-cli/src/tooling.ts
@@ -7,10 +7,13 @@
  */
 
 /**
- * @module
- * @description
- * Tooling support helpers.
+ * @fileoverview
+ * This file is used as a private API channel to shared Angular FW APIs with @angular/cli.
+ *
+ * Any changes to this file should be discussed with the Angular CLI team.
  */
+
+
 
 /**
  * Known values for global variables in `@angular/core` that Terser should set using


### PR DESCRIPTION
Update the pullapprove config to require multiple reviews for sensitive groups in order
to force distribution of knowledge and improve the review quality.