### PR TITLE
feat(router): allow redirect from guards by returning URL string

### DIFF
--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -52,19 +52,19 @@ export declare class ActivationStart {
 }
 
 export declare interface CanActivate {
-    canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree;
+    canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree | string> | Promise<boolean | UrlTree | string> | boolean | UrlTree | string;
 }
 
 export declare interface CanActivateChild {
-    canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree;
+    canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree | string> | Promise<boolean | UrlTree | string> | boolean | UrlTree | string;
 }
 
 export declare interface CanDeactivate<T> {
-    canDeactivate(component: T, currentRoute: ActivatedRouteSnapshot, currentState: RouterStateSnapshot, nextState?: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree;
+    canDeactivate(component: T, currentRoute: ActivatedRouteSnapshot, currentState: RouterStateSnapshot, nextState?: RouterStateSnapshot): Observable<boolean | UrlTree | string> | Promise<boolean | UrlTree | string> | boolean | UrlTree | string;
 }
 
 export declare interface CanLoad {
-    canLoad(route: Route, segments: UrlSegment[]): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree;
+    canLoad(route: Route, segments: UrlSegment[]): Observable<boolean | UrlTree | string> | Promise<boolean | UrlTree | string> | boolean | UrlTree | string;
 }
 
 export declare class ChildActivationEnd {

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -16,7 +16,7 @@ import {RouterConfigLoader} from './router_config_loader';
 import {defaultUrlMatcher, navigationCancelingError, Params, PRIMARY_OUTLET} from './shared';
 import {UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
 import {forEach, waitForMap, wrapIntoObservable} from './utils/collection';
-import {isCanLoad, isFunction, isUrlTree} from './utils/type_guards';
+import {isCanLoad, isFunction, isString, isUrlTree} from './utils/type_guards';
 
 class NoMatch {
   public segmentGroup: UrlSegmentGroup|null;
@@ -336,11 +336,12 @@ class ApplyRedirects {
 
     return obs.pipe(
         concatAll(),
-        tap((result: UrlTree|boolean) => {
-          if (!isUrlTree(result)) return;
+        tap((result: UrlTree|boolean|string) => {
+          if (!isUrlTree(result) && !isString(result)) return;
 
-          const error: Error&{url?: UrlTree} =
-              navigationCancelingError(`Redirecting to "${this.urlSerializer.serialize(result)}"`);
+          const url = isUrlTree(result) ? this.urlSerializer.serialize(result) : result;
+          const error: Error&{url?: UrlTree | string} =
+              navigationCancelingError(`Redirecting to "${url}"`);
           error.url = result;
           throw error;
         }),

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -84,11 +84,11 @@ import {UrlSegment, UrlTree} from './url_tree';
  */
 export interface CanActivate {
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot):
-      Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean|UrlTree;
+      Observable<boolean|UrlTree|string>|Promise<boolean|UrlTree|string>|boolean|UrlTree|string;
 }
 
 export type CanActivateFn = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) =>
-    Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean|UrlTree;
+    Observable<boolean|UrlTree|string>|Promise<boolean|UrlTree|string>|boolean|UrlTree|string;
 
 /**
  * @description
@@ -171,11 +171,11 @@ export type CanActivateFn = (route: ActivatedRouteSnapshot, state: RouterStateSn
  */
 export interface CanActivateChild {
   canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot):
-      Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean|UrlTree;
+      Observable<boolean|UrlTree|string>|Promise<boolean|UrlTree|string>|boolean|UrlTree|string;
 }
 
 export type CanActivateChildFn = (childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot) =>
-    Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean|UrlTree;
+    Observable<boolean|UrlTree|string>|Promise<boolean|UrlTree|string>|boolean|UrlTree|string;
 
 /**
  * @description
@@ -252,14 +252,14 @@ export type CanActivateChildFn = (childRoute: ActivatedRouteSnapshot, state: Rou
 export interface CanDeactivate<T> {
   canDeactivate(
       component: T, currentRoute: ActivatedRouteSnapshot, currentState: RouterStateSnapshot,
-      nextState?: RouterStateSnapshot): Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean
-      |UrlTree;
+      nextState?: RouterStateSnapshot):
+      Observable<boolean|UrlTree|string>|Promise<boolean|UrlTree|string>|boolean|UrlTree|string;
 }
 
 export type CanDeactivateFn<T> =
     (component: T, currentRoute: ActivatedRouteSnapshot, currentState: RouterStateSnapshot,
      nextState?: RouterStateSnapshot) =>
-        Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean|UrlTree;
+        Observable<boolean|UrlTree|string>|Promise<boolean|UrlTree|string>|boolean|UrlTree|string;
 
 /**
  * @description
@@ -405,8 +405,8 @@ export interface Resolve<T> {
  */
 export interface CanLoad {
   canLoad(route: Route, segments: UrlSegment[]):
-      Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean|UrlTree;
+      Observable<boolean|UrlTree|string>|Promise<boolean|UrlTree|string>|boolean|UrlTree|string;
 }
 
 export type CanLoadFn = (route: Route, segments: UrlSegment[]) =>
-    Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean|UrlTree;
+    Observable<boolean|UrlTree|string>|Promise<boolean|UrlTree|string>|boolean|UrlTree|string;

--- a/packages/router/src/operators/check_guards.ts
+++ b/packages/router/src/operators/check_guards.ts
@@ -53,7 +53,7 @@ function runCanDeactivateChecks(
               runCanDeactivate(check.component, check.route, currRSS, futureRSS, moduleInjector)),
       first(result => {
         return result !== true;
-      }, true as boolean | UrlTree));
+      }, true as boolean | UrlTree | string));
 }
 
 function runCanActivateChecks(
@@ -69,11 +69,11 @@ function runCanActivateChecks(
                ])
             .pipe(concatAll(), first(result => {
                     return result !== true;
-                  }, true as boolean | UrlTree));
+                  }, true as boolean | UrlTree | string));
       }),
       first(result => {
         return result !== true;
-      }, true as boolean | UrlTree));
+      }, true as boolean | UrlTree | string));
 }
 
 /**
@@ -112,7 +112,7 @@ function fireChildActivationStart(
 
 function runCanActivate(
     futureRSS: RouterStateSnapshot, futureARS: ActivatedRouteSnapshot,
-    moduleInjector: Injector): Observable<boolean|UrlTree> {
+    moduleInjector: Injector): Observable<boolean|UrlTree|string> {
   const canActivate = futureARS.routeConfig ? futureARS.routeConfig.canActivate : null;
   if (!canActivate || canActivate.length === 0) return of(true);
 
@@ -135,7 +135,7 @@ function runCanActivate(
 
 function runCanActivateChild(
     futureRSS: RouterStateSnapshot, path: ActivatedRouteSnapshot[],
-    moduleInjector: Injector): Observable<boolean|UrlTree> {
+    moduleInjector: Injector): Observable<boolean|UrlTree|string> {
   const futureARS = path[path.length - 1];
 
   const canActivateChildGuards = path.slice(0, path.length - 1)
@@ -165,7 +165,7 @@ function runCanActivateChild(
 
 function runCanDeactivate(
     component: Object|null, currARS: ActivatedRouteSnapshot, currRSS: RouterStateSnapshot,
-    futureRSS: RouterStateSnapshot, moduleInjector: Injector): Observable<boolean|UrlTree> {
+    futureRSS: RouterStateSnapshot, moduleInjector: Injector): Observable<boolean|UrlTree|string> {
   const canDeactivate = currARS && currARS.routeConfig ? currARS.routeConfig.canDeactivate : null;
   if (!canDeactivate || canDeactivate.length === 0) return of(true);
   const canDeactivateObservables = canDeactivate.map((c: any) => {

--- a/packages/router/src/operators/prioritized_guard_value.ts
+++ b/packages/router/src/operators/prioritized_guard_value.ts
@@ -10,13 +10,13 @@ import {combineLatest, Observable, OperatorFunction} from 'rxjs';
 import {filter, map, scan, startWith, switchMap, take} from 'rxjs/operators';
 
 import {UrlTree} from '../url_tree';
-import {isUrlTree} from '../utils/type_guards';
+import {isString, isUrlTree} from '../utils/type_guards';
 
 const INITIAL_VALUE = Symbol('INITIAL_VALUE');
-declare type INTERIM_VALUES = typeof INITIAL_VALUE | boolean | UrlTree;
+declare type INTERIM_VALUES = typeof INITIAL_VALUE | boolean | UrlTree | string;
 
 export function prioritizedGuardValue():
-    OperatorFunction<Observable<boolean|UrlTree>[], boolean|UrlTree> {
+    OperatorFunction<Observable<boolean|UrlTree|string>[], boolean|UrlTree|string> {
   return switchMap(obs => {
     return combineLatest(
                ...obs.map(o => o.pipe(take(1), startWith(INITIAL_VALUE as INTERIM_VALUES))))
@@ -39,7 +39,7 @@ export function prioritizedGuardValue():
                              // cancel navigation
                              if (val === false) return val;
 
-                             if (i === list.length - 1 || isUrlTree(val)) {
+                             if (i === list.length - 1 || isUrlTree(val) || isString(val)) {
                                return val;
                              }
                            }
@@ -49,7 +49,7 @@ export function prioritizedGuardValue():
                        },
                        INITIAL_VALUE),
                    filter(item => item !== INITIAL_VALUE),
-                   map(item => isUrlTree(item) ? item : item === true),  //
-                   take(1)) as Observable<boolean|UrlTree>;
+                   map(item => isUrlTree(item) || isString(item) ? item : item === true),
+                   take(1)) as Observable<boolean|UrlTree|string>;
   });
 }

--- a/packages/router/src/utils/type_guards.ts
+++ b/packages/router/src/utils/type_guards.ts
@@ -30,6 +30,10 @@ export function isBoolean(v: any): v is boolean {
   return typeof v === 'boolean';
 }
 
+export function isString(v: any): v is string {
+  return typeof v === 'string';
+}
+
 export function isUrlTree(v: any): v is UrlTree {
   return v instanceof UrlTree;
 }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2681,6 +2681,60 @@ describe('Integration', () => {
            })));
       });
 
+      describe('should redirect when guard returns URL string', () => {
+        beforeEach(() => TestBed.configureTestingModule({
+          providers: [{
+            provide: 'returnUrlString',
+            useValue: () => {
+              return '/redirected';
+            }
+          }]
+        }));
+
+        it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+             const recordedEvents: any[] = [];
+             let cancelEvent: NavigationCancel = null!;
+             router.events.forEach((e: any) => {
+               recordedEvents.push(e);
+               if (e instanceof NavigationCancel) cancelEvent = e;
+             });
+             router.resetConfig([
+               {path: '', component: SimpleCmp},
+               {path: 'one', component: RouteCmp, canActivate: ['returnUrlString']},
+               {path: 'redirected', component: SimpleCmp}
+             ]);
+
+             const fixture = TestBed.createComponent(RootCmp);
+             router.navigateByUrl('/one');
+
+             advance(fixture);
+
+             expect(location.path()).toEqual('/redirected');
+             expect(fixture.nativeElement).toHaveText('simple');
+             expect(cancelEvent && cancelEvent.reason)
+                 .toBe('NavigationCancelingError: Redirecting to "/redirected"');
+             expectEvents(recordedEvents, [
+               [NavigationStart, '/one'],
+               [RoutesRecognized, '/one'],
+               [GuardsCheckStart, '/one'],
+               [ChildActivationStart, undefined],
+               [ActivationStart, undefined],
+               [NavigationCancel, '/one'],
+               [NavigationStart, '/redirected'],
+               [RoutesRecognized, '/redirected'],
+               [GuardsCheckStart, '/redirected'],
+               [ChildActivationStart, undefined],
+               [ActivationStart, undefined],
+               [GuardsCheckEnd, '/redirected'],
+               [ResolveStart, '/redirected'],
+               [ResolveEnd, '/redirected'],
+               [ActivationEnd, undefined],
+               [ChildActivationEnd, undefined],
+               [NavigationEnd, '/redirected'],
+             ]);
+           })));
+      });
+
       describe('runGuardsAndResolvers', () => {
         let guardRunCount = 0;
         let resolverRunCount = 0;
@@ -3578,6 +3632,12 @@ describe('Integration', () => {
                 return true;
               }
             },
+            {
+              provide: 'returnUrlString',
+              useValue: () => {
+                return '/blank';
+              }
+            },
           ]
         });
       });
@@ -3688,6 +3748,37 @@ describe('Integration', () => {
 
            router.resetConfig([
              {path: 'lazyFalse', canLoad: ['returnUrlTree'], loadChildren: 'lazyFalse'},
+             {path: 'blank', component: BlankCmp}
+           ]);
+
+           const recordedEvents: any[] = [];
+           router.events.forEach(e => recordedEvents.push(e));
+
+
+           router.navigateByUrl('/lazyFalse/loaded');
+           advance(fixture);
+
+           expect(location.path()).toEqual('/blank');
+
+           expectEvents(recordedEvents, [
+             [NavigationStart, '/lazyFalse/loaded'],
+             // No GuardCheck events as `canLoad` is a special guard that's not actually part of
+             // the guard lifecycle.
+             [NavigationCancel, '/lazyFalse/loaded'],
+
+             [NavigationStart, '/blank'], [RoutesRecognized, '/blank'],
+             [GuardsCheckStart, '/blank'], [ChildActivationStart], [ActivationStart],
+             [GuardsCheckEnd, '/blank'], [ResolveStart, '/blank'], [ResolveEnd, '/blank'],
+             [ActivationEnd], [ChildActivationEnd], [NavigationEnd, '/blank']
+           ]);
+         })));
+
+      it('should support returning URL string from within the guard',
+         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+           const fixture = createRoot(router, RootCmp);
+
+           router.resetConfig([
+             {path: 'lazyFalse', canLoad: ['returnUrlString'], loadChildren: 'lazyFalse'},
              {path: 'blank', component: BlankCmp}
            ]);
 

--- a/packages/router/test/router.spec.ts
+++ b/packages/router/test/router.spec.ts
@@ -715,7 +715,7 @@ function checkResolveData(
 
 function checkGuards(
     future: RouterStateSnapshot, curr: RouterStateSnapshot, injector: any,
-    check: (result: boolean|UrlTree) => void): void {
+    check: (result: boolean|UrlTree|string) => void): void {
   // Since we only test the guards, we don't need to provide a full navigation
   // transition object with all properties set.
   of({guards: getAllRouteGuards(future, curr, new ChildrenOutletContexts())} as


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Guards allow returning either boolean or UrlTree.

## What is the new behavior?
Allow returning either boolean, UrlTree or URL string.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
