### PR TITLE
feat(router): add support for canLoadChild

### DIFF
--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -295,6 +295,7 @@ export declare interface Route {
     canActivateChild?: any[];
     canDeactivate?: any[];
     canLoad?: any[];
+    canLoadChild?: any[];
     children?: Routes;
     component?: Type<any>;
     data?: Data;

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 246085,
+        "main-es2015": 246667,
         "polyfills-es2015": 36938,
         "5-es2015": 751
       }
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 221268,
+        "main-es2015": 221813,
         "polyfills-es2015": 36938,
         "5-es2015": 779
       }

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -456,6 +456,12 @@ export interface Route {
    */
   canLoad?: any[];
   /**
+   * An array of DI tokens used to look up `CanLoadChild()` handlers,
+   * in order to determine if the current user is allowed to load
+   * a child of the component. By default, any user can load a child.
+   */
+  canLoadChild?: any[];
+  /**
    * Additional developer-defined data provided to the component via
    * `ActivatedRoute`. By default, no additional data is passed.
    */

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -410,3 +410,91 @@ export interface CanLoad {
 
 export type CanLoadFn = (route: Route, segments: UrlSegment[]) =>
     Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean|UrlTree;
+
+
+/**
+ * @description
+ *
+ * Interface that a class can implement to be a guard deciding if children can be loaded.
+ * If all guards return `true`, navigation will continue. If any guard returns `false`,
+ * navigation will be cancelled. If any guard returns a `UrlTree`, current navigation will
+ * be cancelled and a new navigation will be kicked off to the `UrlTree` returned from the
+ * guard.
+ *
+ * ```
+ * class UserToken {}
+ * class Permissions {
+ *   canLoadChildren(user: UserToken, id: string, segments: UrlSegment[]): boolean {
+ *     return true;
+ *   }
+ * }
+ *
+ * @Injectable()
+ * class CanLoadTeamSection implements CanLoadChild {
+ *   constructor(private permissions: Permissions, private currentUser: UserToken) {}
+ *
+ *   canLoadChild(childRoute: Route, childSegments: UrlSegment[]):
+ * Observable<boolean>|Promise<boolean>|boolean { return
+ * this.permissions.canLoadChildren(this.currentUser, childRoute, childSegments);
+ *   }
+ * }
+ *
+ * @NgModule({
+ *   imports: [
+ *     RouterModule.forRoot([
+ *       {
+ *         path: '',
+ *         canLoadChild: [CanLoadTeamSection],
+ *         children: [
+ *           {
+ *             path: 'team/:id',
+ *             component: TeamComponent,
+ *             loadChildren: 'team.js'
+ *           }
+ *         ]
+ *       }
+ *     ])
+ *   ],
+ *   providers: [CanLoadTeamSection, UserToken, Permissions]
+ * })
+ * class AppModule {}
+ * ```
+ *
+ * You can alternatively provide a function with the `canLoadChild` signature:
+ *
+ * ```
+ * @NgModule({
+ *   imports: [
+ *     RouterModule.forRoot([
+ *       {
+ *         path: '',
+ *         canLoadChild: ['canLoadTeamSection'],
+ *         children: [
+ *           {
+ *             path: 'team/:id',
+ *             component: TeamComponent,
+ *             loadChildren: 'team.js'
+ *           }
+ *         ]
+ *       }
+ *     ])
+ *   ],
+ *   providers: [
+ *     {
+ *       provide: 'canLoadTeamSection',
+ *       useValue: (childRoute: Route, childSegments: UrlSegment[]) => true
+ *     }
+ *   ]
+ * })
+ * class AppModule {}
+ * ```
+ *
+ * @publicApi
+ */
+export interface CanLoadChild {
+  canLoadChild(childRoute: Route, childSegments: UrlSegment[]):
+      Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean|UrlTree;
+}
+
+export type CanLoadChildFn = (childRoute: Route, childSegments: UrlSegment[]) =>
+    Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean|UrlTree;

--- a/packages/router/src/utils/type_guards.ts
+++ b/packages/router/src/utils/type_guards.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CanActivate, CanActivateChild, CanDeactivate, CanLoad} from '../interfaces';
+import {CanActivate, CanActivateChild, CanDeactivate, CanLoad, CanLoadChild} from '../interfaces';
 import {UrlTree} from '../url_tree';
 
 /**
@@ -36,6 +36,10 @@ export function isUrlTree(v: any): v is UrlTree {
 
 export function isCanLoad(guard: any): guard is CanLoad {
   return guard && isFunction<CanLoad>(guard.canLoad);
+}
+
+export function isCanLoadChild(guard: any): guard is CanLoadChild {
+  return guard && isFunction<CanLoad>(guard.canLoadChild);
 }
 
 export function isCanActivate(guard: any): guard is CanActivate {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
It's not possible to define an array of DI tokens in order to determine if the current user is allowed to load a child of the component.

## What is the new behavior?
Allows to define an array of DI tokens in order to determine if the current user is allowed to load a child of the component.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No