### PR TITLE
docs(core): correct type for opts.read

### DIFF
--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -140,7 +140,7 @@ export interface ContentChildrenDecorator {
    *
    * * **selector** - The directive type or the name used for querying.
    * * **descendants** - True to include all descendants, otherwise include only direct children.
-   * * **read** - True to read a different token from the queried elements.
+   * * **read** - Used to read a different token from the queried elements.
    *
    * @usageNotes
    *
@@ -206,7 +206,7 @@ export interface ContentChildDecorator {
    * **Metadata Properties**:
    *
    * * **selector** - The directive type or the name used for querying.
-   * * **read** - True to read a different token from the queried element.
+   * * **read** - Used to read a different token from the queried element.
    * * **static** - True to resolve query results before change detection runs,
    * false to resolve after change detection. Defaults to false.
    *
@@ -267,7 +267,7 @@ export interface ViewChildrenDecorator {
    * **Metadata Properties**:
    *
    * * **selector** - The directive type or the name used for querying.
-   * * **read** - True to read a different token from the queried elements.
+   * * **read** - Used to read a different token from the queried elements.
    *
    * @usageNotes
    *
@@ -322,7 +322,7 @@ export interface ViewChildDecorator {
    * **Metadata Properties**:
    *
    * * **selector** - The directive type or the name used for querying.
-   * * **read** - True to read a different token from the queried elements.
+   * * **read** - Used to read a different token from the queried elements.
    * * **static** - True to resolve query results before change detection runs,
    * false to resolve after change detection. Defaults to false.
    *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
We have 4 decorators: ViewChild, ViewChildren, ContentChild, ContentChildren. They have  accept extra info to read a token, but the typing for `opts.read` is not correct. It set to Boolean right now.

Issue Number: N/A


## What is the new behavior?
Correct type of `opts.read` to any.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
