### PR TITLE
refactor(dev-infra): allow for consumption with rules_nodejs v2.0.0

### DIFF
--- a/dev-infra/BUILD.bazel
+++ b/dev-infra/BUILD.bazel
@@ -38,7 +38,7 @@ genrule(
 pkg_npm(
     name = "npm_package",
     srcs = [
-        "BUILD.bazel",
+        "index.bzl",
         "//dev-infra/bazel:files",
         "//dev-infra/benchmark:files",
     ],

--- a/dev-infra/index.bzl
+++ b/dev-infra/index.bzl
@@ -1,0 +1,9 @@
+# Copyright Google LLC All Rights Reserved.
+#
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file at https://angular.io/license
+
+# File is currently empty but serves as indicator for `rules_nodejs` and instructs it to
+# preserve the content output in the NPM install workspace. This allows consumers to use
+# rules and targets from within Bazel. e.g. by using `@npm//@angular/dev-infra-private/<..>`.
+# See: https://github.com/bazelbuild/rules_nodejs/commit/4f508b1a0be1f5444e9c13b0439e649449792fef.


### PR DESCRIPTION
With `rules_nodejs` v2.0.0 being in RC phase currently, we should
make sure that the package is compatible so that we can use it
in the components repo in combination with rules_nodejs v2.0.0.

In v2.0.0 of the NodeJS rules, Bazel workspaces are recommended
to no longer be symlinked under a separate repository. Instead,
bazel rules and targets should be accessed directly from the
user-selected NPM repository. Usually `@npm`, so that the import
changes to `@npm//@angular/dev-infra-private/<..>`.