### PR TITLE
perf(compiler-cli): fix regression in type-checking program reuse

### DIFF
--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -31,6 +31,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/indexer",
         "//packages/compiler-cli/src/ngtsc/perf",
         "//packages/compiler-cli/src/ngtsc/reflection",
+        "//packages/compiler-cli/src/ngtsc/shims",
         "//packages/compiler-cli/src/ngtsc/typecheck",
         "@npm//@bazel/typescript",
         "@npm//@types/node",

--- a/packages/compiler-cli/src/ngtsc/shims/index.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/index.ts
@@ -9,7 +9,7 @@
 /// <reference types="node" />
 
 export {ShimAdapter} from './src/adapter';
-export {copyFileShimData, isShim} from './src/expando';
+export {copyFileShimData, isShim, retagAllTsFiles, retagTsFile, sfExtensionData, untagAllTsFiles, untagTsFile} from './src/expando';
 export {FactoryGenerator, generatedFactoryTransform} from './src/factory_generator';
 export {ShimReferenceTagger} from './src/reference_tagger';
 export {SummaryGenerator} from './src/summary_generator';

--- a/packages/compiler-cli/src/ngtsc/shims/src/adapter.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/adapter.ts
@@ -12,7 +12,7 @@ import {absoluteFrom, absoluteFromSourceFile, AbsoluteFsPath} from '../../file_s
 import {isDtsPath} from '../../util/src/typescript';
 import {PerFileShimGenerator, TopLevelShimGenerator} from '../api';
 
-import {isFileShimSourceFile, isShim, NgExtension, sfExtensionData} from './expando';
+import {isFileShimSourceFile, isShim, sfExtensionData} from './expando';
 import {makeShimFileName} from './util';
 
 interface ShimGeneratorData {

--- a/packages/compiler-cli/src/ngtsc/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/index.ts
@@ -5,4 +5,4 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-export {getDeclaration, makeProgram} from './src/utils';
+export {expectCompleteReuse, getDeclaration, makeProgram} from './src/utils';

--- a/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
@@ -97,6 +97,23 @@ export function walkForDeclaration(name: string, rootNode: ts.Node): ts.Declarat
   return chosenDecl;
 }
 
