### PR TITLE
docs: mention ng-add save option

### DIFF
--- a/aio/content/examples/schematics-for-libraries/projects/my-lib/package.json
+++ b/aio/content/examples/schematics-for-libraries/projects/my-lib/package.json
@@ -16,5 +16,12 @@
     "@angular/core": "^7.2.0"
   },
 // #docregion collection
-  "schematics": "./schematics/collection.json"
+  "schematics": "./schematics/collection.json",
+// #enddocregion collection
+// #docregion ng-add
+  "ng-add": {
+    "save": "devDependencies"
+  }
+// #enddocregion ng-add
+// #docregion collection
 }

--- a/aio/content/guide/schematics-for-libraries.md
+++ b/aio/content/guide/schematics-for-libraries.md
@@ -57,6 +57,20 @@ The task uses the user's preferred package manager to add the library to the pro
 In this example, the function receives the current `Tree` and returns it without any modifications.
 If you need to, you can do additional setup when your package is installed, such as generating files, updating configuration, or any other initial setup your library requires.
 
+### Define dependency type
+
+Use the `save` option of `ng-add` to configure if the library should be added to the `dependencies`, the `devDepedencies`, or not saved at all in the project's `package.json` configuration file.
+
+<code-example header="projects/my-lib/package.json (ng-add Reference)" path="schematics-for-libraries/projects/my-lib/package.json" region="ng-add">
+</code-example>
+
+Possible values are:
+
+  * `false` - Don't add the package to package.json
+  * `true` - Add the package to the dependencies
+  * `"dependencies"` - Add the package to the dependencies
+  * `"devDependencies"` - Add the package to the devDependencies
+
 ## Building your schematics
 
 To bundle your schematics together with your library, you must configure the library to build the schematics separately, then add them to the bundle.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The `save` option of the `ng-add` schematic, introduced in https://github.com/angular/angular-cli/pull/15815 isn't documented AFAIK. 
Yet, I think it can be useful to library authors.

## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


