### PR TITLE
feat(platform-browser): can config zone/once/passive/capture in event listener

### DIFF
--- a/aio/content/examples/event-binding/src/app/app.component.html
+++ b/aio/content/examples/event-binding/src/app/app.component.html
@@ -29,25 +29,52 @@
   <!-- #enddocregion event-binding-3-->
 </div>
 
+
 <div class="group">
   <h3>Binding to a nested component</h3>
   <h4>Custom events with EventEmitter</h4>
   <!-- #docregion event-binding-to-component -->
   <app-item-detail (deleteRequest)="deleteItem($event)" [item]="currentItem"></app-item-detail>
-    <!-- #enddocregion event-binding-to-component -->
-
+  <!-- #enddocregion event-binding-to-component -->
 
   <h4>Click to see event target class:</h4>
-<div class="parent-div" (click)="onClickMe($event)" clickable>Click me (parent)
-  <div class="child-div">Click me too! (child) </div>
+  <div class="parent-div" (click)="onClickMe($event)" clickable>Click me (parent)
+    <div class="child-div">Click me too! (child) </div>
+  </div>
+
+  <h3>Saves only once:</h3>
+  <div (click)="onSave()" clickable>
+    <button (click)="onSave($event)">Save, no propagation</button>
+  </div>
+
+  <h3>Saves twice:</h3>
+  <div (click)="onSave()" clickable>
+    <button (click)="onSave()">Save with propagation</button>
+  </div>
 </div>
 
-<h3>Saves only once:</h3>
-<div (click)="onSave()" clickable>
-  <button (click)="onSave($event)">Save, no propagation</button>
+<div class="group">
+  <h3>Apply capture/passive/once options when adding the event listener</h3>
+
+  <!-- #docregion event-binding-4-->
+  <div (click)="handleClickOnParentDiv()">
+    <div (click.capture)="handleClickOnChildDiv()"></div>
+  </div>
+  <div (scroll.passive)="handleScroll($event)"></div>
+  <div (click.once)="handleOnceClick()"></div>
+  <div (click.once.capture.passive)="handleClickWithMixedOptions()"></div>
+  <!-- #enddocregion event-binding-4-->
 </div>
 
-<h3>Saves twice:</h3>
-<div (click)="onSave()" clickable>
-  <button (click)="onSave()">Save with propagation</button>
+<div class="group">
+  <h3>Specify zone option on event handler</h3>
+  <h4>Event handler inside angular zone?: {{zoneMessage}}</h4>
+
+  <!-- #docregion event-binding-5-->
+  <div (click.noopZone)="clickInNoopZone()"></div>
+  <button #btnToggle>Toggle</button>
+  <div *ngIf="show">
+    <div (click.ngZone)="clickInNgZone()"></div>
+  </div>
+  <!-- #enddocregion event-binding-5-->
 </div>

--- a/aio/content/examples/event-binding/src/app/app.component.ts
+++ b/aio/content/examples/event-binding/src/app/app.component.ts
@@ -1,20 +1,35 @@
-import { Component } from '@angular/core';
-import { Item } from './item';
+import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, NgZone, ViewChild} from '@angular/core';
 
