### PR TITLE
Correct link to renamed Console app in CLI overview

### DIFF
--- a/aio/content/cli/index.md
+++ b/aio/content/cli/index.md
@@ -1,6 +1,6 @@
 # CLI Overview and Command Reference
 
-The Angular CLI is a command-line interface tool that you use to initialize, develop, scaffold, and maintain Angular applications. You can use the tool directly in a command shell, or indirectly through an interactive UI such as [Angular Console](https://angularconsole.com).
+The Angular CLI is a command-line interface tool that you use to initialize, develop, scaffold, and maintain Angular applications. You can use the tool directly in a command shell, or indirectly through an interactive UI such as [Nx Console](https://nx.dev/angular/cli/console/).
 
 ## Installing Angular CLI
 


### PR DESCRIPTION
The Angular Console third-party desktop app that provides a UI for the Angular CLI has been discontinued, replaced by Nx Console.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The link to the old Console app breaks. 
The link is in the intro to the the CLI overview:
 https://angular.io/cli 

Issue Number:  https://angular-team.slack.com/archives/C46U16D4Z/p1592316738225200

## What is the new behavior?
The intro to the CLI overview links to the current app (renamed Nx Console) 
at https://nx.dev/angular/cli/console/
 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
 