### PR TITLE
fix(compiler): share identical stylesheets between components in the same file

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2987,
-        "main-es2015": 450596,
+        "main-es2015": 448419,
         "polyfills-es2015": 52630
       }
     }

--- a/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
@@ -86,13 +86,15 @@ class IvyTransformationVisitor extends Visitor {
       VisitListEntryResult<ts.Statement, ts.ClassDeclaration> {
     // If this class is not registered in the map, it means that it doesn't have Angular decorators,
     // thus no further processing is required.
-    if (!this.classCompilationMap.has(node)) return {node};
+    if (!this.classCompilationMap.has(node)) {
+      return {node};
+    }
 
     // There is at least one field to add.
     const statements: ts.Statement[] = [];
     const members = [...node.members];
 
-    this.classCompilationMap.get(node)!.forEach(field => {
+    for (const field of this.classCompilationMap.get(node)!) {
       // Translate the initializer for the field into TS nodes.
       const exprNode = translateExpression(
           field.initializer, this.importManager, this.defaultImportRecorder,
@@ -120,7 +122,7 @@ class IvyTransformationVisitor extends Visitor {
           .forEach(stmt => statements.push(stmt));
 
       members.push(property);
-    });
+    }
 
     // Replace the class declaration with an updated version.
     node = ts.updateClassDeclaration(

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -316,5 +316,5 @@ function isVariable(e: o.Expression): e is o.ReadVarExpr {
 
 function isLongStringExpr(expr: o.LiteralExpr): boolean {
   return typeof expr.value === 'string' &&
-      expr.value.length > POOL_INCLUSION_LENGTH_THRESHOLD_FOR_STRINGS;
+      expr.value.length >= POOL_INCLUSION_LENGTH_THRESHOLD_FOR_STRINGS;
 }

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -231,7 +231,7 @@ export function compileComponentFromMetadata(
     const styleValues = meta.encapsulation == core.ViewEncapsulation.Emulated ?
         compileStyles(meta.styles, CONTENT_ATTR, HOST_ATTR) :
         meta.styles;
-    const strings = styleValues.map(str => o.literal(str));
+    const strings = styleValues.map(str => constantPool.getConstLiteral(o.literal(str)));
     definitionMap.set('styles', o.literalArr(strings));
   } else if (meta.encapsulation === core.ViewEncapsulation.Emulated) {
     // If there is no style, don't generate css selectors on elements


### PR DESCRIPTION
This PR consists of 3 separate commits and updates the compiler to allow identical stylesheets to be reused between components in the same file. This is achieved by allowing strings to be handled in `ConstantPool` and actually using `ConstantPool` while generating `styles` array on component def. More information can be found in individual commit messages.

Resolves #38204.
Resolves #38203.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No