### PR TITLE
refactor(compiler): shorten _nghost- and _ngcontent- prefixes to _h- and _c-

### DIFF
--- a/aio/content/guide/component-styles.md
+++ b/aio/content/guide/component-styles.md
@@ -318,10 +318,10 @@ encapsulation enabled, each DOM element has some extra attributes
 attached to it:
 
 <code-example format="">
-  &lt;hero-details _nghost-pmm-5>
-    &lt;h2 _ngcontent-pmm-5>Mister Fantastic&lt;/h2>
-    &lt;hero-team _ngcontent-pmm-5 _nghost-pmm-6>
-      &lt;h3 _ngcontent-pmm-6>Team&lt;/h3>
+  &lt;hero-details _h-pmm-5>
+    &lt;h2 _c-pmm-5>Mister Fantastic&lt;/h2>
+    &lt;hero-team _c-pmm-5 _h-pmm-6>
+      &lt;h3 _c-pmm-6>Team&lt;/h3>
     &lt;/hero-team>
   &lt;/hero-detail>
 
@@ -339,12 +339,12 @@ generated and you never refer to them in application code. But they are targeted
 by the generated component styles, which are in the `<head>` section of the DOM:
 
 <code-example format="">
-  [_nghost-pmm-5] {
+  [_h-pmm-5] {
     display: block;
     border: 1px solid black;
   }
 
-  h3[_ngcontent-pmm-6] {
+  h3[_c-pmm-6] {
     background-color: white;
     border: 1px solid #777;
   }

--- a/aio/content/marketing/test.html
+++ b/aio/content/marketing/test.html
@@ -48,7 +48,7 @@
 &lt;hero-details <em>nghost-pmm-5&gt;
   &lt;h2 </em>ngcontent-pmm-5&gt;Bah Dah Bing&lt;/h2&gt;
   &lt;hero-team <em>ngcontent-pmm-5 </em>nghost-pmm-6&gt;
-    &lt;h3 _ngcontent-pmm-6&gt;Headless Team&lt;/h3&gt;
+    &lt;h3 _c-pmm-6&gt;Headless Team&lt;/h3&gt;
   &lt;/hero-team&gt;
 &lt;/hero-details&gt;
 </code-example>
@@ -58,7 +58,7 @@
 &lt;hero-details <em>nghost-pmm-5&gt;
   &lt;h2 </em>ngcontent-pmm-5&gt;Mister Fantastic&lt;/h2&gt;
   &lt;hero-team <em>ngcontent-pmm-5 </em>nghost-pmm-6&gt;
-    &lt;h3 _ngcontent-pmm-6&gt;Headless Team&lt;/h3&gt;
+    &lt;h3 _c-pmm-6&gt;Headless Team&lt;/h3&gt;
   &lt;/hero-team&gt;
 &lt;/hero-details&gt;
 </code-example>
@@ -68,7 +68,7 @@
   &lt;hero-details <em>nghost-pmm-5&gt;
     &lt;h2 </em>ngcontent-pmm-5&gt;Mister Fantastic&lt;/h2&gt;
     &lt;hero-team <em>ngcontent-pmm-5 </em>nghost-pmm-6&gt;
-      &lt;h3 _ngcontent-pmm-6&gt;Winning Team&lt;/h3&gt;
+      &lt;h3 _c-pmm-6&gt;Winning Team&lt;/h3&gt;
     &lt;/hero-team&gt;
   &lt;/hero-details&gt;
 </code-example>
@@ -78,7 +78,7 @@
   &lt;hero-details <em>nghost-pmm-5&gt;
     &lt;h2 </em>ngcontent-pmm-5&gt;Mister Fantastic&lt;/h2&gt;
     &lt;hero-team <em>ngcontent-pmm-5 </em>nghost-pmm-6&gt;
-      &lt;h3 _ngcontent-pmm-6&gt;Losing Team&lt;/h3&gt;
+      &lt;h3 _c-pmm-6&gt;Losing Team&lt;/h3&gt;
     &lt;/hero-team&gt;
   &lt;/hero-details&gt;
 </code-example>

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -40,7 +40,7 @@ describe('compiler compliance: styling', () => {
          };
 
          const template =
-             'styles: ["div.foo[_ngcontent-%COMP%] { color: red; }", "[_nghost-%COMP%]   p[_ngcontent-%COMP%]:nth-child(even) { --webkit-transition: 1s linear all; }"]';
+             'styles: ["div.foo[_c-%COMP%] { color: red; }", "[_h-%COMP%]   p[_c-%COMP%]:nth-child(even) { --webkit-transition: 1s linear all; }"]';
          const result = compile(files, angularFiles);
          expectEmit(result.source, template, 'Incorrect template');
        });

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -6642,7 +6642,7 @@ export const Foo = Foo__PRE_R3__;
         const jsContents = env.getContents('test.js');
         expect(jsContents)
             .toContain(
-                'styles: ["h2[_ngcontent-%COMP%] {width: 10px}", "h1[_ngcontent-%COMP%] {font-size: larger}"]');
+                'styles: ["h2[_c-%COMP%] {width: 10px}", "h1[_c-%COMP%] {font-size: larger}"]');
       });
 
       it('should process inline <link> tags', () => {
@@ -6659,7 +6659,7 @@ export const Foo = Foo__PRE_R3__;
 
         env.driveMain();
         const jsContents = env.getContents('test.js');
-        expect(jsContents).toContain('styles: ["h1[_ngcontent-%COMP%] {font-size: larger}"]');
+        expect(jsContents).toContain('styles: ["h1[_c-%COMP%] {font-size: larger}"]');
       });
     });
 

