### PR TITLE
fix(service-worker): fix the chrome debugger syntax highlighter

### DIFF
--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -720,7 +720,11 @@ export class Driver implements Debuggable, UpdateSource {
 
   private async deleteAllCaches(): Promise<void> {
     await (await this.scope.caches.keys())
-        .filter(key => key.startsWith(`${this.adapter.cacheNamePrefix}:`))
+        // The Chrome debugger is not able to render the syntax properly when the
+        // code contains backticks. This is a known issue in Chrome and they have an
+        // open [issue](https://bugs.chromium.org/p/chromium/issues/detail?id=659515) for that.
+        // As a work-around for the time being, we can use \\ ` at the end of the line.
+        .filter(key => key.startsWith(`${this.adapter.cacheNamePrefix}:`))  // `
         .reduce(async (previous, key) => {
           await Promise.all([
             previous,


### PR DESCRIPTION
The Chrome debugger is not able to render the syntax properly when the
code contains backticks. This is a known issue in Chrome and they have an
open [issue](https://bugs.chromium.org/p/chromium/issues/detail?id=659515) for that.
This commit adds the work-around to use double backslash with one
backtick ``\\` `` at the end of the line.

This can be reproduced by running the following command. 

`yarn bazel test //packages/forms/test --config=debug`

When opening the chrome debugger tools, you should see the correct code highlighting syntax.

**Before**

![before](https://user-images.githubusercontent.com/59734/89206422-4994a100-d587-11ea-88ba-7dfc1e12005a.png)

**After**

![correct-display](https://user-images.githubusercontent.com/59734/89206442-50231880-d587-11ea-8d46-ed519e31cf37.png)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
