### PR TITLE
fix(docs-infra): correctly generate CLI commands docs when the overview page moves

### DIFF
--- a/aio/tools/transforms/cli-docs-package/processors/processCliCommands.spec.js
+++ b/aio/tools/transforms/cli-docs-package/processors/processCliCommands.spec.js
@@ -258,18 +258,67 @@ describe('processCliCommands processor', () => {
          docType: 'navigation-json',
          data: {
            SideNav: [
-             {url: 'some/page', title: 'Some Page'}, {
+             {url: 'some/page', title: 'Some Page'},
+             {
                title: 'CLI Commands',
                tooltip: 'Angular CLI command reference',
-               children: [{'title': 'Overview', 'url': 'cli'}]
+               children: [{'title': 'Overview', 'url': 'cli'}],
              },
-             {url: 'other/page', title: 'Other Page'}
-           ]
-         }
+             {url: 'other/page', title: 'Other Page'},
+           ],
+         },
        };
        processor.$process([command, navigation]);
        expect(navigation.data.SideNav[1].title).toEqual('CLI Commands');
        expect(navigation.data.SideNav[1].children).toEqual([
+         {url: 'cli', title: 'Overview'},
+         {url: 'cli/command1', title: 'ng command1'},
+       ]);
+     });
+
+  it('should detect the CLI node if it is nested in another node (as long as there is a first child node with a `cli` url',
+     () => {
+       const command = {
+         docType: 'cli-command',
+         name: 'command1',
+         commandAliases: ['alias1', 'alias2'],
+         options: [],
+         path: 'cli/command1',
+       };
+       const navigation = {
+         docType: 'navigation-json',
+         data: {
+           SideNav: [
+             {url: 'some/page', title: 'Some Page'},
+             {
+               title: 'CLI Commands Grandparent',
+               children: [
+                 {url: 'some/nested/page', title: 'Some Nested Page'},
+                 {
+                   title: 'CLI Commands Parent',
+                   children: [
+                     {url: 'some/more/nested/page', title: 'Some More Nested Page'},
+                     {
+                       title: 'CLI Commands',
+                       tooltip: 'Angular CLI command reference',
+                       children: [{'title': 'Overview', 'url': 'cli'}],
+                     },
+                     {url: 'other/more/nested/page', title: 'Other More Nested Page'},
+                   ],
+                 },
+                 {url: 'other/nested/page', title: 'Other Nested Page'},
+               ],
+             },
+             {url: 'other/page', title: 'Other Page'},
+           ],
+         },
+       };
+
+       processor.$process([command, navigation]);
+
+       const cliCommandsNode = navigation.data.SideNav[1].children[1].children[1];
+       expect(cliCommandsNode.title).toEqual('CLI Commands');
+       expect(cliCommandsNode.children).toEqual([
          {url: 'cli', title: 'Overview'},
          {url: 'cli/command1', title: 'ng command1'},
        ]);


### PR DESCRIPTION
Previously, the [processCliCommands][1] dgeni processor, which is used to generate the docs pages for the CLI commands, expected the CLI commands overview page (with a URL of `cli`) to exist as a child of a top-level navigation section (`CLI Commands`). If one tried to move the `CLI Commands` section inside another section, `processCliCommnads` would fail to find it and thus fail to generate the CLI commands docs. This problem came up in #38353.

This commit updates the `processCliCommands` processor to be able to find it regardless of the position of the `CLI Commands` section inside the navigation doc.

[1]: https://github.com/angular/angular/blob/dca4443a8ed65d341356fe62f6df9934e6314dfe/aio/tools/transforms/cli-docs-package/processors/processCliCommands.js#L7-L9
