### PR TITLE
Update Numbering in style guide

### DIFF
--- a/aio/content/guide/styleguide.md
+++ b/aio/content/guide/styleguide.md
@@ -2752,11 +2752,11 @@ A typical *lazy loaded folder* contains a *routing component*, its child compone
 
 ## Components
 
-{@a 05-03}
+{@a 05-01}
 
 ### Components as elements
 
-#### Style 05-03
+#### Style 05-01
 
 <div class="s-rule do">
 
@@ -2808,11 +2808,13 @@ There are a few cases where you give a component an attribute, such as when you 
 
 <a href="#toc">Back to top</a>
 
-{@a 05-04}
+{@a 05-02}
 
 ### Extract templates and styles to their own files
 
-#### Style 05-04
+
+
+#### Style 05-02
 
 
 <div class="s-rule do">
@@ -2926,11 +2928,11 @@ in those editors that support it; it won't help with CSS styles.
 
 <a href="#toc">Back to top</a>
 
-{@a 05-12}
+{@a 05-3}
 
 ### Decorate _input_ and _output_ properties
 
-#### Style 05-12
+#### Style 05-3
 
 
 <div class="s-rule do">
@@ -3019,11 +3021,11 @@ Put it on the line above when doing so is clearly more readable.
 <a href="#toc">Back to top</a>
 
 
-{@a 05-13}
+{@a 05-4}
 
 ### Avoid aliasing _inputs_ and _outputs_
 
-#### Style 05-13
+#### Style 05-4
 
 
 <div class="s-rule avoid">
@@ -3096,11 +3098,11 @@ and the directive name doesn't describe the property.
 
 <a href="#toc">Back to top</a>
 
-{@a 05-14}
+{@a 05-5}
 
 ### Member sequence
 
-#### Style 05-14
+#### Style 05-5
 
 
 <div class="s-rule do">
@@ -3153,11 +3155,11 @@ helps instantly identify which members of the component serve which purpose.
 
 <a href="#toc">Back to top</a>
 
-{@a 05-15}
+{@a 05-6}
 
 ### Delegate complex component logic to services
 
-#### Style 05-15
+#### Style 05-6
 
 
 <div class="s-rule do">
@@ -3242,11 +3244,11 @@ helps instantly identify which members of the component serve which purpose.
 
 <a href="#toc">Back to top</a>
 
-{@a 05-16}
+{@a 05-7}
 
 ### Don't prefix _output_ properties
 
-#### Style 05-16
+#### Style 05-7
 
 
 <div class="s-rule do">
@@ -3325,11 +3327,11 @@ helps instantly identify which members of the component serve which purpose.
 
 <a href="#toc">Back to top</a>
 
-{@a 05-17}
+{@a 05-8}
 
 ### Put presentation logic in the component class
 
-#### Style 05-17
+#### Style 05-8
 
 
 <div class="s-rule do">

--- a/aio/content/guide/styleguide.md
+++ b/aio/content/guide/styleguide.md
@@ -2928,11 +2928,11 @@ in those editors that support it; it won't help with CSS styles.
 
 <a href="#toc">Back to top</a>
 
-{@a 05-3}
+{@a 05-03}
 
 ### Decorate _input_ and _output_ properties
 
-#### Style 05-3
+#### Style 05-03
 
 
 <div class="s-rule do">
@@ -3021,11 +3021,11 @@ Put it on the line above when doing so is clearly more readable.
 <a href="#toc">Back to top</a>
 
 
-{@a 05-4}
+{@a 05-04}
 
 ### Avoid aliasing _inputs_ and _outputs_
 
-#### Style 05-4
+#### Style 05-04
 
 
 <div class="s-rule avoid">
@@ -3098,11 +3098,11 @@ and the directive name doesn't describe the property.
 
 <a href="#toc">Back to top</a>
 
-{@a 05-5}
+{@a 05-05}
 
 ### Member sequence
 
-#### Style 05-5
+#### Style 05-05
 
 
 <div class="s-rule do">
@@ -3155,11 +3155,11 @@ helps instantly identify which members of the component serve which purpose.
 
 <a href="#toc">Back to top</a>
 
-{@a 05-6}
+{@a 05-06}
 
 ### Delegate complex component logic to services
 
-#### Style 05-6
+#### Style 05-06
 
 
 <div class="s-rule do">
@@ -3244,11 +3244,11 @@ helps instantly identify which members of the component serve which purpose.
 
 <a href="#toc">Back to top</a>
 
-{@a 05-7}
+{@a 05-07}
 
 ### Don't prefix _output_ properties
 
-#### Style 05-7
+#### Style 05-07
 
 
 <div class="s-rule do">
@@ -3327,11 +3327,11 @@ helps instantly identify which members of the component serve which purpose.
 
 <a href="#toc">Back to top</a>
 
-{@a 05-8}
+{@a 05-08}
 
 ### Put presentation logic in the component class
 
-#### Style 05-8
+#### Style 05-08
 
 
 <div class="s-rule do">


### PR DESCRIPTION
docs(style-guide): Updated some numbering

This proposes to change the 05 section to the numbers 05-1 to 05-08.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The documentation for the angular style Guide section 05, is numbered sequentially but missing numbers. 


Issue Number: N/A


## What is the new behavior?
This proposes that section 05 in the angular style guide be number 01-08


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
