### PR TITLE
build: add wombot proxy for publish config for @angular/benchpress

### DIFF
--- a/packages/benchpress/package.json
+++ b/packages/benchpress/package.json
@@ -22,5 +22,8 @@
   "bugs": {
     "url": "https://github.com/angular/angular/issues"
   },
-  "homepage": "https://github.com/angular/angular/tree/master/packages/compiler-cli"
+  "homepage": "https://github.com/angular/angular/tree/master/packages/compiler-cli",
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com"
+  }
 }


### PR DESCRIPTION
Adds the publishConfig registry value to the package.json of the
@angular/benchpress package to publish it via wombat rather than
through npm directly.
