### PR TITLE
refactor(compiler-cli): only use type constructors for directives with generic types

### DIFF
--- a/goldens/public-api/compiler-cli/compiler_options.d.ts
+++ b/goldens/public-api/compiler-cli/compiler_options.d.ts
@@ -35,6 +35,7 @@ export interface StrictTemplateOptions {
     strictContextGenerics?: boolean;
     strictDomEventTypes?: boolean;
     strictDomLocalRefTypes?: boolean;
+    strictInputAccessModifiers?: boolean;
     strictInputTypes?: boolean;
     strictLiteralTypes?: boolean;
     strictNullInputTypes?: boolean;

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -15,7 +15,7 @@ import {absoluteFrom, relative} from '../../file_system';
 import {DefaultImportRecorder, ModuleResolver, Reference, ReferenceEmitter} from '../../imports';
 import {DependencyTracker} from '../../incremental/api';
 import {IndexingContext} from '../../indexer';
-import {DirectiveMeta, extractDirectiveGuards, InjectableClassRegistry, MetadataReader, MetadataRegistry} from '../../metadata';
+import {DirectiveMeta, DirectiveTypeCheckMeta, extractDirectiveGuards, InjectableClassRegistry, MetadataReader, MetadataRegistry} from '../../metadata';
 import {flattenInheritedDirectiveMetadata} from '../../metadata/src/inheritance';
 import {EnumValue, PartialEvaluator} from '../../partial_evaluator';
 import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
@@ -51,7 +51,7 @@ export interface ComponentAnalysisData {
    */
   meta: Omit<R3ComponentMetadata, ComponentMetadataResolvedFields>;
   baseClass: Reference<ClassDeclaration>|'dynamic'|null;
-  guards: ReturnType<typeof extractDirectiveGuards>;
+  guards: DirectiveTypeCheckMeta;  // TODO: rename property
   template: ParsedTemplateWithSource;
   metadataStmt: Statement|null;
 
@@ -327,7 +327,7 @@ export class ComponentDecoratorHandler implements
           i18nUseExternalIds: this.i18nUseExternalIds,
           relativeContextFilePath,
         },
-        guards: extractDirectiveGuards(node, this.reflector),
+        guards: extractDirectiveGuards(node, metadata.inputs, this.reflector),
         metadataStmt: generateSetClassMetadataCall(
             node, this.reflector, this.defaultImportRecorder, this.isCore,
             this.annotateForClosureCompiler),

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -15,7 +15,7 @@ import {absoluteFrom, relative} from '../../file_system';
 import {DefaultImportRecorder, ModuleResolver, Reference, ReferenceEmitter} from '../../imports';
 import {DependencyTracker} from '../../incremental/api';
 import {IndexingContext} from '../../indexer';
-import {DirectiveMeta, DirectiveTypeCheckMeta, extractDirectiveGuards, InjectableClassRegistry, MetadataReader, MetadataRegistry} from '../../metadata';
+import {DirectiveMeta, DirectiveTypeCheckMeta, extractDirectiveTypeCheckMeta, InjectableClassRegistry, MetadataReader, MetadataRegistry} from '../../metadata';
 import {flattenInheritedDirectiveMetadata} from '../../metadata/src/inheritance';
 import {EnumValue, PartialEvaluator} from '../../partial_evaluator';
 import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
@@ -51,7 +51,7 @@ export interface ComponentAnalysisData {
    */
   meta: Omit<R3ComponentMetadata, ComponentMetadataResolvedFields>;
   baseClass: Reference<ClassDeclaration>|'dynamic'|null;
-  guards: DirectiveTypeCheckMeta;  // TODO: rename property
+  typeCheckMeta: DirectiveTypeCheckMeta;
   template: ParsedTemplateWithSource;
   metadataStmt: Statement|null;
 
@@ -327,7 +327,7 @@ export class ComponentDecoratorHandler implements
           i18nUseExternalIds: this.i18nUseExternalIds,
           relativeContextFilePath,
         },
-        guards: extractDirectiveGuards(node, metadata.inputs, this.reflector),
+        typeCheckMeta: extractDirectiveTypeCheckMeta(node, metadata.inputs, this.reflector),
         metadataStmt: generateSetClassMetadataCall(
             node, this.reflector, this.defaultImportRecorder, this.isCore,
             this.annotateForClosureCompiler),
@@ -356,7 +356,7 @@ export class ComponentDecoratorHandler implements
       queries: analysis.meta.queries.map(query => query.propertyName),
       isComponent: true,
       baseClass: analysis.baseClass,
-      ...analysis.guards,
+      ...analysis.typeCheckMeta,
     });
 
     this.injectableRegistry.registerInjectable(node);

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
 import {DefaultImportRecorder, Reference} from '../../imports';
