### PR TITLE
fix(core): move generated i18n statements to the `consts` field of ComponentDef

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -182,15 +182,17 @@ const verify = (input: string, output: string, extra: any = {}): void => {
   }
 };
 
-// Describes a simple key-value object.
-type KVList = {
-  [key: string]: string
-};
+// Describes message metadata object.
+interface Meta {
+  desc?: string;
+  meaning?: string;
+  id?: string;
+}
 
 // Describes placeholder type used in tests. Note: the type is an array (not an object), since it's
 // important to preserve the order of placeholders (so that we can compare it with generated
 // output).
-type Placeholder = string[];
+type Placeholder = [string, string];
 
 // Unique message id index that is needed to avoid different i18n vars with the same name to appear
 // in the i18n block while generating an output string (used to verify compiler-generated code).
@@ -202,7 +204,7 @@ let msgIndex = 0;
 const quotedValue = (value: string) => value.startsWith('$') ? value : `"${value}"`;
 
 // Generates a string that represents expected Closure metadata output.
-const i18nMsgClosureMeta = (meta?: KVList): string => {
+const i18nMsgClosureMeta = (meta?: Meta): string => {
   if (!meta || !(meta.desc || meta.meaning)) return '';
   return `
     /**
@@ -220,7 +222,7 @@ const i18nPlaceholdersToString = (placeholders: Placeholder[]): string => {
 };
 
 // Generates a string that represents expected $localize metadata output.
-const i18nMsgLocalizeMeta = (meta?: KVList): string => {
+const i18nMsgLocalizeMeta = (meta?: Meta): string => {
   if (!meta) return '';
   let localizeMeta = '';
   if (meta.meaning) localizeMeta += `${meta.meaning}|`;
@@ -244,7 +246,7 @@ const i18nMsgInsertLocalizePlaceholders =
     };
 
 // Generates a string that represents expected i18n block content for simple message.
-const i18nMsg = (message: string, placeholders: Placeholder[] = [], meta?: KVList) => {
+const i18nMsg = (message: string, placeholders: Placeholder[] = [], meta?: Meta) => {
   const varName = `$I18N_${msgIndex++}$`;
   const closurePlaceholders = i18nPlaceholdersToString(placeholders);
   const locMessageWithPlaceholders = i18nMsgInsertLocalizePlaceholders(message, placeholders);
@@ -263,7 +265,7 @@ const i18nMsg = (message: string, placeholders: Placeholder[] = [], meta?: KVLis
 // Generates a string that represents expected i18n block content for a message that requires
 // post-processing (thus includes `ɵɵi18nPostprocess` in generated code).
 const i18nMsgWithPostprocess =
-    (message: string, placeholders: Placeholder[] = [], meta?: KVList,
+    (message: string, placeholders: Placeholder[] = [], meta?: Meta,
      postprocessPlaceholders?: Placeholder[]) => {
       const varName = `$I18N_${msgIndex}$`;
       const ppPaceholders =
@@ -275,10 +277,9 @@ const i18nMsgWithPostprocess =
     };
 
 // Generates a string that represents expected i18n block content for an ICU.
-const i18nIcuMsg =
-    (message: string, placeholders: string[][] = []) => {
-      return i18nMsgWithPostprocess(message, [], undefined, placeholders);
-    }
+const i18nIcuMsg = (message: string, placeholders: Placeholder[] = []) => {
+  return i18nMsgWithPostprocess(message, [], undefined, placeholders);
+};
 
 describe('i18n support in the template compiler', () => {
   describe('element attributes', () => {
@@ -303,7 +304,7 @@ describe('i18n support in the template compiler', () => {
 
       // Keeping this block as a raw string, since it checks escaping of special chars.
       const i18n_6 = String.raw`
-        var $I18N_23$;
+        var $i18n_23$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           /**
            * @desc [BACKUP_$` +
@@ -311,10 +312,10 @@ describe('i18n support in the template compiler', () => {
           '`' + String.raw`desc
            */
           const $MSG_EXTERNAL_idG$$APP_SPEC_TS_24$ = goog.getMsg("Title G");
-          $I18N_23$ = $MSG_EXTERNAL_idG$$APP_SPEC_TS_24$;
+          $i18n_23$ = $MSG_EXTERNAL_idG$$APP_SPEC_TS_24$;
         }
         else {
-          $I18N_23$ = $localize \`:[BACKUP_$\{MESSAGE}_ID\:idH]\\\`desc@@idG:Title G\`;
+          $i18n_23$ = $localize \`:[BACKUP_$\{MESSAGE}_ID\:idH]\\\`desc@@idG:Title G\`;
         }
       `;
 
@@ -334,53 +335,58 @@ describe('i18n support in the template compiler', () => {
       `;
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
-        const $_c5$ = ["title", $i18n_1$];
-        ${i18n_2}
-        const $_c9$ = ["title", $i18n_2$];
-        ${i18n_3}
-        const $_c13$ = ["title", $i18n_3$];
-        ${i18n_4}
-        const $_c17$ = ["title", $i18n_4$];
-        ${i18n_5}
-        const $_c21$ = ["title", $i18n_5$];
-        ${i18n_6}
-        const $_c25$ = ["title", $i18n_6$];
-        ${i18n_7}
-        …
-        consts: [[${AttributeMarker.I18n}, "title"]],
+        consts: function () {
+          ${i18n_0}
+          ${i18n_1}
+          ${i18n_2}
+          ${i18n_3}
+          ${i18n_4}
+          ${i18n_5}
+          ${i18n_6}
+          ${i18n_7}
+          return [
+            $i18n_0$,
+            [${AttributeMarker.I18n}, "title"],
+            ["title", $i18n_1$],
+            ["title", $i18n_2$],
+            ["title", $i18n_3$],
+            ["title", $i18n_4$],
+            ["title", $i18n_5$],
+            ["title", $i18n_6$],
+            $i18n_7$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
-            $r3$.ɵɵelementStart(2, "div", 0);
-            $r3$.ɵɵi18nAttributes(3, $_c5$);
+            $r3$.ɵɵelementStart(2, "div", 1);
+            $r3$.ɵɵi18nAttributes(3, 2);
             $r3$.ɵɵtext(4, "Content B");
             $r3$.ɵɵelementEnd();
-            $r3$.ɵɵelementStart(5, "div", 0);
-            $r3$.ɵɵi18nAttributes(6, $_c9$);
+            $r3$.ɵɵelementStart(5, "div", 1);
+            $r3$.ɵɵi18nAttributes(6, 3);
             $r3$.ɵɵtext(7, "Content C");
             $r3$.ɵɵelementEnd();
-            $r3$.ɵɵelementStart(8, "div", 0);
-            $r3$.ɵɵi18nAttributes(9, $_c13$);
+            $r3$.ɵɵelementStart(8, "div", 1);
+            $r3$.ɵɵi18nAttributes(9, 4);
             $r3$.ɵɵtext(10, "Content D");
             $r3$.ɵɵelementEnd();
-            $r3$.ɵɵelementStart(11, "div", 0);
-            $r3$.ɵɵi18nAttributes(12, $_c17$);
+            $r3$.ɵɵelementStart(11, "div", 1);
+            $r3$.ɵɵi18nAttributes(12, 5);
             $r3$.ɵɵtext(13, "Content E");
             $r3$.ɵɵelementEnd();
-            $r3$.ɵɵelementStart(14, "div", 0);
-            $r3$.ɵɵi18nAttributes(15, $_c21$);
+            $r3$.ɵɵelementStart(14, "div", 1);
+            $r3$.ɵɵi18nAttributes(15, 6);
             $r3$.ɵɵtext(16, "Content F");
             $r3$.ɵɵelementEnd();
-            $r3$.ɵɵelementStart(17, "div", 0);
-            $r3$.ɵɵi18nAttributes(18, $_c25$);
+            $r3$.ɵɵelementStart(17, "div", 1);
+            $r3$.ɵɵi18nAttributes(18, 7);
             $r3$.ɵɵtext(19, "Content G");
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(20, "div");
-            $r3$.ɵɵi18n(21, $i18n_7$);
+            $r3$.ɵɵi18n(21, 8);
             $r3$.ɵɵelementEnd();
           }
         }
@@ -396,14 +402,17 @@ describe('i18n support in the template compiler', () => {
 
       const i18n_0 = i18nMsg('Hello');
       const output = String.raw`
-        ${i18n_0}
-        const $_c2$ = ["title", $i18n_0$];
-        …
-        consts: [[${AttributeMarker.I18n}, "title"]],
+        consts: function () {
+          ${i18n_0}
+          return [
+            [${AttributeMarker.I18n}, "title"],
+            ["title", $i18n_0$]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_ng_template_0_Template, 0, 0, "ng-template", 0);
-            $r3$.ɵɵi18nAttributes(1, $_c2$);
+            $r3$.ɵɵi18nAttributes(1, 1);
           }
         }
       `;
@@ -417,9 +426,8 @@ describe('i18n support in the template compiler', () => {
           `;
 
          const i18n_0 = i18nMsg('Hello');
+
          const output = String.raw`
-            ${i18n_0}
-            const $_c2$ = ["title", $i18n_0$];
             function MyComponent_0_ng_template_0_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵɵtext(0, "Test");
@@ -428,11 +436,18 @@ describe('i18n support in the template compiler', () => {
             function MyComponent_0_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵɵtemplate(0, MyComponent_0_ng_template_0_Template, 1, 0, "ng-template", 1);
-                $r3$.ɵɵi18nAttributes(1, $_c2$);
+                $r3$.ɵɵi18nAttributes(1, 2);
               }
             }
             …
-            consts: [[${AttributeMarker.Template}, "ngIf"], [${AttributeMarker.I18n}, "title"]],
+            consts: function() {
+              ${i18n_0}
+              return [
+                [${AttributeMarker.Template}, "ngIf"],
+                [${AttributeMarker.I18n}, "title"],
+                ["title", $i18n_0$]
+              ];
+            },
             template: function MyComponent_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵɵtemplate(0, MyComponent_0_Template, 2, 0, undefined, 0);
@@ -454,14 +469,17 @@ describe('i18n support in the template compiler', () => {
          const i18n_0 =
              i18nMsg('Hello {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
          const output = String.raw`
-           ${i18n_0}
-           const $_c2$ = ["title", $i18n_0$];
-           …
-           consts: [[${AttributeMarker.Bindings}, "title"]],
+           consts: function() {
+             ${i18n_0}
+             return [
+               [${AttributeMarker.Bindings}, "title"],
+               ["title", $i18n_0$]
+             ];
+           },
            template: function MyComponent_Template(rf, ctx) {
              if (rf & 1) {
                $r3$.ɵɵtemplate(0, MyComponent_ng_template_0_Template, 0, 0, "ng-template", 0);
-               $r3$.ɵɵi18nAttributes(1, $_c2$);
+               $r3$.ɵɵi18nAttributes(1, 1);
              }
              if (rf & 2) {
                $r3$.ɵɵi18nExp(ctx.name);
@@ -481,13 +499,10 @@ describe('i18n support in the template compiler', () => {
          const i18n_0 =
              i18nMsg('Hello {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
          const output = String.raw`
-            ${i18n_0}
-            const $_c2$ = ["title", $i18n_0$];
-            …
             function MyComponent_0_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵɵtemplate(0, MyComponent_0_ng_template_0_Template, 0, 0, "ng-template", 1);
-                $r3$.ɵɵi18nAttributes(1, $_c2$);
+                $r3$.ɵɵi18nAttributes(1, 2);
               }
               if (rf & 2) {
                 const $ctx_r2$ = $r3$.ɵɵnextContext();
@@ -496,7 +511,14 @@ describe('i18n support in the template compiler', () => {
               }
             }
             …
-            consts: [[${AttributeMarker.Template}, "ngIf"], [${AttributeMarker.Bindings}, "title"]],
+            consts: function() {
+              ${i18n_0}
+              return [
+                [${AttributeMarker.Template}, "ngIf"],
+                [${AttributeMarker.Bindings}, "title"],
+                ["title", $i18n_0$]
+              ];
+            },
             template: function MyComponent_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵɵtemplate(0, MyComponent_0_Template, 2, 1, undefined, 0);
@@ -536,7 +558,6 @@ describe('i18n support in the template compiler', () => {
       `;
 
       const output = `
-        …
         consts: [[3, "title"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
@@ -558,15 +579,19 @@ describe('i18n support in the template compiler', () => {
       `;
 
       const i18n_0 = i18nMsg('introduction', [], {meaning: 'm', desc: 'd'});
+
       const output = String.raw`
-        ${i18n_0}
-        const $_c1$ = ["title", $i18n_0$];
-        …
-        consts: [["id", "static", ${AttributeMarker.I18n}, "title"]],
+        consts: function() {
+          ${i18n_0}
+          return [
+            ["id", "static", ${AttributeMarker.I18n}, "title"],
+            ["title", $i18n_0$]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
-            $r3$.ɵɵi18nAttributes(1, $_c1$);
+            $r3$.ɵɵi18nAttributes(1, 1);
             $r3$.ɵɵelementEnd();
           }
         }
@@ -606,35 +631,30 @@ describe('i18n support in the template compiler', () => {
       const i18n_4 = i18nMsg('{$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
-        ${i18n_2}
-        const $_c1$ = [
-          "aria-roledescription", $i18n_0$,
-          "title", $i18n_1$,
-          "aria-label", $i18n_2$
-        ];
-        ${i18n_3}
-        ${i18n_4}
-        const $_c3$ = [
-          "title", $i18n_3$,
-          "aria-roledescription", $i18n_4$
-        ];
-        …
         decls: 5,
         vars: 8,
-        consts: [["id", "dynamic-1", ${
-          AttributeMarker
-              .I18n}, "aria-roledescription", "title", "aria-label"], ["id", "dynamic-2", ${
-          AttributeMarker.I18n}, "title", "aria-roledescription"]],
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          ${i18n_2}
+          ${i18n_3}
+          ${i18n_4}
+          return [
+            ["id", "dynamic-1", ${AttributeMarker.I18n}, "aria-roledescription",
+                                                                "title", "aria-label"],
+            ["aria-roledescription", $i18n_0$, "title", $i18n_1$, "aria-label", $i18n_2$],
+            ["id", "dynamic-2", ${AttributeMarker.I18n}, "title", "aria-roledescription"],
+            ["title", $i18n_3$, "aria-roledescription", $i18n_4$]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
             $r3$.ɵɵpipe(1, "uppercase");
-            $r3$.ɵɵi18nAttributes(2, $_c1$);
+            $r3$.ɵɵi18nAttributes(2, 1);
             $r3$.ɵɵelementEnd();
-            $r3$.ɵɵelementStart(3, "div", 1);
-            $r3$.ɵɵi18nAttributes(4, $_c3$);
+            $r3$.ɵɵelementStart(3, "div", 2);
+            $r3$.ɵɵi18nAttributes(4, 3);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -658,16 +678,20 @@ describe('i18n support in the template compiler', () => {
       const i18n_0 = i18nMsg(
           'intro {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]],
           {meaning: 'm', desc: 'd'});
+
       const output = String.raw`
-        ${i18n_0}
-        const $_c3$ = ["title", $i18n_0$];
-        …
-        consts: [[${AttributeMarker.I18n}, "title"]],
+        consts: function() {
+          ${i18n_0}
+          return [
+            [${AttributeMarker.I18n}, "title"],
+            ["title", $i18n_0$]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
             $r3$.ɵɵpipe(1, "uppercase");
-            $r3$.ɵɵi18nAttributes(2, $_c3$);
+            $r3$.ɵɵi18nAttributes(2, 1);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -691,14 +715,12 @@ describe('i18n support in the template compiler', () => {
           {meaning: 'm', desc: 'd'});
 
       const output = String.raw`
-        ${i18n_0}
-        const $_c2$ = ["title", $i18n_0$];
         function MyComponent_div_0_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
             $r3$.ɵɵelementStart(1, "div", 1);
             $r3$.ɵɵpipe(2, "uppercase");
-            $r3$.ɵɵi18nAttributes(3, $_c2$);
+            $r3$.ɵɵi18nAttributes(3, 2);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementEnd();
           }
@@ -712,8 +734,14 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 1,
         vars: 1,
-        consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${
-          AttributeMarker.I18n}, "title"]],
+        consts: function() {
+          ${i18n_0}
+          return [
+            [${AttributeMarker.Template}, "ngFor", "ngForOf"],
+            [${AttributeMarker.I18n}, "title"],
+            ["title", $i18n_0$]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 4, 3, "div", 0);
@@ -736,16 +764,19 @@ describe('i18n support in the template compiler', () => {
           i18nMsg('{$interpolation} title', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
 
       const output = String.raw`
-        ${i18n_0}
-        const $_c3$ = ["title", $i18n_0$];
-        …
         decls: 2,
         vars: 1,
-        consts: [[${AttributeMarker.I18n}, "title"]],
+        consts: function() {
+          ${i18n_0}
+          return [
+            [${AttributeMarker.I18n}, "title"],
+            ["title", $i18n_0$]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
-            $r3$.ɵɵi18nAttributes(1, $_c3$);
+            $r3$.ɵɵi18nAttributes(1, 1);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -790,35 +821,30 @@ describe('i18n support in the template compiler', () => {
       const i18n_4 = i18nMsg('{$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
-        ${i18n_2}
-        const $_c1$ = [
-          "aria-roledescription", $i18n_0$,
-          "title", $i18n_1$,
-          "aria-label", $i18n_2$
-        ];
-        ${i18n_3}
-        ${i18n_4}
-        const $_c3$ = [
-          "title", $i18n_3$,
-          "aria-roledescription", $i18n_4$
-        ];
-        …
         decls: 5,
         vars: 8,
-        consts: [[
-          "id", "dynamic-1",
-          ${AttributeMarker.I18n}, "aria-roledescription", "title", "aria-label"
-        ], ["id", "dynamic-2", ${AttributeMarker.I18n}, "title", "aria-roledescription"]],
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          ${i18n_2}
+          ${i18n_3}
+          ${i18n_4}
+          return [
+            ["id", "dynamic-1", ${AttributeMarker.I18n}, "aria-roledescription",
+                                                                "title", "aria-label"],
+            ["aria-roledescription", $i18n_0$, "title", $i18n_1$, "aria-label", $i18n_2$],
+            ["id", "dynamic-2", ${AttributeMarker.I18n}, "title", "aria-roledescription"],
+            ["title", $i18n_3$, "aria-roledescription", $i18n_4$]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
             $r3$.ɵɵpipe(1, "uppercase");
-            $r3$.ɵɵi18nAttributes(2, $_c1$);
+            $r3$.ɵɵi18nAttributes(2, 1);
             $r3$.ɵɵelementEnd();
-            $r3$.ɵɵelementStart(3, "div", 1);
-            $r3$.ɵɵi18nAttributes(4, $_c3$);
+            $r3$.ɵɵelementStart(3, "div", 2);
+            $r3$.ɵɵi18nAttributes(4, 3);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -846,14 +872,12 @@ describe('i18n support in the template compiler', () => {
           {meaning: 'm', desc: 'd'});
 
       const output = String.raw`
-        ${i18n_0}
-        const $_c4$ = ["title", $i18n_0$];
         function MyComponent_div_0_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
             $r3$.ɵɵelementStart(1, "div", 1);
             $r3$.ɵɵpipe(2, "uppercase");
-            $r3$.ɵɵi18nAttributes(3, $_c4$);
+            $r3$.ɵɵi18nAttributes(3, 2);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementEnd();
           }
@@ -867,8 +891,14 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 1,
         vars: 1,
-        consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${
-          AttributeMarker.I18n}, "title"]],
+        consts: function() {
+          ${i18n_0}
+          return [
+            [${AttributeMarker.Template}, "ngFor", "ngForOf"],
+            [${AttributeMarker.I18n}, "title"],
+            ["title", $i18n_0$]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 4, 3, "div", 0);
@@ -891,16 +921,20 @@ describe('i18n support in the template compiler', () => {
       const i18n_1 = i18nMsg('Some content');
 
       const output = String.raw`
-        ${i18n_0}
-        const $_c1$ = ["title", $i18n_0$];
-        ${i18n_1}
-        …
-        consts: [[${AttributeMarker.I18n}, "title"]],
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          return [
+            [${AttributeMarker.I18n}, "title"],
+            ["title", $i18n_0$],
+            $i18n_1$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
-            $r3$.ɵɵi18nAttributes(1, $_c1$);
-            $r3$.ɵɵi18n(2, $i18n_1$);
+            $r3$.ɵɵi18nAttributes(1, 1);
+            $r3$.ɵɵi18n(2, 2);
             $r3$.ɵɵelementEnd();
           }
         }
@@ -925,7 +959,7 @@ describe('i18n support in the template compiler', () => {
         else {
             $I18N_0$ = $localize \`:@@ID.WITH.INVALID.CHARS:Element title\`;
         }
-        const $_c1$ = ["title", $I18N_0$];
+        …
         var $I18N_2$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_ID_WITH_INVALID_CHARS_2$$APP_SPEC_TS_4$ = goog.getMsg(" Some content ");
@@ -934,7 +968,6 @@ describe('i18n support in the template compiler', () => {
         else {
             $I18N_2$ = $localize \`:@@ID.WITH.INVALID.CHARS.2: Some content \`;
         }
-        …
       `;
 
       const exceptions = {
@@ -1030,26 +1063,32 @@ describe('i18n support in the template compiler', () => {
       const i18n_2 = i18nMsg('My i18n block #3');
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
-        ${i18n_2}
-        …
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          ${i18n_2}
+          return [
+            $i18n_0$,
+            $i18n_1$,
+            $i18n_2$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(2, "div");
             $r3$.ɵɵtext(3, "My non-i18n block #1");
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(4, "div");
-            $r3$.ɵɵi18n(5, $i18n_1$);
+            $r3$.ɵɵi18n(5, 1);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(6, "div");
             $r3$.ɵɵtext(7, "My non-i18n block #2");
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(8, "div");
-            $r3$.ɵɵi18n(9, $i18n_2$);
+            $r3$.ɵɵi18n(9, 2);
             $r3$.ɵɵelementEnd();
           }
         }
@@ -1068,7 +1107,7 @@ describe('i18n support in the template compiler', () => {
 
       // Keeping raw content (avoiding `i18nMsg`) to illustrate how named interpolations are
       // generated.
-      const output = String.raw`
+      const i18n_0 = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_7597881511811528589$$APP_SPEC_TS_0$ = goog.getMsg(" Named interpolation: {$phA} Named interpolation with spaces: {$phB} ", {
@@ -1082,13 +1121,21 @@ describe('i18n support in the template compiler', () => {
           String.raw`{"\uFFFD0\uFFFD"}:PH_A: Named interpolation with spaces: $` +
           String.raw`{"\uFFFD1\uFFFD"}:PH_B: \`;
         }
-        …
+      `;
+
+      const output = String.raw`
         decls: 2,
         vars: 2,
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -1110,12 +1157,16 @@ describe('i18n support in the template compiler', () => {
       const i18n_0 = i18nMsg('{$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
 
       const output = String.raw`
-        ${i18n_0}
-        …
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -1144,12 +1195,16 @@ describe('i18n support in the template compiler', () => {
       ]);
 
       const output = String.raw`
-        ${i18n_0}
-        …
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵpipe(2, "async");
             $r3$.ɵɵelementEnd();
           }
@@ -1181,23 +1236,29 @@ describe('i18n support in the template compiler', () => {
           'My i18n block #{$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
-        ${i18n_2}
-        …
         decls: 7,
         vars: 5,
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          ${i18n_2}
+          return [
+            $i18n_0$,
+            $i18n_1$,
+            $i18n_2$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(2, "div");
-            $r3$.ɵɵi18n(3, $i18n_1$);
+            $r3$.ɵɵi18n(3, 1);
             $r3$.ɵɵpipe(4, "uppercase");
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(5, "div");
-            $r3$.ɵɵi18n(6, $i18n_2$);
+            $r3$.ɵɵi18n(6, 2);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -1254,20 +1315,25 @@ describe('i18n support in the template compiler', () => {
           ]);
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
-        …
         decls: 9,
         vars: 5,
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          return [
+            $i18n_0$,
+            $i18n_1$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $i18n_0$);
+            $r3$.ɵɵi18nStart(1, 0);
             $r3$.ɵɵelement(2, "span");
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(3, "div");
-            $r3$.ɵɵi18nStart(4, $i18n_1$);
+            $r3$.ɵɵi18nStart(4, 1);
             $r3$.ɵɵpipe(5, "uppercase");
             $r3$.ɵɵelementStart(6, "div");
             $r3$.ɵɵelementStart(7, "div");
@@ -1328,30 +1394,35 @@ describe('i18n support in the template compiler', () => {
           ]);
 
       const output = String.raw`
-        ${i18n_0}
-        const $_c4$ = ["title", $i18n_0$];
-        ${i18n_1}
-        ${i18n_2}
-        const $_c9$ = ["title", $i18n_2$];
-        ${i18n_3}
-        …
         decls: 9,
         vars: 7,
-        consts: [[${AttributeMarker.I18n}, "title"]],
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          ${i18n_2}
+          ${i18n_3}
+          return [
+            $i18n_0$,
+            [${AttributeMarker.I18n}, "title"],
+            ["title", $i18n_1$],
+            $i18n_2$,
+            ["title", $i18n_3$]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $i18n_1$);
-            $r3$.ɵɵelementStart(2, "span", 0);
-            $r3$.ɵɵi18nAttributes(3, $_c4$);
+            $r3$.ɵɵi18nStart(1, 0);
+            $r3$.ɵɵelementStart(2, "span", 1);
+            $r3$.ɵɵi18nAttributes(3, 2);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(4, "div");
-            $r3$.ɵɵi18nStart(5, $i18n_3$);
+            $r3$.ɵɵi18nStart(5, 3);
             $r3$.ɵɵpipe(6, "uppercase");
-            $r3$.ɵɵelementStart(7, "span", 0);
-            $r3$.ɵɵi18nAttributes(8, $_c9$);
+            $r3$.ɵɵelementStart(7, "span", 1);
+            $r3$.ɵɵi18nAttributes(8, 4);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
@@ -1401,13 +1472,11 @@ describe('i18n support in the template compiler', () => {
           ]);
 
       const output = String.raw`
-        ${i18n_0}
-        …
         function MyComponent_div_2_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
             $r3$.ɵɵelementStart(1, "div");
-            $r3$.ɵɵi18nStart(2, $i18n_0$);
+            $r3$.ɵɵi18nStart(2, 1);
             $r3$.ɵɵelement(3, "div");
             $r3$.ɵɵpipe(4, "uppercase");
             $r3$.ɵɵi18nEnd();
@@ -1424,7 +1493,13 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 3,
         vars: 1,
-        consts: [[${AttributeMarker.Template}, "ngIf"]],
+        consts: function() {
+          ${i18n_0}
+          return [
+            [${AttributeMarker.Template}, "ngIf"],
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
@@ -1458,12 +1533,11 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelement(0, "img", 0);
           }
         }
-        ${i18n_0}
-        const $_c4$ = ["title", $i18n_0$];
+        …
         function MyComponent_img_2_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "img", 3);
-            $r3$.ɵɵi18nAttributes(1, $_c4$);
+            $r3$.ɵɵi18nAttributes(1, 4);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -1475,11 +1549,17 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 3,
         vars: 2,
-        consts: [["src", "logo.png"], ["src", "logo.png", ${
-          AttributeMarker.Template}, "ngIf"], ["src", "logo.png", ${
-          AttributeMarker.Bindings}, "title", ${
-          AttributeMarker.Template}, "ngIf"], ["src", "logo.png", ${
-          AttributeMarker.I18n}, "title"]],
+        consts: function() {
+          ${i18n_0}
+          return [
+            ["src", "logo.png"],
+            ["src", "logo.png", ${AttributeMarker.Template}, "ngIf"],
+            ["src", "logo.png", ${AttributeMarker.Bindings}, "title",
+                                ${AttributeMarker.Template}, "ngIf"],
+            ["src", "logo.png", ${AttributeMarker.I18n}, "title"],
+            ["title", $i18n_0$]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelement(0, "img", 0);
@@ -1546,7 +1626,7 @@ describe('i18n support in the template compiler', () => {
       const output = String.raw`
         function MyComponent_div_2_div_4_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18nStart(0, $I18N_0$, 2);
+            $r3$.ɵɵi18nStart(0, 0, 2);
             $r3$.ɵɵelementStart(1, "div");
             $r3$.ɵɵelement(2, "div");
             $r3$.ɵɵelementEnd();
@@ -1561,11 +1641,11 @@ describe('i18n support in the template compiler', () => {
         }
         function MyComponent_div_2_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18nStart(0, $I18N_0$, 1);
+            $r3$.ɵɵi18nStart(0, 0, 1);
             $r3$.ɵɵelementStart(1, "div");
             $r3$.ɵɵelementStart(2, "div");
             $r3$.ɵɵpipe(3, "uppercase");
-            $r3$.ɵɵtemplate(4, MyComponent_div_2_div_4_Template, 3, 2, "div", 0);
+            $r3$.ɵɵtemplate(4, MyComponent_div_2_div_4_Template, 3, 2, "div", 1);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵi18nEnd();
@@ -1578,10 +1658,10 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵi18nApply(0);
           }
         }
-        ${i18n_0}
+        …
         function MyComponent_div_3_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18nStart(0, $I18N_0$, 3);
+            $r3$.ɵɵi18nStart(0, 0, 3);
             $r3$.ɵɵelementStart(1, "div");
             $r3$.ɵɵelement(2, "div");
             $r3$.ɵɵpipe(3, "uppercase");
@@ -1598,13 +1678,19 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 4,
         vars: 2,
-        consts: [[${AttributeMarker.Template}, "ngIf"]],
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$,
+            [${AttributeMarker.Template}, "ngIf"]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $I18N_0$);
-            $r3$.ɵɵtemplate(2, MyComponent_div_2_Template, 5, 5, "div", 0);
-            $r3$.ɵɵtemplate(3, MyComponent_div_3_Template, 4, 4, "div", 0);
+            $r3$.ɵɵi18nStart(1, 0);
+            $r3$.ɵɵtemplate(2, MyComponent_div_2_Template, 5, 5, "div", 1);
+            $r3$.ɵɵtemplate(3, MyComponent_div_3_Template, 4, 4, "div", 1);
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
           }
@@ -1631,12 +1717,10 @@ describe('i18n support in the template compiler', () => {
       ]);
 
       const output = String.raw`
-        ${i18n_0}
-        …
         function MyComponent_div_0_Template(rf, ctx) {
           if (rf & 1) {
               $r3$.ɵɵelementStart(0, "div");
-              $r3$.ɵɵi18nStart(1, $i18n_0$);
+              $r3$.ɵɵi18nStart(1, 1);
               $r3$.ɵɵelement(2, "span");
               $r3$.ɵɵi18nEnd();
               $r3$.ɵɵelementEnd();
@@ -1651,7 +1735,13 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 1,
         vars: 1,
-        consts: [[${AttributeMarker.Template}, "ngIf"]],
+        consts: function() {
+          ${i18n_0}
+          return [
+            [${AttributeMarker.Template}, "ngIf"],
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 3, 1, "div", 0);
@@ -1673,14 +1763,18 @@ describe('i18n support in the template compiler', () => {
       const i18n_0 = i18nMsg('Hello');
 
       const output = String.raw`
-        ${i18n_0}
-        …
-        consts: [[${AttributeMarker.Bindings}, "click"]],
+        consts: function() {
+          ${i18n_0}
+          return [
+            [${AttributeMarker.Bindings}, "click"],
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
             $r3$.ɵɵlistener("click", function MyComponent_Template_div_click_0_listener() { return ctx.onClick(); });
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 1);
             $r3$.ɵɵelementEnd();
           }
         }
@@ -1699,12 +1793,16 @@ describe('i18n support in the template compiler', () => {
       const i18n_0 = i18nMsg('My i18n block #1');
 
       const output = String.raw`
-        ${i18n_0}
-        …
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
           }
         }
@@ -1723,14 +1821,18 @@ describe('i18n support in the template compiler', () => {
           [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
 
       const output = String.raw`
-        ${i18n_0}
-        …
         decls: 2,
         vars: 1,
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -1754,19 +1856,25 @@ describe('i18n support in the template compiler', () => {
       const i18n_1 = i18nMsg('My i18n block #1');
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
         function MyComponent_ng_template_0_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18n(0, $i18n_1$);
+            $r3$.ɵɵi18n(0, 1);
           }
         }
         …
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          return [
+            $i18n_0$,
+            $i18n_1$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_ng_template_0_Template, 1, 0, "ng-template");
             $r3$.ɵɵelementContainerStart(1);
-            $r3$.ɵɵi18n(2, $i18n_0$);
+            $r3$.ɵɵi18n(2, 0);
             $r3$.ɵɵelementContainerEnd();
           }
         }
@@ -1785,20 +1893,25 @@ describe('i18n support in the template compiler', () => {
       const i18n_1 = i18nMsg('Text #2');
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
-        …
         decls: 4,
         vars: 0,
-        consts: [[${AttributeMarker.Classes}, "myClass"], [${
-          AttributeMarker.Styles}, "padding", "10px"]],
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          return [
+            [${AttributeMarker.Classes}, "myClass"],
+            $i18n_0$,
+            [${AttributeMarker.Styles}, "padding", "10px"],
+            $i18n_1$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "span", 0);
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 1);
             $r3$.ɵɵelementEnd();
-            $r3$.ɵɵelementStart(2, "span", 1);
-            $r3$.ɵɵi18n(3, $i18n_1$);
+            $r3$.ɵɵelementStart(2, "span", 2);
+            $r3$.ɵɵi18n(3, 3);
             $r3$.ɵɵelementEnd();
           }
         }
@@ -1818,14 +1931,18 @@ describe('i18n support in the template compiler', () => {
           i18nMsg('Some content: {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
 
       const output = String.raw`
-        ${i18n_0}
-        …
         decls: 3,
         vars: 3,
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementContainerStart(0);
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵpipe(2, "uppercase");
             $r3$.ɵɵelementContainerEnd();
           }
@@ -1849,10 +1966,9 @@ describe('i18n support in the template compiler', () => {
           i18nMsg('Some content: {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
 
       const output = String.raw`
-        ${i18n_0}
         function MyComponent_ng_template_0_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18n(0, $i18n_0$);
+            $r3$.ɵɵi18n(0, 0);
             $r3$.ɵɵpipe(1, "uppercase");
           } if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵɵnextContext();
@@ -1864,6 +1980,12 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 1,
         vars: 0,
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_ng_template_0_Template, 2, 3, "ng-template");
@@ -1894,10 +2016,9 @@ describe('i18n support in the template compiler', () => {
           ]);
 
       const output = String.raw`
-        ${i18n_0}
         function MyComponent_ng_template_2_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18n(0, $I18N_0$, 1);
+            $r3$.ɵɵi18n(0, 0, 1);
             $r3$.ɵɵpipe(1, "uppercase");
           }
           if (rf & 2) {
@@ -1910,10 +2031,16 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 5,
         vars: 3,
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $i18n_0$);
+            $r3$.ɵɵi18nStart(1, 0);
             $r3$.ɵɵtemplate(2, MyComponent_ng_template_2_Template, 2, 3, "ng-template");
             $r3$.ɵɵelementContainer(3);
             $r3$.ɵɵpipe(4, "uppercase");
@@ -1945,11 +2072,9 @@ describe('i18n support in the template compiler', () => {
           [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
         function MyComponent_ng_template_0_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18n(0, $i18n_1$);
+            $r3$.ɵɵi18n(0, 1);
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵɵnextContext();
@@ -1960,11 +2085,19 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 3,
         vars: 1,
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          return [
+            $i18n_0$,
+            $i18n_1$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_ng_template_0_Template, 1, 1, "ng-template");
             $r3$.ɵɵelementContainerStart(1);
-            $r3$.ɵɵi18n(2, $i18n_0$);
+            $r3$.ɵɵi18n(2, 0);
             $r3$.ɵɵelementContainerEnd();
           }
           if (rf & 2) {
@@ -2011,7 +2144,7 @@ describe('i18n support in the template compiler', () => {
       const output = String.raw`
         function MyComponent_ng_template_2_ng_template_2_ng_template_1_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18n(0, $i18n_0$, 3);
+            $r3$.ɵɵi18n(0, 0, 3);
           }
           if (rf & 2) {
             const $ctx_r2$ = $r3$.ɵɵnextContext(3);
@@ -2021,7 +2154,7 @@ describe('i18n support in the template compiler', () => {
         }
         function MyComponent_ng_template_2_ng_template_2_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18nStart(0, $i18n_0$, 2);
+            $r3$.ɵɵi18nStart(0, 0, 2);
             $r3$.ɵɵtemplate(1, MyComponent_ng_template_2_ng_template_2_ng_template_1_Template, 1, 1, "ng-template");
             $r3$.ɵɵi18nEnd();
           }
@@ -2032,10 +2165,10 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵi18nApply(0);
           }
         }
-        ${i18n_0}
+        …
         function MyComponent_ng_template_2_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18nStart(0, $i18n_0$, 1);
+            $r3$.ɵɵi18nStart(0, 0, 1);
             $r3$.ɵɵpipe(1, "uppercase");
             $r3$.ɵɵtemplate(2, MyComponent_ng_template_2_ng_template_2_Template, 2, 1, "ng-template");
             $r3$.ɵɵi18nEnd();
@@ -2050,10 +2183,16 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 3,
         vars: 0,
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $i18n_0$);
+            $r3$.ɵɵi18nStart(1, 0);
             $r3$.ɵɵtemplate(2, MyComponent_ng_template_2_Template, 3, 3, "ng-template");
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
@@ -2078,11 +2217,9 @@ describe('i18n support in the template compiler', () => {
           [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
         function MyComponent_ng_template_2_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18n(0, $I18N_1$);
+            $r3$.ɵɵi18n(0, 1);
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵɵnextContext();
@@ -2093,10 +2230,18 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 3,
         vars: 1,
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          return [
+            $i18n_0$,
+            $i18n_1$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementContainerStart(0);
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementContainerEnd();
             $r3$.ɵɵtemplate(2, MyComponent_ng_template_2_Template, 1, 1, "ng-template");
           }
@@ -2127,22 +2272,28 @@ describe('i18n support in the template compiler', () => {
           '{$tagImg} is my logo #2 ', [['tagImg', String.raw`\uFFFD#1\uFFFD\uFFFD/#1\uFFFD`]]);
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
         function MyComponent_ng_template_3_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18nStart(0, $i18n_1$);
-            $r3$.ɵɵelement(1, "img", 0);
+            $r3$.ɵɵi18nStart(0, 2);
+            $r3$.ɵɵelement(1, "img", 1);
             $r3$.ɵɵi18nEnd();
           }
         }
         …
-        consts: [["src", "logo.png", "title", "Logo"]],
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          return [
+            $i18n_0$,
+            ["src", "logo.png", "title", "Logo"],
+            $i18n_1$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementContainerStart(0);
-            $r3$.ɵɵi18nStart(1, $i18n_0$);
-            $r3$.ɵɵelement(2, "img", 0);
+            $r3$.ɵɵi18nStart(1, 0);
+            $r3$.ɵɵelement(2, "img", 1);
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementContainerEnd();
             $r3$.ɵɵtemplate(3, MyComponent_ng_template_3_Template, 2, 0, "ng-template");
@@ -2202,14 +2353,18 @@ describe('i18n support in the template compiler', () => {
       ]);
 
       const output = String.raw`
-        ${i18n_0}
-        …
         decls: 3,
         vars: 0,
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $i18n_0$);
+            $r3$.ɵɵi18nStart(1, 0);
             $r3$.ɵɵelementContainer(2);
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
@@ -2238,14 +2393,18 @@ describe('i18n support in the template compiler', () => {
              ]);
 
          const output = String.raw`
-          ${i18n_0}
-          …
           decls: 4,
           vars: 0,
+          consts: function() {
+            ${i18n_0}
+            return [
+              $i18n_0$
+            ];
+          },
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵelementStart(0, "div");
-              $r3$.ɵɵi18nStart(1, I18N_0);
+              $r3$.ɵɵi18nStart(1, 0);
               $r3$.ɵɵelementContainerStart(2);
               $r3$.ɵɵelement(3, "strong");
               $r3$.ɵɵelementContainerEnd();
@@ -2270,10 +2429,9 @@ describe('i18n support in the template compiler', () => {
       const i18n_1 = i18nMsg('Content B');
 
       const output = String.raw`
-        ${i18n_0}
         function MyComponent_0_ng_template_0_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18n(0, $i18n_0$);
+            $r3$.ɵɵi18n(0, 1);
           }
         }
         function MyComponent_0_Template(rf, ctx) {
@@ -2281,18 +2439,26 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵtemplate(0, MyComponent_0_ng_template_0_Template, 1, 0, "ng-template");
           }
         }
-        ${i18n_1}
+        …
         function MyComponent_ng_container_1_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementContainerStart(0);
-            $r3$.ɵɵi18n(1, $i18n_1$);
+            $r3$.ɵɵi18n(1, 2);
             $r3$.ɵɵelementContainerEnd();
           }
         }
         …
         decls: 2,
         vars: 2,
-        consts: [[4, "ngIf"]],
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          return [
+            [${AttributeMarker.Template}, "ngIf"],
+            $i18n_0$,
+            $i18n_1$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_0_Template, 1, 0, undefined, 0);
@@ -2320,7 +2486,7 @@ describe('i18n support in the template compiler', () => {
 
       // Keeping raw content (avoiding `i18nMsg`) to illustrate message layout
       // in case of whitespace preserving mode.
-      const output = String.raw`
+      const i18n_0 = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_963542717423364282$$APP_SPEC_TS_0$ = goog.getMsg("\n          Some text\n          {$startTagSpan}Text inside span{$closeTagSpan}\n        ", {
@@ -2337,12 +2503,20 @@ describe('i18n support in the template compiler', () => {
           String.raw`{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_SPAN:
         \`;
         }
-        …
+      `;
+
+      const output = String.raw`
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtext(0, "\n        ");
             $r3$.ɵɵelementStart(1, "div");
-            $r3$.ɵɵi18nStart(2, $I18N_0$);
+            $r3$.ɵɵi18nStart(2, 0);
             $r3$.ɵɵelement(3, "span");
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
@@ -2366,14 +2540,18 @@ describe('i18n support in the template compiler', () => {
           [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
 
       const output = String.raw`
-        ${i18n_0}
-        …
         decls: 2,
         vars: 1,
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -2419,13 +2597,17 @@ describe('i18n support in the template compiler', () => {
           [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
 
       const output = String.raw`
-        ${i18n_0}
-        …
         decls: 1,
         vars: 1,
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18n(0, $i18n_0$);
+            $r3$.ɵɵi18n(0, 0);
           }
           if (rf & 2) {
             $r3$.ɵɵi18nExp(ctx.age);
@@ -2460,13 +2642,11 @@ describe('i18n support in the template compiler', () => {
           ]);
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
         function MyComponent_div_2_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵelementStart(0, "div", 2);
+            $r3$.ɵɵelementStart(0, "div", 3);
             $r3$.ɵɵtext(1, " ");
-            $r3$.ɵɵi18n(2, $i18n_1$);
+            $r3$.ɵɵi18n(2, 4);
             $r3$.ɵɵtext(3, " ");
             $r3$.ɵɵelementEnd();
           }
@@ -2477,12 +2657,12 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵi18nApply(2);
           }
         }
-        ${i18n_2}
+        …
         function MyComponent_div_3_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵelementStart(0, "div", 3);
+            $r3$.ɵɵelementStart(0, "div", 5);
             $r3$.ɵɵtext(1, " You have ");
-            $r3$.ɵɵi18n(2, $i18n_2$);
+            $r3$.ɵɵi18n(2, 6);
             $r3$.ɵɵtext(3, ". ");
             $r3$.ɵɵelementEnd();
           }
@@ -2496,16 +2676,27 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 4,
         vars: 3,
-        consts: [["title", "icu only", ${
-          AttributeMarker.Template}, "ngIf"], ["title", "icu and text", ${
-          AttributeMarker.Template}, "ngIf"], ["title", "icu only"], ["title", "icu and text"]],
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          ${i18n_2}
+          return [
+            $i18n_0$,
+            ["title", "icu only", ${AttributeMarker.Template}, "ngIf"],
+            ["title", "icu and text", ${AttributeMarker.Template}, "ngIf"],
+            ["title", "icu only"],
+            $i18n_1$,
+            ["title", "icu and text"],
+            $i18n_2$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
-            $r3$.ɵɵtemplate(2, MyComponent_div_2_Template, 4, 1, "div", 0);
-            $r3$.ɵɵtemplate(3, MyComponent_div_3_Template, 4, 2, "div", 1);
+            $r3$.ɵɵtemplate(2, MyComponent_div_2_Template, 4, 1, "div", 1);
+            $r3$.ɵɵtemplate(3, MyComponent_div_3_Template, 4, 2, "div", 2);
           }
           if (rf & 2) {
             $r3$.ɵɵadvance(1);
@@ -2533,12 +2724,16 @@ describe('i18n support in the template compiler', () => {
           ]);
 
       const output = String.raw`
-        ${i18n_0}
-        …
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -2586,18 +2781,22 @@ describe('i18n support in the template compiler', () => {
           ]);
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
-        …
         decls: 5,
         vars: 1,
-        consts: [[1, "other"]],
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          return [
+            $i18n_1$,
+            [${AttributeMarker.Classes}, "other"]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $i18n_1$);
+            $r3$.ɵɵi18nStart(1, 0);
             $r3$.ɵɵelement(2, "b");
-            $r3$.ɵɵelementStart(3, "div", 0);
+            $r3$.ɵɵelementStart(3, "div", 1);
             $r3$.ɵɵelement(4, "i");
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵi18nEnd();
@@ -2627,14 +2826,18 @@ describe('i18n support in the template compiler', () => {
           ]);
 
       const output = String.raw`
-        ${i18n_0}
-        …
         decls: 2,
         vars: 2,
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -2668,16 +2871,20 @@ describe('i18n support in the template compiler', () => {
       ]);
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
-        ${i18n_2}
-        …
         decls: 2,
         vars: 2,
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          ${i18n_2}
+          return [
+            $i18n_2$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $i18n_2$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -2704,7 +2911,9 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
-      const output = String.raw`
+      // Keeping raw content here to illustrate the difference in placeholders generated for
+      // goog.getMsg and $localize calls (see last i18n block).
+      const i18n_0 = String.raw`
         var $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
@@ -2761,9 +2970,12 @@ describe('i18n support in the template compiler', () => {
         $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
           "ICU": [$I18N_1$, $I18N_2$, $I18N_4$]
         });
+      `;
+
+      const output = String.raw`
         function MyComponent_div_3_Template(rf, ctx) {
           if (rf & 1) {
-              $r3$.ɵɵi18nStart(0, $I18N_0$, 1);
+              $r3$.ɵɵi18nStart(0, 0, 1);
               $r3$.ɵɵelement(1, "div");
               $r3$.ɵɵi18nEnd();
           }
@@ -2777,13 +2989,19 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 4,
         vars: 3,
-        consts: [[${AttributeMarker.Template}, "ngIf"]],
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$,
+            [${AttributeMarker.Template}, "ngIf"]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $I18N_0$);
+            $r3$.ɵɵi18nStart(1, 0);
             $r3$.ɵɵelement(2, "div");
-            $r3$.ɵɵtemplate(3, MyComponent_div_3_Template, 2, 1, "div", 0);
+            $r3$.ɵɵtemplate(3, MyComponent_div_3_Template, 2, 1, "div", 1);
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
           }
@@ -2819,15 +3037,19 @@ describe('i18n support in the template compiler', () => {
       const i18n_1 = i18nMsg(' {$icu} ', [['icu', '$i18n_0$']]);
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
-        …
         decls: 2,
         vars: 2,
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          return [
+            $i18n_1$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $i18n_1$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -2865,14 +3087,18 @@ describe('i18n support in the template compiler', () => {
           ]);
 
       const output = String.raw`
-        ${i18n_0}
-        …
         decls: 2,
         vars: 3,
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -2910,13 +3136,9 @@ describe('i18n support in the template compiler', () => {
       ]);
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
-        ${i18n_2}
-        …
         function MyComponent_span_2_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18nStart(0, $i18n_2$, 1);
+            $r3$.ɵɵi18nStart(0, 0, 1);
             $r3$.ɵɵelement(1, "span");
             $r3$.ɵɵi18nEnd();
           }
@@ -2930,12 +3152,20 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 3,
         vars: 2,
-        consts: [[${AttributeMarker.Template}, "ngIf"]],
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          ${i18n_2}
+          return [
+            $i18n_2$,
+            [${AttributeMarker.Template}, "ngIf"]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $i18n_2$);
-            $r3$.ɵɵtemplate(2, MyComponent_span_2_Template, 2, 1, "span", 0);
+            $r3$.ɵɵi18nStart(1, 0);
+            $r3$.ɵɵtemplate(2, MyComponent_span_2_Template, 2, 1, "span", 1);
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
           }
@@ -2981,12 +3211,9 @@ describe('i18n support in the template compiler', () => {
       ]);
 
       const output = String.raw`
-        ${i18n_0}
-        ${i18n_1}
-        ${i18n_2}
         function MyComponent_span_2_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18nStart(0, $i18n_2$, 1);
+            $r3$.ɵɵi18nStart(0, 0, 1);
             $r3$.ɵɵelement(1, "span");
             $r3$.ɵɵi18nEnd();
           }
@@ -3000,12 +3227,20 @@ describe('i18n support in the template compiler', () => {
         …
         decls: 3,
         vars: 4,
-        consts: [[${AttributeMarker.Template}, "ngIf"]],
+        consts: function() {
+          ${i18n_0}
+          ${i18n_1}
+          ${i18n_2}
+          return [
+            $i18n_2$,
+            [${AttributeMarker.Template}, "ngIf"]
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $i18n_2$);
-            $r3$.ɵɵtemplate(2, MyComponent_span_2_Template, 2, 2, "span", 0);
+            $r3$.ɵɵi18nStart(1, 0);
+            $r3$.ɵɵtemplate(2, MyComponent_span_2_Template, 2, 2, "span", 1);
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
           }
@@ -3042,14 +3277,18 @@ describe('i18n support in the template compiler', () => {
           ]);
 
       const output = String.raw`
-        ${i18n_0}
-        …
         decls: 2,
         vars: 4,
+        consts: function() {
+          ${i18n_0}
+          return [
+            $i18n_0$
+          ];
+        },
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $i18n_0$);
+            $r3$.ɵɵi18n(1, 0);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -3283,7 +3522,7 @@ $` + String.raw`{$I18N_4$}:ICU:\`;
         </svg>
       `;
 
-      const output = String.raw`
+      const i18n_0 = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           const $MSG_EXTERNAL_7128002169381370313$$APP_SPEC_TS_1$ = goog.getMsg("{$startTagXhtmlDiv} Count: {$startTagXhtmlSpan}5{$closeTagXhtmlSpan}{$closeTagXhtmlDiv}", {
@@ -3301,15 +3540,26 @@ $` + String.raw`{$I18N_4$}:ICU:\`;
           String.raw`{"\uFFFD/#4\uFFFD"}:CLOSE_TAG__XHTML_SPAN:$` +
           String.raw`{"\uFFFD/#3\uFFFD"}:CLOSE_TAG__XHTML_DIV:\`;
         }
+      `;
+
+      const output = String.raw`
         …
-        function MyComponent_Template(rf, ctx) {
+        consts: function() {
+          ${i18n_0}
+          return [
+            ["xmlns", "http://www.w3.org/2000/svg"],
+            $i18n_0$,
+            ["xmlns", "http://www.w3.org/1999/xhtml"]
+          ];
+        },
+        template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵnamespaceSVG();
             $r3$.ɵɵelementStart(0, "svg", 0);
             $r3$.ɵɵelementStart(1, "foreignObject");
-            $r3$.ɵɵi18nStart(2, $I18N_0$);
+            $r3$.ɵɵi18nStart(2, 1);
             $r3$.ɵɵnamespaceHTML();
-            $r3$.ɵɵelementStart(3, "div", 1);
+            $r3$.ɵɵelementStart(3, "div", 2);
             $r3$.ɵɵelement(4, "span");
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵi18nEnd();
@@ -3333,7 +3583,7 @@ $` + String.raw`{$I18N_4$}:ICU:\`;
         </svg>
       `;
 
-      const output = String.raw`
+      const i18n_0 = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           const $MSG_EXTERNAL_7428861019045796010$$APP_SPEC_TS_1$ = goog.getMsg(" Count: {$startTagXhtmlSpan}5{$closeTagXhtmlSpan}", {
@@ -3347,15 +3597,25 @@ $` + String.raw`{$I18N_4$}:ICU:\`;
           String.raw`{"\uFFFD#4\uFFFD"}:START_TAG__XHTML_SPAN:5$` +
           String.raw`{"\uFFFD/#4\uFFFD"}:CLOSE_TAG__XHTML_SPAN:\`;
         }
-        …
-        function MyComponent_Template(rf, ctx) {
+      `;
+
+      const output = String.raw`
+        consts: function() {
+          ${i18n_0}
+          return [
+            ["xmlns", "http://www.w3.org/2000/svg"],
+            ["xmlns", "http://www.w3.org/1999/xhtml"],
+            $i18n_0$
+          ];
+        },
+        template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵnamespaceSVG();
             $r3$.ɵɵelementStart(0, "svg", 0);
             $r3$.ɵɵelementStart(1, "foreignObject");
             $r3$.ɵɵnamespaceHTML();
             $r3$.ɵɵelementStart(2, "div", 1);
-            $r3$.ɵɵi18nStart(3, $I18N_0$);
+            $r3$.ɵɵi18nStart(3, 2);
             $r3$.ɵɵelement(4, "span");
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
@@ -3365,7 +3625,7 @@ $` + String.raw`{$I18N_4$}:ICU:\`;
         }
       `;
 
-      verify(input, output, {verbose: true});
+      verify(input, output);
     });
   });
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -182,6 +182,104 @@ const verify = (input: string, output: string, extra: any = {}): void => {
   }
 };
 
+// Describes a simple key-value object.
+type KVList = {
+  [key: string]: string
+};
+
+// Describes placeholder type used in tests. Note: the type is an array (not an object), since it's
+// important to preserve the order of placeholders (so that we can compare it with generated
+// output).
+type Placeholder = string[];
+
+// Unique message id index that is needed to avoid different i18n vars with the same name to appear
+// in the i18n block while generating an output string (used to verify compiler-generated code).
+let msgIndex = 0;
+
+// Wraps a string into quotes is needed.
+// Note: if a string starts with `$` is a special case in tests when ICU reference
+// is used as a placeholder value, this we should not wrap it in quotes.
+const quotedValue = (value: string) => value.startsWith('$') ? value : `"${value}"`;
+
+// Generates a string that represents expected Closure metadata output.
+const i18nMsgClosureMeta = (meta?: KVList): string => {
+  if (!meta || !(meta.desc || meta.meaning)) return '';
+  return `
+    /**
+     ${meta.desc ? '* @desc ' + meta.desc : ''}
+     ${meta.meaning ? '* @meaning ' + meta.meaning : ''}
+     */
+  `;
+};
+
+// Converts a set of placeholders to a string (as it's expected from compiler).
+const i18nPlaceholdersToString = (placeholders: Placeholder[]): string => {
+  if (placeholders.length === 0) return '';
+  const result = placeholders.map(([key, value]) => `"${key}": ${quotedValue(value)}`);
+  return `, { ${result.join(',')} }`;
+};
+
+// Generates a string that represents expected $localize metadata output.
+const i18nMsgLocalizeMeta = (meta?: KVList): string => {
+  if (!meta) return '';
+  let localizeMeta = '';
+  if (meta.meaning) localizeMeta += `${meta.meaning}|`;
+  if (meta.desc) localizeMeta += meta.desc;
+  if (meta.id) localizeMeta += `@@${meta.id}`;
+  return `:${localizeMeta}:`;
+};
+
+// Transforms a message in a Closure format to a $localize version.
+const i18nMsgInsertLocalizePlaceholders =
+    (message: string, placeholders: Placeholder[]): string => {
+      if (placeholders.length > 0) {
+        message = message.replace(/{\$(.*?)}/g, function(_, name) {
+          const value = placeholders.find(([k, _]) => k === name)![1];
+          // e.g. startDivTag -> START_DIV_TAG
+          const key = name.replace(/[A-Z]/g, (ch: string) => '_' + ch).toUpperCase();
+          return '$' + String.raw`{${quotedValue(value)}}:${key}:`;
+        });
+      }
+      return message;
+    };
+
+// Generates a string that represents expected i18n block content for simple message.
+const i18nMsg = (message: string, placeholders: Placeholder[] = [], meta?: KVList) => {
+  const varName = `$I18N_${msgIndex++}$`;
+  const closurePlaceholders = i18nPlaceholdersToString(placeholders);
+  const locMessageWithPlaceholders = i18nMsgInsertLocalizePlaceholders(message, placeholders);
+  return String.raw`
+    var ${varName};
+    if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
+        ${i18nMsgClosureMeta(meta)}
+        const $MSG_EXTERNAL_${msgIndex}$ = goog.getMsg("${message}"${closurePlaceholders});
+        ${varName} = $MSG_EXTERNAL_${msgIndex}$;
+    }
+    else {
+      ${varName} = $localize \`${i18nMsgLocalizeMeta(meta)}${locMessageWithPlaceholders}\`;
+    }`;
+};
+
+// Generates a string that represents expected i18n block content for a message that requires
+// post-processing (thus includes `ɵɵi18nPostprocess` in generated code).
+const i18nMsgWithPostprocess =
+    (message: string, placeholders: Placeholder[] = [], meta?: KVList,
+     postprocessPlaceholders?: Placeholder[]) => {
+      const varName = `$I18N_${msgIndex}$`;
+      const ppPaceholders =
+          postprocessPlaceholders ? i18nPlaceholdersToString(postprocessPlaceholders) : '';
+      return String.raw`
+        ${i18nMsg(message, placeholders, meta)}
+        ${varName} = $r3$.ɵɵi18nPostprocess($${varName}$${ppPaceholders});
+      `;
+    };
+
+// Generates a string that represents expected i18n block content for an ICU.
+const i18nIcuMsg =
+    (message: string, placeholders: string[][] = []) => {
+      return i18nMsgWithPostprocess(message, [], undefined, placeholders);
+    }
+
 describe('i18n support in the template compiler', () => {
   describe('element attributes', () => {
     it('should add the meaning and description as JsDoc comments and metadata blocks', () => {
@@ -196,109 +294,66 @@ describe('i18n support in the template compiler', () => {
         <div i18n="Some text \\' [BACKUP_MESSAGE_ID: xxx]">Content H</div>
       `;
 
-      const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc descA
-             * @meaning meaningA
-             */
-            const $MSG_EXTERNAL_idA$$APP_SPEC_TS_1$ = goog.getMsg("Content A");
-            $I18N_0$ = $MSG_EXTERNAL_idA$$APP_SPEC_TS_1$;
-        }
-        else {
-          $I18N_0$ = $localize \`:meaningA|descA@@idA:Content A\`;
-        }
-        var $I18N_3$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc descB
-             * @meaning meaningB
-             */
-            const $MSG_EXTERNAL_idB$$APP_SPEC_TS_4$ = goog.getMsg("Title B");
-            $I18N_3$ = $MSG_EXTERNAL_idB$$APP_SPEC_TS_4$;
-        }
-        else {
-          $I18N_3$ = $localize \`:meaningB|descB@@idB:Title B\`;
-        }
-        const $_c5$ = ["title", $I18N_3$];
-        var $I18N_7$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @meaning meaningC
-             */
-            const $MSG_EXTERNAL_6435899732746131543$$APP_SPEC_TS_8$ = goog.getMsg("Title C");
-            $I18N_7$ = $MSG_EXTERNAL_6435899732746131543$$APP_SPEC_TS_8$;
-        }
-        else {
-          $I18N_7$ = $localize \`:meaningC|:Title C\`;
-        }
-        const $_c9$ = ["title", $I18N_7$];
-        var $I18N_11$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc descD
-             * @meaning meaningD
-             */
-            const $MSG_EXTERNAL_5200291527729162531$$APP_SPEC_TS_12$ = goog.getMsg("Title D");
-            $I18N_11$ = $MSG_EXTERNAL_5200291527729162531$$APP_SPEC_TS_12$;
-        }
-        else {
-          $I18N_11$ = $localize \`:meaningD|descD:Title D\`;
-        }
-        const $_c13$ = ["title", $I18N_11$];
-        var $I18N_15$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc meaningE
-             */
-            const $MSG_EXTERNAL_idE$$APP_SPEC_TS_16$ = goog.getMsg("Title E");
-            $I18N_15$ = $MSG_EXTERNAL_idE$$APP_SPEC_TS_16$;
-        }
-        else {
-          $I18N_15$ = $localize \`:meaningE@@idE:Title E\`;
-        }
-        const $_c17$ = ["title", $I18N_15$];
-        var $I18N_19$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_idF$$APP_SPEC_TS_20$ = goog.getMsg("Title F");
-            $I18N_19$ = $MSG_EXTERNAL_idF$$APP_SPEC_TS_20$;
-        }
-        else {
-            $I18N_19$ = $localize \`:@@idF:Title F\`;
-        }
-        const $_c21$ = ["title", $I18N_19$];
+      const i18n_0 = i18nMsg('Content A', [], {id: 'idA', meaning: 'meaningA', desc: 'descA'});
+      const i18n_1 = i18nMsg('Title B', [], {id: 'idB', meaning: 'meaningB', desc: 'descB'});
+      const i18n_2 = i18nMsg('Title C', [], {meaning: 'meaningC'});
+      const i18n_3 = i18nMsg('Title D', [], {meaning: 'meaningD', desc: 'descD'});
+      const i18n_4 = i18nMsg('Title E', [], {id: 'idE', desc: 'meaningE'});
+      const i18n_5 = i18nMsg('Title F', [], {id: 'idF'});
+
+      // Keeping this block as a raw string, since it checks escaping of special chars.
+      const i18n_6 = String.raw`
         var $I18N_23$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc [BACKUP_$` +
+          /**
+           * @desc [BACKUP_$` +
           String.raw`{MESSAGE}_ID:idH]` +
           '`' + String.raw`desc
-             */
-            const $MSG_EXTERNAL_idG$$APP_SPEC_TS_24$ = goog.getMsg("Title G");
-            $I18N_23$ = $MSG_EXTERNAL_idG$$APP_SPEC_TS_24$;
+           */
+          const $MSG_EXTERNAL_idG$$APP_SPEC_TS_24$ = goog.getMsg("Title G");
+          $I18N_23$ = $MSG_EXTERNAL_idG$$APP_SPEC_TS_24$;
         }
         else {
           $I18N_23$ = $localize \`:[BACKUP_$\{MESSAGE}_ID\:idH]\\\`desc@@idG:Title G\`;
         }
-        const $_c25$ = ["title", $I18N_23$];
-        var $I18N_20$;
+      `;
+
+      // Keeping this block as a raw string, since it checks escaping of special chars.
+      const i18n_7 = String.raw`
+        var $i18n_7$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc Some text \' [BACKUP_MESSAGE_ID: xxx]
-             */
-            const $MSG_EXTERNAL_idG$$APP_SPEC_TS_21$ = goog.getMsg("Content H");
-            $I18N_20$ = $MSG_EXTERNAL_idG$$APP_SPEC_TS_21$;
+          /**
+           * @desc Some text \' [BACKUP_MESSAGE_ID: xxx]
+           */
+          const $MSG_EXTERNAL_idG$$APP_SPEC_TS_21$ = goog.getMsg("Content H");
+          $i18n_7$ = $MSG_EXTERNAL_idG$$APP_SPEC_TS_21$;
         }
         else {
-          $I18N_20$ = $localize \`:Some text \\' [BACKUP_MESSAGE_ID\: xxx]:Content H\`;
+          $i18n_7$ = $localize \`:Some text \\' [BACKUP_MESSAGE_ID\: xxx]:Content H\`;
         }
+      `;
+
+      const output = String.raw`
+        ${i18n_0}
+        ${i18n_1}
+        const $_c5$ = ["title", $i18n_1$];
+        ${i18n_2}
+        const $_c9$ = ["title", $i18n_2$];
+        ${i18n_3}
+        const $_c13$ = ["title", $i18n_3$];
+        ${i18n_4}
+        const $_c17$ = ["title", $i18n_4$];
+        ${i18n_5}
+        const $_c21$ = ["title", $i18n_5$];
+        ${i18n_6}
+        const $_c25$ = ["title", $i18n_6$];
+        ${i18n_7}
         …
         consts: [[${AttributeMarker.I18n}, "title"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(2, "div", 0);
             $r3$.ɵɵi18nAttributes(3, $_c5$);
@@ -325,7 +380,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵtext(19, "Content G");
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(20, "div");
-            $r3$.ɵɵi18n(21, $I18N_20$);
+            $r3$.ɵɵi18n(21, $i18n_7$);
             $r3$.ɵɵelementEnd();
           }
         }
@@ -339,16 +394,10 @@ describe('i18n support in the template compiler', () => {
         <ng-template i18n-title title="Hello"></ng-template>
       `;
 
+      const i18n_0 = i18nMsg('Hello');
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_6616505470450179563$$APP_SPEC_TS_1$ = goog.getMsg("Hello");
-            $I18N_0$ = $MSG_EXTERNAL_6616505470450179563$$APP_SPEC_TS_1$;
-        }
-        else {
-            $I18N_0$ = $localize \`Hello\`;
-        }
-        const $_c2$ = ["title", $I18N_0$];
+        ${i18n_0}
+        const $_c2$ = ["title", $i18n_0$];
         …
         consts: [[${AttributeMarker.I18n}, "title"]],
         template: function MyComponent_Template(rf, ctx) {
@@ -367,16 +416,10 @@ describe('i18n support in the template compiler', () => {
             <ng-template *ngIf="visible" i18n-title title="Hello">Test</ng-template>
           `;
 
+         const i18n_0 = i18nMsg('Hello');
          const output = String.raw`
-            var $I18N_0$;
-            if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-                const $MSG_EXTERNAL_6616505470450179563$$APP_SPEC_TS_1$ = goog.getMsg("Hello");
-                $I18N_0$ = $MSG_EXTERNAL_6616505470450179563$$APP_SPEC_TS_1$;
-            }
-            else {
-                $I18N_0$ = $localize \`Hello\`;
-            }
-            const $_c2$ = ["title", $I18N_0$];
+            ${i18n_0}
+            const $_c2$ = ["title", $i18n_0$];
             function MyComponent_0_ng_template_0_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵɵtext(0, "Test");
@@ -408,19 +451,11 @@ describe('i18n support in the template compiler', () => {
            <ng-template i18n-title title="Hello {{ name }}"></ng-template>
          `;
 
+         const i18n_0 =
+             i18nMsg('Hello {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
          const output = String.raw`
-           var $I18N_0$;
-           if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-             const $MSG_EXTERNAL_3771704108176831903$$APP_SPEC_TS_1$ = goog.getMsg("Hello {$interpolation}", {
-               "interpolation": "\uFFFD0\uFFFD"
-              });
-             $I18N_0$ = $MSG_EXTERNAL_3771704108176831903$$APP_SPEC_TS_1$;
-           }
-           else {
-             $I18N_0$ = $localize \`Hello $` +
-             String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-           }
-           const $_c2$ = ["title", $I18N_0$];
+           ${i18n_0}
+           const $_c2$ = ["title", $i18n_0$];
            …
            consts: [[${AttributeMarker.Bindings}, "title"]],
            template: function MyComponent_Template(rf, ctx) {
@@ -443,19 +478,11 @@ describe('i18n support in the template compiler', () => {
             <ng-template *ngIf="true" i18n-title title="Hello {{ name }}"></ng-template>
           `;
 
+         const i18n_0 =
+             i18nMsg('Hello {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
          const output = String.raw`
-            var $I18N_0$;
-            if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-              const $MSG_EXTERNAL_3771704108176831903$$APP_SPEC_TS__1$ = goog.getMsg("Hello {$interpolation}", {
-                "interpolation": "\uFFFD0\uFFFD"
-              });
-              $I18N_0$ = $MSG_EXTERNAL_3771704108176831903$$APP_SPEC_TS__1$;
-            }
-            else {
-              $I18N_0$ = $localize \`Hello $` +
-             String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-            }
-            const $_c2$ = ["title", $I18N_0$];
+            ${i18n_0}
+            const $_c2$ = ["title", $i18n_0$];
             …
             function MyComponent_0_Template(rf, ctx) {
               if (rf & 1) {
@@ -530,20 +557,10 @@ describe('i18n support in the template compiler', () => {
         <div id="static" i18n-title="m|d" title="introduction"></div>
       `;
 
+      const i18n_0 = i18nMsg('introduction', [], {meaning: 'm', desc: 'd'});
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-          /**
-           * @desc d
-           * @meaning m
-           */
-          const $MSG_EXTERNAL_8809028065680254561$$APP_SPEC_TS_1$ = goog.getMsg("introduction");
-          $I18N_1$ = $MSG_EXTERNAL_8809028065680254561$$APP_SPEC_TS_1$;
-        }
-        else {
-          $I18N_1$ = $localize \`:m|d:introduction\`;
-        }
-        const $_c1$ = ["title", $I18N_1$];
+        ${i18n_0}
+        const $_c1$ = ["title", $i18n_0$];
         …
         consts: [["id", "static", ${AttributeMarker.I18n}, "title"]],
         template: function MyComponent_Template(rf, ctx) {
@@ -571,89 +588,45 @@ describe('i18n support in the template compiler', () => {
         ></div>
       `;
 
+      const i18n_0 = i18nMsg('static text');
+      const i18n_1 = i18nMsg(
+          'intro {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]],
+          {meaning: 'm', desc: 'd'});
+      const i18n_2 = i18nMsg(
+          '{$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]],
+          {meaning: 'm1', desc: 'd1'});
+      const i18n_3 = i18nMsg(
+          '{$interpolation} and {$interpolation_1} and again {$interpolation_2}',
+          [
+            ['interpolation', String.raw`\uFFFD0\uFFFD`],
+            ['interpolation_1', String.raw`\uFFFD1\uFFFD`],
+            ['interpolation_2', String.raw`\uFFFD2\uFFFD`]
+          ],
+          {meaning: 'm2', desc: 'd2'});
+      const i18n_4 = i18nMsg('{$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
+
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-          const $MSG_EXTERNAL_5526535577705876535$$APP_SPEC_TS_1$ = goog.getMsg("static text");
-          $I18N_1$ = $MSG_EXTERNAL_5526535577705876535$$APP_SPEC_TS_1$;
-        }
-        else {
-          $I18N_1$ = $localize \`static text\`;
-        }
-        var $I18N_2$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-          /**
-           * @desc d
-           * @meaning m
-           */
-          const $MSG_EXTERNAL_8977039798304050198$$APP_SPEC_TS_2$ = goog.getMsg("intro {$interpolation}", {
-            "interpolation": "\uFFFD0\uFFFD"
-          });
-          $I18N_2$ = $MSG_EXTERNAL_8977039798304050198$$APP_SPEC_TS_2$;
-        }
-        else {
-          $I18N_2$ = $localize \`:m|d:intro $` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
-        var $I18N_3$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc d1
-             * @meaning m1
-             */
-            const $MSG_EXTERNAL_7432761130955693041$$APP_SPEC_TS_3$ = goog.getMsg("{$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_3$ = $MSG_EXTERNAL_7432761130955693041$$APP_SPEC_TS_3$;
-        }
-        else {
-          $I18N_3$ = $localize \`:m1|d1:$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
+        ${i18n_0}
+        ${i18n_1}
+        ${i18n_2}
         const $_c1$ = [
-          "aria-roledescription", $I18N_1$,
-          "title", $I18N_2$,
-          "aria-label", $I18N_3$
+          "aria-roledescription", $i18n_0$,
+          "title", $i18n_1$,
+          "aria-label", $i18n_2$
         ];
-        var $I18N_6$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc d2
-             * @meaning m2
-             */
-            const $MSG_EXTERNAL_7566208596013750546$$APP_SPEC_TS_6$ = goog.getMsg("{$interpolation} and {$interpolation_1} and again {$interpolation_2}", {
-              "interpolation": "\uFFFD0\uFFFD", "interpolation_1": "\uFFFD1\uFFFD", "interpolation_2": "\uFFFD2\uFFFD"
-            });
-            $I18N_6$ = $MSG_EXTERNAL_7566208596013750546$$APP_SPEC_TS_6$;
-        }
-        else {
-          $I18N_6$ = $localize \`:m2|d2:$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: and $` +
-          String.raw`{"\uFFFD1\uFFFD"}:INTERPOLATION_1: and again $` +
-          String.raw`{"\uFFFD2\uFFFD"}:INTERPOLATION_2:\`;
-        }
-        var $I18N_7$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_6639222533406278123$$APP_SPEC_TS_7$ = goog.getMsg("{$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_7$ = $MSG_EXTERNAL_6639222533406278123$$APP_SPEC_TS_7$;
-        }
-        else {
-            $I18N_7$ = $localize \`$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
+        ${i18n_3}
+        ${i18n_4}
         const $_c3$ = [
-          "title", $I18N_6$,
-          "aria-roledescription", $I18N_7$
+          "title", $i18n_3$,
+          "aria-roledescription", $i18n_4$
         ];
         …
         decls: 5,
         vars: 8,
         consts: [["id", "dynamic-1", ${
-              AttributeMarker
-                  .I18n}, "aria-roledescription", "title", "aria-label"], ["id", "dynamic-2", ${
-              AttributeMarker.I18n}, "title", "aria-roledescription"]],
+          AttributeMarker
+              .I18n}, "aria-roledescription", "title", "aria-label"], ["id", "dynamic-2", ${
+          AttributeMarker.I18n}, "title", "aria-roledescription"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
@@ -682,23 +655,12 @@ describe('i18n support in the template compiler', () => {
         <div i18n-title="m|d" title="intro {% valueA | uppercase %}"></div>
       `;
 
+      const i18n_0 = i18nMsg(
+          'intro {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]],
+          {meaning: 'm', desc: 'd'});
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc d
-             * @meaning m
-             */
-            const $MSG_EXTERNAL_8977039798304050198$ = goog.getMsg("intro {$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_1$ = $MSG_EXTERNAL_8977039798304050198$;
-        }
-        else {
-          $I18N_1$ = $localize \`:m|d:intro $` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
-        const $_c3$ = ["title", $I18N_1$];
+        ${i18n_0}
+        const $_c3$ = ["title", $i18n_0$];
         …
         consts: [[${AttributeMarker.I18n}, "title"]],
         template: function MyComponent_Template(rf, ctx) {
@@ -724,23 +686,13 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nMsg(
+          'different scope {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]],
+          {meaning: 'm', desc: 'd'});
+
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc d
-             * @meaning m
-             */
-            const $MSG_EXTERNAL_8538466649243975456$$APP_SPEC_TS__1$ = goog.getMsg("different scope {$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_1$ = $MSG_EXTERNAL_8538466649243975456$$APP_SPEC_TS__1$;
-        }
-        else {
-          $I18N_1$ = $localize \`:m|d:different scope $` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
-        const $_c2$ = ["title", $I18N_1$];
+        ${i18n_0}
+        const $_c2$ = ["title", $i18n_0$];
         function MyComponent_div_0_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
@@ -761,7 +713,7 @@ describe('i18n support in the template compiler', () => {
         decls: 1,
         vars: 1,
         consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${
-              AttributeMarker.I18n}, "title"]],
+          AttributeMarker.I18n}, "title"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 4, 3, "div", 0);
@@ -780,19 +732,12 @@ describe('i18n support in the template compiler', () => {
         <div i18n-title title="{{valueA.getRawValue()?.getTitle()}} title"></div>
       `;
 
+      const i18n_0 =
+          i18nMsg('{$interpolation} title', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
+
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_3462388422673575127$$APP_SPEC_TS_2$ = goog.getMsg("{$interpolation} title", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_1$ = $MSG_EXTERNAL_3462388422673575127$$APP_SPEC_TS_2$;
-        }
-        else {
-            $I18N_1$ = $localize \`$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: title\`;
-        }
-        const $_c3$ = ["title", $I18N_1$];
+        ${i18n_0}
+        const $_c3$ = ["title", $i18n_0$];
         …
         decls: 2,
         vars: 1,
@@ -827,81 +772,37 @@ describe('i18n support in the template compiler', () => {
         ></div>
       `;
 
+      const i18n_0 = i18nMsg('static text');
+      const i18n_1 = i18nMsg(
+          'intro {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]],
+          {meaning: 'm', desc: 'd'});
+      const i18n_2 = i18nMsg(
+          '{$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]],
+          {meaning: 'm1', desc: 'd1'});
+      const i18n_3 = i18nMsg(
+          '{$interpolation} and {$interpolation_1} and again {$interpolation_2}',
+          [
+            ['interpolation', String.raw`\uFFFD0\uFFFD`],
+            ['interpolation_1', String.raw`\uFFFD1\uFFFD`],
+            ['interpolation_2', String.raw`\uFFFD2\uFFFD`]
+          ],
+          {meaning: 'm2', desc: 'd2'});
+      const i18n_4 = i18nMsg('{$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
+
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_5526535577705876535$$APP_SPEC_TS_1$ = goog.getMsg("static text");
-            $I18N_1$ = $MSG_EXTERNAL_5526535577705876535$$APP_SPEC_TS_1$;
-        }
-        else {
-            $I18N_1$ = $localize \`static text\`;
-        }
-        var $I18N_2$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc d
-             * @meaning m
-             */
-            const $MSG_EXTERNAL_8977039798304050198$$APP_SPEC_TS_2$ = goog.getMsg("intro {$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_2$ = $MSG_EXTERNAL_8977039798304050198$$APP_SPEC_TS_2$;
-        }
-        else {
-          $I18N_2$ = $localize \`:m|d:intro $` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
-        var $I18N_3$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc d1
-             * @meaning m1
-             */
-            const $MSG_EXTERNAL_7432761130955693041$$APP_SPEC_TS_3$ = goog.getMsg("{$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_3$ = $MSG_EXTERNAL_7432761130955693041$$APP_SPEC_TS_3$;
-        }
-        else {
-          $I18N_3$ = $localize \`:m1|d1:$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
+        ${i18n_0}
+        ${i18n_1}
+        ${i18n_2}
         const $_c1$ = [
-          "aria-roledescription", $I18N_1$,
-          "title", $I18N_2$,
-          "aria-label", $I18N_3$
+          "aria-roledescription", $i18n_0$,
+          "title", $i18n_1$,
+          "aria-label", $i18n_2$
         ];
-        var $I18N_6$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc d2
-             * @meaning m2
-             */
-            const $MSG_EXTERNAL_7566208596013750546$$APP_SPEC_TS_6$ = goog.getMsg("{$interpolation} and {$interpolation_1} and again {$interpolation_2}", {
-              "interpolation": "\uFFFD0\uFFFD", "interpolation_1": "\uFFFD1\uFFFD", "interpolation_2": "\uFFFD2\uFFFD"
-            });
-            $I18N_6$ = $MSG_EXTERNAL_7566208596013750546$$APP_SPEC_TS_6$;
-        }
-        else {
-          $I18N_6$ = $localize \`:m2|d2:$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: and $` +
-          String.raw`{"\uFFFD1\uFFFD"}:INTERPOLATION_1: and again $` +
-          String.raw`{"\uFFFD2\uFFFD"}:INTERPOLATION_2:\`;
-        }
-        var $I18N_7$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_6639222533406278123$$APP_SPEC_TS_7$ = goog.getMsg("{$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_7$ = $MSG_EXTERNAL_6639222533406278123$$APP_SPEC_TS_7$;
-        }
-        else {
-            $I18N_7$ = $localize \`$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
+        ${i18n_3}
+        ${i18n_4}
         const $_c3$ = [
-          "title", $I18N_6$,
-          "aria-roledescription", $I18N_7$
+          "title", $i18n_3$,
+          "aria-roledescription", $i18n_4$
         ];
         …
         decls: 5,
@@ -940,23 +841,13 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nMsg(
+          'different scope {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]],
+          {meaning: 'm', desc: 'd'});
+
       const output = String.raw`
-        var $I18N_2$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc d
-             * @meaning m
-             */
-            const $MSG_EXTERNAL_8538466649243975456$$APP_SPEC_TS__3$ = goog.getMsg("different scope {$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_2$ = $MSG_EXTERNAL_8538466649243975456$$APP_SPEC_TS__3$;
-        }
-        else {
-          $I18N_2$ = $localize \`:m|d:different scope $` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
-        const $_c4$ = ["title", $I18N_2$];
+        ${i18n_0}
+        const $_c4$ = ["title", $i18n_0$];
         function MyComponent_div_0_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
@@ -977,7 +868,7 @@ describe('i18n support in the template compiler', () => {
         decls: 1,
         vars: 1,
         consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${
-              AttributeMarker.I18n}, "title"]],
+          AttributeMarker.I18n}, "title"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 4, 3, "div", 0);
@@ -996,35 +887,20 @@ describe('i18n support in the template compiler', () => {
         <div i18n i18n-title="m|d" title="Element title">Some content</div>
       `;
 
+      const i18n_0 = i18nMsg('Element title', [], {meaning: 'm', desc: 'd'});
+      const i18n_1 = i18nMsg('Some content');
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc d
-             * @meaning m
-             */
-            const $MSG_EXTERNAL_7727043314656808423$$APP_SPEC_TS_0$ = goog.getMsg("Element title");
-            $I18N_0$ = $MSG_EXTERNAL_7727043314656808423$$APP_SPEC_TS_0$;
-        }
-        else {
-          $I18N_0$ = $localize \`:m|d:Element title\`;
-        }
-        const $_c1$ = ["title", $I18N_0$];
-        var $I18N_2$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_4969674997806975147$$APP_SPEC_TS_2$ = goog.getMsg("Some content");
-            $I18N_2$ = $MSG_EXTERNAL_4969674997806975147$$APP_SPEC_TS_2$;
-        }
-        else {
-            $I18N_2$ = $localize \`Some content\`;
-        }
+        ${i18n_0}
+        const $_c1$ = ["title", $i18n_0$];
+        ${i18n_1}
         …
         consts: [[${AttributeMarker.I18n}, "title"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
             $r3$.ɵɵi18nAttributes(1, $_c1$);
-            $r3$.ɵɵi18n(2, $I18N_2$);
+            $r3$.ɵɵi18n(2, $i18n_1$);
             $r3$.ɵɵelementEnd();
           }
         }
@@ -1039,6 +915,7 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      // Keeping raw content (avoiding `i18nMsg`) to illustrate message id sanitization.
       const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
@@ -1096,20 +973,8 @@ describe('i18n support in the template compiler', () => {
     });
 
     it('should ignore HTML comments within translated text', () => {
-      const input = `
-        <div i18n>Some <!-- comments --> text</div>
-      `;
-
-      const output = String.raw`
-      var $I18N_0$;
-      if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-          const $MSG_APP_SPEC_TS_1$ = goog.getMsg("Some  text");
-          $I18N_0$ = $MSG_APP_SPEC_TS_1$;
-      }
-      else {
-          $I18N_0$ = $localize \`Some  text\`;
-      }
-    `;
+      const input = `<div i18n>Some <!-- comments --> text</div>`;
+      const output = i18nMsg('Some  text');
       verify(input, output);
     });
 
@@ -1118,6 +983,7 @@ describe('i18n support in the template compiler', () => {
         <div i18n>Some text 'with single quotes', "with double quotes", \`with backticks\` and without quotes.</div>
       `;
 
+      // Keeping raw content (avoiding `i18nMsg`) to illustrate quotes escaping.
       const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
@@ -1135,6 +1001,7 @@ describe('i18n support in the template compiler', () => {
 
     it('should handle interpolations wrapped in backticks', () => {
       const input = '<div i18n>`{{ count }}`</div>';
+      // Keeping raw content (avoiding `i18nMsg`) to illustrate backticks escaping.
       const output = String.raw`
       var $I18N_0$;
       if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
@@ -1158,48 +1025,31 @@ describe('i18n support in the template compiler', () => {
         <div i18n>My i18n block #3</div>
       `;
 
+      const i18n_0 = i18nMsg('My i18n block #1');
+      const i18n_1 = i18nMsg('My i18n block #2');
+      const i18n_2 = i18nMsg('My i18n block #3');
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_4890179241114413722$$APP_SPEC_TS_0$ = goog.getMsg("My i18n block #1");
-            $I18N_0$ = $MSG_EXTERNAL_4890179241114413722$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`My i18n block #1\`;
-        }
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_2413150872298537152$$APP_SPEC_TS_1$ = goog.getMsg("My i18n block #2");
-            $I18N_1$ = $MSG_EXTERNAL_2413150872298537152$$APP_SPEC_TS_1$;
-        }
-        else {
-            $I18N_1$ = $localize \`My i18n block #2\`;
-        }
-        var $I18N_2$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_5023003143537152794$$APP_SPEC_TS_2$ = goog.getMsg("My i18n block #3");
-            $I18N_2$ = $MSG_EXTERNAL_5023003143537152794$$APP_SPEC_TS_2$;
-        }
-        else {
-            $I18N_2$ = $localize \`My i18n block #3\`;
-        }
+        ${i18n_0}
+        ${i18n_1}
+        ${i18n_2}
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(2, "div");
             $r3$.ɵɵtext(3, "My non-i18n block #1");
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(4, "div");
-            $r3$.ɵɵi18n(5, $I18N_1$);
+            $r3$.ɵɵi18n(5, $i18n_1$);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(6, "div");
             $r3$.ɵɵtext(7, "My non-i18n block #2");
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(8, "div");
-            $r3$.ɵɵi18n(9, $I18N_2$);
+            $r3$.ɵɵi18n(9, $i18n_2$);
             $r3$.ɵɵelementEnd();
           }
         }
@@ -1216,6 +1066,8 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      // Keeping raw content (avoiding `i18nMsg`) to illustrate how named interpolations are
+      // generated.
       const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
@@ -1255,23 +1107,15 @@ describe('i18n support in the template compiler', () => {
         <div i18n>{% valueA %}</div>
       `;
 
+      const i18n_0 = i18nMsg('{$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_6749967533321674787$$APP_SPEC_TS_0$ = goog.getMsg("{$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_0$ = $MSG_EXTERNAL_6749967533321674787$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
+        ${i18n_0}
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -1293,34 +1137,28 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nMsg(' {$interpolation} {$interpolation_1} {$interpolation_2} ', [
+        ['interpolation', String.raw`\uFFFD0\uFFFD`],
+        ['interpolation_1', String.raw`\uFFFD1\uFFFD`],
+        ['interpolation_2', String.raw`\uFFFD2\uFFFD`]
+      ]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_APP_SPEC_TS_1$$APP_SPEC_TS_1$ = goog.getMsg(" {$interpolation} {$interpolation_1} {$interpolation_2} ", {
-              "interpolation": "\uFFFD0\uFFFD",
-              "interpolation_1": "\uFFFD1\uFFFD",
-              "interpolation_2": "\uFFFD2\uFFFD"
-            });
-            $I18N_0$ = $MSG_APP_SPEC_TS_1$$APP_SPEC_TS_1$;
-        }
-        else {
-            $I18N_0$ = $localize \` $` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
-          String.raw`{"\uFFFD1\uFFFD"}:INTERPOLATION_1: $` +
-          String.raw`{"\uFFFD2\uFFFD"}:INTERPOLATION_2: \`;
-        }
+        ${i18n_0}
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵpipe(2, "async");
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
             var $tmp_2_0$ = null;
             $r3$.ɵɵadvance(2);
-            $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(2, 3, ctx.valueA))(ctx.valueA == null ? null : ctx.valueA.a == null ? null : ctx.valueA.a.b)(($tmp_2_0$ = ctx.valueA.getRawValue()) == null ? null : $tmp_2_0$.getTitle());
+            $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(2, 3, ctx.valueA))
+                          (ctx.valueA == null ? null : ctx.valueA.a == null ? null : ctx.valueA.a.b)
+                          (($tmp_2_0$ = ctx.valueA.getRawValue()) == null ? null : $tmp_2_0$.getTitle());
             $r3$.ɵɵi18nApply(1);
           }
         }
@@ -1335,54 +1173,31 @@ describe('i18n support in the template compiler', () => {
         <div i18n>My i18n block #{{ three + four + five }}</div>
       `;
 
+      const i18n_0 = i18nMsg(
+          'My i18n block #{$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
+      const i18n_1 = i18nMsg(
+          'My i18n block #{$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
+      const i18n_2 = i18nMsg(
+          'My i18n block #{$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_572579892698764378$$APP_SPEC_TS_0$ = goog.getMsg("My i18n block #{$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_0$ = $MSG_EXTERNAL_572579892698764378$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`My i18n block #$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_609623417156596326$$APP_SPEC_TS_1$ = goog.getMsg("My i18n block #{$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_1$ = $MSG_EXTERNAL_609623417156596326$$APP_SPEC_TS_1$;
-        }
-        else {
-            $I18N_1$ = $localize \`My i18n block #$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
-        var $I18N_2$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_3998119318957372120$$APP_SPEC_TS_2$ = goog.getMsg("My i18n block #{$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_2$ = $MSG_EXTERNAL_3998119318957372120$$APP_SPEC_TS_2$;
-        }
-        else {
-            $I18N_2$ = $localize \`My i18n block #$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
+        ${i18n_0}
+        ${i18n_1}
+        ${i18n_2}
         …
         decls: 7,
         vars: 5,
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(2, "div");
-            $r3$.ɵɵi18n(3, $I18N_1$);
+            $r3$.ɵɵi18n(3, $i18n_1$);
             $r3$.ɵɵpipe(4, "uppercase");
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(5, "div");
-            $r3$.ɵɵi18n(6, $I18N_2$);
+            $r3$.ɵɵi18n(6, $i18n_2$);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -1420,58 +1235,39 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nMsg(
+          ' My i18n block #{$interpolation} {$startTagSpan}Plain text in nested element{$closeTagSpan}',
+          [
+            ['interpolation', String.raw`\uFFFD0\uFFFD`],
+            ['startTagSpan', String.raw`\uFFFD#2\uFFFD`],
+            ['closeTagSpan', String.raw`\uFFFD/#2\uFFFD`]
+          ]);
+      const i18n_1 = i18nMsgWithPostprocess(
+          ' My i18n block #{$interpolation} {$startTagDiv}{$startTagDiv}{$startTagSpan} More bindings in more nested element: {$interpolation_1} {$closeTagSpan}{$closeTagDiv}{$closeTagDiv}',
+          [
+            ['interpolation', String.raw`\uFFFD0\uFFFD`],
+            ['startTagDiv', String.raw`[\uFFFD#6\uFFFD|\uFFFD#7\uFFFD]`],
+            ['startTagSpan', String.raw`\uFFFD#8\uFFFD`],
+            ['interpolation_1', String.raw`\uFFFD1\uFFFD`],
+            ['closeTagSpan', String.raw`\uFFFD/#8\uFFFD`],
+            ['closeTagDiv', String.raw`[\uFFFD/#7\uFFFD|\uFFFD/#6\uFFFD]`]
+          ]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_7905233330103651696$$APP_SPEC_TS_0$ = goog.getMsg(" My i18n block #{$interpolation} {$startTagSpan}Plain text in nested element{$closeTagSpan}", {
-              "interpolation": "\uFFFD0\uFFFD",
-              "startTagSpan": "\uFFFD#2\uFFFD",
-              "closeTagSpan": "\uFFFD/#2\uFFFD"
-            });
-            $I18N_0$ = $MSG_EXTERNAL_7905233330103651696$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \` My i18n block #$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
-          String.raw`{"\uFFFD#2\uFFFD"}:START_TAG_SPAN:Plain text in nested element$` +
-          String.raw`{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_SPAN:\`;
-        }
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_5788821996131681377$$APP_SPEC_TS_1$ = goog.getMsg(" My i18n block #{$interpolation} {$startTagDiv}{$startTagDiv}{$startTagSpan} More bindings in more nested element: {$interpolation_1} {$closeTagSpan}{$closeTagDiv}{$closeTagDiv}", {
-              "interpolation": "\uFFFD0\uFFFD",
-              "startTagDiv": "[\uFFFD#6\uFFFD|\uFFFD#7\uFFFD]",
-              "startTagSpan": "\uFFFD#8\uFFFD",
-              "interpolation_1": "\uFFFD1\uFFFD",
-              "closeTagSpan": "\uFFFD/#8\uFFFD",
-              "closeTagDiv": "[\uFFFD/#7\uFFFD|\uFFFD/#6\uFFFD]"
-            });
-            $I18N_1$ = $MSG_EXTERNAL_5788821996131681377$$APP_SPEC_TS_1$;
-        }
-        else {
-            $I18N_1$ = $localize \` My i18n block #$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
-          String.raw`{"[\uFFFD#6\uFFFD|\uFFFD#7\uFFFD]"}:START_TAG_DIV:$` +
-          String.raw`{"[\uFFFD#6\uFFFD|\uFFFD#7\uFFFD]"}:START_TAG_DIV:$` + String.raw
-      `{"\uFFFD#8\uFFFD"}:START_TAG_SPAN: More bindings in more nested element: $` +
-          String.raw`{"\uFFFD1\uFFFD"}:INTERPOLATION_1: $` +
-          String.raw`{"\uFFFD/#8\uFFFD"}:CLOSE_TAG_SPAN:$` +
-          String.raw`{"[\uFFFD/#7\uFFFD|\uFFFD/#6\uFFFD]"}:CLOSE_TAG_DIV:$` +
-          String.raw`{"[\uFFFD/#7\uFFFD|\uFFFD/#6\uFFFD]"}:CLOSE_TAG_DIV:\`;
-        }
-        $I18N_1$ = $r3$.ɵɵi18nPostprocess($I18N_1$);
+        ${i18n_0}
+        ${i18n_1}
         …
         decls: 9,
         vars: 5,
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $I18N_0$);
+            $r3$.ɵɵi18nStart(1, $i18n_0$);
             $r3$.ɵɵelement(2, "span");
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(3, "div");
-            $r3$.ɵɵi18nStart(4, $I18N_1$);
+            $r3$.ɵɵi18nStart(4, $i18n_1$);
             $r3$.ɵɵpipe(5, "uppercase");
             $r3$.ɵɵelementStart(6, "div");
             $r3$.ɵɵelementStart(7, "div");
@@ -1511,63 +1307,33 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nMsg('Span title {$interpolation} and {$interpolation_1}', [
+        ['interpolation', String.raw`\uFFFD0\uFFFD`], ['interpolation_1', String.raw`\uFFFD1\uFFFD`]
+      ]);
+      const i18n_1 = i18nMsg(
+          ' My i18n block #1 with value: {$interpolation} {$startTagSpan} Plain text in nested element (block #1) {$closeTagSpan}',
+          [
+            ['interpolation', String.raw`\uFFFD0\uFFFD`],
+            ['startTagSpan', String.raw`\uFFFD#2\uFFFD`],
+            ['closeTagSpan', String.raw`\uFFFD/#2\uFFFD`]
+          ]);
+      const i18n_2 =
+          i18nMsg('Span title {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
+      const i18n_3 = i18nMsg(
+          ' My i18n block #2 with value {$interpolation} {$startTagSpan} Plain text in nested element (block #2) {$closeTagSpan}',
+          [
+            ['interpolation', String.raw`\uFFFD0\uFFFD`],
+            ['startTagSpan', String.raw`\uFFFD#7\uFFFD`],
+            ['closeTagSpan', String.raw`\uFFFD/#7\uFFFD`]
+          ]);
+
       const output = String.raw`
-        var $I18N_2$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_4782264005467235841$$APP_SPEC_TS_3$ = goog.getMsg("Span title {$interpolation} and {$interpolation_1}", {
-              "interpolation": "\uFFFD0\uFFFD",
-              "interpolation_1": "\uFFFD1\uFFFD"
-            });
-            $I18N_2$ = $MSG_EXTERNAL_4782264005467235841$$APP_SPEC_TS_3$;
-        }
-        else {
-            $I18N_2$ = $localize \`Span title $` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: and $` +
-          String.raw`{"\uFFFD1\uFFFD"}:INTERPOLATION_1:\`;
-        }
-        const $_c4$ = ["title", $I18N_2$];
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_4446430594603971069$$APP_SPEC_TS_5$ = goog.getMsg(" My i18n block #1 with value: {$interpolation} {$startTagSpan} Plain text in nested element (block #1) {$closeTagSpan}", {
-              "interpolation": "\uFFFD0\uFFFD",
-              "startTagSpan": "\uFFFD#2\uFFFD",
-              "closeTagSpan": "\uFFFD/#2\uFFFD"
-            });
-            $I18N_0$ = $MSG_EXTERNAL_4446430594603971069$$APP_SPEC_TS_5$;
-        }
-        else {
-            $I18N_0$ = $localize \` My i18n block #1 with value: $` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: $` + String.raw
-      `{"\uFFFD#2\uFFFD"}:START_TAG_SPAN: Plain text in nested element (block #1) $` +
-          String.raw`{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_SPAN:\`;
-        }
-        var $I18N_7$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_2719594642740200058$$APP_SPEC_TS_8$ = goog.getMsg("Span title {$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_7$ = $MSG_EXTERNAL_2719594642740200058$$APP_SPEC_TS_8$;
-        }
-        else {
-            $I18N_7$ = $localize \`Span title $` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
-        const $_c9$ = ["title", $I18N_7$];
-        var $I18N_6$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_2778714953278357902$$APP_SPEC_TS_10$ = goog.getMsg(" My i18n block #2 with value {$interpolation} {$startTagSpan} Plain text in nested element (block #2) {$closeTagSpan}", {
-              "interpolation": "\uFFFD0\uFFFD",
-              "startTagSpan": "\uFFFD#7\uFFFD",
-              "closeTagSpan": "\uFFFD/#7\uFFFD"
-            });
-            $I18N_6$ = $MSG_EXTERNAL_2778714953278357902$$APP_SPEC_TS_10$;
-        }
-        else {
-            $I18N_6$ = $localize \` My i18n block #2 with value $` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: $` + String.raw
-      `{"\uFFFD#7\uFFFD"}:START_TAG_SPAN: Plain text in nested element (block #2) $` +
-          String.raw`{"\uFFFD/#7\uFFFD"}:CLOSE_TAG_SPAN:\`;
-        }
+        ${i18n_0}
+        const $_c4$ = ["title", $i18n_0$];
+        ${i18n_1}
+        ${i18n_2}
+        const $_c9$ = ["title", $i18n_2$];
+        ${i18n_3}
         …
         decls: 9,
         vars: 7,
@@ -1575,14 +1341,14 @@ describe('i18n support in the template compiler', () => {
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $I18N_0$);
+            $r3$.ɵɵi18nStart(1, $i18n_1$);
             $r3$.ɵɵelementStart(2, "span", 0);
             $r3$.ɵɵi18nAttributes(3, $_c4$);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(4, "div");
-            $r3$.ɵɵi18nStart(5, $I18N_6$);
+            $r3$.ɵɵi18nStart(5, $i18n_3$);
             $r3$.ɵɵpipe(6, "uppercase");
             $r3$.ɵɵelementStart(7, "span", 0);
             $r3$.ɵɵi18nAttributes(8, $_c9$);
@@ -1625,30 +1391,23 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nMsg(
+          ' Some other content {$interpolation} {$startTagDiv} More nested levels with bindings {$interpolation_1} {$closeTagDiv}',
+          [
+            ['interpolation', String.raw`\uFFFD0\uFFFD`],
+            ['startTagDiv', String.raw`\uFFFD#3\uFFFD`],
+            ['interpolation_1', String.raw`\uFFFD1\uFFFD`],
+            ['closeTagDiv', String.raw`\uFFFD/#3\uFFFD`]
+          ]);
+
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_7679414751795588050$$APP_SPEC_TS__1$ = goog.getMsg(" Some other content {$interpolation} {$startTagDiv} More nested levels with bindings {$interpolation_1} {$closeTagDiv}", {
-              "interpolation": "\uFFFD0\uFFFD",
-              "startTagDiv": "\uFFFD#3\uFFFD",
-              "interpolation_1": "\uFFFD1\uFFFD",
-              "closeTagDiv": "\uFFFD/#3\uFFFD"
-            });
-            $I18N_1$ = $MSG_EXTERNAL_7679414751795588050$$APP_SPEC_TS__1$;
-        }
-        else {
-            $I18N_1$ = $localize \` Some other content $` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION: $` +
-          String.raw`{"\uFFFD#3\uFFFD"}:START_TAG_DIV: More nested levels with bindings $` +
-          String.raw`{"\uFFFD1\uFFFD"}:INTERPOLATION_1: $` +
-          String.raw`{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_DIV:\`;
-        }
+        ${i18n_0}
         …
         function MyComponent_div_2_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
             $r3$.ɵɵelementStart(1, "div");
-            $r3$.ɵɵi18nStart(2, $I18N_1$);
+            $r3$.ɵɵi18nStart(2, $i18n_0$);
             $r3$.ɵɵelement(3, "div");
             $r3$.ɵɵpipe(4, "uppercase");
             $r3$.ɵɵi18nEnd();
@@ -1690,24 +1449,17 @@ describe('i18n support in the template compiler', () => {
         <img src="logo.png" i18n *ngIf="visible" i18n-title title="App logo #{{ id }}" />
       `;
 
+      const i18n_0 =
+          i18nMsg('App logo #{$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
+
       const output = String.raw`
         function MyComponent_img_1_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelement(0, "img", 0);
           }
         }
-        var $I18N_2$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_2367729185105559721$$APP_SPEC_TS__2$ = goog.getMsg("App logo #{$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_2$ = $MSG_EXTERNAL_2367729185105559721$$APP_SPEC_TS__2$;
-        }
-        else {
-            $I18N_2$ = $localize \`App logo #$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
-        const $_c4$ = ["title", $I18N_2$];
+        ${i18n_0}
+        const $_c4$ = ["title", $i18n_0$];
         function MyComponent_img_2_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "img", 3);
@@ -1724,10 +1476,10 @@ describe('i18n support in the template compiler', () => {
         decls: 3,
         vars: 2,
         consts: [["src", "logo.png"], ["src", "logo.png", ${
-              AttributeMarker.Template}, "ngIf"], ["src", "logo.png", ${
-              AttributeMarker.Bindings}, "title", ${
-              AttributeMarker.Template}, "ngIf"], ["src", "logo.png", ${
-              AttributeMarker.I18n}, "title"]],
+          AttributeMarker.Template}, "ngIf"], ["src", "logo.png", ${
+          AttributeMarker.Bindings}, "title", ${
+          AttributeMarker.Template}, "ngIf"], ["src", "logo.png", ${
+          AttributeMarker.I18n}, "title"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelement(0, "img", 0);
@@ -1771,6 +1523,26 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nMsgWithPostprocess(
+          ' Some content {$startTagDiv_2} Some other content {$interpolation} {$startTagDiv} More nested levels with bindings {$interpolation_1} {$startTagDiv_1} Content inside sub-template {$interpolation_2} {$startTagDiv} Bottom level element {$interpolation_3} {$closeTagDiv}{$closeTagDiv}{$closeTagDiv}{$closeTagDiv}{$startTagDiv_3} Some other content {$interpolation_4} {$startTagDiv} More nested levels with bindings {$interpolation_5} {$closeTagDiv}{$closeTagDiv}',
+          [
+            ['startTagDiv_2', String.raw`\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD`],
+            [
+              'closeTagDiv',
+              String
+                  .raw`[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]`
+            ],
+            ['startTagDiv_3', String.raw`\uFFFD*3:3\uFFFD\uFFFD#1:3\uFFFD`],
+            ['interpolation', String.raw`\uFFFD0:1\uFFFD`],
+            ['startTagDiv', String.raw`[\uFFFD#2:1\uFFFD|\uFFFD#2:2\uFFFD|\uFFFD#2:3\uFFFD]`],
+            ['interpolation_1', String.raw`\uFFFD1:1\uFFFD`],
+            ['startTagDiv_1', String.raw`\uFFFD*4:2\uFFFD\uFFFD#1:2\uFFFD`],
+            ['interpolation_2', String.raw`\uFFFD0:2\uFFFD`],
+            ['interpolation_3', String.raw`\uFFFD1:2\uFFFD`],
+            ['interpolation_4', String.raw`\uFFFD0:3\uFFFD`],
+            ['interpolation_5', String.raw`\uFFFD1:3\uFFFD`]
+          ]);
+
       const output = String.raw`
         function MyComponent_div_2_div_4_Template(rf, ctx) {
           if (rf & 1) {
@@ -1806,51 +1578,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵi18nApply(0);
           }
         }
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_1221890473527419724$$APP_SPEC_TS_0$ = goog.getMsg(" Some content {$startTagDiv_2} Some other content {$interpolation} {$startTagDiv} More nested levels with bindings {$interpolation_1} {$startTagDiv_1} Content inside sub-template {$interpolation_2} {$startTagDiv} Bottom level element {$interpolation_3} {$closeTagDiv}{$closeTagDiv}{$closeTagDiv}{$closeTagDiv}{$startTagDiv_3} Some other content {$interpolation_4} {$startTagDiv} More nested levels with bindings {$interpolation_5} {$closeTagDiv}{$closeTagDiv}", {
-              "startTagDiv_2": "\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD",
-              "closeTagDiv": "[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]",
-              "startTagDiv_3": "\uFFFD*3:3\uFFFD\uFFFD#1:3\uFFFD",
-              "interpolation": "\uFFFD0:1\uFFFD",
-              "startTagDiv": "[\uFFFD#2:1\uFFFD|\uFFFD#2:2\uFFFD|\uFFFD#2:3\uFFFD]",
-              "interpolation_1": "\uFFFD1:1\uFFFD",
-              "startTagDiv_1": "\uFFFD*4:2\uFFFD\uFFFD#1:2\uFFFD",
-              "interpolation_2": "\uFFFD0:2\uFFFD",
-              "interpolation_3": "\uFFFD1:2\uFFFD",
-              "interpolation_4": "\uFFFD0:3\uFFFD",
-              "interpolation_5": "\uFFFD1:3\uFFFD"
-            });
-            $I18N_0$ = $MSG_EXTERNAL_1221890473527419724$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \` Some content $` +
-          String.raw
-      `{"\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_DIV_2: Some other content $` +
-          String.raw`{"\uFFFD0:1\uFFFD"}:INTERPOLATION: $` + String.raw
-      `{"[\uFFFD#2:1\uFFFD|\uFFFD#2:2\uFFFD|\uFFFD#2:3\uFFFD]"}:START_TAG_DIV: More nested levels with bindings $` +
-          String.raw`{"\uFFFD1:1\uFFFD"}:INTERPOLATION_1: $` + String.raw
-      `{"\uFFFD*4:2\uFFFD\uFFFD#1:2\uFFFD"}:START_TAG_DIV_1: Content inside sub-template $` +
-          String.raw`{"\uFFFD0:2\uFFFD"}:INTERPOLATION_2: $` + String.raw
-      `{"[\uFFFD#2:1\uFFFD|\uFFFD#2:2\uFFFD|\uFFFD#2:3\uFFFD]"}:START_TAG_DIV: Bottom level element $` +
-          String.raw`{"\uFFFD1:2\uFFFD"}:INTERPOLATION_3: $` + String.raw
-      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:$` +
-          String.raw
-      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:$` +
-          String.raw
-      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:$` +
-          String.raw
-      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:$` +
-          String.raw
-      `{"\uFFFD*3:3\uFFFD\uFFFD#1:3\uFFFD"}:START_TAG_DIV_3: Some other content $` +
-          String.raw`{"\uFFFD0:3\uFFFD"}:INTERPOLATION_4: $` + String.raw
-      `{"[\uFFFD#2:1\uFFFD|\uFFFD#2:2\uFFFD|\uFFFD#2:3\uFFFD]"}:START_TAG_DIV: More nested levels with bindings $` +
-          String.raw`{"\uFFFD1:3\uFFFD"}:INTERPOLATION_5: $` + String.raw
-      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:$` +
-          String.raw
-      `{"[\uFFFD/#2:2\uFFFD|\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD|\uFFFD/#2:1\uFFFD|\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD|\uFFFD/#2:3\uFFFD|\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD]"}:CLOSE_TAG_DIV:\`;
-        }
-        $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$);
+        ${i18n_0}
         function MyComponent_div_3_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵi18nStart(0, $I18N_0$, 3);
@@ -1897,27 +1625,18 @@ describe('i18n support in the template compiler', () => {
         <div i18n *ngIf="visible">Some other content <span>{{ valueA }}</span></div>
       `;
 
+      const i18n_0 = i18nMsg('Some other content {$startTagSpan}{$interpolation}{$closeTagSpan}', [
+        ['startTagSpan', String.raw`\uFFFD#2\uFFFD`], ['interpolation', String.raw`\uFFFD0\uFFFD`],
+        ['closeTagSpan', String.raw`\uFFFD/#2\uFFFD`]
+      ]);
+
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_119975189388320493$$APP_SPEC_TS__1$ = goog.getMsg("Some other content {$startTagSpan}{$interpolation}{$closeTagSpan}", {
-              "startTagSpan": "\uFFFD#2\uFFFD",
-              "interpolation": "\uFFFD0\uFFFD",
-              "closeTagSpan": "\uFFFD/#2\uFFFD"
-            });
-            $I18N_1$ = $MSG_EXTERNAL_119975189388320493$$APP_SPEC_TS__1$;
-        }
-        else {
-            $I18N_1$ = $localize \`Some other content $` +
-          String.raw`{"\uFFFD#2\uFFFD"}:START_TAG_SPAN:$` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:$` +
-          String.raw`{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_SPAN:\`;
-        }
+        ${i18n_0}
         …
         function MyComponent_div_0_Template(rf, ctx) {
           if (rf & 1) {
               $r3$.ɵɵelementStart(0, "div");
-              $r3$.ɵɵi18nStart(1, $I18N_1$);
+              $r3$.ɵɵi18nStart(1, $i18n_0$);
               $r3$.ɵɵelement(2, "span");
               $r3$.ɵɵi18nEnd();
               $r3$.ɵɵelementEnd();
@@ -1951,22 +1670,17 @@ describe('i18n support in the template compiler', () => {
         <div i18n (click)="onClick()">Hello</div>
       `;
 
+      const i18n_0 = i18nMsg('Hello');
+
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_APP_SPEC_TS_2$ = goog.getMsg("Hello");
-            $I18N_1$ = $MSG_APP_SPEC_TS_2$;
-        }
-        else {
-            $I18N_1$ = $localize \`Hello\`;
-        }
+        ${i18n_0}
         …
         consts: [[${AttributeMarker.Bindings}, "click"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
             $r3$.ɵɵlistener("click", function MyComponent_Template_div_click_0_listener() { return ctx.onClick(); });
-            $r3$.ɵɵi18n(1, $I18N_1$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵelementEnd();
           }
         }
@@ -1982,20 +1696,15 @@ describe('i18n support in the template compiler', () => {
         <div i18n>My i18n block #1</div>
       `;
 
+      const i18n_0 = i18nMsg('My i18n block #1');
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_4890179241114413722$$APP_SPEC_TS_0$ = goog.getMsg("My i18n block #1");
-            $I18N_0$ = $MSG_EXTERNAL_4890179241114413722$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`My i18n block #1\`;
-        }
+        ${i18n_0}
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵelementEnd();
           }
         }
@@ -2009,18 +1718,12 @@ describe('i18n support in the template compiler', () => {
         <div i18n>{age, select, 10 {ten} 20 {twenty} other {other}}</div>
       `;
 
+      const i18n_0 = i18nIcuMsg(
+          '{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}',
+          [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_8806993169187953163$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}");
-            $I18N_0$ = $MSG_EXTERNAL_8806993169187953163$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}\`;
-        }
-        $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
-        });
+        ${i18n_0}
         …
         decls: 2,
         vars: 1,
@@ -2047,26 +1750,15 @@ describe('i18n support in the template compiler', () => {
         <ng-container i18n>My i18n block #2</ng-container>
       `;
 
+      const i18n_0 = i18nMsg('My i18n block #2');
+      const i18n_1 = i18nMsg('My i18n block #1');
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_2413150872298537152$$APP_SPEC_TS_0$ = goog.getMsg("My i18n block #2");
-            $I18N_0$ = $MSG_EXTERNAL_2413150872298537152$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`My i18n block #2\`;
-        }
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_4890179241114413722$$APP_SPEC_TS__1$ = goog.getMsg("My i18n block #1");
-            $I18N_1$ = $MSG_EXTERNAL_4890179241114413722$$APP_SPEC_TS__1$;
-        }
-        else {
-            $I18N_1$ = $localize \`My i18n block #1\`;
-        }
+        ${i18n_0}
+        ${i18n_1}
         function MyComponent_ng_template_0_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18n(0, $I18N_1$);
+            $r3$.ɵɵi18n(0, $i18n_1$);
           }
         }
         …
@@ -2074,7 +1766,7 @@ describe('i18n support in the template compiler', () => {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_ng_template_0_Template, 1, 0, "ng-template");
             $r3$.ɵɵelementContainerStart(1);
-            $r3$.ɵɵi18n(2, $I18N_0$);
+            $r3$.ɵɵi18n(2, $i18n_0$);
             $r3$.ɵɵelementContainerEnd();
           }
         }
@@ -2089,23 +1781,12 @@ describe('i18n support in the template compiler', () => {
         <span i18n style="padding: 10px;">Text #2</span>
       `;
 
+      const i18n_0 = i18nMsg('Text #1');
+      const i18n_1 = i18nMsg('Text #2');
+
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_5295701706185791735$$APP_SPEC_TS_1$ = goog.getMsg("Text #1");
-            $I18N_1$ = $MSG_EXTERNAL_5295701706185791735$$APP_SPEC_TS_1$;
-        }
-        else {
-            $I18N_1$ = $localize \`Text #1\`;
-        }
-        var $I18N_3$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_4722270221386399294$$APP_SPEC_TS_3$ = goog.getMsg("Text #2");
-            $I18N_3$ = $MSG_EXTERNAL_4722270221386399294$$APP_SPEC_TS_3$;
-        }
-        else {
-            $I18N_3$ = $localize \`Text #2\`;
-        }
+        ${i18n_0}
+        ${i18n_1}
         …
         decls: 4,
         vars: 0,
@@ -2114,10 +1795,10 @@ describe('i18n support in the template compiler', () => {
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "span", 0);
-            $r3$.ɵɵi18n(1, $I18N_1$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵelementStart(2, "span", 1);
-            $r3$.ɵɵi18n(3, $I18N_3$);
+            $r3$.ɵɵi18n(3, $i18n_1$);
             $r3$.ɵɵelementEnd();
           }
         }
@@ -2133,25 +1814,18 @@ describe('i18n support in the template compiler', () => {
         <ng-container i18n>Some content: {{ valueA | uppercase }}</ng-container>
       `;
 
+      const i18n_0 =
+          i18nMsg('Some content: {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-          const $MSG_EXTERNAL_355394464191978948$$APP_SPEC_TS_0$ = goog.getMsg("Some content: {$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-          $I18N_0$ = $MSG_EXTERNAL_355394464191978948$$APP_SPEC_TS_0$;
-        }
-        else {
-          $I18N_0$ = $localize \`Some content: $` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
+        ${i18n_0}
         …
         decls: 3,
         vars: 3,
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementContainerStart(0);
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵpipe(2, "uppercase");
             $r3$.ɵɵelementContainerEnd();
           }
@@ -2171,21 +1845,14 @@ describe('i18n support in the template compiler', () => {
         <ng-template i18n>Some content: {{ valueA | uppercase }}</ng-template>
       `;
 
+      const i18n_0 =
+          i18nMsg('Some content: {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_355394464191978948$$APP_SPEC_TS__0$ = goog.getMsg("Some content: {$interpolation}", {
-              "interpolation": "\uFFFD0\uFFFD"
-            });
-            $I18N_0$ = $MSG_EXTERNAL_355394464191978948$$APP_SPEC_TS__0$;
-        }
-        else {
-            $I18N_0$ = $localize \`Some content: $` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION:\`;
-        }
+        ${i18n_0}
         function MyComponent_ng_template_0_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18n(0, $I18N_0$);
+            $r3$.ɵɵi18n(0, $i18n_0$);
             $r3$.ɵɵpipe(1, "uppercase");
           } if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵɵnextContext();
@@ -2215,28 +1882,19 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nMsg(
+          '{$startTagNgTemplate}Template content: {$interpolation}{$closeTagNgTemplate}{$startTagNgContainer}Container content: {$interpolation_1}{$closeTagNgContainer}',
+          [
+            ['startTagNgTemplate', String.raw`\uFFFD*2:1\uFFFD`],
+            ['closeTagNgTemplate', String.raw`\uFFFD/*2:1\uFFFD`],
+            ['startTagNgContainer', String.raw`\uFFFD#3\uFFFD`],
+            ['interpolation_1', String.raw`\uFFFD0\uFFFD`],
+            ['closeTagNgContainer', String.raw`\uFFFD/#3\uFFFD`],
+            ['interpolation', String.raw`\uFFFD0:1\uFFFD`]
+          ]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-          const $MSG_EXTERNAL_702706566400598764$$APP_SPEC_TS_0$ = goog.getMsg("{$startTagNgTemplate}Template content: {$interpolation}{$closeTagNgTemplate}{$startTagNgContainer}Container content: {$interpolation_1}{$closeTagNgContainer}", {
-            "startTagNgTemplate": "\uFFFD*2:1\uFFFD",
-            "closeTagNgTemplate": "\uFFFD/*2:1\uFFFD",
-            "startTagNgContainer": "\uFFFD#3\uFFFD",
-            "interpolation_1": "\uFFFD0\uFFFD",
-            "closeTagNgContainer": "\uFFFD/#3\uFFFD",
-            "interpolation": "\uFFFD0:1\uFFFD"
-          });
-          $I18N_0$ = $MSG_EXTERNAL_702706566400598764$$APP_SPEC_TS_0$;
-        }
-        else {
-          $I18N_0$ = $localize \`$` +
-          String.raw`{"\uFFFD*2:1\uFFFD"}:START_TAG_NG_TEMPLATE:Template content: $` +
-          String.raw`{"\uFFFD0:1\uFFFD"}:INTERPOLATION:$` +
-          String.raw`{"\uFFFD/*2:1\uFFFD"}:CLOSE_TAG_NG_TEMPLATE:$` +
-          String.raw`{"\uFFFD#3\uFFFD"}:START_TAG_NG_CONTAINER:Container content: $` +
-          String.raw`{"\uFFFD0\uFFFD"}:INTERPOLATION_1:$` +
-          String.raw`{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
-        }
+        ${i18n_0}
         function MyComponent_ng_template_2_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵi18n(0, $I18N_0$, 1);
@@ -2255,7 +1913,7 @@ describe('i18n support in the template compiler', () => {
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $I18N_0$);
+            $r3$.ɵɵi18nStart(1, $i18n_0$);
             $r3$.ɵɵtemplate(2, MyComponent_ng_template_2_Template, 2, 3, "ng-template");
             $r3$.ɵɵelementContainer(3);
             $r3$.ɵɵpipe(4, "uppercase");
@@ -2279,32 +1937,19 @@ describe('i18n support in the template compiler', () => {
         <ng-container>{age, select, 10 {ten} 20 {twenty} other {other}}</ng-container>
       `;
 
+      const i18n_0 = i18nIcuMsg(
+          '{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}',
+          [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
+      const i18n_1 = i18nIcuMsg(
+          '{VAR_SELECT, select, male {male} female {female} other {other}}',
+          [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_8806993169187953163$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}");
-            $I18N_0$ = $MSG_EXTERNAL_8806993169187953163$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}\`;
-        }
-        $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
-        });
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS__1$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
-            $I18N_1$ = $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS__1$;
-        }
-        else {
-            $I18N_1$ = $localize \`{VAR_SELECT, select, male {male} female {female} other {other}}\`;
-        }
-        $I18N_1$ = $r3$.ɵɵi18nPostprocess($I18N_1$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
-        });
+        ${i18n_0}
+        ${i18n_1}
         function MyComponent_ng_template_0_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18n(0, $I18N_1$);
+            $r3$.ɵɵi18n(0, $i18n_1$);
           }
           if (rf & 2) {
             const $ctx_r0$ = $r3$.ɵɵnextContext();
@@ -2319,7 +1964,7 @@ describe('i18n support in the template compiler', () => {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_ng_template_0_Template, 1, 1, "ng-template");
             $r3$.ɵɵelementContainerStart(1);
-            $r3$.ɵɵi18n(2, $I18N_0$);
+            $r3$.ɵɵi18n(2, $i18n_0$);
             $r3$.ɵɵelementContainerEnd();
           }
           if (rf & 2) {
@@ -2348,10 +1993,25 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nMsgWithPostprocess(
+          '{$startTagNgTemplate} Template A: {$interpolation} {$startTagNgTemplate} Template B: {$interpolation_1} {$startTagNgTemplate} Template C: {$interpolation_2} {$closeTagNgTemplate}{$closeTagNgTemplate}{$closeTagNgTemplate}',
+          [
+            [
+              'startTagNgTemplate', String.raw`[\uFFFD*2:1\uFFFD|\uFFFD*2:2\uFFFD|\uFFFD*1:3\uFFFD]`
+            ],
+            [
+              'closeTagNgTemplate',
+              String.raw`[\uFFFD/*1:3\uFFFD|\uFFFD/*2:2\uFFFD|\uFFFD/*2:1\uFFFD]`
+            ],
+            ['interpolation', String.raw`\uFFFD0:1\uFFFD`],
+            ['interpolation_1', String.raw`\uFFFD0:2\uFFFD`],
+            ['interpolation_2', String.raw`\uFFFD0:3\uFFFD`]
+          ]);
+
       const output = String.raw`
         function MyComponent_ng_template_2_ng_template_2_ng_template_1_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18n(0, $I18N_0$, 3);
+            $r3$.ɵɵi18n(0, $i18n_0$, 3);
           }
           if (rf & 2) {
             const $ctx_r2$ = $r3$.ɵɵnextContext(3);
@@ -2361,7 +2021,7 @@ describe('i18n support in the template compiler', () => {
         }
         function MyComponent_ng_template_2_ng_template_2_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18nStart(0, $I18N_0$, 2);
+            $r3$.ɵɵi18nStart(0, $i18n_0$, 2);
             $r3$.ɵɵtemplate(1, MyComponent_ng_template_2_ng_template_2_ng_template_1_Template, 1, 1, "ng-template");
             $r3$.ɵɵi18nEnd();
           }
@@ -2372,36 +2032,10 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵi18nApply(0);
           }
         }
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_2051477021417799640$$APP_SPEC_TS_0$ = goog.getMsg("{$startTagNgTemplate} Template A: {$interpolation} {$startTagNgTemplate} Template B: {$interpolation_1} {$startTagNgTemplate} Template C: {$interpolation_2} {$closeTagNgTemplate}{$closeTagNgTemplate}{$closeTagNgTemplate}", {
-              "startTagNgTemplate": "[\uFFFD*2:1\uFFFD|\uFFFD*2:2\uFFFD|\uFFFD*1:3\uFFFD]",
-              "closeTagNgTemplate": "[\uFFFD/*1:3\uFFFD|\uFFFD/*2:2\uFFFD|\uFFFD/*2:1\uFFFD]",
-              "interpolation": "\uFFFD0:1\uFFFD",
-              "interpolation_1": "\uFFFD0:2\uFFFD",
-              "interpolation_2": "\uFFFD0:3\uFFFD"
-            });
-            $I18N_0$ = $MSG_EXTERNAL_2051477021417799640$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`$` +
-          String.raw
-      `{"[\uFFFD*2:1\uFFFD|\uFFFD*2:2\uFFFD|\uFFFD*1:3\uFFFD]"}:START_TAG_NG_TEMPLATE: Template A: $` +
-          String.raw`{"\uFFFD0:1\uFFFD"}:INTERPOLATION: $` + String.raw
-      `{"[\uFFFD*2:1\uFFFD|\uFFFD*2:2\uFFFD|\uFFFD*1:3\uFFFD]"}:START_TAG_NG_TEMPLATE: Template B: $` +
-          String.raw`{"\uFFFD0:2\uFFFD"}:INTERPOLATION_1: $` + String.raw
-      `{"[\uFFFD*2:1\uFFFD|\uFFFD*2:2\uFFFD|\uFFFD*1:3\uFFFD]"}:START_TAG_NG_TEMPLATE: Template C: $` +
-          String.raw`{"\uFFFD0:3\uFFFD"}:INTERPOLATION_2: $` + String.raw
-      `{"[\uFFFD/*1:3\uFFFD|\uFFFD/*2:2\uFFFD|\uFFFD/*2:1\uFFFD]"}:CLOSE_TAG_NG_TEMPLATE:$` +
-          String.raw
-      `{"[\uFFFD/*1:3\uFFFD|\uFFFD/*2:2\uFFFD|\uFFFD/*2:1\uFFFD]"}:CLOSE_TAG_NG_TEMPLATE:$` +
-          String.raw
-      `{"[\uFFFD/*1:3\uFFFD|\uFFFD/*2:2\uFFFD|\uFFFD/*2:1\uFFFD]"}:CLOSE_TAG_NG_TEMPLATE:\`;
-        }
-        $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$);
+        ${i18n_0}
         function MyComponent_ng_template_2_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18nStart(0, $I18N_0$, 1);
+            $r3$.ɵɵi18nStart(0, $i18n_0$, 1);
             $r3$.ɵɵpipe(1, "uppercase");
             $r3$.ɵɵtemplate(2, MyComponent_ng_template_2_ng_template_2_Template, 2, 1, "ng-template");
             $r3$.ɵɵi18nEnd();
@@ -2419,7 +2053,7 @@ describe('i18n support in the template compiler', () => {
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $I18N_0$);
+            $r3$.ɵɵi18nStart(1, $i18n_0$);
             $r3$.ɵɵtemplate(2, MyComponent_ng_template_2_Template, 3, 3, "ng-template");
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
@@ -2436,29 +2070,16 @@ describe('i18n support in the template compiler', () => {
         <ng-template i18n>{age, select, 10 {ten} 20 {twenty} other {other}}</ng-template>
       `;
 
+      const i18n_0 = i18nIcuMsg(
+          '{VAR_SELECT, select, male {male} female {female} other {other}}',
+          [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
+      const i18n_1 = i18nIcuMsg(
+          '{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}',
+          [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
-            $I18N_0$ = $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`{VAR_SELECT, select, male {male} female {female} other {other}}\`;
-        }
-        $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
-        });
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_8806993169187953163$$APP_SPEC_TS__1$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}");
-            $I18N_1$ = $MSG_EXTERNAL_8806993169187953163$$APP_SPEC_TS__1$;
-        }
-        else {
-            $I18N_1$ = $localize \`{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}\`;
-        }
-        $I18N_1$ = $r3$.ɵɵi18nPostprocess($I18N_1$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
-        });
+        ${i18n_0}
+        ${i18n_1}
         function MyComponent_ng_template_2_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵi18n(0, $I18N_1$);
@@ -2475,7 +2096,7 @@ describe('i18n support in the template compiler', () => {
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementContainerStart(0);
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵelementContainerEnd();
             $r3$.ɵɵtemplate(2, MyComponent_ng_template_2_Template, 1, 1, "ng-template");
           }
@@ -2500,32 +2121,17 @@ describe('i18n support in the template compiler', () => {
         </ng-template>
       `;
 
+      const i18n_0 = i18nMsg(
+          '{$tagImg} is my logo #1 ', [['tagImg', String.raw`\uFFFD#2\uFFFD\uFFFD/#2\uFFFD`]]);
+      const i18n_1 = i18nMsg(
+          '{$tagImg} is my logo #2 ', [['tagImg', String.raw`\uFFFD#1\uFFFD\uFFFD/#1\uFFFD`]]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_4891196282781544695$$APP_SPEC_TS_0$ = goog.getMsg("{$tagImg} is my logo #1 ", {
-              "tagImg": "\uFFFD#2\uFFFD\uFFFD/#2\uFFFD"
-            });
-            $I18N_0$ = $MSG_EXTERNAL_4891196282781544695$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`$` +
-          String.raw`{"\uFFFD#2\uFFFD\uFFFD/#2\uFFFD"}:TAG_IMG: is my logo #1 \`;
-        }
-        var $I18N_2$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_461986953980355147$$APP_SPEC_TS__2$ = goog.getMsg("{$tagImg} is my logo #2 ", {
-              "tagImg": "\uFFFD#1\uFFFD\uFFFD/#1\uFFFD"
-            });
-            $I18N_2$ = $MSG_EXTERNAL_461986953980355147$$APP_SPEC_TS__2$;
-        }
-        else {
-            $I18N_2$ = $localize \`$` +
-          String.raw`{"\uFFFD#1\uFFFD\uFFFD/#1\uFFFD"}:TAG_IMG: is my logo #2 \`;
-        }
+        ${i18n_0}
+        ${i18n_1}
         function MyComponent_ng_template_3_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18nStart(0, $I18N_2$);
+            $r3$.ɵɵi18nStart(0, $i18n_1$);
             $r3$.ɵɵelement(1, "img", 0);
             $r3$.ɵɵi18nEnd();
           }
@@ -2535,7 +2141,7 @@ describe('i18n support in the template compiler', () => {
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementContainerStart(0);
-            $r3$.ɵɵi18nStart(1, $I18N_0$);
+            $r3$.ɵɵi18nStart(1, $i18n_0$);
             $r3$.ɵɵelement(2, "img", 0);
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementContainerEnd();
@@ -2557,23 +2163,11 @@ describe('i18n support in the template compiler', () => {
         </ng-template>
       `;
 
-      const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_8537814667662432133$$APP_SPEC_TS__0$ = goog.getMsg(" Root content {$startTagNgContainer} Nested content {$closeTagNgContainer}", {
-              "startTagNgContainer": "\uFFFD*1:1\uFFFD\uFFFD#1:1\uFFFD",
-              "closeTagNgContainer": "\uFFFD/#1:1\uFFFD\uFFFD/*1:1\uFFFD"
-            });
-            $I18N_0$ = $MSG_EXTERNAL_8537814667662432133$$APP_SPEC_TS__0$;
-        }
-        else {
-            $I18N_0$ = $localize \` Root content $` +
-          String.raw
-      `{"\uFFFD*1:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_NG_CONTAINER: Nested content $` +
-          String.raw`{"\uFFFD/#1:1\uFFFD\uFFFD/*1:1\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
-        }
-        …
-      `;
+      const output =
+          i18nMsg(' Root content {$startTagNgContainer} Nested content {$closeTagNgContainer}', [
+            ['startTagNgContainer', String.raw`\uFFFD*1:1\uFFFD\uFFFD#1:1\uFFFD`],
+            ['closeTagNgContainer', String.raw`\uFFFD/#1:1\uFFFD\uFFFD/*1:1\uFFFD`]
+          ]);
 
       verify(input, output);
     });
@@ -2586,25 +2180,10 @@ describe('i18n support in the template compiler', () => {
 
       // TODO(FW-635): currently we generate unique consts for each i18n block even though it
       // might contain the same content. This should be optimized by translation statements caching,
-      // that can be implemented in the future within FW-635.
+      // that can be implemented in the future.
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_6563391987554512024$$APP_SPEC_TS_0$ = goog.getMsg("Test");
-            $I18N_0$ = $MSG_EXTERNAL_6563391987554512024$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`Test\`;
-        }
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_6563391987554512024$$APP_SPEC_TS_1$ = goog.getMsg("Test");
-            $I18N_1$ = $MSG_EXTERNAL_6563391987554512024$$APP_SPEC_TS_1$;
-        }
-        else {
-            $I18N_1$ = $localize \`Test\`;
-        }
-        …
+        ${i18nMsg('Test')}
+        ${i18nMsg('Test')}
       `;
 
       verify(input, output);
@@ -2617,24 +2196,20 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nMsg(' Hello {$startTagNgContainer}there{$closeTagNgContainer}', [
+        ['startTagNgContainer', String.raw`\uFFFD#2\uFFFD`],
+        ['closeTagNgContainer', String.raw`\uFFFD/#2\uFFFD`]
+      ]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-          const $MSG_APP_SPEC_TS_1$ = goog.getMsg(" Hello {$startTagNgContainer}there{$closeTagNgContainer}", { "startTagNgContainer": "\uFFFD#2\uFFFD", "closeTagNgContainer": "\uFFFD/#2\uFFFD" });
-          $I18N_0$ = $MSG_APP_SPEC_TS_1$;
-        }
-        else {
-          $I18N_0$ = $localize \` Hello $` +
-          String.raw`{"\uFFFD#2\uFFFD"}:START_TAG_NG_CONTAINER:there$` +
-          String.raw`{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
-        }
+        ${i18n_0}
         …
         decls: 3,
         vars: 0,
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, I18N_0);
+            $r3$.ɵɵi18nStart(1, $i18n_0$);
             $r3$.ɵɵelementContainer(2);
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
@@ -2653,19 +2228,17 @@ describe('i18n support in the template compiler', () => {
           </div>
         `;
 
+         const i18n_0 = i18nMsg(
+             ' Hello {$startTagNgContainer}there {$startTagStrong}!{$closeTagStrong}{$closeTagNgContainer}',
+             [
+               ['startTagNgContainer', String.raw`\uFFFD#2\uFFFD`],
+               ['startTagStrong', String.raw`\uFFFD#3\uFFFD`],
+               ['closeTagStrong', String.raw`\uFFFD/#3\uFFFD`],
+               ['closeTagNgContainer', String.raw`\uFFFD/#2\uFFFD`]
+             ]);
+
          const output = String.raw`
-          var $I18N_0$;
-          if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_APP_SPEC_TS_1$ = goog.getMsg(" Hello {$startTagNgContainer}there {$startTagStrong}!{$closeTagStrong}{$closeTagNgContainer}", { "startTagNgContainer": "\uFFFD#2\uFFFD", "startTagStrong": "\uFFFD#3\uFFFD", "closeTagStrong": "\uFFFD/#3\uFFFD", "closeTagNgContainer": "\uFFFD/#2\uFFFD" });
-            $I18N_0$ = $MSG_APP_SPEC_TS_1$;
-          }
-          else {
-            $I18N_0$ = $localize \` Hello $` +
-             String.raw`{"\uFFFD#2\uFFFD"}:START_TAG_NG_CONTAINER:there $` +
-             String.raw`{"\uFFFD#3\uFFFD"}:START_TAG_STRONG:!$` +
-             String.raw`{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_STRONG:$` +
-             String.raw`{"\uFFFD/#2\uFFFD"}:CLOSE_TAG_NG_CONTAINER:\`;
-          }
+          ${i18n_0}
           …
           decls: 4,
           vars: 0,
@@ -2685,25 +2258,22 @@ describe('i18n support in the template compiler', () => {
          verify(input, output);
        });
 
-    // Note: applying structural directives to <ng-template> is typically user error, but it is
-    // technically allowed, so we need to support it.
+    // Note: applying structural directives to <ng-template> is typically user error,
+    // but it is technically allowed, so we need to support it.
     it('should handle structural directives', () => {
       const input = `
         <ng-template *ngIf="someFlag" i18n>Content A</ng-template>
         <ng-container *ngIf="someFlag" i18n>Content B</ng-container>
       `;
 
+      const i18n_0 = i18nMsg('Content A');
+      const i18n_1 = i18nMsg('Content B');
+
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_3308216566145348998$$APP_SPEC_TS___2$ = goog.getMsg("Content A");
-            $I18N_1$ = $MSG_EXTERNAL_3308216566145348998$$APP_SPEC_TS___2$;
-        } else {
-            $I18N_1$ = $localize \`Content A\`;
-        }
+        ${i18n_0}
         function MyComponent_0_ng_template_0_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18n(0, $I18N_1$);
+            $r3$.ɵɵi18n(0, $i18n_0$);
           }
         }
         function MyComponent_0_Template(rf, ctx) {
@@ -2711,17 +2281,11 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵtemplate(0, MyComponent_0_ng_template_0_Template, 1, 0, "ng-template");
           }
         }
-        var $I18N_3$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_8349021389088127654$$APP_SPEC_TS__4$ = goog.getMsg("Content B");
-            $I18N_3$ = $MSG_EXTERNAL_8349021389088127654$$APP_SPEC_TS__4$;
-        } else {
-            $I18N_3$ = $localize \`Content B\`;
-        }
+        ${i18n_1}
         function MyComponent_ng_container_1_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementContainerStart(0);
-            $r3$.ɵɵi18n(1, $I18N_3$);
+            $r3$.ɵɵi18n(1, $i18n_1$);
             $r3$.ɵɵelementContainerEnd();
           }
         }
@@ -2754,6 +2318,8 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      // Keeping raw content (avoiding `i18nMsg`) to illustrate message layout
+      // in case of whitespace preserving mode.
       const output = String.raw`
         var $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
@@ -2795,18 +2361,12 @@ describe('i18n support in the template compiler', () => {
         <div i18n>{gender, select, male {male} female {female} other {other}}</div>
       `;
 
+      const i18n_0 = i18nIcuMsg(
+          '{VAR_SELECT, select, male {male} female {female} other {other}}',
+          [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
-            $I18N_0$ = $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`{VAR_SELECT, select, male {male} female {female} other {other}}\`;
-        }
-        $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
-        });
+        ${i18n_0}
         …
         decls: 2,
         vars: 1,
@@ -2854,24 +2414,18 @@ describe('i18n support in the template compiler', () => {
         {age, select, 10 {ten} 20 {twenty} other {other}}
       `;
 
+      const i18n_0 = i18nIcuMsg(
+          '{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}',
+          [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_8806993169187953163$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}");
-            $I18N_0$ = $MSG_EXTERNAL_8806993169187953163$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}\`;
-        }
-        $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
-        });
+        ${i18n_0}
         …
         decls: 1,
         vars: 1,
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18n(0, $I18N_0$);
+            $r3$.ɵɵi18n(0, $i18n_0$);
           }
           if (rf & 2) {
             $r3$.ɵɵi18nExp(ctx.age);
@@ -2894,34 +2448,25 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nIcuMsg(
+          '{VAR_SELECT, select, male {male} female {female} other {other}}',
+          [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
+      const i18n_1 = i18nIcuMsg(
+          '{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}',
+          [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
+      const i18n_2 = i18nIcuMsg(
+          '{VAR_SELECT, select, 0 {no emails} 1 {one email} other {{INTERPOLATION} emails}}', [
+            ['VAR_SELECT', String.raw`\uFFFD0\uFFFD`], ['INTERPOLATION', String.raw`\uFFFD1\uFFFD`]
+          ]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
-            $I18N_0$ = $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`{VAR_SELECT, select, male {male} female {female} other {other}}\`;
-        }
-        $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
-        });
-        var $I18N_3$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_8806993169187953163$$APP_SPEC_TS__3$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}");
-            $I18N_3$ = $MSG_EXTERNAL_8806993169187953163$$APP_SPEC_TS__3$;
-        }
-        else {
-            $I18N_3$ = $localize \`{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}\`;
-        }
-        $I18N_3$ = $r3$.ɵɵi18nPostprocess($I18N_3$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
-        });
+        ${i18n_0}
+        ${i18n_1}
         function MyComponent_div_2_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 2);
             $r3$.ɵɵtext(1, " ");
-            $r3$.ɵɵi18n(2, $I18N_3$);
+            $r3$.ɵɵi18n(2, $i18n_1$);
             $r3$.ɵɵtext(3, " ");
             $r3$.ɵɵelementEnd();
           }
@@ -2932,23 +2477,12 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵi18nApply(2);
           }
         }
-        var $I18N_5$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_1922743304863699161$$APP_SPEC_TS__5$ = goog.getMsg("{VAR_SELECT, select, 0 {no emails} 1 {one email} other {{INTERPOLATION} emails}}");
-            $I18N_5$ = $MSG_EXTERNAL_1922743304863699161$$APP_SPEC_TS__5$;
-        }
-        else {
-            $I18N_5$ = $localize \`{VAR_SELECT, select, 0 {no emails} 1 {one email} other {{INTERPOLATION} emails}}\`;
-        }
-        $I18N_5$ = $r3$.ɵɵi18nPostprocess($I18N_5$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD",
-          "INTERPOLATION": "\uFFFD1\uFFFD"
-        });
+        ${i18n_2}
         function MyComponent_div_3_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 3);
             $r3$.ɵɵtext(1, " You have ");
-            $r3$.ɵɵi18n(2, $I18N_5$);
+            $r3$.ɵɵi18n(2, $i18n_2$);
             $r3$.ɵɵtext(3, ". ");
             $r3$.ɵɵelementEnd();
           }
@@ -2968,7 +2502,7 @@ describe('i18n support in the template compiler', () => {
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵelementEnd();
             $r3$.ɵɵtemplate(2, MyComponent_div_2_Template, 4, 1, "div", 0);
             $r3$.ɵɵtemplate(3, MyComponent_div_3_Template, 4, 2, "div", 1);
@@ -2993,24 +2527,18 @@ describe('i18n support in the template compiler', () => {
         <div i18n>{age, select, 10 {ten} 20 {twenty} other {{% other %}}}</div>
       `;
 
+      const i18n_0 =
+          i18nIcuMsg('{VAR_SELECT, select, 10 {ten} 20 {twenty} other {{INTERPOLATION}}}', [
+            ['VAR_SELECT', String.raw`\uFFFD0\uFFFD`], ['INTERPOLATION', String.raw`\uFFFD1\uFFFD`]
+          ]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_2949673783721159566$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} other {{INTERPOLATION}}}");
-            $I18N_0$ = $MSG_EXTERNAL_2949673783721159566$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`{VAR_SELECT, select, 10 {ten} 20 {twenty} other {{INTERPOLATION}}}\`;
-        }
-        $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD",
-          "INTERPOLATION": "\uFFFD1\uFFFD"
-        });
+        ${i18n_0}
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -3033,47 +2561,33 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nIcuMsg(
+          '{VAR_SELECT, select, male {male - {START_BOLD_TEXT}male{CLOSE_BOLD_TEXT}} female {female {START_BOLD_TEXT}female{CLOSE_BOLD_TEXT}} other {{START_TAG_DIV}{START_ITALIC_TEXT}other{CLOSE_ITALIC_TEXT}{CLOSE_TAG_DIV}}}',
+          [
+            ['VAR_SELECT', String.raw`\uFFFD0\uFFFD`],
+            ['START_BOLD_TEXT', '<b>'],
+            ['CLOSE_BOLD_TEXT', '</b>'],
+            ['START_ITALIC_TEXT', '<i>'],
+            ['CLOSE_ITALIC_TEXT', '</i>'],
+            ['START_TAG_DIV', '<div class=\\"other\\">'],
+            ['CLOSE_TAG_DIV', '</div>'],
+          ]);
+
+      const i18n_1 = i18nMsg(
+          ' {$icu} {$startBoldText}Other content{$closeBoldText}{$startTagDiv}{$startItalicText}Another content{$closeItalicText}{$closeTagDiv}',
+          [
+            ['startBoldText', String.raw`\uFFFD#2\uFFFD`],
+            ['closeBoldText', String.raw`\uFFFD/#2\uFFFD`],
+            ['startTagDiv', String.raw`\uFFFD#3\uFFFD`],
+            ['startItalicText', String.raw`\uFFFD#4\uFFFD`],
+            ['closeItalicText', String.raw`\uFFFD/#4\uFFFD`],
+            ['closeTagDiv', String.raw`\uFFFD/#3\uFFFD`],
+            ['icu', '$I18N_0$'],
+          ]);
+
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_2417296354340576868$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male - {START_BOLD_TEXT}male{CLOSE_BOLD_TEXT}} female {female {START_BOLD_TEXT}female{CLOSE_BOLD_TEXT}} other {{START_TAG_DIV}{START_ITALIC_TEXT}other{CLOSE_ITALIC_TEXT}{CLOSE_TAG_DIV}}}");
-            $I18N_1$ = $MSG_EXTERNAL_2417296354340576868$$APP_SPEC_TS_1$;
-        }
-        else {
-            $I18N_1$ = $localize \`{VAR_SELECT, select, male {male - {START_BOLD_TEXT}male{CLOSE_BOLD_TEXT}} female {female {START_BOLD_TEXT}female{CLOSE_BOLD_TEXT}} other {{START_TAG_DIV}{START_ITALIC_TEXT}other{CLOSE_ITALIC_TEXT}{CLOSE_TAG_DIV}}}\`;
-        }
-        $I18N_1$ = $r3$.ɵɵi18nPostprocess($I18N_1$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD",
-          "START_BOLD_TEXT": "<b>",
-          "CLOSE_BOLD_TEXT": "</b>",
-          "START_ITALIC_TEXT": "<i>",
-          "CLOSE_ITALIC_TEXT": "</i>",
-          "START_TAG_DIV": "<div class=\"other\">",
-          "CLOSE_TAG_DIV": "</div>"
-        });
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_5791551881115084301$$APP_SPEC_TS_0$ = goog.getMsg(" {$icu} {$startBoldText}Other content{$closeBoldText}{$startTagDiv}{$startItalicText}Another content{$closeItalicText}{$closeTagDiv}", {
-              "startBoldText": "\uFFFD#2\uFFFD",
-              "closeBoldText": "\uFFFD/#2\uFFFD",
-              "startTagDiv": "\uFFFD#3\uFFFD",
-              "startItalicText": "\uFFFD#4\uFFFD",
-              "closeItalicText": "\uFFFD/#4\uFFFD",
-              "closeTagDiv": "\uFFFD/#3\uFFFD",
-              "icu": $I18N_1$
-            });
-            $I18N_0$ = $MSG_EXTERNAL_5791551881115084301$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \` $` +
-          String.raw`{$I18N_1$}:ICU: $` +
-          String.raw`{"\uFFFD#2\uFFFD"}:START_BOLD_TEXT:Other content$` +
-          String.raw`{"\uFFFD/#2\uFFFD"}:CLOSE_BOLD_TEXT:$` +
-          String.raw`{"\uFFFD#3\uFFFD"}:START_TAG_DIV:$` +
-          String.raw`{"\uFFFD#4\uFFFD"}:START_ITALIC_TEXT:Another content$` +
-          String.raw`{"\uFFFD/#4\uFFFD"}:CLOSE_ITALIC_TEXT:$` +
-          String.raw`{"\uFFFD/#3\uFFFD"}:CLOSE_TAG_DIV:\`;
-        }
+        ${i18n_0}
+        ${i18n_1}
         …
         decls: 5,
         vars: 1,
@@ -3081,7 +2595,7 @@ describe('i18n support in the template compiler', () => {
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $I18N_0$);
+            $r3$.ɵɵi18nStart(1, $i18n_1$);
             $r3$.ɵɵelement(2, "b");
             $r3$.ɵɵelementStart(3, "div", 0);
             $r3$.ɵɵelement(4, "i");
@@ -3105,26 +2619,22 @@ describe('i18n support in the template compiler', () => {
         <div i18n>{gender, select, male {male of age: {{ ageA + ageB + ageC }}} female {female} other {other}}</div>
       `;
 
+      const i18n_0 = i18nIcuMsg(
+          '{VAR_SELECT, select, male {male of age: {INTERPOLATION}} female {female} other {other}}',
+          [
+            ['VAR_SELECT', String.raw`\uFFFD0\uFFFD`],
+            ['INTERPOLATION', String.raw`\uFFFD1\uFFFD`],
+          ]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_6879461626778511059$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male of age: {INTERPOLATION}} female {female} other {other}}");
-            $I18N_0$ = $MSG_EXTERNAL_6879461626778511059$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`{VAR_SELECT, select, male {male of age: {INTERPOLATION}} female {female} other {other}}\`;
-        }
-        $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD",
-          "INTERPOLATION": "\uFFFD1\uFFFD"
-        });
+        ${i18n_0}
         …
         decls: 2,
         vars: 2,
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -3146,48 +2656,28 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nIcuMsg(
+          '{VAR_SELECT, select, male {male} female {female} other {other}}',
+          [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
+      const i18n_1 = i18nIcuMsg(
+          '{VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other}}',
+          [['VAR_SELECT', String.raw`\uFFFD1\uFFFD`]]);
+      const i18n_2 = i18nMsg(' {$icu} {$icu_1} ', [
+        ['icu', '$i18n_0$'],
+        ['icu_1', '$i18n_1$'],
+      ]);
+
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
-            $I18N_1$ = $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_1$;
-        }
-        else {
-            $I18N_1$ = $localize \`{VAR_SELECT, select, male {male} female {female} other {other}}\`;
-        }
-        $I18N_1$ = $r3$.ɵɵi18nPostprocess($I18N_1$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
-        });
-        var $I18N_2$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_7068143081688428291$$APP_SPEC_TS_2$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other}}");
-            $I18N_2$ = $MSG_EXTERNAL_7068143081688428291$$APP_SPEC_TS_2$;
-        }
-        else {
-            $I18N_2$ = $localize \`{VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other}}\`;
-        }
-        $I18N_2$ = $r3$.ɵɵi18nPostprocess($I18N_2$, {
-          "VAR_SELECT": "\uFFFD1\uFFFD"
-        });
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_2967249209167308918$$APP_SPEC_TS_0$ = goog.getMsg(" {$icu} {$icu_1} ", {
-              "icu": $I18N_1$,
-              "icu_1": $I18N_2$
-            });
-            $I18N_0$ = $MSG_EXTERNAL_2967249209167308918$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \` $` +
-          String.raw`{$I18N_1$}:ICU: $` + String.raw`{$I18N_2$}:ICU_1: \`;
-        }
+        ${i18n_0}
+        ${i18n_1}
+        ${i18n_2}
         …
         decls: 2,
         vars: 2,
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_2$);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -3306,9 +2796,9 @@ describe('i18n support in the template compiler', () => {
         }
       `;
 
-      // TODO(akushnir): this use-case is currently supported with
+      // TODO(FW-635): this use-case is currently supported with
       // file-based prefix for translation const names. Translation statements
-      // caching is required to support this use-case (FW-635) with id-based consts.
+      // caching is required to support this use-case with id-based consts.
       verify(input, output, {skipIdBasedCheck: true});
     });
 
@@ -3323,34 +2813,21 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nIcuMsg(
+          '{VAR_SELECT_1, select, male {male of age: {VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other}}} female {female} other {other}}',
+          [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`], ['VAR_SELECT_1', String.raw`\uFFFD1\uFFFD`]]);
+      const i18n_1 = i18nMsg(' {$icu} ', [['icu', '$i18n_0$']]);
+
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_343563413083115114$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT_1, select, male {male of age: {VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other}}} female {female} other {other}}");
-            $I18N_1$ = $MSG_EXTERNAL_343563413083115114$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_1$ = $localize \`{VAR_SELECT_1, select, male {male of age: {VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other}}} female {female} other {other}}\`;
-        }
-        $I18N_1$ = $r3$.ɵɵi18nPostprocess($I18N_1$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD",
-          "VAR_SELECT_1": "\uFFFD1\uFFFD"
-        });
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_3052001905251380936$$APP_SPEC_TS_3$ = goog.getMsg(" {$icu} ", { "icu": $I18N_1$ });
-            $I18N_0$ = $MSG_EXTERNAL_3052001905251380936$$APP_SPEC_TS_3$;
-        }
-        else {
-            $I18N_0$ = $localize \` $` +
-          String.raw`{$I18N_1$}:ICU: \`;
-        }        …
+        ${i18n_0}
+        ${i18n_1}
+        …
         decls: 2,
         vars: 2,
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_1$);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -3379,27 +2856,23 @@ describe('i18n support in the template compiler', () => {
         }</div>
       `;
 
+      const i18n_0 = i18nIcuMsg(
+          '{VAR_PLURAL, plural, =0 {zero} =2 {{INTERPOLATION} {VAR_SELECT, select, cat {cats} dog {dogs} other {animals}} !} other {other - {INTERPOLATION}}}',
+          [
+            ['VAR_SELECT', String.raw`\uFFFD0\uFFFD`],
+            ['VAR_PLURAL', String.raw`\uFFFD1\uFFFD`],
+            ['INTERPOLATION', String.raw`\uFFFD2\uFFFD`],
+          ]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_6870293071705078389$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_PLURAL, plural, =0 {zero} =2 {{INTERPOLATION} {VAR_SELECT, select, cat {cats} dog {dogs} other {animals}} !} other {other - {INTERPOLATION}}}");
-            $I18N_0$ = $MSG_EXTERNAL_6870293071705078389$$APP_SPEC_TS_1$;
-        }
-        else {
-            $I18N_0$ = $localize \`{VAR_PLURAL, plural, =0 {zero} =2 {{INTERPOLATION} {VAR_SELECT, select, cat {cats} dog {dogs} other {animals}} !} other {other - {INTERPOLATION}}}\`;
-        }
-        $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD",
-          "VAR_PLURAL": "\uFFFD1\uFFFD",
-          "INTERPOLATION": "\uFFFD2\uFFFD"
-        });
+        ${i18n_0}
         …
         decls: 2,
         vars: 3,
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -3423,49 +2896,27 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nIcuMsg(
+          '{VAR_SELECT, select, male {male} female {female} other {other}}',
+          [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
+      const i18n_1 = i18nIcuMsg(
+          '{VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other}}',
+          [['VAR_SELECT', String.raw`\uFFFD0:1\uFFFD`]]);
+      const i18n_2 = i18nMsg(' {$icu} {$startTagSpan} {$icu_1} {$closeTagSpan}', [
+        ['startTagSpan', String.raw`\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD`],
+        ['closeTagSpan', String.raw`\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD`],
+        ['icu', '$i18n_0$'],
+        ['icu_1', '$i18n_1$'],
+      ]);
+
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
-            $I18N_1$ = $MSG_EXTERNAL_7842238767399919809$$APP_SPEC_TS_1$;
-        }
-        else {
-            $I18N_1$ = $localize \`{VAR_SELECT, select, male {male} female {female} other {other}}\`;
-        }
-        $I18N_1$ = $r3$.ɵɵi18nPostprocess($I18N_1$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD"
-        });
-        var $I18N_3$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_7068143081688428291$$APP_SPEC_TS__3$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other}}");
-            $I18N_3$ = $MSG_EXTERNAL_7068143081688428291$$APP_SPEC_TS__3$;
-        }
-        else {
-            $I18N_3$ = $localize \`{VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other}}\`;
-        }
-        $I18N_3$ = $r3$.ɵɵi18nPostprocess($I18N_3$, {
-          "VAR_SELECT": "\uFFFD0:1\uFFFD"
-        });
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_1194472282609532229$$APP_SPEC_TS_0$ = goog.getMsg(" {$icu} {$startTagSpan} {$icu_1} {$closeTagSpan}", {
-              "startTagSpan": "\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD",
-              "closeTagSpan": "\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD",
-              "icu": $I18N_1$,
-              "icu_1": $I18N_3$
-            });
-            $I18N_0$ = $MSG_EXTERNAL_1194472282609532229$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \` $` +
-          String.raw`{$I18N_1$}:ICU: $` +
-          String.raw`{"\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_SPAN: $` +
-          String.raw`{$I18N_3$}:ICU_1: $` +
-          String.raw`{"\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD"}:CLOSE_TAG_SPAN:\`;
-        }
+        ${i18n_0}
+        ${i18n_1}
+        ${i18n_2}
+        …
         function MyComponent_span_2_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18nStart(0, $I18N_0$, 1);
+            $r3$.ɵɵi18nStart(0, $i18n_2$, 1);
             $r3$.ɵɵelement(1, "span");
             $r3$.ɵɵi18nEnd();
           }
@@ -3483,7 +2934,7 @@ describe('i18n support in the template compiler', () => {
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $I18N_0$);
+            $r3$.ɵɵi18nStart(1, $i18n_2$);
             $r3$.ɵɵtemplate(2, MyComponent_span_2_Template, 2, 1, "span", 0);
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
@@ -3510,52 +2961,32 @@ describe('i18n support in the template compiler', () => {
         </div>
       `;
 
+      const i18n_0 = i18nIcuMsg(
+          '{VAR_SELECT, select, male {male {INTERPOLATION}} female {female {INTERPOLATION_1}} other {other}}',
+          [
+            ['VAR_SELECT', String.raw`\uFFFD0\uFFFD`],
+            ['INTERPOLATION', String.raw`\uFFFD1\uFFFD`],
+            ['INTERPOLATION_1', String.raw`\uFFFD2\uFFFD`],
+          ]);
+      const i18n_1 = i18nIcuMsg(
+          '{VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other: {INTERPOLATION}}}', [
+            ['VAR_SELECT', String.raw`\uFFFD0:1\uFFFD`],
+            ['INTERPOLATION', String.raw`\uFFFD1:1\uFFFD`],
+          ]);
+      const i18n_2 = i18nMsg(' {$icu} {$startTagSpan} {$icu_1} {$closeTagSpan}', [
+        ['startTagSpan', String.raw`\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD`],
+        ['closeTagSpan', String.raw`\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD`],
+        ['icu', '$i18n_0$'],
+        ['icu_1', '$i18n_1$'],
+      ]);
+
       const output = String.raw`
-        var $I18N_1$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_7825031864601787094$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male {INTERPOLATION}} female {female {INTERPOLATION_1}} other {other}}");
-            $I18N_1$ = $MSG_EXTERNAL_7825031864601787094$$APP_SPEC_TS_1$;
-        }
-        else {
-            $I18N_1$ = $localize \`{VAR_SELECT, select, male {male {INTERPOLATION}} female {female {INTERPOLATION_1}} other {other}}\`;
-        }
-        $I18N_1$ = $r3$.ɵɵi18nPostprocess($I18N_1$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD",
-          "INTERPOLATION": "\uFFFD1\uFFFD",
-          "INTERPOLATION_1": "\uFFFD2\uFFFD"
-        });
-        var $I18N_3$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_2310343208266678305$$APP_SPEC_TS__3$ = goog.getMsg("{VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other: {INTERPOLATION}}}");
-            $I18N_3$ = $MSG_EXTERNAL_2310343208266678305$$APP_SPEC_TS__3$;
-        }
-        else {
-            $I18N_4$ = $localize \`{VAR_SELECT, select, 10 {ten} 20 {twenty} 30 {thirty} other {other: {INTERPOLATION}}}\`;
-        }
-        $I18N_3$ = $r3$.ɵɵi18nPostprocess($I18N_3$, {
-          "VAR_SELECT": "\uFFFD0:1\uFFFD",
-          "INTERPOLATION": "\uFFFD1:1\uFFFD"
-        });
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_7186042105600518133$$APP_SPEC_TS_0$ = goog.getMsg(" {$icu} {$startTagSpan} {$icu_1} {$closeTagSpan}", {
-              "startTagSpan": "\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD",
-              "closeTagSpan": "\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD",
-              "icu": $I18N_1$,
-              "icu_1": $I18N_3$
-            });
-            $I18N_0$ = $MSG_EXTERNAL_7186042105600518133$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \` $` +
-          String.raw`{I18N_1}:ICU: $` +
-          String.raw`{"\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD"}:START_TAG_SPAN: $` +
-          String.raw`{I18N_3}:ICU_1: $` +
-          String.raw`{"\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD"}:CLOSE_TAG_SPAN:\`;
-        }
+        ${i18n_0}
+        ${i18n_1}
+        ${i18n_2}
         function MyComponent_span_2_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵɵi18nStart(0, $I18N_0$, 1);
+            $r3$.ɵɵi18nStart(0, $i18n_2$, 1);
             $r3$.ɵɵelement(1, "span");
             $r3$.ɵɵi18nEnd();
           }
@@ -3573,7 +3004,7 @@ describe('i18n support in the template compiler', () => {
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18nStart(1, $I18N_0$);
+            $r3$.ɵɵi18nStart(1, $i18n_2$);
             $r3$.ɵɵtemplate(2, MyComponent_span_2_Template, 2, 2, "span", 0);
             $r3$.ɵɵi18nEnd();
             $r3$.ɵɵelementEnd();
@@ -3601,28 +3032,24 @@ describe('i18n support in the template compiler', () => {
         }</div>
       `;
 
+      const i18n_0 = i18nIcuMsg(
+          '{VAR_SELECT, select, male {male {PH_A}} female {female {PH_B}} other {other {PH_WITH_SPACES}}}',
+          [
+            ['VAR_SELECT', String.raw`\uFFFD0\uFFFD`],
+            ['PH_A', String.raw`\uFFFD1\uFFFD`],
+            ['PH_B', String.raw`\uFFFD2\uFFFD`],
+            ['PH_WITH_SPACES', String.raw`\uFFFD3\uFFFD`],
+          ]);
+
       const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            const $MSG_EXTERNAL_6318060397235942326$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, male {male {PH_A}} female {female {PH_B}} other {other {PH_WITH_SPACES}}}");
-            $I18N_0$ = $MSG_EXTERNAL_6318060397235942326$$APP_SPEC_TS_0$;
-        }
-        else {
-            $I18N_0$ = $localize \`{VAR_SELECT, select, male {male {PH_A}} female {female {PH_B}} other {other {PH_WITH_SPACES}}}\`;
-        }
-        $I18N_0$ = $r3$.ɵɵi18nPostprocess($I18N_0$, {
-          "VAR_SELECT": "\uFFFD0\uFFFD",
-          "PH_A": "\uFFFD1\uFFFD",
-          "PH_B": "\uFFFD2\uFFFD",
-          "PH_WITH_SPACES": "\uFFFD3\uFFFD"
-        });
+        ${i18n_0}
         …
         decls: 2,
         vars: 4,
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div");
-            $r3$.ɵɵi18n(1, $I18N_0$);
+            $r3$.ɵɵi18n(1, $i18n_0$);
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
@@ -3641,21 +3068,10 @@ describe('i18n support in the template compiler', () => {
         <div i18n="meaningA|descA@@idA">{count, select, 1 {one} other {more than one}}</div>
       `;
 
-      const output = String.raw`
-        var $I18N_0$;
-        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-            /**
-             * @desc descA
-             * @meaning meaningA
-             */
-            const $MSG_EXTERNAL_idA$$APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, 1 {one} other {more than one}}");
-            $I18N_0$ = $MSG_EXTERNAL_idA$$APP_SPEC_TS_1$;
-        }
-        else {
-            $I18N_0$ = $localize \`:meaningA|descA@@idA:{VAR_SELECT, select, 1 {one} other {more than one}}\`;
-        }
-        $I18N_0$ = i0.ɵɵi18nPostprocess($I18N_0$, { "VAR_SELECT": "\uFFFD0\uFFFD" });
-      `;
+      const output = i18nMsgWithPostprocess(
+          '{VAR_SELECT, select, 1 {one} other {more than one}}', [],
+          {meaning: 'meaningA', desc: 'descA', id: 'idA'},
+          [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
 
       verify(input, output);
     });
@@ -3669,25 +3085,16 @@ describe('i18n support in the template compiler', () => {
             </div>
           `;
 
+         const i18n_0 = i18nIcuMsg(
+             '{VAR_SELECT , select , 1 {one} other {more than one}}',
+             [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`]]);
+         const i18n_1 = i18nIcuMsg(
+             '{VAR_PLURAL , plural , =1 {one} other {more than one}}',
+             [['VAR_PLURAL', String.raw`\uFFFD1\uFFFD`]]);
+
          const output = String.raw`
-            var $I18N_1$;
-            if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-                const $MSG_EXTERNAL_199763560911211963$$APP_SPEC_TS_2$ = goog.getMsg("{VAR_SELECT , select , 1 {one} other {more than one}}");
-                $I18N_1$ = $MSG_EXTERNAL_199763560911211963$$APP_SPEC_TS_2$;
-            }
-            else {
-                $I18N_1$ = $localize \`{VAR_SELECT , select , 1 {one} other {more than one}}\`;
-            }
-            $I18N_1$ = i0.ɵɵi18nPostprocess($I18N_1$, { "VAR_SELECT": "\uFFFD0\uFFFD" });
-            var $I18N_3$;
-            if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
-                const $MSG_EXTERNAL_3383986062053865025$$APP_SPEC_TS_4$ = goog.getMsg("{VAR_PLURAL , plural , =1 {one} other {more than one}}");
-                $I18N_3$ = $MSG_EXTERNAL_3383986062053865025$$APP_SPEC_TS_4$;
-            }
-            else {
-                $I18N_3$ = $localize \`{VAR_PLURAL , plural , =1 {one} other {more than one}}\`;
-            }
-            $I18N_3$ = i0.ɵɵi18nPostprocess($I18N_3$, { "VAR_PLURAL": "\uFFFD1\uFFFD" });
+            ${i18n_0}
+            ${i18n_1}
           `;
 
          verify(input, output);

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -196,10 +196,19 @@ export function compileComponentFromMetadata(
   // e.g. `vars: 2`
   definitionMap.set('vars', o.literal(templateBuilder.getVarCount()));
 
-  // e.g. `consts: [['one', 'two'], ['three', 'four']]
-  const consts = templateBuilder.getConsts();
-  if (consts.length > 0) {
-    definitionMap.set('consts', o.literalArr(consts));
+  // Generate `consts` section of ComponentDef:
+  // - either as an array:
+  //   `consts: [['one', 'two'], ['three', 'four']]`
+  // - or as a factory function in case additional statements are present (to support i18n):
+  //   `consts: function() { var i18n_0; if (ngI18nClosureMode) {...} else {...} return [i18n_0]; }`
+  const {constExpressions, prepareStatements} = templateBuilder.getConsts();
+  if (constExpressions.length > 0) {
+    let constsExpr: o.LiteralArrayExpr|o.FunctionExpr = o.literalArr(constExpressions);
+    // Prepare statements are present - turn `consts` into a function.
+    if (prepareStatements.length > 0) {
+      constsExpr = o.fn([], [...prepareStatements, new o.ReturnStatement(constsExpr)]);
+    }
+    definitionMap.set('consts', constsExpr);
   }
 
   definitionMap.set('template', templateFunctionExpression);

--- a/packages/compiler/src/render3/view/i18n/util.ts
+++ b/packages/compiler/src/render3/view/i18n/util.ts
@@ -12,10 +12,14 @@ import * as o from '../../../output/output_ast';
 import * as t from '../../r3_ast';
 
 /* Closure variables holding messages must be named `MSG_[A-Z0-9]+` */
-const CLOSURE_TRANSLATION_PREFIX = 'MSG_';
+const CLOSURE_TRANSLATION_VAR_PREFIX = 'MSG_';
 
-/* Prefix for non-`goog.getMsg` i18n-related vars */
-export const TRANSLATION_PREFIX = 'I18N_';
+/**
+ * Prefix for non-`goog.getMsg` i18n-related vars.
+ * Note: the prefix uses lowercase characters intentionally due to a Closure behavior that
+ * considers variables like `I18N_0` as constants and throws an error when their value changes.
+ */
+export const TRANSLATION_VAR_PREFIX = 'i18n_';
 
 /** Name of the i18n attributes **/
 export const I18N_ATTR = 'i18n';
@@ -166,7 +170,7 @@ export function formatI18nPlaceholderName(name: string, useCamelCase: boolean = 
  * @returns Complete translation const prefix
  */
 export function getTranslationConstPrefix(extra: string): string {
-  return `${CLOSURE_TRANSLATION_PREFIX}${extra}`.toUpperCase();
+  return `${CLOSURE_TRANSLATION_VAR_PREFIX}${extra}`.toUpperCase();
 }
 
 /**

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -36,7 +36,7 @@ import {I18nContext} from './i18n/context';
 import {createGoogleGetMsgStatements} from './i18n/get_msg_utils';
 import {createLocalizeStatements} from './i18n/localize_utils';
 import {I18nMetaVisitor} from './i18n/meta';
-import {assembleBoundTextPlaceholders, assembleI18nBoundString, declareI18nVariable, getTranslationConstPrefix, hasI18nMeta, I18N_ICU_MAPPING_PREFIX, i18nFormatPlaceholderNames, icuFromI18nMessage, isI18nRootNode, isSingleI18nIcu, placeholdersToParams, TRANSLATION_PREFIX, wrapI18nPlaceholder} from './i18n/util';
+import {assembleBoundTextPlaceholders, assembleI18nBoundString, declareI18nVariable, getTranslationConstPrefix, hasI18nMeta, I18N_ICU_MAPPING_PREFIX, i18nFormatPlaceholderNames, icuFromI18nMessage, isI18nRootNode, isSingleI18nIcu, placeholdersToParams, TRANSLATION_VAR_PREFIX, wrapI18nPlaceholder} from './i18n/util';
 import {StylingBuilder, StylingInstruction} from './styling_builder';
 import {asLiteral, chainedInstruction, CONTEXT_NAME, getAttrsForDirectiveMatching, getInterpolationArgsLength, IMPLICIT_REFERENCE, invalid, NON_BINDABLE_ATTR, REFERENCE_PREFIX, RENDER_FLAGS, trimTrailingNulls, unsupported} from './util';
 
@@ -101,6 +101,18 @@ export function prepareEventListenerParameters(
         o.importExpr(GLOBAL_TARGET_RESOLVERS.get(target)!));
   }
   return params;
+}
+
+// Collects information needed to generate `consts` field of the ComponentDef.
+// When a constant requires some pre-processing, the `prepareStatements` section
+// contains corresponding statements.
+export interface ComponentDefConsts {
+  prepareStatements: o.Statement[];
+  constExpressions: o.Expression[];
+}
+
+function createComponentDefConsts(): ComponentDefConsts {
+  return {prepareStatements: [], constExpressions: []};
 }
 
 export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver {
@@ -171,7 +183,8 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       private directiveMatcher: SelectorMatcher|null, private directives: Set<o.Expression>,
       private pipeTypeByName: Map<string, o.Expression>, private pipes: Set<o.Expression>,
       private _namespace: o.ExternalReference, relativeContextFilePath: string,
-      private i18nUseExternalIds: boolean, private _constants: o.Expression[] = []) {
+      private i18nUseExternalIds: boolean,
+      private _constants: ComponentDefConsts = createComponentDefConsts()) {
     this._bindingScope = parentBindingScope.nestedScope(level);
 
     // Turn the relative context file path into an identifier by replacing non-alphanumeric
@@ -307,12 +320,12 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   private i18nTranslate(
       message: i18n.Message, params: {[name: string]: o.Expression} = {}, ref?: o.ReadVarExpr,
       transformFn?: (raw: o.ReadVarExpr) => o.Expression): o.ReadVarExpr {
-    const _ref = ref || o.variable(this.constantPool.uniqueName(TRANSLATION_PREFIX));
+    const _ref = ref || this.i18nGenerateMainBlockVar();
     // Closure Compiler requires const names to start with `MSG_` but disallows any other const to
     // start with `MSG_`. We define a variable starting with `MSG_` just for the `goog.getMsg` call
     const closureVar = this.i18nGenerateClosureVar(message.id);
     const statements = getTranslationDeclStmts(message, _ref, closureVar, params, transformFn);
-    this.constantPool.statements.push(...statements);
+    this._constants.prepareStatements.push(...statements);
     return _ref;
   }
 
@@ -364,6 +377,12 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     return bound;
   }
 
+  // Generates top level vars for i18n blocks (i.e. `i18n_N`).
+  private i18nGenerateMainBlockVar(): o.ReadVarExpr {
+    return o.variable(this.constantPool.uniqueName(TRANSLATION_VAR_PREFIX));
+  }
+
+  // Generates vars with Closure-specific names for i18n blocks (i.e. `MSG_XXX`).
   private i18nGenerateClosureVar(messageId: string): o.ReadVarExpr {
     let name: string;
     const suffix = this.fileBasedI18nSuffix.toUpperCase();
@@ -426,16 +445,13 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   private i18nStart(span: ParseSourceSpan|null = null, meta: i18n.I18nMeta, selfClosing?: boolean):
       void {
     const index = this.allocateDataSlot();
-    if (this.i18nContext) {
-      this.i18n = this.i18nContext.forkChildContext(index, this.templateIndex!, meta);
-    } else {
-      const ref = o.variable(this.constantPool.uniqueName(TRANSLATION_PREFIX));
-      this.i18n = new I18nContext(index, ref, 0, this.templateIndex, meta);
-    }
+    this.i18n = this.i18nContext ?
+        this.i18nContext.forkChildContext(index, this.templateIndex!, meta) :
+        new I18nContext(index, this.i18nGenerateMainBlockVar(), 0, this.templateIndex, meta);
 
     // generate i18nStart instruction
     const {id, ref} = this.i18n;
-    const params: o.Expression[] = [o.literal(index), ref];
+    const params: o.Expression[] = [o.literal(index), this.addToConsts(ref)];
     if (id > 0) {
       // do not push 3rd argument (sub-block id)
       // into i18nStart call for top level i18n context
@@ -507,8 +523,8 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
     if (i18nAttrArgs.length > 0) {
       const index: o.Expression = o.literal(this.allocateDataSlot());
-      const args = this.constantPool.getConstLiteral(o.literalArr(i18nAttrArgs), true);
-      this.creationInstruction(sourceSpan, R3.i18nAttributes, [index, args]);
+      const constIndex = this.addToConsts(o.literalArr(i18nAttrArgs));
+      this.creationInstruction(sourceSpan, R3.i18nAttributes, [index, constIndex]);
       if (hasBindings) {
         this.updateInstruction(sourceSpan, R3.i18nApply, [index]);
       }
@@ -1028,7 +1044,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     return this._pureFunctionSlots;
   }
 
-  getConsts() {
+  getConsts(): ComponentDefConsts {
     return this._constants;
   }
 
@@ -1352,14 +1368,16 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       return o.TYPED_NULL_EXPR;
     }
 
+    const consts = this._constants.constExpressions;
+
     // Try to reuse a literal that's already in the array, if possible.
-    for (let i = 0; i < this._constants.length; i++) {
-      if (this._constants[i].isEquivalent(expression)) {
+    for (let i = 0; i < consts.length; i++) {
+      if (consts[i].isEquivalent(expression)) {
         return o.literal(i);
       }
     }
 
-    return o.literal(this._constants.push(expression) - 1);
+    return o.literal(consts.push(expression) - 1);
   }
 
   private addAttrsToConsts(attrs: o.Expression[]): o.LiteralExpr {

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -18,7 +18,7 @@ import {stringify} from '../util/stringify';
 import {EMPTY_ARRAY, EMPTY_OBJ} from './empty';
 import {NG_COMP_DEF, NG_DIR_DEF, NG_FACTORY_DEF, NG_LOC_ID_DEF, NG_MOD_DEF, NG_PIPE_DEF} from './fields';
 import {ComponentDef, ComponentDefFeature, ComponentTemplate, ComponentType, ContentQueriesFunction, DirectiveDef, DirectiveDefFeature, DirectiveTypesOrFactory, FactoryFn, HostBindingsFunction, PipeDef, PipeType, PipeTypesOrFactory, ViewQueriesFunction} from './interfaces/definition';
-import {AttributeMarker, TAttributes, TConstants} from './interfaces/node';
+import {AttributeMarker, TAttributes, TConstantsOrFactory} from './interfaces/node';
 import {CssSelectorList, SelectorFlags} from './interfaces/projection';
 import {NgModuleType} from './ng_module_ref';
 
@@ -220,7 +220,7 @@ export function ɵɵdefineComponent<T>(componentDefinition: {
    * Constants for the nodes in the component's view.
    * Includes attribute arrays, local definition arrays etc.
    */
-  consts?: TConstants;
+  consts?: TConstantsOrFactory;
 
   /**
    * An array of `ngContent[selector]` values that were found in the template.

--- a/packages/core/src/render3/instructions/i18n.ts
+++ b/packages/core/src/render3/instructions/i18n.ts
@@ -15,6 +15,7 @@ import {i18nAttributesFirstPass, i18nStartFirstPass} from '../i18n/i18n_parse';
 import {i18nPostprocess} from '../i18n/i18n_postprocess';
 import {HEADER_OFFSET} from '../interfaces/view';
 import {getLView, getTView, nextBindingIndex} from '../state';
+import {getConstant} from '../util/view_utils';
 
 import {setDelayProjection} from './all';
 
@@ -42,14 +43,15 @@ import {setDelayProjection} from './all';
  *   `template` instruction index. A `block` that matches the sub-template in which it was declared.
  *
  * @param index A unique index of the translation in the static block.
- * @param message The translation message.
+ * @param messageIndex An index of the translation message from the `def.consts` array.
  * @param subTemplateIndex Optional sub-template index in the `message`.
  *
  * @codeGenApi
  */
-export function ɵɵi18nStart(index: number, message: string, subTemplateIndex?: number): void {
+export function ɵɵi18nStart(index: number, messageIndex: number, subTemplateIndex?: number): void {
   const tView = getTView();
   ngDevMode && assertDefined(tView, `tView should be defined`);
+  const message = getConstant<string>(tView.consts, messageIndex)!;
   pushI18nIndex(index);
   // We need to delay projections until `i18nEnd`
   setDelayProjection(true);
@@ -96,13 +98,13 @@ export function ɵɵi18nEnd(): void {
  *   `template` instruction index. A `block` that matches the sub-template in which it was declared.
  *
  * @param index A unique index of the translation in the static block.
- * @param message The translation message.
+ * @param messageIndex An index of the translation message from the `def.consts` array.
  * @param subTemplateIndex Optional sub-template index in the `message`.
  *
  * @codeGenApi
  */
-export function ɵɵi18n(index: number, message: string, subTemplateIndex?: number): void {
-  ɵɵi18nStart(index, message, subTemplateIndex);
+export function ɵɵi18n(index: number, messageIndex: number, subTemplateIndex?: number): void {
+  ɵɵi18nStart(index, messageIndex, subTemplateIndex);
   ɵɵi18nEnd();
 }
 
@@ -114,11 +116,12 @@ export function ɵɵi18n(index: number, message: string, subTemplateIndex?: numb
  *
  * @codeGenApi
  */
-export function ɵɵi18nAttributes(index: number, values: string[]): void {
+export function ɵɵi18nAttributes(index: number, attrsIndex: number): void {
   const lView = getLView();
   const tView = getTView();
   ngDevMode && assertDefined(tView, `tView should be defined`);
-  i18nAttributesFirstPass(lView, tView, index, values);
+  const attrs = getConstant<string[]>(tView.consts, attrsIndex)!;
+  i18nAttributesFirstPass(lView, tView, index, attrs);
 }
 
 

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -26,7 +26,7 @@ import {executeCheckHooks, executeInitAndCheckHooks, incrementInitPhaseFlags} fr
 import {CONTAINER_HEADER_OFFSET, HAS_TRANSPLANTED_VIEWS, LContainer, MOVED_VIEWS} from '../interfaces/container';
 import {ComponentDef, ComponentTemplate, DirectiveDef, DirectiveDefListOrFactory, PipeDefListOrFactory, RenderFlags, ViewQueriesFunction} from '../interfaces/definition';
 import {INJECTOR_BLOOM_PARENT_SIZE, NodeInjectorFactory} from '../interfaces/injector';
-import {AttributeMarker, InitialInputData, InitialInputs, LocalRefExtractor, PropertyAliases, PropertyAliasValue, TAttributes, TConstants, TContainerNode, TDirectiveHostNode, TElementContainerNode, TElementNode, TIcuContainerNode, TNode, TNodeFlags, TNodeProviderIndexes, TNodeType, TProjectionNode, TViewNode} from '../interfaces/node';
+import {AttributeMarker, InitialInputData, InitialInputs, LocalRefExtractor, PropertyAliases, PropertyAliasValue, TAttributes, TConstantsOrFactory, TContainerNode, TDirectiveHostNode, TElementContainerNode, TElementNode, TIcuContainerNode, TNode, TNodeFlags, TNodeProviderIndexes, TNodeType, TProjectionNode, TViewNode} from '../interfaces/node';
 import {isProceduralRenderer, RComment, RElement, Renderer3, RendererFactory3, RNode, RText} from '../interfaces/renderer';
 import {SanitizerFn} from '../interfaces/sanitization';
 import {isComponentDef, isComponentHost, isContentQueryHost, isLContainer, isRootView} from '../interfaces/type_checks';
@@ -650,7 +650,7 @@ export function createTView(
     type: TViewType, viewIndex: number, templateFn: ComponentTemplate<any>|null, decls: number,
     vars: number, directives: DirectiveDefListOrFactory|null, pipes: PipeDefListOrFactory|null,
     viewQuery: ViewQueriesFunction<any>|null, schemas: SchemaMetadata[]|null,
-    consts: TConstants|null): TView {
+    constsOrFactory: TConstantsOrFactory|null): TView {
   ngDevMode && ngDevMode.tView++;
   const bindingStartIndex = HEADER_OFFSET + decls;
   // This length does not yet contain host bindings from child directives because at this point,
@@ -658,6 +658,7 @@ export function createTView(
   // that has a host binding, we will update the blueprint with that def's hostVars count.
   const initialViewLength = bindingStartIndex + vars;
   const blueprint = createViewBlueprint(bindingStartIndex, initialViewLength);
+  const consts = typeof constsOrFactory === 'function' ? constsOrFactory() : constsOrFactory;
   const tView = blueprint[TVIEW as any] = ngDevMode ?
       new TViewConstructor(
           type,

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -10,7 +10,7 @@ import {SchemaMetadata, ViewEncapsulation} from '../../core';
 import {ProcessProvidersFunction} from '../../di/interface/provider';
 import {Type} from '../../interface/type';
 
-import {TAttributes, TConstants} from './node';
+import {TAttributes, TConstantsOrFactory} from './node';
 import {CssSelectorList} from './projection';
 import {TView} from './view';
 
@@ -299,7 +299,7 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
   readonly template: ComponentTemplate<T>;
 
   /** Constants associated with the component's view. */
-  readonly consts: TConstants|null;
+  readonly consts: TConstantsOrFactory|null;
 
   /**
    * An array of `ngContent[selector]` values that were found in the template.

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -255,8 +255,23 @@ export type TAttributes = (string|AttributeMarker|CssSelector)[];
  * Constants that are associated with a view. Includes:
  * - Attribute arrays.
  * - Local definition arrays.
+ * - Translated messages (i18n).
  */
 export type TConstants = (TAttributes|string)[];
+
+/**
+ * Factory function that returns an array of consts. Consts can be represented as a function in case
+ * any additional statements are required to define consts in the list. An example is i18n where
+ * additional i18n calls are generated, which should be executed when consts are requested for the
+ * first time.
+ */
+export type TConstantsFactory = () => TConstants;
+
+/**
+ * TConstants type that describes how the `consts` field is generated on ComponentDef: it can be
+ * either an array or a factory function that returns that array.
+ */
+export type TConstantsOrFactory = TConstants|TConstantsFactory;
 
 /**
  * Binding data (flyweight) for a particular node that is shared between all templates

--- a/packages/core/test/render3/i18n_spec.ts
+++ b/packages/core/test/render3/i18n_spec.ts
@@ -12,6 +12,7 @@ import {getTranslationForTemplate} from '@angular/core/src/render3/i18n/i18n_par
 import {noop} from '../../../compiler/src/render3/view/util';
 import {setDelayProjection, ɵɵelementEnd, ɵɵelementStart} from '../../src/render3/instructions/all';
 import {I18nUpdateOpCodes, TI18n, TIcu} from '../../src/render3/interfaces/i18n';
+import {TConstants} from '../../src/render3/interfaces/node';
 import {HEADER_OFFSET, LView, TVIEW} from '../../src/render3/interfaces/view';
 import {getNativeByIndex} from '../../src/render3/util/view_utils';
 
@@ -57,26 +58,29 @@ describe('Runtime i18n', () => {
   });
 
   function prepareFixture(
-      createTemplate: () => void, updateTemplate: (() => void)|null, nbConsts = 0,
-      nbVars = 0): TemplateFixture {
-    return new TemplateFixture(createTemplate, updateTemplate || noop, nbConsts, nbVars);
+      createTemplate: () => void, updateTemplate: (() => void)|null, nbConsts = 0, nbVars = 0,
+      consts: TConstants = []): TemplateFixture {
+    return new TemplateFixture(
+        createTemplate, updateTemplate || noop, nbConsts, nbVars, null, null, null, undefined,
+        consts);
   }
 
   function getOpCodes(
-      createTemplate: () => void, updateTemplate: (() => void)|null, nbConsts: number,
-      index: number): TI18n|I18nUpdateOpCodes {
-    const fixture = prepareFixture(createTemplate, updateTemplate, nbConsts);
+      messageOrAtrs: string|string[], createTemplate: () => void, updateTemplate: (() => void)|null,
+      nbConsts: number, index: number): TI18n|I18nUpdateOpCodes {
+    const fixture =
+        prepareFixture(createTemplate, updateTemplate, nbConsts, undefined, [messageOrAtrs]);
     const tView = fixture.hostView[TVIEW];
     return tView.data[index + HEADER_OFFSET] as TI18n;
   }
 
   describe('i18nStart', () => {
     it('for text', () => {
-      const MSG_DIV = `simple text`;
+      const message = 'simple text';
       const nbConsts = 1;
       const index = 0;
-      const opCodes = getOpCodes(() => {
-                        ɵɵi18nStart(index, MSG_DIV);
+      const opCodes = getOpCodes(message, () => {
+                        ɵɵi18nStart(index, 0);
                       }, null, nbConsts, index) as TI18n;
 
       expect(opCodes).toEqual({
@@ -91,13 +95,13 @@ describe('Runtime i18n', () => {
     });
 
     it('for elements', () => {
-      const MSG_DIV = `Hello �#2�world�/#2� and �#3�universe�/#3�!`;
+      const message = `Hello �#2�world�/#2� and �#3�universe�/#3�!`;
       // Template: `<div>Hello <div>world</div> and <span>universe</span>!`
       // 3 consts for the 2 divs and 1 span + 1 const for `i18nStart` = 4 consts
       const nbConsts = 4;
       const index = 1;
-      const opCodes = getOpCodes(() => {
-        ɵɵi18nStart(index, MSG_DIV);
+      const opCodes = getOpCodes(message, () => {
+        ɵɵi18nStart(index, 0);
       }, null, nbConsts, index);
 
       expect(opCodes).toEqual({
@@ -124,11 +128,11 @@ describe('Runtime i18n', () => {
     });
 
     it('for simple bindings', () => {
-      const MSG_DIV = `Hello �0�!`;
+      const message = `Hello �0�!`;
       const nbConsts = 2;
       const index = 1;
-      const opCodes = getOpCodes(() => {
-        ɵɵi18nStart(index, MSG_DIV);
+      const opCodes = getOpCodes(message, () => {
+        ɵɵi18nStart(index, 0);
       }, null, nbConsts, index);
 
       expect((opCodes as any).update.debug).toEqual([
@@ -148,11 +152,11 @@ describe('Runtime i18n', () => {
     });
 
     it('for multiple bindings', () => {
-      const MSG_DIV = `Hello �0� and �1�, again �0�!`;
+      const message = `Hello �0� and �1�, again �0�!`;
       const nbConsts = 2;
       const index = 1;
-      const opCodes = getOpCodes(() => {
-        ɵɵi18nStart(index, MSG_DIV);
+      const opCodes = getOpCodes(message, () => {
+        ɵɵi18nStart(index, 0);
       }, null, nbConsts, index);
 
       expect(opCodes).toEqual({
@@ -176,17 +180,15 @@ describe('Runtime i18n', () => {
       //   </span>
       //   !
       // </div>
-      const MSG_DIV =
+      const message =
           `�0� is rendered as: �*2:1��#1:1�before�*2:2��#1:2�middle�/#1:2��/*2:2�after�/#1:1��/*2:1�!`;
 
       /**** Root template ****/
       // �0� is rendered as: �*2:1��/*2:1�!
       let nbConsts = 3;
       let index = 1;
-      const firstTextNode = 3;
-      const rootTemplate = 2;
-      let opCodes = getOpCodes(() => {
-        ɵɵi18nStart(index, MSG_DIV);
+      let opCodes = getOpCodes(message, () => {
+        ɵɵi18nStart(index, 0);
       }, null, nbConsts, index);
 
       expect(opCodes).toEqual({
@@ -207,10 +209,8 @@ describe('Runtime i18n', () => {
       // �#1:1�before�*2:2�middle�/*2:2�after�/#1:1�
       nbConsts = 3;
       index = 0;
-      const spanElement = 1;
-      const bElementSubTemplate = 2;
-      opCodes = getOpCodes(() => {
-        ɵɵi18nStart(index, MSG_DIV, 1);
+      opCodes = getOpCodes(message, () => {
+        ɵɵi18nStart(index, 0, 1);
       }, null, nbConsts, index);
 
       expect(opCodes).toEqual({
@@ -233,9 +233,8 @@ describe('Runtime i18n', () => {
       // middle
       nbConsts = 2;
       index = 0;
-      const bElement = 1;
-      opCodes = getOpCodes(() => {
-        ɵɵi18nStart(index, MSG_DIV, 2);
+      opCodes = getOpCodes(message, () => {
+        ɵɵi18nStart(index, 0, 2);
       }, null, nbConsts, index);
 
       expect(opCodes).toEqual({
@@ -252,15 +251,15 @@ describe('Runtime i18n', () => {
     });
 
     it('for ICU expressions', () => {
-      const MSG_DIV = `{�0�, plural,
+      const message = `{�0�, plural,
         =0 {no <b title="none">emails</b>!}
         =1 {one <i>email</i>}
         other {�0� <span title="�1�">emails</span>}
       }`;
       const nbConsts = 1;
       const index = 0;
-      const opCodes = getOpCodes(() => {
-                        ɵɵi18nStart(index, MSG_DIV);
+      const opCodes = getOpCodes(message, () => {
+                        ɵɵi18nStart(index, 0);
                       }, null, nbConsts, index) as TI18n;
 
       expect(opCodes).toEqual({
@@ -337,7 +336,7 @@ describe('Runtime i18n', () => {
     });
 
     it('for nested ICU expressions', () => {
-      const MSG_DIV = `{�0�, plural,
+      const message = `{�0�, plural,
         =0 {zero}
         other {�0� {�1�, select,
                        cat {cats}
@@ -347,16 +346,9 @@ describe('Runtime i18n', () => {
       }`;
       const nbConsts = 1;
       const index = 0;
-      const opCodes = getOpCodes(() => {
-        ɵɵi18nStart(index, MSG_DIV);
+      const opCodes = getOpCodes(message, () => {
+        ɵɵi18nStart(index, 0);
       }, null, nbConsts, index);
-      const icuCommentNodeIndex = index + 1;
-      const firstTextNodeIndex = index + 2;
-      const nestedIcuCommentNodeIndex = index + 3;
-      const lastTextNodeIndex = index + 4;
-      const nestedTextNodeIndex = index + 5;
-      const tIcuIndex = 1;
-      const nestedTIcuIndex = 0;
 
       expect(opCodes).toEqual({
         vars: 9,
@@ -443,31 +435,31 @@ describe('Runtime i18n', () => {
 
   describe(`i18nAttribute`, () => {
     it('for text', () => {
-      const MSG_title = `Hello world!`;
-      const MSG_div_attr = ['title', MSG_title];
+      const message = `Hello world!`;
+      const attrs = ['title', message];
       const nbConsts = 2;
       const index = 1;
       const fixture = prepareFixture(() => {
         ɵɵelementStart(0, 'div');
-        ɵɵi18nAttributes(index, MSG_div_attr);
+        ɵɵi18nAttributes(index, 0);
         ɵɵelementEnd();
-      }, null, nbConsts, index);
+      }, null, nbConsts, index, [attrs]);
       const tView = fixture.hostView[TVIEW];
       const opCodes = tView.data[index + HEADER_OFFSET] as I18nUpdateOpCodes;
 
       expect(opCodes).toEqual([]);
       expect(
           (getNativeByIndex(0, fixture.hostView as LView) as any as Element).getAttribute('title'))
-          .toEqual(MSG_title);
+          .toEqual(message);
     });
 
     it('for simple bindings', () => {
-      const MSG_title = `Hello �0�!`;
-      const MSG_div_attr = ['title', MSG_title];
+      const message = `Hello �0�!`;
+      const attrs = ['title', message];
       const nbConsts = 2;
       const index = 1;
-      const opCodes = getOpCodes(() => {
-        ɵɵi18nAttributes(index, MSG_div_attr);
+      const opCodes = getOpCodes(attrs, () => {
+        ɵɵi18nAttributes(index, 0);
       }, null, nbConsts, index);
 
       expect(opCodes).toEqual(debugMatch([
@@ -476,12 +468,12 @@ describe('Runtime i18n', () => {
     });
 
     it('for multiple bindings', () => {
-      const MSG_title = `Hello �0� and �1�, again �0�!`;
-      const MSG_div_attr = ['title', MSG_title];
+      const message = `Hello �0� and �1�, again �0�!`;
+      const attrs = ['title', message];
       const nbConsts = 2;
       const index = 1;
-      const opCodes = getOpCodes(() => {
-        ɵɵi18nAttributes(index, MSG_div_attr);
+      const opCodes = getOpCodes(attrs, () => {
+        ɵɵi18nAttributes(index, 0);
       }, null, nbConsts, index);
 
       expect(opCodes).toEqual(debugMatch([
@@ -490,12 +482,12 @@ describe('Runtime i18n', () => {
     });
 
     it('for multiple attributes', () => {
-      const MSG_title = `Hello �0�!`;
-      const MSG_div_attr = ['title', MSG_title, 'aria-label', MSG_title];
+      const message = `Hello �0�!`;
+      const attrs = ['title', message, 'aria-label', message];
       const nbConsts = 2;
       const index = 1;
-      const opCodes = getOpCodes(() => {
-        ɵɵi18nAttributes(index, MSG_div_attr);
+      const opCodes = getOpCodes(attrs, () => {
+        ɵɵi18nAttributes(index, 0);
       }, null, nbConsts, index);
 
       expect(opCodes).toEqual(debugMatch([


### PR DESCRIPTION
This commit updates the code to move generated i18n statements into the `consts` field of
ComponentDef to avoid invoking `$localize` function before component initialization (to better
support runtime translations) and also avoid problems with lazy-loading when i18n defs may not
be present in a chunk where it's referenced.

Fixes #37092

Prior to this change the i18n statements were generated at the top leve:

```
var I18N_0;
if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
    var MSG_X = goog.getMsg(“…”);
    I18N_0 = MSG_X;
} else {
    I18N_0 = $localize('...');
}

defineComponent({
    // ...
    template: function App_Template(rf, ctx) {
        i0.ɵɵi18n(2, I18N_0);
    }
});
```

This commit updates the logic to generate the following code instead:

```
defineComponent({
    // ...
    consts: function() {
        var I18N_0;
        if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
            var MSG_X = goog.getMsg(“…”);
            I18N_0 = MSG_X;
        } else {
            I18N_0 = $localize('...');
        }
        return [
            I18N_0
        ];
    },
    template: function App_Template(rf, ctx) {
        i0.ɵɵi18n(2, 0);
    }
});
```

Also note that i18n template instructions now refer to the `consts` array using an index (similar to other template instructions).


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No