### PR TITLE
feat(dev-infra): save invalid commit message attempts to be restored on next commit attempt

### DIFF
--- a/dev-infra/commit-message/BUILD.bazel
+++ b/dev-infra/commit-message/BUILD.bazel
@@ -5,8 +5,10 @@ ts_library(
     name = "commit-message",
     srcs = [
         "cli.ts",
+        "commit-message-draft.ts",
         "config.ts",
         "parse.ts",
+        "restore-commit-message.ts",
         "validate.ts",
         "validate-file.ts",
         "validate-range.ts",

--- a/dev-infra/commit-message/cli.ts
+++ b/dev-infra/commit-message/cli.ts
@@ -18,9 +18,24 @@ export function buildCommitMessageParser(localYargs: yargs.Argv) {
   return localYargs.help()
       .strict()
       .command(
-          'restore-commit-message-draft [filePath] [source] [_]', false, {},
+          'restore-commit-message-draft', false, {
+            'file-env-variable': {
+              type: 'string',
+              conflicts: ['file'],
+              required: true,
+              description:
+                  'The key of the environment variable for the path of the commit message file.',
+              coerce: arg => {
+                const [file, source] = process.env[arg].split(' ');
+                if (!file) {
+                  throw new Error(`Provided environment variable "${arg}" was not found.`);
+                }
+                return [file, source];
+              },
+            }
+          },
           args => {
-            restoreCommitMessage(args.filePath, args.source);
+            restoreCommitMessage(args.fileEnvVariable[0], args.fileEnvVariable[1]);
           })
       .command(
           'pre-commit-validate', 'Validate the most recent commit message', {

--- a/dev-infra/commit-message/cli.ts
+++ b/dev-infra/commit-message/cli.ts
@@ -24,9 +24,11 @@ export function buildCommitMessageParser(localYargs: yargs.Argv) {
               conflicts: ['file'],
               required: true,
               description:
-                  'The key of the environment variable for the path of the commit message file.',
+                  'The key for the environment variable which holds the arguments for the ' +
+                  'prepare-commit-msg hook as described here: ' +
+                  'https://git-scm.com/docs/githooks#_prepare_commit_msg',
               coerce: arg => {
-                const [file, source] = process.env[arg].split(' ');
+                const [file, source] = (process.env[arg] || '').split(' ');
                 if (!file) {
                   throw new Error(`Provided environment variable "${arg}" was not found.`);
                 }

--- a/dev-infra/commit-message/cli.ts
+++ b/dev-infra/commit-message/cli.ts
@@ -9,6 +9,7 @@ import * as yargs from 'yargs';
 
 import {info} from '../utils/console';
 
+import {restoreCommitMessage} from './restore-commit-message';
 import {validateFile} from './validate-file';
 import {validateCommitRange} from './validate-range';
 
@@ -16,6 +17,11 @@ import {validateCommitRange} from './validate-range';
 export function buildCommitMessageParser(localYargs: yargs.Argv) {
   return localYargs.help()
       .strict()
+      .command(
+          'restore-commit-message-draft [filePath] [source] [_]', false, {},
+          args => {
+            restoreCommitMessage(args.filePath, args.source);
+          })
       .command(
           'pre-commit-validate', 'Validate the most recent commit message', {
             'file': {

--- a/dev-infra/commit-message/commit-message-draft.ts
+++ b/dev-infra/commit-message/commit-message-draft.ts
@@ -7,24 +7,24 @@
  */
 import {existsSync, readFileSync, unlinkSync, writeFileSync} from 'fs';
 
-const SAVED_COMMIT_MSG_FILE_PATH = '.git/COMMIT_EDITMSG.ngDevSave';
-
 /** Load the commit message draft from the file system if it exists. */
-export function loadCommitMessageDraft() {
-  if (existsSync(SAVED_COMMIT_MSG_FILE_PATH)) {
-    return readFileSync(SAVED_COMMIT_MSG_FILE_PATH).toString();
+export function loadCommitMessageDraft(basePath: string) {
+  const commitMessageDraftPath = `${basePath}.ngDevSave`;
+  if (existsSync(commitMessageDraftPath)) {
+    return readFileSync(commitMessageDraftPath).toString();
   }
   return '';
 }
 
 /** Remove the commit message draft from the file system. */
-export function deleteCommitMessageDraft() {
-  if (existsSync(SAVED_COMMIT_MSG_FILE_PATH)) {
-    unlinkSync(SAVED_COMMIT_MSG_FILE_PATH);
+export function deleteCommitMessageDraft(basePath: string) {
+  const commitMessageDraftPath = `${basePath}.ngDevSave`;
+  if (existsSync(commitMessageDraftPath)) {
+    unlinkSync(commitMessageDraftPath);
   }
 }
 
 /** Save the commit message draft to the file system for later retrieval. */
-export function saveCommitMessageDraft(commitMessage: string) {
-  writeFileSync(SAVED_COMMIT_MSG_FILE_PATH, commitMessage);
+export function saveCommitMessageDraft(basePath: string, commitMessage: string) {
+  writeFileSync(`${basePath}.ngDevSave`, commitMessage);
 }

--- a/dev-infra/commit-message/commit-message-draft.ts
+++ b/dev-infra/commit-message/commit-message-draft.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {existsSync, readFileSync, unlinkSync, writeFileSync} from 'fs';
+
+const SAVED_COMMIT_MSG_FILE_PATH = '.git/COMMIT_EDITMSG.ngDevSave';
+
+/** Load the commit message draft from the file system if it exists. */
+export function loadCommitMessageDraft() {
+  if (existsSync(SAVED_COMMIT_MSG_FILE_PATH)) {
+    return readFileSync(SAVED_COMMIT_MSG_FILE_PATH).toString();
+  }
+  return '';
+}
+
+/** Remove the commit message draft from the file system. */
+export function deleteCommitMessageDraft() {
+  if (existsSync(SAVED_COMMIT_MSG_FILE_PATH)) {
+    unlinkSync(SAVED_COMMIT_MSG_FILE_PATH);
+  }
+}
+
+/** Save the commit message draft to the file system for later retrieval. */
+export function saveCommitMessageDraft(commitMessage: string) {
+  writeFileSync(SAVED_COMMIT_MSG_FILE_PATH, commitMessage);
+}

--- a/dev-infra/commit-message/restore-commit-message.ts
+++ b/dev-infra/commit-message/restore-commit-message.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {info} from 'console';
+import {writeFileSync} from 'fs';
+import {resolve} from 'path';
+
+import {getRepoBaseDir} from '../utils/config';
+
+import {loadCommitMessageDraft} from './commit-message-draft';
+
+/**
+ * Restore the commit message draft to the git to be used as the default commit message.
+ */
+export function restoreCommitMessage(filePath: string, source: string) {
+  if (!!source) {
+    info('Skipping commit message restoration due to flags in the `git commit` command')
+  }
+  /** A draft of a commit message. */
+  const commitMessage = loadCommitMessageDraft();
+
+  // If the commit message draft has content, restore it into the git's COMMIT_EDITMSG.
+  if (commitMessage) {
+    writeFileSync(resolve(getRepoBaseDir(), filePath), commitMessage);
+  }
+  // Exit the process
+  process.exit(0);
+}

--- a/dev-infra/commit-message/restore-commit-message.ts
+++ b/dev-infra/commit-message/restore-commit-message.ts
@@ -19,12 +19,26 @@ import {loadCommitMessageDraft} from './commit-message-draft';
  */
 export function restoreCommitMessage(filePath: string, source: string) {
   if (!!source) {
-    info('Skipping commit message restoration due to flags in the `git commit` command')
+    info('Skipping commit message restoration attempt');
+    if (source === 'message') {
+      info('A commit message was already provided via the command with a -m or -F flag');
+    }
+    if (source === 'template') {
+      info('A commit message was already provided via the -t flag or config.template setting');
+    }
+    if (source === 'squash') {
+      info('A commit message was already provided as a merge action or via .git/MERGE_MSG');
+    }
+    if (source === 'commit') {
+      info('A commit message was already provided via another commit via --fixup, -c, -C');
+      info('or --amend flag');
+    }
+    process.exit(0);
   }
   /** A draft of a commit message. */
-  const commitMessage = loadCommitMessageDraft();
+  const commitMessage = loadCommitMessageDraft(filePath);
 
-  // If the commit message draft has content, restore it into the git's COMMIT_EDITMSG.
+  // If the commit message draft has content, restore it into the provided filepath.
   if (commitMessage) {
     writeFileSync(resolve(getRepoBaseDir(), filePath), commitMessage);
   }

--- a/dev-infra/commit-message/restore-commit-message.ts
+++ b/dev-infra/commit-message/restore-commit-message.ts
@@ -8,16 +8,17 @@
 
 import {info} from 'console';
 import {writeFileSync} from 'fs';
-import {resolve} from 'path';
-
-import {getRepoBaseDir} from '../utils/config';
 
 import {loadCommitMessageDraft} from './commit-message-draft';
 
 /**
  * Restore the commit message draft to the git to be used as the default commit message.
+ *
+ * The source provided may be one of the sources described in
+ *   https://git-scm.com/docs/githooks#_prepare_commit_msg
  */
-export function restoreCommitMessage(filePath: string, source: string) {
+export function restoreCommitMessage(
+    filePath: string, source?: 'message'|'template'|'squash'|'commit') {
   if (!!source) {
     info('Skipping commit message restoration attempt');
     if (source === 'message') {
@@ -30,8 +31,8 @@ export function restoreCommitMessage(filePath: string, source: string) {
       info('A commit message was already provided as a merge action or via .git/MERGE_MSG');
     }
     if (source === 'commit') {
-      info('A commit message was already provided via another commit via --fixup, -c, -C');
-      info('or --amend flag');
+      info('A commit message was already provided through a revision specified via --fixup, -c,');
+      info('-C or --amend flag');
     }
     process.exit(0);
   }
@@ -40,7 +41,7 @@ export function restoreCommitMessage(filePath: string, source: string) {
 
   // If the commit message draft has content, restore it into the provided filepath.
   if (commitMessage) {
-    writeFileSync(resolve(getRepoBaseDir(), filePath), commitMessage);
+    writeFileSync(filePath, commitMessage);
   }
   // Exit the process
   process.exit(0);

--- a/dev-infra/commit-message/validate-file.ts
+++ b/dev-infra/commit-message/validate-file.ts
@@ -11,6 +11,7 @@ import {resolve} from 'path';
 import {getRepoBaseDir} from '../utils/config';
 import {info} from '../utils/console';
 
+import {deleteCommitMessageDraft, saveCommitMessageDraft} from './commit-message-draft';
 import {validateCommitMessage} from './validate';
 
 /** Validate commit message at the provided file path. */
@@ -18,8 +19,12 @@ export function validateFile(filePath: string) {
   const commitMessage = readFileSync(resolve(getRepoBaseDir(), filePath), 'utf8');
   if (validateCommitMessage(commitMessage)) {
     info('√  Valid commit message');
+    deleteCommitMessageDraft();
     return;
   }
+  // On all invalid commit messages, the commit message should be saved as a draft to be
+  // restored on the next commit attempt.
+  saveCommitMessageDraft(commitMessage);
   // If the validation did not return true, exit as a failure.
   process.exit(1);
 }

--- a/dev-infra/commit-message/validate-file.ts
+++ b/dev-infra/commit-message/validate-file.ts
@@ -19,12 +19,12 @@ export function validateFile(filePath: string) {
   const commitMessage = readFileSync(resolve(getRepoBaseDir(), filePath), 'utf8');
   if (validateCommitMessage(commitMessage)) {
     info('√  Valid commit message');
-    deleteCommitMessageDraft();
+    deleteCommitMessageDraft(filePath);
     return;
   }
   // On all invalid commit messages, the commit message should be saved as a draft to be
   // restored on the next commit attempt.
-  saveCommitMessageDraft(commitMessage);
+  saveCommitMessageDraft(filePath, commitMessage);
   // If the validation did not return true, exit as a failure.
   process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -210,7 +210,8 @@
   "husky": {
     "hooks": {
       "pre-commit": "yarn -s ng-dev format staged",
-      "commit-msg": "yarn -s ng-dev commit-message pre-commit-validate --file-env-variable HUSKY_GIT_PARAMS"
+      "commit-msg": "yarn -s ng-dev commit-message pre-commit-validate --file-env-variable HUSKY_GIT_PARAMS",
+      "prepare-commit-msg": "yarn -s ng-dev commit-message restore-commit-message-draft ${HUSKY_GIT_PARAMS}"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "hooks": {
       "pre-commit": "yarn -s ng-dev format staged",
       "commit-msg": "yarn -s ng-dev commit-message pre-commit-validate --file-env-variable HUSKY_GIT_PARAMS",
-      "prepare-commit-msg": "yarn -s ng-dev commit-message restore-commit-message-draft ${HUSKY_GIT_PARAMS}"
+      "prepare-commit-msg": "yarn -s ng-dev commit-message restore-commit-message-draft  --file-env-variable HUSKY_GIT_PARAMS"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "hooks": {
       "pre-commit": "yarn -s ng-dev format staged",
       "commit-msg": "yarn -s ng-dev commit-message pre-commit-validate --file-env-variable HUSKY_GIT_PARAMS",
-      "prepare-commit-msg": "yarn -s ng-dev commit-message restore-commit-message-draft  --file-env-variable HUSKY_GIT_PARAMS"
+      "prepare-commit-msg": "yarn -s ng-dev commit-message restore-commit-message-draft --file-env-variable HUSKY_GIT_PARAMS"
     }
   }
 }


### PR DESCRIPTION
When a commit message fails validation, rather than throwing out the commit message entirely
the commit message is saved into a draft file and restored on the next commit attempt.
