### PR TITLE
feat(dev-infra): migrate to unified commit message types in commit message linting

### DIFF
--- a/.ng-dev/commit-message.ts
+++ b/.ng-dev/commit-message.ts
@@ -7,18 +7,6 @@ export const commitMessage: CommitMessageConfig = {
   maxLineLength: 120,
   minBodyLength: 20,
   minBodyLengthTypeExcludes: ['docs'],
-  types: [
-    'build',
-    'ci',
-    'docs',
-    'feat',
-    'fix',
-    'perf',
-    'refactor',
-    'release',
-    'style',
-    'test',
-  ],
   scopes: [
     'animations',
     'bazel',

--- a/dev-infra/commit-message/config.ts
+++ b/dev-infra/commit-message/config.ts
@@ -31,7 +31,7 @@ export function getCommitMessageConfig() {
 }
 
 /** Scope requirement level to be set for each commit type.  */
-export enum SCOPE_REQUIREMENT {
+export enum ScopeRequirement {
   Required,
   Optional,
   Forbidden,
@@ -39,46 +39,36 @@ export enum SCOPE_REQUIREMENT {
 
 /** A commit type */
 export interface CommitType {
-  value: string;
-  scope: SCOPE_REQUIREMENT;
+  scope: ScopeRequirement;
 }
 
 /** The valid commit types for Angular commit messages. */
 export const COMMIT_TYPES: {[key: string]: CommitType} = {
   build: {
-    value: 'build',
-    scope: SCOPE_REQUIREMENT.Forbidden,
+    scope: ScopeRequirement.Forbidden,
   },
   ci: {
-    value: 'ci',
-    scope: SCOPE_REQUIREMENT.Forbidden,
+    scope: ScopeRequirement.Forbidden,
   },
   docs: {
-    value: 'docs',
-    scope: SCOPE_REQUIREMENT.Optional,
+    scope: ScopeRequirement.Optional,
   },
   feat: {
-    value: 'feat',
-    scope: SCOPE_REQUIREMENT.Required,
+    scope: ScopeRequirement.Required,
   },
   fix: {
-    value: 'fix',
-    scope: SCOPE_REQUIREMENT.Required,
+    scope: ScopeRequirement.Required,
   },
   perf: {
-    value: 'perf',
-    scope: SCOPE_REQUIREMENT.Required,
+    scope: ScopeRequirement.Required,
   },
   refactor: {
-    value: 'refactor',
-    scope: SCOPE_REQUIREMENT.Required,
+    scope: ScopeRequirement.Required,
   },
   release: {
-    value: 'release',
-    scope: SCOPE_REQUIREMENT.Forbidden,
+    scope: ScopeRequirement.Forbidden,
   },
   test: {
-    value: 'test',
-    scope: SCOPE_REQUIREMENT.Required,
+    scope: ScopeRequirement.Required,
   },
 };

--- a/dev-infra/commit-message/config.ts
+++ b/dev-infra/commit-message/config.ts
@@ -12,7 +12,6 @@ export interface CommitMessageConfig {
   maxLineLength: number;
   minBodyLength: number;
   minBodyLengthTypeExcludes?: string[];
-  types: string[];
   scopes: string[];
 }
 
@@ -30,3 +29,56 @@ export function getCommitMessageConfig() {
   assertNoErrors(errors);
   return config as Required<typeof config>;
 }
+
+/** Scope requirement level to be set for each commit type.  */
+export enum SCOPE_REQUIREMENT {
+  Required,
+  Optional,
+  Forbidden,
+}
+
+/** A commit type */
+export interface CommitType {
+  value: string;
+  scope: SCOPE_REQUIREMENT;
+}
+
+/** The valid commit types for Angular commit messages. */
+export const COMMIT_TYPES: {[key: string]: CommitType} = {
+  build: {
+    value: 'build',
+    scope: SCOPE_REQUIREMENT.Forbidden,
+  },
+  ci: {
+    value: 'ci',
+    scope: SCOPE_REQUIREMENT.Forbidden,
+  },
+  docs: {
+    value: 'docs',
+    scope: SCOPE_REQUIREMENT.Optional,
+  },
+  feat: {
+    value: 'feat',
+    scope: SCOPE_REQUIREMENT.Required,
+  },
+  fix: {
+    value: 'fix',
+    scope: SCOPE_REQUIREMENT.Required,
+  },
+  perf: {
+    value: 'perf',
+    scope: SCOPE_REQUIREMENT.Required,
+  },
+  refactor: {
+    value: 'refactor',
+    scope: SCOPE_REQUIREMENT.Required,
+  },
+  release: {
+    value: 'release',
+    scope: SCOPE_REQUIREMENT.Forbidden,
+  },
+  test: {
+    value: 'test',
+    scope: SCOPE_REQUIREMENT.Required,
+  },
+};

--- a/dev-infra/commit-message/validate.spec.ts
+++ b/dev-infra/commit-message/validate.spec.ts
@@ -18,13 +18,6 @@ const config: {commitMessage: CommitMessageConfig} = {
   commitMessage: {
     maxLineLength: 120,
     minBodyLength: 0,
-    types: [
-      'feat',
-      'fix',
-      'refactor',
-      'release',
-      'style',
-    ],
     scopes: [
       'common',
       'compiler',
@@ -33,7 +26,7 @@ const config: {commitMessage: CommitMessageConfig} = {
     ]
   }
 };
-const TYPES = config.commitMessage.types.join(', ');
+const TYPES = Object.keys(validateConfig.COMMIT_TYPES).join(', ');
 const SCOPES = config.commitMessage.scopes.join(', ');
 const INVALID = false;
 const VALID = true;
@@ -47,7 +40,8 @@ describe('validate-commit-message.js', () => {
     lastError = '';
 
     spyOn(console, 'error').and.callFake((msg: string) => lastError = msg);
-    spyOn(validateConfig, 'getCommitMessageConfig').and.returnValue(config);
+    spyOn(validateConfig, 'getCommitMessageConfig')
+        .and.returnValue(config as ReturnType<typeof validateConfig.getCommitMessageConfig>);
   });
 
   describe('validateMessage()', () => {
@@ -55,16 +49,16 @@ describe('validate-commit-message.js', () => {
       expect(validateCommitMessage('feat(packaging): something')).toBe(VALID);
       expect(lastError).toBe('');
 
-      expect(validateCommitMessage('release(packaging): something')).toBe(VALID);
+      expect(validateCommitMessage('fix(packaging): something')).toBe(VALID);
       expect(lastError).toBe('');
 
-      expect(validateCommitMessage('fixup! release(packaging): something')).toBe(VALID);
+      expect(validateCommitMessage('fixup! fix(packaging): something')).toBe(VALID);
       expect(lastError).toBe('');
 
-      expect(validateCommitMessage('squash! release(packaging): something')).toBe(VALID);
+      expect(validateCommitMessage('squash! fix(packaging): something')).toBe(VALID);
       expect(lastError).toBe('');
 
-      expect(validateCommitMessage('Revert: "release(packaging): something"')).toBe(VALID);
+      expect(validateCommitMessage('Revert: "fix(packaging): something"')).toBe(VALID);
       expect(lastError).toBe('');
     });
 
@@ -110,8 +104,8 @@ describe('validate-commit-message.js', () => {
       expect(validateCommitMessage('feat(bah): something')).toBe(INVALID);
       expect(lastError).toContain(errorMessageFor('bah', 'feat(bah): something'));
 
-      expect(validateCommitMessage('style(webworker): something')).toBe(INVALID);
-      expect(lastError).toContain(errorMessageFor('webworker', 'style(webworker): something'));
+      expect(validateCommitMessage('fix(webworker): something')).toBe(INVALID);
+      expect(lastError).toContain(errorMessageFor('webworker', 'fix(webworker): something'));
 
       expect(validateCommitMessage('refactor(security): something')).toBe(INVALID);
       expect(lastError).toContain(errorMessageFor('security', 'refactor(security): something'));
@@ -119,12 +113,12 @@ describe('validate-commit-message.js', () => {
       expect(validateCommitMessage('refactor(docs): something')).toBe(INVALID);
       expect(lastError).toContain(errorMessageFor('docs', 'refactor(docs): something'));
 
-      expect(validateCommitMessage('release(angular): something')).toBe(INVALID);
-      expect(lastError).toContain(errorMessageFor('angular', 'release(angular): something'));
+      expect(validateCommitMessage('feat(angular): something')).toBe(INVALID);
+      expect(lastError).toContain(errorMessageFor('angular', 'feat(angular): something'));
     });
 
     it('should allow empty scope', () => {
-      expect(validateCommitMessage('fix: blablabla')).toBe(VALID);
+      expect(validateCommitMessage('build: blablabla')).toBe(VALID);
       expect(lastError).toBe('');
     });
 
@@ -243,7 +237,6 @@ describe('validate-commit-message.js', () => {
           maxLineLength: 120,
           minBodyLength: 30,
           minBodyLengthTypeExcludes: ['docs'],
-          types: ['fix', 'docs'],
           scopes: ['core']
         }
       };

--- a/dev-infra/commit-message/validate.ts
+++ b/dev-infra/commit-message/validate.ts
@@ -7,7 +7,7 @@
  */
 import {error} from '../utils/console';
 
-import {COMMIT_TYPES, getCommitMessageConfig, SCOPE_REQUIREMENT} from './config';
+import {COMMIT_TYPES, getCommitMessageConfig, ScopeRequirement} from './config';
 import {parseCommitMessage} from './parse';
 
 /** Options for commit message validation. */
@@ -97,20 +97,16 @@ export function validateCommitMessage(
   /** The scope requirement level for the provided type of the commit message. */
   const scopeRequirementForType = COMMIT_TYPES[commit.type].scope;
 
-  if (scopeRequirementForType === SCOPE_REQUIREMENT.Forbidden) {
-    if (commit.scope) {
-      printError(`Scopes are forbidden for commits with type '${commit.type}', but a scope of '${
-          commit.scope}' was provided.`);
-      return false;
-    }
+  if (scopeRequirementForType === ScopeRequirement.Forbidden && commit.scope) {
+    printError(`Scopes are forbidden for commits with type '${commit.type}', but a scope of '${
+        commit.scope}' was provided.`);
+    return false;
   }
 
-  if (scopeRequirementForType === SCOPE_REQUIREMENT.Required) {
-    if (!commit.scope) {
-      printError(
-          `Scopes are required for commits with type '${commit.type}', but no scope was provided.`);
-      return false;
-    }
+  if (scopeRequirementForType === ScopeRequirement.Required && !commit.scope) {
+    printError(
+        `Scopes are required for commits with type '${commit.type}', but no scope was provided.`);
+    return false;
   }
 
   if (commit.scope && !config.scopes.includes(commit.scope)) {

--- a/dev-infra/commit-message/validate.ts
+++ b/dev-infra/commit-message/validate.ts
@@ -7,7 +7,7 @@
  */
 import {error} from '../utils/console';
 
-import {getCommitMessageConfig} from './config';
+import {COMMIT_TYPES, getCommitMessageConfig, SCOPE_REQUIREMENT} from './config';
 import {parseCommitMessage} from './parse';
 
 /** Options for commit message validation. */
@@ -86,9 +86,31 @@ export function validateCommitMessage(
     return false;
   }
 
-  if (!config.types.includes(commit.type)) {
-    printError(`'${commit.type}' is not an allowed type.\n => TYPES: ${config.types.join(', ')}`);
+
+
+  if (COMMIT_TYPES[commit.type] === undefined) {
+    printError(`'${commit.type}' is not an allowed type.\n => TYPES: ${
+        Object.keys(COMMIT_TYPES).join(', ')}`);
     return false;
+  }
+
+  /** The scope requirement level for the provided type of the commit message. */
+  const scopeRequirementForType = COMMIT_TYPES[commit.type].scope;
+
+  if (scopeRequirementForType === SCOPE_REQUIREMENT.Forbidden) {
+    if (commit.scope) {
+      printError(`Scopes are forbidden for commits with type '${commit.type}', but a scope of '${
+          commit.scope}' was provided.`);
+      return false;
+    }
+  }
+
+  if (scopeRequirementForType === SCOPE_REQUIREMENT.Required) {
+    if (!commit.scope) {
+      printError(
+          `Scopes are required for commits with type '${commit.type}', but no scope was provided.`);
+      return false;
+    }
   }
 
   if (commit.scope && !config.scopes.includes(commit.scope)) {


### PR DESCRIPTION
Previously commit message types were provided as part of the ng-dev config in the repository
using the ng-dev toolset.  This change removes this configuration expectation and instead
predefines the valid types for commit messages.

Additionally, with this new unified set of types requirements around providing a scope have
been put in place.  Scopes are either required, optional or forbidden for a given commit
type.
