### PR TITLE
perf(core): avoid pulling in jit-specific code in aot bundles (#37372)

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2987,
-        "main-es2015": 452792,
+        "main-es2015": 451918,
         "polyfills-es2015": 52655
       }
     }

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 142590,
+        "main-es2015": 141394,
         "polyfills-es2015": 36963
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 148510,
+        "main-es2015": 147314,
         "polyfills-es2015": 36963
       }
     }
@@ -30,7 +30,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 138196,
+        "main-es2015": 136873,
         "polyfills-es2015": 37640
       }
     }
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 247942,
+        "main-es2015": 246781,
         "polyfills-es2015": 36657,
         "5-es2015": 751
       }
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 223603,
+        "main-es2015": 221961,
         "polyfills-es2015": 36657,
         "5-es2015": 779
       }
@@ -61,8 +61,8 @@
         "bundle": "TODO(i): temporarily increase the payload size limit from 105779 - this is due to a closure issue related to ESM reexports that still needs to be investigated",
         "bundle": "TODO(i): we should define ngDevMode to false in Closure, but --define only works in the global scope.",
         "bundle": "TODO(i): (FW-2164) TS 3.9 new class shape seems to have broken Closure in big ways. The size went from 169991 to 252338",
-        "bundle": "TODO(i): after removal of tsickle from ngc-wrapped / ng_package, we had to switch to SIMPLE optimizations which increased the size from 252338 to 1197869, see PR#37221 and PR#37317 for more info",
-        "bundle": 1198831
+        "bundle": "TODO(i): after removal of tsickle from ngc-wrapped / ng_package, we had to switch to SIMPLE optimizations which increased the size from 252338 to 1198917, see PR#37221 and PR#37317 for more info",
+        "bundle": 1198917
       }
     }
   }

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -60,21 +60,22 @@ export function compileNgModuleFactory__POST_R3__<M>(
     moduleType: Type<M>): Promise<NgModuleFactory<M>> {
   ngDevMode && assertNgModuleType(moduleType);
 
-  const compilerOptions = injector.get(COMPILER_OPTIONS, []).concat(options);
+  const moduleFactory = new R3NgModuleFactory(moduleType);
 
-  if (typeof ngJitMode === 'undefined' || ngJitMode) {
-    // Configure the compiler to use the provided options. This call may fail when multiple modules
-    // are bootstrapped with incompatible options, as a component can only be compiled according to
-    // a single set of options.
-    setJitOptions({
-      defaultEncapsulation:
-          _lastDefined(compilerOptions.map(options => options.defaultEncapsulation)),
-      preserveWhitespaces:
-          _lastDefined(compilerOptions.map(options => options.preserveWhitespaces)),
-    });
+  // All of the logic below is irrelevant for AOT-compiled code.
+  if (typeof ngJitMode !== 'undefined' && !ngJitMode) {
+    return Promise.resolve(moduleFactory);
   }
 
-  const moduleFactory = new R3NgModuleFactory(moduleType);
+  const compilerOptions = injector.get(COMPILER_OPTIONS, []).concat(options);
+
+  // Configure the compiler to use the provided options. This call may fail when multiple modules
+  // are bootstrapped with incompatible options, as a component can only be compiled according to
+  // a single set of options.
+  setJitOptions({
+    defaultEncapsulation: _lastDefined(compilerOptions.map(opts => opts.defaultEncapsulation)),
+    preserveWhitespaces: _lastDefined(compilerOptions.map(opts => opts.preserveWhitespaces)),
+  });
 
   if (isComponentResourceResolutionQueueEmpty()) {
     return Promise.resolve(moduleFactory);


### PR DESCRIPTION
**Note:** this is the patch-only version of #37372.

In #29083 a call to `getCompilerFacade` was added to `ApplicationRef` which pulls in a bit of JIT-specific code. Since the code path that calls the function can't be hit for an AOT-compiled app, these changes add an `ngJitMode` guard which will allow for dead code elimination to drop it completely. Testing it out against a new CLI project showed a difference of ~1.2kb.

PR Close #37372