-@Component({
-  selector: 'app-root',
-  templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css']
-})
-export class AppComponent {
+import {Item} from './item';
 
-  currentItem = { name: 'teapot'} ;
+@Component(
+    {selector: 'app-root', templateUrl: './app.component.html', styleUrls: ['./app.component.css']})
+export class AppComponent implements AfterViewInit {
+  @ViewChild('btnToggle') btnToggle: ElementRef;
+  currentItem = {name: 'teapot'};
   clickMessage = '';
+  zoneMessage = '';
+
+  show = false;
+
+  constructor(private ngZone: NgZone, private cdr: ChangeDetectorRef) {}
+
+  ngAfterViewInit() {
+    this.ngZone.runOutsideAngular(() => {
+      const el = this.btnToggle.nativeElement as HTMLElement;
+      el.addEventListener('click', e => {
+        this.show = true;
+        this.cdr.detectChanges();
+      })
+    })
+  }
 
   onSave(event?: KeyboardEvent) {
     const evtMsg = event ? ' Event target is ' + (<HTMLElement>event.target).textContent : '';
     alert('Saved.' + evtMsg);
-    if (event) { event.stopPropagation(); }
+    if (event) {
+      event.stopPropagation();
+    }
   }
 
   deleteItem(item: Item) {
@@ -22,8 +37,36 @@ export class AppComponent {
   }
 
   onClickMe(event?: KeyboardEvent) {
-    const evtMsg = event ? ' Event target class is ' + (<HTMLElement>event.target).className  : '';
+    const evtMsg = event ? ' Event target class is ' + (<HTMLElement>event.target).className : '';
     alert('Click me.' + evtMsg);
   }
 
+  handleClickOnParentDiv() {
+    alert('clicked on parent');
+  }
+
+  handleClickOnChildDiv() {
+    alert('clicked on child');
+  }
+
+  handleScroll(event?: Event) {
+    event.preventDefault()
+    alert(`preventDefault does not work in passive event handler, ${event.defaultPrevented}`)
+  }
+
+  handleOnceClick() {
+    alert('this handle should only be called once');
+  }
+
+  handleClickWithMixedOptions() {}
+
+  clickInNoopZone() {
+    this.zoneMessage =
+        NgZone.isInAngularZone() ? `inside the angular zone` : 'outside of the angular zone';
+  }
+
+  clickInNgZone() {
+    this.zoneMessage =
+        NgZone.isInAngularZone() ? `inside the angular zone` : 'outside of the angular zone';
+  }
 }

--- a/aio/content/guide/event-binding.md
+++ b/aio/content/guide/event-binding.md
@@ -68,6 +68,23 @@ To update the `name` property, the changed text is retrieved by following the pa
 If the event belongs to a directive&mdash;recall that components
 are directives&mdash;`$event` has whatever shape the directive produces.
 
+## Apply `capture`, `passive`, `once`, `ngZone`, `noopZone` options
+
+It is possible to apply [AddEventListenerOptions](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) `capture`, `passive`, `once` by combining the event name with the option.
+
+Consider this example:
+
+<code-example path="event-binding/src/app/app.component.html" region="event-binding-4" header="src/app/app.component.html"></code-example>
+
+And it is also possible to apply `ngZone` or `noopZone` option to make sure the event handler run into the specified `zone`.
+
+- `ngZone`: The event handler always runs into the `angular zone`, so it triggers the change detection automatically.
+- `noopZone`: The event handler always runs outside of the `angular zone`, so it does not trigger the change detection automatically.
+
+Consider this example:
+
+<code-example path="event-binding/src/app/app.component.html" region="event-binding-5" header="src/app/app.component.html"></code-example>
+
 ## Custom events with `EventEmitter`
 
 Directives typically raise custom events with an Angular [EventEmitter](api/core/EventEmitter).

--- a/goldens/public-api/platform-browser/platform-browser.d.ts
+++ b/goldens/public-api/platform-browser/platform-browser.d.ts
@@ -36,6 +36,13 @@ export declare class EventManager {
     getZone(): NgZone;
 }
 
+export declare interface EventManagerPluginOptions {
+    capture?: boolean;
+    once?: boolean;
+    passive?: boolean;
+    zone?: 'ngZone' | 'noopZone';
+}
+
 export declare const HAMMER_GESTURE_CONFIG: InjectionToken<HammerGestureConfig>;
 
 export declare const HAMMER_LOADER: InjectionToken<HammerLoader>;
@@ -89,6 +96,8 @@ export declare type MetaDefinition = {
 } & {
     [prop: string]: string;
 };
+
+export declare function onAndCancelWithZone(element: any, eventName: string, handler: EventListener, ngZone: NgZone, options?: EventManagerPluginOptions): Function;
 
 export declare const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef;
 

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2987,
-        "main-es2015": 448419,
+        "main-es2015": 449415,
         "polyfills-es2015": 52630
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3097,
-        "main-es2015": 429885,
+        "main-es2015": 430875,
         "polyfills-es2015": 52195
       }
     }

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 141151,
+        "main-es2015": 142629,
         "polyfills-es2015": 36571
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 147573,
+        "main-es2015": 148562,
         "polyfills-es2015": 36571
       }
     }
