### PR TITLE
build: use new labeling and branching in merge script

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -94,14 +94,14 @@ merge:
 
     # whether the PR shouldn't have a conflict with the base branch
     noConflict: true
-    # list of labels that a PR needs to have, checked with a regexp (e.g. "PR target:" will work for the label "PR target: master")
+    # list of labels that a PR needs to have, checked with a regexp (e.g. "target:" will work for the label "target: master")
     requiredLabels:
-      - "PR target: *"
+      - "target: *"
       - "cla: yes"
 
     # list of labels that a PR shouldn't have, checked after the required labels with a regexp
     forbiddenLabels:
-      - "PR target: TBD"
+      - "target: TBD"
       - "PR action: cleanup"
       - "PR action: review"
       - "PR state: blocked"

--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -1,38 +1,25 @@
-import {MergeConfig} from '../dev-infra/pr/merge/config';
+import {DevInfraMergeConfig} from '../dev-infra/pr/merge/config';
+import {getDefaultTargetLabelConfiguration} from '../dev-infra/pr/merge/defaults';
+import {github} from './github';
 
 /**
  * Configuration for the merge tool in `ng-dev`. This sets up the labels which
  * are respected by the merge script (e.g. the target labels).
  */
-export const merge = (): MergeConfig => {
-  // TODO: resume dynamically determining patch branch
-  const patch = '10.0.x';
+export const merge: DevInfraMergeConfig['merge'] = async api => {
   return {
     githubApiMerge: false,
     claSignedLabel: 'cla: yes',
     mergeReadyLabel: /^PR action: merge(-assistance)?/,
     caretakerNoteLabel: 'PR action: merge-assistance',
     commitMessageFixupLabel: 'commit message fixup',
-    labels: [
-      {
-        pattern: 'PR target: master-only',
-        branches: ['master'],
-      },
-      {
-        pattern: 'PR target: patch-only',
-        branches: [patch],
-      },
-      {
-        pattern: 'PR target: master & patch',
-        branches: ['master', patch],
-      },
-    ],
+    labels: await getDefaultTargetLabelConfiguration(api, github, '@angular/core'),
     requiredBaseCommits: {
       // PRs that target either `master` or the patch branch, need to be rebased
       // on top of the latest commit message validation fix.
       // These SHAs are the commits that update the required license text in the header.
       'master': '5aeb9a4124922d8ac08eb73b8f322905a32b0b3a',
-      [patch]: '27b95ba64a5d99757f4042073fd1860e20e3ed24'
+      '10.0.x': '27b95ba64a5d99757f4042073fd1860e20e3ed24'
     },
   };
 };


### PR DESCRIPTION
We introduced a new shared configuration for merge script
labels that follow the [new proposal](https://docs.google.com/document/d/197kVillDwx-RZtSVOBtPb4BBIAw0E9RT3q3v6DZkykU).

These label semantics and the branching are set up for the Angular
framework with this commit. The goal is that labeling and merging
is consistent between all Angular projects and that clear rules
are defined for branching. This was previously not the case.