### PR TITLE
revert absolute URL changes (patch only)

### DIFF
--- a/packages/platform-server/src/http.ts
+++ b/packages/platform-server/src/http.ts
@@ -10,12 +10,13 @@
 const xhr2: any = require('xhr2');
 
 import {Injectable, Injector, Provider} from '@angular/core';
-import {PlatformLocation} from '@angular/common';
+import {DOCUMENT} from '@angular/common';
 import {HttpEvent, HttpRequest, HttpHandler, HttpBackend, XhrFactory, ɵHttpInterceptingHandler as HttpInterceptingHandler} from '@angular/common/http';
 import {Observable, Observer, Subscription} from 'rxjs';
 
 // @see https://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01#URI-syntax
 const isAbsoluteUrl = /^[a-zA-Z\-\+.]+:\/\//;
+const FORWARD_SLASH = '/';
 
 @Injectable()
 export class ServerXhr implements XhrFactory {
@@ -104,18 +105,20 @@ export abstract class ZoneMacroTaskWrapper<S, R> {
 
 export class ZoneClientBackend extends
     ZoneMacroTaskWrapper<HttpRequest<any>, HttpEvent<any>> implements HttpBackend {
-  constructor(private backend: HttpBackend, private platformLocation: PlatformLocation) {
+  constructor(private backend: HttpBackend, private doc: Document) {
     super();
   }
 
   handle(request: HttpRequest<any>): Observable<HttpEvent<any>> {
-    const {href, protocol, hostname} = this.platformLocation;
-    if (!isAbsoluteUrl.test(request.url) && href !== '/') {
-      const baseHref = this.platformLocation.getBaseHrefFromDOM() || href;
-      const urlPrefix = `${protocol}//${hostname}`;
-      const baseUrl = new URL(baseHref, urlPrefix);
-      const url = new URL(request.url, baseUrl);
-      return this.wrap(request.clone({url: url.toString()}));
+    const href = this.doc.location.href;
+    if (!isAbsoluteUrl.test(request.url) && href) {
+      const urlParts = Array.from(request.url);
+      if (request.url[0] === FORWARD_SLASH && href[href.length - 1] === FORWARD_SLASH) {
+        urlParts.shift();
+      } else if (request.url[0] !== FORWARD_SLASH && href[href.length - 1] !== FORWARD_SLASH) {
+        urlParts.splice(0, 0, FORWARD_SLASH);
+      }
+      return this.wrap(request.clone({url: href + urlParts.join('')}));
     }
     return this.wrap(request);
   }
@@ -126,15 +129,15 @@ export class ZoneClientBackend extends
 }
 
 export function zoneWrappedInterceptingHandler(
-    backend: HttpBackend, injector: Injector, platformLocation: PlatformLocation) {
+    backend: HttpBackend, injector: Injector, doc: Document) {
   const realBackend: HttpBackend = new HttpInterceptingHandler(backend, injector);
-  return new ZoneClientBackend(realBackend, platformLocation);
+  return new ZoneClientBackend(realBackend, doc);
 }
 
 export const SERVER_HTTP_PROVIDERS: Provider[] = [
   {provide: XhrFactory, useClass: ServerXhr}, {
     provide: HttpHandler,
     useFactory: zoneWrappedInterceptingHandler,
-    deps: [HttpBackend, Injector, PlatformLocation]
+    deps: [HttpBackend, Injector, DOCUMENT]
   }
 ];

--- a/packages/platform-server/src/http.ts
+++ b/packages/platform-server/src/http.ts
@@ -10,13 +10,10 @@
 const xhr2: any = require('xhr2');
 
 import {Injectable, Injector, Provider} from '@angular/core';
-import {DOCUMENT} from '@angular/common';
-import {HttpEvent, HttpRequest, HttpHandler, HttpBackend, XhrFactory, ɵHttpInterceptingHandler as HttpInterceptingHandler} from '@angular/common/http';
-import {Observable, Observer, Subscription} from 'rxjs';
 
-// @see https://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01#URI-syntax
-const isAbsoluteUrl = /^[a-zA-Z\-\+.]+:\/\//;
-const FORWARD_SLASH = '/';
+import {HttpEvent, HttpRequest, HttpHandler, HttpBackend, XhrFactory, ɵHttpInterceptingHandler as HttpInterceptingHandler} from '@angular/common/http';
+
+import {Observable, Observer, Subscription} from 'rxjs';
 
 @Injectable()
 export class ServerXhr implements XhrFactory {
@@ -105,21 +102,11 @@ export abstract class ZoneMacroTaskWrapper<S, R> {
 
 export class ZoneClientBackend extends
     ZoneMacroTaskWrapper<HttpRequest<any>, HttpEvent<any>> implements HttpBackend {
-  constructor(private backend: HttpBackend, private doc: Document) {
+  constructor(private backend: HttpBackend) {
     super();
   }
 
   handle(request: HttpRequest<any>): Observable<HttpEvent<any>> {
-    const href = this.doc.location.href;
-    if (!isAbsoluteUrl.test(request.url) && href) {
-      const urlParts = Array.from(request.url);
-      if (request.url[0] === FORWARD_SLASH && href[href.length - 1] === FORWARD_SLASH) {
-        urlParts.shift();
-      } else if (request.url[0] !== FORWARD_SLASH && href[href.length - 1] !== FORWARD_SLASH) {
-        urlParts.splice(0, 0, FORWARD_SLASH);
-      }
-      return this.wrap(request.clone({url: href + urlParts.join('')}));
-    }
     return this.wrap(request);
   }
 
@@ -128,16 +115,12 @@ export class ZoneClientBackend extends
   }
 }
 
-export function zoneWrappedInterceptingHandler(
-    backend: HttpBackend, injector: Injector, doc: Document) {
+export function zoneWrappedInterceptingHandler(backend: HttpBackend, injector: Injector) {
   const realBackend: HttpBackend = new HttpInterceptingHandler(backend, injector);
-  return new ZoneClientBackend(realBackend, doc);
+  return new ZoneClientBackend(realBackend);
 }
 
 export const SERVER_HTTP_PROVIDERS: Provider[] = [
-  {provide: XhrFactory, useClass: ServerXhr}, {
-    provide: HttpHandler,
-    useFactory: zoneWrappedInterceptingHandler,
-    deps: [HttpBackend, Injector, DOCUMENT]
-  }
+  {provide: XhrFactory, useClass: ServerXhr},
+  {provide: HttpHandler, useFactory: zoneWrappedInterceptingHandler, deps: [HttpBackend, Injector]}
 ];

--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -51,7 +51,6 @@ export class ServerPlatformLocation implements PlatformLocation {
       this.pathname = parsedUrl.pathname;
       this.search = parsedUrl.search;
       this.hash = parsedUrl.hash;
-      this.href = _doc.location.href;
     }
   }
 

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -793,54 +793,6 @@ describe('platform-server integration', () => {
          });
        }));
 
-    it('can make relative HttpClient requests', async () => {
-      const platform = platformDynamicServer([
-        {provide: INITIAL_CONFIG, useValue: {document: '<app></app>', url: 'http://localhost'}}
-      ]);
-      const ref = await platform.bootstrapModule(HttpClientExampleModule);
-      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
-      const http = ref.injector.get(HttpClient);
-      ref.injector.get(NgZone).run(() => {
-        http.get<string>('/testing').subscribe((body: string) => {
-          NgZone.assertInAngularZone();
-          expect(body).toEqual('success!');
-        });
-        mock.expectOne('http://localhost/testing').flush('success!');
-      });
-    });
-
-    it('can make relative HttpClient requests two slashes', async () => {
-      const platform = platformDynamicServer([
-        {provide: INITIAL_CONFIG, useValue: {document: '<app></app>', url: 'http://localhost/'}}
-      ]);
-      const ref = await platform.bootstrapModule(HttpClientExampleModule);
-      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
-      const http = ref.injector.get(HttpClient);
-      ref.injector.get(NgZone).run(() => {
-        http.get<string>('/testing').subscribe((body: string) => {
-          NgZone.assertInAngularZone();
-          expect(body).toEqual('success!');
-        });
-        mock.expectOne('http://localhost/testing').flush('success!');
-      });
-    });
-
-    it('can make relative HttpClient requests no slashes', async () => {
-      const platform = platformDynamicServer([
-        {provide: INITIAL_CONFIG, useValue: {document: '<app></app>', url: 'http://localhost'}}
-      ]);
-      const ref = await platform.bootstrapModule(HttpClientExampleModule);
-      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
-      const http = ref.injector.get(HttpClient);
-      ref.injector.get(NgZone).run(() => {
-        http.get<string>('testing').subscribe((body: string) => {
-          NgZone.assertInAngularZone();
-          expect(body).toEqual('success!');
-        });
-        mock.expectOne('http://localhost/testing').flush('success!');
-      });
-    });
-
     it('requests are macrotasks', async(() => {
          const platform = platformDynamicServer(
              [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -841,58 +841,6 @@ describe('platform-server integration', () => {
       });
     });
 
-    it('can make relative HttpClient requests no slashes longer url', async () => {
-      const platform = platformDynamicServer([{
-        provide: INITIAL_CONFIG,
-        useValue: {document: '<app></app>', url: 'http://localhost/path/page'}
-      }]);
-      const ref = await platform.bootstrapModule(HttpClientExampleModule);
-      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
-      const http = ref.injector.get(HttpClient);
-      ref.injector.get(NgZone).run(() => {
-        http.get<string>('testing').subscribe((body: string) => {
-          NgZone.assertInAngularZone();
-          expect(body).toEqual('success!');
-        });
-        mock.expectOne('http://localhost/path/testing').flush('success!');
-      });
-    });
-
-    it('can make relative HttpClient requests slashes longer url', async () => {
-      const platform = platformDynamicServer([{
-        provide: INITIAL_CONFIG,
-        useValue: {document: '<app></app>', url: 'http://localhost/path/page'}
-      }]);
-      const ref = await platform.bootstrapModule(HttpClientExampleModule);
-      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
-      const http = ref.injector.get(HttpClient);
-      ref.injector.get(NgZone).run(() => {
-        http.get<string>('/testing').subscribe((body: string) => {
-          NgZone.assertInAngularZone();
-          expect(body).toEqual('success!');
-        });
-        mock.expectOne('http://localhost/testing').flush('success!');
-      });
-    });
-
-    it('can make relative HttpClient requests slashes longer url with base href', async () => {
-      const platform = platformDynamicServer([{
-        provide: INITIAL_CONFIG,
-        useValue:
-            {document: '<base href="http://other"><app></app>', url: 'http://localhost/path/page'}
-      }]);
-      const ref = await platform.bootstrapModule(HttpClientExampleModule);
-      const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
-      const http = ref.injector.get(HttpClient);
-      ref.injector.get(NgZone).run(() => {
-        http.get<string>('/testing').subscribe((body: string) => {
-          NgZone.assertInAngularZone();
-          expect(body).toEqual('success!');
-        });
-        mock.expectOne('http://other/testing').flush('success!');
-      });
-    });
-
     it('requests are macrotasks', async(() => {
          const platform = platformDynamicServer(
              [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);


### PR DESCRIPTION
In 10.0.0-next.8, a change was introduced into Universal (platform-server) to support relative URL HTTP requests on the server. Previously, this was unsupported and browser-specific behavior (since there is no concept of current page/routing natively on the server). However, there were issues with the behavior, notably that the logic would execute before user's `HttpInterceptor`s, and thus constituted a breaking change. Adding a flag to revert back to the default for all users while allowing opt-in to the new behavior would constitute a public API change, but since we were already in the middle of the RC period, this was not considered the safe approach.

Therefore, the decision was made to revert these changes in the patch branch (10.0.x) and keep the changes plus the public API fix (#37539) in the main branch (10.1.x).


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
