### PR TITLE
Revert "build: remove obsolete Bazel function ctx.new_file (#38080)"

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -277,8 +277,11 @@ def _expected_outs(ctx):
 
     # TODO(alxhub): i18n is only produced by the legacy compiler currently. This should be re-enabled
     # when ngtsc can extract messages
-    if is_legacy_ngc:
+    if is_legacy_ngc and _is_bazel():
         i18n_messages_files = [ctx.actions.declare_file(ctx.label.name + "_ngc_messages.xmb")]
+    elif is_legacy_ngc:
+        # write the xmb file to blaze-genfiles since that path appears in the translation console keys
+        i18n_messages_files = [ctx.new_file(ctx.genfiles_dir, ctx.label.name + "_ngc_messages.xmb")]
     else:
         i18n_messages_files = []
 
@@ -455,13 +458,19 @@ def ngc_compile_action(
     )
 
     if is_legacy_ngc and messages_out != None:
+        # The base path is bin_dir because of the way the ngc
+        # compiler host is configured. Under Blaze, we need to explicitly
+        # point to genfiles/ to redirect the output.
+        # See _expected_outs above, where the output path for the message file
+        # is conditional on whether we are in Bazel.
+        message_file_path = messages_out[0].short_path if _is_bazel() else "../genfiles/" + messages_out[0].short_path
         ctx.actions.run(
             inputs = inputs,
             outputs = messages_out,
             executable = ctx.executable.ng_xi18n,
             arguments = (_EXTRA_NODE_OPTIONS_FLAGS +
                          [tsconfig_file.path] +
-                         [messages_out[0].short_path]),
+                         [message_file_path]),
             progress_message = "Extracting Angular 2 messages (ng_xi18n)",
             mnemonic = "Angular2MessageExtractor",
         )


### PR DESCRIPTION
This reverts commit 406f801b7072f65491eac332056a8e444027dc10.

The reason for the revert is the breakage in i18n subsystem in g3.


## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: revert of the breaking change


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No