### PR TITLE
docs: fix invalid anchor for CLI flags in deprecation guide

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -489,7 +489,7 @@ If you rely on the behavior that the same object instance should cause change de
 - Clone the resulting value so that it has a new identity.
 - Explicitly call [`ChangeDetectorRef.detectChanges()`](api/core/ChangeDetectorRef#detectchanges) to force the update. 
 
-{@ deprecated-cli-flags}
+{@a deprecated-cli-flags}
 ## Deprecated CLI APIs and Options
 
 This section contains a complete list all of the currently deprecated CLI flags.


### PR DESCRIPTION
75218342967591627ee44b73999a4cfd52fb5470 added content for CLI deprecations to the
`angular.io` deprecations guide. It looks like the anchor for the CLI
deprecations is incorrect and ends up showing up as code in the guide.

This PR fixes the anchor so that it doesn't show up as code in the guide.

![image](https://user-images.githubusercontent.com/4987015/85264433-fa7c2c00-b470-11ea-9782-d437e4122cea.png)