### PR TITLE
fix(forms): separate reactive-driven validators from teamplte-driven ones to better support mixed mode

### DIFF
--- a/goldens/public-api/forms/forms.d.ts
+++ b/goldens/public-api/forms/forms.d.ts
@@ -1,5 +1,8 @@
 export declare abstract class AbstractControl {
-    asyncValidator: AsyncValidatorFn | null;
+    set asyncValidator(validator: AsyncValidatorFn | null);
+    get asyncValidator(): AsyncValidatorFn | null;
+    get composedAsyncValidator(): AsyncValidatorFn | null;
+    get composedValidator(): ValidatorFn | null;
     get dirty(): boolean;
     get disabled(): boolean;
     get enabled(): boolean;
@@ -15,9 +18,12 @@ export declare abstract class AbstractControl {
     get untouched(): boolean;
     get updateOn(): FormHooks;
     get valid(): boolean;
-    validator: ValidatorFn | null;
+    set validator(validator: ValidatorFn | null);
+    get validator(): ValidatorFn | null;
     readonly value: any;
     readonly valueChanges: Observable<any>;
+    get viewAsyncValidator(): AsyncValidatorFn | null;
+    get viewValidator(): ValidatorFn | null;
     constructor(validator: ValidatorFn | null, asyncValidator: AsyncValidatorFn | null);
     clearAsyncValidators(): void;
     clearValidators(): void;
@@ -234,7 +240,7 @@ export declare class FormControl extends AbstractControl {
     }): void;
 }
 
-export declare class FormControlDirective extends NgControl implements OnChanges {
+export declare class FormControlDirective extends NgControl implements OnChanges, OnDestroy {
     get asyncValidator(): AsyncValidatorFn | null;
     get control(): FormControl;
     form: FormControl;
@@ -246,6 +252,7 @@ export declare class FormControlDirective extends NgControl implements OnChanges
     viewModel: any;
     constructor(validators: Array<Validator | ValidatorFn>, asyncValidators: Array<AsyncValidator | AsyncValidatorFn>, valueAccessors: ControlValueAccessor[], _ngModelWarningConfig: string | null);
     ngOnChanges(changes: SimpleChanges): void;
+    ngOnDestroy(): void;
     viewToModelUpdate(newValue: any): void;
 }
 
@@ -296,7 +303,7 @@ export declare class FormGroup extends AbstractControl {
     }): void;
 }
 
-export declare class FormGroupDirective extends ControlContainer implements Form, OnChanges {
+export declare class FormGroupDirective extends ControlContainer implements Form, OnChanges, OnDestroy {
     get control(): FormGroup;
     directives: FormControlName[];
     form: FormGroup;
@@ -312,6 +319,7 @@ export declare class FormGroupDirective extends ControlContainer implements Form
     getFormArray(dir: FormArrayName): FormArray;
     getFormGroup(dir: FormGroupName): FormGroup;
     ngOnChanges(changes: SimpleChanges): void;
+    ngOnDestroy(): void;
     onReset(): void;
     onSubmit($event: Event): boolean;
     removeControl(dir: FormControlName): void;

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -16,7 +16,7 @@ import {Form} from './form_interface';
 import {NgControl} from './ng_control';
 import {NgModel} from './ng_model';
 import {NgModelGroup} from './ng_model_group';
-import {composeAsyncValidators, composeValidators, removeDir, setUpControl, setUpFormContainer, syncPendingControls} from './shared';
+import {cleanUpFormContainer, composeAsyncValidators, composeValidators, removeDir, setUpControl, setUpFormContainer, syncPendingControls} from './shared';
 
 export const formDirectiveProvider: any = {
   provide: ControlContainer,
@@ -249,6 +249,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
       const container = this._findContainer(dir.path);
       if (container) {
         container.removeControl(dir.name);
+        cleanUpFormContainer(container, dir);
       }
     });
   }

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -306,7 +306,6 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
 
   private _setUpStandalone(): void {
     setUpControl(this.control, this);
-    this.control.updateValueAndValidity({emitEvent: false});
   }
 
   private _checkForErrors(): void {

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -161,6 +161,28 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         expect(newForm.get('login')!.errors).toEqual({required: true});
       });
 
+      it('should set validator without loosing dir validators from form controls and vice versa',
+         () => {
+           const fixture = initTest(LoginIsEmptyWrapper, LoginIsEmptyValidator);
+           const form = new FormGroup({
+             'login': new FormControl(''),
+             'min': new FormControl(''),
+             'max': new FormControl(''),
+             'pattern': new FormControl('')
+           });
+           fixture.componentInstance.form = form;
+           fixture.detectChanges();
+           expect(form.get('login')!.errors).toEqual({required: true});
+
+           const loginControl = form.get('login');
+           loginControl!.setValidators(ctrl => ({modelError: true}));
+           loginControl!.updateValueAndValidity();
+           expect(form.get('login')!.errors).toEqual({modelError: true, required: true});
+
+           fixture.destroy();
+           expect(form.get('login')!.errors).toEqual({modelError: true});
+         });
+
       it('should pick up dir validators from nested form groups', () => {
         const fixture = initTest(NestedFormGroupComp, LoginIsEmptyValidator);
         const form = new FormGroup({


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
When using ReactiveForms approach mixed with template driven validators (see [Angular Material's Date Picker](https://github.com/angular/components/blob/master/src/material/datepicker/datepicker-input.ts#L43), FormControl's validators are combined on directive's initialization.
If the developer sets its own validators via `setValidators` in a future moment, the FormControl will loose `NG_VALIDATORS` provided by the directive.

Another problem appears when the control is being recreated (by an `*ngIf` for example) and attached to the same FormControl instance: the new combined validator will contain the old validator and the new.
This is both a memory leak and a functional bug.

Issue Number: #20007, #26792, #34538


## What is the new behavior?
I've separated validators (reactive driven) from view validators (template driven) to achieve:
- Cleanup view validators on destroy to avoid strange behaviors and memory leaks
- Separate validators for model and view, this way I can use for example a DatePicker that validates formally the input (viewValidator) and a model validator to check if date respects an interval (validator)

FormControl (FormGroup, FormArray) will combine validators internally before using them to validate the value.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

AbstractControl.setValidators and AbstractControl.setAsyncValidators wont clear validators setted by template directives anymore.

If someone is using setValidators to voluntary remove NG_VALIDATORS setted in the view, he will need to use `formControl.viewValidators = null`.


## Other information
I searched for issues about `validators` and found issues mentioned above, but probabily there are similar issues solved by this patch.
