### PR TITLE
fix(dev-infra): update i18n-related file locations in PullApprove config

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -509,8 +509,8 @@ groups:
       - >
         contains_any_globs(files, [
           'packages/core/src/i18n/**',
-          'packages/core/src/render3/i18n.ts',
-          'packages/core/src/render3/i18n.md',
+          'packages/core/src/render3/i18n/**',
+          'packages/core/src/render3/instructions/i18n.ts',
           'packages/core/src/render3/interfaces/i18n.ts',
           'packages/common/locales/**',
           'packages/common/src/i18n/**',


### PR DESCRIPTION
The changes in https://github.com/angular/angular/pull/38368 split `render3/i18n.ts` files into smaller scripts, but the PullApprove config was not updated to reflect that. This commit updates the PullApprove config to reflect the recent changes in i18n-related files.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No