### PR TITLE
fix(elements): detect matchesSelector prototype without IIFE

### DIFF
--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -7,12 +7,6 @@
  */
 import {ComponentFactoryResolver, Injector, Type} from '@angular/core';
 
-const matches = (() => {
-  const elProto = Element.prototype as any;
-  return elProto.matches || elProto.matchesSelector || elProto.mozMatchesSelector ||
-      elProto.msMatchesSelector || elProto.oMatchesSelector || elProto.webkitMatchesSelector;
-})();
-
 /**
  * Provide methods for scheduling the execution of a callback.
  */
@@ -96,11 +90,20 @@ export function kebabToCamelCase(input: string): string {
   return input.replace(/-([a-z\d])/g, (_, char) => char.toUpperCase());
 }
 
+let _matches: (this: any, selector: string) => boolean;
+
 /**
  * Check whether an `Element` matches a CSS selector.
+ * NOTE: this is duplicated from @angular/upgrade, and can
+ * be consolidated in the future
  */
-export function matchesSelector(element: Element, selector: string): boolean {
-  return matches.call(element, selector);
+export function matchesSelector(el: any, selector: string): boolean {
+  if (!_matches) {
+    const elProto = <any>Element.prototype;
+    _matches = elProto.matches || elProto.matchesSelector || elProto.mozMatchesSelector ||
+        elProto.msMatchesSelector || elProto.oMatchesSelector || elProto.webkitMatchesSelector;
+  }
+  return el.nodeType === Node.ELEMENT_NODE ? _matches.call(el, selector) : false;
 }
 
 /**


### PR DESCRIPTION
Although in SSR we patch the global prototypes with DOM globals
like Element and Node, this patch does not occur before the
matches function is called in Angular Elements. This is similar
to the behavior in @angular/upgrade.

Fixes #24551

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 24551


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
