### PR TITLE
fix(compiler): allow banana-in-a-box bindings to end with non-null assertion

### DIFF
--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -379,8 +379,8 @@ class HtmlAstToIvyAst implements html.Visitor {
         const identifier = bindParts[IDENT_KW_IDX];
         const keySpan = createKeySpan(srcSpan, bindParts[KW_ON_IDX], identifier);
         this.bindingParser.parseEvent(
-            identifier, value, srcSpan, attribute.valueSpan || srcSpan, matchableAttributes, events,
-            keySpan);
+            identifier, value, /* isAssignmentEvent */ false, srcSpan,
+            attribute.valueSpan || srcSpan, matchableAttributes, events, keySpan);
         addEvents(events, boundEvents);
       } else if (bindParts[KW_BINDON_IDX]) {
         const identifier = bindParts[IDENT_KW_IDX];
@@ -432,8 +432,8 @@ class HtmlAstToIvyAst implements html.Visitor {
       } else {
         const events: ParsedEvent[] = [];
         this.bindingParser.parseEvent(
-            identifier, value, srcSpan, attribute.valueSpan || srcSpan, matchableAttributes, events,
-            keySpan);
+            identifier, value, /* isAssignmentEvent */ false, srcSpan,
+            attribute.valueSpan || srcSpan, matchableAttributes, events, keySpan);
         addEvents(events, boundEvents);
       }
 
@@ -486,8 +486,8 @@ class HtmlAstToIvyAst implements html.Visitor {
       boundEvents: t.BoundEvent[], keySpan: ParseSourceSpan) {
     const events: ParsedEvent[] = [];
     this.bindingParser.parseEvent(
-        `${name}Change`, `${expression}=$event`, sourceSpan, valueSpan || sourceSpan,
-        targetMatchableAttrs, events, keySpan);
+        `${name}Change`, `${expression} =$event`, /* isAssignmentEvent */ true, sourceSpan,
+        valueSpan || sourceSpan, targetMatchableAttrs, events, keySpan);
     addEvents(events, boundEvents);
   }
 

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -1163,7 +1163,7 @@ function createParser() {
 }
 
 function parseAction(text: string, location: any = null, offset: number = 0): ASTWithSource {
-  return createParser().parseAction(text, location, offset);
+  return createParser().parseAction(text, /* isAssignmentEvent */ false, location, offset);
 }
 
 function parseBinding(text: string, location: any = null, offset: number = 0): ASTWithSource {

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -421,6 +421,22 @@ describe('R3 template transform', () => {
       ]);
     });
 
+    it('should parse bound events and properties via [(...)] with non-null operator', () => {
+      expectFromHtml('<div [(prop)]="v!"></div>').toEqual([
+        ['Element', 'div'],
+        ['BoundAttribute', BindingType.Property, 'prop', 'v!'],
+        ['BoundEvent', 'propChange', null, 'v = $event'],
+      ]);
+    });
+
+    it('should report an error for assignments into non-null asserted expressions', () => {
+      // TODO(joost): this syntax is allowed in TypeScript. Consider changing the grammar to
+      //  allow this syntax, or improve the error message.
+      // See https://github.com/angular/angular/pull/37809
+      expect(() => parse('<div (prop)="v! = $event"></div>'))
+          .toThrowError(/Unexpected token '=' at column 4/);
+    });
+
     it('should report missing property names in bindon- syntax', () => {
       expect(() => parse('<div bindon-></div>'))
           .toThrowError(/Property name is missing in binding/);


### PR DESCRIPTION
For two-way-bindings that use the banana-in-a-box syntax, the compiler
synthesizes an event assignment expression from the primary expression.
It is valid for the primary expression to be terminated by the non-null
operator, however naive string substitution is used for the synthesized
expression, such that the `!` would immediately precede the `=` token,
resulting in the valid `!=` operator token. The expression would still
parse correctly but it doesn't implement the proper semantics, resulting
in incorrect runtime behavior.

Changing the expression substitution to force a space between the
primary expression and the assignment avoids this mistake, but it
uncovers a new issue. The grammar does not allow for the LHS of an
assignment to be the non-null operator, so the synthesized expression
would fail to parse. To alleviate this, the synthesized expression is
parsed with a special parser flag to allow for this syntax.

Fixes #36551

---

Implementation note: it is up for debate whether extending the grammar to accept more expressions as LHS of an assignment would be desirable for regular output bindings. I choose not to change the grammar at this moment, as it seems like a change that needs to be introduced in at least a minor. Additionally, I feel like the whole expression substitution is a bit of a hack in the first place, so an alternative way of handling this case may be desirable in the future. To allow for this cleanup, I feel like it's best to wait for VE removal as the parser infrastructure is currently quite convoluted.