### PR TITLE
ci: update payload size limits for Closure tests

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -62,7 +62,7 @@
         "bundle": "TODO(i): we should define ngDevMode to false in Closure, but --define only works in the global scope.",
         "bundle": "TODO(i): (FW-2164) TS 3.9 new class shape seems to have broken Closure in big ways. The size went from 169991 to 252338",
         "bundle": "TODO(i): after removal of tsickle from ngc-wrapped / ng_package, we had to switch to SIMPLE optimizations which increased the size from 252338 to 1198917, see PR#37221 and PR#37317 for more info",
-        "bundle": 1214317
+        "bundle": 1214857
       }
     }
   }


### PR DESCRIPTION
Currently the Closure-related tests are not tree-shaking the dev-mode-only content, thus payload size checks are failing even if dev-mode-only content is added. The https://github.com/angular/angular/commit/2e9fdbde9eb26fea17e3e68e272dc1c2cc9f4fa3 commit added some logic to JIT compiler, which is likely triggered the payload size increase. This commit updates the payload size limits for Closure-related test to get master and patch branches back to the "green" state.


## PR Type
What kind of change does this PR introduce?

- [x] CI related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No