### PR TITLE
fix(dev-infra): include `bazel` utility files in npm package

### DIFF
--- a/dev-infra/BUILD.bazel
+++ b/dev-infra/BUILD.bazel
@@ -39,6 +39,7 @@ pkg_npm(
     name = "npm_package",
     srcs = [
         "BUILD.bazel",
+        "//dev-infra/bazel:files",
         "//dev-infra/benchmark:files",
     ],
     substitutions = {

--- a/dev-infra/bazel/BUILD.bazel
+++ b/dev-infra/bazel/BUILD.bazel
@@ -1,1 +1,8 @@
 package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "files",
+    srcs = [
+        "expand_template.bzl",
+    ],
+)


### PR DESCRIPTION
We recently added a new folder for common bazel utilties
to `dev-infra`. The `ng_rollup_bundle` rule relies on an
utility that is provided by this `bazel/` folder.

Unfortunately though it looks like this folder is currently
not included in the NPM package, so that the `ng_rollup_bundle`
rule does not work as expected. This commit fixes that by
including the bazel utilties in the NPM package.