### PR TITLE
fix(router): fix navigation ignoring logic to compare to the browser url

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1126,12 +1126,28 @@ export class Router {
       rawUrl: UrlTree, source: NavigationTrigger, restoredState: RestoredState|null,
       extras: NavigationExtras,
       priorPromise?: {resolve: any, reject: any, promise: Promise<boolean>}): Promise<boolean> {
+    // * Imperative navigations (router.navigate) might trigger additional navigations to the same
+    //   URL via a popstate event and the locationChangeListener. We should skip these duplicate
+    //   navs. Duplicates may also be triggered by attempts to sync AngularJS and Angular router
+    //   states.
+    // * Imperative navigations can be cancelled by router guards, meaning the URL won't change. If
+    //   the user follows that with a navigation using the back/forward button or manual URL change,
+    //   the destination may be the same as the previous imperative attempt. We should not skip
+    //   these navigations because it's a separate case from the one above -- it's not a duplicate
+    //   navigation.
     const lastNavigation = this.getTransition();
-    // If the user triggers a navigation imperatively (e.g., by using navigateByUrl),
-    // and that navigation results in 'replaceState' that leads to the same URL,
-    // we should skip those.
-    if (lastNavigation && source !== 'imperative' && lastNavigation.source === 'imperative' &&
-        lastNavigation.rawUrl.toString() === rawUrl.toString()) {
+    // We don't want to skip duplicate successful navs if they're imperative because
+    // onSameUrlNavigation could be 'reload' (so the duplicate is intended).
+    const browserNavPrecededByRouterNav =
+        source !== 'imperative' && lastNavigation?.source === 'imperative';
+    const lastNavigationSucceeded = this.lastSuccessfulId === lastNavigation.id;
+    // If the last navigation succeeded or is in flight, we can use the rawUrl as the comparison.
+    // However, if it failed, we should compare to the final result (urlAfterRedirects).
+    const lastNavigationUrl = (lastNavigationSucceeded || this.currentNavigation) ?
+        lastNavigation.rawUrl :
+        lastNavigation.urlAfterRedirects;
+    const duplicateNav = lastNavigationUrl.toString() === rawUrl.toString();
+    if (browserNavPrecededByRouterNav && duplicateNav) {
       return Promise.resolve(true);  // return value is not used
     }
 


### PR DESCRIPTION
This PR changes the logic for determining when to skip route processing from
using the URL of the last attempted navigation to the actual resulting URL after
that transition.

Because guards may prevent navigation and reset the browser URL, the raw
URL of the previous transition may not match the actual URL of the
browser at the end of the navigation process. For that reason, we need to use
`urlAfterRedirects` if the previous navigation failed.

Note that this is a resubmit of https://github.com/angular/angular/commit/d3a817549b82c3f8c866296af4e952d1af5ac087 which caused a failure in Google. I've verified that this change does not result in the same failure but this PR should still be merged and synced separately. 