### PR TITLE
fix(elements): fire custom element output events during component initialization (take 2)

### DIFF
--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -187,13 +187,13 @@ export function createCustomElement<P>(
     }
 
     connectedCallback(): void {
-      this.ngElementStrategy.connect(this);
-
       // Listen for events from the strategy and dispatch them as custom events
       this.ngElementEventsSubscription = this.ngElementStrategy.events.subscribe(e => {
         const customEvent = createCustomEvent(this.ownerDocument!, e.name, e.value);
         this.dispatchEvent(customEvent);
       });
+
+      this.ngElementStrategy.connect(this);
     }
 
     disconnectedCallback(): void {

--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -187,13 +187,30 @@ export function createCustomElement<P>(
     }
 
     connectedCallback(): void {
-      // Listen for events from the strategy and dispatch them as custom events
-      this.ngElementEventsSubscription = this.ngElementStrategy.events.subscribe(e => {
-        const customEvent = createCustomEvent(this.ownerDocument!, e.name, e.value);
-        this.dispatchEvent(customEvent);
-      });
+      // For historical reasons, some strategies may not have initialized the `events` property
+      // until after `connect()` is run. Subscribe to `events` if it is available before running
+      // `connect()` (in order to capture events emitted suring inittialization), otherwise
+      // subscribe afterwards.
+      //
+      // TODO: Consider deprecating/removing the post-connect subscription in a future major version
+      //       (e.g. v11).
+
+      let subscribedToEvents = false;
+
+      if (this.ngElementStrategy.events) {
+        // `events` are already available: Subscribe to it asap.
+        this.subscribeToEvents();
+        subscribedToEvents = true;
+      }
 
       this.ngElementStrategy.connect(this);
+
+      if (!subscribedToEvents) {
+        // `events` were not initialized before running `connect()`: Subscribe to them now.
+        // The events emitted during the component initialization have been missed, but at least
+        // future events will be captured.
+        this.subscribeToEvents();
+      }
     }
 
     disconnectedCallback(): void {
@@ -206,6 +223,14 @@ export function createCustomElement<P>(
         this.ngElementEventsSubscription.unsubscribe();
         this.ngElementEventsSubscription = null;
       }
+    }
+
+    private subscribeToEvents(): void {
+      // Listen for events from the strategy and dispatch them as custom events.
+      this.ngElementEventsSubscription = this.ngElementStrategy.events.subscribe(e => {
+        const customEvent = createCustomEvent(this.ownerDocument!, e.name, e.value);
+        this.dispatchEvent(customEvent);
+      });
     }
   }
 

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -41,6 +41,33 @@ describe('ComponentFactoryNgElementStrategy', () => {
     expect(strategyFactory.create(injector)).toBeTruthy();
   });
 
