### PR TITLE
ci: decrease the minBodyLength commit message limit to 20 chars

### DIFF
--- a/.ng-dev/config.ts
+++ b/.ng-dev/config.ts
@@ -3,7 +3,7 @@ import {MergeConfig} from '../dev-infra/pr/merge/config';
 // The configuration for `ng-dev commit-message` commands.
 const commitMessage = {
   'maxLength': 120,
-  'minBodyLength': 100,
+  'minBodyLength': 20,
   'minBodyLengthTypeExcludes': ['docs'],
   'types': [
     'build',


### PR DESCRIPTION
The motivation behind this change is to improve the productivity in the angular/angular repo
without sacrificing the original goal of having better understanding of changes within
the repo.

When the minBodyLength limit was originally introduced the goal was simple: force
committers to provide more contextual information for each change coming into the
repo. Too often we found ourselves in a situation where nobody understood what
motivated some of the changes and we needed more contextual info to know if the
change was correct, desirable, and still relevant (at a later point in time).

When the limit was introduced, we needed to pick a minimum body length - given no
data, and frustration with even big changes being committed with just a words in
the subject (along the lines of "fix(core): fixing a bug"), we overcompensated
and started off with a really high bar of minBodyLength set to 100 chars.

This turned out to be impractical and created a big friction point in making valid
changes in the angular/angular repo, and in fact caused some of the refactorings
and smaller changes to be either skipped or combined into other commits which
increased the burden for code reviewers.

The evidence in the friction points can be seen in the number of PRs that fail to pass
the current lint check on the first try, but more importantly also in the "creative"
writing that some of the committers are forced to resort to in order to satisfy the
current checks. Examples:

- https://github.com/angular/angular/commit/286fbf42c65a02e6da7420cd19a2c5baff3f2656
- https://github.com/angular/angular/commit/b2816a1536075397d876ba27ce2b7dcd785d4a39

Given that we primarily care to document the motivation behind each change
(the answer to the ultimate question: WHY?), I've collected several *common* &
*valid* commit messages that are minimalistic and capture the WHY sufficiently:

```
Refactoring for readability.  => 28 chars
Improving variable naming.    => 26 chars
Additional test coverage.     => 25 chars
Cleaning up the code.         => 21 chars
Simplifies the code.          => 20 chars
```

These commit message bodies in addition to the commit message subject should
sufficiently satisfy the need to capture the context and motivation behind each
change without creating an undue burden on committers.

Example minimalistic commit message:

```
------

refactor(core): cleanup the expression parser

Simplifies the code.

----
```

Given this research, I'm decreasing the minBodyLenth in angular/angular to 20 chars.

The commit message quality can be additionally improved by implementing a commit message
template via `.gitmessage` that will guide the committers in following our commit message
guidelines via instructions provided in the form of in-the-flow help rather than as an after
the fact lint check.

More info: https://thoughtbot.com/blog/better-commit-messages-with-a-gitmessage-template

I'm intentionally deferring such change for a separate PR as not to complicate or delay the
minBodyLength limit decrease.
