### PR TITLE
fix(router): properly compare array queryParams for equality

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -39,7 +39,6 @@ function equalSegmentGroups(container: UrlSegmentGroup, containee: UrlSegmentGro
 }
 
 function containsQueryParams(container: Params, containee: Params): boolean {
-  // TODO: This does not handle array params correctly.
   return Object.keys(containee).length <= Object.keys(container).length &&
       Object.keys(containee).every(key => equalArraysOrString(container[key], containee[key]));
 }

--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModuleFactory, ɵisObservable as isObservable, ɵisPromise as isPromise} from '@angular/core';
+import {ɵisObservable as isObservable, ɵisPromise as isPromise} from '@angular/core';
 import {from, Observable, of} from 'rxjs';
 import {concatAll, last as lastValue, map} from 'rxjs/operators';
 
@@ -45,8 +45,10 @@ export function shallowEqual(a: Params, b: Params): boolean {
  */
 export function equalArraysOrString(a: string|string[], b: string|string[]) {
   if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length != b.length) return false;
-    return a.every(aItem => b.indexOf(aItem) > -1);
+    if (a.length !== b.length) return false;
+    const aSorted = [...a].sort();
+    const bSorted = [...b].sort();
+    return aSorted.every((val, index) => bSorted[index] === val);
   } else {
     return a === b;
   }

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -67,6 +67,24 @@ describe('UrlTree', () => {
         expect(containsTree(t1, t2, true)).toBe(false);
       });
 
+      it('should return false when queryParams are not the same', () => {
+        const t1 = serializer.parse('/one/two?test=4&test=4&test=2');
+        const t2 = serializer.parse('/one/two?test=4&test=3&test=2');
+        expect(containsTree(t1, t2, false)).toBe(false);
+      });
+
+      it('should return true when queryParams are the same in different order', () => {
+        const t1 = serializer.parse('/one/two?test=4&test=3&test=2');
+        const t2 = serializer.parse('/one/two?test=2&test=3&test=4');
+        expect(containsTree(t1, t2, false)).toBe(true);
+      });
+
+      it('should return true when queryParams are the same in different order', () => {
+        const t1 = serializer.parse('/one/two?test=4&test=4&test=1');
+        const t2 = serializer.parse('/one/two?test=1&test=4&test=4');
+        expect(containsTree(t1, t2, false)).toBe(true);
+      });
+
       it('should return false when containee is missing queryParams', () => {
         const t1 = serializer.parse('/one/two?page=5');
         const t2 = serializer.parse('/one/two');


### PR DESCRIPTION
array queryParams will be judged as different if the arrays do not contain the same frequency of elements and the same otherwise.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The queryParams observable or queryParamMap observables were not being fired when the params were arrays that hit an edge case in the equality check.

The `equalArraysOrString` function doesn't do an index-by-index comparison. Rather it just makes sure that for each value in the first array, that value exists anywhere in the 2nd array.

So [4, 4, 2] -> [4, 3, 2] does not emit because 4 and 2 exist in the 2nd array. The other way around works as expected [4, 3, 2] -> [4, 4, 2] because 3 does not exist in the 2nd array.

Issue Number:  #37709


## What is the new behavior?
Now the equality check for arrays ensures that both arrays have the same frequency of values in any order.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

