### PR TITLE
test(language-service): Remove all markers from test project

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -361,12 +361,18 @@ function elementCompletions(info: ng.AstResult): ng.CompletionEntry[] {
 
 function entityCompletions(value: string, position: number): ng.CompletionEntry[] {
   // Look for entity completions
+  // TODO(kyliau): revisit the usefulness of this feature. It provides
+  // autocompletion for HTML entities, which IMO is outside the core functionality
+  // of Angular language service. Besides, we do not have a complete list.
+  // See https://dev.w3.org/html5/html-author/charref
   const re = /&[A-Za-z]*;?(?!\d)/g;
   let found: RegExpExecArray|null;
   let result: ng.CompletionEntry[] = [];
   while (found = re.exec(value)) {
     let len = found[0].length;
-    if (position >= found.index && position < (found.index + len)) {
+    // end position must be inclusive to account for cases like '&|' where
+    // cursor is right behind the ampersand.
+    if (position >= found.index && position <= (found.index + len)) {
       result = Object.keys(NAMED_ENTITIES).map(name => {
         return {
           name: `&${name};`,

--- a/packages/language-service/test/language_service_spec.ts
+++ b/packages/language-service/test/language_service_spec.ts
@@ -18,27 +18,28 @@ describe('service without angular', () => {
   const service = ts.createLanguageService(mockHost);
   const ngHost = new TypeScriptServiceHost(mockHost, service);
   const ngService = createLanguageService(ngHost);
-  const fileName = '/app/test.ng';
-  const position = mockHost.getLocationMarkerFor(fileName, 'h1-content').start;
+  const TEST_TEMPLATE = '/app/test.ng';
+  mockHost.override(TEST_TEMPLATE, '<h1> ~{cursor} </h1>');
+  const position = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor').start;
 
   beforeEach(() => {
     mockHost.reset();
   });
 
   it('should not crash a get diagnostics', () => {
-    expect(() => ngService.getSemanticDiagnostics(fileName)).not.toThrow();
+    expect(() => ngService.getSemanticDiagnostics(TEST_TEMPLATE)).not.toThrow();
   });
 
   it('should not crash a completion', () => {
-    expect(() => ngService.getCompletionsAtPosition(fileName, position)).not.toThrow();
+    expect(() => ngService.getCompletionsAtPosition(TEST_TEMPLATE, position)).not.toThrow();
   });
 
   it('should not crash a get definition', () => {
-    expect(() => ngService.getDefinitionAndBoundSpan(fileName, position)).not.toThrow();
+    expect(() => ngService.getDefinitionAndBoundSpan(TEST_TEMPLATE, position)).not.toThrow();
   });
 
   it('should not crash a hover', () => {
-    expect(() => ngService.getQuickInfoAtPosition(fileName, position)).not.toThrow();
+    expect(() => ngService.getQuickInfoAtPosition(TEST_TEMPLATE, position)).not.toThrow();
   });
 
   it('should not crash with an incomplete class', () => {

--- a/packages/language-service/test/project/app/app.component.ts
+++ b/packages/language-service/test/project/app/app.component.ts
@@ -15,16 +15,9 @@ export interface Hero {
 
 @Component({
   selector: 'my-app',
-  template: `~{empty}
-    <~{start-tag}h~{start-tag-after-h}1~{start-tag-h1} ~{h1-after-space}>
-      ~{h1-content} {{~{sub-start}title~{sub-end}}}
-    </h1>
-    ~{after-h1}<h2>{{~{h2-hero}hero.~{h2-name}name}} details!</h2>
-    <div><label>id: </label>{{~{label-hero}hero.~{label-id}id}}</div>
-    <div ~{div-attributes}>
-      <label>name: </label>
-    </div>
-    &~{entity-amp}amp;
+  template: `
+    <h1>{{title}}</h1>
+    <h2>{{hero.name}} details!</h2>
   `
 })
 export class AppComponent {

--- a/packages/language-service/test/project/app/test.ng
+++ b/packages/language-service/test/project/app/test.ng
@@ -1,7 +1,2 @@
-~{empty}
-<~{start-tag}h~{start-tag-after-h}1~{start-tag-h1} ~{h1-after-space}>
-  ~{h1-content} {{~{sub-start}title~{sub-end}}}
-</h1>
-~{after-h1}<h2>{{~{h2-hero}hero.~{h2-name}name}} details!</h2>
-<div><label>id: </label>{{~{label-hero}hero.~{label-id}id}}</div>
-&~{entity-amp}amp;
+<h1>{{title}}</h1>
+<h2>{{hero.name}} details!</h2>


### PR DESCRIPTION
This commit removes all markers from the inline template in
`AppComponent` and external template in `TemplateReference`.

Test scenarios should be colocated with the test cases themselves.
Besides, many existing cases are not setup correctly.
For example, if we want to test autocomplete for HTML element, the existing test case is like:
```
<~{cursor} h1>
```
This doesn't make much sense, because the language service already sees
the `h1` tag in the template. The more representative test case should be:
```
<~{cursor
```
IMO, this reflects the real-world use case better.

This commit also uncovers a bug in the way HTML entities autocompletion
is done. There's an off-by-one error in which a cursor that is placed immediately after the ampersand character fails to trigger autocomplete.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
