### PR TITLE
refactor(dev-infra): migrate github api in GitClient to rely on GithubClient

### DIFF
--- a/dev-infra/pr/merge/pull-request.ts
+++ b/dev-infra/pr/merge/pull-request.ts
@@ -67,7 +67,7 @@ export async function loadAndValidatePullRequest(
   }
 
   const {data: {state}} =
-      await git.api.repos.getCombinedStatusForRef({...git.remoteParams, ref: prData.head.sha});
+      await git.github.repos.getCombinedStatusForRef({...git.remoteParams, ref: prData.head.sha});
 
   if (state === 'failure' && !ignoreNonFatalFailures) {
     return PullRequestFailure.failingCiJobs();
@@ -102,7 +102,7 @@ export async function loadAndValidatePullRequest(
 async function fetchPullRequestFromGithub(
     git: GitClient, prNumber: number): Promise<Octokit.PullsGetResponse|null> {
   try {
-    const result = await git.api.pulls.get({...git.remoteParams, pull_number: prNumber});
+    const result = await git.github.pulls.get({...git.remoteParams, pull_number: prNumber});
     return result.data;
   } catch (e) {
     // If the pull request could not be found, we want to return `null` so

--- a/dev-infra/pr/merge/strategies/api-merge.ts
+++ b/dev-infra/pr/merge/strategies/api-merge.ts
@@ -94,7 +94,7 @@ export class GithubApiMergeStrategy extends MergeStrategy {
 
     try {
       // Merge the pull request using the Github API into the selected base branch.
-      const result = await this.git.api.pulls.merge(mergeOptions);
+      const result = await this.git.github.pulls.merge(mergeOptions);
 
       mergeStatusCode = result.status;
       targetSha = result.data.sha;
@@ -189,9 +189,9 @@ export class GithubApiMergeStrategy extends MergeStrategy {
 
   /** Gets all commit messages of commits in the pull request. */
   private async _getPullRequestCommitMessages({prNumber}: PullRequest) {
-    const request = this.git.api.pulls.listCommits.endpoint.merge(
+    const request = this.git.github.pulls.listCommits.endpoint.merge(
         {...this.git.remoteParams, pull_number: prNumber});
-    const allCommits: PullsListCommitsResponse = await this.git.api.paginate(request);
+    const allCommits: PullsListCommitsResponse = await this.git.github.paginate(request);
     return allCommits.map(({commit}) => commit.message);
   }
 

--- a/dev-infra/tmpl-package.json
+++ b/dev-infra/tmpl-package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@angular/benchpress": "0.2.0",
     "@octokit/graphql": "<from-root>",
+    "@octokit/types": "<from-root>",
     "brotli": "<from-root>",
     "chalk": "<from-root>",
     "cli-progress": "<from-root>",

--- a/dev-infra/utils/BUILD.bazel
+++ b/dev-infra/utils/BUILD.bazel
@@ -2,7 +2,10 @@ load("@npm_bazel_typescript//:index.bzl", "ts_library")
 
 ts_library(
     name = "utils",
-    srcs = glob(["*.ts"]),
+    srcs = glob([
+        "*.ts",
+        "git/*.ts",
+    ]),
     module_name = "@angular/dev-infra-private/utils",
     visibility = ["//dev-infra:__subpackages__"],
     deps = [

--- a/dev-infra/utils/BUILD.bazel
+++ b/dev-infra/utils/BUILD.bazel
@@ -11,6 +11,7 @@ ts_library(
     deps = [
         "@npm//@octokit/graphql",
         "@npm//@octokit/rest",
+        "@npm//@octokit/types",
         "@npm//@types/inquirer",
         "@npm//@types/node",
         "@npm//@types/shelljs",

--- a/dev-infra/utils/git/_github.ts
+++ b/dev-infra/utils/git/_github.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/****************************************************************************
+ ****************************************************************************
+ ** DO NOT IMPORT THE GithubClient DIRECTLY, INSTEAD IMPORT GitClient from **
+ ** ./index.ts and access the GithubClient via the `.github` member.       **
+ ****************************************************************************
+ ****************************************************************************/
+
+import {graphql} from '@octokit/graphql';
+import * as Octokit from '@octokit/rest';
+import {query, types} from 'typed-graphqlify';
+
+/** Error for failed Github API requests. */
+export class GithubApiRequestError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+  }
+}
+
+/**
+ * A Github client for interacting with the Github APIs.
+ *
+ * Additionally, provides convienience methods for actions which require multiple requests, or
+ * would provide value from memoized style responses.
+ **/
+export class _GithubClient extends Octokit {
+  /** The Github GraphQL (v4) API. */
+  graqhql: GithubGraphqlClient;
+
+  /** The current user based on checking against the Github API. */
+  private _currentUser: string|null = null;
+
+  constructor(token?: string) {
+    // Pass in authentication token to base Octokit class.
+    super({token});
+
+    this.hook.error('request', error => {
+      // Wrap API errors in a known error class. This allows us to
+      // expect Github API errors better and in a non-ambiguous way.
+      throw new GithubApiRequestError(error.status, error.message);
+    });
+
+    // Create authenticated graphql client.
+    this.graqhql = new GithubGraphqlClient(token);
+  }
+
+  /** Retrieve the login of the current user from Github. */
+  async getCurrentUser() {
+    // If the current user has already been retrieved return the current user value again.
+    if (this._currentUser !== null) {
+      return this._currentUser;
+    }
+    const result = await this.graqhql.query({
+      viewer: {
+        login: types.string,
+      }
+    });
+    return this._currentUser = result.viewer.login;
+  }
+}
+
+/**
+ * An object representation of a GraphQL Query to be used as a response type and to generate
+ * a GraphQL query string.
+ */
+type GraphQLQueryObject = Parameters<typeof query>[1];
+/** Parameters for a GraphQL request. */
+type RequestParameters = Parameters<typeof graphql>[1];
+
+/**
+ * A client for interacting with Github's GraphQL API.
+ *
+ * This class is intentionally not exported as it should always be access/used via a
+ * _GithubClient instance.
+ */
+class GithubGraphqlClient {
+  /** The Github GraphQL (v4) API. */
+  private graqhql: typeof graphql;
+
+  constructor(token?: string) {
+    // Set the default headers to include authorization with the provided token for all
+    // graphQL calls.
+    this.graqhql = graphql.defaults({headers: {authorization: `token ${token}`}});
+  }
+
+
+  /** Perform a query using Github's GraphQL API. */
+  async query<T extends GraphQLQueryObject>(queryObject: T, params: RequestParameters = {}) {
+    const queryString = query(queryObject);
+    return (await this.graqhql(queryString, params)) as typeof queryObject;
+  }
+}

--- a/dev-infra/utils/git/index.ts
+++ b/dev-infra/utils/git/index.ts
@@ -13,6 +13,9 @@ import {getConfig, getRepoBaseDir, NgDevConfig} from '../config';
 import {info, yellow} from '../console';
 import {_GithubClient} from './_github';
 
+// Re-export GithubApiRequestError
+export {GithubApiRequestError} from './_github';
+
 /** Github response type extended to include the `x-oauth-scopes` headers presence. */
 type RateLimitResponseWithOAuthScopeHeader = Octokit.Response<Octokit.RateLimitGetResponse>&{
   headers: {'x-oauth-scopes': string};

--- a/dev-infra/utils/git/index.ts
+++ b/dev-infra/utils/git/index.ts
@@ -51,7 +51,7 @@ export class GitClient {
       `https://${this._githubToken}@github.com/${this.remoteConfig.owner}/${
           this.remoteConfig.name}.git`;
   /** Instance of the authenticated Github octokit API. */
-  github: _GithubClient;
+  github = new _GithubClient(this._githubToken);
 
   /** The file path of project's root directory. */
   private _projectRoot = getRepoBaseDir();
@@ -71,8 +71,6 @@ export class GitClient {
     if (_githubToken != null) {
       this._githubTokenRegex = new RegExp(_githubToken, 'g');
     }
-
-    this.github = new _GithubClient(_githubToken);
   }
 
   /** Executes the given git command. Throws if the command fails. */

--- a/dev-infra/utils/git/index.ts
+++ b/dev-infra/utils/git/index.ts
@@ -6,32 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {graphql} from '@octokit/graphql';
 import * as Octokit from '@octokit/rest';
 import {spawnSync, SpawnSyncOptions, SpawnSyncReturns} from 'child_process';
-import {query, types} from 'typed-graphqlify';
 
-import {getConfig, getRepoBaseDir, NgDevConfig} from './config';
-import {info, yellow} from './console';
+import {getConfig, getRepoBaseDir, NgDevConfig} from '../config';
+import {info, yellow} from '../console';
+import {_GithubClient} from './_github';
 
-/**
- * An object representation of a GraphQL Query to be used as a response type and to generate
- * a GraphQL query string.
- */
-type GraphQLQueryObject = Parameters<typeof query>[1];
-/** Parameters for a GraphQL request. */
-type RequestParameters = Parameters<typeof graphql>[1];
 /** Github response type extended to include the `x-oauth-scopes` headers presence. */
 type RateLimitResponseWithOAuthScopeHeader = Octokit.Response<Octokit.RateLimitGetResponse>&{
   headers: {'x-oauth-scopes': string};
 };
-
-/** Error for failed Github API requests. */
-export class GithubApiRequestError extends Error {
-  constructor(public status: number, message: string) {
-    super(message);
-  }
-}
 
 /** Error for failed Git commands. */
 export class GitCommandError extends Error {
@@ -63,10 +48,12 @@ export class GitClient {
       `https://${this._githubToken}@github.com/${this.remoteConfig.owner}/${
           this.remoteConfig.name}.git`;
   /** Instance of the authenticated Github octokit API. */
-  github: GithubClient;
+  github: _GithubClient;
 
   /** The file path of project's root directory. */
   private _projectRoot = getRepoBaseDir();
+  /** The OAuth scopes available for the provided Github token. */
+  private _oauthScopes: Promise<string[]>|null = null;
   /**
    * Regular expression that matches the provided Github token. Used for
    * sanitizing the token from Git child process output.
@@ -82,7 +69,7 @@ export class GitClient {
       this._githubTokenRegex = new RegExp(_githubToken, 'g');
     }
 
-    this.github = new GithubClient(_githubToken);
+    this.github = new _GithubClient(_githubToken);
   }
 
   /** Executes the given git command. Throws if the command fails. */
@@ -190,135 +177,17 @@ export class GitClient {
   /**
    * Retrieve the OAuth scopes for the loaded Github token.
    **/
-  @memoize()
   private async getAuthScopesForToken() {
+    // If the OAuth scopes have already been loaded, return the Promise containing them.
+    if (this._oauthScopes !== null) {
+      return this._oauthScopes;
+    }
     // OAuth scopes are loaded via the /rate_limit endpoint to prevent
     // usage of a request against that rate_limit for this lookup.
-    return this.github.rateLimit.get().then(_response => {
+    return this._oauthScopes = this.github.rateLimit.get().then(_response => {
       const response = _response as RateLimitResponseWithOAuthScopeHeader;
       const scopes: string = response.headers['x-oauth-scopes'] || '';
       return scopes.split(',').map(scope => scope.trim());
     });
   }
-}
-
-
-/**
- * A Github client for interacting with the Github APIs.
- *
- * Additionally, provides convienience methods for actions which require multiple requests, or
- * would provide value from memoized style responses.
- **/
-class GithubClient extends Octokit {
-  /** The Github GraphQL (v4) API. */
-  graqhql: GithubGraphqlClient;
-
-  constructor(token?: string) {
-    // Pass in authentication token to base Octokit class.
-    super({token});
-
-    this.hook.error('request', error => {
-      // Wrap API errors in a known error class. This allows us to
-      // expect Github API errors better and in a non-ambiguous way.
-      throw new GithubApiRequestError(error.status, error.message);
-    });
-
-    // Create authenticated graphql client.
-    this.graqhql = new GithubGraphqlClient(token);
-  }
-
-  /** Retrieve the login of the current user from Github. */
-  @memoize()
-  async getCurrentUser() {
-    return this.graqhql.query({
-      viewer: {
-        login: types.string,
-      }
-    });
-  }
-}
-
-
-/** A client for interacting with Github's GraphQL API. */
-class GithubGraphqlClient {
-  /** The Github GraphQL (v4) API. */
-  private graqhql: typeof graphql;
-
-  constructor(token?: string) {
-    // Set the default headers to include authorization with the provided token for all
-    // graphQL calls.
-    this.graqhql = graphql.defaults({headers: {authorization: `token ${token}`}});
-  }
-
-
-  /** Perform a query using Github's GraphQL API. */
-  async query<T extends GraphQLQueryObject>(queryObject: T, params: RequestParameters = {}) {
-    const queryString = query(queryObject);
-    return (await this.graqhql(queryString, params)) as typeof queryObject;
-  }
-
-  /**
-   * Perform multiple queries using Github's GraphQL API to retrieve multiple pages of queried
-   * information.
-   **/
-  async multiPageQuery<T extends GraphQLQueryObject, O extends {} = T>(
-      queryObject: T, params: RequestParameters,
-      processPage:
-          (result: T,
-           currentResult: O) => {nextCursor: string, mergedResult: O, checkNextPage: boolean}) {
-    /**
-     * The object to be returned after queries are completed, initially empty, to be merged into on
-     * each iteration through pages.
-     */
-    let output: O = <O>{};
-    /** Whether another page should be requested. */
-    let hasNextPage = true;
-    /** The cursor of the last object in the query, used as marker for the next page. */
-    let cursor: string|null = null;
-    while (hasNextPage) {
-      /** The page of results starting at the provided cursor. */
-      const results = await this.query(queryObject, {...params, cursor});
-      /** The new result to be output, and the cursor of the last item in the page. */
-      const {mergedResult, nextCursor, checkNextPage} = processPage(results, output);
-      output = mergedResult;
-      cursor = nextCursor;
-      hasNextPage = checkNextPage;
-    }
-    return output;
-  }
-}
-
-
-/**
- * Simple memoize decorator to returning the cached result when available on each call of decorated
- * methods.
- *
- * This is intentionally not exported as it is written for extremely simple use cases within the
- * scope the GithubClient and GitClient classes.  It is limited to only memoizing methods with no
- * parameters and makes assumptions related to this limitation.
- */
-function memoize() {
-  return (target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<any>) => {
-    /** The original decorated method, to be called directly in the closure function. */
-    const originalMethod = descriptor.value;
-    if (originalMethod.length >= 1) {
-      // Only allow the decorator to be added on methods with no arguements as the decorator
-      // does not track the parameters provided to the method to ensure the same call parameters
-      // and scope occurs.
-      throw Error(
-          `The memoize decorator being used can only be used on methods with no arguments, it\n` +
-          `was used to decorate a method with formal arguements and may cause incorrect values\n` +
-          `to be returned by the method on subsequent calls.`);
-    }
-    /** The symbol being used to store the result in between calls. */
-    let result: any;
-    /**
-     * The new method to be called, in place of the original, calling the original if no result
-     * value is defined.
-     */
-    descriptor.value = function() {
-      return result = result || originalMethod.apply(this, arguments);
-    };
-    return descriptor;
-  };
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@bazel/typescript": "1.7.0",
     "@microsoft/api-extractor": "7.7.11",
     "@octokit/rest": "16.28.7",
+    "@octokit/types": "^5.0.1",
     "@schematics/angular": "10.0.0-rc.2",
     "@types/angular": "^1.6.47",
     "@types/babel__core": "^7.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,6 +1955,13 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@octokit/types@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.0.1.tgz#5459e9a5e9df8565dcc62c17a34491904d71971e"
+  integrity sha512-GorvORVwp244fGKEt3cgt/P+M0MGy4xEDbckw+K5ojEezxyMDgCaYPKVct+/eWQfZXOT7uq0xRpmrl/+hliabA==
+  dependencies:
+    "@types/node" ">= 8"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"


### PR DESCRIPTION
GitClient now uses GithubClient for github API interactions.  GithubClient is
a class which extends Octokit and provides a member which allows for GraphQL
requests against the Github GraphQL api, as well as providing convenience methods
for common/repeated Github API requests.
