### PR TITLE
docs: keep tables in order

### DIFF
--- a/aio/content/guide/structural-directives.md
+++ b/aio/content/guide/structural-directives.md
@@ -318,6 +318,22 @@ When you write your own structural directives, use the following grammar:
 
 The following tables describe each portion of the microsyntax grammar.
 
+<!-- The items in this table seem different. Is there another name for how we should describe them? -->
+<table>
+  <tr>
+    <th></th>
+  </tr>
+  <tr>
+    <td colspan="3"><code>keyExp = :key ":"? :expression ("as" :local)? ";"? </code></td>
+  </tr>
+  <tr>
+    <td colspan="3"><code>let = "let" :local "=" :export ";"?</code></td>
+  </tr>
+  <tr>
+    <td colspan="3"><code>as = :export "as" :local ";"?</code></td>
+  </tr>
+</table>
+
 <!-- What should I put in the table headers? -->
 
 <table>
@@ -346,23 +362,6 @@ The following tables describe each portion of the microsyntax grammar.
     <td>standard Angular expression</td>
   </tr>
 </table>
-
-<!-- The items in this table seem different. Is there another name for how we should describe them? -->
-<table>
-  <tr>
-    <th></th>
-  </tr>
-  <tr>
-    <td colspan="3"><code>keyExp = :key ":"? :expression ("as" :local)? ";"? </code></td>
-  </tr>
-  <tr>
-    <td colspan="3"><code>let = "let" :local "=" :export ";"?</code></td>
-  </tr>
-  <tr>
-    <td colspan="3"><code>as = :export "as" :local ";"?</code></td>
-  </tr>
-</table>
-
 
 ### Translation
 


### PR DESCRIPTION
The things that are explained in first table are there in
second table while explaining the structural directive microsyntax
So the second table should preceed the first table

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
