### PR TITLE
fix(router): set default `relativeLinkResolution` as `corrected`

### DIFF
--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -21,7 +21,7 @@ class NoMatch {}
 export function recognize(
     rootComponentType: Type<any>|null, config: Routes, urlTree: UrlTree, url: string,
     paramsInheritanceStrategy: ParamsInheritanceStrategy = 'emptyOnly',
-    relativeLinkResolution: 'legacy'|'corrected' = 'legacy'): Observable<RouterStateSnapshot> {
+    relativeLinkResolution: 'legacy'|'corrected' = 'corrected'): Observable<RouterStateSnapshot> {
   return new Recognizer(
              rootComponentType, config, urlTree, url, paramsInheritanceStrategy,
              relativeLinkResolution)

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -443,7 +443,7 @@ export class Router {
    * Enables a bug fix that corrects relative link resolution in components with empty paths.
    * @see `RouterModule`
    */
-  relativeLinkResolution: 'legacy'|'corrected' = 'legacy';
+  relativeLinkResolution: 'legacy'|'corrected' = 'corrected';
 
   /**
    * Creates the router service.

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -84,6 +84,10 @@ describe('Integration', () => {
         }]);
       }));
 
+      it('should have defaut value as corrected', fakeAsync(inject([Router], (router: Router) => {
+           expect(router.relativeLinkResolution).toEqual('corrected');
+         })));
+
       it('should not ignore empty paths in legacy mode',
          fakeAsync(inject([Router], (router: Router) => {
            router.relativeLinkResolution = 'legacy';


### PR DESCRIPTION
`relativeLinkResolution: "corrected"` enables a bug fix that corrects relative link resolution
 in components with empty paths but it still continues to cause pain because the default option
 is `legacy` this pr changes default `relativeLinkResolution` to corrected

Fixes #37355

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #37355


## What is the new behavior?


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Whenever user may not have set the default the default will be changed which my cause problems to get rid of the problem user may explicitly set the relativeLinkResolution to legacy

## Other information
