### PR TITLE
fix(zone.js): patch nodejs EventEmtter.prototype.off

### DIFF
--- a/packages/zone.js/lib/node/events.ts
+++ b/packages/zone.js/lib/node/events.ts
@@ -16,6 +16,7 @@ Zone.__load_patch('EventEmitter', (global: any) => {
   const EE_REMOVE_ALL_LISTENER = 'removeAllListeners';
   const EE_LISTENERS = 'listeners';
   const EE_ON = 'on';
+  const EE_OFF = 'off';
 
   const compareTaskCallbackVsDelegate = function(task: any, delegate: any) {
     // same callback, same capture, same event name, just return
@@ -47,6 +48,7 @@ Zone.__load_patch('EventEmitter', (global: any) => {
     });
     if (result && result[0]) {
       obj[EE_ON] = obj[EE_ADD_LISTENER];
+      obj[EE_OFF] = obj[EE_REMOVE_LISTENER];
     }
   }
 

--- a/packages/zone.js/test/node/events.spec.ts
+++ b/packages/zone.js/test/node/events.spec.ts
@@ -66,6 +66,18 @@ describe('nodejs EventEmitter', () => {
       emitter.emit('test2', 'test value');
     });
   });
+  it('should remove listeners by calling off properly', () => {
+    zoneA.run(() => {
+      emitter.on('test', shouldNotRun);
+      emitter.on('test2', shouldNotRun);
+      emitter.off('test', shouldNotRun);
+    });
+    zoneB.run(() => {
+      emitter.off('test2', shouldNotRun);
+      emitter.emit('test', 'test value');
+      emitter.emit('test2', 'test value');
+    });
+  });
   it('remove listener should return event emitter', () => {
     zoneA.run(() => {
       emitter.on('test', shouldNotRun);


### PR DESCRIPTION
Close #35473

zone.js nodejs patch should also patch `EventEmtter.prototype.off`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 35473


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
