### PR TITLE
refactor(compiler): wrap large strings in function

### DIFF
--- a/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
@@ -249,7 +249,7 @@ function transformIvySourceFile(
     importRewriter: ImportRewriter, file: ts.SourceFile, isCore: boolean,
     isClosureCompilerEnabled: boolean,
     defaultImportRecorder: DefaultImportRecorder): ts.SourceFile {
-  const constantPool = new ConstantPool();
+  const constantPool = new ConstantPool(isClosureCompilerEnabled);
   const importManager = new ImportManager(importRewriter);
 
   // The transformation process consists of 2 steps:


### PR DESCRIPTION
Large strings constants are now wrapped in a function which is called whenever used. This works around a unique limitation of Closure, where it will **always** inline string literals at **every** usage, regardless of how large the string literal is or how many times it is used.

The workaround is to use a function rather than a string literal. Closure has differently inlining semantics for functions, where it will check the length of the function and the number of times it is used before choosing to inline it. By using a function, `ngtsc` makes Closure more conservative about inlining large strings, and avoids blowing up the bundle size.

This optimization is only used if the constant is a large string. A wrapping function is not included for other use cases, since it would just increase the bundle size and add unnecessary runtime performance overhead.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Refactoring (no functional changes, no api changes)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Angular Material button component is almost twice as large in Ivy as View Engine. This appears to be because it shares styles across two components (`MatButton` and `MatAnchor`), which are deduplicated in View Engine but not in Ivy. This is partially because Closure compiler will **always** inline string constants at **every** usage. This causes strings to be duplicated, and large strings (such as CSS styling) get duplicated.

Issue Number: http://b/161849099

## What is the new behavior?

The Angular compiler will generate large string constants as being wrapped in a function and invoked where needed. This tricks Closure into **not** inlining the large strings and prevents the bundle size duplication.

## Does this PR introduce a breaking change?

- [X] No

## Other information

Also see http://b/162106151 for additional context and a response from the Closure compiler team.

I'm also not totally sure what implication this will have on Terser. I don't anticipate any unique changes, but maybe we should mark the function pure? I'm not sure how we go about that in the compiler.