### PR TITLE
fix(common): do not round up fractions of a millisecond in `DatePipe` 

### DIFF
--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -734,7 +734,10 @@ export function isoStringToDate(match: RegExpMatchArray): Date {
   const h = Number(match[4] || 0) - tzHour;
   const m = Number(match[5] || 0) - tzMin;
   const s = Number(match[6] || 0);
-  const ms = Math.round(parseFloat('0.' + (match[7] || 0)) * 1000);
+  // The ECMAScript specification (https://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.11)
+  // defines that `DateTime` milliseconds should always be rounded down, so that `999.9ms`
+  // becomes `999ms`.
+  const ms = Math.floor(parseFloat('0.' + (match[7] || 0)) * 1000);
   timeSetter.call(date, h, m, s, ms);
   return date;
 }

--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -85,6 +85,13 @@ import {JitReflector} from '@angular/platform-browser-dynamic/src/compiler_refle
            expect(pipe.transform('2012-12-30T00:00:00', 'w')).toEqual('1');
            expect(pipe.transform('2012-12-31T00:00:00', 'w')).toEqual('1');
          });
+
+
+      it('should round milliseconds down to the nearest millisecond', () => {
+        expect(pipe.transform('2020-08-01T23:59:59.999', 'yyyy-MM-dd')).toEqual('2020-08-01');
+        expect(pipe.transform('2020-08-01T23:59:59.9999', 'yyyy-MM-dd, h:mm:ss SSS'))
+            .toEqual('2020-08-01, 11:59:59 999');
+      });
     });
   });
 }


### PR DESCRIPTION
Date pipe rounds up milliseconds when passed fractional dates.
ECMAScript spec defines that non-integer values passed for any of the parameters to
new Date(year, month, date, hours, minutes, seconds, ms)
should call floor() to remove the fractional part.

BREAKING CHANGE:  Some people may rely on the rounding functionality of date pipe
Fixes #37989

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Date pipe rounds fractional part of seconds

Issue Number: #37989 


## What is the new behavior?
Datepipe floors fractional seconds


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
