### PR TITLE
fix(core): handle spaces after `select` and `plural` ICU keywords

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -3692,7 +3692,7 @@ describe('i18n support in the template compiler', () => {
             $I18N_3$ = i0.ɵɵi18nPostprocess($I18N_3$, { "VAR_PLURAL": "\uFFFD1\uFFFD" });
           `;
 
-         verify(input, output, {verbose: true});
+         verify(input, output);
        });
   });
 

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -3661,6 +3661,39 @@ describe('i18n support in the template compiler', () => {
 
       verify(input, output);
     });
+
+    it('should produce proper messages when `select` or `plural` keywords have spaces after them',
+       () => {
+         const input = `
+            <div i18n>
+              {count, select , 1 {one} other {more than one}}
+              {count, plural , =1 {one} other {more than one}}
+            </div>
+          `;
+
+         const output = String.raw`
+            var $I18N_1$;
+            if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
+                const $MSG_EXTERNAL_199763560911211963$$APP_SPEC_TS_2$ = goog.getMsg("{VAR_SELECT , select , 1 {one} other {more than one}}");
+                $I18N_1$ = $MSG_EXTERNAL_199763560911211963$$APP_SPEC_TS_2$;
+            }
+            else {
+                $I18N_1$ = $localize \`{VAR_SELECT , select , 1 {one} other {more than one}}\`;
+            }
+            $I18N_1$ = i0.ɵɵi18nPostprocess($I18N_1$, { "VAR_SELECT": "\uFFFD0\uFFFD" });
+            var $I18N_3$;
+            if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
+                const $MSG_EXTERNAL_3383986062053865025$$APP_SPEC_TS_4$ = goog.getMsg("{VAR_PLURAL , plural , =1 {one} other {more than one}}");
+                $I18N_3$ = $MSG_EXTERNAL_3383986062053865025$$APP_SPEC_TS_4$;
+            }
+            else {
+                $I18N_3$ = $localize \`{VAR_PLURAL , plural , =1 {one} other {more than one}}\`;
+            }
+            $I18N_3$ = i0.ɵɵi18nPostprocess($I18N_3$, { "VAR_PLURAL": "\uFFFD1\uFFFD" });
+          `;
+
+         verify(input, output, {verbose: true});
+       });
   });
 
   describe('$localize legacy message ids', () => {

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -980,7 +980,6 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
     const i18n = this.i18n!;
     const vars = this.i18nBindProps(icu.vars);
-
     const placeholders = this.i18nBindProps(icu.placeholders);
 
     // output ICU directly and keep ICU reference in context

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -343,15 +343,12 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
   }
 
-  private i18nBindProps(
-      props: {[key: string]: t.Text|t.BoundText},
-      formatKey?: (key: string) => string): {[key: string]: o.Expression} {
+  private i18nBindProps(props: {[key: string]: t.Text|t.BoundText}): {[key: string]: o.Expression} {
     const bound: {[key: string]: o.Expression} = {};
     Object.keys(props).forEach(key => {
       const prop = props[key];
-      const formattedKey = formatKey ? formatKey(key) : key;
       if (prop instanceof t.Text) {
-        bound[formattedKey] = o.literal(prop.value);
+        bound[key] = o.literal(prop.value);
       } else {
         const value = prop.value.visit(this._valueConverter);
         this.allocateBindingSlots(value);
@@ -360,7 +357,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
           const {id, bindings} = this.i18n!;
           const label = assembleI18nBoundString(strings, bindings.size, id);
           this.i18nAppendBindings(expressions);
-          bound[formattedKey] = o.literal(label);
+          bound[key] = o.literal(label);
         }
       }
     });
@@ -982,13 +979,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
 
     const i18n = this.i18n!;
-    // Currently when the `plural` or `select` keywords in an ICU contain trailing spaces (e.g.
-    // `{count, select , ...}`), these spaces are also included into the key names in ICU vars (e.g.
-    // "VAR_SELECT "). These trailing spaces are not desirable, since they will later be converted
-    // into `_` symbols while normalizing placeholder names, which might lead to mismatches at
-    // runtime (i.e. placeholder will not be replaced with the correct value).
-    const keyFormatter = (key: string) => key.trim();
-    const vars = this.i18nBindProps(icu.vars, keyFormatter);
+    const vars = this.i18nBindProps(icu.vars);
 
     const placeholders = this.i18nBindProps(icu.placeholders);
 

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -343,12 +343,15 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
   }
 
-  private i18nBindProps(props: {[key: string]: t.Text|t.BoundText}): {[key: string]: o.Expression} {
+  private i18nBindProps(
+      props: {[key: string]: t.Text|t.BoundText},
+      formatKey?: (key: string) => string): {[key: string]: o.Expression} {
     const bound: {[key: string]: o.Expression} = {};
     Object.keys(props).forEach(key => {
       const prop = props[key];
+      const formattedKey = formatKey ? formatKey(key) : key;
       if (prop instanceof t.Text) {
-        bound[key] = o.literal(prop.value);
+        bound[formattedKey] = o.literal(prop.value);
       } else {
         const value = prop.value.visit(this._valueConverter);
         this.allocateBindingSlots(value);
@@ -357,7 +360,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
           const {id, bindings} = this.i18n!;
           const label = assembleI18nBoundString(strings, bindings.size, id);
           this.i18nAppendBindings(expressions);
-          bound[key] = o.literal(label);
+          bound[formattedKey] = o.literal(label);
         }
       }
     });
@@ -979,7 +982,14 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
 
     const i18n = this.i18n!;
-    const vars = this.i18nBindProps(icu.vars);
+    // Currently when the `plural` or `select` keywords in an ICU contain trailing spaces (e.g.
+    // `{count, select , ...}`), these spaces are also included into the key names in ICU vars (e.g.
+    // "VAR_SELECT "). These trailing spaces are not desirable, since they will later be converted
+    // into `_` symbols while normalizing placeholder names, which might lead to mismatches at
+    // runtime (i.e. placeholder will not be replaced with the correct value).
+    const keyFormatter = (key: string) => key.trim();
+    const vars = this.i18nBindProps(icu.vars, keyFormatter);
+
     const placeholders = this.i18nBindProps(icu.placeholders);
 
     // output ICU directly and keep ICU reference in context

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -627,6 +627,24 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       expect(element.textContent).toContain('ICU start --> Autre <-- ICU end');
     });
 
