### PR TITLE
fix(compiler-cli): Add support for string literal class members

### DIFF
--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -152,13 +152,13 @@ export interface ClassMember {
   name: string;
 
   /**
-   * TypeScript `ts.Identifier` representing the name of the member, or `null` if no such node
-   * is present.
+   * TypeScript `ts.Identifier` or `ts.StringLiteral` representing the name of the member, or `null`
+   * if no such node is present.
    *
    * The `nameNode` is useful in writing references to this member that will be correctly source-
    * mapped back to the original file.
    */
-  nameNode: ts.Identifier|null;
+  nameNode: ts.Identifier|ts.StringLiteral|null;
 
   /**
    * TypeScript `ts.Expression` which represents the value of the member.

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -363,7 +363,7 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     let kind: ClassMemberKind|null = null;
     let value: ts.Expression|null = null;
     let name: string|null = null;
-    let nameNode: ts.Identifier|null = null;
+    let nameNode: ts.Identifier|ts.StringLiteral|null = null;
 
     if (ts.isPropertyDeclaration(node)) {
       kind = ClassMemberKind.Property;
@@ -383,6 +383,9 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     if (ts.isConstructorDeclaration(node)) {
       name = 'constructor';
     } else if (ts.isIdentifier(node.name)) {
+      name = node.name.text;
+      nameNode = node.name;
+    } else if (ts.isStringLiteral(node.name)) {
       name = node.name.text;
       nameNode = node.name;
     } else {


### PR DESCRIPTION
The current implementation of the TypeScriptReflectionHost does not account for members that
are string literals, i.e. `class A { 'string-literal-prop': string; }`
