### PR TITLE
build(docs-infra): improve applying post-install patches

### DIFF
--- a/aio/tools/cli-patches/patch.js
+++ b/aio/tools/cli-patches/patch.js
@@ -1,9 +1,14 @@
-const fs = require('fs');
 const sh = require('shelljs');
 
 const PATCH_LOCK = 'node_modules/@angular/cli/.patched';
 
-if (!fs.existsSync(PATCH_LOCK)) {
+sh.set('-e');
+sh.cd(`${__dirname}/../../`);
+
+if (!sh.test('-f', PATCH_LOCK)) {
+  sh.ls('-l', __dirname)
+      .filter(stat => stat.isFile() && /\.patch$/i.test(stat.name))
+      .forEach(stat => sh.exec(`patch -p0 -i "${__dirname}/${stat.name}"`));
+
   sh.touch(PATCH_LOCK);
 }
-


### PR DESCRIPTION
In `aio/`, we have a mechanism to apply patches in a `postinstall` hook. See `aio/tools/cli-patches/README.md` for more info.

Previously, we had to update `aio/tools/cli-patches/patch.js` to list each `.patch` file separately. While working on #37688, I found it helpful for the script to automatically pick up `.patch` files.

This commit updates the script to automatically pick up and apply `.patch` files from the `aio/tools/cli-patches/` directory. If one wants to keep a `.patch` file but not apply it, they can change the file's extension or move it to a sub-directory (without having to update the script).
