### PR TITLE
fix(compiler-cli): avoid creating value expressions for symbols from type-only imports

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 import {absoluteFromSourceFile} from '../../../src/ngtsc/file_system';
 
 import {Logger} from '../../../src/ngtsc/logging';
-import {ClassDeclaration, ClassMember, ClassMemberKind, CtorParameter, Declaration, Decorator, EnumMember, isDecoratorIdentifier, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, reflectObjectLiteral, SpecialDeclarationKind, TypeScriptReflectionHost, TypeValueReference} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, ClassMember, ClassMemberKind, CtorParameter, Declaration, Decorator, EnumMember, isDecoratorIdentifier, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, reflectObjectLiteral, SpecialDeclarationKind, TypeScriptReflectionHost, TypeValueReference, TypeValueReferenceKind, ValueUnavailableKind} from '../../../src/ngtsc/reflection';
 import {isWithinPackage} from '../analysis/util';
 import {BundleProgram} from '../packages/bundle_program';
 import {findAll, getNameText, hasNameIdentifier, isDefined, stripDollarSuffix} from '../utils';
@@ -1594,7 +1594,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
           {decorators: null, typeExpression: null};
       const nameNode = node.name;
 
-      let typeValueReference: TypeValueReference|null = null;
+      let typeValueReference: TypeValueReference;
       if (typeExpression !== null) {
         // `typeExpression` is an expression in a "type" context. Resolve it to a declared value.
         // Either it's a reference to an imported type, or a type declared locally. Distinguish the
@@ -1603,7 +1603,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
         if (decl !== null && decl.node !== null && decl.viaModule !== null &&
             isNamedDeclaration(decl.node)) {
           typeValueReference = {
-            local: false,
+            kind: TypeValueReferenceKind.IMPORTED,
             valueDeclaration: decl.node,
             moduleName: decl.viaModule,
             importedName: decl.node.name.text,
@@ -1611,11 +1611,16 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
           };
         } else {
           typeValueReference = {
-            local: true,
+            kind: TypeValueReferenceKind.LOCAL,
             expression: typeExpression,
             defaultImportStatement: null,
           };
         }
+      } else {
+        typeValueReference = {
+          kind: TypeValueReferenceKind.UNAVAILABLE,
+          reason: {kind: ValueUnavailableKind.MISSING_TYPE},
+        };
       }
 
       return {

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
-import {ClassMemberKind, ConcreteDeclaration, CtorParameter, DownleveledEnum, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, ConcreteDeclaration, CtorParameter, DownleveledEnum, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost, TypeValueReferenceKind} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {CommonJsReflectionHost} from '../../src/host/commonjs_host';
@@ -1599,7 +1599,7 @@ exports.MissingClass2 = MissingClass2;
               isNamedVariableDeclaration);
           const ctrDecorators = host.getConstructorParameters(classNode)!;
           const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference! as {
-                                                 local: true,
+                                                 kind: TypeValueReferenceKind.LOCAL,
                                                  expression: ts.Identifier,
                                                  defaultImportStatement: null,
                                                }).expression;

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_import_helper_spec.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
-import {ClassMemberKind, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, isNamedVariableDeclaration, TypeValueReferenceKind} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles, loadTsLib} from '../../../test/helpers';
 import {Esm2015ReflectionHost} from '../../src/host/esm2015_host';
@@ -484,7 +484,7 @@ runInEachFileSystem(() => {
                 isNamedVariableDeclaration);
             const ctrDecorators = host.getConstructorParameters(classNode)!;
             const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference! as {
-                                                   local: true,
+                                                   kind: TypeValueReferenceKind.LOCAL,
                                                    expression: ts.Identifier,
                                                    defaultImportStatement: null,
                                                  }).expression;

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_import_helper_spec.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
-import {ClassMemberKind, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, isNamedFunctionDeclaration, isNamedVariableDeclaration, TypeValueReferenceKind} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles, loadTsLib} from '../../../test/helpers';
 import {getIifeBody} from '../../src/host/esm2015_host';
