### PR TITLE
fix(migrations): do not incorrectly add todo for @Injectable or @Pipe

### DIFF
--- a/integration/ng_update_migrations/src/app/migration-tests/undecorated-classes-with-fields.ts
+++ b/integration/ng_update_migrations/src/app/migration-tests/undecorated-classes-with-fields.ts
@@ -4,8 +4,10 @@ import {
   ElementRef,
   HostBinding,
   HostListener,
+  Injectable,
   Input,
-  NgModule
+  NgModule,
+  Pipe
 } from '@angular/core';
 
 export class NonAngularBaseClass {
@@ -75,4 +77,14 @@ export class UndecoratedPipeBase {
 
 export class WithDirectiveLifecycleHook {
   ngOnInit() {}
+}
+
+@Injectable()
+export class MyService {
+  ngOnDestroy() {}
+}
+
+@Pipe({name: 'my-pipe'})
+export class MyPipe {
+  ngOnDestroy() {}
 }

--- a/integration/ng_update_migrations/src/app/migration-tests/undecorated-classes-with-fields.ts
+++ b/integration/ng_update_migrations/src/app/migration-tests/undecorated-classes-with-fields.ts
@@ -79,11 +79,15 @@ export class WithDirectiveLifecycleHook {
   ngOnInit() {}
 }
 
+// This class is already decorated and should not be migrated. i.e. no TODO
+// or Angular decorator should be added. `@Injectable` is sufficient.
 @Injectable()
 export class MyService {
   ngOnDestroy() {}
 }
 
+// This class is already decorated and should not be migrated. i.e. no TODO
+// or Angular decorator should be added. `@Injectable` is sufficient.
 @Pipe({name: 'my-pipe'})
 export class MyPipe {
   ngOnDestroy() {}

--- a/integration/ng_update_migrations/src/app/migration-tests/undecorated-classes-with-fields_expected.ts
+++ b/integration/ng_update_migrations/src/app/migration-tests/undecorated-classes-with-fields_expected.ts
@@ -90,11 +90,15 @@ export class WithDirectiveLifecycleHook {
   ngOnInit() {}
 }
 
+// This class is already decorated and should not be migrated. i.e. no TODO
+// or Angular decorator should be added. `@Injectable` is sufficient.
 @Injectable()
 export class MyService {
   ngOnDestroy() {}
 }
 
+// This class is already decorated and should not be migrated. i.e. no TODO
+// or Angular decorator should be added. `@Injectable` is sufficient.
 @Pipe({name: 'my-pipe'})
 export class MyPipe {
   ngOnDestroy() {}

--- a/integration/ng_update_migrations/src/app/migration-tests/undecorated-classes-with-fields_expected.ts
+++ b/integration/ng_update_migrations/src/app/migration-tests/undecorated-classes-with-fields_expected.ts
@@ -4,8 +4,10 @@ import {
   ElementRef,
   HostBinding,
   HostListener,
+  Injectable,
   Input,
-  NgModule
+  NgModule,
+  Pipe
 } from '@angular/core';
 
 export class NonAngularBaseClass {
@@ -86,4 +88,14 @@ export class UndecoratedPipeBase {
 @Directive()
 export class WithDirectiveLifecycleHook {
   ngOnInit() {}
+}
+
+@Injectable()
+export class MyService {
+  ngOnDestroy() {}
+}
+
+@Pipe({name: 'my-pipe'})
+export class MyPipe {
+  ngOnDestroy() {}
 }

--- a/packages/core/schematics/test/google3/undecorated_classes_with_decorated_fields_spec.ts
+++ b/packages/core/schematics/test/google3/undecorated_classes_with_decorated_fields_spec.ts
@@ -136,24 +136,36 @@ describe('Google3 undecorated classes with decorated fields TSLint rule', () => 
 
   it('should not change decorated classes', () => {
     writeFile('/index.ts', `
-      import { Input, Component, Output, EventEmitter } from '@angular/core';
+      import { Input, Component, Directive, Pipe, Injectable } from '@angular/core';
 
       @Component({})
-      export class Base {
+      export class MyComp {
+        @Input() isActive: boolean;
+      }
+      
+      @Directive({selector: 'dir'})
+      export class MyDir {
         @Input() isActive: boolean;
       }
 
-      export class Child extends Base {
-        @Output() clicked = new EventEmitter<void>();
+      @Injectable()
+      export class MyService {
+        ngOnDestroy() {}
+      }
+      
+      @Pipe({name: 'my-pipe'})
+      export class MyPipe {
+        ngOnDestroy() {}
       }
     `);
 
     runTSLint(true);
     const content = getFile('/index.ts');
-    expect(content).toContain(
-        `import { Input, Component, Output, EventEmitter, Directive } from '@angular/core';`);
-    expect(content).toContain(`@Component({})\n      export class Base {`);
-    expect(content).toContain(`@Directive()\nexport class Child extends Base {`);
+    expect(content).toMatch(/@Component\({}\)\s+export class MyComp {/);
+    expect(content).toMatch(/@Directive\({selector: 'dir'}\)\s+export class MyDir {/);
+    expect(content).toMatch(/@Injectable\(\)\s+export class MyService {/);
+    expect(content).toMatch(/@Pipe\({name: 'my-pipe'}\)\s+export class MyPipe {/);
+    expect(content).not.toContain('TODO');
   });
 
   it('should add @Directive to undecorated classes that have @Output', () => {

--- a/packages/core/schematics/test/helpers.ts
+++ b/packages/core/schematics/test/helpers.ts
@@ -6,9 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/** Regular expression that matches empty line whitespace. */
+const omitEmptyLineWhitespaceRegex = /^[ \t]$/gm;
+
 /**
  * Template string function that can be used to dedent the resulting
  * string literal. The smallest common indentation will be omitted.
+ * Additionally, whitespace in empty lines is removed.
  */
 export function dedent(strings: TemplateStringsArray, ...values: any[]) {
   let joinedString = '';
@@ -24,5 +28,6 @@ export function dedent(strings: TemplateStringsArray, ...values: any[]) {
 
   const minLineIndent = Math.min(...matches.map(el => el.length));
   const omitMinIndentRegex = new RegExp(`^[ \\t]{${minLineIndent}}`, 'gm');
-  return minLineIndent > 0 ? joinedString.replace(omitMinIndentRegex, '') : joinedString;
+  const result = minLineIndent > 0 ? joinedString.replace(omitMinIndentRegex, '') : joinedString;
+  return result.replace(omitEmptyLineWhitespaceRegex, '');
 }

--- a/packages/core/schematics/test/helpers.ts
+++ b/packages/core/schematics/test/helpers.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-/** Regular expression that matches empty line whitespace. */
-const omitEmptyLineWhitespaceRegex = /^[ \t]$/gm;
-
 /**
  * Template string function that can be used to dedent the resulting
  * string literal. The smallest common indentation will be omitted.
@@ -28,6 +25,7 @@ export function dedent(strings: TemplateStringsArray, ...values: any[]) {
 
   const minLineIndent = Math.min(...matches.map(el => el.length));
   const omitMinIndentRegex = new RegExp(`^[ \\t]{${minLineIndent}}`, 'gm');
+  const omitEmptyLineWhitespaceRegex = /^[ \t]+$/gm;
   const result = minLineIndent > 0 ? joinedString.replace(omitMinIndentRegex, '') : joinedString;
   return result.replace(omitEmptyLineWhitespaceRegex, '');
 }


### PR DESCRIPTION
As of v10, the `undecorated-classes-with-decorated-fields` migration
generally deals with undecorated classes using Angular features. We
intended to run this migation as part of v10 again as undecorated
classes with Angular features are no longer supported in planned v11.

The migration currently behaves incorrectly in some cases where an
`@Injectable` or `@Pipe` decorated classes uses the `ngOnDestroy`
lifecycle hook. We incorrectly add a TODO for those classes. This
commit fixes that.

Additionally, this change makes the migration more robust to
not migrate a class if it inherits from a component, pipe
injectable or non-abstract directive. We previously did not
need this as the undecorated-classes-with-di migration ran
before, but this is no longer the case.

Last, this commit fixes an issue where multiple TODO's could be
added. This happens when multiple Angular CLI build targets have
an overlap in source files. Multiple programs then capture the
same source file, causing the migration to detect an undecorated
class multiple times (i.e. adding a TODO twice).

Fixes #37726.