--- a/packages/compiler/src/style_compiler.ts
+++ b/packages/compiler/src/style_compiler.ts
@@ -14,8 +14,8 @@ import {UrlResolver} from './url_resolver';
 import {OutputContext} from './util';
 
 const COMPONENT_VARIABLE = '%COMP%';
-export const HOST_ATTR = `_nghost-${COMPONENT_VARIABLE}`;
-export const CONTENT_ATTR = `_ngcontent-${COMPONENT_VARIABLE}`;
+export const HOST_ATTR = `_h-${COMPONENT_VARIABLE}`;
+export const CONTENT_ATTR = `_c-${COMPONENT_VARIABLE}`;
 
 export class StylesCompileDependency {
   constructor(

--- a/packages/core/test/acceptance/bootstrap_spec.ts
+++ b/packages/core/test/acceptance/bootstrap_spec.ts
@@ -71,7 +71,7 @@ describe('bootstrap', () => {
          const TestModule = createComponentAndModule();
 
          const ngModuleRef = await platformBrowserDynamic().bootstrapModule(TestModule);
-         expect(document.body.innerHTML).toContain('<span _ngcontent-');
+         expect(document.body.innerHTML).toContain('<span _c-');
          ngModuleRef.destroy();
        }));
 
@@ -82,7 +82,7 @@ describe('bootstrap', () => {
          const ngModuleRef = await platformBrowserDynamic().bootstrapModule(
              TestModule, {defaultEncapsulation: ViewEncapsulation.None});
          expect(document.body.innerHTML).toContain('<span>');
-         expect(document.body.innerHTML).not.toContain('_ngcontent-');
+         expect(document.body.innerHTML).not.toContain('_c-');
          ngModuleRef.destroy();
        }));
 
@@ -96,7 +96,7 @@ describe('bootstrap', () => {
                                multi: true
                              }]).bootstrapModule(TestModule);
          expect(document.body.innerHTML).toContain('<span>');
-         expect(document.body.innerHTML).not.toContain('_ngcontent-');
+         expect(document.body.innerHTML).not.toContain('_c-');
          ngModuleRef.destroy();
        }));
 
@@ -106,7 +106,7 @@ describe('bootstrap', () => {
 
          const ngModuleRef = await platformBrowserDynamic().bootstrapModule(
              TestModule, {defaultEncapsulation: ViewEncapsulation.None});
-         expect(document.body.innerHTML).toContain('<span _ngcontent-');
+         expect(document.body.innerHTML).toContain('<span _c-');
          ngModuleRef.destroy();
        }));
 
