### PR TITLE
fix(zone.js): defineProperty patch should not swallow error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -653,8 +653,10 @@ jobs:
           name: Starting Saucelabs tunnel service
           command: ./tools/saucelabs/sauce-service.sh run
           background: true
-      - run: yarn tsc -p packages
-      - run: yarn tsc -p modules
+      # add module umd tsc compile option so the test can work
+      # properly in the legacy browsers
+      - run: yarn tsc -p packages --module UMD
+      - run: yarn tsc -p modules --module UMD
       - run: yarn bazel build //packages/zone.js:npm_package
       # Build test fixtures for a test that rely on Bazel-generated fixtures. Note that disabling
       # specific tests which are reliant on such generated fixtures is not an option as SystemJS

--- a/packages/zone.js/lib/browser/define-property.ts
+++ b/packages/zone.js/lib/browser/define-property.ts
@@ -16,8 +16,6 @@ let _defineProperty: any;
 let _getOwnPropertyDescriptor: any;
 let _create: any;
 let unconfigurablesKey: any;
-const registerElementsCallbacks =
-    ['createdCallback', 'attachedCallback', 'detachedCallback', 'attributeChangedCallback'];
 
 export function propertyPatch() {
   zoneSymbol = Zone.__symbol__;
@@ -105,9 +103,11 @@ function _tryDefineProperty(obj: any, prop: string, desc: any, originalConfigura
         return _defineProperty(obj, prop, desc);
       } catch (error) {
         let swallowError = false;
-        if (typeof document !== 'undefined' && obj === document &&
-            registerElementsCallbacks.find(c => c === prop)) {
+        if (prop === 'createdCallback' || prop === 'attachedCallback' ||
+            prop === 'detachedCallback' || prop === 'attributeChangedCallback') {
           // We only swallow the error in registerElement patch
+          // this is the work around since some applications
+          // fail if we throw the error
           swallowError = true;
         }
         if (!swallowError) {

--- a/packages/zone.js/lib/browser/define-property.ts
+++ b/packages/zone.js/lib/browser/define-property.ts
@@ -16,6 +16,8 @@ let _defineProperty: any;
 let _getOwnPropertyDescriptor: any;
 let _create: any;
 let unconfigurablesKey: any;
+const registerElementsCallbacks =
+    ['createdCallback', 'attachedCallback', 'detachedCallback', 'attributeChangedCallback'];
 
 export function propertyPatch() {
   zoneSymbol = Zone.__symbol__;
@@ -102,6 +104,18 @@ function _tryDefineProperty(obj: any, prop: string, desc: any, originalConfigura
       try {
         return _defineProperty(obj, prop, desc);
       } catch (error) {
+        let swallowError = false;
+        if (typeof document !== 'undefined' && obj === document &&
+            registerElementsCallbacks.find(c => c === prop)) {
+          // We only swallow the error in registerElement patch
+          swallowError = true;
+        }
+        if (!swallowError) {
+          throw error;
+        }
+        // TODO: @JiaLiPassion, Some application such as `registerElement` patch
+        // still need to swallow the error, in the future after these applications
+        // are updated, the following logic can be removed.
         let descJson: string|null = null;
         try {
           descJson = JSON.stringify(desc);


### PR DESCRIPTION
Close #37432

zone.js monkey patches the `Object.defineProperty` API long time ago
https://github.com/angular/zone.js/commit/383b47905d0a55c0fd87983fa6effd0278cf70f1
to resolve issues in very old version of Chrome web which override the
property of `CustomElements`, and this is not an issue any longer, so
we may remove this monkey patch, since it may swallow the errors when the user
want to define property on unconfigurable or frozen object properties.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Since `zone.js` doesn't patch `Object.defineProperty` and not swallow the error when trying to define property on unconfigurable or `undefined` object, some application currently not throw error will begin to break.

For example, in our `saucelab` test for IE and old firefox/chrome, before this PR, the code/spec are compiled to `commonjs`, and the js code will look like this.

```
Object.defineProperty(exports, "__esModule", { value: true })
...
```


And the `exports` is `undefined`, It should throw error that trying to defineProperty on `undefined`, since `zone.js` monkey patch the `Object.defineProperty` and will catch the error and do nothing, so the test cases will continue to work. 
After this PR, `zone.js` will not do that any more, so the test cases will break.

## Other information