@@ -30,7 +30,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 136168,
+        "main-es2015": 137158,
         "polyfills-es2015": 37248
       }
     }
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 245351,
+        "main-es2015": 246352,
         "polyfills-es2015": 36938,
         "5-es2015": 751
       }
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 221897,
+        "main-es2015": 222792,
         "polyfills-es2015": 36938,
         "5-es2015": 779
       }
@@ -62,7 +62,7 @@
         "bundle": "TODO(i): we should define ngDevMode to false in Closure, but --define only works in the global scope.",
         "bundle": "TODO(i): (FW-2164) TS 3.9 new class shape seems to have broken Closure in big ways. The size went from 169991 to 252338",
         "bundle": "TODO(i): after removal of tsickle from ngc-wrapped / ng_package, we had to switch to SIMPLE optimizations which increased the size from 252338 to 1198917, see PR#37221 and PR#37317 for more info",
-        "bundle": 1209659
+        "bundle": 1211019 
       }
     }
   }

--- a/packages/common/src/dom_adapter.ts
+++ b/packages/common/src/dom_adapter.ts
@@ -52,7 +52,8 @@ export abstract class DomAdapter {
   abstract isShadowRoot(node: any): boolean;
 
   // Used by KeyEventsPlugin
-  abstract onAndCancel(el: any, evt: any, listener: any): Function;
+  abstract onAndCancel(el: any, evt: any, listener: any, options?: AddEventListenerOptions):
+      Function;
   abstract supportsDOMEvents(): boolean;
 
   // Used by PlatformLocation and ServerEventManagerPlugin

--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -54,12 +54,14 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     }
   }
 
