### PR TITLE
docs: make Name input conform to WCAG 2.1

### DIFF
--- a/aio/content/examples/getting-started/src/app/cart/cart.component.html
+++ b/aio/content/examples/getting-started/src/app/cart/cart.component.html
@@ -19,7 +19,7 @@
     <label for="name">
       Name
     </label>
-    <input id="name" type="text" formControlName="name">
+    <input id="name" type="text" formControlName="name" autocomplete="name">
   </div>
 
   <div>


### PR DESCRIPTION
To conform to Web Content Accessibility Guidelines 2.1, Success Criterion 1.3.5, an input
requesting the user's full name must have an "autocomplete" attribute with the value
"name". See
https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html.
This code’s details are not explained in the surrounding tutorial, so this code change does
not require any revision in that content.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
User autocomplete agents cannot propose value for Name input.
Issue Number: N/A


## What is the new behavior?
User autocomplete agents can propose value for Name input.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
