### PR TITLE
refactor(compiler): introduce core data structures of the template pipeline

### DIFF
--- a/packages/compiler/src/render3/view/pipeline/README.md
+++ b/packages/compiler/src/render3/view/pipeline/README.md
@@ -1,0 +1,19 @@
+# Template Pipeline
+
+This directory contains the code for the template pipeline, an alternative template compiler which is a replacement for the current `TemplateDefinitionBuilder`.
+
+## Design Philosophy
+
+The template pipeline is built around the concept of an Intermediate Representation (IR) for templates, as a nested structure of create and update blocks. Each block is a linked list of nodes representing various template structures (element declarations, input bindings, embedded views, etc).
+
+A sequence of pipeline stages transforms this IR from the initial version extracted from the template into a form that's ready to be emitted as Ivy instructions. This allows various aspects of Ivy templates to be handled in loosely coupled stages, as opposed to the previous design which performed template compilation monolithically.
+
+For example, one stage might look for `ElementStart` and `ElementEnd` nodes that are adjacent, and replace them with a single self-closing `Element` node instead. Instruction chaining, rather than happening simultaneously with the generation of instructions, now happens as a final transformation during emit, where adjacent instructions that are compatible with chaining are converted into the chained form.
+
+## Status
+
+Currently the pipeline is a work in progress, and is only tested internally.
+
+## Directory Layout
+
+* `ir` - contains the core data structures and interfaces of the intermediate representation.

--- a/packages/compiler/src/render3/view/pipeline/ir/aspect/binding_slot.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/aspect/binding_slot.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Expression} from '../expression';
+import {UpdateNode} from '../node';
+
+export const BindingSlotConsumerAspect = Symbol('BindingSlotConsumerAspect');
+export const BindingSlotOffsetAspect = Symbol('BindingSlotOffsetAspect');
+
+/**
+ * Indicates that a particular `UpdateNode` (or `Expression`) consumes some number of update binding
+ * slots.
+ *
+ * A component definition (or embedded view definition) must report the number of `vars`, (update
+ * binding slots) that it needs to allocate. Additionally, other kinds of transformations might need
+ * to know the number of slots consumed to a point within an update block - for example, to compute
+ * slot offsets for expressions.
+ *
+ * `Expression`s will also implement the `BindingSlotUpdateAspect`.
+ */
+export interface BindingSlotConsumerAspect {
+  [BindingSlotConsumerAspect]: true;
+
+  /**
+   * Calculate the number of binding slots which must be allocated for this node.
+   *
+   * Note that this needs to be calculated after any transformations which might affect the number
+   * of slots needed have been applied.
+   */
+  countUpdateBindingsUsed(): number;
+}
+
+/**
+ * Indicates that a particular `Expression` requires a binding slot offset to be emitted.
+ *
+ * Some instructions within expressions (such as `pipeBind` instructions) must be emitted with an
+ * offset into the binding array where they can store persistent values. This `slotOffset` begins as
+ * `null` and is set by a transform before the `Expression` is finalized.
+ *
+ * Any `Expression` with a slot offset also consumes bindings, and thus must implement the
+ * `BindingSlotConsumerAspect` as well,
+ */
+export interface BindingSlotOffsetAspect extends BindingSlotConsumerAspect {
+  [BindingSlotOffsetAspect]: true;
+
+  /**
+   * The binding slot index at which this `Expression`'s storage begins, or `null` if it has not yet
+   * been set.
+   */
+  slotOffset: number|null;
+}
+
+export function hasBindingSlotAspect(node: Expression): node is Expression&BindingSlotOffsetAspect;
+export function hasBindingSlotAspect(node: UpdateNode): node is UpdateNode&
+    BindingSlotConsumerAspect;
+/**
+ * Checks whether a node has the appropriate binding slot aspect for its type.
+ *
+ * For `UpdateNode`s, this is the `BindingSlotConsumerAspect`. `Expression`s will implement the
+ * `BindingSlotUpdateAspect` instead.
+ */
+export function hasBindingSlotAspect(node: UpdateNode|Expression): boolean {
+  if (node instanceof UpdateNode) {
+    return (node as any)[BindingSlotConsumerAspect] === true;
+  } else {
+    return (node as any)[BindingSlotOffsetAspect] === true;
+  }
+}

--- a/packages/compiler/src/render3/view/pipeline/ir/aspect/data_slot.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/aspect/data_slot.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Expression} from '../expression';
+import {CreateNode, Id, UpdateNode} from '../node';
+
+/**
+ * A slot index into the runtime data structure which stores created entities (element nodes, text
+ * nodes, embedded view definitions, etc).
+ *
+ * Sometimes referred to as a "creation slot" or "element id".
+ */
+export type DataSlot = number&{__brand: 'DataSlot'};
+
+export const CreateSlotAspect = Symbol('CreateSlotAspect');
+export const UpdateSlotAspect = Symbol('UpdateSlotAspect');
+
+/**
+ * Indicates that a `CreateNode` will consume at least one `DataSlot`.
+ *
+ * A `CreateNode` may consume more than one `DataSlot`. For example, the `element` creation
+ * instruction consumes one slot for the element itself, and an additional slot for each local
+ * reference (#ref) declared on it.
+ */
+export interface CreateSlotAspect {
+  [CreateSlotAspect]: true;
+
+  /**
+   * The `Id` of the `CreateNode` in question.
+   *
+   * Any `CreateNode` which allocates a `DataSlot` must have an `Id`.
+   */
+  readonly id: Id;
+
+  /**
+   * The `DataSlot` allocated to this `CreateNode`, or `null` if one has not yet been allocated.
+   */
+  slot: DataSlot|null;
+
+  /**
+   * Assign any extra slots required for this `CreateNode` (for example, local refs on an element
+   * declaration), using the `allocate` callback which allocates one additional slot. `allocate` can
+   * be called as many times as is needed.
+   */
+  allocateExtraSlots(allocate: () => DataSlot): void;
+}
+
+/**
+ * An `UpdateNode` or `Expression` that refers to an entity (such as an element or embedded view
+ * declaration) by its `DataSlot`.
+ *
+ * For example, update instructions that interpolate text into a DOM text node refer to the target
+ * text node from the creation block via its `DataSlot` index.
+ *
+ * This association works based on the internal `Id`. At first, the node with `UpdateSlotAspect`
+ * will have a `null` `slot`, but will have an `id` that matches that of the referenced
+ * `CreateNode`. After slots are allocated to `CreateNode`s, another transform uses the mapping of
+ * `Id` to `DataSlot` to populate the `slot` of all `UpdateSlotAspect` nodes in the template.
+ */
+export interface UpdateSlotAspect {
+  [UpdateSlotAspect]: true;
+
+  readonly id: Id;
+  slot: DataSlot|null;
+}
+
+export function hasSlotAspect(node: CreateNode): node is CreateNode&CreateSlotAspect;
+export function hasSlotAspect(node: UpdateNode): node is UpdateNode&UpdateSlotAspect;
+export function hasSlotAspect(node: Expression): node is Expression&UpdateSlotAspect;
+/**
+ * Checks whether a node has the appropriate `DataSlot` aspect for its type.
+ *
+ * For `CreateNode`s, this is the `CreateSlotAspect`. `UpdateNode`s and `Expression`s that refer to
+ * creation block entities by their `DataSlot` will have the `UpdateSlotAspect`.
+ */
+export function hasSlotAspect(node: CreateNode|UpdateNode|Expression): boolean {
+  if (node instanceof CreateNode) {
+    return (node as any)[CreateSlotAspect] === true;
+  } else {
+    return (node as any)[UpdateSlotAspect] === true;
+  }
+}

