### PR TITLE
feat(localize): expose `canParse()` diagnostics

### DIFF
--- a/packages/localize/src/tools/src/translate/translation_files/translation_loader.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_loader.ts
@@ -57,8 +57,9 @@ export class TranslationLoader {
   private loadBundle(filePath: AbsoluteFsPath, providedLocale: string|undefined):
       TranslationBundle {
     const fileContents = this.fs.readFile(filePath);
+    const canParseDiagnostics = new Diagnostics();
     for (const translationParser of this.translationParsers) {
-      const result = translationParser.canParse(filePath, fileContents);
+      const result = translationParser.canParse(filePath, fileContents, canParseDiagnostics);
       if (!result) {
         continue;
       }
@@ -90,8 +91,9 @@ export class TranslationLoader {
 
       return {locale, translations, diagnostics};
     }
-    throw new Error(
-        `There is no "TranslationParser" that can parse this translation file: ${filePath}.`);
+
+    throw new Error(canParseDiagnostics.formatDiagnostics(
+        `There is no "TranslationParser" that can parse this translation file: ${filePath}.`));
   }
 
   /**

--- a/packages/localize/src/tools/src/translate/translation_files/translation_loader.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_loader.ts
@@ -57,11 +57,11 @@ export class TranslationLoader {
   private loadBundle(filePath: AbsoluteFsPath, providedLocale: string|undefined):
       TranslationBundle {
     const fileContents = this.fs.readFile(filePath);
-    const canParseResults = new Map<TranslationParser<any>, ParseAnalysis<any>>();
+    const unusedParsers = new Map<TranslationParser<any>, ParseAnalysis<any>>();
     for (const translationParser of this.translationParsers) {
       const result = translationParser.analyze(filePath, fileContents);
-      canParseResults.set(translationParser, result);
       if (!result.canParse) {
+        unusedParsers.set(translationParser, result);
         continue;
       }
 
@@ -94,7 +94,7 @@ export class TranslationLoader {
     }
 
     const diagnosticsMessages: string[] = [];
-    for (const [parser, result] of canParseResults.entries()) {
+    for (const [parser, result] of unusedParsers.entries()) {
       diagnosticsMessages.push(result.diagnostics.formatDiagnostics(
           `\n${parser.constructor.name} cannot parse translation file.`));
     }

--- a/packages/localize/src/tools/src/translate/translation_files/translation_loader.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_loader.ts
@@ -9,7 +9,7 @@ import {AbsoluteFsPath, FileSystem} from '@angular/compiler-cli/src/ngtsc/file_s
 import {DiagnosticHandlingStrategy, Diagnostics} from '../../diagnostics';
 import {TranslationBundle} from '../translator';
 
-import {TranslationParser} from './translation_parsers/translation_parser';
+import {ParseAnalysis, TranslationParser} from './translation_parsers/translation_parser';
 
 /**
  * Use this class to load a collection of translation files from disk.
@@ -57,15 +57,16 @@ export class TranslationLoader {
   private loadBundle(filePath: AbsoluteFsPath, providedLocale: string|undefined):
       TranslationBundle {
     const fileContents = this.fs.readFile(filePath);
-    const canParseDiagnostics = new Diagnostics();
+    const canParseResults = new Map<TranslationParser<any>, ParseAnalysis<any>>();
     for (const translationParser of this.translationParsers) {
-      const result = translationParser.canParse(filePath, fileContents, canParseDiagnostics);
-      if (!result) {
+      const result = translationParser.analyze(filePath, fileContents);
+      canParseResults.set(translationParser, result);
+      if (!result.canParse) {
         continue;
       }
 
       const {locale: parsedLocale, translations, diagnostics} =
-          translationParser.parse(filePath, fileContents, result);
+          translationParser.parse(filePath, fileContents, result.hint);
       if (diagnostics.hasErrors) {
         throw new Error(diagnostics.formatDiagnostics(
             `The translation file "${filePath}" could not be parsed.`));
@@ -92,13 +93,19 @@ export class TranslationLoader {
       return {locale, translations, diagnostics};
     }
 
-    throw new Error(canParseDiagnostics.formatDiagnostics(
-        `There is no "TranslationParser" that can parse this translation file: ${filePath}.`));
+    const diagnosticsMessages: string[] = [];
+    for (const [parser, result] of canParseResults.entries()) {
+      diagnosticsMessages.push(result.diagnostics.formatDiagnostics(
+          `\n${parser.constructor.name} cannot parse translation file.`));
+    }
+    throw new Error(
+        `There is no "TranslationParser" that can parse this translation file: ${filePath}.` +
+        diagnosticsMessages.join('\n'));
   }
 
   /**
-   * There is more than one `filePath` for this locale, so load each as a bundle and then merge them
-   * all together.
+   * There is more than one `filePath` for this locale, so load each as a bundle and then merge
+   * them all together.
    */
   private mergeBundles(filePaths: AbsoluteFsPath[], providedLocale: string|undefined):
       TranslationBundle {

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/simple_json_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/simple_json_translation_parser.ts
@@ -38,17 +38,30 @@ export class SimpleJsonTranslationParser implements TranslationParser<Object> {
   analyze(filePath: string, contents: string): ParseAnalysis<Object> {
     const diagnostics = new Diagnostics();
     if (extname(filePath) !== '.json') {
+      diagnostics.warn('File does not have .json extension.');
       return {canParse: false, diagnostics};
     }
     try {
       const json = JSON.parse(contents);
-      return {
-        canParse: (typeof json.locale === 'string' && typeof json.translations === 'object'),
-        diagnostics,
-        hint: json
-      };
+      if (json.locale === undefined) {
+        diagnostics.warn('Required "locale" property missing.');
+        return {canParse: false, diagnostics};
+      }
+      if (typeof json.locale !== 'string') {
+        diagnostics.warn('The "locale" property is not a string.');
+        return {canParse: false, diagnostics};
+      }
+      if (json.translations === undefined) {
+        diagnostics.warn('Required "translations" property missing.');
+        return {canParse: false, diagnostics};
+      }
+      if (typeof json.translations !== 'object') {
+        diagnostics.warn('The "translations" is not an object.');
+        return {canParse: false, diagnostics};
+      }
+      return {canParse: true, diagnostics, hint: json};
     } catch (e) {
-      diagnostics.warn('File is not valid JSON');
+      diagnostics.warn('File is not valid JSON.');
       return {canParse: false, diagnostics};
     }
   }

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/translation_parser.ts
@@ -43,7 +43,7 @@ export interface TranslationParser<Hint = true> {
    * @returns A hint, which can be used in doing the actual parsing, if the file can be parsed by
    * this parser; false otherwise.
    */
-  canParse(filePath: string, contents: string): Hint|false;
+  canParse(filePath: string, contents: string, diagnostics?: Diagnostics): Hint|false;
 
   /**
    * Parses the given file, extracting the target locale and translations.

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/translation_parser.ts
@@ -9,6 +9,29 @@ import {ɵMessageId, ɵParsedTranslation} from '@angular/localize/private';
 import {Diagnostics} from '../../../diagnostics';
 
 /**
+ * Indicates that a parser can parse a given file, with a hint that can be used to speed up actual
+ * parsing.
+ */
+export interface CanParseAnalysis<Hint> {
+  canParse: true;
+  diagnostics: Diagnostics;
+  hint: Hint;
+}
+
+/**
+ * Indicates that a parser cannot parse a given file with diagnostics as why this is.
+ * */
+export interface CannotParseAnalysis {
+  canParse: false;
+  diagnostics: Diagnostics;
+}
+
+/**
+ * Information about whether a `TranslationParser` can parse a given file.
+ */
+export type ParseAnalysis<Hint> = CanParseAnalysis<Hint>|CannotParseAnalysis;
+
+/**
  * An object that holds translations that have been parsed from a translation file.
  */
 export interface ParsedTranslationBundle {
@@ -38,12 +61,23 @@ export interface TranslationParser<Hint = true> {
   /**
    * Can this parser parse the given file?
    *
+   * @deprecated Use `analyze()` instead
+   *
    * @param filePath The absolute path to the translation file.
    * @param contents The contents of the translation file.
    * @returns A hint, which can be used in doing the actual parsing, if the file can be parsed by
    * this parser; false otherwise.
    */
-  canParse(filePath: string, contents: string, diagnostics?: Diagnostics): Hint|false;
+  canParse(filePath: string, contents: string): Hint|false;
+
+  /**
+   * Analyze the file to see if this parser can parse the given file.
+   *
+   * @param filePath The absolute path to the translation file.
+   * @param contents The contents of the translation file.
+   * @returns Information indicating whether the file can be parsed by this parser.
+   */
+  analyze(filePath: string, contents: string): ParseAnalysis<Hint>;
 
   /**
    * Parses the given file, extracting the target locale and translations.

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/translation_utils.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/translation_utils.ts
@@ -8,6 +8,7 @@
 import {Element, LexerRange, Node, ParseError, ParseErrorLevel, ParseSourceSpan, XmlParser} from '@angular/compiler';
 import {Diagnostics} from '../../../diagnostics';
 import {TranslationParseError} from './translation_parse_error';
+import {ParseAnalysis} from './translation_parser';
 
 export function getAttrOrThrow(element: Element, attrName: string): string {
   const attrValue = getAttribute(element, attrName);
@@ -80,39 +81,34 @@ export interface XmlTranslationParserHint {
  * document has the expected format.
  */
 export function canParseXml(
-    filePath: string, contents: string, rootNodeName: string, attributes: Record<string, string>,
-    diagnostics?: Diagnostics): XmlTranslationParserHint|false {
+    filePath: string, contents: string, rootNodeName: string,
+    attributes: Record<string, string>): ParseAnalysis<XmlTranslationParserHint> {
+  const diagnostics = new Diagnostics();
   const xmlParser = new XmlParser();
   const xml = xmlParser.parse(contents, filePath);
 
   if (xml.rootNodes.length === 0 ||
       xml.errors.some(error => error.level === ParseErrorLevel.ERROR)) {
-    if (diagnostics !== undefined) {
-      xml.errors.forEach(e => addParseError(diagnostics, e));
-    }
-    return false;
+    xml.errors.forEach(e => addParseError(diagnostics, e));
+    return {canParse: false, diagnostics};
   }
 
   const rootElements = xml.rootNodes.filter(isNamedElement(rootNodeName));
   const rootElement = rootElements[0];
   if (rootElement === undefined) {
-    if (diagnostics !== undefined) {
-      diagnostics.warn(`The XML file does not contain a <${rootNodeName}> root node.`);
-    }
-    return false;
+    diagnostics.warn(`The XML file does not contain a <${rootNodeName}> root node.`);
+    return {canParse: false, diagnostics};
   }
 
   for (const attrKey of Object.keys(attributes)) {
     const attr = rootElement.attrs.find(attr => attr.name === attrKey);
     if (attr === undefined || attr.value !== attributes[attrKey]) {
-      if (diagnostics !== undefined) {
-        addParseDiagnostic(
-            diagnostics, rootElement.sourceSpan,
-            `The <${rootNodeName}> node does not have the required attribute: ${attrKey}="${
-                attributes[attrKey]}".`,
-            ParseErrorLevel.WARNING);
-      }
-      return false;
+      addParseDiagnostic(
+          diagnostics, rootElement.sourceSpan,
+          `The <${rootNodeName}> node does not have the required attribute: ${attrKey}="${
+              attributes[attrKey]}".`,
+          ParseErrorLevel.WARNING);
+      return {canParse: false, diagnostics};
     }
   }
 
@@ -123,7 +119,7 @@ export function canParseXml(
         ParseErrorLevel.WARNING));
   }
 
-  return {element: rootElement, errors: xml.errors};
+  return {canParse: true, diagnostics, hint: {element: rootElement, errors: xml.errors}};
 }
 
 /**

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff1_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff1_translation_parser.ts
@@ -13,7 +13,7 @@ import {BaseVisitor} from '../base_visitor';
 import {MessageSerializer} from '../message_serialization/message_serializer';
 import {TargetMessageRenderer} from '../message_serialization/target_message_renderer';
 
-import {ParsedTranslationBundle, TranslationParser} from './translation_parser';
+import {ParseAnalysis, ParsedTranslationBundle, TranslationParser} from './translation_parser';
 import {addParseDiagnostic, addParseError, canParseXml, getAttribute, isNamedElement, parseInnerRange, XmlTranslationParserHint} from './translation_utils';
 
 /**
@@ -25,9 +25,16 @@ import {addParseDiagnostic, addParseError, canParseXml, getAttribute, isNamedEle
  * @see Xliff1TranslationSerializer
  */
 export class Xliff1TranslationParser implements TranslationParser<XmlTranslationParserHint> {
-  canParse(filePath: string, contents: string, diagnostics?: Diagnostics): XmlTranslationParserHint|
-      false {
-    return canParseXml(filePath, contents, 'xliff', {version: '1.2'}, diagnostics);
+  /**
+   * @deprecated
+   */
+  canParse(filePath: string, contents: string): XmlTranslationParserHint|false {
+    const result = this.analyze(filePath, contents);
+    return result.canParse && result.hint;
+  }
+
+  analyze(filePath: string, contents: string): ParseAnalysis<XmlTranslationParserHint> {
+    return canParseXml(filePath, contents, 'xliff', {version: '1.2'});
   }
 
   parse(filePath: string, contents: string, hint?: XmlTranslationParserHint):

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff1_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff1_translation_parser.ts
@@ -25,8 +25,9 @@ import {addParseDiagnostic, addParseError, canParseXml, getAttribute, isNamedEle
  * @see Xliff1TranslationSerializer
  */
 export class Xliff1TranslationParser implements TranslationParser<XmlTranslationParserHint> {
-  canParse(filePath: string, contents: string): XmlTranslationParserHint|false {
-    return canParseXml(filePath, contents, 'xliff', {version: '1.2'});
+  canParse(filePath: string, contents: string, diagnostics?: Diagnostics): XmlTranslationParserHint|
+      false {
+    return canParseXml(filePath, contents, 'xliff', {version: '1.2'}, diagnostics);
   }
 
   parse(filePath: string, contents: string, hint?: XmlTranslationParserHint):

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff2_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff2_translation_parser.ts
@@ -24,8 +24,9 @@ import {addParseDiagnostic, addParseError, canParseXml, getAttribute, isNamedEle
  * @see Xliff2TranslationSerializer
  */
 export class Xliff2TranslationParser implements TranslationParser<XmlTranslationParserHint> {
-  canParse(filePath: string, contents: string): XmlTranslationParserHint|false {
-    return canParseXml(filePath, contents, 'xliff', {version: '2.0'});
+  canParse(filePath: string, contents: string, diagnostics?: Diagnostics): XmlTranslationParserHint|
+      false {
+    return canParseXml(filePath, contents, 'xliff', {version: '2.0'}, diagnostics);
   }
 
   parse(filePath: string, contents: string, hint?: XmlTranslationParserHint):

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff2_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff2_translation_parser.ts
@@ -13,7 +13,7 @@ import {BaseVisitor} from '../base_visitor';
 import {MessageSerializer} from '../message_serialization/message_serializer';
 import {TargetMessageRenderer} from '../message_serialization/target_message_renderer';
 
-import {ParsedTranslationBundle, TranslationParser} from './translation_parser';
+import {ParseAnalysis, ParsedTranslationBundle, TranslationParser} from './translation_parser';
 import {addParseDiagnostic, addParseError, canParseXml, getAttribute, isNamedElement, parseInnerRange, XmlTranslationParserHint} from './translation_utils';
 
 /**
@@ -24,9 +24,16 @@ import {addParseDiagnostic, addParseError, canParseXml, getAttribute, isNamedEle
  * @see Xliff2TranslationSerializer
  */
 export class Xliff2TranslationParser implements TranslationParser<XmlTranslationParserHint> {
-  canParse(filePath: string, contents: string, diagnostics?: Diagnostics): XmlTranslationParserHint|
-      false {
-    return canParseXml(filePath, contents, 'xliff', {version: '2.0'}, diagnostics);
+  /**
+   * @deprecated
+   */
+  canParse(filePath: string, contents: string): XmlTranslationParserHint|false {
+    const result = this.analyze(filePath, contents);
+    return result.canParse && result.hint;
+  }
+
+  analyze(filePath: string, contents: string): ParseAnalysis<XmlTranslationParserHint> {
+    return canParseXml(filePath, contents, 'xliff', {version: '2.0'});
   }
 
   parse(filePath: string, contents: string, hint?: XmlTranslationParserHint):

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser.ts
@@ -14,7 +14,7 @@ import {BaseVisitor} from '../base_visitor';
 import {MessageSerializer} from '../message_serialization/message_serializer';
 import {TargetMessageRenderer} from '../message_serialization/target_message_renderer';
 
-import {ParsedTranslationBundle, TranslationParser} from './translation_parser';
+import {ParseAnalysis, ParsedTranslationBundle, TranslationParser} from './translation_parser';
 import {addParseDiagnostic, addParseError, canParseXml, getAttribute, parseInnerRange, XmlTranslationParserHint} from './translation_utils';
 
 
@@ -26,13 +26,22 @@ import {addParseDiagnostic, addParseError, canParseXml, getAttribute, parseInner
  * @see XmbTranslationSerializer
  */
 export class XtbTranslationParser implements TranslationParser<XmlTranslationParserHint> {
-  canParse(filePath: string, contents: string, diagnostics?: Diagnostics): XmlTranslationParserHint|
-      false {
+  /**
+   * @deprecated
+   */
+  canParse(filePath: string, contents: string): XmlTranslationParserHint|false {
+    const result = this.analyze(filePath, contents);
+    return result.canParse && result.hint;
+  }
+
+  analyze(filePath: string, contents: string): ParseAnalysis<XmlTranslationParserHint> {
     const extension = extname(filePath);
     if (extension !== '.xtb' && extension !== '.xmb') {
-      return false;
+      const diagnostics = new Diagnostics();
+      diagnostics.warn('Must have xtb or xmb extension.');
+      return {canParse: false, diagnostics};
     }
-    return canParseXml(filePath, contents, 'translationbundle', {}, diagnostics);
+    return canParseXml(filePath, contents, 'translationbundle', {});
   }
 
   parse(filePath: string, contents: string, hint?: XmlTranslationParserHint):

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser.ts
@@ -26,12 +26,13 @@ import {addParseDiagnostic, addParseError, canParseXml, getAttribute, parseInner
  * @see XmbTranslationSerializer
  */
 export class XtbTranslationParser implements TranslationParser<XmlTranslationParserHint> {
-  canParse(filePath: string, contents: string): XmlTranslationParserHint|false {
+  canParse(filePath: string, contents: string, diagnostics?: Diagnostics): XmlTranslationParserHint|
+      false {
     const extension = extname(filePath);
     if (extension !== '.xtb' && extension !== '.xmb') {
       return false;
     }
-    return canParseXml(filePath, contents, 'translationbundle', {});
+    return canParseXml(filePath, contents, 'translationbundle', {}, diagnostics);
   }
 
   parse(filePath: string, contents: string, hint?: XmlTranslationParserHint):
@@ -81,7 +82,7 @@ class XtbVisitor extends BaseVisitor {
         if (id === undefined) {
           addParseDiagnostic(
               bundle.diagnostics, element.sourceSpan,
-              `Missing required "id" attribute on <trans-unit> element.`, ParseErrorLevel.ERROR);
+              `Missing required "id" attribute on <translation> element.`, ParseErrorLevel.ERROR);
           return;
         }
 

--- a/packages/localize/src/tools/test/translate/translation_files/translation_loader_spec.ts
+++ b/packages/localize/src/tools/test/translate/translation_files/translation_loader_spec.ts
@@ -205,7 +205,7 @@ runInEachFileSystem(() => {
         const loader = new TranslationLoader(fs, [parser], 'error', diagnostics);
         expect(() => loader.loadBundles([[enTranslationPath], [frTranslationPath]], []))
             .toThrowError(`There is no "TranslationParser" that can parse this translation file: ${
-                enTranslationPath}.`);
+                enTranslationPath}.\nWARNINGS:\n - MockTranslationParser parser cannot parse the file`);
       });
     });
   });
@@ -216,7 +216,10 @@ runInEachFileSystem(() => {
         private _canParse: (filePath: string) => boolean, private _locale?: string,
         private _translations: Record<string, ɵParsedTranslation> = {}) {}
 
-    canParse(filePath: string, fileContents: string) {
+    canParse(filePath: string, fileContents: string, diagnostics?: Diagnostics) {
+      if (diagnostics !== undefined) {
+        diagnostics.warn(this.constructor.name + ' parser cannot parse the file');
+      }
       this.log.push(`canParse(${filePath}, ${fileContents})`);
       return this._canParse(filePath);
     }

--- a/packages/localize/src/tools/test/translate/translation_files/translation_parsers/simple_json_spec.ts
+++ b/packages/localize/src/tools/test/translate/translation_files/translation_parsers/simple_json_spec.ts
@@ -23,6 +23,29 @@ describe('SimpleJsonTranslationParser', () => {
        });
   });
 
+  describe('analyze()', () => {
+    it('should return a success object if the file extension  is `.json` and contains top level `locale` and `translations` properties',
+       () => {
+         const parser = new SimpleJsonTranslationParser();
+         expect(parser.analyze('/some/file.json', '{ "locale" : "fr", "translations" : {}}'))
+             .toEqual(jasmine.objectContaining({canParse: true, hint: jasmine.any(Object)}));
+       });
+
+    it('should return a failure object if the file is not a valid format', () => {
+      const parser = new SimpleJsonTranslationParser();
+      expect(parser.analyze('/some/file.xlf', '')).toEqual(jasmine.objectContaining({
+        canParse: false
+      }));
+      expect(parser.analyze('/some/file.json', '{}')).toEqual(jasmine.objectContaining({
+        canParse: false
+      }));
+      expect(parser.analyze('/some/file.json', '{ "translations" : {} }'))
+          .toEqual(jasmine.objectContaining({canParse: false}));
+      expect(parser.analyze('/some/file.json', '{ "locale" : "fr" }'))
+          .toEqual(jasmine.objectContaining({canParse: false}));
+    });
+  });
+
   for (const withHint of [true, false]) {
     describe(`parse() [${withHint ? 'with' : 'without'} hint]`, () => {
       const doParse: (fileName: string, contents: string) => ParsedTranslationBundle =

--- a/packages/localize/src/tools/test/translate/translation_files/translation_parsers/xliff1_translation_parser_spec.ts
+++ b/packages/localize/src/tools/test/translate/translation_files/translation_parsers/xliff1_translation_parser_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ɵcomputeMsgId, ɵmakeParsedTranslation} from '@angular/localize';
+import {Diagnostics} from '../../../../src/diagnostics';
 import {ParsedTranslationBundle} from '../../../../src/translate/translation_files/translation_parsers/translation_parser';
 import {Xliff1TranslationParser} from '../../../../src/translate/translation_files/translation_parsers/xliff1_translation_parser';
 
@@ -29,6 +30,33 @@ describe('Xliff1TranslationParser', () => {
          expect(parser.canParse('/some/file.xlf', '')).toBe(false);
          expect(parser.canParse('/some/file.json', '')).toBe(false);
        });
+
+    it('should fill a diagnostics object, if provided, when the file is not a valid format', () => {
+      let diagnostics: Diagnostics;
+      const parser = new Xliff1TranslationParser();
+
+      diagnostics = new Diagnostics();
+      parser.canParse('/some/file.xlf', '<moo>', diagnostics);
+      expect(diagnostics.messages).toEqual([
+        {type: 'warning', message: 'The XML file does not contain a <xliff> root node.'}
+      ]);
+
+      diagnostics = new Diagnostics();
+      parser.canParse('/some/file.xlf', '<xliff version="2.0">', diagnostics);
+      expect(diagnostics.messages).toEqual([{
+        type: 'warning',
+        message:
+            'The <xliff> node does not have the required attribute: version="1.2". ("[WARNING ->]<xliff version="2.0">"): /some/file.xlf@0:0'
+      }]);
+
+      diagnostics = new Diagnostics();
+      parser.canParse('/some/file.xlf', '<xliff version="1.2"></file>', diagnostics);
+      expect(diagnostics.messages).toEqual([{
+        type: 'error',
+        message:
+            'Unexpected closing tag "file". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags ("<xliff version="1.2">[ERROR ->]</file>"): /some/file.xlf@0:21'
+      }]);
+    });
   });
 
   for (const withHint of [true, false]) {

--- a/packages/localize/src/tools/test/translate/translation_files/translation_parsers/xliff2_translation_parser_spec.ts
+++ b/packages/localize/src/tools/test/translate/translation_files/translation_parsers/xliff2_translation_parser_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ɵcomputeMsgId, ɵmakeParsedTranslation} from '@angular/localize';
+import {Diagnostics} from '../../../../src/diagnostics';
 import {ParsedTranslationBundle} from '../../../../src/translate/translation_files/translation_parsers/translation_parser';
 import {Xliff2TranslationParser} from '../../../../src/translate/translation_files/translation_parsers/xliff2_translation_parser';
 
@@ -30,6 +31,33 @@ describe(
              expect(parser.canParse('/some/file.xlf', '')).toBe(false);
              expect(parser.canParse('/some/file.json', '')).toBe(false);
            });
+
+        it('should fill a diagnostics object, if provided, when the file is not a valid format', () => {
+          let diagnostics: Diagnostics;
+          const parser = new Xliff2TranslationParser();
+
+          diagnostics = new Diagnostics();
+          parser.canParse('/some/file.xlf', '<moo>', diagnostics);
+          expect(diagnostics.messages).toEqual([
+            {type: 'warning', message: 'The XML file does not contain a <xliff> root node.'}
+          ]);
+
+          diagnostics = new Diagnostics();
+          parser.canParse('/some/file.xlf', '<xliff version="1.2">', diagnostics);
+          expect(diagnostics.messages).toEqual([{
+            type: 'warning',
+            message:
+                'The <xliff> node does not have the required attribute: version="2.0". ("[WARNING ->]<xliff version="1.2">"): /some/file.xlf@0:0'
+          }]);
+
+          diagnostics = new Diagnostics();
+          parser.canParse('/some/file.xlf', '<xliff version="2.0"></file>', diagnostics);
+          expect(diagnostics.messages).toEqual([{
+            type: 'error',
+            message:
+                'Unexpected closing tag "file". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags ("<xliff version="2.0">[ERROR ->]</file>"): /some/file.xlf@0:21'
+          }]);
+        });
       });
 
       for (const withHint of [true, false]) {

--- a/packages/localize/src/tools/test/translate/translation_files/translation_parsers/xliff2_translation_parser_spec.ts
+++ b/packages/localize/src/tools/test/translate/translation_files/translation_parsers/xliff2_translation_parser_spec.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ɵcomputeMsgId, ɵmakeParsedTranslation} from '@angular/localize';
-import {Diagnostics} from '../../../../src/diagnostics';
-import {ParsedTranslationBundle} from '../../../../src/translate/translation_files/translation_parsers/translation_parser';
+import {ParseAnalysis, ParsedTranslationBundle} from '../../../../src/translate/translation_files/translation_parsers/translation_parser';
 import {Xliff2TranslationParser} from '../../../../src/translate/translation_files/translation_parsers/xliff2_translation_parser';
 
 describe(
@@ -31,28 +30,59 @@ describe(
              expect(parser.canParse('/some/file.xlf', '')).toBe(false);
              expect(parser.canParse('/some/file.json', '')).toBe(false);
            });
+      });
 
-        it('should fill a diagnostics object, if provided, when the file is not a valid format', () => {
-          let diagnostics: Diagnostics;
+      describe('analyze', () => {
+        it('should return a success object if the file contains an <xliff> element with version="2.0" attribute',
+           () => {
+             const parser = new Xliff2TranslationParser();
+             expect(parser.analyze(
+                        '/some/file.xlf',
+                        '<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0">'))
+                 .toEqual(jasmine.objectContaining({canParse: true, hint: jasmine.any(Object)}));
+             expect(parser.analyze(
+                        '/some/file.json',
+                        '<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0">'))
+                 .toEqual(jasmine.objectContaining({canParse: true, hint: jasmine.any(Object)}));
+             expect(parser.analyze('/some/file.xliff', '<xliff version="2.0">'))
+                 .toEqual(jasmine.objectContaining({canParse: true, hint: jasmine.any(Object)}));
+             expect(parser.analyze('/some/file.json', '<xliff version="2.0">'))
+                 .toEqual(jasmine.objectContaining({canParse: true, hint: jasmine.any(Object)}));
+           });
+
+        it('should return a failure object if the file cannot be parsed as XLIFF 2.0', () => {
+          const parser = new Xliff2TranslationParser();
+          expect(parser.analyze('/some/file.xlf', '<xliff>')).toEqual(jasmine.objectContaining({
+            canParse: false
+          }));
+          expect(parser.analyze('/some/file.xlf', '<xliff version="1.2">'))
+              .toEqual(jasmine.objectContaining({canParse: false}));
+          expect(parser.analyze('/some/file.xlf', '')).toEqual(jasmine.objectContaining({
+            canParse: false
+          }));
+          expect(parser.analyze('/some/file.json', '')).toEqual(jasmine.objectContaining({
+            canParse: false
+          }));
+        });
+
+        it('should return a diagnostics object when the file is not a valid format', () => {
+          let result: ParseAnalysis<any>;
           const parser = new Xliff2TranslationParser();
 
-          diagnostics = new Diagnostics();
-          parser.canParse('/some/file.xlf', '<moo>', diagnostics);
-          expect(diagnostics.messages).toEqual([
+          result = parser.analyze('/some/file.xlf', '<moo>');
+          expect(result.diagnostics.messages).toEqual([
             {type: 'warning', message: 'The XML file does not contain a <xliff> root node.'}
           ]);
 
-          diagnostics = new Diagnostics();
-          parser.canParse('/some/file.xlf', '<xliff version="1.2">', diagnostics);
-          expect(diagnostics.messages).toEqual([{
+          result = parser.analyze('/some/file.xlf', '<xliff version="1.2">');
+          expect(result.diagnostics.messages).toEqual([{
             type: 'warning',
             message:
                 'The <xliff> node does not have the required attribute: version="2.0". ("[WARNING ->]<xliff version="1.2">"): /some/file.xlf@0:0'
           }]);
 
-          diagnostics = new Diagnostics();
-          parser.canParse('/some/file.xlf', '<xliff version="2.0"></file>', diagnostics);
-          expect(diagnostics.messages).toEqual([{
+          result = parser.analyze('/some/file.xlf', '<xliff version="2.0"></file>');
+          expect(result.diagnostics.messages).toEqual([{
             type: 'error',
             message:
                 'Unexpected closing tag "file". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags ("<xliff version="2.0">[ERROR ->]</file>"): /some/file.xlf@0:21'


### PR DESCRIPTION
When loading a translation file we ask each `TranslationParser`
whether it can parse the file. Occasionally, this check can find
errors in the file that would be useful to the developer. For example
if the file has invalid XML.

This commit allows the caller to pass a diagnostics object to the
`canParse()` call which will be filled with any messages that can
be used to diagnose problems with the format of the file.

Closes #37901

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
