### PR TITLE
build: fix outdated payload size

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -31,7 +31,7 @@
       "uncompressed": {
         "runtime-es2015": 1485,
         "main-es2015": 136302,
-        "polyfills-es2015": 37640
+        "polyfills-es2015": 37248
       }
     }
   },


### PR DESCRIPTION
Updates the payload size for one of the bundles that is currently causing one of the CI tasks to fail on master.
