### PR TITLE
fix(forms): FormControlName directive not cleaning up on destroy

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -15,7 +15,7 @@ import {ControlContainer} from '../control_container';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '../control_value_accessor';
 import {NgControl} from '../ng_control';
 import {ReactiveErrors} from '../reactive_errors';
-import {_ngModelWarning, composeAsyncValidators, composeValidators, controlPath, isPropertyUpdated, selectValueAccessor} from '../shared';
+import {_ngModelWarning, cleanUpControl, composeAsyncValidators, composeValidators, controlPath, isPropertyUpdated, selectValueAccessor} from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
 
 import {NG_MODEL_WITH_FORM_CONTROL_WARNING} from './form_control_directive';
@@ -162,6 +162,11 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
   ngOnDestroy(): void {
     if (this.formDirective) {
       this.formDirective.removeControl(this);
+    }
+
+    if (this._added && this.control) {
+      cleanUpControl(this.control, this);
+      (this as {control: FormControl | undefined}).control = undefined;
     }
   }
 

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -73,6 +73,23 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
         expect(form.value).toEqual({'login': 'updatedValue'});
       });
+
+      it('should clean up the FormControlName directive on destroy', () => {
+        const fixture = initTest(FormGroupComp);
+        const loginControl = new FormControl();
+        fixture.componentInstance.control = loginControl;
+        fixture.componentInstance.form = new FormGroup({login: loginControl});
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input'));
+        const formControlName = input.injector.get(FormControlName);
+
+        expect(formControlName.control).toBeTruthy();
+
+        fixture.destroy();
+
+        expect(formControlName.control).toBeFalsy();
+      });
     });
 
     describe('re-bound form groups', () => {


### PR DESCRIPTION
Fixes a memory leak caused by the `FormControlName` directive which wasn't cleaning up after itself on destroy. It ended up retaining a reference to the detached DOM node that the directive is applied to.

Fixes #37431.
