### PR TITLE
refactor(compiler): Shorten %COMP% to %C%

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -40,7 +40,7 @@ describe('compiler compliance: styling', () => {
          };
 
          const template =
-             'styles: ["div.foo[_ngcontent-%COMP%] { color: red; }", "[_nghost-%COMP%]   p[_ngcontent-%COMP%]:nth-child(even) { --webkit-transition: 1s linear all; }"]';
+             'styles: ["div.foo[_ngcontent-%C%] { color: red; }", "[_nghost-%C%]   p[_ngcontent-%C%]:nth-child(even) { --webkit-transition: 1s linear all; }"]';
          const result = compile(files, angularFiles);
          expectEmit(result.source, template, 'Incorrect template');
        });

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -6642,7 +6642,7 @@ export const Foo = Foo__PRE_R3__;
         const jsContents = env.getContents('test.js');
         expect(jsContents)
             .toContain(
-                'styles: ["h2[_ngcontent-%COMP%] {width: 10px}", "h1[_ngcontent-%COMP%] {font-size: larger}"]');
+                'styles: ["h2[_ngcontent-%C%] {width: 10px}", "h1[_ngcontent-%C%] {font-size: larger}"]');
       });
 
       it('should process inline <link> tags', () => {
@@ -6659,7 +6659,7 @@ export const Foo = Foo__PRE_R3__;
 
         env.driveMain();
         const jsContents = env.getContents('test.js');
-        expect(jsContents).toContain('styles: ["h1[_ngcontent-%COMP%] {font-size: larger}"]');
+        expect(jsContents).toContain('styles: ["h1[_ngcontent-%C%] {font-size: larger}"]');
       });
     });
 

--- a/packages/compiler/src/style_compiler.ts
+++ b/packages/compiler/src/style_compiler.ts
@@ -13,7 +13,7 @@ import {ShadowCss} from './shadow_css';
 import {UrlResolver} from './url_resolver';
 import {OutputContext} from './util';
 
-const COMPONENT_VARIABLE = '%COMP%';
+const COMPONENT_VARIABLE = '%C%';
 export const HOST_ATTR = `_nghost-${COMPONENT_VARIABLE}`;
 export const CONTENT_ATTR = `_ngcontent-${COMPONENT_VARIABLE}`;
 

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -19,10 +19,10 @@ export const NAMESPACE_URIS: {[ns: string]: string} = {
   'xmlns': 'http://www.w3.org/2000/xmlns/',
 };
 
-const COMPONENT_REGEX = /%COMP%/g;
+const COMPONENT_REGEX = /%C%/g;
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
 
-export const COMPONENT_VARIABLE = '%COMP%';
+export const COMPONENT_VARIABLE = '%C%';
 export const HOST_ATTR = `_nghost-${COMPONENT_VARIABLE}`;
 export const CONTENT_ATTR = `_ngcontent-${COMPONENT_VARIABLE}`;
 


### PR DESCRIPTION
This commit reduces the length of the component placeholder. No functionality changes.

Shortening the attribute allows a smaller bundle size and a smaller download before the platform-server shis the component attribute with component ID.

All spec tests involving %COMP% have been updated to use %C%.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
