### PR TITLE
fix(dev-infra): roll back phased review conditions

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1160,8 +1160,6 @@ groups:
   public-api:
     <<: *defaults
     conditions:
-      - *no-groups-above-this-pending
-      - *no-groups-above-this-rejected
       - *can-be-global-approved
       - >
         contains_any_globs(files, [
@@ -1192,8 +1190,6 @@ groups:
   size-tracking:
     <<: *defaults
     conditions:
-      - *no-groups-above-this-pending
-      - *no-groups-above-this-rejected
       - *can-be-global-approved
       - >
         contains_any_globs(files, [
@@ -1218,8 +1214,6 @@ groups:
   circular-dependencies:
     <<: *defaults
     conditions:
-      - *no-groups-above-this-pending
-      - *no-groups-above-this-rejected
       - *can-be-global-approved
       - >
         contains_any_globs(files, [


### PR DESCRIPTION
It was determined that the list of 'pending' groups also included inactive groups.
That means that the 'no-groups-above-this-pending' would generally fail because
there's almost always some inactive group above it.

This commit removes the conditions for phased review while we
investigate if the inactive groups can be excluded.
