### PR TITLE
feat(dev-infra): add `#` to outputed list of PRs for discover-new-conflicts

### DIFF
--- a/dev-infra/pr/discover-new-conflicts/index.ts
+++ b/dev-infra/pr/discover-new-conflicts/index.ts
@@ -141,7 +141,7 @@ export async function discoverNewConflictsForPr(
   // Inform about discovered conflicts, exit with failure.
   error.group(`${conflicts.length} PR(s) which conflict(s) after #${newPrNumber} merges:`);
   for (const pr of conflicts) {
-    error(`  - ${pr.number}: ${pr.title}`);
+    error(`  - #${pr.number}: ${pr.title}`);
   }
   error.groupEnd();
   process.exit(1);


### PR DESCRIPTION
Adding in a `#` prepended to each PR number in the list of conflicting PRs
found by the discover-new-conflicts script will allow for users to copy
paste the output from the script into a github comment and have the PRs
automatically link.