--- a/packages/compiler/src/render3/view/pipeline/ir/aspect/orderable.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/aspect/orderable.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Id, UpdateNode} from '../node';
+
+export const OrderableAspect = Symbol('OrderableAspect');
+
+/**
+ * Indicates that an `UpdateNode` requires a specific ordering relative to other `UpdateNode`s for a
+ * given creation entity.
+ *
+ * For example, all of the styling instructions which affect the styles of a particular element must
+ * be ordered in a specific way for correctness. The styling `UpdateNode`s implement
+ * `OrderableAspect` to define this ordering.
+ */
+export interface OrderableAspect {
+  [OrderableAspect]: true;
+
+  /**
+   * The `Id` of the `CreateNode` which this `UpdateNode` is affecting.
+   *
+   * Reordering according to priority will happen to all adjacent `OrderableAspect` `UpdateNode`s
+   * that affect this same `Id`.
+   */
+  readonly id: Id;
+
+  /**
+   * The relative priority applied to this particular `UpdateNode`.
+   *
+   * After ordering is applied, the `UpdateNode`s will be sorted from least to greatest `priority`
+   * values.
+   */
+  readonly priority: number;
+}
+
+/**
+ * Whether the given `UpdateNode` will participate in sorting.
+ */
+export function hasOrderableAspect(node: UpdateNode): node is UpdateNode&OrderableAspect {
+  return (node as any)[OrderableAspect] === true;
+}

--- a/packages/compiler/src/render3/view/pipeline/ir/aspect/template.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/aspect/template.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CreateList, Id, UpdateList} from '../node';
+
+export const TemplateAspect = Symbol('TemplateAspect');
+export const TemplateWithIdAspect = Symbol('TemplateWithIdAspect');
+
+/**
+ * Indicates that an entity represents a template definition (either a top-level component template
+ * or an embedded view).
+ *
+ * This aspect abstracts over a template definition, allowing nested template structures to be
+ * processed without depending on the specific `CreateNode` type(s) which represent embedded views.
+ */
+export interface TemplateAspect {
+  [TemplateAspect]: true;
+
+  /**
+   * The list of `CreateNode`s for this template.
+   */
+  create: CreateList;
+
+  /**
+   * The list of `UpdateNode`s for this template.
+   */
+  update: UpdateList;
+
+  /**
+   * Number of `DataSlot`s used by this template (see `CreateSlotAspect`).
+   */
+  decls: number|null;
+
+  /**
+   * Number of update binding slots used by this template (see `BindingSlotConsumerAspect`).
+   */
+  vars: number|null;
+}
+
+/**
+ * Indicates that a `CreateNode`, in addition to having `TemplateAspect` fields for the template
+ * definition, also have an `Id`.
+ */
+export interface TemplateWithIdAspect extends TemplateAspect {
+  [TemplateWithIdAspect]: true;
+
+  /**
+   * `Id` of the `CreateNode` which defines this embedded view.
+   */
+  id: Id;
+}

--- a/packages/compiler/src/render3/view/pipeline/ir/aspect/template_util.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/aspect/template_util.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CreateNode} from '../node';
+import {RootTemplate} from '../root';
+
+import {TemplateAspect, TemplateWithIdAspect} from './template';
+
+
+export function hasTemplateAspect(node: RootTemplate): node is RootTemplate&TemplateAspect;
+export function hasTemplateAspect<T extends CreateNode>(node: T): node is T&TemplateWithIdAspect;
+/**
+ * Whether the given `entity` represents a template definition.
+ *
+ * Embedded views are `CreateNode`s and thus have `TemplateWithIdAspect`. The root template does not
+ * have an ID, and is only a `TemplateAspect`.
+ */
+export function hasTemplateAspect(node: CreateNode|RootTemplate): boolean {
+  if (node instanceof RootTemplate) {
+    return (node as any)[TemplateAspect] === true;
+  } else {
+    return (node as any)[TemplateWithIdAspect] === true;
+  }
+}

--- a/packages/compiler/src/render3/view/pipeline/ir/aspect/template_util.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/aspect/template_util.ts
@@ -11,6 +11,9 @@ import {RootTemplate} from '../root';
 
 import {TemplateAspect, TemplateWithIdAspect} from './template';
 
+// Note: this exists in a separate file because of the value dependency on `RootTemplate` here.
+// Because `RootTemplate` also has a value dependency on `TemplateAspect`, `hasTemplateAspect` needs
+// to be in a separate file to prevent a cycle.
 
 export function hasTemplateAspect(node: RootTemplate): node is RootTemplate&TemplateAspect;
 export function hasTemplateAspect<T extends CreateNode>(node: T): node is T&TemplateWithIdAspect;
