### PR TITLE
fix(router): ensure duplicate popstate/hashchange events are handled …

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 245488,
+        "main-es2015": 246044,
         "polyfills-es2015": 36938,
         "5-es2015": 751
       }
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 221268,
+        "main-es2015": 221897,
         "polyfills-es2015": 36938,
         "5-es2015": 779
       }


### PR DESCRIPTION
…correctly

The current method of handling duplicate navigations caused by 'hashchange' and 'popstate' events for the same url change does not correctly handle cancelled navigations. Because `scheduleNavigation` is called in a `setTimeout` in the location change subscription, the duplicate navigations are not flushed at the same time. This means that if the initial navigation hits a guard that schedules a new navigation, the navigation for the duplicate event will not compare to the correct transition (because we inserted another navigation between the duplicates). See https://github.com/angular/angular/issues/16710#issuecomment-646919529

Fixes #16710

Change summary: 
* Move the 'hashchange' / 'popstate' duplicate nav checks from `scheduleNavigation` to the location subscription. This is where the events are initially handled / detected 
* Use `pairwise` to compare with the previously detected 'hashchange' / 'popstate'
* Save the current router transition id at the time of the location event to aid in comparison