### PR TITLE
Phased review

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1160,6 +1160,8 @@ groups:
   public-api:
     <<: *defaults
     conditions:
+      - *no-groups-above-this-pending
+      - *no-groups-above-this-rejected
       - *can-be-global-approved
       - >
         contains_any_globs(files, [
@@ -1190,6 +1192,8 @@ groups:
   size-tracking:
     <<: *defaults
     conditions:
+      - *no-groups-above-this-pending
+      - *no-groups-above-this-rejected
       - *can-be-global-approved
       - >
         contains_any_globs(files, [
@@ -1214,6 +1218,8 @@ groups:
   circular-dependencies:
     <<: *defaults
     conditions:
+      - *no-groups-above-this-pending
+      - *no-groups-above-this-rejected
       - *can-be-global-approved
       - >
         contains_any_globs(files, [

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -67,6 +67,23 @@ version: 3
 # Meta field that goes unused by PullApprove to allow for defining aliases to be
 # used throughout the config.
 meta:
+  # The following groups have no file based conditions and will be initially `active` on all PRs
+  # - `global-approvers`
+  # - `global-docs-approvers`
+  # - `required-minimum-review`
+  #
+  # By checking the number of active/pending/rejected groups when these are excluded, we can determine
+  # if any other groups are matched.
+  #
+  # Also note that the ordering of groups matters in this file. The only groups visible to the current
+  # one are those that appear above it.
+  no-groups-above-this-pending: &no-groups-above-this-pending
+    len(groups.pending.exclude("required-minimum-review").exclude("global-approvers").exclude("global-docs-approvers")) == 0
+  no-groups-above-this-rejected: &no-groups-above-this-rejected
+    len(groups.rejected.exclude("required-minimum-review").exclude("global-approvers").exclude("global-docs-approvers")) == 0
+  no-groups-above-this-active: &no-groups-above-this-active
+    len(groups.active.exclude("required-minimum-review").exclude("global-approvers").exclude("global-docs-approvers")) == 0
+
   can-be-global-approved: &can-be-global-approved "\"global-approvers\" not in groups.approved"
   can-be-global-docs-approved: &can-be-global-docs-approved "\"global-docs-approvers\" not in groups.approved"
   defaults: &defaults
@@ -1258,14 +1275,7 @@ groups:
     # `global-approvers` can still approve PRs that match this `fallback` rule,
     # but that should be an exception and not an expectation.
     conditions:
-      # The following groups have no file based conditions and will be initially `active` on all PRs
-      # - `global-approvers`
-      # - `global-docs-approvers`
-      # - `required-minimum-review`
-      #
-      # By checking the number of active groups when these are excluded, we can determine
-      # if any other groups are matched.
-      - len(groups.active.exclude("required-minimum-review").exclude("global-approvers").exclude("global-docs-approvers")) == 0
+      - *no-groups-above-this-active
       # When any of the `global-*` groups is approved, they cause other groups to deactivate.
       # In those cases, the condition above would evaluate to `true` while in reality, only a global
       # approval has been provided. To ensure we don't activate the fallback group in such cases,

--- a/dev-infra/pullapprove/logging.ts
+++ b/dev-infra/pullapprove/logging.ts
@@ -9,14 +9,23 @@
 import {info} from '../utils/console';
 import {PullApproveGroupResult} from './group';
 
+type ConditionGrouping = keyof Pick<
+    PullApproveGroupResult, 'matchedConditions'|'unmatchedConditions'|'unverifiableConditions'>;
+
 /** Create logs for each pullapprove group result. */
-export function logGroup(group: PullApproveGroupResult, matched = true, printMessageFn = info) {
-  const conditions = matched ? group.matchedConditions : group.unmatchedConditions;
+export function logGroup(
+    group: PullApproveGroupResult, conditionsToPrint: ConditionGrouping, printMessageFn = info) {
+  const conditions = group[conditionsToPrint];
   printMessageFn.group(`[${group.groupName}]`);
   if (conditions.length) {
-    conditions.forEach(matcher => {
-      const count = matcher.matchedFiles.size;
-      printMessageFn(`${count} ${count === 1 ? 'match' : 'matches'} - ${matcher.expression}`);
+    conditions.forEach(groupCondition => {
+      const count = groupCondition.matchedFiles.size;
+      if (conditionsToPrint === 'unverifiableConditions') {
+        printMessageFn(`${groupCondition.expression}`);
+      } else {
+        printMessageFn(
+            `${count} ${count === 1 ? 'match' : 'matches'} - ${groupCondition.expression}`);
+      }
     });
     printMessageFn.groupEnd();
   }

--- a/dev-infra/pullapprove/verify.ts
+++ b/dev-infra/pullapprove/verify.ts
@@ -84,11 +84,16 @@ export function verify() {
   info.groupEnd();
   const matchedGroups = resultsByGroup.filter(group => !group.unmatchedCount);
   info.group(`Matched conditions by Group (${matchedGroups.length} groups)`);
-  matchedGroups.forEach(group => logGroup(group, true, debug));
+  matchedGroups.forEach(group => logGroup(group, 'matchedConditions', debug));
   info.groupEnd();
   const unmatchedGroups = resultsByGroup.filter(group => group.unmatchedCount);
   info.group(`Unmatched conditions by Group (${unmatchedGroups.length} groups)`);
-  unmatchedGroups.forEach(group => logGroup(group, false));
+  unmatchedGroups.forEach(group => logGroup(group, 'unmatchedConditions'));
+  info.groupEnd();
+  const unverifiableConditionsInGroups =
+      resultsByGroup.filter(group => group.unverifiableConditions.length > 0);
+  info.group(`Unverifiable conditions by Group (${unverifiableConditionsInGroups.length} groups)`);
+  unverifiableConditionsInGroups.forEach(group => logGroup(group, 'unverifiableConditions'));
   info.groupEnd();
 
   // Provide correct exit code based on verification success.


### PR DESCRIPTION
(see individual commits)
Commit 1:
Extract some potentially useful/reusable aliases to `meta`

Commit 2:
The size-tracking, public-api, and circular-dependencies groups can get a lot of
PRs to review. In addition, the members of these groups do not always           
have the necessary context to fully review the PR in question. This             
change ensures that the owners in the groups where the changes are being        
made have approve the changes (ie, the aren't pending or rejected)              
before requesting final sign-off from these three critical groups.