### PR TITLE
docs(dev-infra): add comment about what the requiredBaseCommit is

### DIFF
--- a/.ng-dev/config.ts
+++ b/.ng-dev/config.ts
@@ -107,6 +107,7 @@ const merge = () => {
     requiredBaseCommits: {
       // PRs that target either `master` or the patch branch, need to be rebased
       // on top of the latest commit message validation fix.
+      // These SHAs are the commits that update the required license text in the header.
       'master': '5aeb9a4124922d8ac08eb73b8f322905a32b0b3a',
       [patch]: '27b95ba64a5d99757f4042073fd1860e20e3ed24'
     },


### PR DESCRIPTION
Add a comment to describe what the commit was for the given SHA so that we don't have to look it up.
