### PR TITLE
docs: minor fixes to docs related to updating to v10

### DIFF
--- a/aio/content/guide/migration-solution-style-tsconfig.md
+++ b/aio/content/guide/migration-solution-style-tsconfig.md
@@ -5,6 +5,7 @@
 This migration adds support to existing projects for TypeScript's new ["solution-style" tsconfig feature](https://devblogs.microsoft.com/typescript/announcing-typescript-3-9/#solution-style-tsconfig).
 
 Support is added by making two changes:
+
 1. Renaming the workspace-level `tsconfig.json` to `tsconfig.base.json`.
 All project [TypeScript configuration files](guide/typescript-configuration) will extend from this base which contains the common options used throughout the workspace.
 

--- a/aio/content/guide/updating-to-version-10.md
+++ b/aio/content/guide/updating-to-version-10.md
@@ -30,7 +30,7 @@ If you're curious about the specific migrations being run by the CLI, see the [a
 * The `minLength` and `maxLength` validators only validate values that have a numeric `length` property. See [PR 36157](https://github.com/angular/angular/pull/36157).
 * Templates with unknown property bindings or unknown element names now log errors instead of warnings. See [PR 36399](https://github.com/angular/angular/pull/36399).
 * `UrlMatcher` can now return `null` values. See [PR 36402](https://github.com/angular/angular/pull/36402).
-* Transplanted views now refresh at insertion point only. See PR 35968](https://github.com/angular/angular/pull/35968).
+* Transplanted views now refresh at insertion point only. See [PR 35968](https://github.com/angular/angular/pull/35968).
 * Formatting times with the `b` or `B` format codes now supports time periods that cross midnight. See [PR 36611](https://github.com/angular/angular/pull/36611).
 * Navigation is canceled for routes with at least one empty resolver. See [PR 24621](https://github.com/angular/angular/pull/24621).
 


### PR DESCRIPTION
This commit includes a couple of minor fixes to docs related to updating to v10:
- Fix markdown link in "Updating to Angular version 10" guide.
- Correctly display numbered list in "Solution-style `tsconfig.json` migration" guide.
