### PR TITLE
ci: add more owners for limited categories

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1175,14 +1175,16 @@ groups:
           ])
     reviewers:
       users:
+        - AndrewKushnir
         - IgorMinar
         - alxhub
+        - atscott
         - jelbourn
         - petebacondarwin
         - pkozlowski-opensource
     reviews:
-      request: -1   # request reviews from everyone
-      required: 3   # require at least 3 approvals
+      request: 4 # Request reviews from four people
+      required: 3 # Require that three people approve
       reviewed_for: required
 
 
@@ -1201,14 +1203,16 @@ groups:
           ])
     reviewers:
       users:
+        - AndrewKushnir
         - IgorMinar
         - alxhub
+        - atscott
         - jelbourn
         - petebacondarwin
         - pkozlowski-opensource
     reviews:
-      request: -1   # request reviews from everyone
-      required: 2   # require at least 2 approvals
+      request: 4 # Request reviews from four people
+      required: 2 # Require that two people approve
       reviewed_for: required
 
 
@@ -1227,9 +1231,11 @@ groups:
         ])
     reviewers:
       users:
+        - AndrewKushnir
         - IgorMinar
+        - alxhub
+        - atscott
         - jelbourn
-        - josephperrott
         - petebacondarwin
         - pkozlowski-opensource
 
@@ -1251,7 +1257,10 @@ groups:
           ])
     reviewers:
       users:
+        - AndrewKushnir
         - IgorMinar
+        - alxhub
+        - atscott
         - jelbourn
         - josephperrott
         - mhevery


### PR DESCRIPTION
* Add alxhub, atscott, and AndrewKushnir to code owners
* Add atscott & AndrewKushnir to public-api and size-tracking
* Change public-api and size-tracking from requesting `-1` (all) to requesting four (still requiring three and two, respectively)

Follow-up to #37994