### PR TITLE
feat(common): add URLSearchParams to request body

### DIFF
--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -69,6 +69,15 @@ function isFormData(value: any): value is FormData {
 }
 
 /**
+ * Safely assert whether the given value is a URLSearchParams instance.
+ *
+ * In some execution environments URLSearchParams is not defined.
+ */
+function isUrlSearchParams(value: any): value is URLSearchParams {
+  return typeof URLSearchParams !== 'undefined' && value instanceof URLSearchParams;
+}
+
+/**
  * An outgoing HTTP request with an optional typed body.
  *
  * `HttpRequest` represents an outgoing request, including URL, method,
@@ -273,7 +282,7 @@ export class HttpRequest<T> {
     // Check whether the body is already in a serialized form. If so,
     // it can just be returned directly.
     if (isArrayBuffer(this.body) || isBlob(this.body) || isFormData(this.body) ||
-        typeof this.body === 'string') {
+        isUrlSearchParams(this.body) || typeof this.body === 'string') {
       return this.body;
     }
     // Check whether the body is an instance of HttpUrlEncodedParams.

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -143,6 +143,10 @@ const TEST_STRING = `I'm a body!`;
         const body = new ArrayBuffer(4);
         expect(baseReq.clone({body}).serializeBody()).toBe(body);
       });
+      it('passes URLSearchParams through', () => {
+        const body = new URLSearchParams("foo=1&bar=2");
+        expect(baseReq.clone({body}).serializeBody()).toBe(body);
+      });
       it('passes strings through', () => {
         const body = 'hello world';
         expect(baseReq.clone({body}).serializeBody()).toBe(body);

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -144,7 +144,7 @@ const TEST_STRING = `I'm a body!`;
         expect(baseReq.clone({body}).serializeBody()).toBe(body);
       });
       it('passes URLSearchParams through', () => {
-        const body = new URLSearchParams("foo=1&bar=2");
+        const body = new URLSearchParams('foo=1&bar=2');
         expect(baseReq.clone({body}).serializeBody()).toBe(body);
       });
       it('passes strings through', () => {


### PR DESCRIPTION
URLSearch params are by default supported in the browser but are not supported by angular/http package added support for URLSearchParams

Fixes #36317

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No support for URL searchParams


Issue Number: 36317


## What is the new behavior?
Support for URL searchParams

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
