### PR TITLE
refactor(compiler-cli): skip class decorators in tooling constructor parameters transform

### DIFF
--- a/packages/compiler-cli/src/tooling.ts
+++ b/packages/compiler-cli/src/tooling.ts
@@ -35,15 +35,15 @@ export const GLOBAL_DEFS_FOR_TERSER_WITH_AOT = {
 /**
  * Transform for downleveling Angular decorators and Angular-decorated class constructor
  * parameters for dependency injection. This transform can be used by the CLI for JIT-mode
- * compilation where decorators should be preserved, but downleveled so that apps are not
- * exposed to the ES2015 temporal dead zone limitation in TypeScript's metadata.
- * See https://github.com/angular/angular-cli/pull/14473 for more details.
+ * compilation where constructor parameters and associated Angular decorators should be
+ * downleveled so that apps are not exposed to the ES2015 temporal dead zone limitation
+ * in TypeScript. See https://github.com/angular/angular-cli/pull/14473 for more details.
  */
-export function decoratorDownlevelTransformerFactory(program: ts.Program):
+export function constructorParametersDownlevelTransform(program: ts.Program):
     ts.TransformerFactory<ts.SourceFile> {
   const typeChecker = program.getTypeChecker();
   const reflectionHost = new TypeScriptReflectionHost(typeChecker);
   return getDownlevelDecoratorsTransform(
       typeChecker, reflectionHost, [], /* isCore */ false,
-      /* enableClosureCompiler */ false);
+      /* enableClosureCompiler */ false, /* skipClassDecorators */ true);
 }

--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -535,8 +535,8 @@ class AngularCompilerProgram implements Program {
       // ignore diagnostics that have been collected by the transformer. These are
       // non-significant failures that shouldn't prevent apps from compiling.
       beforeTs.push(getDownlevelDecoratorsTransform(
-          typeChecker, reflectionHost, [], this.isCompilingAngularCore,
-          annotateForClosureCompiler));
+          typeChecker, reflectionHost, [], this.isCompilingAngularCore, annotateForClosureCompiler,
+          /* skipClassDecorators */ false));
     }
 
     if (metadataTransforms.length > 0) {


### PR DESCRIPTION
We recently added a transformer to NGC that is responsible for downleveling Angular
decorators and constructor parameter types. The primary goal was to mitigate a
TypeScript limitation/issue that surfaces in Angular projects due to the heavy
reliance on type metadata being captured for DI. Additionally this is a
pre-requisite of making `tsickle` optional in the Angular bazel toolchain.

See: 401ef71ae5b01be95d124184a0b6936fc453a5d4 for more context on this.

Another (less important) goal was to make sure that the CLI can re-use
this transformer for its JIT mode compilation. The CLI (as outlined in
the commit mentioned above), already has a transformer for downleveling
constructor parameters. We want to avoid this duplication and exported
the transform through the tooling-private compiler entry-point.

Early experiments in using this transformer over the current one, highlighted
that in JIT, class decorators cannot be downleveled. Angular relies on those
to be invoked immediately for JIT so that factories etc. are generated upon loading
due to side-effects of those decorators.

Before downleveling decorators, upon file loading, the decorator function is invoked
immediately. Resulting in the e.g. factories being generated. Now with the downleveled
ones though, the decorator function is not invoked immediately. This results in missing
factories that are _required_ for JIT compilation.

The transformer we exposed, always downleveles such class decorators
though, so that would break CLI's JIT mode. We can address the CLI's
needs by adding another flag to skip class decorators. This will allow
us to continue with the goal of de-duplication.