### PR TITLE
fix(docs-infra): correctly display SVG icons in IE11

### DIFF
--- a/aio/src/app/shared/custom-icon-registry.ts
+++ b/aio/src/app/shared/custom-icon-registry.ts
@@ -57,10 +57,12 @@ export class CustomIconRegistry extends MatIconRegistry {
   }
 
   private loadSvgElements(svgIcons: SvgIconInfo[]) {
-    const div = document.createElement('DIV');
     svgIcons.forEach(icon => {
       const ns = icon.namespace || DEFAULT_NS;
       const nsIconMap = this.preloadedSvgElements[ns] || (this.preloadedSvgElements[ns] = {});
+
+      // Creating a new `<div>` per icon is necessary for the SVGs to work correctly in IE11.
+      const div = document.createElement('DIV');
 
       // SECURITY: the source for the SVG icons is provided in code by trusted developers
       div.innerHTML = icon.svgSource;

--- a/aio/src/styles/1-layouts/_top-menu.scss
+++ b/aio/src/styles/1-layouts/_top-menu.scss
@@ -244,6 +244,7 @@ aio-search-box.search-container {
   .toolbar-external-icons-container {
     display: flex;
     flex-direction: row;
+    flex-shrink: 0; // This is required for the icons to be displayed correctly in IE11.
     height: 100%;
 
     a {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

Issue Number: https://github.com/angular/angular/issues/37847


## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


## Other information

This PR fixes the issue of hidden icons in IE11

The issue was that there was not enough spacing for the icons-container in IE.

Added right container to the header toolbar to contain the search bar + icons container
 added `flew-grow:1` to search input to take the empty space.

This also fixes that in mobile the icons is truncated in all browsers when width is `320px` (small screen) 
![image](https://user-images.githubusercontent.com/15147809/87434068-b228d780-c5f2-11ea-9f71-3e52691be157.png)


There is still an issue that the Github svg is not shown in IE, its because the svg of gitHub itself somehow can't be rendered by IE.

This is how it looks like now in IE:
![image](https://user-images.githubusercontent.com/15147809/87440441-a6411380-c5fa-11ea-8286-c3b41fab0082.png)
 There is space for gitHub svg but its not rendered
I would be glad if someone can provide updated Github svg