-import {InjectableClassRegistry, MetadataReader, MetadataRegistry} from '../../metadata';
+import {DirectiveTypeCheckMeta, InjectableClassRegistry, MetadataReader, MetadataRegistry} from '../../metadata';
 import {extractDirectiveGuards} from '../../metadata/src/util';
 import {DynamicValue, EnumValue, PartialEvaluator} from '../../partial_evaluator';
 import {ClassDeclaration, ClassMember, ClassMemberKind, Decorator, filterToMembersWithDecorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
@@ -35,7 +35,7 @@ const LIFECYCLE_HOOKS = new Set([
 
 export interface DirectiveHandlerData {
   baseClass: Reference<ClassDeclaration>|'dynamic'|null;
-  guards: ReturnType<typeof extractDirectiveGuards>;
+  guards: DirectiveTypeCheckMeta;  // TODO: rename property
   meta: R3DirectiveMetadata;
   metadataStmt: Statement|null;
   providersRequiringFactory: Set<Reference<ClassDeclaration>>|null;
@@ -102,7 +102,7 @@ export class DirectiveDecoratorHandler implements
             node, this.reflector, this.defaultImportRecorder, this.isCore,
             this.annotateForClosureCompiler),
         baseClass: readBaseClass(node, this.reflector, this.evaluator),
-        guards: extractDirectiveGuards(node, this.reflector),
+        guards: extractDirectiveGuards(node, analysis.inputs, this.reflector),
         providersRequiringFactory
       }
     };

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
 import {DefaultImportRecorder, Reference} from '../../imports';
 import {DirectiveTypeCheckMeta, InjectableClassRegistry, MetadataReader, MetadataRegistry} from '../../metadata';
-import {extractDirectiveGuards} from '../../metadata/src/util';
+import {extractDirectiveTypeCheckMeta} from '../../metadata/src/util';
 import {DynamicValue, EnumValue, PartialEvaluator} from '../../partial_evaluator';
 import {ClassDeclaration, ClassMember, ClassMemberKind, Decorator, filterToMembersWithDecorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
 import {LocalModuleScopeRegistry} from '../../scope';
@@ -35,7 +35,7 @@ const LIFECYCLE_HOOKS = new Set([
 
 export interface DirectiveHandlerData {
   baseClass: Reference<ClassDeclaration>|'dynamic'|null;
-  guards: DirectiveTypeCheckMeta;  // TODO: rename property
+  typeCheckMeta: DirectiveTypeCheckMeta;
   meta: R3DirectiveMetadata;
   metadataStmt: Statement|null;
   providersRequiringFactory: Set<Reference<ClassDeclaration>>|null;
@@ -102,7 +102,7 @@ export class DirectiveDecoratorHandler implements
             node, this.reflector, this.defaultImportRecorder, this.isCore,
             this.annotateForClosureCompiler),
         baseClass: readBaseClass(node, this.reflector, this.evaluator),
-        guards: extractDirectiveGuards(node, analysis.inputs, this.reflector),
+        typeCheckMeta: extractDirectiveTypeCheckMeta(node, analysis.inputs, this.reflector),
         providersRequiringFactory
       }
     };
@@ -122,7 +122,7 @@ export class DirectiveDecoratorHandler implements
       queries: analysis.meta.queries.map(query => query.propertyName),
       isComponent: false,
       baseClass: analysis.baseClass,
-      ...analysis.guards,
+      ...analysis.typeCheckMeta,
     });
 
     this.injectableRegistry.registerInjectable(node);

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -148,6 +148,14 @@ export interface StrictTemplateOptions {
   strictInputTypes?: boolean;
 
   /**
+   * Whether to check if the input binding attempts to assign to a restricted field (readonly,
+   * private, or protected) on the directive/component.
+   *
+   * Defaults to `false`, even if "fullTemplateTypeCheck" and/or "strictInputTypes" is set.
+   */
+  strictInputAccessModifiers?: boolean;
+
+  /**
    * Whether to use strict null types for input bindings for directives.
    *
    * If this is `true`, applications that are compiled with TypeScript's `strictNullChecks` enabled

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -415,6 +415,7 @@ export class NgCompiler {
         checkQueries: false,
         checkTemplateBodies: true,
         checkTypeOfInputBindings: strictTemplates,
+        honorAccessModifiersForInputBindings: false,
         strictNullInputBindings: strictTemplates,
         checkTypeOfAttributes: strictTemplates,
         // Even in full template type-checking mode, DOM binding checks are not quite ready yet.
@@ -442,6 +443,7 @@ export class NgCompiler {
         checkTemplateBodies: false,
         checkTypeOfInputBindings: false,
         strictNullInputBindings: false,
+        honorAccessModifiersForInputBindings: false,
         checkTypeOfAttributes: false,
         checkTypeOfDomBindings: false,
         checkTypeOfOutputEvents: false,
@@ -461,6 +463,10 @@ export class NgCompiler {
     if (this.options.strictInputTypes !== undefined) {
       typeCheckingConfig.checkTypeOfInputBindings = this.options.strictInputTypes;
       typeCheckingConfig.applyTemplateContextGuards = this.options.strictInputTypes;
+    }
+    if (this.options.strictInputAccessModifiers !== undefined) {
+      typeCheckingConfig.honorAccessModifiersForInputBindings =
+          this.options.strictInputAccessModifiers;
     }
     if (this.options.strictNullInputTypes !== undefined) {
       typeCheckingConfig.strictNullInputBindings = this.options.strictNullInputTypes;

--- a/packages/compiler-cli/src/ngtsc/metadata/index.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/index.ts
@@ -9,4 +9,4 @@
 export * from './src/api';
 export {DtsMetadataReader} from './src/dts';
 export {CompoundMetadataRegistry, LocalMetadataRegistry, InjectableClassRegistry} from './src/registry';
-export {extractDirectiveGuards, CompoundMetadataReader} from './src/util';
+export {extractDirectiveTypeCheckMeta, CompoundMetadataReader} from './src/util';

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -61,6 +61,13 @@ export interface DirectiveTypeCheckMeta {
   restrictedInputFields: Set<string>;
 
   /**
+   * The set of input fields which are declared as string literal members in the Directive's class.
+   * We need to track these separately because these fields may not be valid JS identifiers so
+   * we cannot use them with property access expressions when assigning inputs.
+   */
+  stringLiteralInputFields: Set<string>;
+
+  /**
    * The set of input fields which do not have corresponding members in the Directive's class.
    */
   undeclaredInputFields: Set<string>;

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -32,13 +32,33 @@ export interface NgModuleMeta {
   rawDeclarations: ts.Expression|null;
 }
 
+/**
+ * Typing metadata collected for a directive within an NgModule's scope.
+ */
 export interface DirectiveTypeCheckMeta {
+  /**
+   * List of static `ngTemplateGuard_xx` members found on the Directive's class.
+   *  @see `TemplateGuardMeta`
+   */
   ngTemplateGuards: TemplateGuardMeta[];
+  /** Whether the Directive's class has a static ngTemplateContextGuard function. */
   hasNgTemplateContextGuard: boolean;
+  /**
+   * The set of input fields which have a corresponding static `ngAcceptInputType_` on the
+   * Directive's class. This allows inputs to accept a wider range of types and coerce the input to
+   * a narrower type with a getter/setter. See https://angular.io/guide/template-typecheck.
+   */
   coercedInputFields: Set<string>;
+  /** The set of input fields which map to generic members in the Directive's class. */
   genericInputFields: Set<string>;
+  /**
+   * The set of input fields which map to `private` or `protected` members in the Directive's
+   * class.
+   */
   restrictedInputFields: Set<string>;
+  /** The set of input fields which do not have corresponding members in the Directive's class. */
   undeclaredInputFields: Set<string>;
+  /** Whether the Directive's class is generic, i.e. `class MyDir<T> {...}`. */
   isGeneric: boolean;
 }
 

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -32,19 +32,26 @@ export interface NgModuleMeta {
   rawDeclarations: ts.Expression|null;
 }
 
+export interface DirectiveTypeCheckMeta {
+  ngTemplateGuards: TemplateGuardMeta[];
+  hasNgTemplateContextGuard: boolean;
+  coercedInputFields: Set<string>;
+  genericInputFields: Set<string>;
+  restrictedInputFields: Set<string>;
+  undeclaredInputFields: Set<string>;
+  isGeneric: boolean;
+}
+
 /**
  * Metadata collected for a directive within an NgModule's scope.
  */
-export interface DirectiveMeta extends T2DirectiveMeta {
+export interface DirectiveMeta extends T2DirectiveMeta, DirectiveTypeCheckMeta {
   ref: Reference<ClassDeclaration>;
   /**
    * Unparsed selector of the directive, or null if the directive does not have a selector.
    */
   selector: string|null;
   queries: string[];
-  ngTemplateGuards: TemplateGuardMeta[];
-  hasNgTemplateContextGuard: boolean;
-  coercedInputFields: Set<string>;
 
   /**
    * A `Reference` to the base class for the directive, if one was detected.

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -38,27 +38,41 @@ export interface NgModuleMeta {
 export interface DirectiveTypeCheckMeta {
   /**
    * List of static `ngTemplateGuard_xx` members found on the Directive's class.
-   *  @see `TemplateGuardMeta`
+   * @see `TemplateGuardMeta`
    */
   ngTemplateGuards: TemplateGuardMeta[];
-  /** Whether the Directive's class has a static ngTemplateContextGuard function. */
+
+  /**
+   * Whether the Directive's class has a static ngTemplateContextGuard function.
+   */
   hasNgTemplateContextGuard: boolean;
+
   /**
    * The set of input fields which have a corresponding static `ngAcceptInputType_` on the
    * Directive's class. This allows inputs to accept a wider range of types and coerce the input to
    * a narrower type with a getter/setter. See https://angular.io/guide/template-typecheck.
    */
   coercedInputFields: Set<string>;
-  /** The set of input fields which map to generic members in the Directive's class. */
+
+  /**
+   * The set of input fields which map to generic members in the Directive's class.
+   */
   genericInputFields: Set<string>;
+
   /**
    * The set of input fields which map to `private` or `protected` members in the Directive's
    * class.
    */
   restrictedInputFields: Set<string>;
-  /** The set of input fields which do not have corresponding members in the Directive's class. */
+
+  /**
+   * The set of input fields which do not have corresponding members in the Directive's class.
+   */
   undeclaredInputFields: Set<string>;
-  /** Whether the Directive's class is generic, i.e. `class MyDir<T> {...}`. */
+
+  /**
+   * Whether the Directive's class is generic, i.e. `class MyDir<T> {...}`.
+   */
   isGeneric: boolean;
 }
 

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -55,8 +55,8 @@ export interface DirectiveTypeCheckMeta {
   coercedInputFields: Set<string>;
 
   /**
-   * The set of input fields which map to `private` or `protected` members in the Directive's
-   * class.
+   * The set of input fields which map to `readonly`, `private`, or `protected` members in the
+   * Directive's class.
    */
   restrictedInputFields: Set<string>;
 

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -55,11 +55,6 @@ export interface DirectiveTypeCheckMeta {
   coercedInputFields: Set<string>;
 
   /**
-   * The set of input fields which map to generic members in the Directive's class.
-   */
-  genericInputFields: Set<string>;
-
-  /**
    * The set of input fields which map to `private` or `protected` members in the Directive's
    * class.
    */

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -76,16 +76,17 @@ export class DtsMetadataReader implements MetadataReader {
       return null;
     }
 
+    const inputs = readStringMapType(def.type.typeArguments[3]);
     return {
       ref,
       name: clazz.name.text,
       isComponent: def.name === 'ɵcmp',
       selector: readStringType(def.type.typeArguments[1]),
       exportAs: readStringArrayType(def.type.typeArguments[2]),
-      inputs: readStringMapType(def.type.typeArguments[3]),
+      inputs,
       outputs: readStringMapType(def.type.typeArguments[4]),
       queries: readStringArrayType(def.type.typeArguments[5]),
-      ...extractDirectiveGuards(clazz, this.reflector),
+      ...extractDirectiveGuards(clazz, inputs, this.reflector),
       baseClass: readBaseClass(clazz, this.checker, this.reflector),
     };
   }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -12,7 +12,7 @@ import {Reference} from '../../imports';
 import {ClassDeclaration, isNamedClassDeclaration, ReflectionHost} from '../../reflection';
 
 import {DirectiveMeta, MetadataReader, NgModuleMeta, PipeMeta} from './api';
-import {extractDirectiveGuards, extractReferencesFromType, readStringArrayType, readStringMapType, readStringType} from './util';
+import {extractDirectiveTypeCheckMeta, extractReferencesFromType, readStringArrayType, readStringMapType, readStringType} from './util';
 
 /**
  * A `MetadataReader` that can read metadata from `.d.ts` files, which have static Ivy properties
@@ -86,7 +86,7 @@ export class DtsMetadataReader implements MetadataReader {
       inputs,
       outputs: readStringMapType(def.type.typeArguments[4]),
       queries: readStringArrayType(def.type.typeArguments[5]),
-      ...extractDirectiveGuards(clazz, inputs, this.reflector),
+      ...extractDirectiveTypeCheckMeta(clazz, inputs, this.reflector),
       baseClass: readBaseClass(clazz, this.checker, this.reflector),
     };
   }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
@@ -27,9 +27,10 @@ export function flattenInheritedDirectiveMetadata(
 
   let inputs: {[key: string]: string|[string, string]} = {};
   let outputs: {[key: string]: string} = {};
-  let coercedInputFields = new Set<string>();
-  let undeclaredInputFields = new Set<string>();
-  let restrictedInputFields = new Set<string>();
+  const coercedInputFields = new Set<string>();
+  const undeclaredInputFields = new Set<string>();
+  const restrictedInputFields = new Set<string>();
+  const stringLiteralInputFields = new Set<string>();
   let isDynamic = false;
 
   const addMetadata = (meta: DirectiveMeta): void => {
@@ -56,6 +57,9 @@ export function flattenInheritedDirectiveMetadata(
     for (const restrictedInputField of meta.restrictedInputFields) {
       restrictedInputFields.add(restrictedInputField);
     }
+    for (const field of meta.stringLiteralInputFields) {
+      stringLiteralInputFields.add(field);
+    }
   };
 
   addMetadata(topMeta);
@@ -67,6 +71,7 @@ export function flattenInheritedDirectiveMetadata(
     coercedInputFields,
     undeclaredInputFields,
     restrictedInputFields,
+    stringLiteralInputFields,
     baseClass: isDynamic ? 'dynamic' : null,
   };
 }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
@@ -52,6 +52,8 @@ export function flattenInheritedDirectiveMetadata(
     for (const undeclaredInputField of meta.undeclaredInputFields) {
       undeclaredInputFields.add(undeclaredInputField);
     }
+    // TODO: shouldn't we inherit restricted input fields? If this is a child class, it *must* have
+    // the same access modifiers on the members as the base.
   };
 
   addMetadata(topMeta);

--- a/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
@@ -28,6 +28,7 @@ export function flattenInheritedDirectiveMetadata(
   let inputs: {[key: string]: string|[string, string]} = {};
   let outputs: {[key: string]: string} = {};
   let coercedInputFields = new Set<string>();
+  let undeclaredInputFields = new Set<string>();
   let isDynamic = false;
 
   const addMetadata = (meta: DirectiveMeta): void => {
@@ -48,6 +49,9 @@ export function flattenInheritedDirectiveMetadata(
     for (const coercedInputField of meta.coercedInputFields) {
       coercedInputFields.add(coercedInputField);
     }
+    for (const undeclaredInputField of meta.undeclaredInputFields) {
+      undeclaredInputFields.add(undeclaredInputField);
+    }
   };
 
   addMetadata(topMeta);
@@ -57,6 +61,7 @@ export function flattenInheritedDirectiveMetadata(
     inputs,
     outputs,
     coercedInputFields,
+    undeclaredInputFields,
     baseClass: isDynamic ? 'dynamic' : null,
   };
 }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
@@ -29,6 +29,7 @@ export function flattenInheritedDirectiveMetadata(
   let outputs: {[key: string]: string} = {};
   let coercedInputFields = new Set<string>();
   let undeclaredInputFields = new Set<string>();
+  let restrictedInputFields = new Set<string>();
   let isDynamic = false;
 
   const addMetadata = (meta: DirectiveMeta): void => {
@@ -52,8 +53,9 @@ export function flattenInheritedDirectiveMetadata(
     for (const undeclaredInputField of meta.undeclaredInputFields) {
       undeclaredInputFields.add(undeclaredInputField);
     }
-    // TODO: shouldn't we inherit restricted input fields? If this is a child class, it *must* have
-    // the same access modifiers on the members as the base.
+    for (const restrictedInputField of meta.restrictedInputFields) {
+      restrictedInputFields.add(restrictedInputField);
+    }
   };
 
   addMetadata(topMeta);
@@ -64,6 +66,7 @@ export function flattenInheritedDirectiveMetadata(
     outputs,
     coercedInputFields,
     undeclaredInputFields,
+    restrictedInputFields,
     baseClass: isDynamic ? 'dynamic' : null,
   };
 }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
@@ -12,7 +12,7 @@ import {Reference} from '../../imports';
 import {ClassDeclaration, ClassMember, ClassMemberKind, isNamedClassDeclaration, ReflectionHost, reflectTypeEntityToDeclaration} from '../../reflection';
 import {nodeDebugInfo} from '../../util/src/typescript';
 
-import {DirectiveMeta, MetadataReader, NgModuleMeta, PipeMeta, TemplateGuardMeta} from './api';
+import {DirectiveMeta, DirectiveTypeCheckMeta, MetadataReader, NgModuleMeta, PipeMeta, TemplateGuardMeta} from './api';
 
 export function extractReferencesFromType(
     checker: ts.TypeChecker, def: ts.TypeNode, ngModuleImportedFrom: string|null,
@@ -78,13 +78,15 @@ export function readStringArrayType(type: ts.TypeNode): string[] {
   return res;
 }
 
-
-export function extractDirectiveGuards(node: ClassDeclaration, reflector: ReflectionHost): {
-  ngTemplateGuards: TemplateGuardMeta[],
-  hasNgTemplateContextGuard: boolean,
-  coercedInputFields: Set<string>,
-} {
-  const staticMembers = reflector.getMembersOfClass(node).filter(member => member.isStatic);
+/**
+ * TODO: rename to `extractDirectiveInfo` and rename the `guards` field in
+ * `DirectiveHandlerData`/`ComponentAnalysisData` to a more appropriate name.
+ */
+export function extractDirectiveGuards(
+    node: ClassDeclaration, inputs: {[fieldName: string]: string|[string, string]},
+    reflector: ReflectionHost): DirectiveTypeCheckMeta {
+  const members = reflector.getMembersOfClass(node);
+  const staticMembers = members.filter(member => member.isStatic);
   const ngTemplateGuards = staticMembers.map(extractTemplateGuard)
                                .filter((guard): guard is TemplateGuardMeta => guard !== null);
   const hasNgTemplateContextGuard = staticMembers.some(
@@ -93,7 +95,48 @@ export function extractDirectiveGuards(node: ClassDeclaration, reflector: Reflec
   const coercedInputFields =
       new Set(staticMembers.map(extractCoercedInput)
                   .filter((inputName): inputName is string => inputName !== null));
-  return {hasNgTemplateContextGuard, ngTemplateGuards, coercedInputFields};
+
+  const genericInputFields = new Set<string>();
+  const restrictedInputFields = new Set<string>();
+  const undeclaredInputFields = new Set<string>();
+
+  for (const fieldName of Object.keys(inputs)) {
+    const field = members.find(member => member.name === fieldName);
+    if (field === undefined || field.node === null) {
+      undeclaredInputFields.add(fieldName);
+    } else if (isRestricted(field.node)) {
+      restrictedInputFields.add(fieldName);
+    } else if (hasGenericType(field.node)) {
+      genericInputFields.add(fieldName);
+    }
+  }
+
+  const arity = reflector.getGenericArityOfClass(node);
+
+  return {
+    hasNgTemplateContextGuard,
+    ngTemplateGuards,
+    coercedInputFields,
+    genericInputFields,
+    restrictedInputFields,
+    undeclaredInputFields,
+    isGeneric: arity !== null && arity > 0,
+  };
+}
+
+function isRestricted(node: ts.Node): boolean {
+  if (node.modifiers === undefined) {
+    return false;
+  }
+
+  return node.modifiers.some(
+      modifier => modifier.kind === ts.SyntaxKind.PrivateKeyword ||
+          modifier.kind === ts.SyntaxKind.ProtectedKeyword);
+}
+
+function hasGenericType(node: ts.Node): boolean {
+  // TODO: figure this out
+  return true;
 }
 
 function extractTemplateGuard(member: ClassMember): TemplateGuardMeta|null {

--- a/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
@@ -79,10 +79,11 @@ export function readStringArrayType(type: ts.TypeNode): string[] {
 }
 
 /**
- * TODO: rename to `extractDirectiveInfo` and rename the `guards` field in
- * `DirectiveHandlerData`/`ComponentAnalysisData` to a more appropriate name.
+ * Inspects the class' members and extracts the metadata that is used when type-checking templates
+ * that use the directive. This metadata does not contain information from a base class, if any,
+ * making this metadata invariant to changes of inherited classes.
  */
-export function extractDirectiveGuards(
+export function extractDirectiveTypeCheckMeta(
     node: ClassDeclaration, inputs: {[fieldName: string]: string|[string, string]},
     reflector: ReflectionHost): DirectiveTypeCheckMeta {
   const members = reflector.getMembersOfClass(node);

--- a/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
@@ -97,7 +97,6 @@ export function extractDirectiveTypeCheckMeta(
       new Set(staticMembers.map(extractCoercedInput)
                   .filter((inputName): inputName is string => inputName !== null));
 
-  const genericInputFields = new Set<string>();
   const restrictedInputFields = new Set<string>();
   const undeclaredInputFields = new Set<string>();
 
@@ -107,8 +106,6 @@ export function extractDirectiveTypeCheckMeta(
       undeclaredInputFields.add(fieldName);
     } else if (isRestricted(field.node)) {
       restrictedInputFields.add(fieldName);
-    } else if (hasGenericType(field.node)) {
-      genericInputFields.add(fieldName);
     }
   }
 
@@ -118,7 +115,6 @@ export function extractDirectiveTypeCheckMeta(
     hasNgTemplateContextGuard,
     ngTemplateGuards,
     coercedInputFields,
-    genericInputFields,
     restrictedInputFields,
     undeclaredInputFields,
     isGeneric: arity !== null && arity > 0,
@@ -133,11 +129,6 @@ function isRestricted(node: ts.Node): boolean {
   return node.modifiers.some(
       modifier => modifier.kind === ts.SyntaxKind.PrivateKeyword ||
           modifier.kind === ts.SyntaxKind.ProtectedKeyword);
-}
-
-function hasGenericType(node: ts.Node): boolean {
-  // TODO: figure this out
-  return true;
 }
 
 function extractTemplateGuard(member: ClassMember): TemplateGuardMeta|null {

--- a/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
@@ -98,6 +98,7 @@ export function extractDirectiveTypeCheckMeta(
                   .filter((inputName): inputName is string => inputName !== null));
 
   const restrictedInputFields = new Set<string>();
+  const stringLiteralInputFields = new Set<string>();
   const undeclaredInputFields = new Set<string>();
 
   for (const fieldName of Object.keys(inputs)) {
@@ -106,6 +107,9 @@ export function extractDirectiveTypeCheckMeta(
       undeclaredInputFields.add(fieldName);
     } else if (isRestricted(field.node)) {
       restrictedInputFields.add(fieldName);
+    }
+    if (field && field.nameNode !== null && ts.isStringLiteral(field.nameNode)) {
+      stringLiteralInputFields.add(fieldName);
     }
   }
 
@@ -116,6 +120,7 @@ export function extractDirectiveTypeCheckMeta(
     ngTemplateGuards,
     coercedInputFields,
     restrictedInputFields,
+    stringLiteralInputFields,
     undeclaredInputFields,
     isGeneric: arity !== null && arity > 0,
   };

--- a/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
@@ -128,7 +128,8 @@ function isRestricted(node: ts.Node): boolean {
 
   return node.modifiers.some(
       modifier => modifier.kind === ts.SyntaxKind.PrivateKeyword ||
-          modifier.kind === ts.SyntaxKind.ProtectedKeyword);
+          modifier.kind === ts.SyntaxKind.ProtectedKeyword ||
+          modifier.kind === ts.SyntaxKind.ReadonlyKeyword);
 }
 
 function extractTemplateGuard(member: ClassMember): TemplateGuardMeta|null {

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -244,6 +244,7 @@ function fakeDirective(ref: Reference<ClassDeclaration>): DirectiveMeta {
     ngTemplateGuards: [],
     coercedInputFields: new Set<string>(),
     restrictedInputFields: new Set<string>(),
+    stringLiteralInputFields: new Set<string>(),
     undeclaredInputFields: new Set<string>(),
     isGeneric: false,
     baseClass: null,

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -243,6 +243,7 @@ function fakeDirective(ref: Reference<ClassDeclaration>): DirectiveMeta {
     hasNgTemplateContextGuard: false,
     ngTemplateGuards: [],
     coercedInputFields: new Set<string>(),
+    restrictedInputFields: new Set<string>(),
     undeclaredInputFields: new Set<string>(),
     isGeneric: false,
     baseClass: null,

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -243,6 +243,8 @@ function fakeDirective(ref: Reference<ClassDeclaration>): DirectiveMeta {
     hasNgTemplateContextGuard: false,
     ngTemplateGuards: [],
     coercedInputFields: new Set<string>(),
+    undeclaredInputFields: new Set<string>(),
+    isGeneric: false,
     baseClass: null,
   };
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -91,6 +91,14 @@ export interface TypeCheckingConfig {
   checkTypeOfInputBindings: boolean;
 
   /**
+   * Whether to honor the access modifiers on input bindings for the component/directive.
+   *
+   * If a template binding attempts to assign to an input that is private/protected/readonly,
+   * this will produce errors when enabled but will not when disabled.
+   */
+  honorAccessModifiersForInputBindings: boolean;
+
+  /**
    * Whether to use strict null types for input bindings for directives.
    *
    * If this is `true`, applications that are compiled with TypeScript's `strictNullChecks` enabled

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 
 import {AbsoluteFsPath} from '../../file_system';
 import {Reference} from '../../imports';
-import {TemplateGuardMeta} from '../../metadata';
+import {DirectiveTypeCheckMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 
 
@@ -19,12 +19,9 @@ import {ClassDeclaration} from '../../reflection';
  * Extension of `DirectiveMeta` that includes additional information required to type-check the
  * usage of a particular directive.
  */
-export interface TypeCheckableDirectiveMeta extends DirectiveMeta {
+export interface TypeCheckableDirectiveMeta extends DirectiveMeta, DirectiveTypeCheckMeta {
   ref: Reference<ClassDeclaration>;
   queries: string[];
-  ngTemplateGuards: TemplateGuardMeta[];
-  coercedInputFields: Set<string>;
-  hasNgTemplateContextGuard: boolean;
 }
 
 export type TemplateId = string&{__brand: 'TemplateId'};

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -199,12 +199,12 @@ export class TypeCheckContextImpl implements TypeCheckContext {
     for (const dir of boundTarget.getUsedDirectives()) {
       const dirRef = dir.ref as Reference<ClassDeclaration<ts.ClassDeclaration>>;
       const dirNode = dirRef.node;
-      if (requiresInlineTypeCtor(dirNode, this.reflector)) {
+
+      if (dir.isGeneric && requiresInlineTypeCtor(dirNode, this.reflector)) {
         if (this.inlining === InliningMode.Error) {
           missingInlines.push(dirNode);
           continue;
         }
-
         // Add a type constructor operation for the directive.
         this.addInlineTypeCtor(fileData, dirNode.getSourceFile(), dirRef, {
           fnName: 'ngTypeCtor',

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
@@ -90,13 +90,13 @@ export function tsDeclareVariable(id: ts.Identifier, type: ts.TypeNode): ts.Vari
  * Create a `ts.VariableStatement` that initializes a variable with a given expression.
  *
  * Unlike with `tsDeclareVariable`, the type of the variable is inferred from the initializer
- * expression.
+ * expression unless an explicit type is provided.
  */
 export function tsCreateVariable(
-    id: ts.Identifier, initializer: ts.Expression): ts.VariableStatement {
+    id: ts.Identifier, initializer: ts.Expression, type?: ts.TypeNode): ts.VariableStatement {
   const decl = ts.createVariableDeclaration(
       /* name */ id,
-      /* type */ undefined,
+      /* type */ type,
       /* initializer */ initializer);
   return ts.createVariableStatement(
       /* modifiers */ undefined,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
@@ -87,6 +87,21 @@ export function tsDeclareVariable(id: ts.Identifier, type: ts.TypeNode): ts.Vari
 }
 
 /**
+ * Creates a `ts.TypeQueryNode` for a coerced input.
+ *
+ * For example: `typeof MatInput.ngAcceptInputType_value`, where MatInput is `typeName` and `value`
+ * is the `coercedInputName`.
+ *
+ * @param typeName The `EntityName` of the Directive where the static coerced input is defined.
+ * @param coercedInputName The field name of the coerced input
+ */
+export function tsCreateTypeQueryForCoercedInput(
+    typeName: ts.EntityName, coercedInputName: string): ts.TypeQueryNode {
+  return ts.createTypeQueryNode(
+      ts.createQualifiedName(typeName, `ngAcceptInputType_${coercedInputName}`))
+}
+
+/**
  * Create a `ts.VariableStatement` that initializes a variable with a given expression.
  *
  * Unlike with `tsDeclareVariable`, the type of the variable is inferred from the initializer

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
@@ -93,12 +93,12 @@ export function tsDeclareVariable(id: ts.Identifier, type: ts.TypeNode): ts.Vari
  * is the `coercedInputName`.
  *
  * @param typeName The `EntityName` of the Directive where the static coerced input is defined.
- * @param coercedInputName The field name of the coerced input
+ * @param coercedInputName The field name of the coerced input.
  */
 export function tsCreateTypeQueryForCoercedInput(
     typeName: ts.EntityName, coercedInputName: string): ts.TypeQueryNode {
   return ts.createTypeQueryNode(
-      ts.createQualifiedName(typeName, `ngAcceptInputType_${coercedInputName}`))
+      ts.createQualifiedName(typeName, `ngAcceptInputType_${coercedInputName}`));
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -1160,13 +1160,6 @@ class Scope {
   }
 }
 
-type TcbGenericInput = {
-  type: 'binding'; fieldName: string; attr: TmplAstBoundAttribute | TmplAstTextAttribute
-}|{
-  type: 'unset';
-  fieldName: string
-};
-
 interface TcbBoundInput {
   attribute: TmplAstBoundAttribute|TmplAstTextAttribute;
   fieldNames: string[];
@@ -1430,7 +1423,7 @@ function getBoundInputs(
     tcb: Context): TcbBoundInput[] {
   const boundInputs: TcbBoundInput[] = [];
 
-  const propertyToFieldNames = indexInputs(directive.inputs);
+  const propertyToFieldNames = invertInputs(directive.inputs);
   const processAttribute = (attr: TmplAstBoundAttribute|TmplAstTextAttribute) => {
     // Skip non-property bindings.
     if (attr instanceof TmplAstBoundAttribute && attr.type !== BindingType.Property) {
@@ -1459,6 +1452,9 @@ function getBoundInputs(
   return boundInputs;
 }
 
+/**
+ * Translates the given attribute binding to a `ts.Expression`.
+ */
 function translateInput(
     attr: TmplAstBoundAttribute|TmplAstTextAttribute, tcb: Context, scope: Scope): ts.Expression {
   if (attr instanceof TmplAstBoundAttribute) {
@@ -1470,7 +1466,11 @@ function translateInput(
   }
 }
 
-function indexInputs(inputs: {[fieldName: string]: string|[string, string]}):
+/**
+ * Inverts the input-mapping from field-to-property name into property-to-field name, to be able
+ * to match a property in a template with the corresponding field on a directive.
+ */
+function invertInputs(inputs: {[fieldName: string]: string|[string, string]}):
     Map<string, string[]> {
   const propertyToFieldNames = new Map<string, string[]>();
   for (const fieldName of Object.keys(inputs)) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -454,10 +454,11 @@ class TcbDirectiveInputsOp extends TcbOp {
         } else if (this.dir.restrictedInputFields.has(fieldName)) {
           if (this.tcb.env.config.honorAccessModifiersForInputBindings) {
             // To get errors assign directly to the fields on the instance, using property access
-            // when possible
-            // TODO: use element access when field name is not valid identifier
-            // target = ts.createElementAccess(dirId, ts.createStringLiteral(fieldName));
-            target = ts.createPropertyAccess(dirId, ts.createIdentifier(fieldName));
+            // when possible. String literal fields may not be valid JS identifiers so we use
+            // literal element access instead for those cases.
+            target = this.dir.stringLiteralInputFields.has(fieldName) ?
+                ts.createElementAccess(dirId, ts.createStringLiteral(fieldName)) :
+                ts.createPropertyAccess(dirId, ts.createIdentifier(fieldName));
           } else {
             // To ignore errors, assign to temp variable with type of the field
             const id = this.tcb.allocateId();

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -358,11 +358,6 @@ class TcbDirectiveCtorOp extends TcbOp {
     const inputs = getBoundInputs(this.dir, this.node, this.tcb);
     for (const input of inputs) {
       for (const fieldName of input.fieldNames) {
-        // Skip the field if it does not infer any of the generic types.
-        if (!this.dir.genericInputFields.has(fieldName)) {
-          continue;
-        }
-
         // Skip the field if an attribute has already been bound to it; we can't have a duplicate
         // key in the type constructor call.
         if (genericInputs.has(fieldName)) {
@@ -380,7 +375,7 @@ class TcbDirectiveCtorOp extends TcbOp {
     }
 
     // Add unset directive inputs for each of the remaining unset fields.
-    for (const fieldName of this.dir.genericInputFields) {
+    for (const fieldName of Object.keys(this.dir.inputs)) {
       if (!genericInputs.has(fieldName)) {
         genericInputs.set(fieldName, {type: 'unset', field: fieldName});
       }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {tsCreateTypeQueryForCoercedInput} from '@angular/compiler-cli/src/ngtsc/typecheck/src/ts_util';
 import * as ts from 'typescript';
 
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
@@ -151,8 +152,7 @@ function constructTypeCtorParameter(
           /* name */ key,
           /* questionToken */ undefined,
           /* type */
-          ts.createTypeQueryNode(
-              ts.createQualifiedName(rawType.typeName, `ngAcceptInputType_${key}`)),
+          tsCreateTypeQueryForCoercedInput(rawType.typeName, key),
           /* initializer */ undefined));
     }
   }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {tsCreateTypeQueryForCoercedInput} from '@angular/compiler-cli/src/ngtsc/typecheck/src/ts_util';
 import * as ts from 'typescript';
 
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
 import {TypeCtorMetadata} from '../api';
 
+import {tsCreateTypeQueryForCoercedInput} from './ts_util';
 import {TypeParameterEmitter} from './type_parameter_emitter';
 
 export function generateTypeCtorDeclarationFn(
@@ -151,8 +151,7 @@ function constructTypeCtorParameter(
           /* modifiers */ undefined,
           /* name */ key,
           /* questionToken */ undefined,
-          /* type */
-          tsCreateTypeQueryForCoercedInput(rawType.typeName, key),
+          /* type */ tsCreateTypeQueryForCoercedInput(rawType.typeName, key),
           /* initializer */ undefined));
     }
   }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -227,7 +227,8 @@ runInEachFileSystem(() => {
             name: 'GuardDir',
             selector: '[guard]',
             inputs: {'guard': 'guard'},
-            ngTemplateGuards: [{inputName: 'guard', type: 'binding'}]
+            ngTemplateGuards: [{inputName: 'guard', type: 'binding'}],
+            undeclaredInputFields: ['guard'],
           }]);
 
       expect(messages).toEqual([

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -120,8 +120,10 @@ export function ngForDeclaration(): TestDeclaration {
     file: absoluteFrom('/ngfor.d.ts'),
     selector: '[ngForOf]',
     name: 'NgForOf',
-    inputs: {ngForOf: 'ngForOf'},
+    inputs: {ngForOf: 'ngForOf', ngForTrackBy: 'ngForTrackBy', ngForTemplate: 'ngForTemplate'},
     hasNgTemplateContextGuard: true,
+    isGeneric: true,
+    genericInputFields: ['ngForOf', 'ngForTrackBy', 'ngForTemplate'],
   };
 }
 
@@ -175,11 +177,13 @@ export const ALL_ENABLED_CONFIG: TypeCheckingConfig = {
 // Remove 'ref' from TypeCheckableDirectiveMeta and add a 'selector' instead.
 export type TestDirective = Partial<Pick<
     TypeCheckableDirectiveMeta,
-    Exclude<keyof TypeCheckableDirectiveMeta, 'ref'|'coercedInputFields'>>>&{
-  selector: string,
-  name: string,
-  file?: AbsoluteFsPath, type: 'directive',
-  coercedInputFields?: string[],
+    Exclude<
+        keyof TypeCheckableDirectiveMeta,
+        'ref'|'coercedInputFields'|'genericInputFields'|'restrictedInputFields'|
+        'undeclaredInputFields'>>>&{
+  selector: string, name: string, file?: AbsoluteFsPath, type: 'directive',
+      coercedInputFields?: string[], genericInputFields?: string[],
+      restrictedInputFields?: string[], undeclaredInputFields?: string[], isGeneric?: boolean;
 };
 export type TestPipe = {
   name: string,
@@ -417,6 +421,10 @@ function prepareDeclarations(
       isComponent: decl.isComponent || false,
       ngTemplateGuards: decl.ngTemplateGuards || [],
       coercedInputFields: new Set<string>(decl.coercedInputFields || []),
+      genericInputFields: new Set<string>(decl.genericInputFields || []),
+      restrictedInputFields: new Set<string>(decl.restrictedInputFields || []),
+      undeclaredInputFields: new Set<string>(decl.undeclaredInputFields || []),
+      isGeneric: decl.isGeneric ?? false,
       outputs: decl.outputs || {},
       queries: decl.queries || [],
     };

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -178,10 +178,10 @@ export type TestDirective = Partial<Pick<
     TypeCheckableDirectiveMeta,
     Exclude<
         keyof TypeCheckableDirectiveMeta,
-        'ref'|'coercedInputFields'|'genericInputFields'|'restrictedInputFields'|
-        'undeclaredInputFields'>>>&{
+        'ref'|'coercedInputFields'|'restrictedInputFields'|'undeclaredInputFields'>>>&{
   selector: string, name: string, file?: AbsoluteFsPath, type: 'directive',
-      coercedInputFields?: string[], undeclaredInputFields?: string[], isGeneric?: boolean;
+      coercedInputFields?: string[], restrictedInputFields?: string[],
+      undeclaredInputFields?: string[], isGeneric?: boolean;
 };
 export type TestPipe = {
   name: string,
@@ -419,7 +419,6 @@ function prepareDeclarations(
       isComponent: decl.isComponent || false,
       ngTemplateGuards: decl.ngTemplateGuards || [],
       coercedInputFields: new Set<string>(decl.coercedInputFields || []),
-      genericInputFields: new Set<string>(decl.genericInputFields || []),
       restrictedInputFields: new Set<string>(decl.restrictedInputFields || []),
       undeclaredInputFields: new Set<string>(decl.undeclaredInputFields || []),
       isGeneric: decl.isGeneric ?? false,

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -157,6 +157,7 @@ export const ALL_ENABLED_CONFIG: TypeCheckingConfig = {
   checkQueries: false,
   checkTemplateBodies: true,
   checkTypeOfInputBindings: true,
+  honorAccessModifiersForInputBindings: true,
   strictNullInputBindings: true,
   checkTypeOfAttributes: true,
   // Feature is still in development.
@@ -212,6 +213,7 @@ export function tcb(
     applyTemplateContextGuards: true,
     checkQueries: false,
     checkTypeOfInputBindings: true,
+    honorAccessModifiersForInputBindings: false,
     strictNullInputBindings: true,
     checkTypeOfAttributes: true,
     checkTypeOfDomBindings: false,

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -179,10 +179,11 @@ export type TestDirective = Partial<Pick<
     TypeCheckableDirectiveMeta,
     Exclude<
         keyof TypeCheckableDirectiveMeta,
-        'ref'|'coercedInputFields'|'restrictedInputFields'|'undeclaredInputFields'>>>&{
+        'ref'|'coercedInputFields'|'restrictedInputFields'|'stringLiteralInputFields'|
+        'undeclaredInputFields'>>>&{
   selector: string, name: string, file?: AbsoluteFsPath, type: 'directive',
       coercedInputFields?: string[], restrictedInputFields?: string[],
-      undeclaredInputFields?: string[], isGeneric?: boolean;
+      stringLiteralInputFields?: string[], undeclaredInputFields?: string[], isGeneric?: boolean;
 };
 export type TestPipe = {
   name: string,
@@ -422,6 +423,7 @@ function prepareDeclarations(
       ngTemplateGuards: decl.ngTemplateGuards || [],
       coercedInputFields: new Set<string>(decl.coercedInputFields || []),
       restrictedInputFields: new Set<string>(decl.restrictedInputFields || []),
+      stringLiteralInputFields: new Set<string>(decl.stringLiteralInputFields || []),
       undeclaredInputFields: new Set<string>(decl.undeclaredInputFields || []),
       isGeneric: decl.isGeneric ?? false,
       outputs: decl.outputs || {},

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -123,7 +123,6 @@ export function ngForDeclaration(): TestDeclaration {
     inputs: {ngForOf: 'ngForOf', ngForTrackBy: 'ngForTrackBy', ngForTemplate: 'ngForTemplate'},
     hasNgTemplateContextGuard: true,
     isGeneric: true,
-    genericInputFields: ['ngForOf', 'ngForTrackBy', 'ngForTemplate'],
   };
 }
 
@@ -182,8 +181,7 @@ export type TestDirective = Partial<Pick<
         'ref'|'coercedInputFields'|'genericInputFields'|'restrictedInputFields'|
         'undeclaredInputFields'>>>&{
   selector: string, name: string, file?: AbsoluteFsPath, type: 'directive',
-      coercedInputFields?: string[], genericInputFields?: string[],
-      restrictedInputFields?: string[], undeclaredInputFields?: string[], isGeneric?: boolean;
+      coercedInputFields?: string[], undeclaredInputFields?: string[], isGeneric?: boolean;
 };
 export type TestPipe = {
   name: string,

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -252,7 +252,7 @@ describe('type check blocks', () => {
       expect(tcb(TEMPLATE, DIRECTIVES))
           .toContain(
               'var _t2 = Dir.ngTypeCtor({ "fieldA": (((ctx).foo)) }); ' +
-              'var _t3: Dir.ngAcceptInputType_fieldA = (null!); '+
+              'var _t3: typeof Dir.ngAcceptInputType_fieldA = (null!); ' +
               '_t3 = (((ctx).foo));');
     });
   });
@@ -359,23 +359,22 @@ describe('type check blocks', () => {
             '_t3["inputA"] = (_t2);');
   });
 
-  it('should handle undeclared properties',
-     () => {
-       const TEMPLATE = `<div dir [inputA]="foo"></div>`;
-       const DIRECTIVES: TestDeclaration[] = [{
-         type: 'directive',
-         name: 'Dir',
-         selector: '[dir]',
-         inputs: {
-           fieldA: 'inputA',
-         },
-         undeclaredInputFields: ['fieldA']
-       }];
-       expect(tcb(TEMPLATE, DIRECTIVES))
-         .toContain(
-           'var _t2: Dir = (null!); ' +
-           '(((ctx).foo)); ');
-     });
+  it('should handle undeclared properties', () => {
+    const TEMPLATE = `<div dir [inputA]="foo"></div>`;
+    const DIRECTIVES: TestDeclaration[] = [{
+      type: 'directive',
+      name: 'Dir',
+      selector: '[dir]',
+      inputs: {
+        fieldA: 'inputA',
+      },
+      undeclaredInputFields: ['fieldA']
+    }];
+    expect(tcb(TEMPLATE, DIRECTIVES))
+        .toContain(
+            'var _t2: Dir = (null!); ' +
+            '(((ctx).foo)); ');
+  });
 
   it('should handle restricted properties', () => {
     const TEMPLATE = `<div dir [inputA]="foo"></div>`;
@@ -411,42 +410,44 @@ describe('type check blocks', () => {
             '_t2["field2"] = _t2["field1"] = (((ctx).foo));');
   });
 
-  it('should handle a single property bound to multiple fields, where one of them is coerced', () => {
-    const TEMPLATE = `<div dir [inputA]="foo"></div>`;
-    const DIRECTIVES: TestDeclaration[] = [{
-      type: 'directive',
-      name: 'Dir',
-      selector: '[dir]',
-      inputs: {
-        field1: 'inputA',
-        field2: 'inputA',
-      },
-      coercedInputFields: ['field1'],
-    }];
-    expect(tcb(TEMPLATE, DIRECTIVES))
-        .toContain(
-            'var _t2: Dir = (null!); ' +
-            'var _t3: Dir.ngAcceptInputType_field1 = (null!); ' +
-            '_t2["field2"] = _t3 = (((ctx).foo));');
-  });
+  it('should handle a single property bound to multiple fields, where one of them is coerced',
+     () => {
+       const TEMPLATE = `<div dir [inputA]="foo"></div>`;
+       const DIRECTIVES: TestDeclaration[] = [{
+         type: 'directive',
+         name: 'Dir',
+         selector: '[dir]',
+         inputs: {
+           field1: 'inputA',
+           field2: 'inputA',
+         },
+         coercedInputFields: ['field1'],
+       }];
+       expect(tcb(TEMPLATE, DIRECTIVES))
+           .toContain(
+               'var _t2: Dir = (null!); ' +
+               'var _t3: typeof Dir.ngAcceptInputType_field1 = (null!); ' +
+               '_t2["field2"] = _t3 = (((ctx).foo));');
+     });
 
-  it('should handle a single property bound to multiple fields, where one of them is undeclared', () => {
-    const TEMPLATE = `<div dir [inputA]="foo"></div>`;
-    const DIRECTIVES: TestDeclaration[] = [{
-      type: 'directive',
-      name: 'Dir',
-      selector: '[dir]',
-      inputs: {
-        field1: 'inputA',
-        field2: 'inputA',
-      },
-      undeclaredInputFields: ['field1'],
-    }];
-    expect(tcb(TEMPLATE, DIRECTIVES))
-        .toContain(
-            'var _t2: Dir = (null!); ' +
-            '_t2["field2"] = (((ctx).foo));');
-  });
+  it('should handle a single property bound to multiple fields, where one of them is undeclared',
+     () => {
+       const TEMPLATE = `<div dir [inputA]="foo"></div>`;
+       const DIRECTIVES: TestDeclaration[] = [{
+         type: 'directive',
+         name: 'Dir',
+         selector: '[dir]',
+         inputs: {
+           field1: 'inputA',
+           field2: 'inputA',
+         },
+         undeclaredInputFields: ['field1'],
+       }];
+       expect(tcb(TEMPLATE, DIRECTIVES))
+           .toContain(
+               'var _t2: Dir = (null!); ' +
+               '_t2["field2"] = (((ctx).foo));');
+     });
 
   it('should use coercion types if declared', () => {
     const TEMPLATE = `<div dir [inputA]="foo"></div>`;
@@ -462,7 +463,7 @@ describe('type check blocks', () => {
     expect(tcb(TEMPLATE, DIRECTIVES))
         .toContain(
             'var _t2: Dir = (null!); ' +
-            'var _t3: Dir.ngAcceptInputType_fieldA = (null!); '+
+            'var _t3: typeof Dir.ngAcceptInputType_fieldA = (null!); ' +
             '_t3 = (((ctx).foo));');
   });
 
@@ -481,7 +482,7 @@ describe('type check blocks', () => {
     expect(tcb(TEMPLATE, DIRECTIVES))
         .toContain(
             'var _t2: Dir = (null!); ' +
-            'var _t3: Dir.ngAcceptInputType_fieldA = (null!); '+
+            'var _t3: typeof Dir.ngAcceptInputType_fieldA = (null!); ' +
             '_t3 = (((ctx).foo));');
   });
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -50,7 +50,7 @@ describe('type check blocks', () => {
       selector: '[dir]',
       inputs: {inputA: 'inputA'},
     }];
-    expect(tcb(TEMPLATE, DIRECTIVES)).toContain('"inputA": ("value")');
+    expect(tcb(TEMPLATE, DIRECTIVES)).toContain('_t2: DirA = (null!); _t2["inputA"] = ("value");');
   });
 
   it('should handle multiple bindings to the same property', () => {
@@ -62,8 +62,8 @@ describe('type check blocks', () => {
       inputs: {inputA: 'inputA'},
     }];
     const block = tcb(TEMPLATE, DIRECTIVES);
-    expect(block).toContain('"inputA": (1)');
-    expect(block).not.toContain('"inputA": (2)');
+    expect(block).toContain('_t2["inputA"] = (1);');
+    expect(block).toContain('_t2["inputA"] = (2);');
   });
 
   it('should handle empty bindings', () => {
@@ -74,7 +74,7 @@ describe('type check blocks', () => {
       selector: '[dir-a]',
       inputs: {inputA: 'inputA'},
     }];
-    expect(tcb(TEMPLATE, DIRECTIVES)).toContain('"inputA": (undefined)');
+    expect(tcb(TEMPLATE, DIRECTIVES)).toContain('_t2["inputA"] = (undefined);');
   });
 
   it('should handle bindings without value', () => {
@@ -85,7 +85,7 @@ describe('type check blocks', () => {
       selector: '[dir-a]',
       inputs: {inputA: 'inputA'},
     }];
-    expect(tcb(TEMPLATE, DIRECTIVES)).toContain('"inputA": (undefined)');
+    expect(tcb(TEMPLATE, DIRECTIVES)).toContain('_t2["inputA"] = (undefined);');
   });
 
   it('should handle implicit vars on ng-template', () => {
@@ -104,20 +104,157 @@ describe('type check blocks', () => {
     expect(tcb(TEMPLATE)).toContain('var _t2 = _t1.$implicit;');
   });
 
-  it('should handle missing property bindings', () => {
-    const TEMPLATE = `<div dir [inputA]="foo"></div>`;
-    const DIRECTIVES: TestDeclaration[] = [{
-      type: 'directive',
-      name: 'Dir',
-      selector: '[dir]',
-      inputs: {
-        fieldA: 'inputA',
-        fieldB: 'inputB',
-      },
-    }];
-    expect(tcb(TEMPLATE, DIRECTIVES))
-        .toContain(
-            'var _t2 = Dir.ngTypeCtor({ "fieldA": (((ctx).foo)), "fieldB": (null as any) });');
+  describe('type constructors', () => {
+    it('should handle missing property bindings', () => {
+      const TEMPLATE = `<div dir [inputA]="foo"></div>`;
+      const DIRECTIVES: TestDeclaration[] = [{
+        type: 'directive',
+        name: 'Dir',
+        selector: '[dir]',
+        inputs: {
+          fieldA: 'inputA',
+          fieldB: 'inputB',
+        },
+        isGeneric: true,
+        genericInputFields: ['fieldA', 'fieldB'],
+      }];
+      expect(tcb(TEMPLATE, DIRECTIVES))
+          .toContain(
+              'var _t2 = Dir.ngTypeCtor({ "fieldA": (((ctx).foo)), "fieldB": (null as any) });');
+    });
+
+    it('should handle multiple bindings to the same property', () => {
+      const TEMPLATE = `<div dir [inputA]="1" [inputA]="2"></div>`;
+      const DIRECTIVES: TestDeclaration[] = [{
+        type: 'directive',
+        name: 'Dir',
+        selector: '[dir]',
+        inputs: {
+          fieldA: 'inputA',
+        },
+        isGeneric: true,
+        genericInputFields: ['fieldA'],
+      }];
+      const block = tcb(TEMPLATE, DIRECTIVES);
+      expect(block).toContain('"fieldA": (1)');
+      expect(block).not.toContain('"fieldA": (2)');
+    });
+
+
+    it('should only apply property bindings to directives', () => {
+      const TEMPLATE = `
+      <div dir [style.color]="'blue'" [class.strong]="false" [attr.enabled]="true"></div>
+    `;
+      const DIRECTIVES: TestDeclaration[] = [{
+        type: 'directive',
+        name: 'Dir',
+        selector: '[dir]',
+        inputs: {'color': 'color', 'strong': 'strong', 'enabled': 'enabled'},
+        isGeneric: true,
+        genericInputFields: ['color', 'strong', 'enabled'],
+      }];
+      const block = tcb(TEMPLATE, DIRECTIVES);
+      expect(block).toContain(
+          'var _t2 = Dir.ngTypeCtor({ "color": (null as any), "strong": (null as any), "enabled": (null as any) });');
+      expect(block).toContain('"blue"; false; true;');
+    });
+
+    it('should generate a circular directive reference correctly', () => {
+      const TEMPLATE = `
+      <div dir #d="dir" [input]="d"></div>
+    `;
+      const DIRECTIVES: TestDirective[] = [{
+        type: 'directive',
+        name: 'Dir',
+        selector: '[dir]',
+        exportAs: ['dir'],
+        inputs: {input: 'input'},
+        isGeneric: true,
+        genericInputFields: ['input'],
+      }];
+      expect(tcb(TEMPLATE, DIRECTIVES))
+          .toContain(
+              'var _t3 = Dir.ngTypeCtor((null!)); ' +
+              'var _t2 = Dir.ngTypeCtor({ "input": (_t3) });');
+    });
+
+    it('should generate circular references between two directives correctly', () => {
+      const TEMPLATE = `
+    <div #a="dirA" dir-a [inputA]="b">A</div>
+    <div #b="dirB" dir-b [inputB]="a">B</div>
+`;
+      const DIRECTIVES: TestDirective[] = [
+        {
+          type: 'directive',
+          name: 'DirA',
+          selector: '[dir-a]',
+          exportAs: ['dirA'],
+          inputs: {inputA: 'inputA'},
+          isGeneric: true,
+          genericInputFields: ['inputA'],
+        },
+        {
+          type: 'directive',
+          name: 'DirB',
+          selector: '[dir-b]',
+          exportAs: ['dirB'],
+          inputs: {inputB: 'inputB'},
+          isGeneric: true,
+          genericInputFields: ['inputB'],
+        }
+      ];
+      expect(tcb(TEMPLATE, DIRECTIVES))
+          .toContain(
+              'var _t4 = DirA.ngTypeCtor((null!)); ' +
+              'var _t3 = DirB.ngTypeCtor({ "inputB": (_t4) }); ' +
+              'var _t2 = DirA.ngTypeCtor({ "inputA": (_t3) });');
+    });
+
+    it('should handle empty bindings', () => {
+      const TEMPLATE = `<div dir-a [inputA]=""></div>`;
+      const DIRECTIVES: TestDeclaration[] = [{
+        type: 'directive',
+        name: 'DirA',
+        selector: '[dir-a]',
+        inputs: {inputA: 'inputA'},
+        isGeneric: true,
+        genericInputFields: ['inputA'],
+      }];
+      expect(tcb(TEMPLATE, DIRECTIVES)).toContain('"inputA": (undefined)');
+    });
+
+    it('should handle bindings without value', () => {
+      const TEMPLATE = `<div dir-a [inputA]></div>`;
+      const DIRECTIVES: TestDeclaration[] = [{
+        type: 'directive',
+        name: 'DirA',
+        selector: '[dir-a]',
+        inputs: {inputA: 'inputA'},
+        isGeneric: true,
+        genericInputFields: ['inputA'],
+      }];
+      expect(tcb(TEMPLATE, DIRECTIVES)).toContain('"inputA": (undefined)');
+    });
+
+    it('should use coercion types if declared', () => {
+      const TEMPLATE = `<div dir [inputA]="foo"></div>`;
+      const DIRECTIVES: TestDeclaration[] = [{
+        type: 'directive',
+        name: 'Dir',
+        selector: '[dir]',
+        inputs: {
+          fieldA: 'inputA',
+        },
+        isGeneric: true,
+        coercedInputFields: ['fieldA'],
+        genericInputFields: ['fieldA'],
+      }];
+      expect(tcb(TEMPLATE, DIRECTIVES))
+          .toContain(
+              'var _t2 = Dir.ngTypeCtor({ "fieldA": (((ctx).foo)) }); ' +
+              'var _t3: Dir.ngAcceptInputType_fieldA = (null!); '+
+              '_t3 = (((ctx).foo));');
+    });
   });
 
   it('should generate a forward element reference correctly', () => {
@@ -142,7 +279,7 @@ describe('type check blocks', () => {
     }];
     expect(tcb(TEMPLATE, DIRECTIVES))
         .toContain(
-            'var _t1 = Dir.ngTypeCtor({}); "" + ((_t1).value); var _t2 = document.createElement("div");');
+            'var _t1: Dir = (null!); "" + ((_t1).value); var _t2 = document.createElement("div");');
   });
 
   it('should handle style and class bindings specially', () => {
@@ -168,8 +305,10 @@ describe('type check blocks', () => {
       inputs: {'color': 'color', 'strong': 'strong', 'enabled': 'enabled'},
     }];
     const block = tcb(TEMPLATE, DIRECTIVES);
-    expect(block).toContain(
-        'var _t2 = Dir.ngTypeCtor({ "color": (null as any), "strong": (null as any), "enabled": (null as any) });');
+    expect(block).toContain('var _t2: Dir = (null!);');
+    expect(block).not.toContain('"color"');
+    expect(block).not.toContain('"strong"');
+    expect(block).not.toContain('"enabled"');
     expect(block).toContain('"blue"; false; true;');
   });
 
@@ -186,8 +325,8 @@ describe('type check blocks', () => {
     }];
     expect(tcb(TEMPLATE, DIRECTIVES))
         .toContain(
-            'var _t3 = Dir.ngTypeCtor((null!)); ' +
-            'var _t2 = Dir.ngTypeCtor({ "input": (_t3) });');
+            'var _t2: Dir = (null!); ' +
+            '_t2["input"] = (_t2);');
   });
 
   it('should generate circular references between two directives correctly', () => {
@@ -213,9 +352,137 @@ describe('type check blocks', () => {
     ];
     expect(tcb(TEMPLATE, DIRECTIVES))
         .toContain(
-            'var _t4 = DirA.ngTypeCtor((null!)); ' +
-            'var _t3 = DirB.ngTypeCtor({ "inputA": (_t4) }); ' +
-            'var _t2 = DirA.ngTypeCtor({ "inputA": (_t3) });');
+            'var _t2: DirA = (null!); ' +
+            'var _t3: DirB = (null!); ' +
+            '_t2["inputA"] = (_t3); ' +
+            'var _t4 = document.createElement("div"); ' +
+            '_t3["inputA"] = (_t2);');
+  });
+
+  it('should handle undeclared properties',
+     () => {
+       const TEMPLATE = `<div dir [inputA]="foo"></div>`;
+       const DIRECTIVES: TestDeclaration[] = [{
+         type: 'directive',
+         name: 'Dir',
+         selector: '[dir]',
+         inputs: {
+           fieldA: 'inputA',
+         },
+         undeclaredInputFields: ['fieldA']
+       }];
+       expect(tcb(TEMPLATE, DIRECTIVES))
+         .toContain(
+           'var _t2: Dir = (null!); ' +
+           '(((ctx).foo)); ');
+     });
+
+  it('should handle restricted properties', () => {
+    const TEMPLATE = `<div dir [inputA]="foo"></div>`;
+    const DIRECTIVES: TestDeclaration[] = [{
+      type: 'directive',
+      name: 'Dir',
+      selector: '[dir]',
+      inputs: {
+        fieldA: 'inputA',
+      },
+      restrictedInputFields: ['fieldA']
+    }];
+    expect(tcb(TEMPLATE, DIRECTIVES))
+        .toContain(
+            'var _t2: Dir = (null!); ' +
+            '_t2["fieldA"] = (((ctx).foo)); ');
+  });
+
+  it('should handle a single property bound to multiple fields', () => {
+    const TEMPLATE = `<div dir [inputA]="foo"></div>`;
+    const DIRECTIVES: TestDeclaration[] = [{
+      type: 'directive',
+      name: 'Dir',
+      selector: '[dir]',
+      inputs: {
+        field1: 'inputA',
+        field2: 'inputA',
+      },
+    }];
+    expect(tcb(TEMPLATE, DIRECTIVES))
+        .toContain(
+            'var _t2: Dir = (null!); ' +
+            '_t2["field2"] = _t2["field1"] = (((ctx).foo));');
+  });
+
+  it('should handle a single property bound to multiple fields, where one of them is coerced', () => {
+    const TEMPLATE = `<div dir [inputA]="foo"></div>`;
+    const DIRECTIVES: TestDeclaration[] = [{
+      type: 'directive',
+      name: 'Dir',
+      selector: '[dir]',
+      inputs: {
+        field1: 'inputA',
+        field2: 'inputA',
+      },
+      coercedInputFields: ['field1'],
+    }];
+    expect(tcb(TEMPLATE, DIRECTIVES))
+        .toContain(
+            'var _t2: Dir = (null!); ' +
+            'var _t3: Dir.ngAcceptInputType_field1 = (null!); ' +
+            '_t2["field2"] = _t3 = (((ctx).foo));');
+  });
+
+  it('should handle a single property bound to multiple fields, where one of them is undeclared', () => {
+    const TEMPLATE = `<div dir [inputA]="foo"></div>`;
+    const DIRECTIVES: TestDeclaration[] = [{
+      type: 'directive',
+      name: 'Dir',
+      selector: '[dir]',
+      inputs: {
+        field1: 'inputA',
+        field2: 'inputA',
+      },
+      undeclaredInputFields: ['field1'],
+    }];
+    expect(tcb(TEMPLATE, DIRECTIVES))
+        .toContain(
+            'var _t2: Dir = (null!); ' +
+            '_t2["field2"] = (((ctx).foo));');
+  });
+
+  it('should use coercion types if declared', () => {
+    const TEMPLATE = `<div dir [inputA]="foo"></div>`;
+    const DIRECTIVES: TestDeclaration[] = [{
+      type: 'directive',
+      name: 'Dir',
+      selector: '[dir]',
+      inputs: {
+        fieldA: 'inputA',
+      },
+      coercedInputFields: ['fieldA'],
+    }];
+    expect(tcb(TEMPLATE, DIRECTIVES))
+        .toContain(
+            'var _t2: Dir = (null!); ' +
+            'var _t3: Dir.ngAcceptInputType_fieldA = (null!); '+
+            '_t3 = (((ctx).foo));');
+  });
+
+  it('should use coercion types if declared, even when backing field is not declared', () => {
+    const TEMPLATE = `<div dir [inputA]="foo"></div>`;
+    const DIRECTIVES: TestDeclaration[] = [{
+      type: 'directive',
+      name: 'Dir',
+      selector: '[dir]',
+      inputs: {
+        fieldA: 'inputA',
+      },
+      coercedInputFields: ['fieldA'],
+      undeclaredInputFields: ['fieldA'],
+    }];
+    expect(tcb(TEMPLATE, DIRECTIVES))
+        .toContain(
+            'var _t2: Dir = (null!); ' +
+            'var _t3: Dir.ngAcceptInputType_fieldA = (null!); '+
+            '_t3 = (((ctx).foo));');
   });
 
   it('should handle $any casts', () => {
@@ -374,14 +641,14 @@ describe('type check blocks', () => {
 
       it('should include null and undefined when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('Dir.ngTypeCtor({ "dirInput": (((ctx).a)) })');
+        expect(block).toContain('_t2["dirInput"] = (((ctx).a));');
         expect(block).toContain('((ctx).b);');
       });
       it('should use the non-null assertion operator when disabled', () => {
         const DISABLED_CONFIG:
             TypeCheckingConfig = {...BASE_CONFIG, strictNullInputBindings: false};
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('Dir.ngTypeCtor({ "dirInput": (((ctx).a)!) })');
+        expect(block).toContain('_t2["dirInput"] = (((ctx).a)!);');
         expect(block).toContain('((ctx).b)!;');
       });
     });
@@ -390,7 +657,7 @@ describe('type check blocks', () => {
       it('should check types of bindings when enabled', () => {
         const TEMPLATE = `<div dir [dirInput]="a" [nonDirInput]="b"></div>`;
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('Dir.ngTypeCtor({ "dirInput": (((ctx).a)) })');
+        expect(block).toContain('_t2["dirInput"] = (((ctx).a));');
         expect(block).toContain('((ctx).b);');
       });
 
@@ -399,7 +666,7 @@ describe('type check blocks', () => {
         const DISABLED_CONFIG:
             TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfInputBindings: false};
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('Dir.ngTypeCtor({ "dirInput": ((((ctx).a) as any)) })');
+        expect(block).toContain('_t2["dirInput"] = ((((ctx).a) as any));');
         expect(block).toContain('(((ctx).b) as any);');
       });
 
@@ -408,8 +675,7 @@ describe('type check blocks', () => {
         const DISABLED_CONFIG:
             TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfInputBindings: false};
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain(
-            'Dir.ngTypeCtor({ "dirInput": ((((((ctx).a)) === (((ctx).b))) as any)) })');
+        expect(block).toContain('_t2["dirInput"] = ((((((ctx).a)) === (((ctx).b))) as any));');
       });
     });
 
@@ -529,17 +795,17 @@ describe('type check blocks', () => {
 
       it('should assign string value to the input when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('"disabled": ("")');
-        expect(block).toContain('"cols": ("3")');
-        expect(block).toContain('"rows": (2)');
+        expect(block).toContain('_t2["disabled"] = ("");');
+        expect(block).toContain('_t2["cols"] = ("3");');
+        expect(block).toContain('_t2["rows"] = (2);');
       });
 
       it('should use any for attributes but still check bound attributes when disabled', () => {
         const DISABLED_CONFIG: TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfAttributes: false};
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('"disabled": (null as any)');
-        expect(block).toContain('"cols": (null as any)');
-        expect(block).toContain('"rows": (2)');
+        expect(block).not.toContain('"disabled"');
+        expect(block).not.toContain('"cols"');
+        expect(block).toContain('_t2["rows"] = (2);');
       });
     });
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -873,24 +873,25 @@ describe('type check blocks', () => {
     describe('config.checkAccessModifiersForInputBindings', () => {
       const TEMPLATE = `<div dir [inputA]="foo"></div>`;
 
-      xit('should assign restricted properties via element access for field names that are not JS identifiers',
-          () => {
-            const DIRECTIVES: TestDeclaration[] = [{
-              type: 'directive',
-              name: 'Dir',
-              selector: '[dir]',
-              inputs: {
-                'some-input.xs': 'inputA',
-              },
-              restrictedInputFields: ['some-input.xs']
-            }];
-            const enableChecks:
-                TypeCheckingConfig = {...BASE_CONFIG, honorAccessModifiersForInputBindings: true};
-            const block = tcb(TEMPLATE, DIRECTIVES, enableChecks);
-            expect(block).toContain(
-                'var _t2: Dir = (null!); ' +
-                '_t2["some-input.xs"] = (((ctx).foo)); ');
-          });
+      it('should assign restricted properties via element access for field names that are not JS identifiers',
+         () => {
+           const DIRECTIVES: TestDeclaration[] = [{
+             type: 'directive',
+             name: 'Dir',
+             selector: '[dir]',
+             inputs: {
+               'some-input.xs': 'inputA',
+             },
+             restrictedInputFields: ['some-input.xs'],
+             stringLiteralInputFields: ['some-input.xs'],
+           }];
+           const enableChecks:
+               TypeCheckingConfig = {...BASE_CONFIG, honorAccessModifiersForInputBindings: true};
+           const block = tcb(TEMPLATE, DIRECTIVES, enableChecks);
+           expect(block).toContain(
+               'var _t2: Dir = (null!); ' +
+               '_t2["some-input.xs"] = (((ctx).foo)); ');
+         });
 
       it('should assign restricted properties via property access', () => {
         const DIRECTIVES: TestDeclaration[] = [{

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -381,7 +381,8 @@ describe('type check blocks', () => {
     expect(tcb(TEMPLATE, DIRECTIVES))
         .toContain(
             'var _t2: Dir = (null!); ' +
-            '_t2["fieldA"] = (((ctx).foo)); ');
+            'var _t3: typeof _t2["fieldA"] = (null!); ' +
+            '_t3 = (((ctx).foo)); ');
   });
 
   it('should handle a single property bound to multiple fields', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -116,7 +116,6 @@ describe('type check blocks', () => {
           fieldB: 'inputB',
         },
         isGeneric: true,
-        genericInputFields: ['fieldA', 'fieldB'],
       }];
       expect(tcb(TEMPLATE, DIRECTIVES))
           .toContain(
@@ -133,7 +132,6 @@ describe('type check blocks', () => {
           fieldA: 'inputA',
         },
         isGeneric: true,
-        genericInputFields: ['fieldA'],
       }];
       const block = tcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('"fieldA": (1)');
@@ -151,7 +149,6 @@ describe('type check blocks', () => {
         selector: '[dir]',
         inputs: {'color': 'color', 'strong': 'strong', 'enabled': 'enabled'},
         isGeneric: true,
-        genericInputFields: ['color', 'strong', 'enabled'],
       }];
       const block = tcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain(
@@ -170,7 +167,6 @@ describe('type check blocks', () => {
         exportAs: ['dir'],
         inputs: {input: 'input'},
         isGeneric: true,
-        genericInputFields: ['input'],
       }];
       expect(tcb(TEMPLATE, DIRECTIVES))
           .toContain(
@@ -191,7 +187,6 @@ describe('type check blocks', () => {
           exportAs: ['dirA'],
           inputs: {inputA: 'inputA'},
           isGeneric: true,
-          genericInputFields: ['inputA'],
         },
         {
           type: 'directive',
@@ -200,7 +195,6 @@ describe('type check blocks', () => {
           exportAs: ['dirB'],
           inputs: {inputB: 'inputB'},
           isGeneric: true,
-          genericInputFields: ['inputB'],
         }
       ];
       expect(tcb(TEMPLATE, DIRECTIVES))
@@ -218,7 +212,6 @@ describe('type check blocks', () => {
         selector: '[dir-a]',
         inputs: {inputA: 'inputA'},
         isGeneric: true,
-        genericInputFields: ['inputA'],
       }];
       expect(tcb(TEMPLATE, DIRECTIVES)).toContain('"inputA": (undefined)');
     });
@@ -231,7 +224,6 @@ describe('type check blocks', () => {
         selector: '[dir-a]',
         inputs: {inputA: 'inputA'},
         isGeneric: true,
-        genericInputFields: ['inputA'],
       }];
       expect(tcb(TEMPLATE, DIRECTIVES)).toContain('"inputA": (undefined)');
     });
@@ -247,7 +239,6 @@ describe('type check blocks', () => {
         },
         isGeneric: true,
         coercedInputFields: ['fieldA'],
-        genericInputFields: ['fieldA'],
       }];
       expect(tcb(TEMPLATE, DIRECTIVES))
           .toContain(

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker_spec.ts
@@ -84,6 +84,7 @@ runInEachFileSystem(() => {
         selector: '[dir]',
         file: dirFile,
         type: 'directive',
+        isGeneric: true,
       };
       const {program, templateTypeChecker, programStrategy} = setup([
         {
@@ -102,7 +103,7 @@ runInEachFileSystem(() => {
                 // A non-exported interface used as a type bound for a generic directive causes
                 // an inline type constructor to be required.
                 interface NotExported {}
-                export class TestDir<T extends NotExported> {}`,
+                export abstract class TestDir<T extends NotExported> {}`,
           templates: {},
         },
       ]);
@@ -159,7 +160,7 @@ runInEachFileSystem(() => {
         const {program, templateTypeChecker} = setup(
             [{
               fileName,
-              source: `class Cmp {} // not exported, so requires inline`,
+              source: `abstract class Cmp {} // not exported, so requires inline`,
               templates: {'Cmp': '<div></div>'}
             }],
             {inlining: false});
@@ -183,6 +184,7 @@ runInEachFileSystem(() => {
                   selector: '[dir]',
                   file: dirFile,
                   type: 'directive',
+                  isGeneric: true,
                 }]
               },
               {
@@ -191,7 +193,7 @@ runInEachFileSystem(() => {
                   // A non-exported interface used as a type bound for a generic directive causes
                   // an inline type constructor to be required.
                   interface NotExported {}
-                  export class TestDir<T extends NotExported> {}`,
+                  export abstract class TestDir<T extends NotExported> {}`,
                 templates: {},
               }
             ],

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -19,7 +19,7 @@ import {NgtscTestEnvironment} from './env';
 const testFiles = loadStandardTestFiles();
 
 runInEachFileSystem(() => {
-  describe('ngtsc type checking', () => {
+  fdescribe('ngtsc type checking', () => {
     let env!: NgtscTestEnvironment;
 
     beforeEach(() => {
@@ -136,10 +136,41 @@ export declare class AnimationEvent {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toEqual(`Type 'string' is not assignable to type 'number'.`);
+      expect(diags[0].messageText).toEqual(`Type '"2"' is not assignable to type 'number'.`);
       // The reported error code should be in the TS error space, not a -99 "NG" code.
       expect(diags[0].code).toBeGreaterThan(0);
     });
+
+    it('should produce diagnostics when mapping to multiple fields and bound types are incorrect',
+       () => {
+         env.tsconfig(
+             {fullTemplateTypeCheck: true, strictInputTypes: true, strictAttributeTypes: true});
+         env.write('test.ts', `
+        import {Component, Directive, NgModule, Input} from '@angular/core';
+
+        @Component({
+          selector: 'test',
+          template: '<div dir foo="2"></div>',
+        })
+        class TestCmp {}
+
+        @Directive({selector: '[dir]'})
+        class TestDir {
+          @Input('foo') foo1: number;
+          @Input('foo') foo2: number;
+        }
+
+        @NgModule({
+          declarations: [TestCmp, TestDir],
+        })
+        class Module {}
+      `);
+
+         const diags = env.driveDiagnostics();
+         expect(diags.length).toBe(2);
+         expect(diags[0].messageText).toEqual(`Type '"2"' is not assignable to type 'number'.`);
+         expect(diags[0].messageText).toEqual(`Type '"2"' is not assignable to type 'number'.`);
+       });
 
     it('should support inputs and outputs with names that are not JavaScript identifiers', () => {
       env.tsconfig(
@@ -173,7 +204,7 @@ export declare class AnimationEvent {
 
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(2);
-      expect(diags[0].messageText).toEqual(`Type 'number' is not assignable to type 'string'.`);
+      expect(diags[0].messageText).toEqual(`Type '2' is not assignable to type 'string'.`);
       expect(diags[1].messageText)
           .toEqual(`Argument of type 'string' is not assignable to parameter of type 'number'.`);
     });
@@ -349,7 +380,7 @@ export declare class AnimationEvent {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toEqual(`Type 'number' is not assignable to type 'string'.`);
+        expect(diags[0].messageText).toEqual(`Type '1' is not assignable to type 'string'.`);
         expect(diags[1].messageText)
             .toEqual(`Property 'invalid' does not exist on type 'TestCmp'.`);
       });
@@ -359,7 +390,7 @@ export declare class AnimationEvent {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toEqual(`Type 'number' is not assignable to type 'string'.`);
+        expect(diags[0].messageText).toEqual(`Type '1' is not assignable to type 'string'.`);
         expect(diags[1].messageText)
             .toEqual(`Property 'invalid' does not exist on type 'TestCmp'.`);
       });
@@ -685,8 +716,8 @@ export declare class AnimationEvent {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toEqual(`Type 'string' is not assignable to type 'boolean'.`);
-        expect(diags[1].messageText).toEqual(`Type 'string' is not assignable to type 'number'.`);
+        expect(diags[0].messageText).toEqual(`Type '""' is not assignable to type 'boolean'.`);
+        expect(diags[1].messageText).toEqual(`Type '"3"' is not assignable to type 'number'.`);
       });
 
       it('should produce an error for text attributes when overall strictness is enabled', () => {
@@ -694,8 +725,8 @@ export declare class AnimationEvent {
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
-        expect(diags[0].messageText).toEqual(`Type 'string' is not assignable to type 'boolean'.`);
-        expect(diags[1].messageText).toEqual(`Type 'string' is not assignable to type 'number'.`);
+        expect(diags[0].messageText).toEqual(`Type '""' is not assignable to type 'boolean'.`);
+        expect(diags[1].messageText).toEqual(`Type '"3"' is not assignable to type 'number'.`);
       });
 
       it('should not produce an error for text attributes when not enabled', () => {
@@ -1212,9 +1243,9 @@ export declare class AnimationEvent {
       expect(diags.length).toBe(3);
       expect(diags[0].messageText).toBe(`Type 'true' is not assignable to type 'number'.`);
       expect(getSourceCodeForDiagnostic(diags[0])).toEqual('[fromAbstract]="true"');
-      expect(diags[1].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
+      expect(diags[1].messageText).toBe(`Type '3' is not assignable to type 'string'.`);
       expect(getSourceCodeForDiagnostic(diags[1])).toEqual('[fromBase]="3"');
-      expect(diags[2].messageText).toBe(`Type 'number' is not assignable to type 'boolean'.`);
+      expect(diags[2].messageText).toBe(`Type '4' is not assignable to type 'boolean'.`);
       expect(getSourceCodeForDiagnostic(diags[2])).toEqual('[fromChild]="4"');
     });
 
@@ -1269,9 +1300,9 @@ export declare class AnimationEvent {
       expect(diags.length).toBe(3);
       expect(diags[0].messageText).toBe(`Type 'true' is not assignable to type 'number'.`);
       expect(getSourceCodeForDiagnostic(diags[0])).toEqual('[fromAbstract]="true"');
-      expect(diags[1].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
+      expect(diags[1].messageText).toBe(`Type '3' is not assignable to type 'string'.`);
       expect(getSourceCodeForDiagnostic(diags[1])).toEqual('[fromBase]="3"');
-      expect(diags[2].messageText).toBe(`Type 'number' is not assignable to type 'boolean'.`);
+      expect(diags[2].messageText).toBe(`Type '4' is not assignable to type 'boolean'.`);
       expect(getSourceCodeForDiagnostic(diags[2])).toEqual('[fromChild]="4"');
     });
 
@@ -1476,7 +1507,7 @@ export declare class AnimationEvent {
       it('should give an error if the binding expression type is not accepted by the coercion function',
          () => {
            env.write('test.ts', `
-            import {Component, NgModule} from '@angular/core';
+            import {Component, NgModule, Input, Directive} from '@angular/core';
             import {MatInputModule} from '@angular/material';
 
             @Component({
@@ -1489,7 +1520,7 @@ export declare class AnimationEvent {
 
             @NgModule({
               declarations: [FooCmp],
-              imports: [MatInputModule],
+              imports: [MatInputModule]
             })
             export class FooModule {}
         `);
@@ -1499,6 +1530,72 @@ export declare class AnimationEvent {
                .toBe(`Type 'boolean' is not assignable to type 'string | number'.`);
          });
     });
+
+    it('should not produce diagnostics for inputs which assign to private or protected fields',
+       () => {
+         env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+         env.write('test.ts', `
+            import {Component, NgModule, Input, Directive} from '@angular/core';
+
+            @Component({
+              selector: 'blah',
+              template: '<div dir [protectedField]="value" [privateField]="value"></div>',
+            })
+            export class FooCmp {
+              value = "value";
+            }
+
+            @Directive({selector: '[dir]'})
+            export class TestDir {
+              @Input()
+              protected protectedField!: string;
+              @Input()
+              private privateField!: string;
+            }
+
+            @NgModule({
+              declarations: [FooCmp, TestDir],
+            })
+            export class FooModule {}
+        `);
+         const diags = env.driveDiagnostics();
+         expect(diags.length).toBe(0);
+       });
+
+    it('should produce diagnostics when assigning incorrect type to private or protected fields',
+       () => {
+         env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+         env.write('test.ts', `
+            import {Component, NgModule, Input, Directive} from '@angular/core';
+
+            @Component({
+              selector: 'blah',
+              template: '<div dir [protectedField]="value" [privateField]="value"></div>',
+            })
+            export class FooCmp {
+              value = "value";
+            }
+
+            @Directive({selector: '[dir]'})
+            export class TestDir {
+              @Input()
+              protected protectedField!: number;
+              @Input()
+              private privateField!: number;
+            }
+
+            @NgModule({
+              declarations: [FooCmp, TestDir],
+            })
+            export class FooModule {}
+        `);
+         const diags = env.driveDiagnostics();
+         expect(diags.length).toBe(2);
+         expect(diags[0].messageText)
+             .toEqual('Type \'string\' is not assignable to type \'number\'.');
+         expect(diags[1].messageText)
+             .toEqual('Type \'string\' is not assignable to type \'number\'.');
+       });
 
     describe('legacy schema checking with the DOM schema', () => {
       beforeEach(() => {

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -1544,14 +1544,7 @@ export declare class AnimationEvent {
             }
       `;
 
-      describe('with strict inputs', () => {
-        beforeEach(() => {
-          env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
-        });
-
-        it('should not produce diagnostics for correct inputs which assign to readonly, private, or protected fields',
-           () => {
-             env.write('test.ts', `
+      const correctTypeInputsToRestrictedFields = `
             import {Component, NgModule, Input, Directive} from '@angular/core';
 
             @Component({
@@ -1568,14 +1561,9 @@ export declare class AnimationEvent {
               declarations: [FooCmp, TestDir],
             })
             export class FooModule {}
-        `);
-             const diags = env.driveDiagnostics();
-             expect(diags.length).toBe(0);
-           });
+        `;
 
-        it('should not produce diagnostics for correct inputs which assign to readonly, private, or protected fields inherited from a base class',
-           () => {
-             env.write('test.ts', `
+      const correctInputsToRestrictedFieldsFromBaseClass = `
             import {Component, NgModule, Input, Directive} from '@angular/core';
 
             @Component({
@@ -1596,7 +1584,55 @@ export declare class AnimationEvent {
               declarations: [FooCmp, ChildDir],
             })
             export class FooModule {}
-        `);
+        `;
+      describe('with strictInputAccessModifiers', () => {
+        beforeEach(() => {
+          env.tsconfig({
+            fullTemplateTypeCheck: true,
+            strictInputTypes: true,
+            strictInputAccessModifiers: true
+          });
+        });
+
+        it('should produce diagnostics for inputs which assign to readonly, private, and protected fields',
+           () => {
+             env.write('test.ts', correctTypeInputsToRestrictedFields);
+             expectIllegalAssignmentErrors(env.driveDiagnostics());
+           });
+
+        it('should produce diagnostics for inputs which assign to readonly, private, and protected fields inherited from a base class',
+           () => {
+             env.write('test.ts', correctInputsToRestrictedFieldsFromBaseClass);
+             expectIllegalAssignmentErrors(env.driveDiagnostics());
+           });
+
+        function expectIllegalAssignmentErrors(diags: ReadonlyArray<ts.Diagnostic>) {
+          expect(diags.length).toBe(3);
+          const actualMessages = diags.map(d => d.messageText).sort();
+          const expectedMessages = [
+            `Property 'protectedField' is protected and only accessible within class 'TestDir' and its subclasses.`,
+            `Property 'privateField' is private and only accessible within class 'TestDir'.`,
+            `Cannot assign to 'readonlyField' because it is a read-only property.`,
+          ].sort();
+          expect(actualMessages).toEqual(expectedMessages);
+        }
+      });
+
+      describe('with strict inputs', () => {
+        beforeEach(() => {
+          env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+        });
+
+        it('should not produce diagnostics for correct inputs which assign to readonly, private, or protected fields',
+           () => {
+             env.write('test.ts', correctTypeInputsToRestrictedFields);
+             const diags = env.driveDiagnostics();
+             expect(diags.length).toBe(0);
+           });
+
+        it('should not produce diagnostics for correct inputs which assign to readonly, private, or protected fields inherited from a base class',
+           () => {
+             env.write('test.ts', correctInputsToRestrictedFieldsFromBaseClass);
              const diags = env.driveDiagnostics();
              expect(diags.length).toBe(0);
            });

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -1616,6 +1616,36 @@ export declare class AnimationEvent {
           ].sort();
           expect(actualMessages).toEqual(expectedMessages);
         }
+
+        it('should report invalid type assignment when field name is not a valid JS identifier',
+           () => {
+             env.write('test.ts', `
+            import {Component, NgModule, Input, Directive} from '@angular/core';
+
+            @Component({
+              selector: 'blah',
+              template: '<div dir [private-input.xs]="value"></div>',
+            })
+            export class FooCmp {
+              value = 5;
+            }
+
+            @Directive({selector: '[dir]'})
+            export class TestDir {
+              @Input()
+              private 'private-input.xs'!: string;
+            }
+
+            @NgModule({
+              declarations: [FooCmp, TestDir],
+            })
+            export class FooModule {}
+          `);
+             const diags = env.driveDiagnostics();
+             expect(diags.length).toBe(1);
+             expect(diags[0].messageText)
+                 .toEqual(`Type 'number' is not assignable to type 'string'.`);
+           });
       });
 
       describe('with strict inputs', () => {

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -19,7 +19,7 @@ import {NgtscTestEnvironment} from './env';
 const testFiles = loadStandardTestFiles();
 
 runInEachFileSystem(() => {
-  fdescribe('ngtsc type checking', () => {
+  describe('ngtsc type checking', () => {
     let env!: NgtscTestEnvironment;
 
     beforeEach(() => {
@@ -169,7 +169,7 @@ export declare class AnimationEvent {
          const diags = env.driveDiagnostics();
          expect(diags.length).toBe(2);
          expect(diags[0].messageText).toEqual(`Type '"2"' is not assignable to type 'number'.`);
-         expect(diags[0].messageText).toEqual(`Type '"2"' is not assignable to type 'number'.`);
+         expect(diags[1].messageText).toEqual(`Type '"2"' is not assignable to type 'number'.`);
        });
 
     it('should support inputs and outputs with names that are not JavaScript identifiers', () => {
@@ -1520,7 +1520,7 @@ export declare class AnimationEvent {
 
             @NgModule({
               declarations: [FooCmp],
-              imports: [MatInputModule]
+              imports: [MatInputModule],
             })
             export class FooModule {}
         `);
@@ -1531,7 +1531,7 @@ export declare class AnimationEvent {
          });
     });
 
-    it('should not produce diagnostics for inputs which assign to private or protected fields',
+    it('should not produce diagnostics for correct inputs which assign to private or protected fields',
        () => {
          env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
          env.write('test.ts', `
@@ -1551,6 +1551,41 @@ export declare class AnimationEvent {
               protected protectedField!: string;
               @Input()
               private privateField!: string;
+            }
+
+            @NgModule({
+              declarations: [FooCmp, TestDir],
+            })
+            export class FooModule {}
+        `);
+         const diags = env.driveDiagnostics();
+         expect(diags.length).toBe(0);
+       });
+
+    it('should not produce diagnostics for correct inputs which assign to private or protected fields inherited from a base class',
+       () => {
+         env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+         env.write('test.ts', `
+            import {Component, NgModule, Input, Directive} from '@angular/core';
+
+            @Component({
+              selector: 'blah',
+              template: '<div dir [protectedField]="value" [privateField]="value"></div>',
+            })
+            export class FooCmp {
+              value = "value";
+            }
+
+            @Directive()
+            export class BaseDir {
+              @Input()
+              protected protectedField!: string;
+              @Input()
+              private privateField!: string;
+            }
+
+            @Directive({selector: '[dir]'})
+            export class TestDir extends BaseDir {
             }
 
             @NgModule({
@@ -1591,11 +1626,100 @@ export declare class AnimationEvent {
         `);
          const diags = env.driveDiagnostics();
          expect(diags.length).toBe(2);
-         expect(diags[0].messageText)
-             .toEqual('Type \'string\' is not assignable to type \'number\'.');
-         expect(diags[1].messageText)
-             .toEqual('Type \'string\' is not assignable to type \'number\'.');
+         expect(diags[0].messageText).toEqual(`Type 'string' is not assignable to type 'number'.`);
+         expect(diags[1].messageText).toEqual(`Type 'string' is not assignable to type 'number'.`);
        });
+
+    it('should not produce diagnostics for undeclared inputs', () => {
+      env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+      env.write('test.ts', `
+            import {Component, NgModule, Input, Directive} from '@angular/core';
+
+            @Component({
+              selector: 'blah',
+              template: '<div dir [undeclared]="value"></div>',
+            })
+            export class FooCmp {
+              value = "value";
+            }
+
+            @Directive({
+              selector: '[dir]',
+              inputs: ['undeclared'],
+            })
+            export class TestDir {
+            }
+
+            @NgModule({
+              declarations: [FooCmp, TestDir],
+            })
+            export class FooModule {}
+        `);
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
+
+    it('should produce diagnostics for invalid expressions when assigned into an undeclared input',
+       () => {
+         env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+         env.write('test.ts', `
+            import {Component, NgModule, Input, Directive} from '@angular/core';
+
+            @Component({
+              selector: 'blah',
+              template: '<div dir [undeclared]="value"></div>',
+            })
+            export class FooCmp {
+            }
+
+            @Directive({
+              selector: '[dir]',
+              inputs: ['undeclared'],
+            })
+            export class TestDir {
+            }
+
+            @NgModule({
+              declarations: [FooCmp, TestDir],
+            })
+            export class FooModule {}
+        `);
+         const diags = env.driveDiagnostics();
+         expect(diags.length).toBe(1);
+         expect(diags[0].messageText).toBe(`Property 'value' does not exist on type 'FooCmp'.`);
+       });
+
+    it('should not produce diagnostics for undeclared inputs inherited from a base class', () => {
+      env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+      env.write('test.ts', `
+            import {Component, NgModule, Input, Directive} from '@angular/core';
+
+            @Component({
+              selector: 'blah',
+              template: '<div dir [undeclaredBase]="value"></div>',
+            })
+            export class FooCmp {
+              value = "value";
+            }
+
+            @Directive({
+              inputs: ['undeclaredBase'],
+            })
+            export class BaseDir {
+            }
+
+            @Directive({selector: '[dir]'})
+            export class TestDir extends BaseDir {
+            }
+
+            @NgModule({
+              declarations: [FooCmp, TestDir],
+            })
+            export class FooModule {}
+        `);
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
 
     describe('legacy schema checking with the DOM schema', () => {
       beforeEach(() => {


### PR DESCRIPTION
Should wait on #38273, as this addresses the same issue when the Directive/Component is not generic (since non-generic Directive/Components will no longer use the type constructor)