### PR TITLE
build(docs-infra): upgrade cli command docs sources to a404d2a86

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -23,7 +23,7 @@
     "build-local-with-viewengine": "yarn ~~build",
     "prebuild-local-with-viewengine-ci": "node scripts/switch-to-viewengine && yarn setup-local-ci",
     "build-local-with-viewengine-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 14af4e07c",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js a404d2a86",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#10.0.x](https://github.com/angular/angular/tree/10.0.x) from [cli-builds#10.0.x](https://github.com/angular/cli-builds/tree/10.0.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/14af4e07c...a404d2a86):

**Modified**
- help/update.json