### PR TITLE
test(core): update symbols used in the test app

### DIFF
--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1164,7 +1164,7 @@
     "name": "shouldSearchParent"
   },
   {
-    "name": "storeCleanupFn"
+    "name": "storeCleanupWithContext"
   },
   {
     "name": "stringify"


### PR DESCRIPTION
This commit updates the golden file that contains the set of symbols used in the test TODO app. The `storeCleanupFn` function was replaced by `storeCleanupWithContext` in https://github.com/angular/angular/commit/75b119eafc8a9c3d02bbdc06835fc3e46b495882 and this commit updates the golden file to reflect that.


## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: test-related changes, updating golden file.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No