### PR TITLE
fix(platform-browser): key event handler should run in the correct zone

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -599,9 +599,7 @@ export class ApplicationRef {
       private _initStatus: ApplicationInitStatus) {
     this._onMicrotaskEmptySubscription = this._zone.onMicrotaskEmpty.subscribe({
       next: () => {
-        this._zone.run(() => {
-          this.tick();
-        });
+        this.tick();
       }
     });
 
@@ -831,6 +829,15 @@ export class ApplicationRef {
    * detection pass during which all change detection must complete.
    */
   tick(): void {
+    if (NgZone.isInAngularZone()) {
+      this._tick();
+    } else {
+      this._zone.run(() => this._tick());
+    }
+  }
+
+  /** @internal */
+  _tick(): void {
     if (this._runningTick) {
       const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
           'ApplicationRef.tick is called recursively' :

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -359,20 +359,12 @@ export class DebugElement extends DebugNode {
     // that Zone.js only adds to `EventTarget` in browser environments.
     if (typeof node.eventListeners === 'function') {
       // Note that in Ivy we wrap event listeners with a call to `event.preventDefault` in some
-      // cases. We use '__ngUnwrap__' as a special token that gives us access to the actual event
+      // cases. We use '__ngUnwrap__' as a special property that gives us access to the actual event
       // listener.
       node.eventListeners(eventName).forEach((listener: Function) => {
-        // In order to ensure that we can detect the special __ngUnwrap__ token described above, we
-        // use `toString` on the listener and see if it contains the token. We use this approach to
-        // ensure that it still worked with compiled code since it cannot remove or rename string
-        // literals. We also considered using a special function name (i.e. if(listener.name ===
-        // special)) but that was more cumbersome and we were also concerned the compiled code could
-        // strip the name, turning the condition in to ("" === "") and always returning true.
-        if (listener.toString().indexOf('__ngUnwrap__') !== -1) {
-          const unwrappedListener = listener('__ngUnwrap__');
-          return invokedListeners.indexOf(unwrappedListener) === -1 &&
-              unwrappedListener.call(node, eventObj);
-        }
+        const unwrappedListener = (listener as any)['__ngUnwrap__'];
+        return unwrappedListener && invokedListeners.indexOf(unwrappedListener) === -1 &&
+            unwrappedListener.call(node, eventObj);
       });
     }
   }

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -612,7 +612,7 @@ class SomeComponent {
       const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
       const zone: NgZone = TestBed.inject(NgZone);
       appRef.attachView(fixture.componentRef.hostView);
-      zone.run(() => appRef.tick());
+      appRef.tick();
 
       let i = 0;
       appRef.isStable.subscribe({
@@ -673,7 +673,7 @@ class SomeComponent {
            const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
            const zone: NgZone = TestBed.inject(NgZone);
            appRef.attachView(fixture.componentRef.hostView);
-           zone.run(() => appRef.tick());
+           appRef.tick();
 
            fixture.whenStable().then(() => {
              expectUnstable(appRef);

--- a/packages/platform-browser/src/dom/events/dom_events.ts
+++ b/packages/platform-browser/src/dom/events/dom_events.ts
@@ -24,11 +24,6 @@ export class DomEventsPlugin extends EventManagerPlugin {
   }
 
   override addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
-    element.addEventListener(eventName, handler as EventListener, false);
-    return () => this.removeEventListener(element, eventName, handler as EventListener);
-  }
-
-  removeEventListener(target: any, eventName: string, callback: Function): void {
-    return target.removeEventListener(eventName, callback as EventListener);
+    return this.ensureAddListenerInZone(element, eventName, handler);
   }
 }

--- a/packages/platform-browser/src/dom/events/event_manager.ts
+++ b/packages/platform-browser/src/dom/events/event_manager.ts
@@ -122,12 +122,12 @@ export abstract class EventManagerPlugin {
    */
   ensureAddListenerInZone(element: HTMLElement, eventName: string, handler: Function): Function {
     const zone = this.manager.getZone();
-    if (!NgZone.isInAngularZone()) {
-      return zone.run(() => {
-        return getDOM().onAndCancel(element, eventName, handler);
-      });
-    } else {
-      return getDOM().onAndCancel(element, eventName, handler);
-    }
+    return zone.runOutsideAngular(() => {
+      const handlerInZone = () => {
+        return zone.run(handler as any, element, [eventName]);
+      };
+      handlerInZone['__ngUnwrap__'] = (handler as any)['__ngUnwrap__'] || handler;
+      return getDOM().onAndCancel(element, eventName, handlerInZone);
+    });
   }
 }

--- a/packages/platform-browser/src/dom/events/event_manager.ts
+++ b/packages/platform-browser/src/dom/events/event_manager.ts
@@ -108,4 +108,26 @@ export abstract class EventManagerPlugin {
     }
     return this.addEventListener(target, eventName, handler);
   }
+
+  /**
+   * Ensure that the event listener is added inside NgZone so the listener will trigger
+   * change detection automatically. if currently the context is already the NgZone,
+   * we just call addEventListener directly, otherwise run inside NgZone.
+   *
+   * @param element The HTML element to receive event notifications.
+   * @param eventName The name of the event to listen for.
+   * @param handler A function to call when the notification occurs. Receives the
+   * event object as an argument.
+   * @returns  A callback function that can be used to remove the handler.
+   */
+  ensureAddListenerInZone(element: HTMLElement, eventName: string, handler: Function): Function {
+    const zone = this.manager.getZone();
+    if (!NgZone.isInAngularZone()) {
+      return zone.run(() => {
+        return getDOM().onAndCancel(element, eventName, handler);
+      });
+    } else {
+      return getDOM().onAndCancel(element, eventName, handler);
+    }
+  }
 }


### PR DESCRIPTION
Close #38260 .

Currently the KeyEventPlugin handle key event such as `keydown.enter` and always run into `ngZone` no matter
which zone it is added. And this behavior is not consistent with the other event handlers.

So this commit fixes this issue.

Also it make sure the `event handler` in key event plugin call on the correct context object.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #38260

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
