### PR TITLE
fix(compiler-cli): ensure literal types are retained when `strictNullInputTypes` is disabled

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -277,6 +277,46 @@ runInEachFileSystem(() => {
       ]);
     });
 
+    it('should retain literal types in object literals together if strictNullInputBindings is disabled',
+       () => {
+         const messages = diagnose(
+             `<div dir [ngModelOptions]="{updateOn: 'change'}"></div>`, `
+              class Dir {
+                ngModelOptions: { updateOn: 'change'|'blur' };
+              }
+
+              class TestComponent {}`,
+             [{
+               type: 'directive',
+               name: 'Dir',
+               selector: '[dir]',
+               inputs: {'ngModelOptions': 'ngModelOptions'},
+             }],
+             [], {strictNullInputBindings: false});
+
+         expect(messages).toEqual([]);
+       });
+
+    it('should retain literal types in array literals together if strictNullInputBindings is disabled',
+       () => {
+         const messages = diagnose(
+             `<div dir [options]="['literal']"></div>`, `
+                class Dir {
+                  options!: Array<'literal'>;
+                }
+
+                class TestComponent {}`,
+             [{
+               type: 'directive',
+               name: 'Dir',
+               selector: '[dir]',
+               inputs: {'options': 'options'},
+             }],
+             [], {strictNullInputBindings: false});
+
+         expect(messages).toEqual([]);
+       });
+
     it('does not produce diagnostics for user code', () => {
       const messages = diagnose(`{{ person.name }}`, `
       class TestComponent {

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -46,6 +46,7 @@ export function typescriptLibDts(): TestFile {
         [index: number]: T;
         length: number;
       }
+      declare interface Iterable<T> {}
       declare interface String {
         length: number;
       }
@@ -63,7 +64,7 @@ export function typescriptLibDts(): TestFile {
       }
       declare interface HTMLElement {
         addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any): void;
-        addEventListener(type: string, listener: (evt: Event): void;): void;
+        addEventListener(type: string, listener: (evt: Event) => void): void;
       }
       declare interface HTMLDivElement extends HTMLElement {}
       declare interface HTMLImageElement extends HTMLElement {
@@ -94,8 +95,8 @@ export function angularCoreDts(): TestFile {
     name: absoluteFrom('/node_modules/@angular/core/index.d.ts'),
     contents: `
     export declare class TemplateRef<C> {
-      abstract readonly elementRef: unknown;
-      abstract createEmbeddedView(context: C): unknown;
+      readonly elementRef: unknown;
+      createEmbeddedView(context: C): unknown;
     }
 
     export declare class EventEmitter<T> {


### PR DESCRIPTION
Consider the `NgModel` directive which has the `ngModelOptions` input:

```ts
class NgModel {
  @Input() ngModelOptions: { updateOn: 'blur'|'change'|'submit' };
}
```

In a template this may be set using an object literal as follows:

```html
<input ngModel [ngModelOptions]="{updateOn: 'blur'}">
```

This assignment should be accepted, as the object's type aligns with the
`ngModelOptions` input in `NgModel`. However, if the `strictNullInputTypes`
option is disabled this assignment would inadvertently produce an error:

```
Type '{ updateOn: string; }' is not assignable to type '{ updateOn: "blur"|"change"|"submit"; }'.
  Types of property 'updateOn' are incompatible.
    Type 'string' is not assignable to type '"blur"|"change"|"submit"'
```

This is due to the `'blur'` value being inferred to be of type `string`
instead of retaining its literal type. The non-null assertion operator
that is automatically inserted for input binding assignments when
`strictNullInputTypes` is disabled inhibits TypeScript from inferring
the string value as its literal type.

This commit fixes the issue by omitting the insertion of the non-null
operator for object literals and array literals.