### PR TITLE
fix(forms): ValueAccessor.writeValue(...) sometimes called with null

### DIFF
--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -185,13 +185,27 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    *
    * @param dir The `NgModel` directive instance.
    */
-  addControl(dir: NgModel): void {
+  addControl(dir: NgModel): void;
+  /**
+   * @description
+   * Method that sets up the control directive in this group, re-calculates its value
+   * and validity, and adds the instance to the internal list of directives.
+   *
+   * @param dir The `NgModel` directive instance.
+   * @param opts An optional set of options. If `skipValueInitialization` is true, the control's
+   *     validity and value will not be updated and value accessors will not be written to. Use this
+   *     flag if the control's value is updated immediately after this call.
+   * @internal
+   */
+  addControl(dir: NgModel, opts: {skipValueInitialization?: boolean}): void;
+  /** @internal */
+  addControl(dir: NgModel, opts?: {skipValueInitialization?: boolean}) {
     resolvedPromise.then(() => {
       const container = this._findContainer(dir.path);
       (dir as {control: FormControl}).control =
           <FormControl>container.registerControl(dir.name, dir.control);
-      setUpControl(dir.control, dir);
-      dir.control.updateValueAndValidity({emitEvent: false});
+      setUpControl(dir.control, dir, opts);
+      if (!opts?.skipValueInitialization) dir.control.updateValueAndValidity({emitEvent: false});
       this._directives.push(dir);
     });
   }

--- a/packages/forms/test/spies.ts
+++ b/packages/forms/test/spies.ts
@@ -8,6 +8,7 @@
 
 import {ChangeDetectorRef} from '@angular/core/src/change_detection/change_detector_ref';
 import {SpyObject} from '@angular/core/testing/src/testing_internal';
+import {ControlValueAccessor} from '..';
 
 export class SpyChangeDetectorRef extends SpyObject {
   constructor() {
@@ -20,6 +21,7 @@ export class SpyNgControl extends SpyObject {
   path = [];
 }
 
-export class SpyValueAccessor extends SpyObject {
-  writeValue: any;
+export function createSpyControlValueAccessor(): ControlValueAccessor {
+  return jasmine.createSpyObj(
+      'ControlValueAccessor', ['writeValue', 'registerOnChange', 'registerOnTouched']);
 }

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -1450,6 +1450,9 @@ export class NgModelCustomComp implements ControlValueAccessor {
   changeFn!: (value: any) => void;
 
   writeValue(value: any) {
+    if (typeof value !== 'string') {
+      throw new Error(`Typeof value must be string! type=${typeof value}, value=${value}`);
+    }
     this.model = value;
   }
 


### PR DESCRIPTION
Fixes #14988
Fixes [@ckelley7's marriage](https://github.com/angular/angular/issues/14988#issuecomment-396342060)
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
(technically no, but no doc changes were needed)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`ValueAccessor.writeValue(...)` is called twice on the very first `ngModel` change if the form has not yet been set up; once by `setUpControl` and once when the value is actually updated. However, because `setUpControl` is called before the value is set, the first call passes `null`.

The bug is most common for standalone form controls which are never set up before the first `ngModel` change but may also happen if any other form control is not added to its parent first by calling `NgForm.addControl(...)`.

Issue Number: #14988


## What is the new behavior?
Optionally skip the `writeValue(...)` call in `setUpControl` if the value is a special sentinel value indicating it has not yet been initialized.

## Does this PR introduce a breaking change?

- [x] Yes
(see [below](https://github.com/angular/angular/pull/38140#issuecomment-661516210))
- [ ] No


## Other information
