### PR TITLE
build: set up caretaker note label in merge tooling

### DIFF
--- a/.ng-dev/config.ts
+++ b/.ng-dev/config.ts
@@ -84,6 +84,7 @@ const merge = () => {
     githubApiMerge: false,
     claSignedLabel: 'cla: yes',
     mergeReadyLabel: /^PR action: merge(-assistance)?/,
+    caretakerNoteLabel: 'PR action: merge-assistance',
     commitMessageFixupLabel: 'commit message fixup',
     labels: [
       {


### PR DESCRIPTION
Leverage the caretaker note label configuration in ng-dev's merge
tooling to prompt the caretaker for confirmation  when a PR has
the `PR action: merge-assistance` label. This should help to
surface for the caretaker, PRs which may need additional steps
taken, announcement messaging, etc.
