### PR TITLE
refactor(platform-browser): specify return type of parseEventName

### DIFF
--- a/packages/platform-browser/src/dom/events/key_events.ts
+++ b/packages/platform-browser/src/dom/events/key_events.ts
@@ -111,7 +111,7 @@ export class KeyEventsPlugin extends EventManagerPlugin {
     });
   }
 
-  static parseEventName(eventName: string): {[key: string]: string}|null {
+  static parseEventName(eventName: string): {fullKey: string, domEventName: string}|null {
     const parts: string[] = eventName.toLowerCase().split('.');
 
     const domEventName = parts.shift();
@@ -136,10 +136,7 @@ export class KeyEventsPlugin extends EventManagerPlugin {
       return null;
     }
 
-    const result: {[k: string]: string} = {};
-    result['domEventName'] = domEventName;
-    result['fullKey'] = fullKey;
-    return result;
+    return {domEventName, fullKey};
   }
 
   static getEventFullKey(event: KeyboardEvent): string {

--- a/packages/platform-browser/src/dom/events/key_events.ts
+++ b/packages/platform-browser/src/dom/events/key_events.ts
@@ -136,7 +136,13 @@ export class KeyEventsPlugin extends EventManagerPlugin {
       return null;
     }
 
-    return {domEventName, fullKey};
+    // NOTE: Please don't rewrite this as so, as it will break JSCompiler property renaming.
+    //       The code must remain in the `result['domEventName']` form.
+    // return {domEventName, fullKey};
+    const result: {fullKey: string, domEventName: string} = {} as any;
+    result['domEventName'] = domEventName;
+    result['fullKey'] = fullKey;
+    return result;
   }
 
   static getEventFullKey(event: KeyboardEvent): string {


### PR DESCRIPTION
This PR is a followup of the original PR [here](https://github.com/angular/angular/pull/37274).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
