### PR TITLE
fix(dev-infra): support running scripts from within a detached head

### DIFF
--- a/dev-infra/pr/merge/strategies/autosquash-merge.ts
+++ b/dev-infra/pr/merge/strategies/autosquash-merge.ts
@@ -59,7 +59,7 @@ export class AutosquashMergeStrategy extends MergeStrategy {
     // is desired, we set the `GIT_SEQUENCE_EDITOR` environment variable to `true` so that
     // the rebase seems interactive to Git, while it's not interactive to the user.
     // See: https://github.com/git/git/commit/891d4a0313edc03f7e2ecb96edec5d30dc182294.
-    const branchBeforeRebase = this.git.getCurrentBranch();
+    const branchOrRevisionBeforeRebase = this.git.getCurrentBranchOrRevision();
     const rebaseEnv =
         needsCommitMessageFixup ? undefined : {...process.env, GIT_SEQUENCE_EDITOR: 'true'};
     this.git.run(
@@ -69,9 +69,9 @@ export class AutosquashMergeStrategy extends MergeStrategy {
     // Update pull requests commits to reference the pull request. This matches what
     // Github does when pull requests are merged through the Web UI. The motivation is
     // that it should be easy to determine which pull request contained a given commit.
-    // **Note**: The filter-branch command relies on the working tree, so we want to make
-    // sure that we are on the initial branch where the merge script has been run.
-    this.git.run(['checkout', '-f', branchBeforeRebase]);
+    // Note: The filter-branch command relies on the working tree, so we want to make sure
+    // that we are on the initial branch or revision where the merge script has been invoked.
+    this.git.run(['checkout', '-f', branchOrRevisionBeforeRebase]);
     this.git.run(
         ['filter-branch', '-f', '--msg-filter', `${MSG_FILTER_SCRIPT} ${prNumber}`, revisionRange]);
 

--- a/dev-infra/pr/rebase/index.ts
+++ b/dev-infra/pr/rebase/index.ts
@@ -50,10 +50,10 @@ export async function rebasePr(
   }
 
   /**
-   * The branch originally checked out before this method performs any Git
-   * operations that may change the working branch.
+   * The branch or revision originally checked out before this method performed
+   * any Git operations that may change the working branch.
    */
-  const originalBranch = git.getCurrentBranch();
+  const previousBranchOrRevision = git.getCurrentBranchOrRevision();
   /* Get the PR information from Github. */
   const pr = await getPr(PR_SCHEMA, prNumber, config.github);
 
@@ -121,7 +121,7 @@ export async function rebasePr(
     info();
     info(`To abort the rebase and return to the state of the repository before this command`);
     info(`run the following command:`);
-    info(` $ git rebase --abort && git reset --hard && git checkout ${originalBranch}`);
+    info(` $ git rebase --abort && git reset --hard && git checkout ${previousBranchOrRevision}`);
     process.exit(1);
   } else {
     info(`Cleaning up git state, and restoring previous state.`);
@@ -137,7 +137,7 @@ export async function rebasePr(
     // Ensure that any changes in the current repo state are cleared.
     git.runGraceful(['reset', '--hard'], {stdio: 'ignore'});
     // Checkout the original branch from before the run began.
-    git.runGraceful(['checkout', originalBranch], {stdio: 'ignore'});
+    git.runGraceful(['checkout', previousBranchOrRevision], {stdio: 'ignore'});
   }
 }
 

--- a/dev-infra/utils/git/index.ts
+++ b/dev-infra/utils/git/index.ts
@@ -119,9 +119,16 @@ export class GitClient {
     return this.run(['branch', branchName, '--contains', sha]).stdout !== '';
   }
 
-  /** Gets the currently checked out branch. */
-  getCurrentBranch(): string {
-    return this.run(['rev-parse', '--abbrev-ref', 'HEAD']).stdout.trim();
+  /** Gets the currently checked out branch or revision. */
+  getCurrentBranchOrRevision(): string {
+    const branchName = this.run(['rev-parse', '--abbrev-ref', 'HEAD']).stdout.trim();
+    // If no branch name could be resolved. i.e. `HEAD` has been returned, then Git
+    // is currently in a detached state. In those cases, we just want to return the
+    // currently checked out revision/SHA.
+    if (branchName === 'HEAD') {
+      return this.run(['rev-parse', 'HEAD']).stdout.trim();
+    }
+    return branchName;
   }
 
   /** Gets whether the current Git repository has uncommitted changes. */


### PR DESCRIPTION
Scripts provided in the `ng-dev` command might use local `git`
commands. For such scripts, we keep track of the branch that
has been checked out before the command has been invoked.

We do this so that we can later (upon command completion)
restore back to the original branch. We do not want to
leave the Git repository in a dirty state.

It looks like this logic currently only deals with branches
but does not work properly when a command is invoked from
a detached head. We can make it work by just checking out
the previous revision (if no branch is checked out).