### PR TITLE
Adapt the Http Client to return class objects

### DIFF
--- a/goldens/public-api/common/http/http.d.ts
+++ b/goldens/public-api/common/http/http.d.ts
@@ -186,6 +186,18 @@ export declare class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
+    delete<T>(url: string, jsonParser: JsonParser<T>, options?: {
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
+        observe?: 'body';
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
+        reportProgress?: boolean;
+        responseType?: 'json';
+        withCredentials?: boolean;
+    }): Observable<T>;
     get(url: string, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -366,6 +378,18 @@ export declare class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
+    get<T>(url: string, jsonParser: JsonParser<T>, options?: {
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
+        observe?: 'body';
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
+        reportProgress?: boolean;
+        responseType?: 'json';
+        withCredentials?: boolean;
+    }): Observable<T>;
     head(url: string, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -535,6 +559,18 @@ export declare class HttpClient {
         withCredentials?: boolean;
     }): Observable<Object>;
     head<T>(url: string, options?: {
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
+        observe?: 'body';
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
+        reportProgress?: boolean;
+        responseType?: 'json';
+        withCredentials?: boolean;
+    }): Observable<T>;
+    head<T>(url: string, jsonParser: JsonParser<T>, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -728,6 +764,18 @@ export declare class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
+    options<T>(url: string, jsonParser: JsonParser<T>, options?: {
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
+        observe?: 'body';
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
+        reportProgress?: boolean;
+        responseType?: 'json';
+        withCredentials?: boolean;
+    }): Observable<T>;
     patch(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -897,6 +945,18 @@ export declare class HttpClient {
         withCredentials?: boolean;
     }): Observable<Object>;
     patch<T>(url: string, body: any | null, options?: {
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
+        observe?: 'body';
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
+        reportProgress?: boolean;
+        responseType?: 'json';
+        withCredentials?: boolean;
+    }): Observable<T>;
+    patch<T>(url: string, body: any | null, jsonParser: JsonParser<T>, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1088,6 +1148,18 @@ export declare class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
+    post<T>(url: string, body: any | null, jsonParser: JsonParser<T>, options?: {
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
+        observe?: 'body';
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
+        reportProgress?: boolean;
+        responseType?: 'json';
+        withCredentials?: boolean;
+    }): Observable<T>;
     put(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1253,6 +1325,18 @@ export declare class HttpClient {
         withCredentials?: boolean;
     }): Observable<Object>;
     put<T>(url: string, body: any | null, options?: {
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
+        observe?: 'body';
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
+        reportProgress?: boolean;
+        responseType?: 'json';
+        withCredentials?: boolean;
+    }): Observable<T>;
+    put<T>(url: string, body: any | null, jsonParser: JsonParser<T>, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1448,6 +1532,19 @@ export declare class HttpClient {
         withCredentials?: boolean;
     }): Observable<Object>;
     request<R>(method: string, url: string, options?: {
+        body?: any;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
+        observe?: 'body';
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
+        responseType?: 'json';
+        reportProgress?: boolean;
+        withCredentials?: boolean;
+    }): Observable<R>;
+    request<R>(method: string, url: string, jsonParser: JsonParser<R>, options?: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3097,
-        "main-es2015": 429200,
+        "main-es2015": 429572,
         "polyfills-es2015": 52195
       }
     }

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -212,7 +212,7 @@ export class HttpClient {
    * @param url     The endpoint URL.
    * @param options The HTTP options to send with the request.
    *
-   * @return An `Observable` of all `HttpEvents` for the reques,
+   * @return An `Observable` of all `HttpEvents` for the request,
    * with the response body of type string.
    */
   request(method: string, url: string, options: {
@@ -402,7 +402,7 @@ export class HttpClient {
    * @param url     The endpoint URL.
    * @param options The HTTP options to send with the request.
    *
-   * @return An `Observable` of the reuested response, wuth body of type `any`.
+   * @return An `Observable` of the requested response, with body of type `any`.
    */
   request(method: string, url: string, options?: {
     body?: any,
@@ -1326,7 +1326,7 @@ export class HttpClient {
    * @param options The HTTP options to send with the request.
    *
    * @return An `Observable` of the `HTTPResponse` for the request,
-   * with a responmse body of the requested type.
+   * with a response body of the requested type.
    */
   head<T>(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
@@ -1705,7 +1705,7 @@ export class HttpClient {
   /**
    * Constructs an `Observable` that, when subscribed, causes the configured
    * `OPTIONS` request to execute on the server. This method allows the client
-   * to determine the supported HTTP methods and other capabilites of an endpoint,
+   * to determine the supported HTTP methods and other capabilities of an endpoint,
    * without implying a resource action. See the individual overloads for
    * details on the return type.
    */
@@ -1782,7 +1782,7 @@ export class HttpClient {
    * @param body The resources to edit.
    * @param options HTTP options.
    *
-   * @return An `Observable` of all the `HTTPevents` for the request,
+   * @return An `Observable` of all the `HTTPEvents` for the request,
    * with the response body as an `ArrayBuffer`.
    */
 
@@ -1801,7 +1801,7 @@ export class HttpClient {
    * @param body The resources to edit.
    * @param options HTTP options.
    *
-   * @return An `Observable` of all the `HTTPevents` for the request, with the
+   * @return An `Observable` of all the `HTTPEvents` for the request, with the
    * response body as `Blob`.
    */
   patch(url: string, body: any|null, options: {
@@ -1819,7 +1819,7 @@ export class HttpClient {
    * @param body The resources to edit.
    * @param options HTTP options.
    *
-   * @return An `Observable` of all the `HTTPevents`for the request, with a
+   * @return An `Observable` of all the `HTTPEvents`for the request, with a
    * response body of type string.
    */
   patch(url: string, body: any|null, options: {
@@ -1837,7 +1837,7 @@ export class HttpClient {
    * @param body The resources to edit.
    * @param options HTTP options.
    *
-   * @return An `Observable` of all the `HTTPevents` for the request,
+   * @return An `Observable` of all the `HTTPEvents` for the request,
    * with a response body of type `Object`.
    */
   patch(url: string, body: any|null, options: {
@@ -1856,7 +1856,7 @@ export class HttpClient {
    * @param body The resources to edit.
    * @param options HTTP options.
    *
-   * @return An `Observable` of all the `HTTPevents` for the request,
+   * @return An `Observable` of all the `HTTPEvents` for the request,
    *  with a response body in the requested type.
    */
   patch<T>(url: string, body: any|null, options: {
@@ -2038,7 +2038,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The content to replace with.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the response, with the response body as a `Blob`.
    */
@@ -2056,7 +2056,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The content to replace with.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the response, with a response body of type string.
    */
@@ -2074,7 +2074,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The content to replace with.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of all `HttpEvents` for the request,
    * with the response body as an `ArrayBuffer`.
@@ -2092,7 +2092,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The content to replace with.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of all `HttpEvents` for the request, with the response body as `Blob`.
    */
@@ -2109,7 +2109,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The content to replace with.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return  An `Observable` of all `HttpEvents` for the request,
    * with a response body of type string.
@@ -2127,7 +2127,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The content to replace with.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return  An `Observable` of all `HttpEvents` for the request,
    * with a response body of type `Object`.
@@ -2146,7 +2146,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The content to replace with.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of all `HttpEvents` for the request,
    * with a response body in the requested type.
@@ -2161,11 +2161,11 @@ export class HttpClient {
 
   /**
    * Constructs a POST request that interprets the body as an `ArrayBuffer`
-   *  and returns the full `HTTPresponse`.
+   *  and returns the full `HTTPResponse`.
    *
    * @param url The endpoint URL.
    * @param body The content to replace with.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return  An `Observable` of the `HTTPResponse` for the request, with the response body as an
    *     `ArrayBuffer`.
@@ -2183,7 +2183,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The content to replace with.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the `HTTPResponse` for the request,
    * with the response body as a `Blob`.
@@ -2201,7 +2201,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The content to replace with.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return  An `Observable` of the `HTTPResponse` for the request,
    * with a response body of type string.
@@ -2219,7 +2219,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The content to replace with.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the `HTTPResponse` for the request, with a response body of type
    * `Object`.
@@ -2239,7 +2239,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The content to replace with.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the `HTTPResponse` for the request, with a response body in the
    *     requested type.
@@ -2258,7 +2258,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The content to replace with.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the response, with the response body as a JSON object.
    */
@@ -2277,7 +2277,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The content to replace with.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return  An `Observable` of the `HTTPResponse` for the request, with a response body in the
    *     requested type.
@@ -2314,7 +2314,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the response, with the response body as an `ArrayBuffer`.
    */
@@ -2332,7 +2332,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the response, with the response body as a `Blob`.
    */
@@ -2350,7 +2350,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the response, with a response body of type string.
    */
@@ -2368,7 +2368,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of all `HttpEvents` for the request,
    * with the response body as an `ArrayBuffer`.
@@ -2386,7 +2386,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of all `HttpEvents` for the request,
    * with the response body as a `Blob`.
@@ -2404,7 +2404,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of all HttpEvents for the request, with a response body
    * of type string.
@@ -2422,7 +2422,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of all `HttpEvents` for the request, with a response body of
    * type `Object`.
@@ -2441,7 +2441,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of all `HttpEvents` for the request,
    * with a response body in the requested type.
@@ -2458,7 +2458,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the `HTTPResponse` for the request, with the response body as an
    *     `ArrayBuffer`.
@@ -2476,7 +2476,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the `HTTPResponse` for the request,
    * with the response body as a `Blob`.
@@ -2494,7 +2494,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the `HTTPResponse` for the request, with a response body of type
    *     string.
@@ -2512,7 +2512,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the `HTTPResponse` for the request, with a response body
    * of type 'Object`.
@@ -2531,7 +2531,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the `HTTPResponse` for the request,
    * with a response body in the requested type.
@@ -2550,7 +2550,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the response, with the response body as a JSON object.
    */
@@ -2569,7 +2569,7 @@ export class HttpClient {
    *
    * @param url The endpoint URL.
    * @param body The resources to add/update.
-   * @param options HTTP options
+   * @param options HTTP options.
    *
    * @return An `Observable` of the `HTTPResponse` for the request, with a response body in the
    *     requested type.


### PR DESCRIPTION
This proposal aims to establish the fromJSON/toJSON standard and adapt the Http Client to use it to return class objects.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently, the Http Client provides the return types: string, ArrayBuffer, Blob and JSON objects typed with interfaces.

As an example, consider that we have an API endpoint that delivers the following JSON response and a class to manage this information:

```
 {
    "firstName": "John",
    "lastName": "Smith",
    "dateOfBirth": "2000-01-01"
 }
```

```
 class Person {
    firstName: string;
    lastName: string;
    dateOfBirth: Date;

    getFullName(): string {
        return this.firstName + ' ' + this.lastName;
    }
 }
```

In order to get a typed response, we can create the following interface and use a map to parse the response:

```
 interface PersonJson {
 	firstName: string;
	lastName: string;
	dateOfBirth: string;
 }

 function getPerson(): Observable<Person> {
    this.httpClient.get<PersonJson>('/person').pipe(map(personJson => {
        const person = new Person();
        person.firstName = personJson.firstName;
        person.lastName = personJson.lastName;
        person.dateOfBirth = new Date(personJson.dateOfBirth + ' 00:00:00');
    }));
 }
```

## What is the new behavior?

First, I would like to propose the standard of implementing the methods toJSON (standard JavaScript function) and fromJSON (static) in the Person class:

```
 class Person {
    firstName: string;
    lastName: string;
    dateOfBirth: Date;

    static fromJSON(obj: any): Person {
         const person = new Person();
         person.firstName = obj.firstName;
         person.lastName = obj.lastName;
         person.dateOfBirth = new Date(obj.dateOfBirth + ' 00:00:00');
         return person;
    }

    toJSON(): object {
        return {
            ...this,
            dateOfBirth: this.dateOfBirth.getFullYear().toString() + '-' +
                (this.dateOfBirth.getMonth() + 1).toString().padStart(2, '0') + '-' +
                this.dateOfBirth.getDate().toString().padStart(2, '0')
        };
    }

    getFullName(): string {
        return this.firstName + ' ' + this.lastName;
    }
 }
```

This way, with no modifications in the Http Client, the last code can be shortened to:

```
 getPerson(): Observable<Person> {
    return this.httpClient.get('/person').pipe(map(Person.fromJSON));
 }
```

But it could be even shorter/better if we adapt the Http Client to recognize this standard and accept as a parameter a class that implements the static method fromJSON. By doing this, the Http Client can use the fromJSON method to return parsed class objects instead of plain JSON objects. The proposed implementation results in the following code:

```
 getPerson(): Observable<Person> {
    return this.httpClient.get('/person', Person);
 }
```

Complementary, it is important to remark that the standard toJSON method is automatically used by the Http Client to parse Person objects to JSON objects when sending it in the body of PATCH/POST/PUT requests.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Support for array of objects is also added. Consider that in the above example the endpoint returns an array of Persons. In this case, it is only necessary to change the generic type of the get function to Person[]:

```
 function getPerson(): Observable<Person> {
    return this.httpClient.get<Person[]>('/person', Person);
 }
```

Additionally, a second commit was included to fix some typos and missing punctuation.
