### PR TITLE
fix(router): Set route snapshot fragment default value as null

### DIFF
--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -193,7 +193,7 @@ export declare class NavigationError extends RouterEvent {
 }
 
 export declare interface NavigationExtras {
-    fragment?: string;
+    fragment?: string | null;
     preserveFragment?: boolean;
     /** @deprecated */ preserveQueryParams?: boolean;
     queryParams?: Params | null;
@@ -405,7 +405,7 @@ export declare class RouterLinkActive implements OnChanges, OnDestroy, AfterCont
 }
 
 export declare class RouterLinkWithHref implements OnChanges, OnDestroy {
-    fragment: string;
+    fragment: string | null;
     href: string;
     preserveFragment: boolean;
     /** @deprecated */ set preserveQueryParams(value: boolean);

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -13,7 +13,7 @@ import {forEach, last, shallowEqual} from './utils/collection';
 
 export function createUrlTree(
     route: ActivatedRoute, urlTree: UrlTree, commands: any[], queryParams: Params,
-    fragment: string): UrlTree {
+    fragment: string|null): UrlTree {
   if (commands.length === 0) {
     return tree(urlTree.root, urlTree.root, urlTree, queryParams, fragment);
   }
@@ -39,7 +39,7 @@ function isMatrixParams(command: any): boolean {
 
 function tree(
     oldSegmentGroup: UrlSegmentGroup, newSegmentGroup: UrlSegmentGroup, urlTree: UrlTree,
-    queryParams: Params, fragment: string): UrlTree {
+    queryParams: Params, fragment: string|null): UrlTree {
   let qp: any = {};
   if (queryParams) {
     forEach(queryParams, (value: any, name: any) => {

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -250,7 +250,6 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
    * @see {@link NavigationExtras#fragment NavigationExtras#fragment}
    * @see {@link Router#createUrlTree Router#createUrlTree}
    */
-  // TODO(issue/24571): remove '!'.
   @Input() fragment: string|null = null;
   /**
    * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -251,7 +251,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
    * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   // TODO(issue/24571): remove '!'.
-  @Input() fragment!: string;
+  @Input() fragment: string|null = null;
   /**
    * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the `NavigationExtras`.
    * @see {@link NavigationExtras#queryParamsHandling NavigationExtras#queryParamsHandling}

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -95,7 +95,7 @@ export interface NavigationExtras {
    * this.router.navigate(['/results'], { fragment: 'top' });
    * ```
    */
-  fragment?: string;
+  fragment?: string|null;
 
   /**
    * **DEPRECATED**: Use `queryParamsHandling: "preserve"` instead to preserve

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1817,6 +1817,30 @@ describe('Integration', () => {
          expect(cmp.route.snapshot.data).toEqual({two: 2});
        })));
 
+    it('should have a null fragment', fakeAsync(inject([Router], (router: Router) => {
+         const fixture = createRoot(router, RootCmp);
+
+         router.resetConfig([{
+           path: 'parent',
+           resolve: {two: 'resolveTwo'},
+           children: [
+             {path: 'child1', component: CollectParamsCmp},
+             {path: 'child2', component: CollectParamsCmp}
+           ]
+         }]);
+
+         router.navigateByUrl('/parent/child1');
+         advance(fixture);
+
+         const cmp = fixture.debugElement.children[1].componentInstance;
+         expect(cmp.route.snapshot.fragment).toEqual(null);
+
+         router.navigateByUrl('/parent/child2');
+         advance(fixture);
+
+         expect(cmp.route.snapshot.fragment).toEqual(null);
+       })));
+
     it('should rerun resolvers when the urls segments of a wildcard route change',
        fakeAsync(inject([Router, Location], (router: Router) => {
          const fixture = createRoot(router, RootCmp);


### PR DESCRIPTION
When a route snapshot is initialized for the first time, this value is undefined. However, when the user refreshes the page, this value is changed to null. This commit sets null as the default value of the fragment.

PR Close #29391

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 29391


## What is the new behavior?

This commit sets null as the default value of the fragment.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
