### PR TITLE
fix(http): Add support for requesting body as URLSearchParams type

### DIFF
--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -70,7 +70,7 @@ function isFormData(value: any): value is FormData {
  *
  * In some execution environments URLSearchParams is not defined.
  */
-function isURLSearchParams(value: any): value is URLSearchParams {
+function isURLSearchParams(value: unknown): value is URLSearchParams {
   return typeof URLSearchParams !== 'undefined' && value instanceof URLSearchParams;
 }
 

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -66,6 +66,15 @@ function isFormData(value: any): value is FormData {
 }
 
 /**
+ * Safely assert whether the given value is a URLSearchParams.
+ *
+ * In some execution environments URLSearchParams is not defined.
+ */
+function isURLSearchParams(value: any): value is URLSearchParams {
+  return typeof URLSearchParams !== 'undefined' && value instanceof URLSearchParams;
+}
+
+/**
  * An outgoing HTTP request with an optional typed body.
  *
  * `HttpRequest` represents an outgoing request, including URL, method,
@@ -247,8 +256,8 @@ export class HttpRequest<T> {
         typeof this.body === 'string') {
       return this.body;
     }
-    // Check whether the body is an instance of HttpUrlEncodedParams.
-    if (this.body instanceof HttpParams) {
+    // Check whether the body is an instance of HttpUrlEncodedParams or URLSearchParams.
+    if (this.body instanceof HttpParams || isURLSearchParams(this.body)) {
       return this.body.toString();
     }
     // Check whether the body is an object or array, and serialize with JSON if so.
@@ -289,8 +298,8 @@ export class HttpRequest<T> {
     if (typeof this.body === 'string') {
       return 'text/plain';
     }
-    // `HttpUrlEncodedParams` has its own content-type.
-    if (this.body instanceof HttpParams) {
+    // `HttpUrlEncodedParams` and `URLSearchParams` have their own content-type.
+    if (this.body instanceof HttpParams || isURLSearchParams(this.body)) {
       return 'application/x-www-form-urlencoded;charset=UTF-8';
     }
     // Arrays, objects, and numbers will be encoded as JSON.

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -146,6 +146,15 @@ const TEST_STRING = `I'm a body!`;
         expect(withParams.detectContentTypeHeader())
             .toEqual('application/x-www-form-urlencoded;charset=UTF-8');
       });
+      it('serializes parameters as urlencoded', () => {
+        const params = new URLSearchParams();
+        params.set('first', 'test');
+        params.set('second', 'data');
+        const withParams = baseReq.clone({body: params});
+        expect(withParams.serializeBody()).toEqual('first=test&second=data');
+        expect(withParams.detectContentTypeHeader())
+            .toEqual('application/x-www-form-urlencoded;charset=UTF-8');
+      });
     });
     describe('parameter handling', () => {
       const baseReq = new HttpRequest('GET', '/test', null);

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -147,7 +147,7 @@ const TEST_STRING = `I'm a body!`;
             .toEqual('application/x-www-form-urlencoded;charset=UTF-8');
       });
       it('serializes parameters as urlencoded', () => {
-        if(typeof URLSearchParams !== 'undefined'){
+        if (typeof URLSearchParams !== 'undefined') {
           const params = new URLSearchParams();
           params.set('first', 'test');
           params.set('second', 'data');

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -147,13 +147,15 @@ const TEST_STRING = `I'm a body!`;
             .toEqual('application/x-www-form-urlencoded;charset=UTF-8');
       });
       it('serializes parameters as urlencoded', () => {
-        const params = new URLSearchParams();
-        params.set('first', 'test');
-        params.set('second', 'data');
-        const withParams = baseReq.clone({body: params});
-        expect(withParams.serializeBody()).toEqual('first=test&second=data');
-        expect(withParams.detectContentTypeHeader())
-            .toEqual('application/x-www-form-urlencoded;charset=UTF-8');
+        if(typeof URLSearchParams !== 'undefined'){
+          const params = new URLSearchParams();
+          params.set('first', 'test');
+          params.set('second', 'data');
+          const withParams = baseReq.clone({body: params});
+          expect(withParams.serializeBody()).toEqual('first=test&second=data');
+          expect(withParams.detectContentTypeHeader())
+              .toEqual('application/x-www-form-urlencoded;charset=UTF-8');
+        }
       });
     });
     describe('parameter handling', () => {


### PR DESCRIPTION
There is no support for URLSearchParams type request in the current version. This commit adds serialize body function for URLSearchParams type.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 36317

There is no support for URLSearchParams type request in the current version. When a user passes the body parameter with this type, Angular considers it as a random object. It ends up being omitted. 

## What is the new behavior?
This commit adds serialization for URLSearchParams type. It will handle URLSearchParams type request, it will not be omitted.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