@@ -173,7 +173,7 @@ describe('bootstrap', () => {
                    'Provided value for `defaultEncapsulation` can not be changed once it has been set.');
 
            // The options should not have been changed
-           expect(document.body.innerHTML).not.toContain('_ngcontent-');
+           expect(document.body.innerHTML).not.toContain('_c-');
 
            ngModuleRefB.destroy();
          }));

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -131,16 +131,16 @@ describe('component', () => {
       fixture.detectChanges();
       expect(fixture.nativeElement.innerHTML)
           .toMatch(
-              /<encapsulated _nghost-[a-z\-]+(\d+)="">foo<leaf _ngcontent-[a-z\-]+\1=""><span>bar<\/span><\/leaf><\/encapsulated>/);
+              /<encapsulated _h-[a-z\-]+(\d+)="">foo<leaf _c-[a-z\-]+\1=""><span>bar<\/span><\/leaf><\/encapsulated>/);
     });
 
     it('should encapsulate host', () => {
       const fixture = TestBed.createComponent(EncapsulatedComponent);
       fixture.detectChanges();
       const html = fixture.nativeElement.outerHTML;
-      const match = html.match(/_nghost-([a-z\-]+\d+)/);
+      const match = html.match(/_h-([a-z\-]+\d+)/);
       expect(match).toBeDefined();
-      expect(html).toMatch(new RegExp(`<leaf _ngcontent-${match[1]}=""><span>bar</span></leaf>`));
+      expect(html).toMatch(new RegExp(`<leaf _c-${match[1]}=""><span>bar</span></leaf>`));
     });
 
     it('should encapsulate host and children with different attributes', () => {
@@ -150,7 +150,7 @@ describe('component', () => {
       const fixture = TestBed.createComponent(EncapsulatedComponent);
       fixture.detectChanges();
       const html = fixture.nativeElement.outerHTML;
-      const match = html.match(/_nghost-([a-z\-]+\d+)/g);
+      const match = html.match(/_h-([a-z\-]+\d+)/g);
       expect(match).toBeDefined();
       expect(match.length).toEqual(2);
       expect(html).toMatch(

--- a/packages/core/test/bundling/todo_r2/todo_e2e_spec.ts
+++ b/packages/core/test/bundling/todo_r2/todo_e2e_spec.ts
@@ -27,8 +27,7 @@ describe('functional test for todo', () => {
            const toDoAppComponent = (window as any).toDoAppComponent;
            await whenRendered(toDoAppComponent);
 
-           const styleContent =
-               findStyleTextForSelector('.todo-list\\\[_ngcontent-[a-z]+-\\\w+\\\]');
+           const styleContent = findStyleTextForSelector('.todo-list\\\[_c-[a-z]+-\\\w+\\\]');
            expect(styleContent).toMatch(/font-weight:\s*bold;/);
            expect(styleContent).toMatch(/color:\s*#d9d9d9;/);
          }));

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -1103,7 +1103,7 @@ describe('providers', () => {
          fixture.update();
          expect(fixture.html)
              .toMatch(
-                 /<host-cmp>foo<\/host-cmp><embedded-cmp _nghost-[a-z]+-c(\d+)="">From module injector<\/embedded-cmp>/);
+                 /<host-cmp>foo<\/host-cmp><embedded-cmp _h-[a-z]+-c(\d+)="">From module injector<\/embedded-cmp>/);
        });
 
     it('should cross the root view boundary to the parent of the host, thanks to the default root view injector',

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -23,8 +23,8 @@ const COMPONENT_REGEX = /%COMP%/g;
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
 
 export const COMPONENT_VARIABLE = '%COMP%';
-export const HOST_ATTR = `_nghost-${COMPONENT_VARIABLE}`;
-export const CONTENT_ATTR = `_ngcontent-${COMPONENT_VARIABLE}`;
+export const HOST_ATTR = `_h-${COMPONENT_VARIABLE}`;
+export const CONTENT_ATTR = `_c-${COMPONENT_VARIABLE}`;
 
 export function shimContentAttribute(componentShortId: string): string {
   return CONTENT_ATTR.replace(COMPONENT_REGEX, componentShortId);

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -678,7 +678,7 @@ describe('platform-server integration', () => {
     it('sets a prefix for the _nghost and _ngcontent attributes', async(() => {
          renderModule(ExampleStylesModule, {document: doc}).then(output => {
            expect(output).toMatch(
-               /<html><head><style ng-transition="example-styles">div\[_ngcontent-sc\d+\] {color: blue; } \[_nghost-sc\d+\] { color: red; }<\/style><\/head><body><app _nghost-sc\d+="" ng-version="0.0.0-PLACEHOLDER"><div _ngcontent-sc\d+="">Works!<\/div><\/app><\/body><\/html>/);
+               /<html><head><style ng-transition="example-styles">div\[_c-sc\d+\] {color: blue; } \[_h-sc\d+\] { color: red; }<\/style><\/head><body><app _h-sc\d+="" ng-version="0.0.0-PLACEHOLDER"><div _c-sc\d+="">Works!<\/div><\/app><\/body><\/html>/);
            called = true;
          });
        }));


### PR DESCRIPTION
This replaces all occurrences of _nghost- to _h- and _ngcontent to _c-, including in docs and tests.

Shortening _nghost and _ngcontent will significantly reduce the overhead from adding additional attributes to HTML elements.

This allows for smaller bundles, which can improve download speeds and reduce parsing time.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
