### PR TITLE
refactor(dev-infra): update commit body checks

### DIFF
--- a/.ng-dev/commit-message.ts
+++ b/.ng-dev/commit-message.ts
@@ -6,7 +6,7 @@ import {CommitMessageConfig} from '../dev-infra/commit-message/config';
 export const commitMessage: CommitMessageConfig = {
   maxLineLength: 120,
   minBodyLength: 20,
-  minBodyLengthTypeExcludes: ['docs'],
+  minBodyLengthTypeExcludes: ['docs', 'release'],
   types: [
     'build',
     'ci',

--- a/dev-infra/commit-message/validate.spec.ts
+++ b/dev-infra/commit-message/validate.spec.ts
@@ -69,12 +69,17 @@ describe('validate-commit-message.js', () => {
     });
 
     it('should validate max length', () => {
-      const msg =
+      const msgWithLongHeader =
           'fix(compiler): something super mega extra giga tera long, maybe even longer and longer and longer and longer and longer and longer...';
-
-      expect(validateCommitMessage(msg)).toBe(INVALID);
+      expect(validateCommitMessage(msgWithLongHeader)).toBe(INVALID);
       expect(lastError).toContain(`The commit message header is longer than ${
           config.commitMessage.maxLineLength} characters`);
+
+      // Should not trigger an error in case commit body contains lines longer than `maxLineLength`
+      // config value.
+      const msgWithLongLinesInBody = 'fix(compiler): some header\n\n' +
+          'Commit body is one line and it\'s super mega extra giga tera long, maybe even longer and longer and longer and longer and longer and longer...';
+      expect(validateCommitMessage(msgWithLongLinesInBody)).toBe(VALID);
     });
 
     it('should skip max length limit for URLs', () => {
@@ -242,8 +247,8 @@ describe('validate-commit-message.js', () => {
         commitMessage: {
           maxLineLength: 120,
           minBodyLength: 30,
-          minBodyLengthTypeExcludes: ['docs'],
-          types: ['fix', 'docs'],
+          minBodyLengthTypeExcludes: ['docs', 'release'],
+          types: ['fix', 'docs', 'release'],
           scopes: ['core']
         }
       };
@@ -271,6 +276,8 @@ describe('validate-commit-message.js', () => {
            expect(validateCommitMessage(
                       'docs(core): just fixing a typo\n\nThis was just a silly typo.'))
                .toBe(VALID);
+           expect(validateCommitMessage('release: some description')).toBe(VALID);
+           expect(validateCommitMessage('release(core): something')).toBe(VALID);
          });
     });
   });

--- a/dev-infra/commit-message/validate.spec.ts
+++ b/dev-infra/commit-message/validate.spec.ts
@@ -82,15 +82,6 @@ describe('validate-commit-message.js', () => {
       expect(validateCommitMessage(msgWithLongLinesInBody)).toBe(VALID);
     });
 
-    it('should skip max length limit for URLs', () => {
-      const msg = 'fix(compiler): this is just an usual commit message tile\n\n' +
-          'This is a normal commit message body which does not exceed the max length\n' +
-          'limit. For more details see the following super long URL:\n\n' +
-          'https://github.com/angular/components/commit/e2ace018ddfad10608e0e32932c43dcfef4095d7#diff-9879d6db96fd29134fc802214163b95a';
-
-      expect(validateCommitMessage(msg)).toBe(VALID);
-    });
-
     it('should validate "<type>(<scope>): <subject>" format', () => {
       const msg = 'not correct format';
 
@@ -267,6 +258,13 @@ describe('validate-commit-message.js', () => {
         expect(validateCommitMessage('fix(core): something')).toBe(INVALID);
         expect(lastError).toContain(
             'The commit message body does not meet the minimum length of 30 characters');
+      });
+
+      it('should not take into account lines that start with `#`', () => {
+        const commitMsg = 'fix: some test commit header\n\n' +
+            '# Please enter the commit message for your changes. Lines starting\n' +
+            '# with `#` will be ignored, and an empty message aborts the commit.';
+        expect(validateCommitMessage(commitMsg)).toBe(INVALID);
       });
 
       it('should pass validation if the body is shorter than `minBodyLength` but the commit type is in the `minBodyLengthTypeExclusions` list',

--- a/dev-infra/commit-message/validate.ts
+++ b/dev-infra/commit-message/validate.ts
@@ -149,7 +149,8 @@ export function validateCommitMessage(
         bodyByLine
             // Exclude lines that start with `#`, since these lines are ignored by git.
             .filter(line => !line.startsWith('#'))
-            .join('')
+            .join('\n')
+            .trim()
             .length;
     if (actualBodyLength < config.minBodyLength) {
       printError(`The commit message body does not meet the minimum length of ${


### PR DESCRIPTION
This commit updates the commit body checking logic:
* avoid checking the length of lines in commit body
* ignores lines that start with `#` char, since these lines are skipped by git
* adds `release` into the `minBodyLengthTypeExcludes` list in a config rather than having a hard-coded exclusion for this commit type in the code

Resolves #37865.


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No