### PR TITLE
fix(compiler-cli): NgTscPlugin should clean up after program creation

### DIFF
--- a/packages/compiler-cli/src/ngtsc/tsc_plugin.ts
+++ b/packages/compiler-cli/src/ngtsc/tsc_plugin.ts
@@ -91,6 +91,7 @@ export class NgTscPlugin implements TscPlugin {
     if (this.host === null || this.options === null) {
       throw new Error('Lifecycle error: setupCompilation() before wrapHost().');
     }
+    this.host.postProgramCreationCleanup();
     const typeCheckStrategy = new ReusedProgramStrategy(
         program, this.host, this.options, this.host.shimExtensionPrefixes);
     this._compiler = new NgCompiler(

--- a/packages/compiler-cli/test/ngtsc/plugin_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/plugin_spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../helpers/src/mock_file_loading';
+
+import {NgtscTestEnvironment} from './env';
+
+
+const testFiles = loadStandardTestFiles();
+
+runInEachFileSystem(() => {
+  describe('NgTscPlugin', () => {
+    let env!: NgtscTestEnvironment;
+
+    beforeEach(() => {
+      env = NgtscTestEnvironment.setup(testFiles);
+      env.tsconfig();
+    });
+
+    it('should not leave triple-slash references to typecheck files in output .d.ts', () => {
+      env.write('main.ts', `
+        import {Injectable} from '@angular/core';
+
+        @Injectable()
+        export class FooService {}
+      `);
+      const diags = env.drivePluginDiagnostics();
+      expect(diags).toEqual([]);
+
+      const dtsContents = env.getContents('main.d.ts');
+      expect(dtsContents).not.toContain('<reference');
+      expect(dtsContents).not.toContain('ngtypecheck');
+    });
+  });
+});


### PR DESCRIPTION
`NgTscPlugin` wraps an incoming `ts.CompilerHost` in an `NgCompilerHost`
which patches all `ts.SourceFile`s in the program with referenced shims. In
order to not emit triple-slash `<reference>` directives that refer to shim
files, these patches have to be cleaned up by calling
`NgCompilerHost.postProgramCreationCleanup()` before emit. Previously, the
`NgTscPlugin` was not doing this cleanup.

This commit fixes the bug (which is a one-line change), plus adds a
mechanism in the `NgtscTestEnvironment` to run compilation via the plugin,
allowing for a test to be written.
