### PR TITLE
test(compiler-cli): re-enable dynamic value diagnostic tests on Windows CI

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/diagnostics_spec.ts
@@ -6,99 +6,92 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {platform} from 'os';
 import * as ts from 'typescript';
 
-import {FatalDiagnosticError} from '../../diagnostics';
-import {absoluteFrom as _} from '../../file_system';
+import {absoluteFrom as _, getSourceFileOrError} from '../../file_system';
 import {runInEachFileSystem, TestFile} from '../../file_system/testing';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {TypeScriptReflectionHost} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';
 import {createValueHasWrongTypeError} from '../src/diagnostics';
 
-runInEachFileSystem(os => {
+runInEachFileSystem(() => {
   describe('ngtsc annotation diagnostics', () => {
-    // These tests are currently disabled when running in Windows mode as the assertions involving
-    // the filename attached to the diagnostic are suffering from a case-sensitivity issue.
-    //
-    // TODO(JoostK): re-enable on Windows once the case issue has been solved.
-    if (os !== 'Windows' && platform() !== 'win32') {
-      describe('createValueError()', () => {
-        it('should include a trace for dynamic values', () => {
-          const error = createError('', 'nonexistent', 'Error message');
+    describe('createValueError()', () => {
+      it('should include a trace for dynamic values', () => {
+        const {error, program} = createError('', 'nonexistent', 'Error message');
+        const entrySf = getSourceFileOrError(program, _('/entry.ts'));
 
-          if (typeof error.message === 'string') {
-            return fail('Created error must have a message chain');
-          }
-          expect(error.message.messageText).toBe('Error message');
-          expect(error.message.next!.length).toBe(1);
-          expect(error.message.next![0].messageText)
-              .toBe(`Value could not be determined statically.`);
+        if (typeof error.message === 'string') {
+          return fail('Created error must have a message chain');
+        }
+        expect(error.message.messageText).toBe('Error message');
+        expect(error.message.next!.length).toBe(1);
+        expect(error.message.next![0].messageText)
+            .toBe(`Value could not be determined statically.`);
 
-          expect(error.relatedInformation).toBeDefined();
-          expect(error.relatedInformation!.length).toBe(1);
+        expect(error.relatedInformation).toBeDefined();
+        expect(error.relatedInformation!.length).toBe(1);
 
-          expect(error.relatedInformation![0].messageText).toBe('Unknown reference.');
-          expect(error.relatedInformation![0].file!.fileName).toBe(_('/entry.ts'));
-          expect(getSourceCode(error.relatedInformation![0])).toBe('nonexistent');
-        });
-
-        it('should include a pointer for a reference to a named declaration', () => {
-          const error = createError(
-              `import {Foo} from './foo';`, 'Foo', 'Error message',
-              [{name: _('/foo.ts'), contents: 'export class Foo {}'}]);
-
-          if (typeof error.message === 'string') {
-            return fail('Created error must have a message chain');
-          }
-          expect(error.message.messageText).toBe('Error message');
-          expect(error.message.next!.length).toBe(1);
-          expect(error.message.next![0].messageText).toBe(`Value is a reference to 'Foo'.`);
-
-          expect(error.relatedInformation).toBeDefined();
-          expect(error.relatedInformation!.length).toBe(1);
-          expect(error.relatedInformation![0].messageText).toBe('Reference is declared here.');
-          expect(error.relatedInformation![0].file!.fileName).toBe(_('/foo.ts'));
-          expect(getSourceCode(error.relatedInformation![0])).toBe('Foo');
-        });
-
-        it('should include a pointer for a reference to an anonymous declaration', () => {
-          const error = createError(
-              `import Foo from './foo';`, 'Foo', 'Error message',
-              [{name: _('/foo.ts'), contents: 'export default class {}'}]);
-
-          if (typeof error.message === 'string') {
-            return fail('Created error must have a message chain');
-          }
-          expect(error.message.messageText).toBe('Error message');
-          expect(error.message.next!.length).toBe(1);
-          expect(error.message.next![0].messageText)
-              .toBe(`Value is a reference to an anonymous declaration.`);
-
-          expect(error.relatedInformation).toBeDefined();
-          expect(error.relatedInformation!.length).toBe(1);
-          expect(error.relatedInformation![0].messageText).toBe('Reference is declared here.');
-          expect(error.relatedInformation![0].file!.fileName).toBe(_('/foo.ts'));
-          expect(getSourceCode(error.relatedInformation![0])).toBe('export default class {}');
-        });
-
-        it('should include a representation of the value\'s type', () => {
-          const error = createError('', '{a: 2}', 'Error message');
-
-          if (typeof error.message === 'string') {
-            return fail('Created error must have a message chain');
-          }
-          expect(error.message.messageText).toBe('Error message');
-          expect(error.message.next!.length).toBe(1);
-          expect(error.message.next![0].messageText).toBe(`Value is of type '{ a: number }'.`);
-
-          expect(error.relatedInformation).not.toBeDefined();
-        });
+        expect(error.relatedInformation![0].messageText).toBe('Unknown reference.');
+        expect(error.relatedInformation![0].file!.fileName).toBe(entrySf.fileName);
+        expect(getSourceCode(error.relatedInformation![0])).toBe('nonexistent');
       });
-    }
 
-    it('should not be empty', () => {});
+      it('should include a pointer for a reference to a named declaration', () => {
+        const {error, program} = createError(
+            `import {Foo} from './foo';`, 'Foo', 'Error message',
+            [{name: _('/foo.ts'), contents: 'export class Foo {}'}]);
+        const fooSf = getSourceFileOrError(program, _('/foo.ts'));
+
+        if (typeof error.message === 'string') {
+          return fail('Created error must have a message chain');
+        }
+        expect(error.message.messageText).toBe('Error message');
+        expect(error.message.next!.length).toBe(1);
+        expect(error.message.next![0].messageText).toBe(`Value is a reference to 'Foo'.`);
+
+        expect(error.relatedInformation).toBeDefined();
+        expect(error.relatedInformation!.length).toBe(1);
+        expect(error.relatedInformation![0].messageText).toBe('Reference is declared here.');
+        expect(error.relatedInformation![0].file!.fileName).toBe(fooSf.fileName);
+        expect(getSourceCode(error.relatedInformation![0])).toBe('Foo');
+      });
+
+      it('should include a pointer for a reference to an anonymous declaration', () => {
+        const {error, program} = createError(
+            `import Foo from './foo';`, 'Foo', 'Error message',
+            [{name: _('/foo.ts'), contents: 'export default class {}'}]);
+        const fooSf = getSourceFileOrError(program, _('/foo.ts'));
+
+        if (typeof error.message === 'string') {
+          return fail('Created error must have a message chain');
+        }
+        expect(error.message.messageText).toBe('Error message');
+        expect(error.message.next!.length).toBe(1);
+        expect(error.message.next![0].messageText)
+            .toBe(`Value is a reference to an anonymous declaration.`);
+
+        expect(error.relatedInformation).toBeDefined();
+        expect(error.relatedInformation!.length).toBe(1);
+        expect(error.relatedInformation![0].messageText).toBe('Reference is declared here.');
+        expect(error.relatedInformation![0].file!.fileName).toBe(fooSf.fileName);
+        expect(getSourceCode(error.relatedInformation![0])).toBe('export default class {}');
+      });
+
+      it('should include a representation of the value\'s type', () => {
+        const {error} = createError('', '{a: 2}', 'Error message');
+
+        if (typeof error.message === 'string') {
+          return fail('Created error must have a message chain');
+        }
+        expect(error.message.messageText).toBe('Error message');
+        expect(error.message.next!.length).toBe(1);
+        expect(error.message.next![0].messageText).toBe(`Value is of type '{ a: number }'.`);
+
+        expect(error.relatedInformation).not.toBeDefined();
+      });
+    });
   });
 });
 
@@ -108,8 +101,7 @@ function getSourceCode(diag: ts.DiagnosticRelatedInformation): string {
 }
 
 function createError(
-    code: string, expr: string, messageText: string,
-    supportingFiles: TestFile[] = []): FatalDiagnosticError {
+    code: string, expr: string, messageText: string, supportingFiles: TestFile[] = []) {
   const {program} = makeProgram(
       [{name: _('/entry.ts'), contents: `${code}; const target$ = ${expr}`}, ...supportingFiles],
       /* options */ undefined, /* host */ undefined, /* checkForErrors */ false);
@@ -121,5 +113,6 @@ function createError(
   const evaluator = new PartialEvaluator(reflectionHost, checker, /* dependencyTracker */ null);
 
   const value = evaluator.evaluate(valueExpr);
-  return createValueHasWrongTypeError(valueExpr, value, messageText);
+  const error = createValueHasWrongTypeError(valueExpr, value, messageText);
+  return {error, program};
 }

--- a/packages/compiler-cli/src/ngtsc/file_system/testing/src/mock_file_system_windows.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/testing/src/mock_file_system_windows.ts
@@ -42,6 +42,6 @@ export class MockFileSystemWindows extends MockFileSystem {
   }
 
   normalize<T extends PathString>(path: T): T {
-    return path.replace(/^[\/\\]/i, 'c:/').replace(/\\/g, '/') as T;
+    return path.replace(/^[\/\\]/i, 'C:/').replace(/\\/g, '/') as T;
   }
 }


### PR DESCRIPTION
Essentially reverts #37763 and fixes the test + emulation to allow tests to pass on Windows.