### PR TITLE
i18n: check duplicate messages

### DIFF
--- a/packages/localize/src/tools/src/diagnostics.ts
+++ b/packages/localize/src/tools/src/diagnostics.ts
@@ -35,8 +35,8 @@ export class Diagnostics {
     this.messages.push(...other.messages);
   }
   formatDiagnostics(message: string): string {
-    const errors = this.messages!.filter(d => d.type === 'error').map(d => ' - ' + d.message);
-    const warnings = this.messages!.filter(d => d.type === 'warning').map(d => ' - ' + d.message);
+    const errors = this.messages.filter(d => d.type === 'error').map(d => ' - ' + d.message);
+    const warnings = this.messages.filter(d => d.type === 'warning').map(d => ' - ' + d.message);
     if (errors.length) {
       message += '\nERRORS:\n' + errors.join('\n');
     }

--- a/packages/localize/src/tools/src/extract/duplicates.ts
+++ b/packages/localize/src/tools/src/extract/duplicates.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {AbsoluteFsPath, FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {ɵMessageId, ɵParsedMessage} from '@angular/localize';
+
+import {DiagnosticHandlingStrategy, Diagnostics} from '../diagnostics';
+import {serializeLocationPosition} from '../source_file_utils';
+
+/**
+ * Check each of the given `messages` to find those that have the same id but different message
+ * text. Add diagnostics messages for each of these duplicate messages to the given `diagnostics`
+ * object (as necessary).
+ */
+export function checkDuplicateMessages(
+    fs: FileSystem, messages: ɵParsedMessage[],
+    duplicateMessageHandling: DiagnosticHandlingStrategy, basePath: AbsoluteFsPath): Diagnostics {
+  const diagnostics = new Diagnostics();
+  if (duplicateMessageHandling === 'ignore') return diagnostics;
+
+  const messageMap = new Map<ɵMessageId, ɵParsedMessage[]>();
+  for (const message of messages) {
+    if (messageMap.has(message.id)) {
+      messageMap.get(message.id)!.push(message);
+    } else {
+      messageMap.set(message.id, [message]);
+    }
+  }
+
+  for (const duplicates of messageMap.values()) {
+    if (duplicates.length <= 1) continue;
+    if (duplicates.every(message => message.text === duplicates[0].text)) continue;
+
+    const diagnosticMessage = `Duplicate messages with id "${duplicates[0].id}":\n` +
+        duplicates.map(message => serializeMessage(fs, basePath, message)).join('\n');
+    diagnostics.add(duplicateMessageHandling, diagnosticMessage);
+  }
+
+  return diagnostics;
+}
+
+/**
+ * Serialize the given `message` object into a string.
+ */
+function serializeMessage(
+    fs: FileSystem, basePath: AbsoluteFsPath, message: ɵParsedMessage): string {
+  if (message.location === undefined) {
+    return `   - "${message.text}"`;
+  } else {
+    const locationFile = fs.relative(basePath, message.location.file);
+    const locationPosition = serializeLocationPosition(message.location);
+    return `   - "${message.text}" : ${locationFile}:${locationPosition}`;
+  }
+}

--- a/packages/localize/src/tools/src/source_file_utils.ts
+++ b/packages/localize/src/tools/src/source_file_utils.ts
@@ -365,6 +365,13 @@ export function getLocation(startPath: NodePath, endPath?: NodePath): ɵSourceLo
   };
 }
 
+export function serializeLocationPosition(location: ɵSourceLocation): string {
+  const endLineString = location.end !== undefined && location.end.line !== location.start.line ?
+      `,${location.end.line + 1}` :
+      '';
+  return `${location.start.line + 1}${endLineString}`;
+}
+
 function getFileFromPath(path: NodePath|undefined): AbsoluteFsPath|null {
   const opts = path?.hub.file.opts;
   return opts?.filename ?

--- a/packages/localize/src/tools/test/extract/integration/test_files/duplicate.js
+++ b/packages/localize/src/tools/test/extract/integration/test_files/duplicate.js
@@ -1,0 +1,7 @@
+// Different interpolation values will not affect message text
+const a = $localize`:@@message-1:message ${10} contents`;
+const b = $localize`:@@message-1:message ${20} contents`;
+
+// But different actual text content will
+const c = $localize`:@@message-2:message contents`;
+const d = $localize`:@@message-2:different message contents`;


### PR DESCRIPTION
Previously, the i18n message extractor just quietly ignored messages that
it extracted that had the same id. It can be helpful to identify these
to track down messages that have the same id but different message text.

Now the messages are checked for duplicate ids with different message text.
Any that are found can be reported based on the new `--duplicateMessage`
command line option (or `duplicateMessage` API options property).

* "ignore" - no action is taken
* "warning" - a diagnostic warning is written to the logger
* "error" - the extractor throws an error and exits

Fixes #38077
