### PR TITLE
fix(dev-infra): merge script should not always require full repo permissions

### DIFF
--- a/dev-infra/utils/config.ts
+++ b/dev-infra/utils/config.ts
@@ -21,6 +21,8 @@ export interface GitClientConfig {
   name: string;
   /** If SSH protocol should be used for git interactions. */
   useSsh?: boolean;
+  /** Whether the specified repository is private. */
+  private?: boolean;
 }
 
 /**

--- a/dev-infra/utils/git/index.ts
+++ b/dev-infra/utils/git/index.ts
@@ -21,6 +21,9 @@ type RateLimitResponseWithOAuthScopeHeader = Octokit.Response<Octokit.RateLimitG
   headers: {'x-oauth-scopes': string};
 };
 
+/** Describes a function that can be used to test for given Github OAuth scopes. */
+export type OAuthScopeTestFunction = (scopes: string[], missing: string[]) => void;
+
 /** Error for failed Git commands. */
 export class GitCommandError extends Error {
   constructor(client: GitClient, public args: string[]) {
@@ -148,14 +151,11 @@ export class GitClient {
    * Assert the GitClient instance is using a token with permissions for the all of the
    * provided OAuth scopes.
    */
-  async hasOauthScopes(...requestedScopes: string[]): Promise<true|{error: string}> {
-    const missingScopes: string[] = [];
+  async hasOauthScopes(testFn: OAuthScopeTestFunction): Promise<true|{error: string}> {
     const scopes = await this.getAuthScopesForToken();
-    requestedScopes.forEach(scope => {
-      if (!scopes.includes(scope)) {
-        missingScopes.push(scope);
-      }
-    });
+    const missingScopes: string[] = [];
+    // Test Github OAuth scopes and collect missing ones.
+    testFn(scopes, missingScopes);
     // If no missing scopes are found, return true to indicate all OAuth Scopes are available.
     if (missingScopes.length === 0) {
       return true;


### PR DESCRIPTION
We recently added OAuth scope checking to the dev-infra Git client
and started leveraging it for the merge script. We set the `repo` scope
as required for running the merge script. We can loosen this requirement
as in the Angular org where the script is consumed, only pull requests on
public repositories are merged through the script.

This should help with reducing the risk with compromised tokens as no
access had to be granted on `repo:invite`, `repo_deployment` etc.