### PR TITLE
fix(dev-infra): exclude type-only imports from circular deps check

### DIFF
--- a/dev-infra/ts-circular-dependencies/parser.ts
+++ b/dev-infra/ts-circular-dependencies/parser.ts
@@ -16,7 +16,7 @@ import * as ts from 'typescript';
 export function getModuleReferences(node: ts.SourceFile): string[] {
   const references: string[] = [];
   const visitNode = (node: ts.Node) => {
-    if ((ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+    if ((ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) && !isTypeOnlyImport(node) &&
         node.moduleSpecifier !== undefined && ts.isStringLiteral(node.moduleSpecifier)) {
       references.push(node.moduleSpecifier.text);
     }
@@ -24,4 +24,12 @@ export function getModuleReferences(node: ts.SourceFile): string[] {
   };
   ts.forEachChild(node, visitNode);
   return references;
+}
+
+function isTypeOnlyImport(node: ts.Node): boolean {
+  if (!ts.isImportDeclaration(node) || node.importClause === undefined) {
+    return false;
+  }
+
+  return node.importClause.isTypeOnly;
 }


### PR DESCRIPTION
The circular dependency check exists to prevent runtime dependency cycles
in the codebase, as not all bundlers and downstream JavaScript tooling
supports such cycles. However, circular _type_ imports are fine, and handled
internally within TypeScript without being emitted into generated JS code.

This commit patches the circular dependency checker to exclude TypeScript's
type-only imports (`import type {...}`) from counting as references to
check.
