### PR TITLE
fix(router): stricter typing for Route.pathMatch

### DIFF
--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -302,7 +302,7 @@ export declare interface Route {
     matcher?: UrlMatcher;
     outlet?: string;
     path?: string;
-    pathMatch?: string;
+    pathMatch?: 'prefix' | 'full';
     redirectTo?: string;
     resolve?: ResolveData;
     runGuardsAndResolvers?: RunGuardsAndResolvers;

--- a/modules/playground/src/routing/app/inbox-app.ts
+++ b/modules/playground/src/routing/app/inbox-app.ts
@@ -8,7 +8,7 @@
 
 
 import {Component, Injectable} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
+import {ActivatedRoute, Router, Routes} from '@angular/router';
 
 import * as db from './data';
 
@@ -122,7 +122,7 @@ export class DraftsCmp {
   }
 }
 
-export const ROUTER_CONFIG = [
+export const ROUTER_CONFIG: Routes = [
   {path: '', pathMatch: 'full', redirectTo: 'inbox'}, {path: 'inbox', component: InboxCmp},
   {path: 'drafts', component: DraftsCmp}, {path: 'detail', loadChildren: 'app/inbox-detail.js'}
 ];

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -889,7 +889,7 @@ describe('ngc transformer command-line', () => {
       it('should lower loadChildren in an exported variable expression', () => {
         write('mymodule.ts', `
           import {Component, NgModule} from '@angular/core';
-          import {RouterModule} from '@angular/router';
+          import {RouterModule, Routes} from '@angular/router';
 
           export function foo(): string {
             console.log('side-effect');
@@ -902,7 +902,7 @@ describe('ngc transformer command-line', () => {
           })
           export class Route {}
 
-          export const routes = [
+          export const routes: Routes = [
             {path: '', pathMatch: 'full', component: Route, loadChildren: foo()}
           ];
 

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -409,7 +409,7 @@ export interface Route {
    * to the redirect destination, creating an endless loop.
    *
    */
-  pathMatch?: string;
+  pathMatch?: 'prefix'|'full';
   /**
    * A custom URL-matching function. Cannot be used together with `path`.
    */

--- a/packages/router/test/config.spec.ts
+++ b/packages/router/test/config.spec.ts
@@ -137,6 +137,7 @@ describe('config', () => {
 
     it('should throw when pathMatch is invalid', () => {
       expect(() => {
+        // @ts-expect-error
         validateConfig([{path: 'a', pathMatch: 'invalid', component: ComponentB}]);
       })
           .toThrowError(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #37469

## What is the new behavior?

```
interface Route {
  pathMatch?: 'prefix' | 'full';
}
```

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
