### PR TITLE
refactor(forms): remove dead code

### DIFF
--- a/packages/forms/src/directives/select_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_control_value_accessor.ts
@@ -115,16 +115,12 @@ export class SelectControlValueAccessor extends BuiltInControlValueAccessor impl
   private _compareWith: (o1: any, o2: any) => boolean = Object.is;
 
   /**
-   * Sets the "value" property on the input element. The "selectedIndex"
-   * property is also set if an ID is provided on the option element.
+   * Sets the "value" property on the select element.
    * @nodoc
    */
   writeValue(value: any): void {
     this.value = value;
     const id: string|null = this._getOptionId(value);
-    if (id == null) {
-      this.setProperty('selectedIndex', -1);
-    }
     const valueString = _buildValueString(id, value);
     this.setProperty('value', valueString);
   }


### PR DESCRIPTION
This functionally dead code was originally introduced via pull request #13903, apparently in a blind attempt to fix issue #10010. But no tests were added to verify the fix, and the many comments on that issue after it was closed indicate that it wasn't actually resolved.

In fact, setting `selectedIndex` does absolutely nothing here, since the selected index is immediately overridden by setting the `value` property. A working fix (with tests) for the Safari/IE behavior is in pull request #23784. Originally this dead code was removed as part of that PR, but @AndrewKushnir recommended creating a separate PR for the cleanup.

## PR Type
What kind of change does this PR introduce?
- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?
- [x] No