### PR TITLE
fix(compiler-cli): use `null` in type checking of safe navigation operators

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -248,7 +248,7 @@ class AstTranslator implements AstVisitor {
       const method = ts.createPropertyAccess(ts.createNonNullExpression(receiver), ast.name);
       addParseSpanInfo(method, ast.nameSpan);
       const call = ts.createCall(method, undefined, args);
-      node = ts.createParen(ts.createConditional(NULL_AS_ANY, call, UNDEFINED));
+      node = ts.createParen(ts.createConditional(NULL_AS_ANY, call, ts.createNull()));
     } else if (VeSafeLhsInferenceBugDetector.veWillInferAnyFor(ast)) {
       // "a?.method(...)" becomes (a as any).method(...)
       const method = ts.createPropertyAccess(tsCastToAny(receiver), ast.name);
@@ -274,7 +274,7 @@ class AstTranslator implements AstVisitor {
       // "a?.b" becomes (null as any ? a!.b : undefined)
       // The type of this expression is (typeof a!.b) | undefined, which is exactly as desired.
       const expr = ts.createPropertyAccess(ts.createNonNullExpression(receiver), ast.name);
-      node = ts.createParen(ts.createConditional(NULL_AS_ANY, expr, UNDEFINED));
+      node = ts.createParen(ts.createConditional(NULL_AS_ANY, expr, ts.createNull()));
     } else if (VeSafeLhsInferenceBugDetector.veWillInferAnyFor(ast)) {
       // Emulate a View Engine bug where 'any' is inferred for the left-hand side of the safe
       // navigation operation. With this bug, the type of the left-hand side is regarded as any.

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -246,6 +246,36 @@ runInEachFileSystem(() => {
       expect(messages).toEqual([]);
     });
 
+    describe('safe navigation', () => {
+      it('should use `null` as default value for safe property access', () => {
+        const messages = diagnose(`{{ formatName(person?.name) }}`, `
+        export class TestComponent {
+          person?: {
+            name: string;
+          };
+          formatName(name: string | undefined): string;
+        }`);
+
+        expect(messages).toEqual([
+          `synthetic.html(1, 15): Argument of type 'string | null' is not assignable to parameter of type 'string | undefined'.`
+        ]);
+      });
+
+      it('should use `null` as default value for safe method call', () => {
+        const messages = diagnose(`{{ formatName(person?.getName()) }}`, `
+        export class TestComponent {
+          person?: {
+            getName(): string;
+          };
+          formatName(name: string | undefined): string;
+        }`);
+
+        expect(messages).toEqual([
+          `synthetic.html(1, 15): Argument of type 'string | null' is not assignable to parameter of type 'string | undefined'.`
+        ]);
+      });
+    });
+
     describe('outputs', () => {
       it('should produce a diagnostic for directive outputs', () => {
         const messages = diagnose(

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -106,14 +106,14 @@ describe('type check blocks diagnostics', () => {
     it('should annotate safe property access', () => {
       const TEMPLATE = `{{ a?.b }}`;
       expect(tcbWithSpans(TEMPLATE))
-          .toContain('((null as any) ? (((ctx).a /*3,4*/) /*3,4*/)!.b : undefined) /*3,7*/');
+          .toContain('((null as any) ? (((ctx).a /*3,4*/) /*3,4*/)!.b : null) /*3,7*/');
     });
 
     it('should annotate safe method calls', () => {
       const TEMPLATE = `{{ a?.method(b) }}`;
       expect(tcbWithSpans(TEMPLATE))
           .toContain(
-              '((null as any) ? (((ctx).a /*3,4*/) /*3,4*/)!.method /*6,12*/(((ctx).b /*13,14*/) /*13,14*/) : undefined) /*3,15*/');
+              '((null as any) ? (((ctx).a /*3,4*/) /*3,4*/)!.method /*6,12*/(((ctx).b /*13,14*/) /*13,14*/) : null) /*3,15*/');
     });
 
     it('should annotate $any casts', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -565,10 +565,10 @@ describe('type check blocks', () => {
     describe('config.strictSafeNavigationTypes', () => {
       const TEMPLATE = `{{a?.b}} {{a?.method()}}`;
 
-      it('should use undefined for safe navigation operations when enabled', () => {
+      it('should use null for safe navigation operations when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('((null as any) ? (((ctx).a))!.method() : undefined)');
-        expect(block).toContain('((null as any) ? (((ctx).a))!.b : undefined)');
+        expect(block).toContain('((null as any) ? (((ctx).a))!.method() : null)');
+        expect(block).toContain('((null as any) ? (((ctx).a))!.b : null)');
       });
       it('should use an \'any\' type for safe navigation operations when disabled', () => {
         const DISABLED_CONFIG:
@@ -583,8 +583,8 @@ describe('type check blocks', () => {
       const TEMPLATE = `{{a.method()?.b}} {{a()?.method()}}`;
       it('should check the presence of a property/method on the receiver when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('((null as any) ? ((((ctx).a)).method())!.b : undefined)');
-        expect(block).toContain('((null as any) ? ((ctx).a())!.method() : undefined)');
+        expect(block).toContain('((null as any) ? ((((ctx).a)).method())!.b : null)');
+        expect(block).toContain('((null as any) ? ((ctx).a())!.method() : null)');
       });
       it('should not check the presence of a property/method on the receiver when disabled', () => {
         const DISABLED_CONFIG:


### PR DESCRIPTION
Safe navigation operators in Angular templates will evaluate to `null` if the LHS
operand is `null` or `undefined`, however the type checker would use `undefined`
instead. This results in inaccurate type checking when `strictNullChecks` is enabled.

BREAKING CHANGE:

Using the safe navigation operator in templates will now infer the type of the
expressions to be a union type including `null`, instead of `undefined` as it
previously was. If TypeScript's `strictNullChecks` is enabled together with Angular's
`strictTemplates` or `strictSafeNavigationTypes` you may start to see new type errors.
The previous behavior of including `undefined` in the type does not correspond with
the behavior at runtime, where the `null` value is used instead.

Fixes #37622