### PR TITLE
fix(common): LBP currency should have 2 decimals but it has 0

### DIFF
--- a/packages/common/src/i18n/currencies.ts
+++ b/packages/common/src/i18n/currencies.ts
@@ -81,7 +81,7 @@ export const CURRENCIES_EN:
       'KYD': [undefined, '$'],
       'KZT': [undefined, '₸'],
       'LAK': [undefined, '₭', 0],
-      'LBP': [undefined, 'L£', 0],
+      'LBP': [undefined, 'L£', 2],
       'LKR': [undefined, 'Rs'],
       'LRD': [undefined, '$'],
       'LTL': [undefined, 'Lt'],


### PR DESCRIPTION
Currencies are formatted according to ISO_4217. LBP (Lebanese pound) should have 2 decimal places, but it has zero. Added 2 decimal places to LBP

Fixes #37921

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #37921


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
