### PR TITLE
docs(router): Fix typo in https://angular.io/guide/router#activated-route

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -133,7 +133,7 @@ The order of routes is important because the `Router` uses a first-match wins st
 List routes with a static path first, followed by an empty path route, which matches the default route.
 The [wildcard route](guide/router#setting-up-wildcard-routes) comes last because it matches every URL and the `Router`  selects it only if no other routes match first.
 
-{@a activated-route}
+{@a getting-route-information}
 
 ## Getting route information
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In angular.io, it linked to the wrong part of the page. https://angular.io/guide/router#activated-route

Issue Number: N/A


## What is the new behavior?
It should now link to the right header.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
