### PR TITLE
build(compiler-cli): fix bazel deps rules for ngtsc testing packages

### DIFF
--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -61,6 +61,8 @@ pkg_npm(
     deps = [
         ":compiler-cli",
         "//packages/compiler-cli/ngcc",
+        "//packages/compiler-cli/src/ngtsc/file_system/testing",
+        "//packages/compiler-cli/src/ngtsc/logging/testing",
     ],
 )
 

--- a/packages/compiler-cli/src/ngtsc/file_system/testing/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/file_system/testing/BUILD.bazel
@@ -4,13 +4,14 @@ package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",
-    testonly = True,
     srcs = glob([
         "**/*.ts",
     ]),
     deps = [
         "//packages:types",
         "//packages/compiler-cli/src/ngtsc/file_system",
+        "@npm//@types/jasmine",
+        "@npm//@types/node",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/logging/testing/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/logging/testing/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "testing",
-    testonly = True,
     srcs = glob([
         "**/*.ts",
     ]),


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Build related changes


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

2 testing packages are missing from the bazel deps rules, which means that they are not included in the releases


## What is the new behavior?
They should be released with the next version of compiler-cli


## Does this PR introduce a breaking change?

- [x] No

