### PR TITLE
fix(docs-infra): correctly display copy button in IE11

### DIFF
--- a/aio/src/styles/2-modules/_code.scss
+++ b/aio/src/styles/2-modules/_code.scss
@@ -108,6 +108,7 @@ aio-code pre {
   top: -7px;
   right: -19px;
   padding: 0;
+  overflow: visible; // This is required for the button to be displayed correctly in IE11.
 
   color: $blue-grey-200;
   background-color: transparent;


### PR DESCRIPTION
Fix button top portion was clipped in IE11 by setting overflow to visible

Fixes #37816

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #37816


## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


## Other information
Adding `overflow: visible` fixes the clipping issue of the top portion of the button

