### PR TITLE
feat(dev-infra): allow prefixed versions in git tags for build-env-stamp

### DIFF
--- a/dev-infra/release/config.ts
+++ b/dev-infra/release/config.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {assertNoErrors, getConfig, NgDevConfig} from '../utils/config';
+
+export interface ReleaseConfig {
+  tagPrefix?: string;
+}
+
+/** Retrieve and validate the config as `ReleaseConfig`. */
+export function getReleaseConfig() {
+  // List of errors encountered validating the config.
+  const errors: string[] = [];
+  // The unvalidated config object.
+  const config: Partial<NgDevConfig<{release: ReleaseConfig}>> = getConfig();
+
+  assertNoErrors(errors);
+  return config as Required<typeof config>;
+}

--- a/dev-infra/release/env-stamp.ts
+++ b/dev-infra/release/env-stamp.ts
@@ -45,15 +45,16 @@ function hasLocalChanges() {
 
 /** Get the version based on the most recent semver tag. */
 function getSCMVersion(config = getReleaseConfig()) {
-  const tagPrefix = config?.release?.tagPrefix || '';
-  const version = exec(`git describe --match ${tagPrefix}[0-9]*.[0-9]*.[0-9]* --abbrev=7 --tags HEAD`);
-  const tagPrefixRegex = new RegExp(`^${tagPrefix}`);
-  const parsedVersion =  version
-    // Remove the semver tag prefix, i.e. `v` in `v1.0.0`
-    .replace(tagPrefixRegex, '')
-    // Replace the git indication of the distance from tag with a reference which does not break semver.
-    // e.g.  0.0.0-next.0-44-abcd1234 becomes 0.0.0.next.0+44.sha-abcd1234
-    .replace(/-([0-9]+)-g/, '+$1.sha-');
+  const prefix = config?.release?.tagPrefix || '';
+  const version = exec(`git describe --match ${prefix}[0-9]*.[0-9]*.[0-9]* --abbrev=7 --tags HEAD`);
+  const tagPrefixRegex = new RegExp(`^${prefix}`);
+  const parsedVersion =
+      version
+          // Remove the semver tag prefix, i.e. `v` in `v1.0.0`
+          .replace(tagPrefixRegex, '')
+          // Replace the git indication of the distance from tag with a reference which does not
+          // break semver. e.g.  0.0.0-next.0-44-abcd1234 becomes 0.0.0.next.0+44.sha-abcd1234
+          .replace(/-([0-9]+)-g/, '+$1.sha-');
   return `${parsedVersion}${(hasLocalChanges() ? '.with-local-changes' : '')}`;
 }
 


### PR DESCRIPTION
Adding support for prefixes of versions for git tags will allow for
angular/angular-cli to utilize the merge tooling provided by ng-dev.
This change allows for a configuration to allow for proper discovery
of the current version for determining target patch branches.
