### PR TITLE
fix(zone.js): remove global declaration

### DIFF
--- a/packages/zone.js/lib/zone-global.d.ts
+++ b/packages/zone.js/lib/zone-global.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// CommonJS / Node have global context exposed as "global" variable.
+// This code should run in a Browser, so we don't want to include the whole node.d.ts
+// typings for this compilation unit.
+// We'll just fake the global "global" var for now.
+declare var global: NodeJS.Global;

--- a/packages/zone.js/lib/zone.ts
+++ b/packages/zone.js/lib/zone.ts
@@ -675,12 +675,6 @@ type AmbientZone = Zone;
 /** @internal */
 type AmbientZoneDelegate = ZoneDelegate;
 
-// CommonJS / Node have global context exposed as "global" variable.
-// This code should run in a Browser, so we don't want to include the whole node.d.ts
-// typings for this compilation unit.
-// We'll just fake the global "global" var for now.
-declare var global: NodeJS.Global;
-
 const Zone: ZoneType = (function(global: any) {
   const performance: {mark(name: string): void; measure(name: string, label: string): void;} =
       global['performance'];


### PR DESCRIPTION
Close #37531

Remove `global` declaration in zone.ts to avoid compile error when
upgrade to `@types/node`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 37531


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