@@ -22,7 +25,7 @@ export function hasTemplateAspect<T extends CreateNode>(node: T): node is T&Temp
  */
 export function hasTemplateAspect(node: CreateNode|RootTemplate): boolean {
   if (node instanceof RootTemplate) {
-    return (node as any)[TemplateAspect] === true;
+    return node[TemplateAspect];
   } else {
     return (node as any)[TemplateWithIdAspect] === true;
   }

--- a/packages/compiler/src/render3/view/pipeline/ir/expression.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/expression.ts
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+
+/**
+ * Base class for all IR `o.Expression`s.
+ *
+ * The IR defines several new kinds of expression nodes, all of which can exist within an
+ * `o.Expression` AST (for example, pure function expressions). This base class provides a
+ * foundation which bridges the `o.Expression` abstraction with the IR abstraction, and allows for
+ * visitors and transformers which specifically understand IR expression nodes (like the
+ * `ExpressionTransformer` defined below).
+ *
+ * IR `Expression`s cannot be output during code generation, and an exception will be thrown if one
+ * is left in an `o.Expression` AST and passed to the code generator. `Expression`s should be
+ * converted into a non-IR `o.Expression` via `toFinalExpression` prior to code generation.
+ */
+export abstract class Expression extends o.Expression {
+  constructor() {
+    super(/* type */ undefined);
+  }
+
+  visitExpression(visitor: ExpressionVisitor, ctx: any): o.Expression {
+    // IR expressions can only be visited by a visitor which implements `visitIrExpression`.
+    if (visitor.visitIrExpression !== undefined) {
+      return visitor.visitIrExpression(this, ctx);
+    } else {
+      throw new Error('ir.Expression cannot be used in this context: ' + this.kind);
+    }
+  }
+
+  isEquivalent(): boolean {
+    throw new Error(`Comparisons of ir.Expressions are not supported.`);
+  }
+
+  isConstant(): boolean {
+    return false;
+  }
+
+  abstract readonly kind: string;
+
+  /**
+   * Visit any `o.Expression`s which are stored in the current `Expression` with the given visitor.
+   */
+  abstract visitChildren(visitor: o.ExpressionVisitor, ctx?: any): void;
+
+  /**
+   * Finalize this expression into a non-IR `o.Expression` suitable for code generation.
+   */
+  abstract toFinalExpression(): o.Expression;
+}
+
+/**
+ * An `o.ExpressionVisitor` which is potentially capable of visiting IR `Expression` nodes.
+ *
+ * This interface is directly compatible with `o.ExpressionVisitor` as the `visitIrExpression`
+ * method is optional.
+ */
+export interface ExpressionVisitor<C = unknown> extends o.ExpressionVisitor {
+  /**
+   * Visit an IR `Expression`.
+   */
+  visitIrExpression?(node: Expression, ctx: C): any;
+}
+
+/**
+ * A base class for transformers which process `o.Expression` ASTs that include embedded IR
+ * `Expression`s.
+ */
+export abstract class ExpressionTransformer<C = unknown> implements ExpressionVisitor {
+  visitIrExpression(expr: Expression, ctx: C): o.Expression {
+    expr.visitChildren(this, ctx);
+    return expr;
+  }
+
+  visitReadVarExpr(ast: o.ReadVarExpr, ctx: C): o.Expression {
+    return ast;
+  }
+
+  visitWriteVarExpr(expr: o.WriteVarExpr, ctx: C): o.Expression {
+    expr.value = expr.value.visitExpression(this, ctx);
+    return expr;
+  }
+
+  visitWriteKeyExpr(expr: o.WriteKeyExpr, ctx: C): o.Expression {
+    expr.receiver = expr.receiver.visitExpression(this, ctx);
+    expr.value = expr.value.visitExpression(this, ctx);
+    return expr;
+  }
+
+  visitWritePropExpr(expr: o.WritePropExpr, ctx: C): o.Expression {
+    expr.receiver = expr.receiver.visitExpression(this, ctx);
+    expr.value = expr.value.visitExpression(this, ctx);
+    return expr;
+  }
+
+  visitInvokeMethodExpr(ast: o.InvokeMethodExpr, ctx: C): o.Expression {
+    ast.receiver = ast.receiver.visitExpression(this, ctx);
+    for (let i = 0; i < ast.args.length; i++) {
+      ast.args[i] = ast.args[i].visitExpression(this, ctx);
+    }
+    return ast;
+  }
+
+  visitInvokeFunctionExpr(ast: o.InvokeFunctionExpr, ctx: C): o.Expression {
+    ast.fn = ast.fn.visitExpression(this, ctx);
+    for (let i = 0; i < ast.args.length; i++) {
+      ast.args[i] = ast.args[i].visitExpression(this, ctx);
+    }
+    return ast;
+  }
+
+  visitInstantiateExpr(ast: o.InstantiateExpr, ctx: C): o.Expression {
+    ast.classExpr = ast.classExpr.visitExpression(this, ctx);
+    for (let i = 0; i < ast.args.length; i++) {
+      ast.args[i] = ast.args[i].visitExpression(this, ctx);
+    }
+    return ast;
+  }
+
+  visitLiteralExpr(ast: o.LiteralExpr, ctx: C): o.Expression {
+    return ast;
+  }
+
+  visitLocalizedString(ast: o.LocalizedString, ctx: C): o.Expression {
+    for (let i = 0; i < ast.expressions.length; i++) {
+      ast.expressions[i] = ast.expressions[i].visitExpression(this, ctx);
+    }
+    return ast;
+  }
+
+  visitExternalExpr(ast: o.ExternalExpr, ctx: C): o.Expression {
+    return ast;
+  }
+
+  visitConditionalExpr(ast: o.ConditionalExpr, ctx: C): o.Expression {
+    ast.condition = ast.condition.visitExpression(this, ctx);
+    ast.trueCase = ast.trueCase.visitExpression(this, ctx);
+    ast.falseCase = ast.falseCase?.visitExpression(this, ctx);
+    return ast;
+  }
+
+  visitNotExpr(ast: o.NotExpr, ctx: C): o.Expression {
+    ast.condition = ast.condition.visitExpression(this, ctx);
+    return ast;
+  }
+
+  visitAssertNotNullExpr(ast: o.AssertNotNull, ctx: C): o.Expression {
+    ast.condition = ast.condition.visitExpression(this, ctx);
+    return ast;
+  }
+
+  visitCastExpr(ast: o.CastExpr, ctx: C): o.Expression {
+    ast.value = ast.value.visitExpression(this, ctx);
+    return ast;
+  }
+
+  visitFunctionExpr(ast: o.FunctionExpr, ctx: C): o.Expression {
+    throw new Error('unsupported in this context');
+  }
+
+  visitBinaryOperatorExpr(ast: o.BinaryOperatorExpr, ctx: C): o.Expression {
+    ast.lhs = ast.lhs.visitExpression(this, ctx);
+    ast.rhs = ast.rhs.visitExpression(this, ctx);
+    return ast;
+  }
+
+  visitReadPropExpr(ast: o.ReadPropExpr, ctx: C): o.Expression {
+    ast.receiver = ast.receiver.visitExpression(this, ctx);
+    return ast;
+  }
+
+  visitReadKeyExpr(ast: o.ReadKeyExpr, ctx: C): o.Expression {
+    ast.receiver = ast.receiver.visitExpression(this, ctx);
+    return ast;
+  }
+
+  visitLiteralArrayExpr(ast: o.LiteralArrayExpr, ctx: C): o.Expression {
+    for (let i = 0; i < ast.entries.length; i++) {
+      ast.entries[i] = ast.entries[i].visitExpression(this, ctx);
+    }
+    return ast;
+  }
+
+  visitLiteralMapExpr(ast: o.LiteralMapExpr, ctx: C): o.Expression {
+    for (let i = 0; i < ast.entries.length; i++) {
+      ast.entries[i].value = ast.entries[i].value.visitExpression(this, ctx);
+    }
+    return ast;
+  }
+
+  visitCommaExpr(ast: o.CommaExpr, ctx: C): o.Expression {
+    for (let i = 0; i < ast.parts.length; i++) {
+      ast.parts[i] = ast.parts[i].visitExpression(this, ctx);
+    }
+    return ast;
+  }
+
+  visitWrappedNodeExpr(ast: o.WrappedNodeExpr<any>, ctx: C): o.Expression {
+    return ast;
+  }
+
+  visitTypeofExpr(ast: o.TypeofExpr, ctx: C): o.Expression {
+    ast.expr = ast.expr.visitExpression(this, ctx);
+    return ast;
+  }
+}

--- a/packages/compiler/src/render3/view/pipeline/ir/index.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './expression';
+export * from './linked_list';
+export * from './node';
+export * from './root';
+export * from './stage';
+export * from './template_scope';
+
+export * from './aspect/binding_slot';
+export * from './aspect/data_slot';
+export * from './aspect/orderable';
+export * from './aspect/template';

--- a/packages/compiler/src/render3/view/pipeline/ir/index.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/index.ts
@@ -17,3 +17,4 @@ export * from './aspect/binding_slot';
 export * from './aspect/data_slot';
 export * from './aspect/orderable';
 export * from './aspect/template';
+export * from './aspect/template_util';

--- a/packages/compiler/src/render3/view/pipeline/ir/linked_list.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/linked_list.ts
@@ -1,0 +1,339 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * A node in an intrinsic doubly linked list, of type `T`.
+ */
+export interface LinkedListNode<T extends LinkedListNode<T>> {
+  next: T|null;
+  prev: T|null;
+}
+
+/**
+ * An intrinsic doubly linked list, which stores nodes of type `T`.
+ */
+export class LinkedList<T extends LinkedListNode<T>> {
+  /**
+   * Head of the list, or `null` if the list is empty.
+   */
+  head: T|null = null;
+
+  /**
+   * Tail of the list, or `null` if the list is empty.
+   */
+  tail: T|null = null;
+
+  /**
+   * Insert a new node (`insert`) before another (`before`).
+   */
+  insertBefore(before: T, insert: T): void {
+    assertNodeIsEmpty(insert);
+
+    if (this.head === before) {
+      this.head = insert;
+    }
+
+    insert.prev = before.prev;
+    insert.next = before;
+
+    if (before.prev !== null) {
+      before.prev.next = insert;
+    }
+    before.prev = insert;
+  }
+
+  /**
+   * Insert a new node (`insert`) after another (`before`).
+   */
+  insertAfter(after: T, insert: T): void {
+    assertNodeIsEmpty(insert);
+
+    if (this.tail === after) {
+      this.tail = insert;
+    }
+
+    insert.prev = after;
+    insert.next = after.next;
+
+    if (after.next !== null) {
+      after.next.prev = insert;
+    }
+    after.next = insert;
+  }
+
+  /**
+   * Append the given node at the tail of the list.
+   */
+  append(node: T): void {
+    assertNodeIsEmpty(node);
+
+    if (this.tail !== null) {
+      node.prev = this.tail;
+      this.tail.next = node;
+      this.tail = node;
+    } else {
+      this.head = node;
+      this.tail = node;
+    }
+  }
+
+  /**
+   * Splice in a new list of nodes before the head of this one.
+   */
+  prependList(list: LinkedList<T>): void {
+    if (list.tail === null || list.head === null) {
+      return;
+    } else if (this.head === null) {
+      this.head = list.head;
+      this.tail = list.tail;
+      return;
+    }
+
+    this.head.prev = list.tail;
+    list.tail.next = this.head;
+    this.head = list.head;
+  }
+
+  /**
+   * Remove the given node from the list and return it.
+   *
+   * This operation clears the `prev` and `next` pointers of the node. Therefore it's safe to
+   * reinsert the node later.
+   */
+  remove(node: T): T|null {
+    const next = node.next;
+
+    if (this.head === node) {
+      this.head = node.next as T;
+      if (this.tail === node) {
+        this.tail = node.next as T;
+      }
+    } else if (node.prev !== null) {
+      node.prev.next = node.next;
+      if (this.tail === node) {
+        this.tail = node.prev as T;
+      } else if (node.next !== null) {
+        node.next.prev = node.prev;
+      } else {
+        throw new Error('AssertionError: non-tail node has null next pointer');
+      }
+    } else {
+      throw new Error('AssertionError: non-head node has null prev pointer');
+    }
+
+    node.prev = null;
+    node.next = null;
+
+    return next as T;
+  }
+
+  /**
+   * Apply a transformation operation to all of the nodes in the list.
+   */
+  applyTransform(transform: Transform<T>): void {
+    if (transform.visitList !== undefined) {
+      transform.visitList(this);
+    }
+    if (transform.visit !== undefined) {
+      let node = this.head;
+      while (node !== null) {
+        node = transform.visit(node, this) as T;
+
+        // Need to ensure:
+        // - if node is at the beginning, this.head is updated
+        // - if node is at the end, this.tail is updated
+        // - node.next.prev is node
+        // - node.prev.next is node
+        if (node.prev !== null) {
+          node.prev.next = node;
+        } else {
+          this.head = node;
+        }
+
+        if (node.next !== null) {
+          node.next.prev = node;
+        } else {
+          this.tail = node;
+        }
+
+        node = node.next as T;
+      }
+    }
+    if (transform.finalize !== undefined) {
+      transform.finalize();
+    }
+  }
+
+  /**
+   * Sort the nodes from `start` to `end`, using `cmp` to compare.
+   *
+   * Returns the new `start` and `end` nodes, which are guaranteed to be nodes within the original
+   * range.
+   *
+   * The algorithm in use is an in-place insertion sort.
+   */
+  sortSubset(start: T, end: T, cmp: (a: T, b: T) => number): {start: T, end: T} {
+    if (start === end) {
+      return {start, end};
+    }
+
+    // Track the new start/end nodes as the sort progresses.
+    let tmpStart = start;
+    let tmpEnd = start;
+
+    // Temporary assignment - will be overwritten with `start.next` as soon as the loop begins.
+    let node = start;
+
+    // Safe because there are at least two nodes, otherwise the `start === end` check above would
+    // have caused an early return.
+    let next: T = start.next!;
+
+    // The single-node special case was handled above, so there is at least one node to process (the
+    // end node).
+    //
+    // This loop body therefore always executes at least once, at which point the while condition
+    // will exit the loop if the last node processed was the ending node.
+    do {
+      // Advance the node to the next one to process, and capture its `next` pointer now since it
+      // can change as the sort progresses.
+      node = next;
+      // Safe because either:
+      // 1) this is the first iteration, which guarantees there are at least two nodes due to the
+      //    `start !== end` check above, or
+      // 2) the loop condition `node !== end` was true, meaning there is a next node.
+      next = node.next!;
+
+      // Remove node from its current position.
+      this.remove(node);
+
+      // Look through the already sorted part of the subset (from `tmpStart` up until `next`) and
+      // check if the node belongs before any of the previously sorted nodes.
+      let inserted = false;
+      // `pos.next!` is safe here because `tmpStart` is always before `pos` and thus there is always
+      // a node after `pos`.
+      for (let pos = tmpStart; pos !== next; pos = pos.next!) {
+        if (cmp(node, pos) < 0) {
+          // Yes, the node belongs before `pos`. Insert it there.
+          this.insertBefore(pos, node);
+
+          // If `pos` was the beginning, then the current node is now the new beginning.
+          if (pos === tmpStart) {
+            tmpStart = node;
+          }
+
+          inserted = true;
+          break;
+        }
+      }
+
+      // Handle the case where the node didn't fit before any prior nodes.
+      if (!inserted) {
+        // The node belongs in its original position. How it gets put back there depends on whether
+        // it was the tail end of the list or not.
+        if (next !== null) {
+          this.insertBefore(next, node);
+        } else {
+          this.append(node);
+        }
+
+        // This node is now the tail end of the "sorted" segment.
+        tmpEnd = node;
+      }
+    } while (node !== end);
+
+    // At this point, `tmpStart` and `tmpEnd` are the correct head/tail pointers of the now-sorted
+    // segment of the list.
+    return {start: tmpStart, end: tmpEnd};
+  }
+
+  /**
+   * Convert the list to an array.
+   */
+  toArray(): T[] {
+    const arr: T[] = [];
+    for (let node = this.head; node !== null; node = node.next) {
+      arr.push(node);
+    }
+    return arr;
+  }
+
+  /**
+   * Stringify the list for debugging purposes.
+   */
+  toString(printer: (node: T) => string): string {
+    const strings: string[] = [];
+    for (let node = this.head; node !== null; node = node.next) {
+      strings.push(printer(node));
+    }
+    return strings.join('\n');
+  }
+}
+
+/**
+ * A transformation which can be applied to a `LinkedList` and its nodes.
+ *
+ * As part of the transformation, nodes within the list can be mutated, which can result in nodes
+ * being removed, replaced, or added during the transformation.
+ *
+ * Transformations run in 3 stages, all of which are optional:
+ *
+ * * First, the transformer gets an opportunity to visit the list as a whole. This can be useful if
+ *   a certain transformation requires out-of-order iteration of the list.
+ * * Next, the transformer can visit each node individually, and can mutate or replace it.
+ * * Once iteration is complete, a `finalize` method allows the transformer to perform any cleanup
+ *   work after all the nodes have been processed.
+ *
+ * See the individual method descriptions for specifics.
+ */
+export interface Transform<T extends LinkedListNode<T>> {
+  /**
+   * Process the entire list at once.
+   *
+   * This method is useful if a transformer needs to iterate the nodes and process them in a
+   * different order than the normal node visitor would use.
+   */
+  visitList?(list: LinkedList<T>): void;
+
+  /**
+   * Visit a node in the list and return its replacement.
+   *
+   * This method allows a transformer to examine each node individually, and return a replacement.
+   * Replacing a node is subject to several constraints:
+   *
+   * `node.prev` and `node.next` of the replacement node will be honored, and the list state updated
+   * to reflect these changes. This means that `node.prev` must point to a chain of nodes that
+   * terminates in the list head, and `node.next` must point to a chain of nodes that terminates in
+   * the list tail.
+   *
+   * Of course, if the node being replaced is the head, then `node.prev` must terminate in `null`.
+   * The same goes for replacing the tail and `node.next`.
+   *
+   * It is not necessary to update `node.prev.next` or `node.next.prev` as the `LinkedList` will
+   * apply such changes automatically. This makes it easy to replace one node with a single other
+   * node simply by copying its `prev` and `next` pointers into the new node.
+   *
+   * It _is_ possible to corrupt the `LinkedList` with improper manipulation of nodes during
+   * transforms, so exercise caution when replacing nodes this way.
+   */
+  visit?(node: T, list: LinkedList<T>): T;
+
+  /**
+   * Called when all nodes have been visited and the transformation is otherwise complete.
+   */
+  finalize?(): void;
+}
+
+/**
+ * Throw an error if the given `node` does not have empty `prev` and `next` pointers.
+ */
+function assertNodeIsEmpty<T extends LinkedListNode<T>>(node: LinkedListNode<T>): void {
+  if (node.prev !== null || node.next !== null) {
+    throw new Error(`AssertionError: attempt to insert a non-empty ${
+        Object.getPrototypeOf(node).constructor.name} node in a LinkedList`);
+  }
+}

--- a/packages/compiler/src/render3/view/pipeline/ir/linked_list.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/linked_list.ts
@@ -32,7 +32,7 @@ export class LinkedList<T extends LinkedListNode<T>> {
    * Insert a new node (`insert`) before another (`before`).
    */
   insertBefore(before: T, insert: T): void {
-    assertNodeIsEmpty(insert);
+    assertNodeIsDetached(insert);
 
     if (this.head === before) {
       this.head = insert;
@@ -51,7 +51,7 @@ export class LinkedList<T extends LinkedListNode<T>> {
    * Insert a new node (`insert`) after another (`before`).
    */
   insertAfter(after: T, insert: T): void {
-    assertNodeIsEmpty(insert);
+    assertNodeIsDetached(insert);
 
     if (this.tail === after) {
       this.tail = insert;
@@ -70,7 +70,7 @@ export class LinkedList<T extends LinkedListNode<T>> {
    * Append the given node at the tail of the list.
    */
   append(node: T): void {
-    assertNodeIsEmpty(node);
+    assertNodeIsDetached(node);
 
     if (this.tail !== null) {
       node.prev = this.tail;
@@ -252,25 +252,24 @@ export class LinkedList<T extends LinkedListNode<T>> {
   }
 
   /**
-   * Convert the list to an array.
-   */
-  toArray(): T[] {
-    const arr: T[] = [];
-    for (let node = this.head; node !== null; node = node.next) {
-      arr.push(node);
-    }
-    return arr;
-  }
-
-  /**
    * Stringify the list for debugging purposes.
    */
   toString(printer: (node: T) => string): string {
     const strings: string[] = [];
-    for (let node = this.head; node !== null; node = node.next) {
+    for (const node of this) {
       strings.push(printer(node));
     }
     return strings.join('\n');
+  }
+
+  /**
+   * Generator function implementation of the iterator protocol, which allows `LinkedList`s to be
+   * used in for-of loops.
+   */
+  * [Symbol.iterator](): Iterator<T> {
+    for (let node = this.head; node !== null; node = node.next) {
+      yield node;
+    }
   }
 }
 
@@ -331,7 +330,7 @@ export interface Transform<T extends LinkedListNode<T>> {
 /**
  * Throw an error if the given `node` does not have empty `prev` and `next` pointers.
  */
-function assertNodeIsEmpty<T extends LinkedListNode<T>>(node: LinkedListNode<T>): void {
+function assertNodeIsDetached<T extends LinkedListNode<T>>(node: LinkedListNode<T>): void {
   if (node.prev !== null || node.next !== null) {
     throw new Error(`AssertionError: attempt to insert a non-empty ${
         Object.getPrototypeOf(node).constructor.name} node in a LinkedList`);

--- a/packages/compiler/src/render3/view/pipeline/ir/node.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/node.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+
+import {ExpressionVisitor} from './expression';
+import {LinkedList, LinkedListNode, Transform} from './linked_list';
+
+/**
+ * In the IR, some `CreateNode`s are assigned a unique identifier, which is only relevant to
+ * internal processing of the IR and is never reflected in generated code.
+ *
+ * `UpdateNode`s can refer to specific `CreateNode`s via this identifier, without needing to keep
+ * either a reference to the `CreateNode` or to have knowledge of its `DataSlot` (the runtime data
+ * structure index which _is_ reflected in generated code). Using `Id`, this kind of relationship
+ * between creation and update nodes can be defined before `DataSlot`s are assigned (which allows
+ * for optimizations to take place beforehand). It can also persist even if the nodes themselves are
+ * transformed or replaced. For example, an `ElementStart` node can be replaced with a self-closing
+ * equivalent that keeps the same `Id`, preserving its relationship with any `UpdateNode`s that
+ * affect it.
+ */
+export type Id = number&{__brand: 'IrId'};
+
+const CREATE_BRAND = Symbol('CreateNode');
+
+/**
+ * A node in a template creation block list.
+ */
+export abstract class CreateNode implements LinkedListNode<CreateNode> {
+  /**
+   * Required because `CreateNode` and `UpdateNode` are otherwise type-compatible.
+   */
+  private readonly[CREATE_BRAND] = true;
+
+  prev: CreateNode|null = null;
+  next: CreateNode|null = null;
+
+  /**
+   * Apply an `ExpressionVisitor` to any `o.Expression` ASTs directly within this creation node.
+   */
+  visitExpressions(visitor: ExpressionVisitor, ctx?: any): void {
+    // Most `CreateNode`s do not contain expressions, and so for convenience a default no-op
+    // implementation of `visitExpressions` is provided.
+  }
+
+  /**
+   * Change the `prev` and `next` pointers of this node in a fluent way.
+   */
+  withPrevAndNext(prev: CreateNode|null, next: CreateNode|null): this {
+    this.prev = prev;
+    this.next = next;
+    return this;
+  }
+}
+
+/**
+ * Convenience type for a `LinkedList` of `CreateNode`s.
+ */
+export type CreateList = LinkedList<CreateNode>;
+export const CreateList: {new (): CreateList} = LinkedList;
+
+/**
+ * Convenience type for a `Transform` that applies to `CreateNode`s.
+ */
+export type CreateTransform = Transform<CreateNode>;
+
+/**
+ * A code generator which can recognize some `CreateNode` instances and generate an `o.Statement`
+ * for them.
+ *
+ * `CreateEmitter`s are not required to handle every subtype of `CreateNode`.
+ */
+export interface CreateEmitter {
+  /**
+   * Potentially generate a statement for the given `CreateNode`, or return `null` if the specific
+   * node type is not handled by this emitter.
+   */
+  emit(node: CreateNode): o.Statement|null;
+}
+
+const UPDATE_BRAND = Symbol('UpdateNode');
+
+/**
+ * A node in a template update block list.
+ */
+export abstract class UpdateNode implements LinkedListNode<UpdateNode> {
+  /**
+   * Required because `CreateNode` and `UpdateNode` are otherwise type-compatible.
+   */
+  private readonly[UPDATE_BRAND] = true;
+
+  prev: UpdateNode|null = null;
+  next: UpdateNode|null = null;
+
+
+  /**
+   * Apply an `ExpressionVisitor` to any `o.Expression` ASTs directly within this update node.
+   *
+   * No default implementation is provided here as most `UpdateNode`s will have expressions within
+   * them, so a no-op implementation would almost alwawys be incorrect.
+   */
+  abstract visitExpressions(visitor: ExpressionVisitor, ctx?: any): void;
+
+  /**
+   * Change the `prev` and `next` pointers of this node in a fluent way.
+   */
+  withPrevAndNext(prev: UpdateNode|null, next: UpdateNode|null): this {
+    this.prev = prev;
+    this.next = next;
+    return this;
+  }
+}
+
+/**
+ * Convenience type for a `LinkedList` of `UpdateNode`s.
+ */
+export type UpdateList = LinkedList<UpdateNode>;
+export const UpdateList: {new (): UpdateList} = LinkedList;
+
+/**
+ * Convenience type for a `Transform` that applies to `UpdateNode`s.
+ */
+export type UpdateTransform = Transform<UpdateNode>;
+
+/**
+ * A code generator which can recognize some `UpdateNode` instances and generate an `o.Statement`
+ * for them.
+ *
+ * `UpdateEmitter`s are not required to handle every subtype of `UpdateNode`.
+ */
+export interface UpdateEmitter {
+  /**
+   * Potentially generate a statement for the given `UpdateNode`, or return `null` if the specific
+   * node type is not handled by this emitter.
+   */
+  emit(node: UpdateNode): o.Statement|null;
+}

--- a/packages/compiler/src/render3/view/pipeline/ir/root.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/root.ts
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+
+import {TemplateAspect} from './aspect/template';
+import {CreateList, UpdateList} from './node';
+import {Scope} from './template_scope';
+
+/**
+ * Represents a template declaration for a component's top-level template.
+ *
+ * In addition to the normal properties of a template (defined in `TemplateAspect`), the
+ * `RootTemplate` contains additional context about the template extracted from the template AST and
+ * the component host.
+ *
+ * After processing, the `RootTemplate` will also contain top-level data for the template, such as
+ * the `consts` array to which constants from the template are extracted, which will be expressed in
+ * the component definition.
+ */
+export class RootTemplate implements TemplateAspect {
+  readonly[TemplateAspect] = true;
+
+  create: CreateList;
+  update: UpdateList;
+
+  decls: number|null = null;
+  vars: number|null = null;
+
+  /**
+   * `Scope` that was extracted from this template when it was converted to IR.
+   *
+   * This contains useful information about the named entities within the template and their
+   * relationship to the initial IR.
+   */
+  scope: Scope;
+
+  constructor(create: CreateList, update: UpdateList, scope: Scope) {
+    this.create = create;
+    this.update = update;
+    this.scope = scope;
+  }
+
+  /**
+   * Name of the template function (usually the name of the component which declared the template).
+   */
+  name: string|null = null;
+
+  /**
+   * Array of constants extracted from the template during processing.
+   *
+   * Emitted instructions will refer to these constants via their index in this array.
+   */
+  consts: o.Expression[]|null = null;
+
+  /**
+   * Transform this `RootTemplate` with a sequence of `TemplateStage`s.
+   */
+  transform(...stages: TemplateStage[]): void {
+    for (const stage of stages) {
+      stage.transform(this);
+    }
+  }
+}
+
+/**
+ * Represents a host binding function, which looks similar to a template in some ways (create and
+ * update blocks, `decls` and `vars`, etc) but is not a recursive structure (no embedded views) and
+ * uses a different set of instructions.
+ */
+export class Host {
+  /**
+   * Creation block of the host binding function.
+   */
+  create = new CreateList();
+
+  /**
+   * Update block of the host binding function.
+   */
+  update = new UpdateList();
+
+
+  attrs: o.Expression[]|null = null;
+
+  decls: number|null = null;
+  vars: number|null = null;
+
+  constructor(public name: string) {}
+
+  /**
+   * Transform this `Host` with a sequence of `HostStage`s.
+   */
+  transform(...stages: HostStage[]): void {
+    for (const stage of stages) {
+      stage.transform(this);
+    }
+  }
+
+  /**
+   * Check if this host binding function is empty.
+   */
+  isEmpty(): boolean {
+    return this.update.head === null && this.create.head === null;
+  }
+}
+
+/**
+ * A single stage in a processing pipeline for a template IR.
+ *
+ * A stage is conceptually similar to one of the `CreateTransform` or `UpdateTransform`
+ * transformations, but is applied recursively to both the `RootTemplate` and any embedded views
+ * within it (which may contain their own embedded views, etc). Stages also process both the
+ * creation and update blocks of the template.
+ */
+export interface TemplateStage {
+  transform(tmpl: RootTemplate): void;
+}
+
+/**
+ * A single stage in a processing pipeline for a host binding function IR.
+ *
+ * Like a `TemplateStage` the `HostStage` processes both the creation and update blocks of the host
+ * binding function IR. Unlike its template equivalent, the host binding function IR is
+ * non-recursive.
+ */
+export interface HostStage {
+  transform(host: Host): void;
+}

--- a/packages/compiler/src/render3/view/pipeline/ir/root.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/root.ts
@@ -90,7 +90,7 @@ export class Host {
   decls: number|null = null;
   vars: number|null = null;
 
-  constructor(public name: string) {}
+  constructor(readonly name: string) {}
 
   /**
    * Transform this `Host` with a sequence of `HostStage`s.

--- a/packages/compiler/src/render3/view/pipeline/ir/stage.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/stage.ts
@@ -70,7 +70,7 @@ export abstract class BaseTemplateStage<CT extends CreateTransform, UT extends U
     }
 
     // Recurse into any child create nodes that have the TemplateAspect.
-    for (let node = tmpl.create.head; node !== null; node = node.next) {
+    for (const node of tmpl.create) {
       if (hasTemplateAspect(node)) {
         this.transformImpl(root, node, currCreate, currUpdate);
       }
@@ -130,12 +130,12 @@ export abstract class UpdateOnlyTemplateStage extends BaseTemplateStage<never, U
 export abstract class ExpressionOnlyTemplateStage extends ExpressionTransformer implements
     TemplateStage {
   transform(tmpl: TemplateAspect): void {
-    for (let node = tmpl.update.head; node !== null; node = node.next) {
+    for (const node of tmpl.update) {
       node.visitExpressions(this);
     }
 
     // Recurse into any child create nodes that have the TemplateAspect.
-    for (let node = tmpl.create.head; node !== null; node = node.next) {
+    for (const node of tmpl.create) {
       if (hasTemplateAspect(node)) {
         this.transform(node);
       }

--- a/packages/compiler/src/render3/view/pipeline/ir/stage.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/stage.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {TemplateAspect, TemplateWithIdAspect} from './aspect/template';
+import {hasTemplateAspect} from './aspect/template_util';
+import {ExpressionTransformer} from './expression';
+import {CreateTransform, UpdateTransform} from './node';
+import {RootTemplate, TemplateStage} from './root';
+
+/**
+ * A base class for `TemplateStage`s which provides some common functionality around processing
+ * nested `TemplateAspect`s.
+ *
+ * A subclass of `BaseTemplateStage` must provide factory functions to create both a
+ * `CreateTransform` and `UpdateTransform`, which will be called each time a `TemplateAspect`
+ * (either `RootTemplate` or an embedded view) is processed.
+ *
+ * Thus, the `BaseTemplateStage` is a wrapper which takes `CreateTransform` and `UpdateTransform`
+ * implementations and applies them recursively to an entire template IR.
+ */
+export abstract class BaseTemplateStage<CT extends CreateTransform, UT extends UpdateTransform>
+    implements TemplateStage {
+  /**
+   * Get a `CreateTransform` which will be applied to one `TemplateAspect`.
+   *
+   * Because the `CreateTransform` instance used for a parent template is passed to the factory
+   * function when creating the transform for each child template, it's possible to pass state from
+   * the parent transform to any child transforms if required.
+   *
+   * @param root The `RootTemplate` for the entire template IR.
+   * @param prev The previous instance of `CreateTransform` used for this template's parent, if any.
+   * @param tmpl The `TemplateAspectWithId` of the child template which will be processed by this
+   *     transform, or `null` if the template is the `RootTemplate`.
+   */
+  protected abstract makeCreateTransform(
+      root: RootTemplate, prev: CT|null, tmpl: TemplateWithIdAspect|null): CT|null;
+
+
+  /**
+   * Get an `UpdateTransform` which will be applied to one `TemplateAspect`.
+   *
+   * Because the `UpdateTransform` instance used for a parent template is passed to the factory
+   * function when creating the transform for each child template, it's possible to pass state from
+   * the parent transform to any child transforms if required.
+   *
+   * @param root The `RootTemplate` for the entire template IR.
+   * @param prev The previous instance of `UpdateTransform` used for this template's parent, if any.
+   * @param tmpl The `TemplateAspectWithId` of the child template which will be processed by this
+   *     transform, or `null` if the template is the `RootTemplate`.
+   */
+  protected abstract makeUpdateTransform(
+      root: RootTemplate, prev: UT|null, tmpl: TemplateWithIdAspect|null, create: CT|null): UT|null;
+
+  private transformImpl(
+      root: RootTemplate, tmpl: TemplateAspect, prevCreate: CT|null, prevUpdate: UT|null): void {
+    const childNode = tmpl instanceof RootTemplate ? null : (tmpl as TemplateWithIdAspect);
+    const currCreate = this.makeCreateTransform(root, prevCreate, childNode);
+    const currUpdate = this.makeUpdateTransform(root, prevUpdate, childNode, currCreate);
+
+    if (currCreate !== null) {
+      tmpl.create.applyTransform(currCreate);
+    }
+    if (currUpdate !== null) {
+      tmpl.update.applyTransform(currUpdate);
+    }
+
+    // Recurse into any child create nodes that have the TemplateAspect.
+    for (let node = tmpl.create.head; node !== null; node = node.next) {
+      if (hasTemplateAspect(node)) {
+        this.transformImpl(root, node, currCreate, currUpdate);
+      }
+    }
+  }
+
+  transform(tmpl: RootTemplate): void {
+    this.transformImpl(tmpl, tmpl, null, null);
+  }
+}
+
+/**
+ * A convenient `TemplateStage` for transformations which only operate on the create side of the
+ * template, and can be expressed with a single transformation instance for the entire template
+ * (including nested views).
+ *
+ * A `CreateOnlyTemplateStage` is expected to implement the `CreateTransform` interface. In a sense,
+ * inheriting from `CreateOnlyTemplateStage` adapts a singleton `CreateTransform` into a
+ * `TemplateStage`.
+ */
+export abstract class CreateOnlyTemplateStage extends BaseTemplateStage<CreateTransform, never> {
+  makeCreateTransform(): CreateTransform {
+    return this as CreateTransform;
+  }
+
+  makeUpdateTransform(): null {
+    return null;
+  }
+}
+
+/**
+ * A convenient `TemplateStage` for transformations which only operate on the update side of the
+ * template, and can be expressed with a single transformation instance for the entire template
+ * (including nested views).
+ *
+ * An `UpdateOnlyTemplateStage` is expected to implement the `UpdateTransform` interface. In a
+ * sense, inheriting from `UpdateOnlyTemplateStage` adapts a singleton `UpdateTransform` into a
+ * `TemplateStage`.
+ */
+export abstract class UpdateOnlyTemplateStage extends BaseTemplateStage<never, UpdateTransform> {
+  makeCreateTransform(): null {
+    return null;
+  }
+
+  makeUpdateTransform(): UpdateTransform {
+    return this as UpdateTransform;
+  }
+}
+
+/**
+ * A convenient `TemplateStage` for transformations which only operate on IR `Expression`s within
+ * the template.
+ *
+ * An `ExpressionOnlyTemplateStage` implements the `ExpressionTransformer` interface. Most consumers
+ * will want to implement the optional `visitIrExpression` method from this interface.
+ */
+export abstract class ExpressionOnlyTemplateStage extends ExpressionTransformer implements
+    TemplateStage {
+  transform(tmpl: TemplateAspect): void {
+    for (let node = tmpl.update.head; node !== null; node = node.next) {
+      node.visitExpressions(this);
+    }
+
+    // Recurse into any child create nodes that have the TemplateAspect.
+    for (let node = tmpl.create.head; node !== null; node = node.next) {
+      if (hasTemplateAspect(node)) {
+        this.transform(node);
+      }
+    }
+  }
+}

--- a/packages/compiler/src/render3/view/pipeline/ir/template_scope.ts
+++ b/packages/compiler/src/render3/view/pipeline/ir/template_scope.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DataSlot} from './aspect/data_slot';
+import {Id} from './node';
+
+/**
+ * Tracks information about the named entities defined at a particular level of the template.
+ *
+ * Each template/embedded view may define a number of named entities: variables, local references,
+ * etc. As part of converting the template into IR, this information is extracted and stored in a
+ * `Scope` for that particular view.
+ *
+ * The `Scope` can be used to retrieve a singleton mutable metadata object for each entity defined
+ * in the template. This allows transformation stages to both access information about the named
+ * entity, and tag it with additional context for later stages to consume.
+ */
+export interface Scope {
+  /**
+   * Map of entity names defined in this template to their target metadata.
+   */
+  readonly targets: Map<string, Target>;
+
+  readonly parent: Scope|null;
+
+  /**
+   * Look up `name` in the context of this scope.
+   *
+   * `name` might refer to an entity that's defined at this level of the template, or at a higher
+   * level (in a parent template).
+   *
+   * If no entity with the given name is found, then `name` is assumed to refer to a "root context"
+   * property - a property of the component for which the template is declared.
+   */
+  lookup(name: string): Target;
+
+  /**
+   * Look up a child template within this scope by its `Id`.
+   */
+  getChild(id: Id): Scope;
+}
+
+/**
+ * The kind of entity a target represents.
+ */
+export enum TargetKind {
+  /**
+   * The entity is a local reference (#ref).
+   */
+  Reference,
+
+  /**
+   * The entity is a variable declaration made when declaring an embedded view.
+   */
+  Variable,
+
+  /**
+   * The entity refers to a property read from the root context (component property).
+   */
+  RootContext,
+
+  /**
+   * The entity refers to `$event`.
+   */
+  Event,
+}
+
+/**
+ * Metadata specific to a local reference entity.
+ */
+export interface Reference {
+  kind: TargetKind.Reference;
+
+  /**
+   * The runtime index in the data array where the value of this reference will be stored, or `null`
+   * if it has not yet been set.
+   */
+  slot: DataSlot|null;
+
+  /**
+   * Name of the local reference.
+   */
+  name: string;
+
+  /**
+   * Value of the local reference, such as the `exportAs` of a directive.
+   */
+  value: string;
+}
+
+/**
+ * Metadata specific to a template context variable.
+ */
+export interface Variable {
+  kind: TargetKind.Variable;
+
+  /**
+   * The `Id` of the template which declared this context variable.
+   */
+  template: Id;
+
+  /**
+   * The property name of the template context object to which this variable refers.
+   */
+  value: string;
+}
+
+/**
+ * Metadata which indicates that the targeted value is a property of the root context (component
+ * class).
+ *
+ * This metadata is effectively a singleton - there is no mutable metadata for a component property
+ * target.
+ */
+export interface RootContext {
+  kind: TargetKind.RootContext;
+}
+
+/**
+ * Metadata which indicates that the targeted value is the event value of an event binding.
+ *
+ * This likely indicates the target was `$event` in the template.
+ *
+ * This metadata is effectively a singleton - there is no mutable metadata for an event target.
+ */
+export interface Event {
+  kind: TargetKind.Event;
+}
+
+/**
+ * Metadata of a named entity within the template, disambiguated by its `kind` field.
+ */
+export type Target = Reference|Variable|RootContext|Event;

--- a/packages/compiler/test/render3/view/pipeline/BUILD.bazel
+++ b/packages/compiler/test/render3/view/pipeline/BUILD.bazel
@@ -1,0 +1,21 @@
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
+
+ts_library(
+    name = "pipeline_lib",
+    testonly = True,
+    srcs = glob(
+        ["**/*.ts"],
+    ),
+    deps = [
+        "//packages:types",
+        "//packages/compiler",
+    ],
+)
+
+jasmine_node_test(
+    name = "pipeline",
+    bootstrap = ["//tools/testing:node_no_angular"],
+    deps = [
+        ":pipeline_lib",
+    ],
+)

--- a/packages/compiler/test/render3/view/pipeline/ir/linked_list_spec.ts
+++ b/packages/compiler/test/render3/view/pipeline/ir/linked_list_spec.ts
@@ -35,7 +35,7 @@ function makeList(...args: number[]): LinkedList<TestNode> {
 }
 
 function expectListToEqual(list: LinkedList<TestNode>, expected: number[]): void {
-  const actual = list.toArray().map(n => n.value);
+  const actual = Array.from(list).map(n => n.value);
   expect(actual).toEqual(expected);
 }
 
@@ -55,13 +55,13 @@ describe('LinkedList', () => {
 
     it('should sort a beginning subset of the list', () => {
       const list = makeList(2, 1, 5, 7, 6, 3, 4);
-      list.sortSubset(list.head!, list.toArray()[4], compare);
+      list.sortSubset(list.head!, Array.from(list)[4], compare);
       expectListToEqual(list, [1, 2, 5, 6, 7, 3, 4]);
     });
 
     it('should sort an ending subset of the list', () => {
       const list = makeList(2, 1, 5, 7, 6, 3, 4);
-      list.sortSubset(list.toArray()[3], list.tail!, compare);
+      list.sortSubset(Array.from(list)[3], list.tail!, compare);
       expectListToEqual(list, [2, 1, 5, 3, 4, 6, 7]);
     });
   });

--- a/packages/compiler/test/render3/view/pipeline/ir/linked_list_spec.ts
+++ b/packages/compiler/test/render3/view/pipeline/ir/linked_list_spec.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {LinkedList, LinkedListNode} from '../../../../../src/render3/view/pipeline/ir/linked_list';
+
+export interface TestNode extends LinkedListNode<TestNode> {
+  value: number;
+}
+
+function compare(a: TestNode, b: TestNode) {
+  if (a.value < b.value) {
+    return -1;
+  } else if (a.value > b.value) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+function makeList(...args: number[]): LinkedList<TestNode> {
+  const list = new LinkedList<TestNode>();
+  for (const arg of args) {
+    list.append({
+      prev: null,
+      next: null,
+      value: arg,
+    });
+  }
+  return list;
+}
+
+function expectListToEqual(list: LinkedList<TestNode>, expected: number[]): void {
+  const actual = list.toArray().map(n => n.value);
+  expect(actual).toEqual(expected);
+}
+
+describe('LinkedList', () => {
+  describe('sorting', () => {
+    it('should sort an entire list', () => {
+      const list = makeList(2, 1, 5, 3, 4);
+      list.sortSubset(list.head!, list.tail!, compare);
+      expectListToEqual(list, [1, 2, 3, 4, 5]);
+    });
+
+    it('should sort a middle subset of the list', () => {
+      const list = makeList(2, 1, 5, 7, 6, 3, 4);
+      list.sortSubset(list.head!.next!, list.tail!.prev!, compare);
+      expectListToEqual(list, [2, 1, 3, 5, 6, 7, 4]);
+    });
+
+    it('should sort a beginning subset of the list', () => {
+      const list = makeList(2, 1, 5, 7, 6, 3, 4);
+      list.sortSubset(list.head!, list.toArray()[4], compare);
+      expectListToEqual(list, [1, 2, 5, 6, 7, 3, 4]);
+    });
+
+    it('should sort an ending subset of the list', () => {
+      const list = makeList(2, 1, 5, 7, 6, 3, 4);
+      list.sortSubset(list.toArray()[3], list.tail!, compare);
+      expectListToEqual(list, [2, 1, 5, 3, 4, 6, 7]);
+    });
+  });
+});


### PR DESCRIPTION
This commit is the first of several to bring the "template pipeline"
in-progress refactoring of the `TemplateDefinitionBuilder` into the `master`
branch. The template pipeline is currently being implemented as a parallel
template compiler, while the compiler continues to use the TDB in
production. Eventually, once feature parity is achieved, the compiler can
switch to using it for template compilation.

In this commit, the core data structures of the template pipeline which
define its intermediate representation (IR) are added.