### PR TITLE
test: fix test failure in saucelabs ivy ie10

### DIFF
--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -2304,6 +2304,18 @@ describe('di', () => {
   });
 
   it('should not be able to inject ViewRef', () => {
+    // If the current browser does not support `__proto__` natively, this test will never
+    // result in an error as the `__NG_ELEMENT_ID__` from `ChangeDetectorRef` is directly
+    // assigned to the `ViewRef` instance, due to TypeScript, and `setPrototypeOf` polyfills
+    // not being able to simulate the prototype chain. This means that Angular's DI system
+    // considers `ViewRef` as injectable due to it having a `__NG_ELEMENT_ID__` directly
+    // assigned. We skip this test in such cases. This is currently the case in IE9 and
+    // IE10 as those don't support `__proto__`. Related TypeScript issue:
+    // https://github.com/microsoft/TypeScript/issues/1601#issuecomment-94892833.
+    if (!('__proto__' in {})) {
+      return;
+    }
+
     @Component({template: ''})
     class App {
       constructor(_viewRef: ViewRef) {}


### PR DESCRIPTION
One of the ivy acceptance tests currently fails in IE10. This is because we
recently added a new test that asserts that injecting `ViewRef` results in
a `NullInjectorError`.

Due to limitations in TypeScript and in polyfills for `setPrototypeOf`, the error
cannot be thrown as `ViewRef` is always considered injectable. In reality, `ViewRef`
should not be injectable, as explicitly noted in https://github.com/angular/angular/commit/c00f4ab2ae703e8a3ee4a3850170c9bbf0f9bc42.

There seems no way to simulate the proper prototype chain in such browsers
that do not natively support `__proto__`, so TypeScript and `core-js` polyfills
simply break the prototype chain and assign inherited properties directly
on `ViewRef`. i.e. so that `ViewRef.__NG_ELEMENT_ID__` exists and DI picks it up.

There is a way for TypeScript to theoretically generate proper prototype chain in
ES5 output, but they intend to only bother about the proper prototype chain in ES6
where `setPrototypeOf` etc. are officially standardized. See the response: https://github.com/microsoft/TypeScript/issues/1601#issuecomment-94892833.


I have a feeling  that it's better keeping the `hasOwnProperty` logic (as added with c00f4ab2ae703e8a3ee4a3850170c9bbf0f9bc42),
as IE10 will not fail but rather just be less strict. At the same time though, it could also
be an option to just enforce consistency by reverting your fix. Either way seems not 100%
ideal. I assume it's a conceptual issue with how `__NG_ELEMENT_ID` is handled.