### PR TITLE
ci: upload build results to ResultStore for CI linux bazel executions

### DIFF
--- a/.circleci/bazel.linux.rc
+++ b/.circleci/bazel.linux.rc
@@ -19,4 +19,12 @@ build --local_ram_resources=14336
 
 # All build executed remotely should be done using our RBE configuration.
 build:remote --google_default_credentials
+
+# Upload to GCP's Build Status viewer to allow for us to have better viewing of execution/build
+# logs. This is only done on CI as the BES (GCP's Build Status viewer) API requires credentials
+# from service accounts, rather than end user accounts.
+build:remote --bes_backend=buildeventservice.googleapis.com
+build:remote --bes_timeout=30s
+build:remote --bes_results_url="https://source.cloud.google.com/results/invocations/"
+
 build --config=remote


### PR DESCRIPTION
Bazel invocations will upload to ResultStore to allow for us to have better viewing
of execution/build logs.  This is only done on CI as the BES API requires credentials
from service accounts, rather than end user accounts.


Example of what the ResultStore entry looks like: https://source.cloud.google.com/results/invocations/410a5790-54eb-43e8-96eb-c3cfa0f8960d