### PR TITLE
fix(common): add body to delete request

### DIFF
--- a/goldens/public-api/common/http/http.d.ts
+++ b/goldens/public-api/common/http/http.d.ts
@@ -6,7 +6,7 @@ export declare abstract class HttpBackend implements HttpHandler {
 
 export declare class HttpClient {
     constructor(handler: HttpHandler);
-    delete(url: string, options: {
+    delete(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -18,7 +18,7 @@ export declare class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
-    delete(url: string, options: {
+    delete(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -30,7 +30,7 @@ export declare class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
-    delete(url: string, options: {
+    delete(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -42,7 +42,7 @@ export declare class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
-    delete(url: string, options: {
+    delete(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -54,7 +54,7 @@ export declare class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
-    delete(url: string, options: {
+    delete(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -66,7 +66,7 @@ export declare class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
-    delete(url: string, options: {
+    delete(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -78,7 +78,7 @@ export declare class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
-    delete(url: string, options: {
+    delete(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -90,7 +90,7 @@ export declare class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Object>>;
-    delete<T>(url: string, options: {
+    delete<T>(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -102,7 +102,7 @@ export declare class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<T>>;
-    delete(url: string, options: {
+    delete(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -114,7 +114,7 @@ export declare class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
-    delete(url: string, options: {
+    delete(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -126,7 +126,7 @@ export declare class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
-    delete(url: string, options: {
+    delete(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -138,7 +138,7 @@ export declare class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
-    delete(url: string, options: {
+    delete(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -150,7 +150,7 @@ export declare class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
-    delete<T>(url: string, options: {
+    delete<T>(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -162,7 +162,7 @@ export declare class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<T>>;
-    delete(url: string, options?: {
+    delete(url: string, body: any | null, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -174,7 +174,7 @@ export declare class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<Object>;
-    delete<T>(url: string, options?: {
+    delete<T>(url: string, body: any | null, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1591,14 +1591,14 @@ export declare class HttpRequest<T> {
     readonly url: string;
     readonly urlWithParams: string;
     readonly withCredentials: boolean;
-    constructor(method: 'DELETE' | 'GET' | 'HEAD' | 'JSONP' | 'OPTIONS', url: string, init?: {
+    constructor(method: 'DELETE' | 'POST' | 'PUT' | 'PATCH', url: string, body: T | null, init?: {
         headers?: HttpHeaders;
         reportProgress?: boolean;
         params?: HttpParams;
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
         withCredentials?: boolean;
     });
-    constructor(method: 'POST' | 'PUT' | 'PATCH', url: string, body: T | null, init?: {
+    constructor(method: 'GET' | 'HEAD' | 'JSONP' | 'OPTIONS', url: string, init?: {
         headers?: HttpHeaders;
         reportProgress?: boolean;
         params?: HttpParams;

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -561,11 +561,12 @@ export class HttpClient {
    *  and returns the response as an `ArrayBuffer`.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return  An `Observable` of the response body as an `ArrayBuffer`.
    */
-  delete(url: string, options: {
+  delete(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
     params?: HttpParams|{[param: string]: string | string[]},
@@ -579,11 +580,12 @@ export class HttpClient {
    * the response as a `Blob`.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of the response body as a `Blob`.
    */
-  delete(url: string, options: {
+  delete(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
     params?: HttpParams|{[param: string]: string | string[]},
@@ -596,11 +598,12 @@ export class HttpClient {
    * a string.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of the response, with the response body of type string.
    */
-  delete(url: string, options: {
+  delete(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
     params?: HttpParams|{[param: string]: string | string[]},
@@ -613,12 +616,13 @@ export class HttpClient {
    *  and returns the full event stream.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of all `HTTPEvents` for the request,
    * with response body as an `ArrayBuffer`.
    */
-  delete(url: string, options: {
+  delete(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -630,12 +634,13 @@ export class HttpClient {
    *  and returns the full event stream.
    *
    * @param url     The endpoint URL.
+   * @param body The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of all the `HTTPEvents` for the request, with the response body as a
    * `Blob`.
    */
-  delete(url: string, options: {
+  delete(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean, responseType: 'blob',
@@ -647,12 +652,13 @@ export class HttpClient {
    * and returns the full event stream.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of all `HTTPEvents` for the request, with the response
    *  body of type string.
    */
-  delete(url: string, options: {
+  delete(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean, responseType: 'text',
@@ -664,12 +670,13 @@ export class HttpClient {
    * and returns the full event stream.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of all `HTTPEvents` for the request, with response body of
    * type `Object`.
    */
-  delete(url: string, options: {
+  delete(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
@@ -682,12 +689,13 @@ export class HttpClient {
    * and returns the full event stream.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of all the `HTTPEvents` for the request, with a response
    * body in the requested type.
    */
-  delete<T>(url: string, options: {
+  delete<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
@@ -700,11 +708,12 @@ export class HttpClient {
    *  the full `HTTPResponse`.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of the full `HTTPResponse`, with the response body as an `ArrayBuffer`.
    */
-  delete(url: string, options: {
+  delete(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -716,11 +725,12 @@ export class HttpClient {
    * `HTTPResponse`.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of the `HTTPResponse`, with the response body of type `Blob`.
    */
-  delete(url: string, options: {
+  delete(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean, responseType: 'blob',
@@ -732,11 +742,12 @@ export class HttpClient {
    *  returns the full `HTTPResponse`.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of the full `HTTPResponse`, with the response body of type string.
    */
-  delete(url: string, options: {
+  delete(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean, responseType: 'text',
@@ -748,12 +759,13 @@ export class HttpClient {
    * the full `HTTPResponse`.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of the `HTTPResponse`, with the response body of type `Object`.
    *
    */
-  delete(url: string, options: {
+  delete(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
@@ -766,11 +778,12 @@ export class HttpClient {
    * and returns the full `HTTPResponse`.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of the `HTTPResponse`, with the response body of the requested type.
    */
-  delete<T>(url: string, options: {
+  delete<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
@@ -783,11 +796,12 @@ export class HttpClient {
    * returns the response body as a JSON object.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of the response, with the response body of type `Object`.
    */
-  delete(url: string, options?: {
+  delete(url: string, body: any|null, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
     params?: HttpParams|{[param: string]: string | string[]},
@@ -801,11 +815,12 @@ export class HttpClient {
    * the response in a given type.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of the `HTTPResponse`, with response body in the requested type.
    */
-  delete<T>(url: string, options?: {
+  delete<T>(url: string, body: any|null, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
     params?: HttpParams|{[param: string]: string | string[]},
@@ -820,10 +835,11 @@ export class HttpClient {
    * details on the return type.
    *
    * @param url     The endpoint URL.
+   * @param body    The content to replace with.
    * @param options The HTTP options to send with the request.
    *
    */
-  delete(url: string, options: {
+  delete(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: HttpObserve,
     params?: HttpParams|{[param: string]: string | string[]},
@@ -831,7 +847,7 @@ export class HttpClient {
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
   } = {}): Observable<any> {
-    return this.request<any>('DELETE', url, options as any);
+    return this.request<any>('DELETE', url, addBody(options, body));
   }
 
 

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -27,7 +27,6 @@ interface HttpRequestInit {
  */
 function mightHaveBody(method: string): boolean {
   switch (method) {
-    case 'DELETE':
     case 'GET':
     case 'HEAD':
     case 'OPTIONS':
@@ -128,14 +127,14 @@ export class HttpRequest<T> {
    */
   readonly urlWithParams: string;
 
-  constructor(method: 'DELETE'|'GET'|'HEAD'|'JSONP'|'OPTIONS', url: string, init?: {
+  constructor(method: 'GET'|'HEAD'|'JSONP'|'OPTIONS', url: string, init?: {
     headers?: HttpHeaders,
     reportProgress?: boolean,
     params?: HttpParams,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
   });
-  constructor(method: 'POST'|'PUT'|'PATCH', url: string, body: T|null, init?: {
+  constructor(method: 'DELETE'|'POST'|'PUT'|'PATCH', url: string, body: T|null, init?: {
     headers?: HttpHeaders,
     reportProgress?: boolean,
     params?: HttpParams,

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -114,6 +114,17 @@ import {toArray} from 'rxjs/operators';
         expect(testReq.request.body).toBe(body);
         testReq.flush('hello world');
       });
+      it('with json data', done => {
+        const body = {data: 'json body'};
+        client.delete('/test', body, {observe: 'response', responseType: 'text'}).subscribe(res => {
+          expect(res.ok).toBeTruthy();
+          expect(res.status).toBe(200);
+          done();
+        });
+        const testReq = backend.expectOne('/test');
+        expect(testReq.request.body).toBe(body);
+        testReq.flush('hello world');
+      });
       it('with a json body of false', done => {
         client.post('/test', false, {observe: 'response', responseType: 'text'}).subscribe(res => {
           expect(res.ok).toBeTruthy();


### PR DESCRIPTION
delete request supports a body but it was left out as many dont support the http body. As it is supported by default so angular should not take any decision weather to add it or not the decision should be given to the developer

Fixes #19438

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Delete request cannot send a body

Issue Number: #19438


## What is the new behavior?
Delete request can send a body

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
