### PR TITLE
fix(common): date pipe is giving error weeks

### DIFF
--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -384,6 +384,11 @@ function weekGetter(size: number, monthBased = false): DateFormatter {
     } else {
       let firstThurs = getFirstThursdayOfYear(date.getFullYear());
       const thisThurs = getThursdayThisWeek(date);
+      /*
+       If some days of a year are part of next year according
+       to ISO 8601. Change the firstThurs for those days to next
+       year firstThurs
+      */
       if (thisThurs.getFullYear() !== firstThurs.getFullYear()) {
         firstThurs = getFirstThursdayOfYear(date.getFullYear() + 1);
       }

--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -382,8 +382,11 @@ function weekGetter(size: number, monthBased = false): DateFormatter {
       const today = date.getDate();
       result = 1 + Math.floor((today + nbDaysBefore1stDayOfMonth) / 7);
     } else {
-      const firstThurs = getFirstThursdayOfYear(date.getFullYear());
+      let firstThurs = getFirstThursdayOfYear(date.getFullYear());
       const thisThurs = getThursdayThisWeek(date);
+      if (thisThurs.getFullYear() !== firstThurs.getFullYear()) {
+        firstThurs = getFirstThursdayOfYear(date.getFullYear() + 1);
+      }
       const diff = thisThurs.getTime() - firstThurs.getTime();
       result = 1 + Math.round(diff / 6.048e8);  // 6.048e8 ms per week
     }

--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -382,16 +382,10 @@ function weekGetter(size: number, monthBased = false): DateFormatter {
       const today = date.getDate();
       result = 1 + Math.floor((today + nbDaysBefore1stDayOfMonth) / 7);
     } else {
-      let firstThurs = getFirstThursdayOfYear(date.getFullYear());
       const thisThurs = getThursdayThisWeek(date);
-      /*
-       If some days of a year are part of next year according
-       to ISO 8601. Change the firstThurs for those days to next
-       year firstThurs
-      */
-      if (thisThurs.getFullYear() !== firstThurs.getFullYear()) {
-        firstThurs = getFirstThursdayOfYear(date.getFullYear() + 1);
-      }
+      // Some days of a year are part of next year according to ISO 8601.
+      // Compute the firstThurs from the year of this week's Thursday
+      const firstThurs = getFirstThursdayOfYear(thisThurs.getFullYear());
       const diff = thisThurs.getTime() - firstThurs.getTime();
       result = 1 + Math.round(diff / 6.048e8);  // 6.048e8 ms per week
     }

--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -74,7 +74,16 @@ import {JitReflector} from '@angular/platform-browser-dynamic/src/compiler_refle
 
       it('should return first week if some dates fall in previous year but belong to next year according to ISO 8601 format',
          () => {
+           expect(pipe.transform('2019-12-28T00:00:00', 'w')).toEqual('52');
            expect(pipe.transform('2019-12-29T00:00:00', 'w')).toEqual('1');
+           expect(pipe.transform('2019-12-30T00:00:00', 'w')).toEqual('1');
+         });
+
+      it('should return first week if some dates fall in previous leap year but belong to next year according to ISO 8601 format',
+         () => {
+           expect(pipe.transform('2012-12-29T00:00:00', 'w')).toEqual('52');
+           expect(pipe.transform('2019-12-30T00:00:00', 'w')).toEqual('1');
+           expect(pipe.transform('2019-12-31T00:00:00', 'w')).toEqual('1');
          });
     });
   });

--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -82,8 +82,8 @@ import {JitReflector} from '@angular/platform-browser-dynamic/src/compiler_refle
       it('should return first week if some dates fall in previous leap year but belong to next year according to ISO 8601 format',
          () => {
            expect(pipe.transform('2012-12-29T00:00:00', 'w')).toEqual('52');
-           expect(pipe.transform('2019-12-30T00:00:00', 'w')).toEqual('1');
-           expect(pipe.transform('2019-12-31T00:00:00', 'w')).toEqual('1');
+           expect(pipe.transform('2012-12-30T00:00:00', 'w')).toEqual('1');
+           expect(pipe.transform('2012-12-31T00:00:00', 'w')).toEqual('1');
          });
     });
   });

--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -71,6 +71,11 @@ import {JitReflector} from '@angular/platform-browser-dynamic/src/compiler_refle
     describe('transform', () => {
       it('should use "mediumDate" as the default format',
          () => expect(pipe.transform('2017-01-11T10:14:39+0000')).toEqual('Jan 11, 2017'));
+
+      it('should return first week if some dates fall in previous year but belong to next year according to ISO 8601 format',
+         () => {
+           expect(pipe.transform('2019-12-29T00:00:00', 'w')).toEqual('1');
+         });
     });
   });
 }


### PR DESCRIPTION
DDtae pipe is giving wrong week number made a change that will return correct week numbers for ifferent years

Fixes #33961

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
