### PR TITLE
docs(ngcc): add additional next steps to an error

### DIFF
--- a/packages/compiler-cli/ngcc/src/writing/in_place_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/in_place_file_writer.ts
@@ -49,8 +49,12 @@ export class InPlaceFileWriter implements FileWriter {
             `Tried to write ${
                 backPath} with an ngcc back up file but it already exists so not writing, nor backing up, ${
                 file.path}.\n` +
-            `This error may be because two or more entry-points overlap and ngcc has been asked to process some files more than once.\n` +
-            `You should check other entry-points in this package and set up a config to ignore any that you are not using.`);
+            `This error may be caused by one of the following:\n` +
+            `* two or more entry-points overlap and ngcc has been asked to process some files more than once.\n` +
+            `  In this case, you should check other entry-points in this package\n` +
+            `  and set up a config to ignore any that you are not using.\n` +
+            `* a previous run of ngcc was killed in the middle of processing, in a way that cannot be recovered.\n` +
+            `  In this case, you should try cleaning the node_modules directory and any dist directories that contain local libraries. Then try again.`);
       }
     } else {
       if (this.fs.exists(file.path)) {

--- a/packages/compiler-cli/ngcc/test/writing/in_place_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/in_place_file_writer_spec.ts
@@ -101,8 +101,12 @@ runInEachFileSystem(() => {
              `Tried to write ${
                  absoluteBackupPath}.__ivy_ngcc_bak with an ngcc back up file but it already exists so not writing, nor backing up, ${
                  absoluteBackupPath}.\n` +
-             `This error may be because two or more entry-points overlap and ngcc has been asked to process some files more than once.\n` +
-             `You should check other entry-points in this package and set up a config to ignore any that you are not using.`
+             `This error may be caused by one of the following:\n` +
+             `* two or more entry-points overlap and ngcc has been asked to process some files more than once.\n` +
+             `  In this case, you should check other entry-points in this package\n` +
+             `  and set up a config to ignore any that you are not using.\n` +
+             `* a previous run of ngcc was killed in the middle of processing, in a way that cannot be recovered.\n` +
+             `  In this case, you should try cleaning the node_modules directory and any dist directories that contain local libraries. Then try again.`
            ]]);
          });
     });


### PR DESCRIPTION
The file-writing error in the this commit can also be the result
of the ngcc process dying in the middle of writing files.

This commit improves the error message to offer a resolution
in case this is the reason for the error.

Fixes #36393
