### PR TITLE
fix(docs-infra): fix deploy-to-firebase.sh for master and v10.0.x branches

### DIFF
--- a/aio/scripts/deploy-to-firebase.sh
+++ b/aio/scripts/deploy-to-firebase.sh
@@ -64,16 +64,27 @@ fi
 case $deployEnv in
   next)
     readonly projectId=aio-staging
+    readonly siteId=$projectId
     readonly deployedUrl=https://next.angular.io/
     readonly firebaseToken=$CI_SECRET_AIO_DEPLOY_FIREBASE_TOKEN
     ;;
   stable)
     readonly projectId=angular-io
+    readonly siteId=$projectId
     readonly deployedUrl=https://angular.io/
     readonly firebaseToken=$CI_SECRET_AIO_DEPLOY_FIREBASE_TOKEN
     ;;
   archive)
-    readonly projectId=v${majorVersion}-angular-io
+    # Special case v9-angular-io because its piloting the firebase hosting "multisites" setup
+    # See https://angular-team.atlassian.net/browse/DEV-125 for more info.
+    if [[ "$majorVersion" == "9" ]]; then
+      readonly projectId=aio-staging
+      readonly siteId=v9-angular-io
+    else
+      readonly projectId=v${majorVersion}-angular-io
+      readonly siteId=$projectId
+    fi
+
     readonly deployedUrl=https://v${majorVersion}.angular.io/
     readonly firebaseToken=$CI_SECRET_AIO_DEPLOY_FIREBASE_TOKEN
     ;;
@@ -82,6 +93,7 @@ esac
 echo "Git branch        : $CI_BRANCH"
 echo "Build/deploy mode : $deployEnv"
 echo "Firebase project  : $projectId"
+echo "Firebase site     : $siteId"
 echo "Deployment URL    : $deployedUrl"
 
 if [[ ${1:-} == "--dry-run" ]]; then
@@ -92,34 +104,29 @@ fi
 (
   cd "`dirname $0`/.."
 
-  # Build the app
+  echo "\n\n\n==== Build the aio app ====\n"
   yarn build --configuration=$deployEnv --progress=false
 
-  # Include any mode-specific files
+
+  echo "\n\n\n==== Add any mode-specific files into the aio distribution ====\n"
   cp -rf src/extra-files/$deployEnv/. dist/
 
-  # Set deployedUrl as parameter in the opensearch description
+
+  echo "\n\n\n==== Update opensearch descriptor for aio with the deployedUrl ====\n"
   # deployedUrl must end with /
   yarn set-opensearch-url $deployedUrl
 
-  # Check payload size
+  echo "\n\n\n==== Check payload size and upload the numbers to firebase db ====\n"
   yarn payload-size
 
 
-  # Deploy to Firebase
+  echo "\n\n\n==== Deploy aio to firebase hosting ====\n"
 
-  # Special case v9-angular-io because its piloting the firebase hosting "multisites" setup
-  # See https://angular-team.atlassian.net/browse/DEV-125 for more info.
-  if [[ "$projectId" == "v9-angular-io" ]]; then
-    yarn firebase use aio-staging --token "$firebaseToken"
-    yarn firebase target:apply hosting aio $projectId --token "$firebaseToken"
-    yarn firebase deploy --only hosting:aio --message "Commit: $CI_COMMIT" --non-interactive --token "$firebaseToken"
-  else
-    yarn firebase use "$projectId" --token "$firebaseToken"
-    yarn firebase deploy --message "Commit: $CI_COMMIT" --non-interactive --token "$firebaseToken"
-  fi
+  yarn firebase use "${projectId}" --token "$firebaseToken"
+  yarn firebase target:apply hosting aio $siteId --token "$firebaseToken"
+  yarn firebase deploy --only hosting:aio --message "Commit: $CI_COMMIT" --non-interactive --token "$firebaseToken"
 
 
-  # Run PWA-score tests
+  echo "\n\n\n==== Run PWA-score tests ====\n"
   yarn test-pwa-score "$deployedUrl" "$CI_AIO_MIN_PWA_SCORE"
 )

--- a/aio/scripts/deploy-to-firebase.test.sh
+++ b/aio/scripts/deploy-to-firebase.test.sh
@@ -68,6 +68,7 @@ function check {
   expected="Git branch        : master
 Build/deploy mode : next
 Firebase project  : aio-staging
+Firebase site     : aio-staging
 Deployment URL    : https://next.angular.io/"
   check "$actual" "$expected"
 )
@@ -103,6 +104,7 @@ Deployment URL    : https://next.angular.io/"
   expected="Git branch        : 4.3.x
 Build/deploy mode : stable
 Firebase project  : angular-io
+Firebase site     : angular-io
 Deployment URL    : https://angular.io/"
   check "$actual" "$expected"
 )
@@ -139,6 +141,7 @@ Deployment URL    : https://angular.io/"
   expected="Git branch        : 2.4.x
 Build/deploy mode : archive
 Firebase project  : v2-angular-io
+Firebase site     : v2-angular-io
 Deployment URL    : https://v2.angular.io/"
   check "$actual" "$expected"
 )
@@ -158,7 +161,8 @@ Deployment URL    : https://v2.angular.io/"
   )
   expected="Git branch        : 9.1.x
 Build/deploy mode : archive
-Firebase project  : v9-angular-io
+Firebase project  : aio-staging
+Firebase site     : v9-angular-io
 Deployment URL    : https://v9.angular.io/"
   # TODO: This test incorrectly expects the Firebase project to be v9-angular-io.
   #       v9-angular-io is a "multisites" project currently within the aio-staging project


### PR DESCRIPTION
The deployment to aio is currently failing because #37721 introduced
"project" entry into the firebase.json which means that we now need to
select the deployment target before deploying to firebase.

This change fixes the issue and refactors the file to be easier to read.

I also added extra echo statements so that the CI logs are easier to
read in case we need to troubleshoot future issues.
