### PR TITLE
fix(router): If users are using the Alt key when clicking the router links, prioritize browser’s default behavior

### DIFF
--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -432,7 +432,7 @@ export declare class RouterLinkWithHref implements OnChanges, OnDestroy {
     constructor(router: Router, route: ActivatedRoute, locationStrategy: LocationStrategy);
     ngOnChanges(changes: SimpleChanges): any;
     ngOnDestroy(): any;
-    onClick(button: number, ctrlKey: boolean, metaKey: boolean, shiftKey: boolean): boolean;
+    onClick(button: number, ctrlKey: boolean, shiftKey: boolean, altKey: boolean, metaKey: boolean): boolean;
 }
 
 export declare class RouterModule {

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -359,9 +359,12 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   }
 
   /** @nodoc */
-  @HostListener('click', ['$event.button', '$event.ctrlKey', '$event.metaKey', '$event.shiftKey'])
-  onClick(button: number, ctrlKey: boolean, metaKey: boolean, shiftKey: boolean): boolean {
-    if (button !== 0 || ctrlKey || metaKey || shiftKey) {
+  @HostListener(
+      'click',
+      ['$event.button', '$event.ctrlKey', '$event.shiftKey', '$event.altKey', '$event.metaKey'])
+  onClick(button: number, ctrlKey: boolean, shiftKey: boolean, altKey: boolean, metaKey: boolean):
+      boolean {
+    if (button !== 0 || ctrlKey || shiftKey || altKey || metaKey) {
       return true;
     }
 


### PR DESCRIPTION
When users click a link while holding the Alt key together, the browsers behave as follows.

Windows 10:

|Browser|Behavior|
|:--|:--|
|Chrome 84|Download the target resource|
|Firefox 79|Prevent navigation and therefore do nothing|
|Edge 84|Download the target resource|
|IE 11|No impact|

macOS Catalina:

|Browser|Behavior|
|:--|:--|
|Chrome 84|Download the target resource|
|Firefox 79|Prevent navigation and therefore do nothing|
|Safari 13|Download the target resource|

The Alt key has no impact on IE, but on most other browsers it does. As with other modifier keys, the router should stop the original navigation to avoid preventing the browser’s default behavior.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

This doesn't have an associate test for a few reasons:
* No tests exist for the meta keys already, so adding one for this would take more effort
* The test, if it were to be a unit test, wouldn't provide much value because it would have to pass in `true` specifically for the meta key and simply expect `true` back. This is akin to a change detector test
* The ideal test would be a protractor test that verifies the behavior as described above -- i.e. that the Angular router does not trigger a navigation by clicking the routerLink, but instead the browser handles the click natively. This may be a little overkill to write for this simple change.