### PR TITLE
feat(forms): AbstractControl to store raw validators in addition to combined validators function

### DIFF
--- a/goldens/public-api/forms/forms.d.ts
+++ b/goldens/public-api/forms/forms.d.ts
@@ -1,5 +1,6 @@
 export declare abstract class AbstractControl {
-    asyncValidator: AsyncValidatorFn | null;
+    get asyncValidator(): AsyncValidatorFn | null;
+    set asyncValidator(asyncValidatorFn: AsyncValidatorFn | null);
     get dirty(): boolean;
     get disabled(): boolean;
     get enabled(): boolean;
@@ -15,10 +16,11 @@ export declare abstract class AbstractControl {
     get untouched(): boolean;
     get updateOn(): FormHooks;
     get valid(): boolean;
-    validator: ValidatorFn | null;
+    get validator(): ValidatorFn | null;
+    set validator(validatorFn: ValidatorFn | null);
     readonly value: any;
     readonly valueChanges: Observable<any>;
-    constructor(validator: ValidatorFn | null, asyncValidator: AsyncValidatorFn | null);
+    constructor(validators: ValidatorFn | ValidatorFn[] | null, asyncValidators: AsyncValidatorFn | AsyncValidatorFn[] | null);
     clearAsyncValidators(): void;
     clearValidators(): void;
     disable(opts?: {

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -69,17 +69,24 @@ function _find(control: AbstractControl, path: Array<string|number>|string, deli
   return controlToFind;
 }
 
+/**
+ * Gets validators from either an options object or given validators.
+ */
 function pickValidators(validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|
                         null): ValidatorFn|ValidatorFn[]|null {
   return (isOptionsObj(validatorOrOpts) ? validatorOrOpts.validators : validatorOrOpts) || null;
 }
 
-function coerceToValidator(validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|
-                           null): ValidatorFn|null {
-  const validator = pickValidators(validatorOrOpts);
+/**
+ * Creates validator function by combining provided validators.
+ */
+function coerceToValidator(validator: ValidatorFn|ValidatorFn[]|null): ValidatorFn|null {
   return Array.isArray(validator) ? composeValidators(validator) : validator || null;
 }
 
+/**
+ * Gets async validators from either an options object or given validators.
+ */
 function pickAsyncValidators(
     asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null,
     validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null): AsyncValidatorFn|
@@ -87,13 +94,13 @@ function pickAsyncValidators(
   return (isOptionsObj(validatorOrOpts) ? validatorOrOpts.asyncValidators : asyncValidator) || null;
 }
 
-function coerceToAsyncValidator(
-    asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null,
-    validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null): AsyncValidatorFn|
-    null {
-  const origAsyncValidator = pickAsyncValidators(asyncValidator, validatorOrOpts);
-  return Array.isArray(origAsyncValidator) ? composeAsyncValidators(origAsyncValidator) :
-                                             origAsyncValidator || null;
+/**
+ * Creates async validator function by combining provided async validators.
+ */
+function coerceToAsyncValidator(asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|
+                                null): AsyncValidatorFn|null {
+  return Array.isArray(asyncValidator) ? composeAsyncValidators(asyncValidator) :
+                                         asyncValidator || null;
 }
 
 export type FormHooks = 'change'|'blur'|'submit';
@@ -176,7 +183,7 @@ export abstract class AbstractControl {
    *
    * @internal
    */
-  private _coercedValidator: ValidatorFn|null;
+  private _composedValidatorFn: ValidatorFn|null;
 
   /**
    * Contains the result of merging asynchronous validators into a single validator function
@@ -184,7 +191,7 @@ export abstract class AbstractControl {
    *
    * @internal
    */
-  private _coercedAsyncValidator: AsyncValidatorFn|null;
+  private _composedAsyncValidatorFn: AsyncValidatorFn|null;
 
   /**
    * Synchronous validators as they were provided:
@@ -233,28 +240,28 @@ export abstract class AbstractControl {
       asyncValidators: AsyncValidatorFn|AsyncValidatorFn[]|null) {
     this._rawValidators = validators;
     this._rawAsyncValidators = asyncValidators;
-    this._coercedValidator = coerceToValidator(this._rawValidators);
-    this._coercedAsyncValidator = coerceToAsyncValidator(this._rawAsyncValidators);
+    this._composedValidatorFn = coerceToValidator(this._rawValidators);
+    this._composedAsyncValidatorFn = coerceToAsyncValidator(this._rawAsyncValidators);
   }
 
   /**
    * The function that is used to determine the validity of this control synchronously.
    */
   get validator(): ValidatorFn|null {
-    return this._coercedValidator;
+    return this._composedValidatorFn;
   }
   set validator(validatorFn: ValidatorFn|null) {
-    this._rawValidators = this._coercedValidator = validatorFn;
+    this._rawValidators = this._composedValidatorFn = validatorFn;
   }
 
   /**
    * The function that is used to determine the validity of this control asynchronously.
    */
   get asyncValidator(): AsyncValidatorFn|null {
-    return this._coercedAsyncValidator;
+    return this._composedAsyncValidatorFn;
   }
   set asyncValidator(asyncValidatorFn: AsyncValidatorFn|null) {
-    this._rawAsyncValidators = this._coercedAsyncValidator = asyncValidatorFn;
+    this._rawAsyncValidators = this._composedAsyncValidatorFn = asyncValidatorFn;
   }
 
   /**
@@ -426,7 +433,7 @@ export abstract class AbstractControl {
    */
   setValidators(newValidator: ValidatorFn|ValidatorFn[]|null): void {
     this._rawValidators = newValidator;
-    this._coercedValidator = coerceToValidator(newValidator);
+    this._composedValidatorFn = coerceToValidator(newValidator);
   }
 
   /**
@@ -439,7 +446,7 @@ export abstract class AbstractControl {
    */
   setAsyncValidators(newValidator: AsyncValidatorFn|AsyncValidatorFn[]|null): void {
     this._rawAsyncValidators = newValidator;
-    this._coercedAsyncValidator = coerceToAsyncValidator(newValidator);
+    this._composedAsyncValidatorFn = coerceToAsyncValidator(newValidator);
   }
 
   /**

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -263,6 +263,57 @@ describe('FormControl', () => {
       expect(c.valid).toEqual(true);
     });
 
+    it('should override validators using `setValidators` function', () => {
+      const c = new FormControl('');
+      expect(c.valid).toEqual(true);
+
+      c.setValidators([Validators.minLength(5), Validators.required]);
+
+      c.setValue('');
+      expect(c.valid).toEqual(false);
+
+      c.setValue('abc');
+      expect(c.valid).toEqual(false);
+
+      c.setValue('abcde');
+      expect(c.valid).toEqual(true);
+
+      // Define new set of validators, overriding previously applied ones.
+      c.setValidators([Validators.maxLength(2)]);
+
+      c.setValue('abcdef');
+      expect(c.valid).toEqual(false);
+
+      c.setValue('a');
+      expect(c.valid).toEqual(true);
+    });
+
+    it('should override validators by setting `control.validator` field value', () => {
+      const c = new FormControl('');
+      expect(c.valid).toEqual(true);
+
+      // Define new set of validators, overriding previously applied ones.
+      c.validator = Validators.compose([Validators.minLength(5), Validators.required]);
+
+      c.setValue('');
+      expect(c.valid).toEqual(false);
+
+      c.setValue('abc');
+      expect(c.valid).toEqual(false);
+
+      c.setValue('abcde');
+      expect(c.valid).toEqual(true);
+
+      // Define new set of validators, overriding previously applied ones.
+      c.validator = Validators.compose([Validators.maxLength(2)]);
+
+      c.setValue('abcdef');
+      expect(c.valid).toEqual(false);
+
+      c.setValue('a');
+      expect(c.valid).toEqual(true);
+    });
+
     it('should clear validators', () => {
       const c = new FormControl('', Validators.required);
       expect(c.valid).toEqual(false);
@@ -409,6 +460,59 @@ describe('FormControl', () => {
          c.setValue('expected');
          tick();
 
+         expect(c.valid).toEqual(true);
+       }));
+
+    it('should override validators using `setAsyncValidators` function', fakeAsync(() => {
+         const c = new FormControl('');
+         expect(c.valid).toEqual(true);
+
+         c.setAsyncValidators([asyncValidator('expected')]);
+
+         c.setValue('');
+         tick();
+         expect(c.valid).toEqual(false);
+
+         c.setValue('expected');
+         tick();
+         expect(c.valid).toEqual(true);
+
+         // Define new set of validators, overriding previously applied ones.
+         c.setAsyncValidators([asyncValidator('new expected')]);
+
+         c.setValue('expected');
+         tick();
+         expect(c.valid).toEqual(false);
+
+         c.setValue('new expected');
+         tick();
+         expect(c.valid).toEqual(true);
+       }));
+
+    it('should override validators by setting `control.asyncValidator` field value',
+       fakeAsync(() => {
+         const c = new FormControl('');
+         expect(c.valid).toEqual(true);
+
+         c.asyncValidator = Validators.composeAsync([asyncValidator('expected')]);
+
+         c.setValue('');
+         tick();
+         expect(c.valid).toEqual(false);
+
+         c.setValue('expected');
+         tick();
+         expect(c.valid).toEqual(true);
+
+         // Define new set of validators, overriding previously applied ones.
+         c.asyncValidator = Validators.composeAsync([asyncValidator('new expected')]);
+
+         c.setValue('expected');
+         tick();
+         expect(c.valid).toEqual(false);
+
+         c.setValue('new expected');
+         tick();
          expect(c.valid).toEqual(true);
        }));
 


### PR DESCRIPTION
This commit refactors the way we store validators in AbstractControl-based classes: in addition to the combined validators function that we have, we also store the original list of validators. This is needed to have an ability to clean then up later at destroy time (currently it's problematic since they are combined in a single function).

The change preserves backwards compatibility by making sure public APIs stay the same. The only public API update is the change to the `AbstractControl` class constructor to extend the set of possible types that is can accept and process (which should not be breaking).


## PR Type
What kind of change does this PR introduce?

- [x] Feature


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No