### PR TITLE
docs: add v9.angular.io to the angular.io version picker

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -1014,6 +1014,10 @@
   ],
   "docVersions": [
     {
+      "title": "v9",
+      "url": "https://v9.angular.io/"
+    },
+    {
       "title": "v8",
       "url": "https://v8.angular.io/"
     },


### PR DESCRIPTION
Now that v10 is out, it's time to add the v9.angular.io link to the version picker, so here we go...
