### PR TITLE
docs: updating guides and docs related to the v10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<!--
+<a name="10.0.0"></a>
+# [10.0.0](https://github.com/angular/angular/compare/10.0.0-next.0...10.0.0) (2020-06-24)
+
+
+### Release Highlights & Update instructions
+To learn about the release highlights and our CLI-powered automated update workflow for your projects please check out the [v10 release announcement](https://blog.angular.io/TODO).
+
+
+#### Dependency updates
+@angular/compiler-cli now requires:
+- TypeScript 3.9
+-->
+
+
 <a name="10.0.0-rc.6"></a>
 # [10.0.0-rc.6](https://github.com/angular/angular/compare/10.0.0-rc.5...10.0.0-rc.6) (2020-06-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ To learn about the release highlights and our CLI-powered automated update workf
 #### Dependency updates
 @angular/compiler-cli now requires:
 - TypeScript 3.9
+
+TODO: concat all the 10.0.0-next.* & -rc.* release notes, and group them by area/package just like in https://github.com/angular/angular/blob/master/CHANGELOG.md#900-2020-02-06 but consider listing features before bugfixes because people care about feature in major releases more than about bug fixes.
 -->
 
 

--- a/aio/content/guide/migration-update-libraries-tslib.md
+++ b/aio/content/guide/migration-update-libraries-tslib.md
@@ -1,4 +1,4 @@
-# tslib Direct Dependency Migration
+# `tslib` direct dependency migration
 
 ## What does this migration do?
 

--- a/aio/content/guide/migration-update-module-and-target-compiler-options.md
+++ b/aio/content/guide/migration-update-module-and-target-compiler-options.md
@@ -1,4 +1,4 @@
-# Update module and target compiler options migration
+# Update `module` and `target` compiler options migration
 
 ## What does this migration do?
 

--- a/aio/content/guide/migration-update-module-and-target-compiler-options.md
+++ b/aio/content/guide/migration-update-module-and-target-compiler-options.md
@@ -14,7 +14,7 @@ Used in `browser` builder options (`ng build` for applications) | `"module"` | `
 Used in `ng-packgr` builder options (`ng build` for libraries) | `"module"` | `"esnext"` | `"es2020"`
 Used in `karma` builder options (`ng test` for applications) | `"module"` | `"esnext"` | `"es2020"`
 Used in `server` builder options (universal) | `"module"` | `"commonjs"` | _removed_
-&nbsp; | `"target"` | _any_ | `"es2016"`
+Used in `server` builder options (universal) | `"target"` | _any_ | `"es2016"`
 Used in `protractor` builder options (`ng e2e` for applications) | `"target"` | `"es5"` | `"es2018"`
 
 ## Why is this migration necessary?

--- a/aio/content/guide/updating-to-version-10.md
+++ b/aio/content/guide/updating-to-version-10.md
@@ -39,7 +39,6 @@ If you're curious about the specific migrations being run by the CLI, see the [a
 
 | Area                          | API or Feature                                                                 | May be removed in |
 | ----------------------------- | ---------------------------------------------------------------------------    | ----------------- |
-| `@angular/bazel`              | [`Bazel builder and schematics`](guide/deprecations#bazelbuilder)                            | v10 |
 | `@angular/core`               | [`WrappedValue`](guide/deprecations#wrapped-value)                                     | <!--v10--> v12 |
 | browser support               | [`IE 9, 10, and IE Mobile`](guide/deprecations#ie-9-10-and-ie-mobile-support) | <!--v10--> v11 |
 
@@ -54,6 +53,8 @@ The following APIs have been removed starting with version 10.0.0*:
 | `@angular/core`  | Undecorated base classes that use Angular features | Add Angular decorator | See [migration guide](guide/migration-undecorated-classes) for more info |
 | `@angular/core`  | `ModuleWithProviders` without a generic             | `ModuleWithProviders` with a generic | See [migration guide](guide/migration-module-with-providers) for more info |
 | `@angular/core`  | Style Sanitization | no action needed | See [style sanitization API removal](/guide/deprecations#style-sanitization) for more info
+| `@angular/bazel` | [`Bazel builder and schematics`](guide/deprecations#bazelbuilder) | `bazelbuild/rules_nodejs` | [More info](https://github.com/angular/angular/tree/10.0.x/packages/bazel/src/schematics) |
+
 
 *To see APIs removed in version 9, check out this guide on the [version 9 docs site](https://v9.angular.io/guide/deprecations#removed).
 
@@ -76,3 +77,6 @@ Read about the migrations the CLI handles for you automatically:
 
 * [Migrating missing `@Directive()`/`@Component()` decorators](guide/migration-undecorated-classes)
 * [Migrating `ModuleWithProviders`](guide/migration-module-with-providers)
+* [Solution-style `tsconfig.json` migration](guide/migration-solution-style-tsconfig)
+* [`tslib` direct dependency migration](guide/migration-update-libraries-tslib)
+* [Update `module` and `target` compiler options migration](guide/migration-update-module-and-target-compiler-options)

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -803,6 +803,21 @@
                   "url": "guide/migration-injectable",
                   "title": "Missing @Injectable() Decorators",
                   "tooltip": "Migration to add missing @Injectable() decorators and incomplete provider definitions."
+                },
+                {
+                  "url": "guide/migration-solution-style-tsconfig",
+                  "title": "Solution-style `tsconfig.json`",
+                  "tooltip": "Migration to create a solution-style `tsconfig.json`."
+                },
+                {
+                  "url": "guide/migration-update-libraries-tslib",
+                  "title": "`tslib` direct dependency",
+                  "tooltip": "Migration to a direct dependency on the `tslib` npm package."
+                },
+                {
+                  "url": "guide/migration-update-module-and-target-compiler-options",
+                  "title": "",
+                  "tooltip": "Migration to update `module` and `target` compiler options."
                 }
               ]
             }

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -816,7 +816,7 @@
                 },
                 {
                   "url": "guide/migration-update-module-and-target-compiler-options",
-                  "title": "",
+                  "title": "`module` and `target` compiler options",
                   "tooltip": "Migration to update `module` and `target` compiler options."
                 }
               ]


### PR DESCRIPTION
Mostly just adding links to the migrations that were missing, adding the migrations into the navbar,
as well as correcting the @angular/bazel removal in the update guide.

I also added a commented out preamble for the release notes.