@@ -544,7 +544,7 @@ export { AliasedDirective$1 };
                 isNamedVariableDeclaration);
             const ctrDecorators = host.getConstructorParameters(classNode)!;
             const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference! as {
-                                                   local: true,
+                                                   kind: TypeValueReferenceKind.LOCAL,
                                                    expression: ts.Identifier,
                                                    defaultImportStatement: null,
                                                  }).expression;

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
-import {ClassMemberKind, ConcreteDeclaration, CtorParameter, Decorator, DownleveledEnum, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, ConcreteDeclaration, CtorParameter, Decorator, DownleveledEnum, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost, TypeValueReferenceKind} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {DelegatingReflectionHost} from '../../src/host/delegating_host';
@@ -1670,7 +1670,7 @@ runInEachFileSystem(() => {
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const ctrDecorators = host.getConstructorParameters(classNode)!;
         const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference! as {
-                                               local: true,
+                                               kind: TypeValueReferenceKind.LOCAL,
                                                expression: ts.Identifier,
                                                defaultImportStatement: null,
                                              }).expression;

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
-import {ClassMemberKind, ConcreteDeclaration, CtorParameter, DownleveledEnum, Import, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, ConcreteDeclaration, CtorParameter, DownleveledEnum, Import, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost, TypeValueReferenceKind} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {DelegatingReflectionHost} from '../../src/host/delegating_host';
@@ -1709,7 +1709,7 @@ runInEachFileSystem(() => {
             bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
         const ctrDecorators = host.getConstructorParameters(classNode)!;
         const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference! as {
-                                               local: true,
+                                               kind: TypeValueReferenceKind.LOCAL,
                                                expression: ts.Identifier,
                                                defaultImportStatement: null,
                                              }).expression;

--- a/packages/compiler-cli/ngcc/test/host/util.ts
+++ b/packages/compiler-cli/ngcc/test/host/util.ts
@@ -1,4 +1,3 @@
-
 /**
  * @license
  * Copyright Google LLC All Rights Reserved.
@@ -7,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
-import {CtorParameter} from '../../../src/ngtsc/reflection';
+import {CtorParameter, TypeValueReferenceKind} from '../../../src/ngtsc/reflection';
 
 /**
  * Check that a given list of `CtorParameter`s has `typeValueReference`s of specific `ts.Identifier`
@@ -18,19 +17,21 @@ export function expectTypeValueReferencesForParameters(
   parameters!.forEach((param, idx) => {
     const expected = expectedParams[idx];
     if (expected !== null) {
-      if (param.typeValueReference === null) {
+      if (param.typeValueReference.kind === TypeValueReferenceKind.UNAVAILABLE) {
         fail(`Incorrect typeValueReference generated, expected ${expected}`);
-      } else if (param.typeValueReference.local && fromModule !== null) {
+      } else if (
+          param.typeValueReference.kind === TypeValueReferenceKind.LOCAL && fromModule !== null) {
         fail(`Incorrect typeValueReference generated, expected non-local`);
-      } else if (!param.typeValueReference.local && fromModule === null) {
+      } else if (
+          param.typeValueReference.kind !== TypeValueReferenceKind.LOCAL && fromModule === null) {
         fail(`Incorrect typeValueReference generated, expected local`);
-      } else if (param.typeValueReference.local) {
+      } else if (param.typeValueReference.kind === TypeValueReferenceKind.LOCAL) {
         if (!ts.isIdentifier(param.typeValueReference.expression)) {
-          fail(`Incorrect typeValueReference generated, expected identifer`);
+          fail(`Incorrect typeValueReference generated, expected identifier`);
         } else {
           expect(param.typeValueReference.expression.text).toEqual(expected);
         }
-      } else if (param.typeValueReference !== null) {
+      } else if (param.typeValueReference.kind === TypeValueReferenceKind.IMPORTED) {
         expect(param.typeValueReference.moduleName).toBe(fromModule!);
         expect(param.typeValueReference.importedName).toBe(expected);
       }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/metadata.ts
@@ -10,7 +10,7 @@ import {Expression, ExternalExpr, FunctionExpr, Identifiers, InvokeFunctionExpr,
 import * as ts from 'typescript';
 
 import {DefaultImportRecorder} from '../../imports';
-import {CtorParameter, Decorator, ReflectionHost} from '../../reflection';
+import {CtorParameter, Decorator, ReflectionHost, TypeValueReferenceKind} from '../../reflection';
 
 import {valueReferenceToExpression, wrapFunctionExpressionsInParens} from './util';
 
@@ -105,7 +105,7 @@ function ctorParameterToMetadata(
     isCore: boolean): Expression {
   // Parameters sometimes have a type that can be referenced. If so, then use it, otherwise
   // its type is undefined.
-  const type = param.typeValueReference !== null ?
+  const type = param.typeValueReference.kind !== TypeValueReferenceKind.UNAVAILABLE ?
       valueReferenceToExpression(param.typeValueReference, defaultImportRecorder) :
       new LiteralExpr(undefined);
 

--- a/packages/compiler-cli/src/ngtsc/reflection/src/type_to_value.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/type_to_value.ts
@@ -47,6 +47,11 @@ export function typeToValue(
       // This is a default import.
       //   import Foo from 'foo';
 
+      if (firstDecl.isTypeOnly) {
+        // Type-only imports cannot be represented as value
+        return null;
+      }
+
       return {
         local: true,
         // Copying the name here ensures the generated references will be correctly transformed
@@ -59,6 +64,11 @@ export function typeToValue(
       //   import {Foo} from 'foo';
       // or
       //   import {Foo as Bar} from 'foo';
+
+      if (firstDecl.parent.parent.isTypeOnly) {
+        // Type-only imports cannot be represented as value
+        return null;
+      }
 
       // Determine the name to import (`Foo`) from the import specifier, as the symbol names of
       // the imported type could refer to a local alias (like `Bar` in the example above).
@@ -79,6 +89,11 @@ export function typeToValue(
     } else if (ts.isNamespaceImport(firstDecl)) {
       // The import is a namespace import
       //   import * as Foo from 'foo';
+
+      if (firstDecl.parent.isTypeOnly) {
+        // Type-only imports cannot be represented as value
+        return null;
+      }
 
       if (symbols.symbolNames.length === 1) {
         // The type refers to the namespace itself, which cannot be represented as a value.

--- a/packages/compiler-cli/src/ngtsc/reflection/src/type_to_value.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/type_to_value.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {TypeValueReference} from './host';
+import {TypeValueReference, TypeValueReferenceKind, UnavailableTypeValueReference, ValueUnavailableKind} from './host';
 
 /**
  * Potentially convert a `ts.TypeNode` to a `TypeValueReference`, which indicates how to use the
@@ -18,22 +18,26 @@ import {TypeValueReference} from './host';
  * declaration, or if it is not possible to statically understand.
  */
 export function typeToValue(
-    typeNode: ts.TypeNode|null, checker: ts.TypeChecker): TypeValueReference|null {
+    typeNode: ts.TypeNode|null, checker: ts.TypeChecker): TypeValueReference {
   // It's not possible to get a value expression if the parameter doesn't even have a type.
-  if (typeNode === null || !ts.isTypeReferenceNode(typeNode)) {
-    return null;
+  if (typeNode === null) {
+    return missingType();
+  }
+
+  if (!ts.isTypeReferenceNode(typeNode)) {
+    return unsupportedType(typeNode);
   }
 
   const symbols = resolveTypeSymbols(typeNode, checker);
   if (symbols === null) {
-    return null;
+    return unknownReference(typeNode);
   }
 
   const {local, decl} = symbols;
   // It's only valid to convert a type reference to a value reference if the type actually
   // has a value declaration associated with it.
   if (decl.valueDeclaration === undefined) {
-    return null;
+    return noValueDeclaration(typeNode, decl.declarations[0]);
   }
 
   // The type points to a valid value declaration. Rewrite the TypeReference into an
@@ -48,12 +52,12 @@ export function typeToValue(
       //   import Foo from 'foo';
 
       if (firstDecl.isTypeOnly) {
-        // Type-only imports cannot be represented as value
-        return null;
+        // Type-only imports cannot be represented as value.
+        return typeOnlyImport(typeNode, firstDecl);
       }
 
       return {
-        local: true,
+        kind: TypeValueReferenceKind.LOCAL,
         // Copying the name here ensures the generated references will be correctly transformed
         // along with the import.
         expression: ts.updateIdentifier(firstDecl.name),
@@ -66,8 +70,8 @@ export function typeToValue(
       //   import {Foo as Bar} from 'foo';
 
       if (firstDecl.parent.parent.isTypeOnly) {
-        // Type-only imports cannot be represented as value
-        return null;
+        // Type-only imports cannot be represented as value.
+        return typeOnlyImport(typeNode, firstDecl.parent.parent);
       }
 
       // Determine the name to import (`Foo`) from the import specifier, as the symbol names of
@@ -80,7 +84,7 @@ export function typeToValue(
 
       const moduleName = extractModuleName(firstDecl.parent.parent.parent);
       return {
-        local: false,
+        kind: TypeValueReferenceKind.IMPORTED,
         valueDeclaration: decl.valueDeclaration,
         moduleName,
         importedName,
@@ -91,13 +95,13 @@ export function typeToValue(
       //   import * as Foo from 'foo';
 
       if (firstDecl.parent.isTypeOnly) {
-        // Type-only imports cannot be represented as value
-        return null;
+        // Type-only imports cannot be represented as value.
+        return typeOnlyImport(typeNode, firstDecl.parent);
       }
 
       if (symbols.symbolNames.length === 1) {
         // The type refers to the namespace itself, which cannot be represented as a value.
-        return null;
+        return namespaceImport(typeNode, firstDecl.parent);
       }
 
       // The first symbol name refers to the local name of the namespace, which is is discarded
@@ -107,7 +111,7 @@ export function typeToValue(
 
       const moduleName = extractModuleName(firstDecl.parent.parent);
       return {
-        local: false,
+        kind: TypeValueReferenceKind.IMPORTED,
         valueDeclaration: decl.valueDeclaration,
         moduleName,
         importedName,
@@ -120,13 +124,58 @@ export function typeToValue(
   const expression = typeNodeToValueExpr(typeNode);
   if (expression !== null) {
     return {
-      local: true,
+      kind: TypeValueReferenceKind.LOCAL,
       expression,
       defaultImportStatement: null,
     };
   } else {
-    return null;
+    return unsupportedType(typeNode);
   }
+}
+
+function unsupportedType(typeNode: ts.TypeNode): UnavailableTypeValueReference {
+  return {
+    kind: TypeValueReferenceKind.UNAVAILABLE,
+    reason: {kind: ValueUnavailableKind.UNSUPPORTED, typeNode},
+  };
+}
+
+function noValueDeclaration(
+    typeNode: ts.TypeNode, decl: ts.Declaration): UnavailableTypeValueReference {
+  return {
+    kind: TypeValueReferenceKind.UNAVAILABLE,
+    reason: {kind: ValueUnavailableKind.NO_VALUE_DECLARATION, typeNode, decl},
+  };
+}
+
+function typeOnlyImport(
+    typeNode: ts.TypeNode, importClause: ts.ImportClause): UnavailableTypeValueReference {
+  return {
+    kind: TypeValueReferenceKind.UNAVAILABLE,
+    reason: {kind: ValueUnavailableKind.TYPE_ONLY_IMPORT, typeNode, importClause},
+  };
+}
+
+function unknownReference(typeNode: ts.TypeNode): UnavailableTypeValueReference {
+  return {
+    kind: TypeValueReferenceKind.UNAVAILABLE,
+    reason: {kind: ValueUnavailableKind.UNKNOWN_REFERENCE, typeNode},
+  };
+}
+
+function namespaceImport(
+    typeNode: ts.TypeNode, importClause: ts.ImportClause): UnavailableTypeValueReference {
+  return {
+    kind: TypeValueReferenceKind.UNAVAILABLE,
+    reason: {kind: ValueUnavailableKind.NAMESPACE, typeNode, importClause},
+  };
+}
+
+function missingType(): UnavailableTypeValueReference {
+  return {
+    kind: TypeValueReferenceKind.UNAVAILABLE,
+    reason: {kind: ValueUnavailableKind.MISSING_TYPE},
+  };
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -68,8 +68,6 @@ export class TypeScriptReflectionHost implements ReflectionHost {
 
         if (childTypeNodes.length === 1) {
           typeNode = childTypeNodes[0];
-        } else {
-          typeNode = null;
         }
       }
 

--- a/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
@@ -9,7 +9,7 @@ import * as ts from 'typescript';
 import {absoluteFrom, getSourceFileOrError} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {getDeclaration, makeProgram} from '../../testing';
-import {ClassMember, ClassMemberKind, CtorParameter} from '../src/host';
+import {ClassMember, ClassMemberKind, CtorParameter, TypeValueReferenceKind} from '../src/host';
 import {TypeScriptReflectionHost} from '../src/typescript';
 import {isNamedClassDeclaration} from '../src/util';
 
@@ -178,7 +178,7 @@ runInEachFileSystem(() => {
         const args = host.getConstructorParameters(clazz)!;
         expect(args.length).toBe(1);
         const param = args[0].typeValueReference;
-        if (param === null || !param.local) {
+        if (param === null || param.kind !== TypeValueReferenceKind.LOCAL) {
           return fail('Expected local parameter');
         }
         expect(param).not.toBeNull();
@@ -548,17 +548,20 @@ runInEachFileSystem(() => {
     if (type === undefined) {
       expect(param.typeValueReference).toBeNull();
     } else {
-      if (param.typeValueReference === null) {
+      if (param.typeValueReference.kind === TypeValueReferenceKind.UNAVAILABLE) {
         return fail(`Expected parameter ${name} to have a typeValueReference`);
       }
-      if (param.typeValueReference.local && typeof type === 'string') {
+      if (param.typeValueReference.kind === TypeValueReferenceKind.LOCAL &&
+          typeof type === 'string') {
         expect(argExpressionToString(param.typeValueReference.expression)).toEqual(type);
-      } else if (!param.typeValueReference.local && typeof type !== 'string') {
+      } else if (
+          param.typeValueReference.kind === TypeValueReferenceKind.IMPORTED &&
+          typeof type !== 'string') {
         expect(param.typeValueReference.moduleName).toEqual(type.moduleName);
         expect(param.typeValueReference.importedName).toEqual(type.name);
       } else {
         return fail(`Mismatch between typeValueReference and expected type: ${param.name} / ${
-            param.typeValueReference.local}`);
+            param.typeValueReference.kind}`);
       }
     }
     if (decorator !== undefined) {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2079,7 +2079,13 @@ runInEachFileSystem(os => {
 
              const errors = env.driveDiagnostics();
              expect(errors.length).toBe(1);
-             expect(errors[0].messageText).toContain('No suitable injection token for parameter');
+             expect(ts.flattenDiagnosticMessageText(errors[0].messageText, '\n'))
+                 .toBe(
+                     `No suitable injection token for parameter 'notInjectable' of class 'Test'.\n` +
+                     `  Consider using the @Inject decorator to specify an injection token.`);
+             expect(errors[0].relatedInformation!.length).toBe(1);
+             expect(errors[0].relatedInformation![0].messageText)
+                 .toBe('This type is not supported as injection token.');
            });
 
         it('should give a compile-time error if an invalid @Injectable is used with an argument',
@@ -2096,8 +2102,138 @@ runInEachFileSystem(os => {
 
              const errors = env.driveDiagnostics();
              expect(errors.length).toBe(1);
-             expect(errors[0].messageText).toContain('No suitable injection token for parameter');
+             expect(ts.flattenDiagnosticMessageText(errors[0].messageText, '\n'))
+                 .toBe(
+                     `No suitable injection token for parameter 'notInjectable' of class 'Test'.\n` +
+                     `  Consider using the @Inject decorator to specify an injection token.`);
+             expect(errors[0].relatedInformation!.length).toBe(1);
+             expect(errors[0].relatedInformation![0].messageText)
+                 .toBe('This type is not supported as injection token.');
            });
+
+        it('should report an error when using a type-only import as injection token', () => {
+          env.tsconfig({strictInjectionParameters: true});
+          env.write(`types.ts`, `
+             export class TypeOnly {}
+           `);
+          env.write(`test.ts`, `
+             import {Injectable} from '@angular/core';
+             import type {TypeOnly} from './types';
+
+             @Injectable()
+             export class MyService {
+               constructor(param: TypeOnly) {}
+             }
+          `);
+
+          const diags = env.driveDiagnostics();
+          expect(diags.length).toBe(1);
+          expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '\n'))
+              .toBe(
+                  `No suitable injection token for parameter 'param' of class 'MyService'.\n` +
+                  `  Consider changing the type-only import to a regular import, ` +
+                  `or use the @Inject decorator to specify an injection token.`);
+          expect(diags[0].relatedInformation!.length).toBe(2);
+          expect(diags[0].relatedInformation![0].messageText)
+              .toBe(
+                  'This type is imported using a type-only import, ' +
+                  'which prevents it from being usable as an injection token.');
+          expect(diags[0].relatedInformation![1].messageText)
+              .toBe('The type-only import occurs here.');
+        });
+
+        it('should report an error when using a primitive type as injection token', () => {
+          env.tsconfig({strictInjectionParameters: true});
+          env.write(`test.ts`, `
+             import {Injectable} from '@angular/core';
+
+             @Injectable()
+             export class MyService {
+               constructor(param: string) {}
+             }
+          `);
+
+          const diags = env.driveDiagnostics();
+          expect(diags.length).toBe(1);
+          expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '\n'))
+              .toBe(
+                  `No suitable injection token for parameter 'param' of class 'MyService'.\n` +
+                  `  Consider using the @Inject decorator to specify an injection token.`);
+          expect(diags[0].relatedInformation!.length).toBe(1);
+          expect(diags[0].relatedInformation![0].messageText)
+              .toBe('This type is not supported as injection token.');
+        });
+
+        it('should report an error when using a union type as injection token', () => {
+          env.tsconfig({strictInjectionParameters: true});
+          env.write(`test.ts`, `
+             import {Injectable} from '@angular/core';
+
+             export class ClassA {}
+             export class ClassB {}
+
+             @Injectable()
+             export class MyService {
+               constructor(param: ClassA|ClassB) {}
+             }
+          `);
+
+          const diags = env.driveDiagnostics();
+          expect(diags.length).toBe(1);
+          expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '\n'))
+              .toBe(
+                  `No suitable injection token for parameter 'param' of class 'MyService'.\n` +
+                  `  Consider using the @Inject decorator to specify an injection token.`);
+          expect(diags[0].relatedInformation!.length).toBe(1);
+          expect(diags[0].relatedInformation![0].messageText)
+              .toBe('This type is not supported as injection token.');
+        });
+
+        it('should report an error when using an interface as injection token', () => {
+          env.tsconfig({strictInjectionParameters: true});
+          env.write(`test.ts`, `
+             import {Injectable} from '@angular/core';
+
+             export interface Interface {}
+
+             @Injectable()
+             export class MyService {
+               constructor(param: Interface) {}
+             }
+          `);
+
+          const diags = env.driveDiagnostics();
+          expect(diags.length).toBe(1);
+          expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '\n'))
+              .toBe(
+                  `No suitable injection token for parameter 'param' of class 'MyService'.\n` +
+                  `  Consider using the @Inject decorator to specify an injection token.`);
+          expect(diags[0].relatedInformation!.length).toBe(2);
+          expect(diags[0].relatedInformation![0].messageText)
+              .toBe('This type does not have a value, so it cannot be used as injection token.');
+          expect(diags[0].relatedInformation![1].messageText).toBe('The type is declared here.');
+        });
+
+        it('should report an error when no type is present', () => {
+          env.tsconfig({strictInjectionParameters: true, noImplicitAny: false});
+          env.write(`test.ts`, `
+             import {Injectable} from '@angular/core';
+
+             @Injectable()
+             export class MyService {
+               constructor(param) {}
+             }
+          `);
+
+          const diags = env.driveDiagnostics();
+          expect(diags.length).toBe(1);
+          expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '\n'))
+              .toBe(
+                  `No suitable injection token for parameter 'param' of class 'MyService'.\n` +
+                  `  Consider adding a type to the parameter or ` +
+                  `use the @Inject decorator to specify an injection token.`);
+          expect(diags[0].relatedInformation).toBeUndefined();
+        });
 
         it('should not give a compile-time error if an invalid @Injectable is used with useValue',
            () => {
@@ -2240,7 +2376,8 @@ runInEachFileSystem(os => {
 
           const errors = env.driveDiagnostics();
           expect(errors.length).toBe(1);
-          expect(errors[0].messageText).toContain('No suitable injection token for parameter');
+          expect(ts.flattenDiagnosticMessageText(errors[0].messageText, '\n'))
+              .toContain('No suitable injection token for parameter');
         });
       });
 
@@ -4171,9 +4308,16 @@ runInEachFileSystem(os => {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
-        expect(diags[0].messageText)
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '\n'))
             .toBe(
-                `No suitable injection token for parameter 'foo' of class 'MyService'.\nFound Foo`);
+                `No suitable injection token for parameter 'foo' of class 'MyService'.\n` +
+                `  Consider using the @Inject decorator to specify an injection token.`);
+        expect(diags[0].relatedInformation!.length).toBe(2);
+        expect(diags[0].relatedInformation![0].messageText)
+            .toBe(
+                'This type corresponds with a namespace, which cannot be used as injection token.');
+        expect(diags[0].relatedInformation![1].messageText)
+            .toBe('The namespace import occurs here.');
       });
     });
 


### PR DESCRIPTION
In TypeScript 3.8 support was added for type-only imports, which only brings in
the symbol as a type, not their value. The Angular compiler did not yet take
the type-only keyword into account when representing symbols in type positions
as value expressions. The class metadata that the compiler emits would include
the value expression for its parameter types, generating actual imports as
necessary. For type-only imports this should not be done, as it introduces an
actual import of the module that was originally just a type-only import.

This commit lets the compiler deal with type-only imports specially, preventing
a value expression from being created.

Fixes #37900

---

<img width="862" alt="image" src="https://user-images.githubusercontent.com/123679/87227797-7812c800-c39d-11ea-8ae9-f2d6a0d48301.png">