-  onAndCancel(el: Node, evt: any, listener: any): Function {
-    el.addEventListener(evt, listener, false);
+  onAndCancel(el: Node, evt: any, listener: any, options?: AddEventListenerOptions): Function {
+    options ? el.addEventListener(evt, listener, options) : el.addEventListener(evt, listener);
     // Needed to follow Dart's subscription semantic, until fix of
     // https://code.google.com/p/dart/issues/detail?id=17406
     return () => {
-      el.removeEventListener(evt, listener, false);
+      options && typeof options.capture === 'boolean' ?
+          el.removeEventListener(evt, listener, {capture: options.capture}) :
+          el.removeEventListener(evt, listener);
     };
   }
   dispatchEvent(el: Node, evt: any) {

--- a/packages/platform-browser/src/dom/events/dom_events.ts
+++ b/packages/platform-browser/src/dom/events/dom_events.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DOCUMENT} from '@angular/common';
+import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
 import {Inject, Injectable} from '@angular/core';
 
-import {EventManagerPlugin} from './event_manager';
+import {EventManagerPlugin, EventManagerPluginOptions} from './event_manager';
+import {onAndCancelWithZone} from './zone_event_util';
 
 @Injectable()
 export class DomEventsPlugin extends EventManagerPlugin {
@@ -23,12 +24,10 @@ export class DomEventsPlugin extends EventManagerPlugin {
     return true;
   }
 
-  addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
-    element.addEventListener(eventName, handler as EventListener, false);
-    return () => this.removeEventListener(element, eventName, handler as EventListener);
-  }
-
-  removeEventListener(target: any, eventName: string, callback: Function): void {
-    return target.removeEventListener(eventName, callback as EventListener);
+  addEventListener(
+      element: HTMLElement, eventName: string, handler: Function,
+      options?: EventManagerPluginOptions): Function {
+    return onAndCancelWithZone(
+        element, eventName, handler as EventListener, this.manager.getZone(), options);
   }
 }

--- a/packages/platform-browser/src/dom/events/key_events.ts
+++ b/packages/platform-browser/src/dom/events/key_events.ts
@@ -8,7 +8,7 @@
 
 import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
 import {Inject, Injectable, NgZone} from '@angular/core';
-import {EventManagerPlugin} from './event_manager';
+import {EventManagerPlugin, EventManagerPluginOptions} from './event_manager';
 
 /**
  * Defines supported modifiers for key events.
@@ -100,14 +100,16 @@ export class KeyEventsPlugin extends EventManagerPlugin {
    * event object as an argument.
    * @returns The key event that was registered.
    */
-  addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
+  addEventListener(
+      element: HTMLElement, eventName: string, handler: Function,
+      options?: EventManagerPluginOptions): Function {
     const parsedEvent = KeyEventsPlugin.parseEventName(eventName)!;
 
     const outsideHandler =
         KeyEventsPlugin.eventCallback(parsedEvent['fullKey'], handler, this.manager.getZone());
 
     return this.manager.getZone().runOutsideAngular(() => {
-      return getDOM().onAndCancel(element, parsedEvent['domEventName'], outsideHandler);
+      return getDOM().onAndCancel(element, parsedEvent['domEventName'], outsideHandler, options);
     });
   }
 

--- a/packages/platform-browser/src/dom/events/zone_event_util.ts
+++ b/packages/platform-browser/src/dom/events/zone_event_util.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ɵgetDOM as getDOM} from '@angular/common';
+import {NgZone} from '@angular/core';
+import {EventManagerPluginOptions} from './event_manager';
+
+/**
+ *
+ * @param element
+ * @param eventName
+ * @param handler
+ * @param ngZone
+ * @param options
+ *
+ * @publicApi
+ */
+export function onAndCancelWithZone(
+    element: any, eventName: string, handler: EventListener, ngZone: NgZone,
+    options?: EventManagerPluginOptions): Function {
+  const dom = getDOM();
+  const zoneOption = options?.zone;
+  // remove options.zone and only pass AddEventListenerOptions to the dom
+  let hasDOMOptions = false;
+  if (typeof options?.capture === 'boolean' || typeof options?.once === 'boolean' ||
+      typeof options?.passive === 'boolean') {
+    hasDOMOptions = true;
+  }
+  let listenerOptions = hasDOMOptions ? {...options} : undefined;
+  if (listenerOptions) {
+    delete listenerOptions.zone;
+  }
+  if (zoneOption === 'noopZone') {
+    if (NgZone.isInAngularZone()) {
+      // Currently inside ngZone, we need to add the listener outside of ngZone
+      return ngZone.runOutsideAngular(() => {
+        return dom.onAndCancel(element, eventName, handler, listenerOptions);
+      });
+    }
+  }
+  if (zoneOption === 'ngZone') {
+    if (!NgZone.isInAngularZone()) {
+      // Currently outside ngZone, we need to add the listener inside ngZone
+      return ngZone.run(() => {
+        return dom.onAndCancel(element, eventName, handler, listenerOptions);
+      });
+    }
+  }
+  return dom.onAndCancel(element, eventName, handler, listenerOptions);
+}

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -12,8 +12,9 @@ export {Title} from './browser/title';
 export {disableDebugTools, enableDebugTools} from './browser/tools/tools';
 export {BrowserTransferStateModule, makeStateKey, StateKey, TransferState} from './browser/transfer_state';
 export {By} from './dom/debug/by';
