### PR TITLE
fix(elements): elements should run in correct zone (#24181)

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2987,
-        "main-es2015": 450301,
+        "main-es2015": 450596,
         "polyfills-es2015": 52630
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3097,
-        "main-es2015": 429200,
+        "main-es2015": 429885,
         "polyfills-es2015": 52195
       }
     }

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, EventEmitter, Injector, OnChanges, SimpleChange, SimpleChanges, Type} from '@angular/core';
+import {ApplicationRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, EventEmitter, Injector, NgZone, OnChanges, SimpleChange, SimpleChanges, Type} from '@angular/core';
 import {merge, Observable, ReplaySubject} from 'rxjs';
 import {map, switchMap} from 'rxjs/operators';
 
@@ -73,6 +73,13 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
    */
   private readonly unchangedInputs = new Set<string>();
 
+  /** Service for setting zone context. */
+  private readonly ngZone = this.injector.get<NgZone>(NgZone);
+
+  /** The zone the element was created in or `null` if Zone.js is not loaded. */
+  private readonly elementZone =
+      (typeof Zone === 'undefined') ? null : this.ngZone.run(() => Zone.current);
+
   constructor(private componentFactory: ComponentFactory<any>, private injector: Injector) {}
 
   /**
@@ -80,16 +87,19 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
    * destruction.
    */
   connect(element: HTMLElement) {
-    // If the element is marked to be destroyed, cancel the task since the component was reconnected
-    if (this.scheduledDestroyFn !== null) {
-      this.scheduledDestroyFn();
-      this.scheduledDestroyFn = null;
-      return;
-    }
+    this.runInZone(() => {
+      // If the element is marked to be destroyed, cancel the task since the component was
+      // reconnected
+      if (this.scheduledDestroyFn !== null) {
+        this.scheduledDestroyFn();
+        this.scheduledDestroyFn = null;
+        return;
+      }
 
-    if (this.componentRef === null) {
-      this.initializeComponent(element);
-    }
+      if (this.componentRef === null) {
+        this.initializeComponent(element);
+      }
+    });
   }
 
   /**
@@ -97,19 +107,21 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
    * being moved across the DOM.
    */
   disconnect() {
-    // Return if there is no componentRef or the component is already scheduled for destruction
-    if (this.componentRef === null || this.scheduledDestroyFn !== null) {
-      return;
-    }
-
-    // Schedule the component to be destroyed after a small timeout in case it is being
-    // moved elsewhere in the DOM
-    this.scheduledDestroyFn = scheduler.schedule(() => {
-      if (this.componentRef !== null) {
-        this.componentRef.destroy();
-        this.componentRef = null;
+    this.runInZone(() => {
+      // Return if there is no componentRef or the component is already scheduled for destruction
+      if (this.componentRef === null || this.scheduledDestroyFn !== null) {
+        return;
       }
-    }, DESTROY_DELAY);
+
+      // Schedule the component to be destroyed after a small timeout in case it is being
+      // moved elsewhere in the DOM
+      this.scheduledDestroyFn = scheduler.schedule(() => {
+        if (this.componentRef !== null) {
+          this.componentRef.destroy();
+          this.componentRef = null;
+        }
+      }, DESTROY_DELAY);
+    });
   }
 
   /**
@@ -117,11 +129,13 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
    * retrieved from the cached initialization values.
    */
   getInputValue(property: string): any {
-    if (this.componentRef === null) {
-      return this.initialInputValues.get(property);
-    }
+    return this.runInZone(() => {
+      if (this.componentRef === null) {
+        return this.initialInputValues.get(property);
+      }
 
-    return this.componentRef.instance[property];
+      return this.componentRef.instance[property];
+    });
   }
 
   /**
@@ -129,22 +143,24 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
    * cached and set when the component is created.
    */
   setInputValue(property: string, value: any): void {
-    if (this.componentRef === null) {
-      this.initialInputValues.set(property, value);
-      return;
-    }
+    this.runInZone(() => {
+      if (this.componentRef === null) {
+        this.initialInputValues.set(property, value);
+        return;
+      }
 
-    // Ignore the value if it is strictly equal to the current value, except if it is `undefined`
-    // and this is the first change to the value (because an explicit `undefined` _is_ strictly
-    // equal to not having a value set at all, but we still need to record this as a change).
-    if (strictEquals(value, this.getInputValue(property)) &&
-        !((value === undefined) && this.unchangedInputs.has(property))) {
-      return;
-    }
+      // Ignore the value if it is strictly equal to the current value, except if it is `undefined`
+      // and this is the first change to the value (because an explicit `undefined` _is_ strictly
+      // equal to not having a value set at all, but we still need to record this as a change).
+      if (strictEquals(value, this.getInputValue(property)) &&
+          !((value === undefined) && this.unchangedInputs.has(property))) {
+        return;
+      }
 
-    this.recordInputChange(property, value);
-    this.componentRef.instance[property] = value;
-    this.scheduleDetectChanges();
+      this.recordInputChange(property, value);
+      this.componentRef.instance[property] = value;
+      this.scheduleDetectChanges();
+    });
   }
 
   /**
@@ -263,5 +279,10 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
 
     this.callNgOnChanges(this.componentRef);
     this.componentRef.changeDetectorRef.detectChanges();
+  }
+
+  /** Runs in the angular zone, if present. */
+  private runInZone(fn: () => unknown) {
+    return (this.elementZone && Zone.current !== this.elementZone) ? this.ngZone.run(fn) : fn();
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

When an angular element is created outside the angular zone, such as in setTimeout(), automatic change detection no longer works

Issue Number:  [#24181](https://github.com/angular/angular/issues/24181)


## What is the new behavior?
ComponentNgElementStrategy captures the zone it was created in and insures all methods are run in that zone.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No



## Other information
