### PR TITLE
fix(dev-infra): change commit body `maxLineLength` to 100

### DIFF
--- a/.ng-dev/commit-message.ts
+++ b/.ng-dev/commit-message.ts
@@ -4,7 +4,7 @@ import {CommitMessageConfig} from '../dev-infra/commit-message/config';
  * The configuration for `ng-dev commit-message` commands.
  */
 export const commitMessage: CommitMessageConfig = {
-  maxLineLength: 120,
+  maxLineLength: 100,
   minBodyLength: 20,
   minBodyLengthTypeExcludes: ['docs'],
   types: [

--- a/dev-infra/commit-message/validate.spec.ts
+++ b/dev-infra/commit-message/validate.spec.ts
@@ -16,7 +16,7 @@ type CommitMessageConfig = validateConfig.CommitMessageConfig;
 // Constants
 const config: {commitMessage: CommitMessageConfig} = {
   commitMessage: {
-    maxLineLength: 120,
+    maxLineLength: 100,
     minBodyLength: 0,
     types: [
       'feat',
@@ -70,7 +70,7 @@ describe('validate-commit-message.js', () => {
 
     it('should validate max length', () => {
       const msg =
-          'fix(compiler): something super mega extra giga tera long, maybe even longer and longer and longer and longer and longer and longer...';
+          'fix(compiler): something super mega extra giga tera long, maybe even longer and longer and longer and longer...';
 
       expect(validateCommitMessage(msg)).toBe(INVALID);
       expect(lastError).toContain(`The commit message header is longer than ${
@@ -240,7 +240,7 @@ describe('validate-commit-message.js', () => {
     describe('minBodyLength', () => {
       const minBodyLengthConfig: {commitMessage: CommitMessageConfig} = {
         commitMessage: {
-          maxLineLength: 120,
+          maxLineLength: 100,
           minBodyLength: 30,
           minBodyLengthTypeExcludes: ['docs'],
           types: ['fix', 'docs'],


### PR DESCRIPTION
The current limit of 120 characters is a work-around that we forgot to revert: `bf57df3`.
Changed the default maxLineLength of git message to 100 characters.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Commit msg maxLineLength: 120 characters

Issue Number: N/A


## What is the new behavior?
Commit msg maxLineLength: 100 characters

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
