### PR TITLE
docs: Remove incorrect RxJS-related instruction

### DIFF
--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -38,14 +38,6 @@ You can then inject the `HttpClient` service as a dependency of an application c
   header="app/config/config.service.ts (excerpt)">
 </code-example>
 
-The `HttpClient` service makes use of [observables](guide/glossary#observable "Observable definition") for all transactions. You must import the RxJS observable and operator symbols that appear in the example snippets. These `ConfigService` imports are typical.
-
-<code-example
-  path="http/src/app/config/config.service.ts"
-  region="rxjs-imports"
-  header="app/config/config.service.ts (RxJS imports)">
-</code-example>
-
 <div class="alert is-helpful">
 
 You can run the <live-example></live-example> that accompanies this guide.


### PR DESCRIPTION
It appears that this was changed code from the pre-pipeable operator days.

I'm making this PR to draw it to your attention more than anything. I'm not sure how you want to word this, but now users would just pull in whatever operators they need, if they need to, from `rxjs/operators` directly in the files they use them in. What's here looks like it's a remnant from when we had to modify `Observable.prototype` with things like `import "rxjs/add/operator/map"` etc.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
