### PR TITLE
fix(service-worker): fix handling absolute and relative base href

### DIFF
--- a/packages/service-worker/config/src/generator.ts
+++ b/packages/service-worker/config/src/generator.ts
@@ -131,7 +131,10 @@ function matches(file: string, patterns: {positive: boolean, regex: RegExp}[]): 
 
 function urlToRegex(url: string, baseHref: string, literalQuestionMark?: boolean): string {
   if (!url.startsWith('/') && url.indexOf('://') === -1) {
-    url = joinUrls(baseHref, url);
+    // Prefix relative URLs with `baseHref`.
+    // Strip a leading `.` from a relative `baseHref` (e.g. `./foo/`), since it would result in an
+    // incorrect regex (matching a literal `.`).
+    url = joinUrls(baseHref.replace(/^\.(?=\/)/, ''), url);
   }
 
   return globToRegex(url, literalQuestionMark);

--- a/packages/service-worker/config/test/generator_spec.ts
+++ b/packages/service-worker/config/test/generator_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Generator} from '../src/generator';
+import {Generator, processNavigationUrls} from '../src/generator';
 import {AssetGroup} from '../src/in';
 import {MockFilesystem} from '../testing/mock';
 
@@ -253,6 +253,58 @@ describe('Generator', () => {
         '/index.html': 'a54d88e06612d820bc3be72877c74f257b561b19',
         '/main.js': '41347a66676cdc0516934c76d9d13010df420f2c',
       },
+    });
+  });
+
+  describe('processNavigationUrls()', () => {
+    const customNavigationUrls = [
+      'https://host/positive/external/**',
+      '!https://host/negative/external/**',
+      '/positive/absolute/**',
+      '!/negative/absolute/**',
+      'positive/relative/**',
+      '!negative/relative/**',
+    ];
+
+    it('uses the default `navigationUrls` if not provided', () => {
+      expect(processNavigationUrls('/')).toEqual([
+        {positive: true, regex: '^\\/.*$'},
+        {positive: false, regex: '^\\/(?:.+\\/)?[^/]*\\.[^/]*$'},
+        {positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*$'},
+        {positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*\\/.*$'},
+      ]);
+    });
+
+    it('prepends `baseHref` to relative URL patterns only', () => {
+      expect(processNavigationUrls('/base/href/', customNavigationUrls)).toEqual([
+        {positive: true, regex: '^https:\\/\\/host\\/positive\\/external\\/.*$'},
+        {positive: false, regex: '^https:\\/\\/host\\/negative\\/external\\/.*$'},
+        {positive: true, regex: '^\\/positive\\/absolute\\/.*$'},
+        {positive: false, regex: '^\\/negative\\/absolute\\/.*$'},
+        {positive: true, regex: '^\\/base\\/href\\/positive\\/relative\\/.*$'},
+        {positive: false, regex: '^\\/base\\/href\\/negative\\/relative\\/.*$'},
+      ]);
+    });
+
+    it('strips a leading single `.` from a relative `baseHref`', () => {
+      expect(processNavigationUrls('./relative/base/href/', customNavigationUrls)).toEqual([
+        {positive: true, regex: '^https:\\/\\/host\\/positive\\/external\\/.*$'},
+        {positive: false, regex: '^https:\\/\\/host\\/negative\\/external\\/.*$'},
+        {positive: true, regex: '^\\/positive\\/absolute\\/.*$'},
+        {positive: false, regex: '^\\/negative\\/absolute\\/.*$'},
+        {positive: true, regex: '^\\/relative\\/base\\/href\\/positive\\/relative\\/.*$'},
+        {positive: false, regex: '^\\/relative\\/base\\/href\\/negative\\/relative\\/.*$'},
+      ]);
+
+      // We can't correctly handle double dots in `baseHref`, so leave them as literal matches.
+      expect(processNavigationUrls('../double/dots/', customNavigationUrls)).toEqual([
+        {positive: true, regex: '^https:\\/\\/host\\/positive\\/external\\/.*$'},
+        {positive: false, regex: '^https:\\/\\/host\\/negative\\/external\\/.*$'},
+        {positive: true, regex: '^\\/positive\\/absolute\\/.*$'},
+        {positive: false, regex: '^\\/negative\\/absolute\\/.*$'},
+        {positive: true, regex: '^\\.\\.\\/double\\/dots\\/positive\\/relative\\/.*$'},
+        {positive: false, regex: '^\\.\\.\\/double\\/dots\\/negative\\/relative\\/.*$'},
+      ]);
     });
   });
 });

