### PR TITLE
fix(animations): Prevent potential TypeError elementStates : Unable to get property 'xxx' of undefined 

### DIFF
--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -380,7 +380,7 @@ export class AnimationTransitionNamespace {
         const trigger = this._triggers[triggerName];
         const transition = trigger.fallbackTransition;
         const elementStates = this._engine.statesByElement.get(element)!;
-        const fromState = elementStates[triggerName] || DEFAULT_STATE_VALUE;
+        const fromState = (elementStates && elementStates[triggerName]) || DEFAULT_STATE_VALUE;
         const toState = new StateValue(VOID_VALUE);
         const player = new TransitionAnimationPlayer(this.id, triggerName, element);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

![Annotazione 2020-06-22 173914](https://user-images.githubusercontent.com/8948699/85374051-7a1eff00-b534-11ea-825e-3ba495eb2e5b.png)
Used in conjunction with the CDKVirtualScroll, the animation trigger causes this error, for items not yet entered in the viewport.

Follow this [PR ](https://github.com/angular/angular/pull/19661) of some time ago.

## What is the new behavior?
The costant fromState is correctly set to DEFAULT_STATE_VALUE.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