+  describe('before connected', () => {
+    it('should allow subscribing to output events', () => {
+      const events: NgElementStrategyEvent[] = [];
+      strategy.events.subscribe(e => events.push(e));
+
+      // No events before connecting (since `componentRef` is not even on the strategy yet).
+      componentRef.instance.output1.next('output-1a');
+      componentRef.instance.output1.next('output-1b');
+      componentRef.instance.output2.next('output-2a');
+      expect(events).toEqual([]);
+
+      // No events upon connecting (since events are not cached/played back).
+      strategy.connect(document.createElement('div'));
+      expect(events).toEqual([]);
+
+      // Events emitted once connected.
+      componentRef.instance.output1.next('output-1c');
+      componentRef.instance.output1.next('output-1d');
+      componentRef.instance.output2.next('output-2b');
+      expect(events).toEqual([
+        {name: 'templateOutput1', value: 'output-1c'},
+        {name: 'templateOutput1', value: 'output-1d'},
+        {name: 'templateOutput2', value: 'output-2b'},
+      ]);
+    });
+  });
+
   describe('after connected', () => {
     beforeEach(() => {
       // Set up an initial value to make sure it is passed to the component

--- a/packages/elements/test/create-custom-element_spec.ts
+++ b/packages/elements/test/create-custom-element_spec.ts
@@ -117,6 +117,16 @@ if (browserDetection.supportsCustomElements) {
       expect(eventValue).toEqual(null);
     });
 
+    it('should listen to output events during initialization', () => {
+      const events: string[] = [];
+
+      const element = new NgElementCtor(injector);
+      element.addEventListener('strategy-event', evt => events.push((evt as CustomEvent).detail));
+      element.connectedCallback();
+
+      expect(events).toEqual(['connect']);
+    });
+
     it('should properly set getters/setters on the element', () => {
       const element = new NgElementCtor(injector);
       element.fooFoo = 'foo-foo-value';
@@ -255,6 +265,7 @@ if (browserDetection.supportsCustomElements) {
       events = new Subject<NgElementStrategyEvent>();
 
       connect(element: HTMLElement): void {
+        this.events.next({name: 'strategy-event', value: 'connect'});
         this.connectedElement = element;
       }
 

--- a/packages/elements/test/create-custom-element_spec.ts
+++ b/packages/elements/test/create-custom-element_spec.ts
@@ -40,12 +40,7 @@ if (browserDetection.supportsCustomElements) {
             strategyFactory = new TestStrategyFactory();
             strategy = strategyFactory.testStrategy;
 
-            const {selector, ElementCtor} = createTestCustomElement();
-            NgElementCtor = ElementCtor;
-
-            // The `@webcomponents/custom-elements/src/native-shim.js` polyfill allows us to create
-            // new instances of the NgElement which extends HTMLElement, as long as we define it.
-            customElements.define(selector, NgElementCtor);
+            NgElementCtor = createAndRegisterTestCustomElement(strategyFactory);
           })
           .then(done, done.fail);
     });
@@ -127,6 +122,37 @@ if (browserDetection.supportsCustomElements) {
       expect(events).toEqual(['connect']);
     });
 
+    it('should not break if `NgElementStrategy#events` is not available before calling `NgElementStrategy#connect()`',
+       () => {
+         class TestStrategyWithLateEvents extends TestStrategy {
+           events: Subject<NgElementStrategyEvent> = undefined!;
+
+           connect(element: HTMLElement): void {
+             this.connectedElement = element;
+             this.events = new Subject<NgElementStrategyEvent>();
+             this.events.next({name: 'strategy-event', value: 'connect'});
+           }
+         }
+
+         const strategyWithLateEvents = new TestStrategyWithLateEvents();
+         const capturedEvents: string[] = [];
+
+         const NgElementCtorWithLateEventsStrategy =
+             createAndRegisterTestCustomElement({create: () => strategyWithLateEvents});
+
+         const element = new NgElementCtorWithLateEventsStrategy(injector);
+         element.addEventListener(
+             'strategy-event', evt => capturedEvents.push((evt as CustomEvent).detail));
+         element.connectedCallback();
+
+         // The "connect" event (emitted during initialization) was missed, but things didn't break.
+         expect(capturedEvents).toEqual([]);
+
+         // Subsequent events are still captured.
+         strategyWithLateEvents.events.next({name: 'strategy-event', value: 'after-connect'});
+         expect(capturedEvents).toEqual(['after-connect']);
+       });
+
     it('should properly set getters/setters on the element', () => {
       const element = new NgElementCtor(injector);
       element.fooFoo = 'foo-foo-value';
@@ -154,7 +180,7 @@ if (browserDetection.supportsCustomElements) {
 
     it('should capture properties set before upgrading the element', () => {
       // Create a regular element and set properties on it.
-      const {selector, ElementCtor} = createTestCustomElement();
+      const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
       const element = Object.assign(document.createElement(selector), {
         fooFoo: 'foo-prop-value',
         barBar: 'bar-prop-value',
@@ -175,7 +201,7 @@ if (browserDetection.supportsCustomElements) {
     it('should capture properties set after upgrading the element but before inserting it into the DOM',
        () => {
          // Create a regular element and set properties on it.
-         const {selector, ElementCtor} = createTestCustomElement();
+         const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
          const element = Object.assign(document.createElement(selector), {
            fooFoo: 'foo-prop-value',
            barBar: 'bar-prop-value',
@@ -203,7 +229,7 @@ if (browserDetection.supportsCustomElements) {
     it('should allow overwriting properties with attributes after upgrading the element but before inserting it into the DOM',
        () => {
          // Create a regular element and set properties on it.
-         const {selector, ElementCtor} = createTestCustomElement();
+         const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
          const element = Object.assign(document.createElement(selector), {
            fooFoo: 'foo-prop-value',
            barBar: 'bar-prop-value',
@@ -229,7 +255,17 @@ if (browserDetection.supportsCustomElements) {
        });
 
     // Helpers
-    function createTestCustomElement() {
+    function createAndRegisterTestCustomElement(strategyFactory: NgElementStrategyFactory) {
+      const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
+
+      // The `@webcomponents/custom-elements/src/native-shim.js` polyfill allows us to create
+      // new instances of the NgElement which extends HTMLElement, as long as we define it.
+      customElements.define(selector, ElementCtor);
+
+      return ElementCtor;
+    }
+
+    function createTestCustomElement(strategyFactory: NgElementStrategyFactory) {
       return {
         selector: `test-element-${++selectorUid}`,
         ElementCtor: createCustomElement<WithFooBar>(TestComponent, {injector, strategyFactory}),


### PR DESCRIPTION
The first commit of this PR (`fire custom element output events during component initialization`) was originally introduced in #36161, but then reverted in #37524 (as it was deemed breaking).

This PR enhances the fix (the new changes are in the fixup commit) to avoid the breaking change.

Fixes #36141.