### PR TITLE
fix(forms): remove validators while cleaning up a control

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1003,37 +1003,13 @@
     "packages/core/testing/src/test_bed.ts"
   ],
   [
-    "packages/forms/src/directives/abstract_control_directive.ts",
-    "packages/forms/src/model.ts",
-    "packages/forms/src/directives/shared.ts"
-  ],
-  [
-    "packages/forms/src/directives/abstract_control_directive.ts",
-    "packages/forms/src/model.ts",
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/directives/abstract_form_group_directive.ts",
-    "packages/forms/src/directives/control_container.ts"
-  ],
-  [
-    "packages/forms/src/directives/abstract_control_directive.ts",
-    "packages/forms/src/model.ts",
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/directives/abstract_form_group_directive.ts",
-    "packages/forms/src/directives/control_container.ts",
-    "packages/forms/src/directives/form_interface.ts",
-    "packages/forms/src/directives/ng_control.ts"
-  ],
-  [
     "packages/forms/src/directives/abstract_form_group_directive.ts",
     "packages/forms/src/directives/control_container.ts",
     "packages/forms/src/directives/form_interface.ts"
   ],
   [
     "packages/forms/src/directives/abstract_form_group_directive.ts",
-    "packages/forms/src/directives/control_container.ts",
-    "packages/forms/src/directives/form_interface.ts",
-    "packages/forms/src/model.ts",
-    "packages/forms/src/directives/shared.ts"
+    "packages/forms/src/directives/form_interface.ts"
   ],
   [
     "packages/forms/src/directives/abstract_form_group_directive.ts",
@@ -1041,13 +1017,59 @@
   ],
   [
     "packages/forms/src/directives/abstract_form_group_directive.ts",
-    "packages/forms/src/model.ts",
-    "packages/forms/src/directives/shared.ts"
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/directives/control_container.ts",
+    "packages/forms/src/directives/form_interface.ts"
   ],
   [
+    "packages/forms/src/directives/abstract_form_group_directive.ts",
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/directives/ng_control.ts",
     "packages/forms/src/directives/control_container.ts",
-    "packages/forms/src/directives/form_interface.ts",
-    "packages/forms/src/directives/ng_control.ts"
+    "packages/forms/src/directives/form_interface.ts"
+  ],
+  [
+    "packages/forms/src/directives/abstract_form_group_directive.ts",
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_name.ts"
+  ],
+  [
+    "packages/forms/src/directives/abstract_form_group_directive.ts",
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
+    "packages/forms/src/directives/control_container.ts",
+    "packages/forms/src/directives/form_interface.ts"
+  ],
+  [
+    "packages/forms/src/directives/abstract_form_group_directive.ts",
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
+    "packages/forms/src/directives/control_container.ts",
+    "packages/forms/src/directives/form_interface.ts"
+  ],
+  [
+    "packages/forms/src/directives/abstract_form_group_directive.ts",
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
+    "packages/forms/src/directives/form_interface.ts"
+  ],
+  [
+    "packages/forms/src/directives/abstract_form_group_directive.ts",
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
+    "packages/forms/src/directives/reactive_directives/form_control_name.ts"
+  ],
+  [
+    "packages/forms/src/directives/abstract_form_group_directive.ts",
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
+    "packages/forms/src/directives/reactive_directives/form_control_name.ts",
+    "packages/forms/src/directives/control_container.ts",
+    "packages/forms/src/directives/form_interface.ts"
   ],
   [
     "packages/forms/src/directives/ng_form.ts",
@@ -1066,14 +1088,6 @@
     "packages/forms/src/directives/reactive_directives/form_control_name.ts"
   ],
   [
-    "packages/forms/src/directives/reactive_directives/form_control_directive.ts",
-    "packages/forms/src/model.ts",
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
-    "packages/forms/src/directives/reactive_directives/form_control_name.ts"
-  ],
-  [
     "packages/forms/src/directives/reactive_directives/form_control_name.ts",
     "packages/forms/src/directives/reactive_directives/form_group_directive.ts"
   ],
@@ -1084,13 +1098,6 @@
   ],
   [
     "packages/forms/src/directives/reactive_directives/form_control_name.ts",
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_directive.ts"
-  ],
-  [
-    "packages/forms/src/directives/reactive_directives/form_control_name.ts",
-    "packages/forms/src/model.ts",
     "packages/forms/src/directives/shared.ts",
     "packages/forms/src/directives/reactive_directives/form_group_name.ts",
     "packages/forms/src/directives/reactive_directives/form_group_directive.ts"
@@ -1101,12 +1108,6 @@
   ],
   [
     "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_name.ts"
-  ],
-  [
-    "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
-    "packages/forms/src/model.ts",
     "packages/forms/src/directives/shared.ts",
     "packages/forms/src/directives/reactive_directives/form_group_name.ts"
   ],
