### PR TITLE
fix(language-service): remove completion for string

### DIFF
--- a/packages/language-service/src/expressions.ts
+++ b/packages/language-service/src/expressions.ts
@@ -75,7 +75,16 @@ export function getExpressionCompletions(
     visitKeyedWrite(_ast) {},
     visitLiteralArray(_ast) {},
     visitLiteralMap(_ast) {},
-    visitLiteralPrimitive(_ast) {},
+    visitLiteralPrimitive(ast) {
+      // The type `LiteralPrimitive` include the `ERROR`, and it's wrapped as `string`.
+      // packages/compiler/src/template_parser/binding_parser.ts#L308
+      // So exclude the `ERROR` here.
+      if (typeof ast.value === 'string' &&
+          ast.value ===
+              templateInfo.source.slice(ast.sourceSpan.start + 1, ast.sourceSpan.end - 1)) {
+        result = undefined;
+      }
+    },
     visitMethodCall(_ast) {},
     visitPipe(ast) {
       if (position >= ast.exp.span.end &&

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -848,6 +848,13 @@ describe('completions', () => {
     const completions = ngLS.getCompletionsAtPosition(TEST_TEMPLATE, marker.start);
     expect(completions).toBeUndefined();
   });
+
+  it('should not provide completions for string', () => {
+    mockHost.override(TEST_TEMPLATE, `<div [ngClass]="'str~{cursor}'"></div>`);
+    const marker = mockHost.getLocationMarkerFor(TEST_TEMPLATE, 'cursor');
+    const completions = ngLS.getCompletionsAtPosition(TEST_TEMPLATE, marker.start);
+    expect(completions).toBeUndefined();
+  });
 });
 
 function expectContain(


### PR DESCRIPTION
If the user inputs a string(e.g. `<div [ngClass]="'str~{cursor}'"></div>`), the completion is useless.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
