### PR TITLE
Mark eager `NgModuleFactory` construction as not side effectful

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -307,7 +307,10 @@ export class NgModuleDecoratorHandler implements
     });
 
     if (this.factoryTracker !== null) {
-      this.factoryTracker.track(node.getSourceFile(), analysis.factorySymbolName);
+      this.factoryTracker.track(node.getSourceFile(), {
+        name: analysis.factorySymbolName,
+        hasId: !!analysis.id,
+      });
     }
 
     this.injectableRegistry.registerInjectable(node);

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -309,7 +309,7 @@ export class NgModuleDecoratorHandler implements
     if (this.factoryTracker !== null) {
       this.factoryTracker.track(node.getSourceFile(), {
         name: analysis.factorySymbolName,
-        hasId: !!analysis.id,
+        hasId: analysis.id !== null,
       });
     }
 

--- a/packages/compiler-cli/src/ngtsc/imports/src/core.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/core.ts
@@ -65,6 +65,7 @@ const CORE_SUPPORTED_SYMBOLS = new Map<string, string>([
   ['ɵɵInjectorDef', 'ɵɵInjectorDef'],
   ['ɵɵNgModuleDefWithMeta', 'ɵɵNgModuleDefWithMeta'],
   ['ɵNgModuleFactory', 'NgModuleFactory'],
+  ['ɵnoSideEffects', 'ɵnoSideEffects'],
 ]);
 
 const CORE_MODULE = '@angular/core';

--- a/packages/compiler-cli/src/ngtsc/shims/api.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/api.ts
@@ -61,10 +61,15 @@ export interface PerFileShimGenerator {
 export interface FactoryTracker {
   readonly sourceInfo: Map<string, FactoryInfo>;
 
-  track(sf: ts.SourceFile, factorySymbolName: string): void;
+  track(sf: ts.SourceFile, moduleInfo: ModuleInfo): void;
 }
 
 export interface FactoryInfo {
   sourceFilePath: string;
-  moduleSymbolNames: Set<string>;
+  moduleSymbols: Map<string, ModuleInfo>;
+}
+
+export interface ModuleInfo {
+  name: string;
+  hasId: boolean;
 }

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -292,5 +292,8 @@ export {
   ɵɵsanitizeUrl,
   ɵɵsanitizeUrlOrResourceUrl,
 } from './sanitization/sanitization';
+export {
+  noSideEffects as ɵnoSideEffects,
+} from './util/closure';
 
 // clang-format on

--- a/packages/core/src/r3_symbols.ts
+++ b/packages/core/src/r3_symbols.ts
@@ -28,6 +28,7 @@ export {ɵɵdefineNgModule} from './render3/definition';
 export {ɵɵFactoryDef} from './render3/interfaces/definition';
 export {setClassMetadata} from './render3/metadata';
 export {NgModuleFactory} from './render3/ng_module_ref';
+export {noSideEffects as ɵnoSideEffects} from './util/closure';
 
 
 


### PR DESCRIPTION
Roll forward of #38147.

This allows Closure compiler to tree shake unused constructor calls to `NgModuleFactory`, which is otherwise considered
side-effectful. The Angular compiler generates factory objects which are exported but typically not used, as they are
only needed for compatibility with View Engine. This results in top-level constructor calls, such as:

```typescript
export const FooNgFactory = new NgModuleFactory(Foo);
```

`NgModuleFactory` has a side-effecting constructor, so this statement cannot be tree shaken, even if `FooNgFactory` is
never imported. The `NgModuleFactory` continues to reference its associated `NgModule` and prevents the module and all
its unused dependencies from being tree shaken, making Closure builds significantly larger than necessary.

The fix here is to wrap `NgModuleFactory` constructor with `noSideEffects(() => /* ... */)`, which tricks the Closure
compiler into assuming that the invoked function has no side effects. This allows it to tree-shake unused
`NgModuleFactory()` constructors when they aren't imported. Since the factory can be removed, the module can also be
removed (if nothing else references it), thus tree shaking unused dependencies as expected.

The one notable edge case is for lazy loaded modules. Internally, lazy loading is done as a side effect when the lazy
script is evaluated. For Angular, this side effect is registering the `NgModule`. In Ivy this is done by the
`NgModuleFactory` constructor, so lazy loaded modules **cannot** have their top-level `NgModuleFactory` constructor
call tree shaken. We handle this case by looking for the `id` field on `@NgModule` annotations. All lazy loaded modules
include an `id`. When this `id` is found, the `NgModuleFactory` is generated **without** with `noSideEffects()` call,
so Closure will not tree shake it and the module will lazy-load correctly.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Closure does not tree shake unused `NgModule`s from the bundle.

Issue Number: http://b/161548609


## What is the new behavior?
Closure will now tree shake unused `NgModule`s.

## Does this PR introduce a breaking change?

- [X] No