### PR TITLE
docs: fix live examples in testing guides

### DIFF
--- a/aio/content/guide/test-debugging.md
+++ b/aio/content/guide/test-debugging.md
@@ -4,9 +4,9 @@ If your tests aren't working as you expect them to, you can inspect and debug th
 
 <div class="alert is-helpful">
 
-  For the sample app that the testing guides describe, see the <live-example embedded-style noDownload>sample app</live-example>.
+  For the sample app that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
 
-  For the tests features in the testing guides, see <live-example stackblitz="specs" noDownload>tests</live-example>.
+  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-attribute-directives.md
+++ b/aio/content/guide/testing-attribute-directives.md
@@ -8,9 +8,9 @@ Its name reflects the way the directive is applied: as an attribute on a host el
 
 <div class="alert is-helpful">
 
-  For the sample app that the testing guides describe, see the <live-example embedded-style noDownload>sample app</live-example>.
+  For the sample app that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
 
-  For the tests features in the testing guides, see <live-example stackblitz="specs" noDownload>tests</live-example>.
+  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-code-coverage.md
+++ b/aio/content/guide/testing-code-coverage.md
@@ -7,9 +7,9 @@ Code coverage reports show you any parts of your code base that may not be prope
 
 <div class="alert is-helpful">
 
-  For the sample app that the testing guides describe, see the <live-example embedded-style noDownload>sample app</live-example>.
+  For the sample app that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
 
-  For the tests features in the testing guides, see <live-example stackblitz="specs" noDownload>tests</live-example>.
+  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-components-basics.md
+++ b/aio/content/guide/testing-components-basics.md
@@ -15,9 +15,9 @@ can validate much of the component's behavior in an easier, more obvious way.
 
 <div class="alert is-helpful">
 
-  For the sample app that the testing guides describe, see the <live-example embedded-style noDownload>sample app</live-example>.
+  For the sample app that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
 
-  For the tests features in the testing guides, see <live-example stackblitz="specs" noDownload>tests</live-example>.
+  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-components-scenarios.md
+++ b/aio/content/guide/testing-components-scenarios.md
@@ -4,9 +4,9 @@ This guide explores common component testing use cases.
 
 <div class="alert is-helpful">
 
-  For the sample app that the testing guides describe, see the <live-example embedded-style noDownload>sample app</live-example>.
+  For the sample app that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
 
-  For the tests features in the testing guides, see <live-example stackblitz="specs" noDownload>tests</live-example>.
+  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-pipes.md
+++ b/aio/content/guide/testing-pipes.md
@@ -4,9 +4,9 @@ You can test [pipes](guide/pipes) without the Angular testing utilities.
 
 <div class="alert is-helpful">
 
-  For the sample app that the testing guides describe, see the <live-example embedded-style noDownload>sample app</live-example>.
+  For the sample app that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
 
-  For the tests features in the testing guides, see <live-example stackblitz="specs" noDownload>tests</live-example>.
+  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-services.md
+++ b/aio/content/guide/testing-services.md
@@ -5,9 +5,9 @@ To check that your services are working as you intend, you can write tests speci
 
 <div class="alert is-helpful">
 
-  For the sample app that the testing guides describe, see the <live-example embedded-style noDownload>sample app</live-example>.
+  For the sample app that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
 
-  For the tests features in the testing guides, see <live-example stackblitz="specs" noDownload>tests</live-example>.
+  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -21,7 +21,7 @@ This sample application is much like the one in the [_Tour of Heroes_ tutorial](
 
 <div class="alert is-helpful">
 
-  For the sample app that the testing guides describe, see the <live-example embedded-style noDownload>sample app</live-example>.
+  For the sample app that the testing guides describe, see the <live-example noDownload>sample app</live-example>.
 
   For the tests features in the testing guides, see <live-example stackblitz="specs" noDownload>tests</live-example>.
 


### PR DESCRIPTION
In #37957, parts of the testing guide were broken out into separate guides. As part of that work, the `<live-example>` tags were also copied to the new guides. These `<live-example>` tags did not specify the targeted example project via the `name` attribute, thus they were implicitly targeting the example with the same name as the guide they were in. See the [Docs style guide][1] for more info.

However, there is only one example project (`testing/`) and all `<live-example>` tags were supposed to target that. This worked fine on the `testing.md` guide, but it broke on other guides (which tried to target non-existing example projects based on their names).

This commit fixes it by explicitly specifying which example is targeted by the `<live-example>` tags. It also removes the `embedded-style` attribute that has no effect.

Fixes #38036.

[1]: https://angular.io/guide/docs-style-guide#live-examples
