### PR TITLE
feat(platform-server): add option for absolute URL HTTP support

### DIFF
--- a/goldens/public-api/platform-server/platform-server.d.ts
+++ b/goldens/public-api/platform-server/platform-server.d.ts
@@ -5,6 +5,7 @@ export declare const INITIAL_CONFIG: InjectionToken<PlatformConfig>;
 export declare interface PlatformConfig {
     document?: string;
     url?: string;
+    useAbsoluteUrl?: boolean;
 }
 
 export declare const platformDynamicServer: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;

--- a/packages/platform-server/src/tokens.ts
+++ b/packages/platform-server/src/tokens.ts
@@ -14,8 +14,25 @@ import {InjectionToken} from '@angular/core';
  * @publicApi
  */
 export interface PlatformConfig {
+  /**
+   * The initial DOM to use to bootstrap the server application.
+   * @default create a new DOM using Domino
+   */
   document?: string;
+  /**
+   * The URL for the current application state. This is
+   * used for initializing the platform's location and
+   * for setting absolute URL resolution for HTTP requests.
+   * @default none
+   */
   url?: string;
+  /**
+   * Whether to append the absolute URL to any relative HTTP
+   * requests. If set to true, this logic executes prior to
+   * any HTTP interceptors that may run later on in the request.
+   * @default false
+   */
+  useAbsoluteUrl?: boolean;
 }
 
 /**

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -793,104 +793,149 @@ describe('platform-server integration', () => {
          });
        }));
 
-    it('can make relative HttpClient requests', async () => {
-      const platform = platformDynamicServer([
-        {provide: INITIAL_CONFIG, useValue: {document: '<app></app>', url: 'http://localhost'}}
-      ]);
-      const ref = await platform.bootstrapModule(HttpClientExampleModule);
-      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
-      const http = ref.injector.get(HttpClient);
-      ref.injector.get(NgZone).run(() => {
-        http.get<string>('/testing').subscribe((body: string) => {
-          NgZone.assertInAngularZone();
-          expect(body).toEqual('success!');
+    describe('relative requests', () => {
+      it('correctly maps to absolute URL request with base config', async () => {
+        const platform = platformDynamicServer([{
+          provide: INITIAL_CONFIG,
+          useValue: {document: '<app></app>', url: 'http://localhost', useAbsoluteUrl: true}
+        }]);
+        const ref = await platform.bootstrapModule(HttpClientExampleModule);
+        const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+        const http = ref.injector.get(HttpClient);
+        ref.injector.get(NgZone).run(() => {
+          http.get<string>('/testing').subscribe((body: string) => {
+            NgZone.assertInAngularZone();
+            expect(body).toEqual('success!');
+          });
+          mock.expectOne('http://localhost/testing').flush('success!');
         });
-        mock.expectOne('http://localhost/testing').flush('success!');
       });
-    });
 
-    it('can make relative HttpClient requests two slashes', async () => {
-      const platform = platformDynamicServer([
-        {provide: INITIAL_CONFIG, useValue: {document: '<app></app>', url: 'http://localhost/'}}
-      ]);
-      const ref = await platform.bootstrapModule(HttpClientExampleModule);
-      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
-      const http = ref.injector.get(HttpClient);
-      ref.injector.get(NgZone).run(() => {
-        http.get<string>('/testing').subscribe((body: string) => {
-          NgZone.assertInAngularZone();
-          expect(body).toEqual('success!');
+      it('uses default URL behavior when not enabled', async () => {
+        const platform = platformDynamicServer([{
+          provide: INITIAL_CONFIG,
+          useValue: {document: '<app></app>', url: 'http://localhost', useAbsoluteUrl: false}
+        }]);
+        const ref = await platform.bootstrapModule(HttpClientExampleModule);
+        const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+        const http = ref.injector.get(HttpClient);
+        ref.injector.get(NgZone).run(() => {
+          http.get<string>('/testing').subscribe(() => {}, (body: string) => {
+            NgZone.assertInAngularZone();
+            expect(body).toEqual('error');
+          });
+          mock.expectOne('/testing').flush('error');
         });
-        mock.expectOne('http://localhost/testing').flush('success!');
       });
-    });
 
-    it('can make relative HttpClient requests no slashes', async () => {
-      const platform = platformDynamicServer([
-        {provide: INITIAL_CONFIG, useValue: {document: '<app></app>', url: 'http://localhost'}}
-      ]);
-      const ref = await platform.bootstrapModule(HttpClientExampleModule);
-      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
-      const http = ref.injector.get(HttpClient);
-      ref.injector.get(NgZone).run(() => {
-        http.get<string>('testing').subscribe((body: string) => {
-          NgZone.assertInAngularZone();
-          expect(body).toEqual('success!');
+      it('correctly maps to absolute URL request with port', async () => {
+        const platform = platformDynamicServer([{
+          provide: INITIAL_CONFIG,
+          useValue: {document: '<app></app>', url: 'http://localhost:5000', useAbsoluteUrl: true}
+        }]);
+        const ref = await platform.bootstrapModule(HttpClientExampleModule);
+        const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+        const http = ref.injector.get(HttpClient);
+        ref.injector.get(NgZone).run(() => {
+          http.get<string>('/testing').subscribe((body: string) => {
+            NgZone.assertInAngularZone();
+            expect(body).toEqual('success!');
+          });
+          mock.expectOne('http://localhost:5000/testing').flush('success!');
         });
-        mock.expectOne('http://localhost/testing').flush('success!');
       });
-    });
 
-    it('can make relative HttpClient requests no slashes longer url', async () => {
-      const platform = platformDynamicServer([{
-        provide: INITIAL_CONFIG,
-        useValue: {document: '<app></app>', url: 'http://localhost/path/page'}
-      }]);
-      const ref = await platform.bootstrapModule(HttpClientExampleModule);
-      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
-      const http = ref.injector.get(HttpClient);
-      ref.injector.get(NgZone).run(() => {
-        http.get<string>('testing').subscribe((body: string) => {
-          NgZone.assertInAngularZone();
-          expect(body).toEqual('success!');
+      it('correctly maps to absolute URL request with two slashes', async () => {
+        const platform = platformDynamicServer([{
+          provide: INITIAL_CONFIG,
+          useValue: {document: '<app></app>', url: 'http://localhost/', useAbsoluteUrl: true}
+        }]);
+        const ref = await platform.bootstrapModule(HttpClientExampleModule);
+        const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+        const http = ref.injector.get(HttpClient);
+        ref.injector.get(NgZone).run(() => {
+          http.get<string>('/testing').subscribe((body: string) => {
+            NgZone.assertInAngularZone();
+            expect(body).toEqual('success!');
+          });
+          mock.expectOne('http://localhost/testing').flush('success!');
         });
-        mock.expectOne('http://localhost/path/testing').flush('success!');
       });
-    });
 
-    it('can make relative HttpClient requests slashes longer url', async () => {
-      const platform = platformDynamicServer([{
-        provide: INITIAL_CONFIG,
-        useValue: {document: '<app></app>', url: 'http://localhost/path/page'}
-      }]);
-      const ref = await platform.bootstrapModule(HttpClientExampleModule);
-      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
-      const http = ref.injector.get(HttpClient);
-      ref.injector.get(NgZone).run(() => {
-        http.get<string>('/testing').subscribe((body: string) => {
-          NgZone.assertInAngularZone();
-          expect(body).toEqual('success!');
+      it('correctly maps to absolute URL request with no slashes', async () => {
+        const platform = platformDynamicServer([{
+          provide: INITIAL_CONFIG,
+          useValue: {document: '<app></app>', url: 'http://localhost', useAbsoluteUrl: true}
+        }]);
+        const ref = await platform.bootstrapModule(HttpClientExampleModule);
+        const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+        const http = ref.injector.get(HttpClient);
+        ref.injector.get(NgZone).run(() => {
+          http.get<string>('testing').subscribe((body: string) => {
+            NgZone.assertInAngularZone();
+            expect(body).toEqual('success!');
+          });
+          mock.expectOne('http://localhost/testing').flush('success!');
         });
-        mock.expectOne('http://localhost/testing').flush('success!');
       });
-    });
 
-    it('can make relative HttpClient requests slashes longer url with base href', async () => {
-      const platform = platformDynamicServer([{
-        provide: INITIAL_CONFIG,
-        useValue:
-            {document: '<base href="http://other"><app></app>', url: 'http://localhost/path/page'}
-      }]);
-      const ref = await platform.bootstrapModule(HttpClientExampleModule);
-      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
-      const http = ref.injector.get(HttpClient);
-      ref.injector.get(NgZone).run(() => {
-        http.get<string>('/testing').subscribe((body: string) => {
-          NgZone.assertInAngularZone();
-          expect(body).toEqual('success!');
+      it('correctly maps to absolute URL request with longer url and no slashes', async () => {
+        const platform = platformDynamicServer([{
+          provide: INITIAL_CONFIG,
+          useValue:
+              {document: '<app></app>', url: 'http://localhost/path/page', useAbsoluteUrl: true}
+        }]);
+        const ref = await platform.bootstrapModule(HttpClientExampleModule);
+        const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+        const http = ref.injector.get(HttpClient);
+        ref.injector.get(NgZone).run(() => {
+          http.get<string>('testing').subscribe((body: string) => {
+            NgZone.assertInAngularZone();
+            expect(body).toEqual('success!');
+          });
+          mock.expectOne('http://localhost/path/testing').flush('success!');
         });
-        mock.expectOne('http://other/testing').flush('success!');
       });
+
+      it('correctly maps to absolute URL request with longer url and slashes', async () => {
+        const platform = platformDynamicServer([{
+          provide: INITIAL_CONFIG,
+          useValue:
+              {document: '<app></app>', url: 'http://localhost/path/page', useAbsoluteUrl: true}
+        }]);
+        const ref = await platform.bootstrapModule(HttpClientExampleModule);
+        const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+        const http = ref.injector.get(HttpClient);
+        ref.injector.get(NgZone).run(() => {
+          http.get<string>('/testing').subscribe((body: string) => {
+            NgZone.assertInAngularZone();
+            expect(body).toEqual('success!');
+          });
+          mock.expectOne('http://localhost/testing').flush('success!');
+        });
+      });
+
+      it('correctly maps to absolute URL request with longer url, slashes, and base href',
+         async () => {
+           const platform = platformDynamicServer([{
+             provide: INITIAL_CONFIG,
+             useValue: {
+               document: '<base href="http://other"><app></app>',
+               url: 'http://localhost/path/page',
+               useAbsoluteUrl: true
+             }
+           }]);
+           const ref = await platform.bootstrapModule(HttpClientExampleModule);
+           const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+           const http = ref.injector.get(HttpClient);
+           ref.injector.get(NgZone).run(() => {
+             http.get<string>('/testing').subscribe((body: string) => {
+               NgZone.assertInAngularZone();
+               expect(body).toEqual('success!');
+             });
+             mock.expectOne('http://other/testing').flush('success!');
+           });
+         });
     });
 
     it('requests are macrotasks', async(() => {


### PR DESCRIPTION
In version 10.0.0-next.8, we introduced absolute URL support for
server-based HTTP requests, so long as the fully-resolved URL was
provided in the initial config. However, doing so represents a
breaking change for users who already have their own interceptors
to model this functionality, since our logic executes before all
interceptors fire on a request.

Therefore, we introduce a flag to make this change consistent with
v9 behavior, allowing users to opt in to this new behavior. This
commit also fixes two issues with the previous implementation:
1. if the server was initiated with a relative URL, the absolute
URL construction would fail because needed components were empty
2. if the user's absolute URL was on a port, the port would not
be included

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
