### PR TITLE
Update developer test documentation

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -80,8 +80,10 @@ Bazel is used as the primary tool for building and testing Angular. Building and
 incremental with Bazel, and it's possible to only run tests for an individual package instead
 of for all packages. Read more about this in the [BAZEL.md](./BAZEL.md) document.
 
-You should execute all test suites before submitting a PR to GitHub:
-- `yarn bazel test packages/...`
+You should execute all test suites before submitting a PR to GitHub. Note that not all tests
+support both Ivy and View Engine, so they need to be run separately:
+- `yarn test-ivy-aot //packages/...`
+- `yarn test-non-ivy //packages/...`
 
 **Note**: The first test run will be much slower than future runs. This is because future runs will
 benefit from Bazel's capability to do incremental builds.


### PR DESCRIPTION
A couple times now I've run `yarn bazel test //packages/...` as the documentation suggests only to find some tests failing. This is because it runs all tests with View Engine even though not all actually support View Engine. I've updated the docs to use `yarn test-ivy-aot` and `yarn test-non-ivy` which filter out tests that do not support each renderer.