### PR TITLE
fix(docs-infra): fix typo in the deploy-to-firebase.sh script

### DIFF
--- a/aio/scripts/deploy-to-firebase.sh
+++ b/aio/scripts/deploy-to-firebase.sh
@@ -114,7 +114,7 @@ fi
     yarn firebase use aio-staging --token "$firebaseToken"
     yarn firebase target:apply hosting aio $projectId --token "$firebaseToken"
     yarn firebase deploy --only hosting:aio --message "Commit: $CI_COMMIT" --non-interactive --token "$firebaseToken"
-  elif
+  else
     yarn firebase use "$projectId" --token "$firebaseToken"
     yarn firebase deploy --message "Commit: $CI_COMMIT" --non-interactive --token "$firebaseToken"
   fi


### PR DESCRIPTION
This typo caused the script to fail on Linux (interestingly it works fine on Mac).

This is a painful reminder that we should not write any more Bash scripts EVER. shelljs FTW! :-)