### PR TITLE
refactor(dev-infra): use promptConfirm util in ng-dev's formatter

### DIFF
--- a/dev-infra/format/BUILD.bazel
+++ b/dev-infra/format/BUILD.bazel
@@ -10,12 +10,10 @@ ts_library(
     deps = [
         "//dev-infra/utils",
         "@npm//@types/cli-progress",
-        "@npm//@types/inquirer",
         "@npm//@types/node",
         "@npm//@types/shelljs",
         "@npm//@types/yargs",
         "@npm//cli-progress",
-        "@npm//inquirer",
         "@npm//multimatch",
         "@npm//shelljs",
         "@npm//yargs",

--- a/dev-infra/format/format.ts
+++ b/dev-infra/format/format.ts
@@ -6,9 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {prompt} from 'inquirer';
-
-import {error, info} from '../utils/console';
+import {error, info, promptConfirm} from '../utils/console';
 
 import {runFormatterInParallel} from './run-commands-parallel';
 
@@ -57,11 +55,7 @@ export async function checkFiles(files: string[]) {
     // If the command is run in a non-CI environment, prompt to format the files immediately.
     let runFormatter = false;
     if (!process.env['CI']) {
-      runFormatter = (await prompt({
-                       type: 'confirm',
-                       name: 'runFormatter',
-                       message: 'Format the files now?',
-                     })).runFormatter;
+      runFormatter = await promptConfirm('Format the files now?', true);
     }
 
     if (runFormatter) {


### PR DESCRIPTION
Use the promptConfirm util instead of manually creating a confirm prompt with
inquirer.
