### PR TITLE
docs: fix DOCUMENT import path

### DIFF
--- a/aio/content/guide/aot-metadata-errors.md
+++ b/aio/content/guide/aot-metadata-errors.md
@@ -430,7 +430,7 @@ Angular does something similar with the `DOCUMENT` token so you can inject the b
 
 ```ts
 import { Inject }   from '@angular/core';
-import { DOCUMENT } from '@angular/platform-browser';
+import { DOCUMENT } from '@angular/common';
 
 @Component({ ... })
 export class MyComponent {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Just changing the import path on https://angular.io/guide/aot-metadata-errors#could-not-resolve-type from:
`import { DOCUMENT } from '@angular/platform-browser';` to `import { DOCUMENT } from '@angular/common';`

Issue Number: #38158 


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

