### PR TITLE
ci: only check active groups for the `no-groups-above-this-*` checks

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1162,6 +1162,8 @@ groups:
   public-api:
     <<: *defaults
     conditions:
+      - *no-groups-above-this-pending
+      - *no-groups-above-this-rejected
       - *can-be-global-approved
       - >
         contains_any_globs(files, [
@@ -1194,6 +1196,8 @@ groups:
   size-tracking:
     <<: *defaults
     conditions:
+      - *no-groups-above-this-pending
+      - *no-groups-above-this-rejected
       - *can-be-global-approved
       - >
         contains_any_globs(files, [
@@ -1220,6 +1224,8 @@ groups:
   circular-dependencies:
     <<: *defaults
     conditions:
+      - *no-groups-above-this-pending
+      - *no-groups-above-this-rejected
       - *can-be-global-approved
       - >
         contains_any_globs(files, [

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -75,12 +75,14 @@ meta:
   # By checking the number of active/pending/rejected groups when these are excluded, we can determine
   # if any other groups are matched.
   #
+  # Note: Because all inactive groups start as pending, we are only checking pending and rejected active groups.
+  #
   # Also note that the ordering of groups matters in this file. The only groups visible to the current
   # one are those that appear above it.
   no-groups-above-this-pending: &no-groups-above-this-pending
-    len(groups.pending.exclude("required-minimum-review").exclude("global-approvers").exclude("global-docs-approvers")) == 0
+    len(groups.active.pending.exclude("required-minimum-review").exclude("global-approvers").exclude("global-docs-approvers")) == 0
   no-groups-above-this-rejected: &no-groups-above-this-rejected
-    len(groups.rejected.exclude("required-minimum-review").exclude("global-approvers").exclude("global-docs-approvers")) == 0
+    len(groups.active.rejected.exclude("required-minimum-review").exclude("global-approvers").exclude("global-docs-approvers")) == 0
   no-groups-above-this-active: &no-groups-above-this-active
     len(groups.active.exclude("required-minimum-review").exclude("global-approvers").exclude("global-docs-approvers")) == 0
 


### PR DESCRIPTION
Since PullApprove starts all inactive groups as a pending state, to properly
assess if any groups we care about are pending we must only check the active
groups.  We additionally do this with rejected because the intention of the
reusable checks is around checking active rules only.


Must go in after #38257