--- a/packages/service-worker/worker/main.ts
+++ b/packages/service-worker/worker/main.ts
@@ -12,5 +12,5 @@ import {Driver} from './src/driver';
 
 const scope = self as any as ServiceWorkerGlobalScope;
 
-const adapter = new Adapter(scope);
+const adapter = new Adapter(scope.registration.scope);
 const driver = new Driver(scope, adapter, new CacheDatabase(scope, adapter));

--- a/packages/service-worker/worker/src/adapter.ts
+++ b/packages/service-worker/worker/src/adapter.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {NormalizedUrl} from './api';
+
+
 /**
  * Adapts the service worker to its runtime environment.
  *
@@ -75,16 +78,10 @@ export class Adapter {
    * @param url The raw request URL.
    * @return A normalized representation of the URL.
    */
-  normalizeUrl(url: string): string {
+  normalizeUrl(url: string): NormalizedUrl {
     // Check the URL's origin against the ServiceWorker's.
     const parsed = this.parseUrl(url, this.scopeUrl);
-    if (parsed.origin === this.origin) {
-      // The URL is relative to the SW's origin: Return the path only.
-      return parsed.path;
-    } else {
-      // The URL is not relative to the SW's origin: Return the full URL.
-      return url;
-    }
+    return (parsed.origin === this.origin ? parsed.path : url) as NormalizedUrl;
   }
 
   /**

--- a/packages/service-worker/worker/src/api.ts
+++ b/packages/service-worker/worker/src/api.ts
@@ -13,6 +13,18 @@ export enum UpdateCacheStatus {
 }
 
 /**
+ * A `string` representing a URL that has been normalized relative to an origin (usually that of the
+ * ServiceWorker).
+ *
+ * If the URL is relative to the origin, then it is representated by the path part only. Otherwise,
+ * the full URL is used.
+ *
+ * NOTE: A `string` is not assignable to a `NormalizedUrl`, but a `NormalizedUrl` is assignable to a
+ *       `string`.
+ */
+export type NormalizedUrl = string&{_brand: 'normalizedUrl'};
+
+/**
  * A source for old versions of URL contents and other resources.
  *
  * Used to abstract away the fetching of old contents, to avoid a
@@ -27,7 +39,7 @@ export interface UpdateSource {
    * If an old version of the resource doesn't exist, or exists but does
    * not match the hash given, this returns null.
    */
-  lookupResourceWithHash(url: string, hash: string): Promise<Response|null>;
+  lookupResourceWithHash(url: NormalizedUrl, hash: string): Promise<Response|null>;
 
   /**
    * Lookup an older version of a resource for which the hash is not known.
@@ -37,7 +49,7 @@ export interface UpdateSource {
    * `Response`, but the cache metadata needed to re-cache the resource in
    * a newer `AppVersion`.
    */
-  lookupResourceWithoutHash(url: string): Promise<CacheState|null>;
+  lookupResourceWithoutHash(url: NormalizedUrl): Promise<CacheState|null>;
 
   /**
    * List the URLs of all of the resources which were previously cached.
@@ -45,7 +57,7 @@ export interface UpdateSource {
    * This allows for the discovery of resources which are not listed in the
    * manifest but which were picked up because they matched URL patterns.
    */
-  previouslyCachedResources(): Promise<string[]>;
+  previouslyCachedResources(): Promise<NormalizedUrl[]>;
 
   /**
    * Check whether a particular resource exists in the most recent cache.

--- a/packages/service-worker/worker/src/app-version.ts
+++ b/packages/service-worker/worker/src/app-version.ts
@@ -7,7 +7,7 @@
  */
 
 import {Adapter, Context} from './adapter';
-import {CacheState, UpdateCacheStatus, UpdateSource} from './api';
+import {CacheState, NormalizedUrl, UpdateCacheStatus, UpdateSource} from './api';
 import {AssetGroup, LazyAssetGroup, PrefetchAssetGroup} from './assets';
 import {DataGroup} from './data';
 import {Database} from './database';
@@ -31,10 +31,9 @@ const BACKWARDS_COMPATIBILITY_NAVIGATION_URLS = [
  */
 export class AppVersion implements UpdateSource {
   /**
-   * A Map of absolute URL paths (/foo.txt) to the known hash of their
-   * contents (if available).
+   * A Map of absolute URL paths (`/foo.txt`) to the known hash of their contents (if available).
    */
-  private hashTable = new Map<string, string>();
+  private hashTable = new Map<NormalizedUrl, string>();
 
   /**
    * All of the asset groups active in this version of the app.
@@ -218,7 +217,7 @@ export class AppVersion implements UpdateSource {
   /**
    * Check this version for a given resource with a particular hash.
    */
-  async lookupResourceWithHash(url: string, hash: string): Promise<Response|null> {
+  async lookupResourceWithHash(url: NormalizedUrl, hash: string): Promise<Response|null> {
     // Verify that this version has the requested resource cached. If not,
     // there's no point in trying.
     if (!this.hashTable.has(url)) {
@@ -238,7 +237,7 @@ export class AppVersion implements UpdateSource {
   /**
    * Check this version for a given resource regardless of its hash.
    */
-  lookupResourceWithoutHash(url: string): Promise<CacheState|null> {
+  lookupResourceWithoutHash(url: NormalizedUrl): Promise<CacheState|null> {
     // Limit the search to asset groups, and only scan the cache, don't
     // load resources from the network.
     return this.assetGroups.reduce(async (potentialResponse, group) => {
@@ -256,10 +255,10 @@ export class AppVersion implements UpdateSource {
   /**
    * List all unhashed resources from all asset groups.
    */
-  previouslyCachedResources(): Promise<string[]> {
-    return this.assetGroups.reduce(async (resources, group) => {
-      return (await resources).concat(await group.unhashedResources());
-    }, Promise.resolve<string[]>([]));
+  previouslyCachedResources(): Promise<NormalizedUrl[]> {
+    return this.assetGroups.reduce(
+        async (resources, group) => (await resources).concat(await group.unhashedResources()),
+        Promise.resolve<NormalizedUrl[]>([]));
   }
 
   async recentCacheStatus(url: string): Promise<UpdateCacheStatus> {

--- a/packages/service-worker/worker/src/app-version.ts
+++ b/packages/service-worker/worker/src/app-version.ts
@@ -53,6 +53,12 @@ export class AppVersion implements UpdateSource {
   private navigationUrls: {include: RegExp[], exclude: RegExp[]};
 
   /**
+   * The normalized URL to the file that serves as the index page to satisfy navigation requests.
+   * Usually this is `/index.html`.
+   */
+  private indexUrl = this.adapter.normalizeUrl(this.manifest.index);
+
+  /**
    * Tracks whether the manifest has encountered any inconsistencies.
    */
   private _okay = true;
@@ -67,7 +73,7 @@ export class AppVersion implements UpdateSource {
       readonly manifestHash: string) {
     // The hashTable within the manifest is an Object - convert it to a Map for easier lookups.
     Object.keys(this.manifest.hashTable).forEach(url => {
-      this.hashTable.set(url, this.manifest.hashTable[url]);
+      this.hashTable.set(adapter.normalizeUrl(url), this.manifest.hashTable[url]);
     });
 
     // Process each `AssetGroup` declared in the manifest. Each declared group gets an `AssetGroup`
@@ -179,10 +185,10 @@ export class AppVersion implements UpdateSource {
 
     // Next, check if this is a navigation request for a route. Detect circular
     // navigations by checking if the request URL is the same as the index URL.
-    if (req.url !== this.manifest.index && this.isNavigationRequest(req)) {
+    if (this.adapter.normalizeUrl(req.url) !== this.indexUrl && this.isNavigationRequest(req)) {
       // This was a navigation request. Re-enter `handleFetch` with a request for
       // the URL.
-      return this.handleFetch(this.adapter.newRequest(this.manifest.index), context);
+      return this.handleFetch(this.adapter.newRequest(this.indexUrl), context);
     }
 
     return null;

--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -7,7 +7,7 @@
  */
 
 import {Adapter, Context} from './adapter';
-import {CacheState, UpdateCacheStatus, UpdateSource, UrlMetadata} from './api';
+import {CacheState, NormalizedUrl, UpdateCacheStatus, UpdateSource, UrlMetadata} from './api';
 import {Database, Table} from './database';
 import {errorToString, SwCriticalError} from './error';
 import {IdleScheduler} from './idle';
@@ -29,7 +29,7 @@ export abstract class AssetGroup {
   /**
    * Normalized resource URLs.
    */
-  protected urls: string[] = [];
+  protected urls: NormalizedUrl[] = [];
 
   /**
    * Regular expression patterns.
@@ -266,7 +266,7 @@ export abstract class AssetGroup {
   /**
    * Lookup all resources currently stored in the cache which have no associated hash.
    */
-  async unhashedResources(): Promise<string[]> {
+  async unhashedResources(): Promise<NormalizedUrl[]> {
     const cache = await this.cache;
     // Start with the set of all cached requests.
     return (await cache.keys())

--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -47,9 +47,6 @@ export abstract class AssetGroup {
    */
   protected metadata: Promise<Table>;
 
-
-  private origin: string;
-
   constructor(
       protected scope: ServiceWorkerGlobalScope, protected adapter: Adapter,
       protected idle: IdleScheduler, protected config: AssetGroupConfig,
@@ -67,10 +64,6 @@ export abstract class AssetGroup {
     // the timestamp of when it was added to the cache.
     this.metadata =
         this.db.open(`${this.prefix}:${this.config.name}:meta`, this.config.cacheQueryOptions);
-
-    // Determine the origin from the registration scope. This is used to differentiate between
-    // relative and absolute URLs.
-    this.origin = this.adapter.parseUrl(this.scope.registration.scope).origin;
   }
 
   async cacheStatus(url: string): Promise<UpdateCacheStatus> {
@@ -108,7 +101,7 @@ export abstract class AssetGroup {
    * Process a request for a given resource and return it, or return null if it's not available.
    */
   async handleFetch(req: Request, ctx: Context): Promise<Response|null> {
-    const url = this.getConfigUrl(req.url);
+    const url = this.adapter.normalizeUrl(req.url);
     // Either the request matches one of the known resource URLs, one of the patterns for
     // dynamically matched URLs, or neither. Determine which is the case for this request in
     // order to decide how to handle it.
@@ -153,18 +146,6 @@ export abstract class AssetGroup {
       return res.clone();
     } else {
       return null;
-    }
-  }
-
-  private getConfigUrl(url: string): string {
-    // If the URL is relative to the SW's own origin, then only consider the path relative to
-    // the domain root. Determine this by checking the URL's origin against the SW's.
-    const parsed = this.adapter.parseUrl(url, this.scope.registration.scope);
-    if (parsed.origin === this.origin) {
-      // The URL is relative to the SW's origin domain.
-      return parsed.path;
-    } else {
-      return url;
     }
   }
 
@@ -373,7 +354,7 @@ export abstract class AssetGroup {
    * Load a particular asset from the network, accounting for hash validation.
    */
   protected async cacheBustedFetchFromNetwork(req: Request): Promise<Response> {
-    const url = this.getConfigUrl(req.url);
+    const url = this.adapter.normalizeUrl(req.url);
 
     // If a hash is available for this resource, then compare the fetched version with the
     // canonical hash. Otherwise, the network version will have to be trusted.
@@ -456,7 +437,7 @@ export abstract class AssetGroup {
    */
   protected async maybeUpdate(updateFrom: UpdateSource, req: Request, cache: Cache):
       Promise<boolean> {
-    const url = this.getConfigUrl(req.url);
+    const url = this.adapter.normalizeUrl(req.url);
     const meta = await this.metadata;
     // Check if this resource is hashed and already exists in the cache of a prior version.
     if (this.hashes.has(url)) {
@@ -546,7 +527,7 @@ export class PrefetchAssetGroup extends AssetGroup {
           // First, narrow down the set of resources to those which are handled by this group.
           // Either it's a known URL, or it matches a given pattern.
           .filter(
-              url => this.config.urls.some(cacheUrl => cacheUrl === url) ||
+              url => this.config.urls.indexOf(url) !== -1 ||
                   this.patterns.some(pattern => pattern.test(url)))
           // Finally, process each resource in turn.
           .reduce(async (previous, url) => {

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -99,6 +99,8 @@ export class Driver implements Debuggable, UpdateSource {
    */
   private loggedInvalidOnlyIfCachedRequest: boolean = false;
 
+  private ngswStatePath = this.adapter.parseUrl('ngsw/state', this.scope.registration.scope).path;
+
   /**
    * A scheduler which manages a queue of tasks that need to be executed when the SW is
    * not doing any other work (not processing any other requests).
@@ -184,7 +186,7 @@ export class Driver implements Debuggable, UpdateSource {
     }
 
     // The only thing that is served unconditionally is the debug page.
-    if (requestUrlObj.path === '/ngsw/state') {
+    if (requestUrlObj.path === this.ngswStatePath) {
       // Allow the debugger to handle the request, but don't affect SW state in any other way.
       event.respondWith(this.debugger.handleFetch(req));
       return;

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -7,7 +7,7 @@
  */
 
 import {Adapter} from './adapter';
-import {CacheState, Debuggable, DebugIdleState, DebugState, DebugVersion, UpdateCacheStatus, UpdateSource} from './api';
+import {CacheState, Debuggable, DebugIdleState, DebugState, DebugVersion, NormalizedUrl, UpdateCacheStatus, UpdateSource} from './api';
 import {AppVersion} from './app-version';
 import {Database} from './database';
 import {DebugHandler} from './debug';
@@ -959,7 +959,7 @@ export class Driver implements Debuggable, UpdateSource {
    * Determine if a specific version of the given resource is cached anywhere within the SW,
    * and fetch it if so.
    */
-  lookupResourceWithHash(url: string, hash: string): Promise<Response|null> {
+  lookupResourceWithHash(url: NormalizedUrl, hash: string): Promise<Response|null> {
     return Array
         // Scan through the set of all cached versions, valid or otherwise. It's safe to do such
         // lookups even for invalid versions as the cached version of a resource will have the
@@ -981,13 +981,13 @@ export class Driver implements Debuggable, UpdateSource {
         }, Promise.resolve<Response|null>(null));
   }
 
-  async lookupResourceWithoutHash(url: string): Promise<CacheState|null> {
+  async lookupResourceWithoutHash(url: NormalizedUrl): Promise<CacheState|null> {
     await this.initialized;
     const version = this.versions.get(this.latestHash!);
     return version ? version.lookupResourceWithoutHash(url) : null;
   }
 
-  async previouslyCachedResources(): Promise<string[]> {
+  async previouslyCachedResources(): Promise<NormalizedUrl[]> {
     await this.initialized;
     const version = this.versions.get(this.latestHash!);
     return version ? version.previouslyCachedResources() : [];

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -893,6 +893,34 @@ describe('Driver', () => {
        expect(await scope.caches.keys()).not.toEqual([]);
      });
 
+  describe('serving ngsw/state', () => {
+    it('should show debug info (when in NORMAL state)', async () => {
+      expect(await makeRequest(scope, '/ngsw/state'))
+          .toMatch(/^NGSW Debug Info:\n\nDriver state: NORMAL/);
+    });
+
+    it('should show debug info (when in EXISTING_CLIENTS_ONLY state)', async () => {
+      driver.state = DriverReadyState.EXISTING_CLIENTS_ONLY;
+      expect(await makeRequest(scope, '/ngsw/state'))
+          .toMatch(/^NGSW Debug Info:\n\nDriver state: EXISTING_CLIENTS_ONLY/);
+    });
+
+    it('should show debug info (when in SAFE_MODE state)', async () => {
+      driver.state = DriverReadyState.SAFE_MODE;
+      expect(await makeRequest(scope, '/ngsw/state'))
+          .toMatch(/^NGSW Debug Info:\n\nDriver state: SAFE_MODE/);
+    });
+
+    it('should show debug info when the scope is not root', async () => {
+      const newScope =
+          new SwTestHarnessBuilder('http://localhost/foo/bar/').withServerState(server).build();
+      new Driver(newScope, newScope, new CacheDatabase(newScope, newScope));
+
+      expect(await makeRequest(newScope, '/foo/bar/ngsw/state'))
+          .toMatch(/^NGSW Debug Info:\n\nDriver state: NORMAL/);
+    });
+  });
+
   describe('cache naming', () => {
     // Helpers
     const cacheKeysFor = (baseHref: string) =>

--- a/packages/service-worker/worker/testing/utils.ts
+++ b/packages/service-worker/worker/testing/utils.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Get a normalized representation of a URL relative to a provided base URL.
+ *
+ * More specifically:
+ * 1. Resolve the URL relative to the provided base URL.
+ * 2. If the URL is relative to the base URL, then strip the origin (and only return the path and
+ *    search parts). Otherwise, return the full URL.
+ *
+ * @param url The raw URL.
+ * @param relativeTo The base URL to resolve `url` relative to.
+ *     (This is usually the ServiceWorker's origin or registration scope).
+ * @return A normalized representation of the URL.
+ */
+export function normalizeUrl(url: string, relativeTo: string): string {
+  const {origin, path, search} = parseUrl(url, relativeTo);
+  const {origin: relativeToOrigin} = parseUrl(relativeTo);
+
+  return (origin === relativeToOrigin) ? path + search : url;
+}
+
+/**
+ * Parse a URL into its different parts, such as `origin`, `path` and `search`.
+ */
+export function parseUrl(
+    url: string, relativeTo?: string): {origin: string, path: string, search: string} {
+  const parsedUrl: URL = (typeof URL === 'function') ?
+      (!relativeTo ? new URL(url) : new URL(url, relativeTo)) :
+      require('url').parse(require('url').resolve(relativeTo || '', url));
+
+  return {
+    origin: parsedUrl.origin || `${parsedUrl.protocol}//${parsedUrl.host}`,
+    path: parsedUrl.pathname,
+    search: parsedUrl.search || '',
+  };
+}

--- a/packages/service-worker/worker/testing/utils.ts
+++ b/packages/service-worker/worker/testing/utils.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {NormalizedUrl} from '../src/api';
+
+
 /**
  * Get a normalized representation of a URL relative to a provided base URL.
  *
@@ -19,11 +22,11 @@
  *     (This is usually the ServiceWorker's origin or registration scope).
  * @return A normalized representation of the URL.
  */
-export function normalizeUrl(url: string, relativeTo: string): string {
+export function normalizeUrl(url: string, relativeTo: string): NormalizedUrl {
   const {origin, path, search} = parseUrl(url, relativeTo);
   const {origin: relativeToOrigin} = parseUrl(relativeTo);
 
-  return (origin === relativeToOrigin) ? path + search : url;
+  return ((origin === relativeToOrigin) ? path + search : url) as NormalizedUrl;
 }
 
 /**


### PR DESCRIPTION
Various fixes to allow the Angular ServiceWorker to correctly work when the app has an absolute or relative base href.
See individual commits for details.

Fixes #25055 and #30505.
