### PR TITLE
ci(docs-infra): disable flaky tests

### DIFF
--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
@@ -401,7 +401,10 @@ describe('DocViewerComponent', () => {
         expect(loadElementsSpy.calls.argsFor(1)).toEqual([docViewer.nextViewContainer]);
       });
 
-      it('should unsubscribe from the previous "embed" observable when unsubscribed from', () => {
+      // This test sometimes incorrectly fails on CI.
+      // Reported in https://github.com/angular/angular/issues/37629.
+      // Investigated in https://github.com/angular/angular/pull/37637.
+      xit('should unsubscribe from the previous "embed" observable when unsubscribed from', () => {
         const obs = new ObservableWithSubscriptionSpies();
         loadElementsSpy.and.returnValue(obs);
 
@@ -436,7 +439,10 @@ describe('DocViewerComponent', () => {
         expect(swapViewsSpy).toHaveBeenCalledWith(addTitleAndTocSpy);
       });
 
-      it('should unsubscribe from the previous "swap" observable when unsubscribed from', () => {
+      // This test sometimes incorrectly fails on CI.
+      // Reported in https://github.com/angular/angular/issues/37629.
+      // Investigated in https://github.com/angular/angular/pull/37637.
+      xit('should unsubscribe from the previous "swap" observable when unsubscribed from', () => {
         const obs = new ObservableWithSubscriptionSpies();
         swapViewsSpy.and.returnValue(obs);
 


### PR DESCRIPTION
I could not figure out the root cause of the flakes, so disabling the flaky tests for now. See https://github.com/angular/angular/pull/37637#issuecomment-647608149 for more info.

Fixes #37629.
