### PR TITLE
Revert "build: remove wombot proxy registry from package.jsons for release (#37378)"

### DIFF
--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -18,5 +18,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -52,5 +52,8 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+  },
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -23,5 +23,8 @@
   "sideEffects": [
     "**/global/*.js",
     "**/closure-locale.*"
-  ]
+  ],
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -48,5 +48,8 @@
   "homepage": "https://github.com/angular/angular/tree/master/packages/compiler-cli",
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+  },
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -15,5 +15,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": true
+  "sideEffects": true,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,5 +20,8 @@
     "migrations": "./schematics/migrations.json",
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -21,5 +21,8 @@
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
   "sideEffects": false,
-  "schematics": "./schematics/collection.json"
+  "schematics": "./schematics/collection.json",
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -21,5 +21,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -14,5 +14,8 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+  },
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -31,5 +31,8 @@
   "peerDependencies": {
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "@angular/compiler-cli": "0.0.0-PLACEHOLDER"
+  },
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/platform-browser-dynamic/package.json
+++ b/packages/platform-browser-dynamic/package.json
@@ -21,5 +21,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -25,5 +25,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -28,5 +28,8 @@
   "sideEffects": false,
   "engines": {
     "node": ">=8.0"
+  },
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/platform-webworker-dynamic/package.json
+++ b/packages/platform-webworker-dynamic/package.json
@@ -22,5 +22,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/platform-webworker/package.json
+++ b/packages/platform-webworker/package.json
@@ -20,5 +20,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -29,5 +29,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -22,5 +22,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -21,5 +21,8 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  }
 }

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -37,6 +37,9 @@
     "url": "git://github.com/angular/angular.git",
     "directory": "packages/zone.js"
   },
+  "publishConfig":{
+    "registry":"https://wombat-dressing-room.appspot.com"
+  },
   "author": "Brian Ford",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This reverts commit 26849ca99dcafc45fb8cb0e97af7aeb85ea11852.


This is safe to do as the underlying issue with npm rate limiting has been resolved.