### PR TITLE
feat(dev-infra): add a way to pass assets down to a benchmark applica…

### DIFF
--- a/dev-infra/benchmark/component_benchmark/component_benchmark.bzl
+++ b/dev-infra/benchmark/component_benchmark/component_benchmark.bzl
@@ -25,6 +25,7 @@ def component_benchmark(
         driver_deps,
         ng_srcs,
         ng_deps,
+        ng_assets = [],
         assets = None,
         styles = None,
         entry_point = None,
@@ -65,6 +66,7 @@ def component_benchmark(
       driver_deps: Driver's dependencies
       ng_srcs: All of the ts srcs for the angular app
       ng_deps: Dependencies for the angular app
+      ng_assets: The static assets for the angular app
       assets: Static files
       styles: Stylesheets
       entry_point: Main entry point for the angular app
@@ -104,6 +106,7 @@ def component_benchmark(
     ng_module(
         name = app_lib,
         srcs = ng_srcs,
+        assets = ng_assets,
         # Creates ngFactory and ngSummary to be imported by the app's entry point.
         generate_ve_shims = True,
         deps = ng_deps,


### PR DESCRIPTION
…tion

* add a param called ng_assets to the component_benchmark macro to allow static assets to be provided to the base angular app, not just through the ts_devserver

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently static assets can only be provided through ts_devserver.

Issue Number: N/A


## What is the new behavior?
We will now be able to provide static assets through a new param  called ng_assets.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
