### PR TITLE
fix(compiler-cli): infer quote expressions as any type in type checker

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -234,8 +234,8 @@ class AstTranslator implements AstVisitor {
     return node;
   }
 
-  visitQuote(ast: Quote): never {
-    throw new Error('Method not implemented.');
+  visitQuote(ast: Quote): ts.Expression {
+    return NULL_AS_ANY;
   }
 
   visitSafeMethodCall(ast: SafeMethodCall): ts.Expression {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -42,6 +42,11 @@ describe('type check blocks', () => {
         .toContain('(((ctx).a) ? ((ctx).b) : (((ctx).c) ? ((ctx).d) : ((ctx).e)))');
   });
 
+  it('should handle quote expressions as any type', () => {
+    const TEMPLATE = `<span [quote]="sql:expression"></span>`;
+    expect(tcb(TEMPLATE)).toContain('null as any');
+  });
+
   it('should handle attribute values for directive inputs', () => {
     const TEMPLATE = `<div dir inputA="value"></div>`;
     const DIRECTIVES: TestDeclaration[] = [{


### PR DESCRIPTION
"Quote expressions" are expressions that start with an identifier followed by a
comma, allowing arbitrary syntax to follow. These kinds of expressions would
throw a an error in the template type checker, which would make them hard to
track down. As quote expressions are not generally used at all, the error would
typically occur for URLs that would inadvertently occur in a binding:

```html
<a [href]="https://example.com"></a>
```

This commit lets such bindings be inferred as the `any` type.

Fixes #36568
Resolves FW-2051