### PR TITLE
fix(language-service): Improve signature selection by finding exact match

### DIFF
--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -832,6 +832,20 @@ describe('completions', () => {
       expectContain(completions, CompletionKind.METHOD, ['charAt', 'substring']);
     });
   });
+
+  it('should select the right signature for a pipe given exact type', () => {
+    mockHost.override(TEST_TEMPLATE, '{{ ("world" | prefixPipe:"hello").~{cursor} }}');
+    const m1 = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
+    const c1 = ngLS.getCompletionsAtPosition(TEST_TEMPLATE, m1.start);
+    // should resolve to transform(value: string, prefix: string): string
+    expectContain(c1, CompletionKind.METHOD, ['charCodeAt', 'trim']);
+
+    mockHost.override(TEST_TEMPLATE, '{{ (456 | prefixPipe:123).~{cursor} }}');
+    const m2 = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
+    const c2 = ngLS.getCompletionsAtPosition(TEST_TEMPLATE, m2.start);
+    // should resolve to transform(value: number, prefix: number): number
+    expectContain(c2, CompletionKind.METHOD, ['toFixed', 'toExponential']);
+  });
 });
 
 function expectContain(

--- a/packages/language-service/test/project/app/main.ts
+++ b/packages/language-service/test/project/app/main.ts
@@ -22,6 +22,7 @@ import * as ParsingCases from './parsing-cases';
     ParsingCases.StringModel,
     ParsingCases.TemplateReference,
     ParsingCases.TestComponent,
+    ParsingCases.TestPipe,
     ParsingCases.WithContextDirective,
   ]
 })

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, EventEmitter, Input, OnChanges, Output, SimpleChanges, TemplateRef, ViewContainerRef} from '@angular/core';
+import {Component, Directive, EventEmitter, Input, OnChanges, Output, Pipe, PipeTransform, SimpleChanges, TemplateRef, ViewContainerRef} from '@angular/core';
 
 import {Hero} from './app.component';
 
@@ -66,6 +66,20 @@ export class WithContextDirective {
   static ngTemplateContextGuard(dir: WithContextDirective, ctx: unknown):
       ctx is WithContextDirectiveContext {
     return true;
+  }
+}
+
+@Pipe({
+  name: 'prefixPipe',
+})
+export class TestPipe implements PipeTransform {
+  transform(value: string, prefix: string): string;
+  transform(value: number, prefix: number): number;
+  transform(value: string|number, prefix: string|number): string|number {
+    if (typeof value === 'string') {
+      return `${prefix} ${value}`;
+    }
+    return parseInt(`${prefix}${value}`, 10 /* radix */);
   }
 }
 


### PR DESCRIPTION
The function signature selection algorithm is totally naive. It'd
unconditionally pick the first signature if there are multiple
overloads. This commit improves the algorithm by returning an exact
match if one exists.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
