### PR TITLE
Update documentation on configuring project for Travis CI

### DIFF
--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -145,19 +145,12 @@ Your project should start building.
 Step 1: Create a file called `.travis.yml` at the project root, with the following content:
 
 ```
-dist: trusty
-sudo: false
-
 language: node_js
 node_js:
   - "10"
 
 addons:
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable
+  chrome: stable
 
 cache:
   directories:


### PR DESCRIPTION
Update .travis.yml example file in **Configure Project for Travis CI** section,
in the documentation under guides, under testing.
Remove sudo since it no longer has use in Travis CI build configurations.
Change chrome addons to use the latest required method.
Remove dist to make the Travis CI builds run in the latest Ubuntu release: Xenial.
This because Trusty uses an older version of Chrome which is not supported
by the current the latest Chrome Driver, used in ng e2e tests.

Fixes #36451

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Travis CI builds fail because of out-of-date configurations in `travis.yml` file. 
Issue Number: 36451


## What is the new behavior?
Travis CI builds pass if the tests locally.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
