### PR TITLE
fix(compiler-cli): match wrapHost parameter types within plugin interface

### DIFF
--- a/packages/compiler-cli/src/ngtsc/tsc_plugin.ts
+++ b/packages/compiler-cli/src/ngtsc/tsc_plugin.ts
@@ -79,7 +79,7 @@ export class NgTscPlugin implements TscPlugin {
   }
 
   wrapHost(
-      host: ts.CompilerHost&UnifiedModulesHost, inputFiles: readonly string[],
+      host: ts.CompilerHost&Partial<UnifiedModulesHost>, inputFiles: readonly string[],
       options: ts.CompilerOptions): PluginCompilerHost {
     // TODO(alxhub): Eventually the `wrapHost()` API will accept the old `ts.Program` (if one is
     // available). When it does, its `ts.SourceFile`s need to be re-tagged to enable proper


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The `TscPlugin` interface using a type of `ts.CompilerHost&Partial<UnifiedModulesHost>` for the `host` parameter of the `wrapHost` method.  However, prior to this change, the interface implementing `NgTscPlugin` class used a type of `ts.CompilerHost&UnifiedModulesHost` for the parameter.  

## What is the new behavior?
This change corrects the inconsistency and allows `UnifiedModulesHost` members to be optional when using the `NgtscPlugin`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
