### PR TITLE
fix(zone.js): clearTimeout/clearInterval should call on object global

### DIFF
--- a/packages/zone.js/lib/common/timers.ts
+++ b/packages/zone.js/lib/common/timers.ts
@@ -55,7 +55,7 @@ export function patchTimer(window: any, setName: string, cancelName: string, nam
   }
 
   function clearTask(task: Task) {
-    return clearNative!((<TimerOptions>task.data).handleId);
+    return clearNative!.call(window, (<TimerOptions>task.data).handleId);
   }
 
   setNative =

--- a/packages/zone.js/test/common/setTimeout.spec.ts
+++ b/packages/zone.js/test/common/setTimeout.spec.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {patchTimer} from '../../lib/common/timers';
 import {isNode, zoneSymbol} from '../../lib/common/utils';
+
 declare const global: any;
 const wtfMock = global.wtfMock;
 
@@ -54,6 +56,25 @@ describe('setTimeout', function() {
         done();
       }, 1);
     });
+  });
+
+  it('should call native clearTimeout with the correct context', function() {
+    // since clearTimeout has been patched already, we can not test `clearTimeout` directly
+    // we will fake another API patch to test
+    let context: any = null;
+    const fakeGlobal = {
+      setTimeout: function() {
+        return 1;
+      },
+      clearTimeout: function(id: number) {
+        context = this;
+      }
+    };
+    patchTimer(fakeGlobal, 'set', 'clear', 'Timeout')
+    const cancelId = fakeGlobal.setTimeout();
+    const m = fakeGlobal.clearTimeout;
+    m.call({}, cancelId);
+    expect(context).toBe(fakeGlobal);
   });
 
   it('should allow cancelation of fns registered with setTimeout after invocation', function(done) {


### PR DESCRIPTION
Close #37333

`clearTimeout` is patched by `zone.js`, and it finally calls the native version of `clearTimeout`,
the current implemention only call `clearNative(id)`, but it should call on object `global` like
`clearNative.call(global, id)`. Otherwise in some env, it will throw error
`clearTimeout called on an object that does not implement interface Window`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 37333


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