+const COMPLETE_REUSE_FAILURE_MESSAGE =
+    'The original program was not reused completely, even though no changes should have been made to its structure';
+
+/**
+ * Extracted from TypeScript's internal enum `StructureIsReused`.
+ */
+enum TsStructureIsReused {
+  Not = 0,
+  SafeModules = 1,
+  Completely = 2,
+}
+
+export function expectCompleteReuse(oldProgram: ts.Program): void {
+  // Assert complete reuse using TypeScript's private API.
+  expect((oldProgram as any).structureIsReused)
+      .toBe(TsStructureIsReused.Completely, COMPLETE_REUSE_FAILURE_MESSAGE);
+}
 
 function bindingNameEquals(node: ts.BindingName, name: string): boolean {
   if (ts.isIdentifier(node)) {

--- a/packages/compiler-cli/src/ngtsc/tsc_plugin.ts
+++ b/packages/compiler-cli/src/ngtsc/tsc_plugin.ts
@@ -13,6 +13,7 @@ import {NgCompilerOptions, UnifiedModulesHost} from './core/api';
 import {NodeJSFileSystem, setFileSystem} from './file_system';
 import {PatchedProgramIncrementalBuildStrategy} from './incremental';
 import {NOOP_PERF_RECORDER} from './perf';
+import {untagAllTsFiles} from './shims';
 import {ReusedProgramStrategy} from './typecheck/src/augmented_program';
 
 // The following is needed to fix a the chicken-and-egg issue where the sync (into g3) script will
@@ -80,6 +81,9 @@ export class NgTscPlugin implements TscPlugin {
   wrapHost(
       host: ts.CompilerHost&UnifiedModulesHost, inputFiles: readonly string[],
       options: ts.CompilerOptions): PluginCompilerHost {
+    // TODO(alxhub): Eventually the `wrapHost()` API will accept the old `ts.Program` (if one is
+    // available). When it does, its `ts.SourceFile`s need to be re-tagged to enable proper
+    // incremental compilation.
     this.options = {...this.ngOptions, ...options} as NgCompilerOptions;
     this.host = NgCompilerHost.wrap(host, inputFiles, this.options, /* oldProgram */ null);
     return this.host;
@@ -92,6 +96,8 @@ export class NgTscPlugin implements TscPlugin {
     if (this.host === null || this.options === null) {
       throw new Error('Lifecycle error: setupCompilation() before wrapHost().');
     }
+    this.host.postProgramCreationCleanup();
+    untagAllTsFiles(program);
     const typeCheckStrategy = new ReusedProgramStrategy(
         program, this.host, this.options, this.host.shimExtensionPrefixes);
     this._compiler = new NgCompiler(

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/BUILD.bazel
@@ -16,6 +16,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/incremental",
         "//packages/compiler-cli/src/ngtsc/reflection",
+        "//packages/compiler-cli/src/ngtsc/shims",
         "//packages/compiler-cli/src/ngtsc/testing",
         "//packages/compiler-cli/src/ngtsc/typecheck",
         "//packages/compiler-cli/src/ngtsc/util",

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/program_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/program_spec.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {absoluteFrom, AbsoluteFsPath, getSourceFileOrError} from '../../file_system';
+import {runInEachFileSystem} from '../../file_system/testing';
+import {sfExtensionData, ShimReferenceTagger} from '../../shims';
+import {expectCompleteReuse, makeProgram} from '../../testing';
+import {UpdateMode} from '../src/api';
+import {ReusedProgramStrategy} from '../src/augmented_program';
+
+import {createProgramWithNoTemplates} from './test_utils';
+
+runInEachFileSystem(() => {
+  describe('template type-checking program', () => {
+    it('should not be created if no components need to be checked', () => {
+      const {program, templateTypeChecker, programStrategy} = createProgramWithNoTemplates();
+      templateTypeChecker.refresh();
+      // expect() here would create a really long error message, so this is checked manually.
+      if (programStrategy.getProgram() !== program) {
+        fail('Template type-checking created a new ts.Program even though it had no changes.');
+      }
+    });
+
+    it('should have complete reuse if no structural changes are made to shims', () => {
+      const {program, host, options, typecheckPath} = makeSingleFileProgramWithTypecheckShim();
+      const programStrategy = new ReusedProgramStrategy(program, host, options, ['ngtypecheck']);
+
+      // Update /main.ngtypecheck.ts without changing its shape. Verify that the old program was
+      // reused completely.
+      programStrategy.updateFiles(
+          new Map([[typecheckPath, 'export const VERSION = 2;']]), UpdateMode.Complete);
+
+      expectCompleteReuse(program);
+    });
+
+    it('should have complete reuse if no structural changes are made to input files', () => {
+      const {program, host, options, mainPath} = makeSingleFileProgramWithTypecheckShim();
+      const programStrategy = new ReusedProgramStrategy(program, host, options, ['ngtypecheck']);
+
+      // Update /main.ts without changing its shape. Verify that the old program was reused
+      // completely.
+      programStrategy.updateFiles(
+          new Map([[mainPath, 'export const STILL_NOT_A_COMPONENT = true;']]), UpdateMode.Complete);
+
+      expectCompleteReuse(program);
+    });
+  });
+});
+
+function makeSingleFileProgramWithTypecheckShim(): {
+  program: ts.Program,
+  host: ts.CompilerHost,
+  options: ts.CompilerOptions,
+  mainPath: AbsoluteFsPath,
+  typecheckPath: AbsoluteFsPath,
+} {
+  const mainPath = absoluteFrom('/main.ts');
+  const typecheckPath = absoluteFrom('/main.ngtypecheck.ts');
+  const {program, host, options} = makeProgram([
+    {
+      name: mainPath,
+      contents: 'export const NOT_A_COMPONENT = true;',
+    },
+    {
+      name: typecheckPath,
+      contents: 'export const VERSION = 1;',
+    }
+  ]);
+
+  const sf = getSourceFileOrError(program, mainPath);
+  const typecheckSf = getSourceFileOrError(program, typecheckPath);
+
+  // To ensure this test is validating the correct behavior, the initial conditions of the
+  // input program must be such that:
+  //
+  // 1) /main.ts was previously tagged with a reference to its ngtypecheck shim.
+  // 2) /main.ngtypecheck.ts is marked as a shim itself.
+
+  // Condition 1:
+  const tagger = new ShimReferenceTagger(['ngtypecheck']);
+  tagger.tag(sf);
+  tagger.finalize();
+
+  // Condition 2:
+  sfExtensionData(typecheckSf).fileShim = {
+    extension: 'ngtypecheck',
+    generatedFrom: mainPath,
+  };
+
+  return {program, host, options, mainPath, typecheckPath};
+}

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/file_system/testing",
         "//packages/compiler-cli/src/ngtsc/indexer",
         "//packages/compiler-cli/src/ngtsc/routing",
+        "//packages/compiler-cli/src/ngtsc/testing",
         "//packages/compiler-cli/src/ngtsc/util",
         "//packages/compiler-cli/test:test_utils",
         "//packages/compiler-cli/test/helpers",

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -128,6 +128,13 @@ export class NgtscTestEnvironment {
     return this.oldProgram.getTsProgram();
   }
 
+  getReuseTsProgram(): ts.Program {
+    if (this.oldProgram === null) {
+      throw new Error('No ts.Program has been created yet.');
+    }
+    return (this.oldProgram as NgtscProgram).getReuseTsProgram();
+  }
+
   /**
    * Older versions of the CLI do not provide the `CompilerHost.getModifiedResourceFiles()` method.
    * This results in the `changedResources` set being `null`.

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -9,8 +9,9 @@
 import * as ts from 'typescript';
 
 import {ErrorCode, ngErrorCode} from '../../src/ngtsc/diagnostics';
-import {absoluteFrom as _, getFileSystem} from '../../src/ngtsc/file_system';
+import {absoluteFrom as _, getFileSystem, getSourceFileOrError} from '../../src/ngtsc/file_system';
 import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
+import {expectCompleteReuse} from '../../src/ngtsc/testing';
 import {loadStandardTestFiles} from '../helpers/src/mock_file_loading';
 
 import {NgtscTestEnvironment} from './env';
@@ -1862,18 +1863,26 @@ export declare class AnimationEvent {
         expect(env.driveDiagnostics()).toEqual([]);
       });
 
-      it('should not leave references to shims after execution', () => {
-        // This test verifies that proper cleanup is performed for the technique being used to
-        // include shim files in the ts.Program, and that none are left in the referencedFiles of
-        // any ts.SourceFile after compilation.
+      it('should not leave referencedFiles in a tagged state', () => {
         env.enableMultipleCompilations();
 
         env.driveMain();
-        for (const sf of env.getTsProgram().getSourceFiles()) {
-          for (const ref of sf.referencedFiles) {
-            expect(ref.fileName).not.toContain('.ngtypecheck.ts');
-          }
-        }
+        const sf = getSourceFileOrError(env.getTsProgram(), _('/test.ts'));
+        expect(sf.referencedFiles.map(ref => ref.fileName)).toEqual([]);
+      });
+
+      it('should allow for complete program reuse during incremental compilations', () => {
+        env.enableMultipleCompilations();
+
+        env.write('other.ts', `export const VERSION = 1;`);
+
+        env.driveMain();
+        const firstProgram = env.getReuseTsProgram();
+
+        env.write('other.ts', `export const VERSION = 2;`);
+        env.driveMain();
+
+        expectCompleteReuse(firstProgram);
       });
     });
   });


### PR DESCRIPTION
perf(compiler-cli): fix regressions in incremental program reuse
    
Commit 4213e8d5 introduced shim reference tagging into the compiler, and
changed how the `TypeCheckProgramHost` worked under the hood during the
creation of a template type-checking program. This work enabled a more
incremental flow for template type-checking, but unintentionally introduced
several regressions in performance, caused by poor incrementality during
`ts.Program` creation.

1. The `TypeCheckProgramHost` was made to rely on the `ts.CompilerHost` to
   retrieve instances of `ts.SourceFile`s from the original program. If the
   host does not return the original instance of such files, but instead
   creates new instances, this has two negative effects: it incurs
   additional parsing time, and it interferes with TypeScript's ability to
   reuse information about such files.

2. During the incremental creation of a `ts.Program`, TypeScript compares
   the `referencedFiles` of `ts.SourceFile` instances from the old program
   with those in the new program. If these arrays differ, TypeScript cannot
   fully reuse the old program. The implementation of reference tagging
   introduced in 4213e8d5 restores the original `referencedFiles` array
   after a `ts.Program` is created, which means that future incremental
   operations involving that program will always fail this comparison,
   effectively limiting the incrementality TypeScript can achieve.

Problem 1 exacerbates problem 2: if a new `ts.SourceFile` is created by the
host after shim generation has been disabled, it will have an untagged
`referencedFiles` array even if the original file's `referencedFiles` was
not restored, triggering problem 2 when creating the template type-checking
program.

To fix these issues, `referencedFiles` arrays are no longer cleaned up.
This is safe to do (it's how View Engine worked) but it now requires
`referencedFiles` to be temporarily cleaned during emit, so as not to
produce triple-slash references directives in .d.ts files (this temporary
cleanup is also something that View Engine did).

Additionally, the `TypeCheckProgramHost` now uses the original `ts.Program`
to retrieve original instances of `ts.SourceFile`s where possible,
preventing issues when a host would otherwise return fresh instances.

Together, these fixes ensure that program reuse is as incremental as
possible, and tests have been added to verify this for certain scenarios.

An optimization was further added to prevent the creation of a type-checking
`ts.Program` in the first place if no type-checking is necessary.

In the case of the `NgTscPlugin`, there is no current API hook that notifies
the plugin of the impending emit operation. Instead, shims are removed
during the emit operation, by a transformer that the plugin inserts. In the
future an API hook can be introduced which tsc_wrapped calls prior to emit,
allowing for a cleaner integration.
