### PR TITLE
Detect and print cycles that cause `setComponentScope()` to be used

### DIFF
--- a/packages/compiler-cli/src/ngtsc/cycles/src/analyzer.ts
+++ b/packages/compiler-cli/src/ngtsc/cycles/src/analyzer.ts
@@ -21,7 +21,18 @@ export class CycleAnalyzer {
    */
   wouldCreateCycle(from: ts.SourceFile, to: ts.SourceFile): boolean {
     // Import of 'from' -> 'to' is illegal if an edge 'to' -> 'from' already exists.
-    return this.importGraph.transitiveImportsOf(to).has(from);
+    const cycle = this.importGraph.transitiveImportsOf(to).has(from);
+    if (!cycle) return false;
+
+    // Print out the cycle for debugging purposes.
+    const path = this.importGraph.somePath(to, from);
+    if (path) {
+      console.error(`Cycle detected, falling back to setComponentScope():\n${
+          [from, ...path].map((src) => src.fileName).join('\n')}`);
+    } else {
+      console.error(`Cycle detected, but could not be traced.`);
+    }
+    process.exit(1);
   }
 
   /**

--- a/packages/compiler-cli/src/ngtsc/cycles/src/imports.ts
+++ b/packages/compiler-cli/src/ngtsc/cycles/src/imports.ts
@@ -34,6 +34,22 @@ export class ImportGraph {
   }
 
   /**
+   * Finds an import path from the first source to the second source. Returns a
+   * list of source files that connect the two, starting with the first file and
+   * ending with the second file. Returns `undefined` if no path could be found.
+   */
+  somePath(from: ts.SourceFile, to: ts.SourceFile): ts.SourceFile[]|undefined {
+    if (from.fileName === to.fileName) return [to];
+
+    const imports = this.importsOf(from);
+    for (const imp of imports) {
+      const path = this.somePath(imp, to);
+      if (path) return [from, ...path];
+    }
+    return undefined;
+  }
+
+  /**
    * Lists the transitive imports of a given `ts.SourceFile`.
    */
   transitiveImportsOf(sf: ts.SourceFile): Set<ts.SourceFile> {


### PR DESCRIPTION
This detects and prints any cycles which cause `setComponentScope()` to be used and deoptimize tree-shakeability.

This patch serves as a work-around for #38211.