### PR TITLE
feat(compiler-cli): support getting resource dependencies for a source file

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -163,6 +163,17 @@ export class NgCompiler {
   }
 
   /**
+   * Get the resource dependencies of a file.
+   *
+   * If the file is not part of the compilation, an empty array will be returned.
+   */
+  getResourceDependencies(file: ts.SourceFile): string[] {
+    this.ensureAnalyzed();
+
+    return this.incrementalDriver.depGraph.getResourceDependencies(file);
+  }
+
+  /**
    * Get all Angular-related diagnostics for this compilation.
    *
    * If a `ts.SourceFile` is passed, only diagnostics related to that file are returned.

--- a/packages/compiler-cli/src/ngtsc/incremental/src/dependency_tracking.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/src/dependency_tracking.ts
@@ -53,6 +53,12 @@ export class FileDependencyGraph<T extends {fileName: string} = ts.SourceFile> i
     }
   }
 
+  getResourceDependencies(from: T): AbsoluteFsPath[] {
+    const node = this.nodes.get(from);
+
+    return node ? [...node.usesResources] : [];
+  }
+
   isStale(sf: T, changedTsPaths: Set<string>, changedResources: Set<AbsoluteFsPath>): boolean {
     return isLogicallyChanged(sf, this.nodeFor(sf), changedTsPaths, EMPTY_SET, changedResources);
   }


### PR DESCRIPTION
The compiler maintains an internal dependency graph of all resource
dependencies for application source files. This information can be useful
for tools that integrate the compiler and need to support file watching.
This change adds a `getResourceDependencies` method to the
`NgCompiler` class that allows compiler integrations to access resource
dependencies of files within the compilation.

This will be used within the CLI's webpack plugin to optimize the dependency discovery process.
Currently within the CLI, the AST for each source file is manually analyzed for directive metadata which results in a large amount of duplication with the compiler that needs to be kept synchronized with the internals of the AOT compiler.