### PR TITLE
docs(language-service): Clarify WebStorm installation instructions

### DIFF
--- a/aio/content/guide/language-service.md
+++ b/aio/content/guide/language-service.md
@@ -64,36 +64,9 @@ In the marketplace, search for Angular Language Service extension, and click the
 
 ### WebStorm
 
-In [WebStorm](https://www.jetbrains.com/webstorm/), you must install the language service package as a project dependency.
+[WebStorm](https://www.jetbrains.com/webstorm/) automatically bundles an [extension](https://plugins.jetbrains.com/plugin/6971-angular-and-angularjs) which has the same feature set as the Angular Language Service. In other JetBrain products the plugin can be installed through the marketplace. Make sure that you have AngularJS or Angular library files in your project (for example, in the node_modules folder) – this is required for the IDE to enable Angular support for this project.
 
-1. Add the following to your `devDependencies` in your project's `package.json`
-
-<code-example language="json" header="package.json">
-devDependencies {
-  "@angular/language-service": "^6.0.0"
-}
-</code-example>
-
-2. In the terminal window at the root of your project, install the `devDependencies` with `npm` or `yarn`:
-
-```sh
-npm install
-```
-*OR*
-
-```sh
-yarn
-```
-
-*OR*
-
-```sh
-yarn install
-```
-
-When Angular sees this dev dependency, it provides the language service in the WebStorm environment.
-WebStorm then gives you colorization inside the template and autocomplete in addition to the Angular Language Service.
-
+Make sure to follow the instructions for [creating a new project](https://www.jetbrains.com/help/webstorm/angular.html#create_new_angular_app) or [using an existing angular project](https://www.jetbrains.com/help/webstorm/angular.html#angular_cli_open_existing_application)
 
 ### Sublime Text
 

--- a/aio/content/guide/language-service.md
+++ b/aio/content/guide/language-service.md
@@ -64,7 +64,7 @@ In the marketplace, search for Angular Language Service extension, and click the
 
 ### WebStorm
 
-[WebStorm](https://www.jetbrains.com/webstorm/) automatically bundles an [extension](https://plugins.jetbrains.com/plugin/6971-angular-and-angularjs) which has the same feature set as the Angular Language Service. In other JetBrain products the plugin can be installed through the marketplace. Make sure that you have AngularJS or Angular library files in your project (for example, in the node_modules folder) – this is required for the IDE to enable Angular support for this project.
+[WebStorm](https://www.jetbrains.com/webstorm/) automatically bundles an [extension](https://plugins.jetbrains.com/plugin/6971-angular-and-angularjs) which has the same feature set as the Angular Language Service. In other JetBrain products (for example IntelliJ IDEA, AppCode or PyCharm) the plugin can be installed through the marketplace. Make sure that you have AngularJS or Angular library files in your project (for example, in the node_modules folder) – this is required for the IDE to enable Angular support for this project.
 
 Make sure to follow the instructions for [creating a new project](https://www.jetbrains.com/help/webstorm/angular.html#create_new_angular_app) or [using an existing angular project](https://www.jetbrains.com/help/webstorm/angular.html#angular_cli_open_existing_application)
 


### PR DESCRIPTION
The instructions for WebStorm don't match the official docs anymore. JetBrains seems to have a much easier setup for their IDE now. Updated the documentation to reflect that.

This is a second attempt at a pull request, after I broke something trying to rebase, and did not know how to recover.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
