### PR TITLE
fix(docs-infra): preserve focus on copy (and prevent scrolling to bottom on IE11)

### DIFF
--- a/aio/src/app/shared/copier.service.ts
+++ b/aio/src/app/shared/copier.service.ts
@@ -59,14 +59,13 @@ export class CopierService {
     style.padding = '0';
     style.margin = '0';
 
-    // Move element out of screen horizontally.
-    style.position = 'absolute';
-    style[ isRTL ? 'right' : 'left' ] = '-9999px';
+    // Make the element invisible and move it out of screen horizontally.
+    style.opacity = '0';
+    style.position = 'fixed';
+    style.top = '0';
+    style[isRTL ? 'right' : 'left'] = '-999em';
 
-    // Move element to the same position vertically.
-    const yPosition = window.pageYOffset || docElem.scrollTop;
-    style.top = yPosition + 'px';
-
+    textArea.setAttribute('aria-hidden', 'true');
     textArea.setAttribute('readonly', '');
     textArea.value = text;
 

--- a/aio/src/app/shared/copier.service.ts
+++ b/aio/src/app/shared/copier.service.ts
@@ -5,6 +5,9 @@
  * - https://github.com/zenorocha/clipboard.js/
  *
  * Both released under MIT license - © Zeno Rocha
+ *
+ * It is also influenced by the Angular CDK `PendingCopy` class:
+ * https://github.com/angular/components/blob/master/src/cdk/clipboard/pending-copy.ts
  */
 
 
@@ -18,6 +21,8 @@ export class CopierService {
    * @return Whether the copy operation was successful.
    */
   private copyTextArea(textArea: HTMLTextAreaElement): boolean {
+    const currentFocus = document.activeElement as HTMLOrSVGElement | null;
+
     try {
       textArea.select();
       textArea.setSelectionRange(0, textArea.value.length);
@@ -25,6 +30,8 @@ export class CopierService {
       return document.execCommand('copy');
     } catch {
       return false;
+    } finally {
+      currentFocus?.focus();
     }
   }
 

--- a/aio/src/app/shared/copier.service.ts
+++ b/aio/src/app/shared/copier.service.ts
@@ -10,11 +10,11 @@
 
 export class CopierService {
   /**
-   * Copy the contents of a `<textarea>` element to clipboard.
+   * Copy the contents of a `<textarea>` element to the clipboard.
    *
    * NOTE: For this method to work, the elements must be already inserted into the DOM.
    *
-   * @param textArea The area containing the text to be copied to clipboard.
+   * @param textArea The area containing the text to be copied to the clipboard.
    * @return Whether the copy operation was successful.
    */
   private copyTextArea(textArea: HTMLTextAreaElement): boolean {
@@ -65,9 +65,9 @@ export class CopierService {
   }
 
   /**
-   * Copy the specified text to clipboard.
+   * Copy the specified text to the clipboard.
    *
-   * @param text The text to be copied to clipboard.
+   * @param text The text to be copied to the clipboard.
    * @return Whether the copy operation was successful.
    */
   copyText(text: string): boolean {

--- a/aio/src/app/shared/copier.service.ts
+++ b/aio/src/app/shared/copier.service.ts
@@ -12,6 +12,8 @@ export class CopierService {
   /**
    * Copy the contents of a `<textarea>` element to clipboard.
    *
+   * NOTE: For this method to work, the elements must be already inserted into the DOM.
+   *
    * @param textArea The area containing the text to be copied to clipboard.
    * @return Whether the copy operation was successful.
    */
@@ -27,8 +29,7 @@ export class CopierService {
   }
 
   /**
-   * Create a temporary, hidden `<textarea>` element, set its value to the specified text and insert
-   * it into the DOM.
+   * Create a temporary, hidden `<textarea>` element and set its value to the specified text.
    *
    * @param text The text to be inserted into the textarea.
    * @return The temporary `<textarea>` element containing the specified text.
@@ -60,8 +61,6 @@ export class CopierService {
     textArea.setAttribute('readonly', '');
     textArea.value = text;
 
-    document.body.appendChild(textArea);
-
     return textArea;
   }
 
@@ -72,9 +71,16 @@ export class CopierService {
    * @return Whether the copy operation was successful.
    */
   copyText(text: string): boolean {
+    // Create a `<textarea>` element with the specified text.
     const textArea = this.createTextArea(text);
+
+    // Insert it into the DOM.
+    document.body.appendChild(textArea);
+
+    // Copy its contents to the clipboard.
     const success = this.copyTextArea(textArea);
 
+    // Remove it from the DOM, so it can be garbage-collected.
     if (textArea.parentNode) {
       // We cannot use ChildNode.remove() because of IE11.
       textArea.parentNode.removeChild(textArea);

--- a/aio/src/app/shared/copier.service.ts
+++ b/aio/src/app/shared/copier.service.ts
@@ -9,59 +9,77 @@
 
 
 export class CopierService {
-    private fakeElem: HTMLTextAreaElement|null;
+  /**
+   * Copy the contents of a `<textarea>` element to clipboard.
+   *
+   * @param textArea The area containing the text to be copied to clipboard.
+   * @return Whether the copy operation was successful.
+   */
+  private copyTextArea(textArea: HTMLTextAreaElement): boolean {
+    try {
+      textArea.select();
+      textArea.setSelectionRange(0, textArea.value.length);
 
-    /**
-     * Creates a fake textarea element, sets its value from `text` property,
-     * and makes a selection on it.
-     */
-    createFake(text: string) {
-      const docElem = document.documentElement!;
-      const isRTL = docElem.getAttribute('dir') === 'rtl';
+      return document.execCommand('copy');
+    } catch {
+      return false;
+    }
+  }
 
-      // Create a fake element to hold the contents to copy
-      this.fakeElem = document.createElement('textarea');
+  /**
+   * Create a temporary, hidden `<textarea>` element, set its value to the specified text and insert
+   * it into the DOM.
+   *
+   * @param text The text to be inserted into the textarea.
+   * @return The temporary `<textarea>` element containing the specified text.
+   */
+  private createTextArea(text: string): HTMLTextAreaElement {
+    const docElem = document.documentElement!;
+    const isRTL = docElem.getAttribute('dir') === 'rtl';
 
-      // Prevent zooming on iOS
-      this.fakeElem.style.fontSize = '12pt';
+    // Create a temporary element to hold the contents to copy.
+    const textArea = document.createElement('textarea');
+    const style = textArea.style;
 
-      // Reset box model
-      this.fakeElem.style.border = '0';
-      this.fakeElem.style.padding = '0';
-      this.fakeElem.style.margin = '0';
+    // Prevent zooming on iOS.
+    style.fontSize = '12pt';
 
-      // Move element out of screen horizontally
-      this.fakeElem.style.position = 'absolute';
-      this.fakeElem.style[ isRTL ? 'right' : 'left' ] = '-9999px';
+    // Reset box model.
+    style.border = '0';
+    style.padding = '0';
+    style.margin = '0';
 
-      // Move element to the same position vertically
-      const yPosition = window.pageYOffset || docElem.scrollTop;
-      this.fakeElem.style.top = yPosition + 'px';
+    // Move element out of screen horizontally.
+    style.position = 'absolute';
+    style[ isRTL ? 'right' : 'left' ] = '-9999px';
 
-      this.fakeElem.setAttribute('readonly', '');
-      this.fakeElem.value = text;
+    // Move element to the same position vertically.
+    const yPosition = window.pageYOffset || docElem.scrollTop;
+    style.top = yPosition + 'px';
 
-      document.body.appendChild(this.fakeElem);
+    textArea.setAttribute('readonly', '');
+    textArea.value = text;
 
-      this.fakeElem.select();
-      this.fakeElem.setSelectionRange(0, this.fakeElem.value.length);
+    document.body.appendChild(textArea);
+
+    return textArea;
+  }
+
+  /**
+   * Copy the specified text to clipboard.
+   *
+   * @param text The text to be copied to clipboard.
+   * @return Whether the copy operation was successful.
+   */
+  copyText(text: string): boolean {
+    const textArea = this.createTextArea(text);
+    const success = this.copyTextArea(textArea);
+
+    if (textArea.parentNode) {
+      // We cannot use ChildNode.remove() because of IE11.
+      textArea.parentNode.removeChild(textArea);
     }
 
-    removeFake() {
-      if (this.fakeElem) {
-        document.body.removeChild(this.fakeElem);
-        this.fakeElem = null;
-      }
-    }
-
-    copyText(text: string) {
-      try {
-        this.createFake(text);
-        return document.execCommand('copy');
-      } catch (err) {
-        return false;
-      } finally {
-        this.removeFake();
-      }
-    }
+    return success;
+  }
 }

--- a/aio/src/app/shared/copier.service.ts
+++ b/aio/src/app/shared/copier.service.ts
@@ -31,6 +31,8 @@ export class CopierService {
     } catch {
       return false;
     } finally {
+      // Calling `.select()` on the `<textarea>` element may have also focused it.
+      // Change the focus back to the previously focused element.
       currentFocus?.focus();
     }
   }


### PR DESCRIPTION
The `CopierService` is used for copying text to the user's clipboard. It is, for example, used in `CodeComponent` to copy example code snippets. This is implemented by creating a temporary, hidden `<textarea>` elements, setting its value to the text that needs to be copied, executing the `copy` command and finally removing the element from the DOM.

Previously, as a result of `CopierService`'s implementation, the focused element would lose focus, while the temporary `<textarea>` element would implicitly gain focus when selecting its contents. This had an even worse side-effect on IE11, which seems to scroll to the bottom of the containing element (here `<body>`) when the focused element is removed.

This PR fixes these issues by keeping track of the previously focused element and restoring its focus after the copy operation. It also includes some minor refactorings. See individual commits for more details.