@@ -1115,28 +1116,17 @@
     "packages/forms/src/directives/shared.ts"
   ],
   [
-    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
-    "packages/forms/src/model.ts",
-    "packages/forms/src/directives/shared.ts"
-  ],
-  [
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/model.ts"
-  ],
-  [
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/validators.ts",
     "packages/forms/src/directives/validators.ts",
-    "packages/forms/src/model.ts"
-  ],
-  [
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/validators.ts",
     "packages/forms/src/model.ts"
   ],
   [
     "packages/forms/src/directives/validators.ts",
     "packages/forms/src/validators.ts"
+  ],
+  [
+    "packages/forms/src/directives/validators.ts",
+    "packages/forms/src/validators.ts",
+    "packages/forms/src/model.ts"
   ],
   [
     "packages/language-service/src/completions.ts",

--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1129,6 +1129,10 @@
     "packages/forms/src/model.ts"
   ],
   [
+    "packages/forms/src/model.ts",
+    "packages/forms/src/utils/validators.ts"
+  ],
+  [
     "packages/language-service/src/completions.ts",
     "packages/language-service/src/template.ts",
     "packages/language-service/src/typescript_host.ts",

--- a/goldens/public-api/forms/forms.d.ts
+++ b/goldens/public-api/forms/forms.d.ts
@@ -67,6 +67,7 @@ export declare abstract class AbstractControl {
 }
 
 export declare abstract class AbstractControlDirective {
+    get asyncValidator(): AsyncValidatorFn | null;
     abstract get control(): AbstractControl | null;
     get dirty(): boolean | null;
     get disabled(): boolean | null;
@@ -81,6 +82,7 @@ export declare abstract class AbstractControlDirective {
     get touched(): boolean | null;
     get untouched(): boolean | null;
     get valid(): boolean | null;
+    get validator(): ValidatorFn | null;
     get value(): any;
     get valueChanges(): Observable<any> | null;
     getError(errorCode: string, path?: Array<string | number> | string): any;
@@ -95,11 +97,9 @@ export declare interface AbstractControlOptions {
 }
 
 export declare class AbstractFormGroupDirective extends ControlContainer implements OnInit, OnDestroy {
-    get asyncValidator(): AsyncValidatorFn | null;
     get control(): FormGroup;
     get formDirective(): Form | null;
     get path(): string[];
-    get validator(): ValidatorFn | null;
     ngOnDestroy(): void;
     ngOnInit(): void;
 }
@@ -193,12 +193,10 @@ export declare class FormArray extends AbstractControl {
 }
 
 export declare class FormArrayName extends ControlContainer implements OnInit, OnDestroy {
-    get asyncValidator(): AsyncValidatorFn | null;
     get control(): FormArray;
     get formDirective(): FormGroupDirective | null;
     name: string | number | null;
     get path(): string[];
-    get validator(): ValidatorFn | null;
     constructor(parent: ControlContainer, validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[]);
     ngOnDestroy(): void;
     ngOnInit(): void;
@@ -237,14 +235,12 @@ export declare class FormControl extends AbstractControl {
 }
 
 export declare class FormControlDirective extends NgControl implements OnChanges {
-    get asyncValidator(): AsyncValidatorFn | null;
     get control(): FormControl;
     form: FormControl;
     set isDisabled(isDisabled: boolean);
     /** @deprecated */ model: any;
     get path(): string[];
     /** @deprecated */ update: EventEmitter<any>;
-    get validator(): ValidatorFn | null;
     viewModel: any;
     constructor(validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[], valueAccessors: ControlValueAccessor[], _ngModelWarningConfig: string | null);
     ngOnChanges(changes: SimpleChanges): void;
@@ -252,7 +248,6 @@ export declare class FormControlDirective extends NgControl implements OnChanges
 }
 
 export declare class FormControlName extends NgControl implements OnChanges, OnDestroy {
-    get asyncValidator(): AsyncValidatorFn;
     readonly control: FormControl;
     get formDirective(): any;
     set isDisabled(isDisabled: boolean);
@@ -260,7 +255,6 @@ export declare class FormControlName extends NgControl implements OnChanges, OnD
     name: string | number | null;
     get path(): string[];
     /** @deprecated */ update: EventEmitter<any>;
-    get validator(): ValidatorFn | null;
     constructor(parent: ControlContainer, validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[], valueAccessors: ControlValueAccessor[], _ngModelWarningConfig: string | null);
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
@@ -306,7 +300,7 @@ export declare class FormGroupDirective extends ControlContainer implements Form
     ngSubmit: EventEmitter<any>;
     get path(): string[];
     readonly submitted: boolean;
-    constructor(_validators: (Validator | ValidatorFn)[], _asyncValidators: (AsyncValidator | AsyncValidatorFn)[]);
+    constructor(validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[]);
     addControl(dir: FormControlName): FormControl;
     addFormArray(dir: FormArrayName): void;
     addFormGroup(dir: FormGroupName): void;
@@ -352,9 +346,7 @@ export declare const NG_VALIDATORS: InjectionToken<(Function | Validator)[]>;
 export declare const NG_VALUE_ACCESSOR: InjectionToken<readonly ControlValueAccessor[]>;
 
 export declare abstract class NgControl extends AbstractControlDirective {
-    get asyncValidator(): AsyncValidatorFn | null;
     name: string | number | null;
-    get validator(): ValidatorFn | null;
     valueAccessor: ControlValueAccessor | null;
     abstract viewToModelUpdate(newValue: any): void;
 }
@@ -398,7 +390,6 @@ export declare class NgForm extends ControlContainer implements Form, AfterViewI
 }
 
 export declare class NgModel extends NgControl implements OnChanges, OnDestroy {
-    get asyncValidator(): AsyncValidatorFn | null;
     readonly control: FormControl;
     get formDirective(): any;
     isDisabled: boolean;
@@ -411,7 +402,6 @@ export declare class NgModel extends NgControl implements OnChanges, OnDestroy {
     };
     get path(): string[];
     update: EventEmitter<any>;
-    get validator(): ValidatorFn | null;
     viewModel: any;
     constructor(parent: ControlContainer, validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[], valueAccessors: ControlValueAccessor[]);
     ngOnChanges(changes: SimpleChanges): void;

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -759,6 +759,9 @@
     "name": "classIndexOf"
   },
   {
+    "name": "cleanUpValidators"
+  },
+  {
     "name": "cleanUpView"
   },
   {
@@ -964,6 +967,12 @@
   },
   {
     "name": "getConstant"
+  },
+  {
+    "name": "getControlAsyncValidators"
+  },
+  {
+    "name": "getControlValidators"
   },
   {
     "name": "getCurrentTNode"
@@ -1314,6 +1323,9 @@
     "name": "mergeHostAttrs"
   },
   {
+    "name": "mergeValidators"
+  },
+  {
     "name": "modelGroupProvider"
   },
   {
@@ -1362,7 +1374,10 @@
     "name": "noop"
   },
   {
-    "name": "normalizeValidators"
+    "name": "normalizeAsyncValidator"
+  },
+  {
+    "name": "normalizeValidator"
   },
   {
     "name": "observable"
@@ -1414,6 +1429,9 @@
   },
   {
     "name": "registerDestroyHooksIfSupported"
+  },
+  {
+    "name": "registerOnValidatorChange"
   },
   {
     "name": "registerPostOrderHooks"
@@ -1540,6 +1558,9 @@
   },
   {
     "name": "setUpFormContainer"
+  },
+  {
+    "name": "setUpValidators"
   },
   {
     "name": "shareSubjectFactory"

--- a/packages/forms/src/directives/abstract_control_directive.ts
+++ b/packages/forms/src/directives/abstract_control_directive.ts
@@ -7,8 +7,12 @@
  */
 
 import {Observable} from 'rxjs';
+
 import {AbstractControl} from '../model';
-import {ValidationErrors} from './validators';
+import {composeAsyncValidators, composeValidators} from '../validators';
+
+import {AsyncValidator, AsyncValidatorFn, ValidationErrors, Validator, ValidatorFn} from './validators';
+
 
 /**
  * @description
@@ -163,6 +167,69 @@ export abstract class AbstractControlDirective {
    */
   get path(): string[]|null {
     return null;
+  }
+
+  /**
+   * Contains the result of merging synchronous validators into a single validator function
+   * (combined using `Validators.compose`).
+   * @internal
+   */
+  private _composedValidatorFn: ValidatorFn|null|undefined;
+
+  /**
+   * Contains the result of merging asynchronous validators into a single validator function
+   * (combined using `Validators.composeAsync`).
+   * @internal
+   */
+  private _composedAsyncValidatorFn: AsyncValidatorFn|null|undefined;
+
+  /**
+   * Set of synchronous validators as they were provided while calling `setValidators` function.
+   * @internal
+   */
+  _rawValidators: Array<Validator|ValidatorFn> = [];
+
+  /**
+   * Set of asynchronous validators as they were provided while calling `setAsyncValidators`
+   * function.
+   * @internal
+   */
+  _rawAsyncValidators: Array<AsyncValidator|AsyncValidatorFn> = [];
+
+  /**
+   * Sets synchronous validators for this directive.
+   * @internal
+   */
+  _setValidators(validators: Array<Validator|ValidatorFn>|undefined): void {
+    this._rawValidators = validators || [];
+    this._composedValidatorFn = composeValidators(this._rawValidators);
+  }
+
+  /**
+   * Sets asynchronous validators for this directive.
+   * @internal
+   */
+  _setAsyncValidators(validators: Array<AsyncValidator|AsyncValidatorFn>|undefined): void {
+    this._rawAsyncValidators = validators || [];
+    this._composedAsyncValidatorFn = composeAsyncValidators(this._rawAsyncValidators);
+  }
+
+  /**
+   * @description
+   * Synchronous validator function composed of all the synchronous validators registered with this
+   * directive.
+   */
+  get validator(): ValidatorFn|null {
+    return this._composedValidatorFn || null;
+  }
+
+  /**
+   * @description
+   * Asynchronous validator function composed of all the asynchronous validators registered with
+   * this directive.
+   */
+  get asyncValidator(): AsyncValidatorFn|null {
+    return this._composedAsyncValidatorFn || null;
   }
 
   /**

--- a/packages/forms/src/directives/abstract_control_directive.ts
+++ b/packages/forms/src/directives/abstract_control_directive.ts
@@ -9,7 +9,7 @@
 import {Observable} from 'rxjs';
 
 import {AbstractControl} from '../model';
-import {composeAsyncValidators, composeValidators} from '../validators';
+import {composeAsyncValidators, composeValidators} from '../utils/validators';
 
 import {AsyncValidator, AsyncValidatorFn, ValidationErrors, Validator, ValidatorFn} from './validators';
 

--- a/packages/forms/src/directives/abstract_form_group_directive.ts
+++ b/packages/forms/src/directives/abstract_form_group_directive.ts
@@ -12,8 +12,7 @@ import {FormGroup} from '../model';
 
 import {ControlContainer} from './control_container';
 import {Form} from './form_interface';
-import {composeAsyncValidators, composeValidators, controlPath} from './shared';
-import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from './validators';
+import {controlPath} from './shared';
 
 
 
@@ -33,24 +32,6 @@ export class AbstractFormGroupDirective extends ControlContainer implements OnIn
    */
   // TODO(issue/24571): remove '!'.
   _parent!: ControlContainer;
-
-  /**
-   * @description
-   * An array of synchronous validators for the group
-   *
-   * @internal
-   */
-  // TODO(issue/24571): remove '!'.
-  _validators!: (Validator|ValidatorFn)[];
-
-  /**
-   * @description
-   * An array of async validators for the group
-   *
-   * @internal
-   */
-  // TODO(issue/24571): remove '!'.
-  _asyncValidators!: (AsyncValidator|AsyncValidatorFn)[];
 
   /** @nodoc */
   ngOnInit(): void {
@@ -89,22 +70,6 @@ export class AbstractFormGroupDirective extends ControlContainer implements OnIn
    */
   get formDirective(): Form|null {
     return this._parent ? this._parent.formDirective : null;
-  }
-
-  /**
-   * @description
-   * The synchronous validators registered with this group.
-   */
-  get validator(): ValidatorFn|null {
-    return composeValidators(this._validators);
-  }
-
-  /**
-   * @description
-   * The async validators registered with this group.
-   */
-  get asyncValidator(): AsyncValidatorFn|null {
-    return composeAsyncValidators(this._asyncValidators);
   }
 
   /** @internal */

--- a/packages/forms/src/directives/abstract_form_group_directive.ts
+++ b/packages/forms/src/directives/abstract_form_group_directive.ts
@@ -15,7 +15,6 @@ import {Form} from './form_interface';
 import {controlPath} from './shared';
 
 
-
 /**
  * @description
  * A base class for code shared between the `NgModelGroup` and `FormGroupName` directives.

--- a/packages/forms/src/directives/ng_control.ts
+++ b/packages/forms/src/directives/ng_control.ts
@@ -6,17 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-
 import {AbstractControlDirective} from './abstract_control_directive';
 import {ControlContainer} from './control_container';
 import {ControlValueAccessor} from './control_value_accessor';
-import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from './validators';
 
-function unimplemented(): any {
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
-    throw new Error('unimplemented');
-  }
-}
 
 /**
  * @description
@@ -45,42 +38,6 @@ export abstract class NgControl extends AbstractControlDirective {
    * The value accessor for the control
    */
   valueAccessor: ControlValueAccessor|null = null;
-
-  /**
-   * @description
-   * The uncomposed array of synchronous validators for the control
-   *
-   * @internal
-   */
-  _rawValidators: Array<Validator|ValidatorFn> = [];
-
-  /**
-   * @description
-   * The uncomposed array of async validators for the control
-   *
-   * @internal
-   */
-  _rawAsyncValidators: Array<AsyncValidator|AsyncValidatorFn> = [];
-
-  /**
-   * @description
-   * The registered synchronous validator function for the control
-   *
-   * @throws An exception that this method is not implemented
-   */
-  get validator(): ValidatorFn|null {
-    return <ValidatorFn>unimplemented();
-  }
-
-  /**
-   * @description
-   * The registered async validator function for the control
-   *
-   * @throws An exception that this method is not implemented
-   */
-  get asyncValidator(): AsyncValidatorFn|null {
-    return <AsyncValidatorFn>unimplemented();
-  }
 
   /**
    * @description

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -9,14 +9,14 @@
 import {AfterViewInit, Directive, EventEmitter, forwardRef, Inject, Input, Optional, Self} from '@angular/core';
 
 import {AbstractControl, FormControl, FormGroup, FormHooks} from '../model';
-import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
+import {composeAsyncValidators, composeValidators, NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
 
 import {ControlContainer} from './control_container';
 import {Form} from './form_interface';
 import {NgControl} from './ng_control';
 import {NgModel} from './ng_model';
 import {NgModelGroup} from './ng_model_group';
-import {composeAsyncValidators, composeValidators, removeDir, setUpControl, setUpFormContainer, syncPendingControls} from './shared';
+import {removeDir, setUpControl, setUpFormContainer, syncPendingControls} from './shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from './validators';
 
 export const formDirectiveProvider: any = {

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -9,7 +9,8 @@
 import {AfterViewInit, Directive, EventEmitter, forwardRef, Inject, Input, Optional, Self} from '@angular/core';
 
 import {AbstractControl, FormControl, FormGroup, FormHooks} from '../model';
-import {composeAsyncValidators, composeValidators, NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
+import {composeAsyncValidators, composeValidators} from '../utils/validators';
+import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
 
 import {ControlContainer} from './control_container';
 import {Form} from './form_interface';

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -17,7 +17,7 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor'
 import {NgControl} from './ng_control';
 import {NgForm} from './ng_form';
 import {NgModelGroup} from './ng_model_group';
-import {composeAsyncValidators, composeValidators, controlPath, isPropertyUpdated, selectValueAccessor, setUpControl} from './shared';
+import {controlPath, isPropertyUpdated, selectValueAccessor, setUpControl} from './shared';
 import {TemplateDrivenErrors} from './template_driven_errors';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from './validators';
 
@@ -208,8 +208,8 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
       @Optional() @Self() @Inject(NG_VALUE_ACCESSOR) valueAccessors: ControlValueAccessor[]) {
     super();
     this._parent = parent;
-    this._rawValidators = validators || [];
-    this._rawAsyncValidators = asyncValidators || [];
+    this._setValidators(validators);
+    this._setAsyncValidators(asyncValidators);
     this.valueAccessor = selectValueAccessor(this, valueAccessors);
   }
 
@@ -247,24 +247,6 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
    */
   get formDirective(): any {
     return this._parent ? this._parent.formDirective : null;
-  }
-
-  /**
-   * @description
-   * Synchronous validator function composed of all the synchronous validators
-   * registered with this directive.
-   */
-  get validator(): ValidatorFn|null {
-    return composeValidators(this._rawValidators);
-  }
-
-  /**
-   * @description
-   * Async validator function composed of all the async validators registered with this
-   * directive.
-   */
-  get asyncValidator(): AsyncValidatorFn|null {
-    return composeAsyncValidators(this._rawAsyncValidators);
   }
 
   /**

--- a/packages/forms/src/directives/ng_model_group.ts
+++ b/packages/forms/src/directives/ng_model_group.ts
@@ -64,8 +64,8 @@ export class NgModelGroup extends AbstractFormGroupDirective implements OnInit, 
           (AsyncValidator|AsyncValidatorFn)[]) {
     super();
     this._parent = parent;
-    this._validators = validators;
-    this._asyncValidators = asyncValidators;
+    this._setValidators(validators);
+    this._setAsyncValidators(asyncValidators);
   }
 
   /** @internal */

--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -13,7 +13,7 @@ import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '../control_value_accessor';
 import {NgControl} from '../ng_control';
 import {ReactiveErrors} from '../reactive_errors';
-import {_ngModelWarning, composeAsyncValidators, composeValidators, isPropertyUpdated, selectValueAccessor, setUpControl} from '../shared';
+import {_ngModelWarning, isPropertyUpdated, selectValueAccessor, setUpControl} from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
 
 
@@ -51,7 +51,6 @@ export const formControlBinding: any = {
  * @publicApi
  */
 @Directive({selector: '[formControl]', providers: [formControlBinding], exportAs: 'ngForm'})
-
 export class FormControlDirective extends NgControl implements OnChanges {
   /**
    * Internal reference to the view model value.
@@ -111,8 +110,8 @@ export class FormControlDirective extends NgControl implements OnChanges {
       @Optional() @Inject(NG_MODEL_WITH_FORM_CONTROL_WARNING) private _ngModelWarningConfig: string|
       null) {
     super();
-    this._rawValidators = validators || [];
-    this._rawAsyncValidators = asyncValidators || [];
+    this._setValidators(validators);
+    this._setAsyncValidators(asyncValidators);
     this.valueAccessor = selectValueAccessor(this, valueAccessors);
   }
 
@@ -139,24 +138,6 @@ export class FormControlDirective extends NgControl implements OnChanges {
    */
   get path(): string[] {
     return [];
-  }
-
-  /**
-   * @description
-   * Synchronous validator function composed of all the synchronous validators
-   * registered with this directive.
-   */
-  get validator(): ValidatorFn|null {
-    return composeValidators(this._rawValidators);
-  }
-
-  /**
-   * @description
-   * Async validator function composed of all the async validators registered with this
-   * directive.
-   */
-  get asyncValidator(): AsyncValidatorFn|null {
-    return composeAsyncValidators(this._rawAsyncValidators);
   }
 
   /**

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -15,7 +15,7 @@ import {ControlContainer} from '../control_container';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '../control_value_accessor';
 import {NgControl} from '../ng_control';
 import {ReactiveErrors} from '../reactive_errors';
-import {_ngModelWarning, composeAsyncValidators, composeValidators, controlPath, isPropertyUpdated, selectValueAccessor} from '../shared';
+import {_ngModelWarning, controlPath, isPropertyUpdated, selectValueAccessor} from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
 
 import {NG_MODEL_WITH_FORM_CONTROL_WARNING} from './form_control_directive';
@@ -136,8 +136,8 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
       null) {
     super();
     this._parent = parent;
-    this._rawValidators = validators || [];
-    this._rawAsyncValidators = asyncValidators || [];
+    this._setValidators(validators);
+    this._setAsyncValidators(asyncValidators);
     this.valueAccessor = selectValueAccessor(this, valueAccessors);
   }
 
@@ -184,24 +184,6 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
    */
   get formDirective(): any {
     return this._parent ? this._parent.formDirective : null;
-  }
-
-  /**
-   * @description
-   * Synchronous validator function composed of all the synchronous validators
-   * registered with this directive.
-   */
-  get validator(): ValidatorFn|null {
-    return composeValidators(this._rawValidators);
-  }
-
-  /**
-   * @description
-   * Async validator function composed of all the async validators registered with this
-   * directive.
-   */
-  get asyncValidator(): AsyncValidatorFn {
-    return composeAsyncValidators(this._rawAsyncValidators)!;
   }
 
   private _checkParentType(): void {

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -13,7 +13,7 @@ import {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from '../../validators';
 import {ControlContainer} from '../control_container';
 import {Form} from '../form_interface';
 import {ReactiveErrors} from '../reactive_errors';
-import {cleanUpControl, composeAsyncValidators, composeValidators, removeDir, setUpControl, setUpFormContainer, syncPendingControls} from '../shared';
+import {cleanUpControl, removeDir, setUpControl, setUpFormContainer, syncPendingControls} from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
 
 import {FormControlName} from './form_control_name';
@@ -82,10 +82,12 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
   @Output() ngSubmit = new EventEmitter();
 
   constructor(
-      @Optional() @Self() @Inject(NG_VALIDATORS) private _validators: (Validator|ValidatorFn)[],
-      @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) private _asyncValidators:
+      @Optional() @Self() @Inject(NG_VALIDATORS) private validators: (Validator|ValidatorFn)[],
+      @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) private asyncValidators:
           (AsyncValidator|AsyncValidatorFn)[]) {
     super();
+    this._setValidators(validators);
+    this._setAsyncValidators(asyncValidators);
   }
 
   /** @nodoc */
@@ -280,11 +282,9 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
   }
 
   private _updateValidators() {
-    const sync = composeValidators(this._validators);
-    this.form.validator = Validators.compose([this.form.validator!, sync!]);
-
-    const async = composeAsyncValidators(this._asyncValidators);
-    this.form.asyncValidator = Validators.composeAsync([this.form.asyncValidator!, async!]);
+    this.form.validator = Validators.compose([this.form.validator, this.validator]);
+    this.form.asyncValidator =
+        Validators.composeAsync([this.form.asyncValidator, this.asyncValidator]);
   }
 
   private _checkFormPresent() {

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -9,11 +9,11 @@
 import {Directive, EventEmitter, forwardRef, Inject, Input, OnChanges, Optional, Output, Self, SimpleChanges} from '@angular/core';
 
 import {FormArray, FormControl, FormGroup} from '../../model';
-import {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from '../../validators';
+import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {ControlContainer} from '../control_container';
 import {Form} from '../form_interface';
 import {ReactiveErrors} from '../reactive_errors';
-import {cleanUpControl, removeDir, setUpControl, setUpFormContainer, syncPendingControls} from '../shared';
+import {cleanUpControl, cleanUpValidators, removeDir, setUpControl, setUpFormContainer, setUpValidators, syncPendingControls} from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
 
 import {FormControlName} from './form_control_name';
@@ -60,8 +60,12 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
    */
   public readonly submitted: boolean = false;
 
-  // TODO(issue/24571): remove '!'.
-  private _oldForm!: FormGroup;
+  /**
+   * @description
+   * Reference to an old form group input value, which is needed to cleanup old instance in case it
+   * was replaced with a new one.
+   */
+  private _oldForm: FormGroup|undefined;
 
   /**
    * @description
@@ -97,6 +101,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
       this._updateValidators();
       this._updateDomValue();
       this._updateRegistrations();
+      this._oldForm = this.form;
     }
   }
 
@@ -266,7 +271,9 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
     this.directives.forEach(dir => {
       const newCtrl: any = this.form.get(dir.path);
       if (dir.control !== newCtrl) {
-        cleanUpControl(dir.control, dir);
+        // Note: the value of the `dir.control` may not be defined, for example when it's a first
+        // `FormControl` that is added to a `FormGroup` instance (via `addControl` call).
+        cleanUpControl(dir.control || null, dir);
         if (newCtrl) setUpControl(newCtrl, dir);
         (dir as {control: FormControl}).control = newCtrl;
       }
@@ -277,14 +284,16 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
 
   private _updateRegistrations() {
     this.form._registerOnCollectionChange(() => this._updateDomValue());
-    if (this._oldForm) this._oldForm._registerOnCollectionChange(() => {});
-    this._oldForm = this.form;
+    if (this._oldForm) {
+      this._oldForm._registerOnCollectionChange(() => {});
+    }
   }
 
   private _updateValidators() {
-    this.form.validator = Validators.compose([this.form.validator, this.validator]);
-    this.form.asyncValidator =
-        Validators.composeAsync([this.form.asyncValidator, this.asyncValidator]);
+    setUpValidators(this.form, this, /* handleOnValidatorChange */ false);
+    if (this._oldForm) {
+      cleanUpValidators(this._oldForm, this, /* handleOnValidatorChange */ false);
+    }
   }
 
   private _checkFormPresent() {

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -82,8 +82,8 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
   @Output() ngSubmit = new EventEmitter();
 
   constructor(
-      @Optional() @Self() @Inject(NG_VALIDATORS) private validators: (Validator|ValidatorFn)[],
-      @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) private asyncValidators:
+      @Optional() @Self() @Inject(NG_VALIDATORS) validators: (Validator|ValidatorFn)[],
+      @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) asyncValidators:
           (AsyncValidator|AsyncValidatorFn)[]) {
     super();
     this._setValidators(validators);

--- a/packages/forms/src/directives/reactive_directives/form_group_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_name.ts
@@ -13,7 +13,7 @@ import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {AbstractFormGroupDirective} from '../abstract_form_group_directive';
 import {ControlContainer} from '../control_container';
 import {ReactiveErrors} from '../reactive_errors';
-import {composeAsyncValidators, composeValidators, controlPath} from '../shared';
+import {controlPath} from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
 
 import {FormGroupDirective} from './form_group_directive';
@@ -91,8 +91,8 @@ export class FormGroupName extends AbstractFormGroupDirective implements OnInit,
           (AsyncValidator|AsyncValidatorFn)[]) {
     super();
     this._parent = parent;
-    this._validators = validators;
-    this._asyncValidators = asyncValidators;
+    this._setValidators(validators);
+    this._setAsyncValidators(asyncValidators);
   }
 
   /** @internal */
@@ -137,12 +137,6 @@ export class FormArrayName extends ControlContainer implements OnInit, OnDestroy
   /** @internal */
   _parent: ControlContainer;
 
-  /** @internal */
-  _validators: (Validator|ValidatorFn)[];
-
-  /** @internal */
-  _asyncValidators: (AsyncValidator|AsyncValidatorFn)[];
-
   /**
    * @description
    * Tracks the name of the `FormArray` bound to the directive. The name corresponds
@@ -162,8 +156,8 @@ export class FormArrayName extends ControlContainer implements OnInit, OnDestroy
           (AsyncValidator|AsyncValidatorFn)[]) {
     super();
     this._parent = parent;
-    this._validators = validators;
-    this._asyncValidators = asyncValidators;
+    this._setValidators(validators);
+    this._setAsyncValidators(asyncValidators);
   }
 
   /**
@@ -209,23 +203,6 @@ export class FormArrayName extends ControlContainer implements OnInit, OnDestroy
    */
   get path(): string[] {
     return controlPath(this.name == null ? this.name : this.name.toString(), this._parent);
-  }
-
-  /**
-   * @description
-   * Synchronous validator function composed of all the synchronous validators registered with this
-   * directive.
-   */
-  get validator(): ValidatorFn|null {
-    return composeValidators(this._validators);
-  }
-
-  /**
-   * @description
-   * Async validator function composed of all the async validators registered with this directive.
-   */
-  get asyncValidator(): AsyncValidatorFn|null {
-    return composeAsyncValidators(this._asyncValidators);
   }
 
   private _checkParentType(): void {

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -9,7 +9,7 @@
 import {isDevMode} from '@angular/core';
 
 import {FormArray, FormControl, FormGroup} from '../model';
-import {normalizeValidators, Validators} from '../validators';
+import {Validators} from '../validators';
 
 import {AbstractControlDirective} from './abstract_control_directive';
 import {AbstractFormGroupDirective} from './abstract_form_group_directive';
@@ -148,18 +148,6 @@ function _throwError(dir: AbstractControlDirective, message: string): void {
     messageEnd = 'unspecified name attribute';
   }
   throw new Error(`${message} ${messageEnd}`);
-}
-
-export function composeValidators(validators: Array<Validator|ValidatorFn>): ValidatorFn|null {
-  return validators != null ? Validators.compose(normalizeValidators<ValidatorFn>(validators)) :
-                              null;
-}
-
-export function composeAsyncValidators(validators: Array<AsyncValidator|AsyncValidatorFn>):
-    AsyncValidatorFn|null {
-  return validators != null ?
-      Validators.composeAsync(normalizeValidators<AsyncValidatorFn>(validators)) :
-      null;
 }
 
 export function isPropertyUpdated(changes: {[key: string]: any}, viewModel: any): boolean {

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -8,8 +8,8 @@
 
 import {isDevMode} from '@angular/core';
 
-import {FormArray, FormControl, FormGroup} from '../model';
-import {Validators} from '../validators';
+import {AbstractControl, FormArray, FormControl, FormGroup} from '../model';
+import {getControlAsyncValidators, getControlValidators, mergeValidators} from '../utils/validators';
 
 import {AbstractControlDirective} from './abstract_control_directive';
 import {AbstractFormGroupDirective} from './abstract_form_group_directive';
@@ -25,7 +25,7 @@ import {FormArrayName} from './reactive_directives/form_group_name';
 import {ReactiveErrors} from './reactive_errors';
 import {SelectControlValueAccessor} from './select_control_value_accessor';
 import {SelectMultipleControlValueAccessor} from './select_multiple_control_value_accessor';
-import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from './validators';
+import {AsyncValidatorFn, Validator, ValidatorFn} from './validators';
 
 
 export function controlPath(name: string|null, parent: ControlContainer): string[] {
@@ -38,8 +38,8 @@ export function setUpControl(control: FormControl, dir: NgControl): void {
     if (!dir.valueAccessor) _throwError(dir, 'No value accessor for form control with');
   }
 
-  control.validator = Validators.compose([control.validator!, dir.validator]);
-  control.asyncValidator = Validators.composeAsync([control.asyncValidator!, dir.asyncValidator]);
+  setUpValidators(control, dir, /* handleOnValidatorChange */ true);
+
   dir.valueAccessor!.writeValue(control.value);
 
   setUpViewChangePipeline(control, dir);
@@ -52,20 +52,9 @@ export function setUpControl(control: FormControl, dir: NgControl): void {
       dir.valueAccessor!.setDisabledState!(isDisabled);
     });
   }
-
-  // re-run validation when validator binding changes, e.g. minlength=3 -> minlength=4
-  dir._rawValidators.forEach((validator: Validator|ValidatorFn) => {
-    if ((<Validator>validator).registerOnValidatorChange)
-      (<Validator>validator).registerOnValidatorChange!(() => control.updateValueAndValidity());
-  });
-
-  dir._rawAsyncValidators.forEach((validator: AsyncValidator|AsyncValidatorFn) => {
-    if ((<Validator>validator).registerOnValidatorChange)
-      (<Validator>validator).registerOnValidatorChange!(() => control.updateValueAndValidity());
-  });
 }
 
-export function cleanUpControl(control: FormControl, dir: NgControl) {
+export function cleanUpControl(control: FormControl|null, dir: NgControl) {
   const noop = () => {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       _noControlError(dir);
@@ -75,19 +64,84 @@ export function cleanUpControl(control: FormControl, dir: NgControl) {
   dir.valueAccessor!.registerOnChange(noop);
   dir.valueAccessor!.registerOnTouched(noop);
 
-  dir._rawValidators.forEach((validator: any) => {
-    if (validator.registerOnValidatorChange) {
-      validator.registerOnValidatorChange(null);
-    }
-  });
-
-  dir._rawAsyncValidators.forEach((validator: any) => {
-    if (validator.registerOnValidatorChange) {
-      validator.registerOnValidatorChange(null);
-    }
-  });
+  cleanUpValidators(control, dir, /* handleOnValidatorChange */ true);
 
   if (control) control._clearChangeFns();
+}
+
+function registerOnValidatorChange<V>(validators: (V|Validator)[], onChange: () => void): void {
+  validators.forEach((validator: (V|Validator)) => {
+    if ((<Validator>validator).registerOnValidatorChange)
+      (<Validator>validator).registerOnValidatorChange!(onChange);
+  });
+}
+
+/**
+ * Sets up sync and async directive validators on provided form control.
+ *
+ * @param control Form control where directive validators should be setup.
+ * @param dir Directive instance that contains validators to be setup.
+ * @param handleOnValidatorChange Flag that determines whether directive validators should be setup
+ *     to handle validator input change.
+ */
+export function setUpValidators(
+    control: AbstractControl, dir: AbstractControlDirective,
+    handleOnValidatorChange: boolean): void {
+  if (dir.validator !== null) {
+    control.setValidators(
+        mergeValidators<ValidatorFn>(getControlValidators(control), dir.validator));
+  }
+
+  if (dir.asyncValidator !== null) {
+    control.setAsyncValidators(
+        mergeValidators<AsyncValidatorFn>(getControlAsyncValidators(control), dir.asyncValidator));
+  }
+
+  // Re-run validation when validator binding changes, e.g. minlength=3 -> minlength=4
+  if (handleOnValidatorChange) {
+    const onValidatorChange = () => control.updateValueAndValidity();
+    registerOnValidatorChange<ValidatorFn>(dir._rawValidators, onValidatorChange);
+    registerOnValidatorChange<AsyncValidatorFn>(dir._rawAsyncValidators, onValidatorChange);
+  }
+}
+
+/**
+ * Cleans up sync and async directive validators on provided form control.
+ * This function undoes the setup performed by the `setUpValidators` function.
+ *
+ * @param control Form control from where directive validators should be removed.
+ * @param dir Directive instance that contains validators to be removed.
+ * @param handleOnValidatorChange Flag that determines whether directive validators should be
+ *     cleaned up to stop handling validator input change.
+ */
+export function cleanUpValidators(
+    control: AbstractControl|null, dir: AbstractControlDirective,
+    handleOnValidatorChange: boolean): void {
+  if (control !== null) {
+    if (dir.validator !== null) {
+      const validators = getControlValidators(control);
+      if (Array.isArray(validators) && validators.length > 0) {
+        // Filter out directive validator function.
+        control.setValidators(validators.filter(validator => validator !== dir.validator));
+      }
+    }
+
+    if (dir.asyncValidator !== null) {
+      const asyncValidators = getControlAsyncValidators(control);
+      if (Array.isArray(asyncValidators) && asyncValidators.length > 0) {
+        // Filter out directive validator function.
+        control.setAsyncValidators(
+            asyncValidators.filter(asyncValidator => asyncValidator !== dir.asyncValidator));
+      }
+    }
+  }
+
+  if (handleOnValidatorChange) {
+    // Clear onValidatorChange callbacks by providing a noop callback.
+    const noop = () => {};
+    registerOnValidatorChange<ValidatorFn>(dir._rawValidators, noop);
+    registerOnValidatorChange<AsyncValidatorFn>(dir._rawAsyncValidators, noop);
+  }
 }
 
 function setUpViewChangePipeline(control: FormControl, dir: NgControl): void {
@@ -130,8 +184,7 @@ export function setUpFormContainer(
     control: FormGroup|FormArray, dir: AbstractFormGroupDirective|FormArrayName) {
   if (control == null && (typeof ngDevMode === 'undefined' || ngDevMode))
     _throwError(dir, 'Cannot find control with');
-  control.validator = Validators.compose([control.validator, dir.validator]);
-  control.asyncValidator = Validators.composeAsync([control.asyncValidator, dir.asyncValidator]);
+  setUpValidators(control, dir, /* handleOnValidatorChange */ false);
 }
 
 function _noControlError(dir: NgControl) {

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -8,9 +8,9 @@
 
 import {EventEmitter} from '@angular/core';
 import {Observable} from 'rxjs';
-import {composeAsyncValidators, composeValidators} from './directives/shared';
+
 import {AsyncValidatorFn, ValidationErrors, ValidatorFn} from './directives/validators';
-import {toObservable} from './validators';
+import {composeAsyncValidators, composeValidators, toObservable} from './validators';
 
 /**
  * Reports that a FormControl is valid, meaning that no errors exist in the input value.

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -10,7 +10,8 @@ import {EventEmitter} from '@angular/core';
 import {Observable} from 'rxjs';
 
 import {AsyncValidatorFn, ValidationErrors, ValidatorFn} from './directives/validators';
-import {composeAsyncValidators, composeValidators, toObservable} from './validators';
+import {composeAsyncValidators, composeValidators} from './utils/validators';
+import {toObservable} from './validators';
 
 /**
  * Reports that a FormControl is valid, meaning that no errors exist in the input value.

--- a/packages/forms/src/utils/validators.ts
+++ b/packages/forms/src/utils/validators.ts
@@ -45,3 +45,28 @@ export function composeAsyncValidators(validators: Array<AsyncValidator|AsyncVal
   return validators != null ? Validators.composeAsync(validators.map(normalizeAsyncValidator)) :
                               null;
 }
+
+/**
+ * Retrieves the list of raw synchronous validators attached to a given control.
+ */
+export function getControlValidators(control: AbstractControl): ValidatorFn|ValidatorFn[]|null {
+  return (control as any)._rawValidators as ValidatorFn | ValidatorFn[] | null;
+}
+
+/**
+ * Retrieves the list of raw asynchronous validators attached to a given control.
+ */
+export function getControlAsyncValidators(control: AbstractControl): AsyncValidatorFn|
+    AsyncValidatorFn[]|null {
+  return (control as any)._rawAsyncValidators as AsyncValidatorFn | AsyncValidatorFn[] | null;
+}
+
+/**
+ * Merges raw control validators with a given directive validator and returns the combined list of
+ * validators as an array.
+ */
+export function mergeValidators<V>(controlValidators: V|V[]|null, dirValidator: V): V[] {
+  if (controlValidators === null) return [dirValidator];
+  return Array.isArray(controlValidators) ? [...controlValidators, dirValidator] :
+                                            [controlValidators, dirValidator];
+}

--- a/packages/forms/src/utils/validators.ts
+++ b/packages/forms/src/utils/validators.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../directives/validators';
+import {AbstractControl} from '../model';
+import {Validators} from '../validators';
+
+
+export function normalizeValidator(validator: ValidatorFn|Validator): ValidatorFn {
+  if (!!(<Validator>validator).validate) {
+    return (c: AbstractControl) => (<Validator>validator).validate(c);
+  } else {
+    return <ValidatorFn>validator;
+  }
+}
+
+export function normalizeAsyncValidator(validator: AsyncValidatorFn|
+                                        AsyncValidator): AsyncValidatorFn {
+  if (!!(<AsyncValidator>validator).validate) {
+    return (c: AbstractControl) => (<AsyncValidator>validator).validate(c);
+  } else {
+    return <AsyncValidatorFn>validator;
+  }
+}
+
+/**
+ * Merges synchronous validators into a single validator function (combined using
+ * `Validators.compose`).
+ */
+export function composeValidators(validators: Array<Validator|ValidatorFn>): ValidatorFn|null {
+  return validators != null ? Validators.compose(validators.map(normalizeValidator)) : null;
+}
+
+/**
+ * Merges asynchronous validators into a single validator function (combined using
+ * `Validators.composeAsync`).
+ */
+export function composeAsyncValidators(validators: Array<AsyncValidator|AsyncValidatorFn>):
+    AsyncValidatorFn|null {
+  return validators != null ? Validators.composeAsync(validators.map(normalizeAsyncValidator)) :
+                              null;
+}

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -513,3 +513,23 @@ export function normalizeValidators<V>(validators: (V|Validator|AsyncValidator)[
         ((c: AbstractControl) => validator.validate(c)) as unknown as V;
   });
 }
+
+/**
+ * Merges synchronous validators into a single validator function (combined using
+ * `Validators.compose`).
+ */
+export function composeValidators(validators: Array<Validator|ValidatorFn>): ValidatorFn|null {
+  return validators != null ? Validators.compose(normalizeValidators<ValidatorFn>(validators)) :
+                              null;
+}
+
+/**
+ * Merges asynchronous validators into a single validator function (combined using
+ * `Validators.composeAsync`).
+ */
+export function composeAsyncValidators(validators: Array<AsyncValidator|AsyncValidatorFn>):
+    AsyncValidatorFn|null {
+  return validators != null ?
+      Validators.composeAsync(normalizeValidators<AsyncValidatorFn>(validators)) :
+      null;
+}

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -10,7 +10,8 @@ import {SimpleChange} from '@angular/core';
 import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {beforeEach, describe, expect, it} from '@angular/core/testing/src/testing_internal';
 import {AbstractControl, CheckboxControlValueAccessor, ControlValueAccessor, DefaultValueAccessor, FormArray, FormArrayName, FormControl, FormControlDirective, FormControlName, FormGroup, FormGroupDirective, FormGroupName, NgControl, NgForm, NgModel, NgModelGroup, SelectControlValueAccessor, SelectMultipleControlValueAccessor, ValidationErrors, Validator, Validators} from '@angular/forms';
-import {composeValidators, selectValueAccessor} from '@angular/forms/src/directives/shared';
+import {selectValueAccessor} from '@angular/forms/src/directives/shared';
+import {composeValidators} from '@angular/forms/src/validators';
 import {SpyNgControl, SpyValueAccessor} from './spies';
 import {asyncValidator} from './util';
 

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -11,7 +11,7 @@ import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {beforeEach, describe, expect, it} from '@angular/core/testing/src/testing_internal';
 import {AbstractControl, CheckboxControlValueAccessor, ControlValueAccessor, DefaultValueAccessor, FormArray, FormArrayName, FormControl, FormControlDirective, FormControlName, FormGroup, FormGroupDirective, FormGroupName, NgControl, NgForm, NgModel, NgModelGroup, SelectControlValueAccessor, SelectMultipleControlValueAccessor, ValidationErrors, Validator, Validators} from '@angular/forms';
 import {selectValueAccessor} from '@angular/forms/src/directives/shared';
-import {composeValidators} from '@angular/forms/src/validators';
+import {composeValidators} from '@angular/forms/src/utils/validators';
 import {SpyNgControl, SpyValueAccessor} from './spies';
 import {asyncValidator} from './util';
 

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -10,6 +10,7 @@ import {fakeAsync, tick} from '@angular/core/testing';
 import {describe, expect, it} from '@angular/core/testing/src/testing_internal';
 import {AbstractControl, AsyncValidatorFn, FormArray, FormControl, Validators} from '@angular/forms';
 import {AsyncValidator, ValidationErrors, ValidatorFn} from '@angular/forms/src/directives/validators';
+import {normalizeAsyncValidator} from '@angular/forms/src/utils/validators';
 import {Observable, of, timer} from 'rxjs';
 import {first, map} from 'rxjs/operators';
 

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -8,7 +8,8 @@
 
 import {fakeAsync, tick} from '@angular/core/testing';
 import {describe, expect, it} from '@angular/core/testing/src/testing_internal';
-import {AbstractControl, AsyncValidator, AsyncValidatorFn, FormArray, FormControl, ValidationErrors, ValidatorFn, Validators} from '@angular/forms';
+import {AbstractControl, AsyncValidatorFn, FormArray, FormControl, Validators} from '@angular/forms';
+import {AsyncValidator, ValidationErrors, ValidatorFn} from '@angular/forms/src/directives/validators';
 import {Observable, of, timer} from 'rxjs';
 import {first, map} from 'rxjs/operators';
 


### PR DESCRIPTION
Prior to this commit, the `cleanUpControl` function (responsible for cleaning up control instance)
was not taking validators into account. As a result, these validators remain registered on a detached
form control instance, thus causing memory leaks. This commit updates the `cleanUpControl` function
logic to also run validators cleanup.

As a part of this change, the logic to setup and cleanup validators was refactored and moved to
separate functions, so that they can be reused in the future.

NOTE: this PR resolves memory leaks in **certain scenarios only**. Other scenarios will be handled in followup PRs.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No