### PR TITLE
refactor(dev-infra): allow use-case and confusing types to be marked as triaged

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -156,11 +156,9 @@ triage:
       - "comp: *"
     -
       - "type: confusing"
-      - "freq*"
       - "comp: *"
     -
       - "type: use-case"
-      - "freq*"
       - "comp: *"
 
 # options for the triage PR plugin

--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -154,6 +154,14 @@ triage:
     -
       - "type: RFC / Discussion / question"
       - "comp: *"
+    -
+      - "type: confusing"
+      - "freq*"
+      - "comp: *"
+    -
+      - "type: use-case"
+      - "freq*"
+      - "comp: *"
 
 # options for the triage PR plugin
 triagePR:

--- a/docs/TRIAGE_AND_LABELS.md
+++ b/docs/TRIAGE_AND_LABELS.md
@@ -62,6 +62,8 @@ What kind of problem is this?
 * `type: feature`
 * `type: performance`
 * `type: refactor`
+* `type: use-case`
+* `type: confusing`
 
 
 ## Caretaker Triage Process (Primary Triage)
@@ -83,8 +85,8 @@ Once the primary triage is done, the ng-bot automatically adds the milestone `ne
 The component owner is responsible for assigning one of the labels from each of these categories to the issues that have the milestone `needsTriage`:
 
 - `type: *`
-- `frequency: *`
-- `severity: *`
+- `frequency: *` (only required for `type: bug/fix`)
+- `severity: *` (only required for `type: bug/fix`)
 
 We've adopted the issue categorization based on [user pain](http://www.lostgarden.com/2008/05/improving-bug-triage-with-user-pain.html) used by AngularJS. In this system every issue is assigned frequency and severity based on which the total user pain score is calculated.
 


### PR DESCRIPTION
Some issue reports don't really fall into any of the current buckets that count
towards triage level 2: bug/fix, feature, or refactor. Some reports are:
* working as intended but confusing - the labels might be 'type: confusing', 'comp: docs', 'comp: router'
* generally working as originally designed but a use-case could be argued for a different implementation.
 This type of report is a little hard to triage; it may be neither a bug, nor feature but more of a
 'type: use-case'. These may eventually turn into a bug/fix or feature, but can't necessarily be
 put in those buckets immediately.