+    it('when `select` or `plural` keywords have spaces after them', () => {
+      loadTranslations({
+        [computeMsgId('{VAR_SELECT , select , 10 {ten} 20 {twenty} other {other}}')]:
+            '{VAR_SELECT , select , 10 {dix} 20 {vingt} other {autre}}',
+        [computeMsgId('{VAR_PLURAL , plural , =0 {zero} =1 {one} other {other}}')]:
+            '{VAR_PLURAL , plural , =0 {zéro} =1 {une} other {autre}}'
+      });
+      const fixture = initWithTemplate(AppComp, `
+        <div i18n>
+          {count, select , 10 {ten} 20 {twenty} other {other}} -
+          {count, plural , =0 {zero} =1 {one} other {other}}
+        </div>
+      `);
+
+      const element = fixture.nativeElement;
+      expect(element.textContent).toContain('autre - zéro');
+    });
+
     it('with no root node and text and DOM nodes surrounding ICU', () => {
       loadTranslations({
         [computeMsgId('{VAR_SELECT, select, 10 {Ten} 20 {Twenty} other {Other}}')]:


### PR DESCRIPTION
Currently when the `plural` or `select` keywords in an ICU contain trailing spaces (e.g. `{count, select , ...}`), these spaces are also included into the key names in ICU vars (e.g. "VAR_SELECT "). These trailing spaces are not desirable, since they will later be converted into `_` symbols while normalizing placeholder names, thus causing mismatches at runtime (i.e. placeholder will not be replaced with the correct value). This commit updates the code to trim these spaces while generating an object with placeholders, to make sure the runtime logic can replace these placeholders with the right values.

Another approach that I was considering is to trim these spaces at the Lexer level, but that would be a big breaking change affecting a portion of apps due to the fact that i18n message ids would be changed in this case.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No