### PR TITLE
docs: edit intro testing page

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -633,6 +633,7 @@ groups:
           'aio/content/guide/testing-code-coverage.md',
           'aio/content/guide/testing-components-basics.md',
           'aio/content/guide/testing-components-scenarios.md',
+          'aio/content/guide/continuous-integration.md',
           'aio/content/guide/testing-pipes.md',
           'aio/content/guide/testing-services.md',
           'aio/content/guide/testing-utility-apis.md',

--- a/aio/content/guide/continuous-integration.md
+++ b/aio/content/guide/continuous-integration.md
@@ -1,0 +1,142 @@
+# Setting up continuous integration
+
+Continuous integration (CI) services run your project's tests on every commit and change request, which helps minimize bugs in your project.
+
+You can select one of several CI services.
+Popular choices for GitHub users include CircleCI and Travis CI, which are paid services that offer a free option for open source projects.
+You can also host your own CI using services such as Jenkins.
+
+The following sections show you how to configure your project to run Circle CI and Travis CI, as well as update your test configuration to run tests in the Chrome browser.
+
+## Configuring Circle CI
+
+1. Create a folder called `.circleci` at the project root.
+
+1. In the new folder, create a file called `config.yml` with the following content:
+
+  ```
+  version: 2
+  jobs:
+    build:
+      working_directory: ~/my-project
+      docker:
+        - image: circleci/node:10-browsers
+      steps:
+        - checkout
+        - restore_cache:
+            key: my-project-{{ .Branch }}-{{ checksum "package-lock.json" }}
+        - run: npm install
+        - save_cache:
+            key: my-project-{{ .Branch }}-{{ checksum "package-lock.json" }}
+            paths:
+              - "node_modules"
+        - run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+        - run: npm run e2e -- --protractor-config=e2e/protractor-ci.conf.js
+  ```
+
+  This configuration caches `node_modules/` and uses [`npm run`](https://docs.npmjs.com/cli/run-script) to run CLI commands, because `@angular/cli` is not installed globally.
+  These commands use the double dash (`--`) to pass arguments into the `npm` script.
+
+1. Commit your changes and push them to your repository on GitHub.
+
+1. [Sign up for Circle CI](https://circleci.com/docs/2.0/first-steps/#section=getting-started) and add your project.
+Your project should start building.
+
+For more information, see the [Circle CI documentation](https://circleci.com/docs/2.0/).
+
+## Configuring Travis CI
+
+Travis CI automatically builds and tests the changes you make to your code and lets you know if those changes are successful.
+
+1. Create a file called `.travis.yml` at the project root, with the following content:
+
+  ```
+  dist: trusty
+  sudo: false
+
+  language: node_js
+  node_js:
+    - "10"
+
+  addons:
+    apt:
+      sources:
+        - google-chrome
+      packages:
+        - google-chrome-stable
+
+  cache:
+    directories:
+       - ./node_modules
+
+  install:
+    - npm install
+
+  script:
+    - npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+    - npm run e2e -- --protractor-config=e2e/protractor-ci.conf.js
+  ```
+
+1. Commit your changes and push them to your repository.
+
+1. [Sign up for Travis CI](https://travis-ci.org) and [add your project](https://travis-ci.org/getting_started).
+To trigger a build, push a new commit or use the Travis dashboard UI.
+
+For more information about Travis CI testing, see the [Travis CI documentation](https://docs.travis-ci.com/).
+
+## Configuring the CLI for CI testing in Chrome
+
+You can  adjust your configuration to run the Chrome browser tests when running the Angular CLI commands `ng test` and `ng e2e`.
+
+
+An Angular project typically contains configuration files for both unit tests (with the [Karma test runner](https://karma-runner.github.io/latest/config/configuration-file.html)) and end-to-end tests (with [Protractor](https://www.protractortest.org/#/api-overview)).
+You can control the browser in which your tests run by modifying these files as below. These configurations include the `--headless` flag to run Chrome without bringing up the browser's full user interface.
+
+These examples also use the `--no-sandbox` flag, which
+[disables Chrome's sandboxing feature](https://developers.google.com/web/tools/puppeteer/troubleshooting#setting_up_chrome_linux_sandbox). This flag should only be used when testing code that you *completely trust*.
+The setup to run headless Chrome with sandboxing enabled will vary based
+on your CI environment.
+
+These examples use [Headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome#cli).
+
+1. In the Karma configuration file, `karma.conf.js`, add a custom launcher called ChromeHeadlessCI below browsers:
+
+  ```
+  browsers: ['Chrome'],
+  customLaunchers: {
+    ChromeHeadlessCI: {
+      base: 'ChromeHeadless',
+      flags: ['--no-sandbox']
+    }
+  },
+  ```
+
+1. In the root folder of your e2e tests project, create a new file named `protractor-ci.conf.js`. This new file extends the original `protractor.conf.js`.
+
+  ```
+  const config = require('./protractor.conf').config;
+
+  config.capabilities = {
+    browserName: 'chrome',
+    chromeOptions: {
+      args: ['--headless', '--no-sandbox']
+    }
+  };
+
+  exports.config = config;
+  ```
+
+Now you can run the following commands to use the `--no-sandbox` flag:
+
+<code-example language="sh" class="code-shell">
+  ng test --no-watch --no-progress --browsers=ChromeHeadlessCI
+  ng e2e --protractor-config=e2e/protractor-ci.conf.js
+</code-example>
+
+<div class="alert is-helpful">
+
+   **Note:** If you're using Windows, you may want to include the `--disable-gpu` flag. See [crbug.com/737678](https://crbug.com/737678) for more information.
+
+</div>
+
+

--- a/aio/content/guide/test-debugging.md
+++ b/aio/content/guide/test-debugging.md
@@ -13,7 +13,7 @@ If your tests aren't working as you expect them to, you can inspect and debug th
 
 Debug specs in the browser in the same way that you debug an application.
 
-1. Reveal the Karma browser window. See [Set up testing](guide/testing#set-up-testing) if you need help with this step.
+1. Reveal the Karma browser window. See [Testing your application](guide/testing) if you need help with this step.
 1. Click the **DEBUG** button; it opens a new browser tab and re-runs the tests.
 1. Open the browser's “Developer Tools” (`Ctrl-Shift-I` on Windows; `Command-Option-I` in macOS).
 1. Pick the "sources" section.

--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -1,49 +1,16 @@
-{@a top}
-
-# Testing
-
-Testing your Angular application helps you check that your app is working as you expect.
-
-## Prerequisites
-
-Before writing tests for your Angular app, you should have a basic understanding of the following concepts:
-
-* Angular fundamentals
-* JavaScript
-* HTML
-* CSS
-* [Angular CLI](/cli)
-
-<hr>
-
-The testing documentation offers tips and techniques for unit and integration testing Angular applications through a sample application created with the [Angular CLI](cli).
-This sample application is much like the one in the [_Tour of Heroes_ tutorial](tutorial).
-
-<div class="alert is-helpful">
-
-  For the sample app that the testing guides describe, see the <live-example noDownload>sample app</live-example>.
-
-  For the tests features in the testing guides, see <live-example stackblitz="specs" noDownload>tests</live-example>.
-
-</div>
-
-{@a setup}
-
-## Set up testing
+# Testing your application
 
 The Angular CLI downloads and installs everything you need to test an Angular application with the [Jasmine test framework](https://jasmine.github.io/).
 
-The project you create with the CLI is immediately ready to test.
-Just run the [`ng test`](cli/test) CLI command:
+To test an Angular CLI project, run the [`ng test`](cli/test) command:
 
 <code-example language="sh" class="code-shell">
   ng test
 </code-example>
 
-The `ng test` command builds the app in _watch mode_,
-and launches the [Karma test runner](https://karma-runner.github.io).
+The `ng test` command builds the app in watch mode and launches the [Karma test runner](https://karma-runner.github.io).
 
-The console output looks a bit like this:
+The console output is similar to the following:
 
 <code-example language="sh" class="code-shell">
 10% building modules 1/1 modules 0 active
@@ -54,240 +21,64 @@ The console output looks a bit like this:
 Chrome ...: Executed 3 of 3 SUCCESS (0.135 secs / 0.205 secs)
 </code-example>
 
-The last line of the log is the most important.
-It shows that Karma ran three tests that all passed.
+The last line of the log shows that Karma ran three tests that your app passed each one.
 
-A Chrome browser also opens and displays the test output in the "Jasmine HTML Reporter" like this.
+A Chrome browser also opens and displays the test output in the "Jasmine HTML Reporter" as in the following image.
 
 <div class="lightbox">
   <img src='generated/images/guide/testing/initial-jasmine-html-reporter.png' alt="Jasmine HTML Reporter in the browser">
 </div>
 
-Most people find this browser output easier to read than the console log.
-You can click on a test row to re-run just that test or click on a description to re-run the tests in the selected test group ("test suite").
+You can click on a test row to re-run that individual test.
+You can also click on a description to re-run the tests in that test group, or "test suite".
 
-Meanwhile, the `ng test` command is watching for changes.
+The `ng test` command watches for changes.
+This means that when you make a change and save, the tests run again, the browser refreshes, and the new test results appear.
 
-To see this in action, make a small change to `app.component.ts` and save.
-The tests run again, the browser refreshes, and the new test results appear.
+## Editing the testing configuration
 
-## Configuration
-
-The CLI takes care of Jasmine and Karma configuration for you.
-
-You can fine-tune many options by editing the `karma.conf.js` and
-the `test.ts` files in the `src/` folder.
+The CLI sets up a default testing configuration for Jasmine and Karma.
+You can edit many testing options by editing the `karma.conf.js` and the `test.ts` files in the `src/` folder.
 
 The `karma.conf.js` file is a partial Karma configuration file.
-The CLI constructs the full runtime configuration in memory, based on application structure specified in the `angular.json` file, supplemented by `karma.conf.js`.
+The CLI constructs the full runtime configuration in memory, based on the application structure as described by the `angular.json` and `karma.conf.js` configuration files.
 
-Search the web for more details about Jasmine and Karma configuration.
+<div class="callout is-helpful">
 
-### Other test frameworks
+<header>Using other test frameworks</header>
 
-You can also unit test an Angular app with other testing libraries and test runners.
-Each library and runner has its own distinctive installation procedures, configuration, and syntax.
-
-Search the web to learn more.
-
-### Test file name and location
-
-Look inside the `src/app` folder.
-
-The CLI generated a test file for the `AppComponent` named `app.component.spec.ts`.
-
-<div class="alert is-important">
-
-The test file extension **must be `.spec.ts`** so that tooling can identify it as a file with tests (AKA, a _spec_ file).
+By default, Angular CLI uses the Jasmine test framework and the Karma test runner.
+While this guide only covers this default setup, you can change your project to use other test frameworks and test runners.
 
 </div>
 
-The `app.component.ts` and `app.component.spec.ts` files are siblings in the same folder.
-The root file names (`app.component`) are the same for both files.
+{@a test-name-location}
 
-Adopt these two conventions in your own projects for _every kind_ of test file.
+## Finding test files
 
-{@a q-spec-file-location}
+The CLI includes test files when it generates a new Angular application.
+The testing framework identifies test files, or "spec" files, by the extension `spec.ts`.
+By convention, the spec files for each component are in the same directory as that component.
 
-#### Place your spec file next to the file it tests
+For example, the CLI gives the `app.component` spec file the extension `.spec.ts` and places this `app.component.spec.ts` in the `src/app` folder with the `AppComponent`.
 
-It's a good idea to put unit test spec files in the same folder
-as the application source code files that they test:
+The component definition file is `app.component.ts`, and the corresponding test file is `app.component.spec.ts`.
 
-- Such tests are easy to find.
-- You see at a glance if a part of your application lacks tests.
-- Nearby tests can reveal how a part works in context.
-- When you move the source (inevitable), you remember to move the test.
-- When you rename the source file (inevitable), you remember to rename the test file.
-
-{@a q-specs-in-test-folder}
-
-#### Place your spec files in a test folder
-
-Application integration specs can test the interactions of multiple parts
-spread across folders and modules.
-They don't really belong to any part in particular, so they don't have a
-natural home next to any one file.
-
-It's often better to create an appropriate folder for them in the `tests` directory.
-
-Of course specs that test the test helpers belong in the `test` folder,
-next to their corresponding helper files.
-
-
-{@a ci}
-
-## Set up continuous integration
-
-One of the best ways to keep your project bug-free is through a test suite, but it's easy to forget to run tests all the time.
-Continuous integration (CI) servers let you set up your project repository so that your tests run on every commit and pull request.
-
-There are paid CI services like Circle CI and Travis CI, and you can also host your own for free using Jenkins and others.
-Although Circle CI and Travis CI are paid services, they are provided free for open source projects.
-You can create a public project on GitHub and add these services without paying.
-Contributions to the Angular repo are automatically run through a whole suite of Circle CI tests.
-
-This article explains how to configure your project to run Circle CI and Travis CI, and also update your test configuration to be able to run tests in the Chrome browser in either environment.
-
-
-### Configure project for Circle CI
-
-Step 1: Create a folder called `.circleci` at the project root.
-
-Step 2: In the new folder, create a file called `config.yml` with the following content:
-
-```
-version: 2
-jobs:
-  build:
-    working_directory: ~/my-project
-    docker:
-      - image: circleci/node:10-browsers
-    steps:
-      - checkout
-      - restore_cache:
-          key: my-project-{{ .Branch }}-{{ checksum "package-lock.json" }}
-      - run: npm install
-      - save_cache:
-          key: my-project-{{ .Branch }}-{{ checksum "package-lock.json" }}
-          paths:
-            - "node_modules"
-      - run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
-      - run: npm run e2e -- --protractor-config=e2e/protractor-ci.conf.js
-```
-
-This configuration caches `node_modules/` and uses [`npm run`](https://docs.npmjs.com/cli/run-script) to run CLI commands, because `@angular/cli` is not installed globally.
-The double dash (`--`) is needed to pass arguments into the `npm` script.
-
-Step 3: Commit your changes and push them to your repository.
-
-Step 4: [Sign up for Circle CI](https://circleci.com/docs/2.0/first-steps/) and [add your project](https://circleci.com/add-projects).
-Your project should start building.
-
-* Learn more about Circle CI from [Circle CI documentation](https://circleci.com/docs/2.0/).
-
-### Configure project for Travis CI
-
-Step 1: Create a file called `.travis.yml` at the project root, with the following content:
-
-```
-dist: trusty
-sudo: false
-
-language: node_js
-node_js:
-  - "10"
-
-addons:
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable
-
-cache:
-  directories:
-     - ./node_modules
-
-install:
-  - npm install
-
-script:
-  - npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
-  - npm run e2e -- --protractor-config=e2e/protractor-ci.conf.js
-```
-
-This does the same things as the Circle CI configuration, except that Travis doesn't come with Chrome, so we use Chromium instead.
-
-Step 2: Commit your changes and push them to your repository.
-
-Step 3: [Sign up for Travis CI](https://travis-ci.org/auth) and [add your project](https://travis-ci.org/profile).
-You'll need to push a new commit to trigger a build.
-
-* Learn more about Travis CI testing from [Travis CI documentation](https://docs.travis-ci.com/).
-
-### Configure CLI for CI testing in Chrome
-
-When the CLI commands `ng test` and `ng e2e` are generally running the CI tests in your environment, you might still need to adjust your configuration to run the Chrome browser tests.
-
-There are configuration files for both the [Karma JavaScript test runner](https://karma-runner.github.io/latest/config/configuration-file.html)
-and [Protractor](https://www.protractortest.org/#/api-overview) end-to-end testing tool,
-which you must adjust to start Chrome without sandboxing.
-
-We'll be using [Headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome#cli) in these examples.
-
-* In the Karma configuration file, `karma.conf.js`, add a custom launcher called ChromeHeadlessCI below browsers:
-```
-browsers: ['Chrome'],
-customLaunchers: {
-  ChromeHeadlessCI: {
-    base: 'ChromeHeadless',
-    flags: ['--no-sandbox']
-  }
-},
-```
-
-* In the root folder of your e2e tests project, create a new file named `protractor-ci.conf.js`. This new file extends the original `protractor.conf.js`.
-```
-const config = require('./protractor.conf').config;
-
-config.capabilities = {
-  browserName: 'chrome',
-  chromeOptions: {
-    args: ['--headless', '--no-sandbox']
-  }
-};
-
-exports.config = config;
-```
-
-Now you can run the following commands to use the `--no-sandbox` flag:
-
-<code-example language="sh" class="code-shell">
-  ng test --no-watch --no-progress --browsers=ChromeHeadlessCI
-  ng e2e --protractor-config=e2e/protractor-ci.conf.js
-</code-example>
-
-<div class="alert is-helpful">
-
-   **Note:** Right now, you'll also want to include the `--disable-gpu` flag if you're running on Windows. See [crbug.com/737678](https://crbug.com/737678).
-
-</div>
-
+The testing framework does not require that a test be in the same directory as its corresponding component.
+However, this convention makes tests easy to find, helps reveal how a component works in context, and reminds you to include the tests when moving or renaming parts of your application.
 
 <hr />
 
-## More info on testing
+## What's next
 
-After you've set up your app for testing, you may find the following testing  guides useful.
+For more on testing, you may find the following testing guides helpful.
 
-* [Code coverage](guide/testing-code-coverage)&mdash;find out how much of your app your tests are covering and how to specify required amounts.
-* [Testing services](guide/testing-services)&mdash;learn how to test the services your app uses.
 * [Basics of testing components](guide/testing-components-basics)&mdash;discover the basics of testing Angular components.
 * [Component testing scenarios](guide/testing-components-scenarios)&mdash;read about the various kinds of component testing scenarios and use cases.
 * [Testing attribute directives](guide/testing-attribute-directives)&mdash;learn about how to test your attribute directives.
 * [Testing pipes](guide/testing-pipes)&mdash;find out how to test attribute directives.
+* [Testing services](guide/testing-services)&mdash;learn how to test the services your app uses.
 * [Debugging tests](guide/testing-attribute-directives)&mdash;uncover common testing bugs.
+* [Code coverage](guide/testing-code-coverage)&mdash;find out how much of your app your tests are covering and how to specify required amounts.
 * [Testing utility APIs](guide/testing-utility-apis)&mdash;get familiar with Angular testing features.
-
-
+* [Setting up continuous integration tutorial](guide/continuous-integration)&mdash;see how to set up Circle CI, Travis CI, and how to configure the Angular CLI for for CI testing in Chrome.

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -616,18 +616,8 @@
           "children": [
             {
               "url": "guide/testing",
-              "title": "Intro to Testing",
+              "title": "Testing your application",
               "tooltip": "Introduction to testing an Angular app."
-            },
-            {
-              "url": "guide/testing-code-coverage",
-              "title": "Code Coverage",
-              "tooltip": "Determine how much of your code is tested."
-            },
-            {
-              "url": "guide/testing-services",
-              "title": "Testing Services",
-              "tooltip": "How to test services."
             },
             {
               "url": "guide/testing-components-basics",
@@ -650,9 +640,19 @@
               "tooltip": "Writing tests for pipes."
             },
             {
+              "url": "guide/testing-services",
+              "title": "Testing Services",
+              "tooltip": "How to test services."
+            },
+            {
               "url": "guide/test-debugging",
               "title": "Debugging Tests",
               "tooltip": "How to debug tests."
+            },
+            {
+              "url": "guide/testing-code-coverage",
+              "title": "Code Coverage",
+              "tooltip": "Determine how much of your code is tested."
             },
             {
               "url": "guide/testing-utility-apis",
@@ -803,6 +803,11 @@
           "url": "guide/forms",
           "title": "Building a Template-driven Form",
           "tooltip": "Create a template-driven form using directives and Angular template syntax."
+        },
+        {
+          "url": "guide/continuous-integration",
+          "title": "Setting up Continuous Integration",
+          "tooltip": "Configure continuous integration in your app."
         }
       ]
     },


### PR DESCRIPTION
This commit edits the copy of the introductory page to the testing section. This includes moving the CI
sections into the Tutorials. It removes colloquialisms and brings document in line with Google styleguide in intro and CI sections.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently text isn't completely inline with Google style guide.
 
Issue Number: N/A


## What is the new behavior?

Updates to style guide styles.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
