### PR TITLE
fix(dev-infra): fix typo in ng-dev config

### DIFF
--- a/.ng-dev/config.ts
+++ b/.ng-dev/config.ts
@@ -4,7 +4,7 @@ import {MergeConfig} from '../dev-infra/pr/merge/config';
 const commitMessage = {
   'maxLength': 120,
   'minBodyLength': 100,
-  'minBodyLengthExcludes': ['docs'],
+  'minBodyLengthTypeExcludes': ['docs'],
   'types': [
     'build',
     'ci',


### PR DESCRIPTION
The logic to exclude certain types of commits (specifically 'docs' ones) was implemented in https://github.com/angular/angular/commit/c5b125b7db50914840849a8d86cbb3304d2f4e68. The ng-dev config was updated in the followup commit https://github.com/angular/angular/commit/acf3cff9eedbcfbc4476e0597d0a3c7a883bd05f, but there was a typo that prevented the new logic from being activated. This commit updates the name of the config option in the ng-dev config to the right one (minBodyLengthTypeExcludes).


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No