### PR TITLE
fix(forms): fix enabling form control after it was disabled

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -108,8 +108,7 @@ export class FormControlDirective extends NgControl implements OnChanges {
 
   /**
    * @description
-   * Instance property used to allow enabling  ngModel warning has been sent out for this
-   * particular `FormControlDirective` instance. Used to support warning config of "always".
+   * Instance property used to allow enabling the control once it is disabled on initialization.
    *
    * @internal
    */
@@ -122,13 +121,13 @@ export class FormControlDirective extends NgControl implements OnChanges {
       @Optional() @Self() @Inject(NG_VALUE_ACCESSOR) valueAccessors: ControlValueAccessor[],
       @Optional() @Inject(NG_MODEL_WITH_FORM_CONTROL_WARNING) private _ngModelWarningConfig: string|
       null,
-      @Optional() @Inject(ALLOW_ENABLE_FORM_CONTROL) _allowEnableFormControlConfig:
+      @Optional() @Inject(ALLOW_ENABLE_FORM_CONTROL) allowEnableFormControlConfig:
           boolean|null) {
     super();
     this._rawValidators = validators || [];
     this._rawAsyncValidators = asyncValidators || [];
     this.valueAccessor = selectValueAccessor(this, valueAccessors);
-    this._allowEnableFormControl = _allowEnableFormControlConfig;
+    this._allowEnableFormControl = allowEnableFormControlConfig;
   }
 
   /**

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -225,9 +225,6 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
   private _setUpControl() {
     this._checkParentType();
     (this as {control: FormControl}).control = this.formDirective.addControl(this);
-    if (this.valueAccessor!.setDisabledState) {
-      this.valueAccessor!.setDisabledState!(this.control.disabled);
-    }
     this._added = true;
   }
 }

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -225,8 +225,8 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
   private _setUpControl() {
     this._checkParentType();
     (this as {control: FormControl}).control = this.formDirective.addControl(this);
-    if (this.control.disabled && this.valueAccessor!.setDisabledState) {
-      this.valueAccessor!.setDisabledState!(true);
+    if (this.valueAccessor!.setDisabledState) {
+      this.valueAccessor!.setDisabledState!(this.control.disabled);
     }
     this._added = true;
   }

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -10,6 +10,7 @@ import {isDevMode} from '@angular/core';
 
 import {FormArray, FormControl, FormGroup} from '../model';
 import {Validators} from '../validators';
+
 import {AbstractControlDirective} from './abstract_control_directive';
 import {AbstractFormGroupDirective} from './abstract_form_group_directive';
 import {CheckboxControlValueAccessor} from './checkbox_value_accessor';
@@ -21,6 +22,7 @@ import {normalizeAsyncValidator, normalizeValidator} from './normalize_validator
 import {NumberValueAccessor} from './number_value_accessor';
 import {RadioControlValueAccessor} from './radio_control_value_accessor';
 import {RangeValueAccessor} from './range_value_accessor';
+import {FormControlDirective} from './reactive_directives/form_control_directive';
 import {FormArrayName} from './reactive_directives/form_group_name';
 import {ReactiveErrors} from './reactive_errors';
 import {SelectControlValueAccessor} from './select_control_value_accessor';
@@ -46,6 +48,15 @@ export function setUpControl(control: FormControl, dir: NgControl): void {
   setUpBlurPipeline(control, dir);
 
   if (dir.valueAccessor!.setDisabledState) {
+    if ((<FormControlDirective>dir)._allowEnableFormControl) {
+      // new functionality allowing the control to be enabled/disabled
+      dir.valueAccessor!.setDisabledState!(control.disabled);
+    } else {
+      // backwards compatibility which allowed only to disable the control, but not to enable it back.
+      if (dir.disabled) {
+        dir.valueAccessor!.setDisabledState!(true);
+      }
+    }
     control.registerOnDisabledChange((isDisabled: boolean) => {
       dir.valueAccessor!.setDisabledState!(isDisabled);
     });

--- a/packages/forms/src/form_providers.ts
+++ b/packages/forms/src/form_providers.ts
@@ -10,6 +10,7 @@ import {ModuleWithProviders, NgModule} from '@angular/core';
 
 import {InternalFormsSharedModule, NG_MODEL_WITH_FORM_CONTROL_WARNING, REACTIVE_DRIVEN_DIRECTIVES, TEMPLATE_DRIVEN_DIRECTIVES} from './directives';
 import {RadioControlRegistry} from './directives/radio_control_value_accessor';
+import {ALLOW_ENABLE_FORM_CONTROL} from './directives/reactive_directives/form_control_directive';
 import {FormBuilder} from './form_builder';
 
 /**
@@ -53,12 +54,14 @@ export class ReactiveFormsModule {
    * binding is used with reactive form directives.
    */
   static withConfig(opts: {
-    /** @deprecated as of v6 */ warnOnNgModelWithFormControl: 'never'|'once'|'always'
+    /** @deprecated as of v6 */ warnOnNgModelWithFormControl: 'never'|'once'|'always',
+    allowEnableFormControl?: boolean
   }): ModuleWithProviders<ReactiveFormsModule> {
     return {
       ngModule: ReactiveFormsModule,
       providers: [
-        {provide: NG_MODEL_WITH_FORM_CONTROL_WARNING, useValue: opts.warnOnNgModelWithFormControl}
+        {provide: NG_MODEL_WITH_FORM_CONTROL_WARNING, useValue: opts.warnOnNgModelWithFormControl},
+        {provide: ALLOW_ENABLE_FORM_CONTROL, useValue: opts.allowEnableFormControl}
       ]
     };
   }

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -15,12 +15,16 @@ import {SpyNgControl, SpyValueAccessor} from './spies';
 
 class DummyControlValueAccessor implements ControlValueAccessor {
   writtenValue: any;
+  disabled: boolean = false;
 
   registerOnChange(fn: any) {}
   registerOnTouched(fn: any) {}
 
   writeValue(obj: any): void {
     this.writtenValue = obj;
+  }
+  setDisabledState?(isDisabled: boolean): void {
+    this.disabled = isDisabled;
   }
 }
 
@@ -517,7 +521,8 @@ function asyncValidator(expected: any, timeout = 0) {
       };
 
       beforeEach(() => {
-        controlDir = new FormControlDirective([Validators.required], [], [defaultAccessor], null);
+        controlDir =
+            new FormControlDirective([Validators.required], [], [defaultAccessor], null, false);
         controlDir.valueAccessor = new DummyControlValueAccessor();
 
         control = new FormControl(null);
@@ -621,6 +626,38 @@ function asyncValidator(expected: any, timeout = 0) {
 
            expect(ngModel.control.errors).toEqual({'async': true});
          }));
+
+      it('should toggle enable/disable status on control', () => {
+        const controlDir =
+            new FormControlDirective([Validators.required], [], [defaultAccessor], null, false);
+        controlDir.valueAccessor = new DummyControlValueAccessor();
+        const spyOnDisabledState = spyOn(controlDir.valueAccessor, 'setDisabledState');
+
+        let enabledControl = new FormControl(1);
+        controlDir.form = enabledControl;
+        controlDir.ngOnChanges({'form': new SimpleChange(undefined, enabledControl, true)});
+
+        expect(enabledControl.status).toEqual('VALID');
+        expect(spyOnDisabledState).toHaveBeenCalledWith(false);
+        spyOnDisabledState.calls.reset();
+
+        const disabledControl = new FormControl(2);
+        controlDir.form = disabledControl;
+        disabledControl.disable();
+        controlDir.ngOnChanges({'form': new SimpleChange(enabledControl, disabledControl, false)});
+
+        expect(disabledControl.status).toEqual('DISABLED');
+        expect(spyOnDisabledState).toHaveBeenCalledWith(true);
+        spyOnDisabledState.calls.reset();
+
+        enabledControl = new FormControl(3);
+        controlDir.form = enabledControl;
+        enabledControl.enable();
+        controlDir.ngOnChanges({'form': new SimpleChange(disabledControl, enabledControl, false)});
+
+        expect(enabledControl.status).toEqual('VALID');
+        expect(spyOnDisabledState).toHaveBeenCalledWith(false);
+      });
 
       it('should mark as disabled properly', fakeAsync(() => {
            ngModel.ngOnChanges({isDisabled: new SimpleChange('', undefined, false)});

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -1054,6 +1054,40 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              expect(fixture.componentInstance.control.status).toEqual('DISABLED');
            });
 
+        describe('should support custom accessors with setDisabledState - formControlName', () => {
+          let fixture: ComponentFixture<CvaWithDisabledStateForm>;
+
+          beforeEach(() => {
+            fixture = initTest(CvaWithDisabledStateForm, CvaWithDisabledState);
+          });
+
+          it('sets the disabled state when the control is initally disabled', () => {
+            fixture.componentInstance.form = new FormGroup({
+              'login': new FormControl({value: 'aa', disabled: true}),
+            });
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.form.status).toEqual('DISABLED');
+            expect(fixture.componentInstance.form.get('login')!.status).toEqual('DISABLED');
+            expect(fixture.debugElement.query(By.directive(CvaWithDisabledState))
+                       .nativeElement.textContent)
+                .toEqual('DISABLED');
+          });
+
+          it('sets the enabled state when the control is initally enabled', () => {
+            fixture.componentInstance.form = new FormGroup({
+              'login': new FormControl({value: 'aa', disabled: false}),
+            });
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.form.status).toEqual('VALID');
+            expect(fixture.componentInstance.form.get('login')!.status).toEqual('VALID');
+            expect(fixture.debugElement.query(By.directive(CvaWithDisabledState))
+                       .nativeElement.textContent)
+                .toEqual('ENABLED');
+          });
+        });
+
         it('should populate control in ngOnInit when injecting NgControl', () => {
           const fixture = initTest(MyInputForm, MyInput);
           fixture.componentInstance.form = new FormGroup({'login': new FormControl('aa')});
@@ -1367,6 +1401,29 @@ class WrappedValue implements ControlValueAccessor {
   }
 }
 
+@Component({
+  selector: 'cva-with-disabled-state',
+  template: `{{disabled ? 'DISABLED' : 'ENABLED'}}`,
+  providers: [
+    {provide: NG_VALUE_ACCESSOR, multi: true, useExisting: CvaWithDisabledState},
+  ]
+})
+class CvaWithDisabledState implements ControlValueAccessor {
+  // TODO(issue/24571): remove '!'.
+
+  disabled!: boolean;
+  onChange!: Function;
+
+  writeValue(value: any) {}
+
+  registerOnChange(fn: (value: any) => void) {}
+  registerOnTouched(fn: any) {}
+
+  setDisabledState(disabled: boolean) {
+    this.disabled = disabled;
+  }
+}
+
 @Component({selector: 'my-input', template: ''})
 export class MyInput implements ControlValueAccessor {
   @Output('input') onInput = new EventEmitter();
@@ -1410,6 +1467,19 @@ export class MyInputForm {
   form!: FormGroup;
   @ViewChild(MyInput) myInput: MyInput|null = null;
 }
+
+@Component({
+  selector: 'wrapped-value-form',
+  template: `
+    <div [formGroup]="form">
+      <cva-with-disabled-state formControlName="login"></cva-with-disabled-state>
+    </div>`
+})
+class CvaWithDisabledStateForm {
+  // TODO(issue/24571): remove '!'.
+  form!: FormGroup;
+}
+
 
 @Component({
   selector: 'wrapped-value-form',


### PR DESCRIPTION
Previously, it was not possible to enable a form control after it was disabled.
This commit fixes this by making sure that the form is enabled and that
`setDisabledState` is called with `false`.

Closes #35565

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
