### PR TITLE
Renderer flag

### DIFF
--- a/packages/bazel/src/external.bzl
+++ b/packages/bazel/src/external.bzl
@@ -35,6 +35,11 @@ compile_ts = _compile_ts
 DEPS_ASPECTS = _DEPS_ASPECTS
 ts_providers_dict_to_struct = _ts_providers_dict_to_struct
 
+# Should be defined as `BuildSettingInfo` from Skylib, but a dependency on
+# Skylib is not necessary here because this is only used in google3 where Skylib
+# is loaded differently anyways where this file is overridden.
+BuildSettingInfo = provider(doc = "Not used outside google3.")
+
 DEFAULT_API_EXTRACTOR = "@npm//@angular/bazel/bin:api-extractor"
 DEFAULT_NG_COMPILER = "@npm//@angular/bazel/bin:ngc-wrapped"
 DEFAULT_NG_XI18N = "@npm//@angular/bazel/bin:xi18n"

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -7,6 +7,7 @@
 
 load(
     ":external.bzl",
+    "BuildSettingInfo",
     "COMMON_ATTRIBUTES",
     "COMMON_OUTPUTS",
     "DEFAULT_API_EXTRACTOR",
@@ -35,6 +36,15 @@ def is_ivy_enabled(ctx):
     Returns:
       Boolean, Whether the ivy compiler should be used.
     """
+
+    # Check the renderer flag to see if Ivy is enabled.
+    # This is intended to support a transition use case for google3 migration.
+    # The `_renderer` attribute will never be set externally, but will always be
+    # set internally as a `string_flag()` with the allowed values of:
+    # "view_engine" or "ivy".
+    if ((hasattr(ctx.attr, "_renderer") and
+         ctx.attr._renderer[BuildSettingInfo].value == "ivy")):
+        return True
 
     # TODO(josephperott): Remove after ~Feb 2020, to allow local script migrations
     if "compile" in ctx.var and ctx.workspace_name == "angular":


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [N/A] Tests for the changes have been added (for bug fixes / features)
    * Tested by manually patching this into google3 into a workspace with the new flag and verified that setting it via command line in Blaze correctly enables Ivy as expected.
- [N/A] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: http://b/158246077

Currently there is no way to set a particular `ng_module()` to build with View Engine or Ivy via a Bazel transition. Choosing a renderer is an "all or nothing" approach, where the entire compilation uses one renderer or the other.

## What is the new behavior?

`ng_module()` now supports a `string_flag()` being provided as a `_renderer` attribute and will use it to decide whether to build with View Engine or Ivy. Such flags can be set via a transition on a per-target basis, making the flag much more flexible for migration use cases.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This flag is not intended for external use cases and will only ever be set inside google3. It is also **not** intended to replace `--config ivy` or `--define angular_ivy_enabled=True`.

See [cl/315749946](http://cl/315749946) for a g3 patch which adds the flag to be compatible with this PR.