### PR TITLE
fix(forms): correct usage of `selectedOptions`

### DIFF
--- a/packages/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -92,8 +92,6 @@ export class SelectMultipleControlValueAccessor implements ControlValueAccessor 
   _optionMap: Map<string, ɵNgSelectMultipleOption> = new Map<string, ɵNgSelectMultipleOption>();
   /** @internal */
   _idCounter: number = 0;
-  /** @internal */
-  _hasNativeSelectedOptionsSupport = HTMLSelectElement.prototype.hasOwnProperty('selectedOptions');
 
   /**
    * @description
@@ -158,7 +156,7 @@ export class SelectMultipleControlValueAccessor implements ControlValueAccessor 
   registerOnChange(fn: (value: any) => any): void {
     this.onChange = (_: any) => {
       const selected: Array<any> = [];
-      if (this._hasNativeSelectedOptionsSupport) {
+      if (_.selectedOptions !== undefined) {
         const options: HTMLCollection = _.selectedOptions;
         for (let i = 0; i < options.length; i++) {
           const opt: any = options.item(i);

--- a/packages/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -92,6 +92,8 @@ export class SelectMultipleControlValueAccessor implements ControlValueAccessor 
   _optionMap: Map<string, ɵNgSelectMultipleOption> = new Map<string, ɵNgSelectMultipleOption>();
   /** @internal */
   _idCounter: number = 0;
+  /** @internal */
+  _hasNativeSelectedOptionsSupport = HTMLSelectElement.prototype.hasOwnProperty('selectedOptions');
 
   /**
    * @description
@@ -156,7 +158,7 @@ export class SelectMultipleControlValueAccessor implements ControlValueAccessor 
   registerOnChange(fn: (value: any) => any): void {
     this.onChange = (_: any) => {
       const selected: Array<any> = [];
-      if (_.hasOwnProperty('selectedOptions')) {
+      if (this._hasNativeSelectedOptionsSupport) {
         const options: HTMLCollection = _.selectedOptions;
         for (let i = 0; i < options.length; i++) {
           const opt: any = options.item(i);

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -499,6 +499,20 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           }
         };
 
+        if (HTMLSelectElement.prototype.hasOwnProperty('selectedOptions')) {
+          it('verify that native `selectedOptions` field is used while detecting the list of selected options',
+             fakeAsync(() => {
+               if (isNode) return;
+               const spy = spyOnProperty(HTMLSelectElement.prototype, 'selectedOptions', 'get')
+                               .and.callThrough();
+               setSelectedCities([]);
+
+               selectOptionViaUI('1: Object');
+               assertOptionElementSelectedState([false, true, false]);
+               expect(spy.calls.count()).toBe(1);
+             }));
+        }
+
         it('should reflect state of model after option selected and new options subsequently added',
            fakeAsync(() => {
              if (isNode) return;

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -499,19 +499,17 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           }
         };
 
-        if (HTMLSelectElement.prototype.hasOwnProperty('selectedOptions')) {
-          it('verify that native `selectedOptions` field is used while detecting the list of selected options',
-             fakeAsync(() => {
-               if (isNode) return;
-               const spy = spyOnProperty(HTMLSelectElement.prototype, 'selectedOptions', 'get')
-                               .and.callThrough();
-               setSelectedCities([]);
+        it('verify that native `selectedOptions` field is used while detecting the list of selected options',
+           fakeAsync(() => {
+             if (isNode || !HTMLSelectElement.prototype.hasOwnProperty('selectedOptions')) return;
+             const spy = spyOnProperty(HTMLSelectElement.prototype, 'selectedOptions', 'get')
+                             .and.callThrough();
+             setSelectedCities([]);
 
-               selectOptionViaUI('1: Object');
-               assertOptionElementSelectedState([false, true, false]);
-               expect(spy.calls.count()).toBe(1);
-             }));
-        }
+             selectOptionViaUI('1: Object');
+             assertOptionElementSelectedState([false, true, false]);
+             expect(spy.calls.count()).toBe(2);
+           }));
 
         it('should reflect state of model after option selected and new options subsequently added',
            fakeAsync(() => {


### PR DESCRIPTION
Previously, `registerOnChange` used `hasOwnProperty` to identify if the
property is supported. However, this does not work as the `selectedOptions`
property is an inherited property. This commit fixes this by verifying
the property on the prototype instead.

Closes #37433

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #37433


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
