### PR TITLE
docs: add missing single quote

### DIFF
--- a/aio/content/guide/i18n.md
+++ b/aio/content/guide/i18n.md
@@ -834,7 +834,7 @@ Global variants of the locale data are available in [`@angular/common/locales/gl
 The following example imports the global variants for French (`fr`):
 
 <code-example language="javascript" header="app.module.ts">
-import '@angular/common/locales/global/fr;
+import '@angular/common/locales/global/fr';
 </code-example>
 
 {@a custom-id}


### PR DESCRIPTION
The current code is missing a single quote at the end of the import.
