### PR TITLE
feat(language-service): Remove HTML entities autocompletion

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AbsoluteSourceSpan, AST, AstPath, AttrAst, Attribute, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, Element, ElementAst, EmptyExpr, ExpressionBinding, getHtmlTagDefinition, HtmlAstPath, NAMED_ENTITIES, Node as HtmlAst, NullTemplateVisitor, ParseSpan, ReferenceAst, TagContentType, TemplateBinding, Text, VariableBinding} from '@angular/compiler';
+import {AbsoluteSourceSpan, AST, AstPath, AttrAst, Attribute, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, Element, ElementAst, EmptyExpr, ExpressionBinding, getHtmlTagDefinition, HtmlAstPath, Node as HtmlAst, NullTemplateVisitor, ParseSpan, ReferenceAst, TagContentType, TemplateBinding, Text, VariableBinding} from '@angular/compiler';
 import {$$, $_, isAsciiLetter, isDigit} from '@angular/compiler/src/chars';
 
 import {ATTR, getBindingDescriptor} from './binding_utils';
@@ -164,9 +164,6 @@ export function getTemplateCompletions(
             }
           },
           visitText(ast) {
-            // Check if we are in a entity.
-            result = entityCompletions(getSourceText(template, spanOf(ast)), astPosition);
-            if (result.length) return result;
             result = interpolationCompletions(templateInfo, templatePosition);
             if (result.length) return result;
             const element = path.first(Element);
@@ -357,33 +354,6 @@ function elementCompletions(info: ng.AstResult): ng.CompletionEntry[] {
   }
 
   return results;
-}
-
-function entityCompletions(value: string, position: number): ng.CompletionEntry[] {
-  // Look for entity completions
-  // TODO(kyliau): revisit the usefulness of this feature. It provides
-  // autocompletion for HTML entities, which IMO is outside the core functionality
-  // of Angular language service. Besides, we do not have a complete list.
-  // See https://dev.w3.org/html5/html-author/charref
-  const re = /&[A-Za-z]*;?(?!\d)/g;
-  let found: RegExpExecArray|null;
-  let result: ng.CompletionEntry[] = [];
-  while (found = re.exec(value)) {
-    let len = found[0].length;
-    // end position must be inclusive to account for cases like '&|' where
-    // cursor is right behind the ampersand.
-    if (position >= found.index && position <= (found.index + len)) {
-      result = Object.keys(NAMED_ENTITIES).map(name => {
-        return {
-          name: `&${name};`,
-          kind: ng.CompletionKind.ENTITY,
-          sortText: name,
-        };
-      });
-      break;
-    }
-  }
-  return result;
 }
 
 function interpolationCompletions(info: ng.AstResult, position: number): ng.CompletionEntry[] {
@@ -596,10 +566,6 @@ class ExpressionVisitor extends NullTemplateVisitor {
       }
     }
   }
-}
-
-function getSourceText(template: ng.TemplateSource, span: ng.Span): string {
-  return template.source.substring(span.start, span.end);
 }
 
 interface AngularAttributes {

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -27,13 +27,6 @@ describe('completions', () => {
     mockHost.reset();
   });
 
-  it('should be able to get entity completions', () => {
-    mockHost.overrideInlineTemplate(APP_COMPONENT, '&~{cursor}');
-    const marker = mockHost.getLocationMarkerFor(APP_COMPONENT, 'cursor');
-    const completions = ngLS.getCompletionsAtPosition(APP_COMPONENT, marker.start);
-    expectContain(completions, CompletionKind.ENTITY, ['&amp;', '&gt;', '&lt;', '&iota;']);
-  });
-
   it('should be able to return html elements', () => {
     mockHost.overrideInlineTemplate(APP_COMPONENT, '<~{cursor}');
     const marker = mockHost.getLocationMarkerFor(APP_COMPONENT, 'cursor');
@@ -241,13 +234,6 @@ describe('completions', () => {
   });
 
   describe('in external template', () => {
-    it('should be able to get entity completions in external template', () => {
-      mockHost.override(TEST_TEMPLATE, '&~{cursor}');
-      const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
-      const completions = ngLS.getCompletionsAtPosition(TEST_TEMPLATE, marker.start);
-      expectContain(completions, CompletionKind.ENTITY, ['&amp;', '&gt;', '&lt;', '&iota;']);
-    });
-
     it('should not return html elements', () => {
       mockHost.override(TEST_TEMPLATE, '<~{cursor}');
       const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');


### PR DESCRIPTION
This commit removes the autocompletion feature for HTML entities.
HTML entites are things like `&amp;`, `&lt;` etc.

There are a few reasons for the decision:

1. It is outside the core functionality of Angular LS
2. The implementation relies on regex, which incurs performance cost
3. There isn't much value if users do not already know which entity
   they want to use
4. The list that we provide is not exhaustive

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
