### PR TITLE
refactor(docs-infra): Lazy-loads SVG icons

### DIFF
--- a/aio/src/app/shared/custom-icon-registry.ts
+++ b/aio/src/app/shared/custom-icon-registry.ts
@@ -58,7 +58,7 @@ export class CustomIconRegistry extends MatIconRegistry {
         : super.getNamedSvgIcon(iconName, namespace);
   }
 
-  private loadSvgElement(iconName: string, namespace?: string) {
+  private loadSvgElement(iconName: string, namespace?: string): SVGElement | undefined {
     const svgIcon = this.svgIcons.find(icon => {
       return namespace
       ? icon.name === iconName && icon.namespace === namespace

--- a/aio/src/app/shared/custom-icon-registry.ts
+++ b/aio/src/app/shared/custom-icon-registry.ts
@@ -40,19 +40,17 @@ const DEFAULT_NS = '$$default';
 @Injectable()
 export class CustomIconRegistry extends MatIconRegistry {
   private cachedSvgElements: SvgIconMap = {[DEFAULT_NS]: {}};
-  private svgIcons: SvgIconInfo[];
 
   constructor(http: HttpClient, sanitizer: DomSanitizer, @Optional() @Inject(DOCUMENT) document: Document,
-              errorHandler: ErrorHandler, @Inject(SVG_ICONS) svgIcons: SvgIconInfo[]) {
+              errorHandler: ErrorHandler, @Inject(SVG_ICONS) private svgIcons: SvgIconInfo[]) {
     super(http, sanitizer, document, errorHandler);
-    this.svgIcons = svgIcons;
   }
 
   getNamedSvgIcon(iconName: string, namespace?: string) {
     const nsIconMap = this.cachedSvgElements[namespace || DEFAULT_NS];
     let preloadedElement: SVGElement | undefined = nsIconMap && nsIconMap[iconName];
     if (!preloadedElement) {
-      preloadedElement = this.lazyloadSvgElement(iconName, namespace);
+      preloadedElement = this.loadSvgElement(iconName, namespace);
     }
 
     return preloadedElement
@@ -60,7 +58,7 @@ export class CustomIconRegistry extends MatIconRegistry {
         : super.getNamedSvgIcon(iconName, namespace);
   }
 
-  private lazyloadSvgElement(iconName: string, namespace?: string) {
+  private loadSvgElement(iconName: string, namespace?: string) {
     const svgIcon = this.svgIcons.find(icon => {
       return namespace
       ? icon.name === iconName && icon.namespace === namespace

--- a/aio/src/app/shared/custom-icon-registry.ts
+++ b/aio/src/app/shared/custom-icon-registry.ts
@@ -39,35 +39,50 @@ const DEFAULT_NS = '$$default';
  */
 @Injectable()
 export class CustomIconRegistry extends MatIconRegistry {
-  private preloadedSvgElements: SvgIconMap = {[DEFAULT_NS]: {}};
+  private cachedSvgElements: SvgIconMap = {[DEFAULT_NS]: {}};
+  private svgIcons: SvgIconInfo[];
 
   constructor(http: HttpClient, sanitizer: DomSanitizer, @Optional() @Inject(DOCUMENT) document: Document,
               errorHandler: ErrorHandler, @Inject(SVG_ICONS) svgIcons: SvgIconInfo[]) {
     super(http, sanitizer, document, errorHandler);
-    this.loadSvgElements(svgIcons);
+    this.svgIcons = svgIcons;
   }
 
   getNamedSvgIcon(iconName: string, namespace?: string) {
-    const nsIconMap = this.preloadedSvgElements[namespace || DEFAULT_NS];
-    const preloadedElement = nsIconMap && nsIconMap[iconName];
+    const nsIconMap = this.cachedSvgElements[namespace || DEFAULT_NS];
+    let preloadedElement: SVGElement | undefined = nsIconMap && nsIconMap[iconName];
+    if (!preloadedElement) {
+      preloadedElement = this.lazyloadSvgElement(iconName, namespace);
+    }
 
     return preloadedElement
         ? of(preloadedElement.cloneNode(true) as SVGElement)
         : super.getNamedSvgIcon(iconName, namespace);
   }
 
-  private loadSvgElements(svgIcons: SvgIconInfo[]) {
-    svgIcons.forEach(icon => {
-      const ns = icon.namespace || DEFAULT_NS;
-      const nsIconMap = this.preloadedSvgElements[ns] || (this.preloadedSvgElements[ns] = {});
-
-      // Creating a new `<div>` per icon is necessary for the SVGs to work correctly in IE11.
-      const div = document.createElement('DIV');
-
-      // SECURITY: the source for the SVG icons is provided in code by trusted developers
-      div.innerHTML = icon.svgSource;
-
-      nsIconMap[icon.name] = div.querySelector('svg')!;
+  private lazyloadSvgElement(iconName: string, namespace?: string) {
+    const svgIcon = this.svgIcons.find(icon => {
+      return namespace
+      ? icon.name === iconName && icon.namespace === namespace
+      : icon.name === iconName;
     });
+
+    if (!svgIcon) {
+      return;
+    }
+
+    const ns = svgIcon.namespace || DEFAULT_NS;
+    const nsIconMap = this.cachedSvgElements[ns] || (this.cachedSvgElements[ns] = {});
+
+    // Creating a new `<div>` per icon is necessary for the SVGs to work correctly in IE11.
+    const div = document.createElement('DIV');
+
+    // SECURITY: the source for the SVG icons is provided in code by trusted developers
+    div.innerHTML = svgIcon.svgSource;
+
+    const svgElement = div.querySelector('svg')!;
+    nsIconMap[svgIcon.name] = svgElement;
+
+    return svgElement;
   }
 }


### PR DESCRIPTION
Prior to this commit, SVG icons were all loaded in the constructor
of the `CustomIconRegistry`. This commit avoids that, and loads SVG
icons on demand.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
