### PR TITLE
fix(core): ICU expression previous value not removed inside template

### DIFF
--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -756,8 +756,10 @@ function createDynamicNodeAtIndex(
     tView: TView, lView: LView, index: number, type: TNodeType, native: RElement|RText|null,
     name: string|null): TElementNode|TIcuContainerNode {
   const previousOrParentTNode = getPreviousOrParentTNode();
-  ngDevMode && assertDataInRange(lView, index + HEADER_OFFSET);
-  lView[index + HEADER_OFFSET] = native;
+  const nodeIndex = index + HEADER_OFFSET;
+  ngDevMode && assertDataInRange(lView, nodeIndex);
+  lView[nodeIndex] !== null && removeNode(tView, lView, index, false);
+  lView[nodeIndex] = native;
   // FIXME(misko): Why does this create A TNode??? I would not expect this to be here.
   const tNode = getOrCreateTNode(tView, lView[T_HOST], index, type as any, name, null);
 

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -1435,6 +1435,45 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       // checking the second ICU case
       expect(fixture.nativeElement.textContent.trim()).toBe('deux articles');
     });
+
+    it('should handle select expressions without an `other` parameter inside a template', () => {
+      const fixture = initWithTemplate(AppComp, `
+        <p *ngFor="let item of items">{item.value, select, 0 {A} 1 {B} 2 {C}}</p>
+      `);
+      fixture.componentInstance.items = [{value: 0}, {value: 1}, {value: 1337}];
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent.trim()).toBe('AB');
+
+      fixture.componentInstance.items[0].value = 2;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent.trim()).toBe('CB');
+    });
+
+    it('should render an element whose case did not match initially', () => {
+      const fixture = initWithTemplate(AppComp, `
+        <p *ngFor="let item of items">{item.value, select, 0 {A} 1 {B} 2 {C}}</p>
+      `);
+      fixture.componentInstance.items = [{value: 0}, {value: 1}, {value: 1337}];
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent.trim()).toBe('AB');
+
+      fixture.componentInstance.items[2].value = 2;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent.trim()).toBe('ABC');
+    });
+
+    it('should remove an element whose case matched initially, but does not anymore', () => {
+      const fixture = initWithTemplate(AppComp, `
+        <p *ngFor="let item of items">{item.value, select, 0 {A} 1 {B} 2 {C}}</p>
+      `);
+      fixture.componentInstance.items = [{value: 0}, {value: 1}];
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent.trim()).toBe('AB');
+
+      fixture.componentInstance.items[0].value = 1337;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent.trim()).toBe('B');
+    });
   });
 
   describe('should support attributes', () => {
@@ -2589,7 +2628,7 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
   });
 });
 
-function initWithTemplate(compType: Type<any>, template: string) {
+function initWithTemplate<T>(compType: Type<T>, template: string) {
   TestBed.overrideComponent(compType, {set: {template}});
   const fixture = TestBed.createComponent(compType);
   fixture.detectChanges();
@@ -2601,6 +2640,8 @@ class AppComp {
   name = `Angular`;
   visible = true;
   count = 0;
+  items: any[] = [];
+  obj: any;
 }
 
 @Component({


### PR DESCRIPTION
Fixes an issue where the previous value of an ICU expression wasn't being
removed, if it didn't have an `other` parameter and it's the last value inside
a template. The issue is due to the `createDynamicNodeAtIndex` function
which sets a new node at a particular index inside the `LView`, but it doesn't
account for any node that may have existed there beforehand. Since we've
overwritten the reference, we don't have a way of removing the node from
the DOM anymore.

Also cleans up an optional parameter in one of the internal functions and
adds stronger typing to the i18n unit tests.

Fixes #38073.