### PR TITLE
docs(router): fix routerLink docs

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -173,8 +173,7 @@ export class RouterLink {
   }
 
   /**
-   * @param commands An array of commands to pass to {@link Router#createUrlTree
-   *     Router#createUrlTree}.
+   * Commands to pass to {@link Router#createUrlTree Router#createUrlTree}.
    *   - **array**: commands to pass to {@link Router#createUrlTree Router#createUrlTree}.
    *   - **string**: shorthand for array of commands with just the string, i.e. `['/route']`
    *   - **null|undefined**: shorthand for an empty array of commands, i.e. `[]`
@@ -306,8 +305,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   }
 
   /**
-   * @param commands An array of commands to pass to {@link Router#createUrlTree
-   *     Router#createUrlTree}.
+   * Commands to pass to {@link Router#createUrlTree Router#createUrlTree}.
    *   - **array**: commands to pass to {@link Router#createUrlTree Router#createUrlTree}.
    *   - **string**: shorthand for array of commands with just the string, i.e. `['/route']`
    *   - **null|undefined**: shorthand for an empty array of commands, i.e. `[]`


### PR DESCRIPTION
The current content for the routerLink commands input does not make it to aio.
fixes #35414
