### PR TITLE
release(benchpress): bump version to v0.2.1 and update `@angular/core` peer dependency

### DIFF
--- a/packages/benchpress/BUILD.bazel
+++ b/packages/benchpress/BUILD.bazel
@@ -14,8 +14,6 @@ ts_library(
         "//packages:types",
         "//packages/core",
         "@npm//@types/node",
-        "@npm//@types/q",
-        "@npm//q",
         "@npm//reflect-metadata",
     ],
 )

--- a/packages/benchpress/package.json
+++ b/packages/benchpress/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@angular/benchpress",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Benchpress - a framework for e2e performance tests",
   "main": "index.js",
   "typings": "./index.d.ts",
   "strictNullChecks": true,
   "dependencies": {
-    "@angular/core": "^9.0.0",
+    "@angular/core": "^10.0.0-0 || ^11.0.0",
     "reflect-metadata": "^0.1.13"
   },
   "repository": {

--- a/packages/benchpress/package.json
+++ b/packages/benchpress/package.json
@@ -7,12 +7,7 @@
   "strictNullChecks": true,
   "dependencies": {
     "@angular/core": "^9.0.0",
-    "@types/node": "^12.11.1",
-    "@types/q": "^1.5.2",
-    "protractor": "^5.4.2",
-    "q": "^1.5.1",
-    "reflect-metadata": "^0.1.2",
-    "selenium-webdriver": "^2.53.3"
+    "reflect-metadata": "^0.1.13"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updates the version of `@angular/benchpress` to the next patch
version. i.e. `v0.2.1`. Additionally, the peer dependency
on `@angular/core` has been updated to be satisifed with
Angular v10 and v11.

Benchpress should be at least compatibe with the next two major
versions as it does not rely on any deprecated API from `@angular/core`.

**Note**: You might be wondering why this PR proposes the version bump. This is because
benchpress is not released as part of other framework packages, and after this PR being
merged, we should cut a manual release of benchpress with the new version.