-export {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
+export {EVENT_MANAGER_PLUGINS, EventManager, EventManagerPluginOptions} from './dom/events/event_manager';
 export {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HAMMER_PROVIDERS__POST_R3__ as ɵHAMMER_PROVIDERS__POST_R3__, HammerGestureConfig, HammerLoader, HammerModule} from './dom/events/hammer_gestures';
+export {onAndCancelWithZone} from './dom/events/zone_event_util';
 export {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl, SafeValue} from './security/dom_sanitization_service';
 
 export * from './private_export';

--- a/packages/platform-server/src/server_events.ts
+++ b/packages/platform-server/src/server_events.ts
@@ -7,26 +7,31 @@
  */
 
 import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
-import {Inject, Injectable} from '@angular/core';
+import {Inject, Injectable, NgZone} from '@angular/core';
+import {EventManagerPluginOptions, onAndCancelWithZone} from '@angular/platform-browser';
 
 @Injectable()
 export class ServerEventManagerPlugin /* extends EventManagerPlugin which is private */ {
-  constructor(@Inject(DOCUMENT) private doc: any) {}
+  constructor(@Inject(DOCUMENT) private doc: any, private ngZone: NgZone) {}
 
   // Handle all events on the server.
   supports(eventName: string) {
     return true;
   }
 
-  addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
-    return getDOM().onAndCancel(element, eventName, handler);
+  addEventListener(
+      element: HTMLElement, eventName: string, handler: Function,
+      options?: EventManagerPluginOptions): Function {
+    return onAndCancelWithZone(element, eventName, handler as EventListener, this.ngZone, options);
   }
 
-  addGlobalEventListener(element: string, eventName: string, handler: Function): Function {
+  addGlobalEventListener(
+      element: string, eventName: string, handler: Function,
+      options?: EventManagerPluginOptions): Function {
     const target: HTMLElement = getDOM().getGlobalEventTarget(this.doc, element);
     if (!target) {
       throw new Error(`Unsupported event target ${target} for event ${eventName}`);
     }
-    return this.addEventListener(target, eventName, handler);
+    return this.addEventListener(target, eventName, handler, options);
   }
 }


### PR DESCRIPTION
Close #19878

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 19878


## What is the new behavior?


### can't pass `passive`, `capture`, `once` parameters to `addEventListener`.

### not easy to config use ngzone or noopzone with HostListener

user need to explicitly call `runOutsideOfAngular` to make sure  `eventhandler` run outsideof`ngZone` 

```javascript
@HostListener('window:resize', ['$event.target'])
  onResize(target: any) {
    this.ngZone.runOutsideOfAngular(() => {
       console.log('resize triggered');
    });
  }
```
or call `ngZone.run` explicitly make sure `eventhandler` run into `ngZone`.

```javascript
@HostListener('window:resize', ['$event.target'])
  onResize(target: any) {
    this.ngZone.run(() => {
       console.log('resize triggered');
    });
  }
```

### not easy to run event handler outsideOfAngular in template

```javascript
<div (mouseover)="mouseover();"></div>
```

```javascript
mouseover() {
  this.ngZone.runOfAngular(() => {
    ...
  });
}
```

## What is the new behavior?
Can config which `zone` will event handler will run into in `@HostListener` decorator.

### can config `passive`, `capture`, `once` parameters to `addEventListener`.
- in template, can config those parameter like below.

```javascript
<div (mouseover.capture.once.passive)="mouseover();"></div>
```

### can config `ngzone` which will guarantee eventhandler run in `ngZone` even the handler was 
added not in `ngZone`.

```javascript
 @HostListener('window:resize.ngzone', ['$event.target'])
  onResize(target: any) {
    console.log('resize triggered');
  }
```

- can config `noopzone` which will guarantee eventhandler run outside of  `ngZone` even the handler was added  in `ngZone`. **and if config `outsideOfAngular`, DOMEventManager will bypass zone.js and directly use native addEventListener to improve performance.**

And it can also work with #20672 to get better performance.

```javascript
 @HostListener('window:resize.noopzone', ['$event.target'])
  onResize(target: any) {
    console.log('resize triggered');
  }
```