### PR TITLE
docs: add dayjs date adapter to resources page

### DIFF
--- a/aio/content/marketing/resources.json
+++ b/aio/content/marketing/resources.json
@@ -429,6 +429,12 @@
             "desc": "Jigsaw provides a set of web components based on Angular. It is supporting the development of all applications of Big Data Product of ZTE (https://www.zte.com.cn).",
             "title": "Awade Jigsaw (Chinese)",
             "url": "https://jigsaw-zte.gitee.io"
+          },
+          "material-dayjs-adapter": {
+            "desc": "A DayJS implementation of @angular/material's DateAdapter that results in smaller bundle sizes than its MomentJS counterpart.",
+            "rev": true,
+            "title": "material-dayjs-adapter",
+            "url": "https://www.npmjs.com/package/@tabuckner/material-dayjs-adapter"
           }
         }
       }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Angular Material's documentation suggests usage of a MomentJS implementation of the DateAdapter. Moment adds a lot of overhead in regards to Locales, whereas Day.js allows users to pick the locales they wish to include. 

An earlier PR suggested adding the [mat-dayjs-adapter](https://www.npmjs.com/package/@tabuckner/material-dayjs-adapter) package to the docs as an alternative for smaller bundles with ISO string support. However, it was suggested to add them to AIO instead.

Issue Number: https://github.com/angular/components/issues/18337


## What is the new behavior?
The alternative DateAdapter implementation would be included here.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Shifting this PR over to the angular.io site in response to a [comment](https://github.com/angular/components/pull/18354#issuecomment-580902582) on https://github.com/angular/components/pull/18354. 
