### PR TITLE
feat(compiler-cli): Add ability to retrieve symbol from ast

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ParseError, TmplAstNode} from '@angular/compiler';
+import {AST, ParseError, TmplAstNode} from '@angular/compiler';
 import * as ts from 'typescript';
 
 /**
@@ -69,6 +69,19 @@ export interface TemplateTypeChecker {
    * This method always runs in `OptimizeFor.SingleFile` mode.
    */
   getTypeCheckBlock(component: ts.ClassDeclaration): ts.Node|null;
+
+  /**
+   * Given a template AST expression and the component class for the template, finds and returns the
+   * `ts.Symbol` for the expression.
+   *
+   * Not all expressions will have symbols (e.g. there is no symbol associated with the expression a
+   * + b, but there are symbols for both the a and b nodes individually).
+   *
+   * When the expression is an assignment to an intermediate variable, either through a template
+   * context or a local reference, this method returns the `ts.Symbol` for the context or actual
+   * reference rather than the intermediate variable.
+   */
+  getSymbolOfTemplateExpression(expression: AST, component: ts.ClassDeclaration): ts.Symbol|null;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/diagnostics.ts
@@ -314,7 +314,7 @@ function getTemplateId(node: ts.Node, sourceFile: ts.SourceFile): TemplateId|nul
 
 const parseSpanComment = /^(\d+),(\d+)$/;
 
-function readSpanComment(sourceFile: ts.SourceFile, node: ts.Node): AbsoluteSourceSpan|null {
+export function readSpanComment(sourceFile: ts.SourceFile, node: ts.Node): AbsoluteSourceSpan|null {
   return ts.forEachTrailingCommentRange(sourceFile.text, node.getEnd(), (pos, end, kind) => {
     if (kind !== ts.SyntaxKind.MultiLineCommentTrivia) {
       return null;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -98,7 +98,7 @@ class AstTranslator implements AstVisitor {
     const trueExpr = this.translate(ast.trueExp);
     // Wrap `falseExpr` in parens so that the trailing parse span info is not attributed to the
     // whole conditional.
-    const falseExpr = ts.createParen(this.translate(ast.falseExp));
+    const falseExpr = wrapForDiagnostics(this.translate(ast.falseExp));
     const node = ts.createParen(ts.createConditional(condExpr, trueExpr, falseExpr));
     addParseSpanInfo(node, ast.sourceSpan);
     return node;
@@ -122,7 +122,7 @@ class AstTranslator implements AstVisitor {
     // the type is inferred as 'string'.
     return ast.expressions.reduce(
         (lhs, ast) =>
-            ts.createBinary(lhs, ts.SyntaxKind.PlusToken, ts.createParen(this.translate(ast))),
+            ts.createBinary(lhs, ts.SyntaxKind.PlusToken, wrapForDiagnostics(this.translate(ast))),
         ts.createLiteral(''));
   }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -96,7 +96,9 @@ class AstTranslator implements AstVisitor {
   visitConditional(ast: Conditional): ts.Expression {
     const condExpr = this.translate(ast.condition);
     const trueExpr = this.translate(ast.trueExp);
-    const falseExpr = this.translate(ast.falseExp);
+    // Wrap `falseExpr` in parens so that the trailing parse span info is not attributed to the
+    // whole conditional.
+    const falseExpr = ts.createParen(this.translate(ast.falseExp));
     const node = ts.createParen(ts.createConditional(condExpr, trueExpr, falseExpr));
     addParseSpanInfo(node, ast.sourceSpan);
     return node;
@@ -119,7 +121,8 @@ class AstTranslator implements AstVisitor {
     // interpolation's expressions. The chain is started using an actual string literal to ensure
     // the type is inferred as 'string'.
     return ast.expressions.reduce(
-        (lhs, ast) => ts.createBinary(lhs, ts.SyntaxKind.PlusToken, this.translate(ast)),
+        (lhs, ast) =>
+            ts.createBinary(lhs, ts.SyntaxKind.PlusToken, ts.createParen(this.translate(ast))),
         ts.createLiteral(''));
   }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {AbsoluteSourceSpan, ParseSourceSpan} from '@angular/compiler';
 import * as ts from 'typescript';
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
@@ -1,0 +1,21 @@
+import {AbsoluteSourceSpan, ParseSourceSpan} from '@angular/compiler';
+import * as ts from 'typescript';
+
+import {readSpanComment} from './diagnostics';
+
+export function findNodeWithAbsoluteSourceSpan<T extends ts.Node>(
+    sourceSpan: AbsoluteSourceSpan, tcb: ts.Node, filter: (node: ts.Node) => node is T): T|null {
+  function visitor(node: ts.Node): T|undefined {
+    const comment = readSpanComment(tcb.getSourceFile(), node);
+    if (sourceSpan.start === comment?.start && sourceSpan.end === comment?.end && filter(node)) {
+      return node;
+    }
+    return node.forEachChild(visitor);
+  }
+  return tcb.forEachChild(visitor) ?? null;
+}
+export function findNodeWithSourceSpan<T extends ts.Node>(
+    sourceSpan: ParseSourceSpan, tcb: ts.Node, filter: (node: ts.Node) => node is T): T|null {
+  const absoluteSourceSpan = new AbsoluteSourceSpan(sourceSpan.start.offset, sourceSpan.end.offset);
+  return findNodeWithAbsoluteSourceSpan(absoluteSourceSpan, tcb, filter);
+}

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -18,12 +18,12 @@ describe('type check blocks diagnostics', () => {
     it('should annotate conditions', () => {
       expect(tcbWithSpans('{{ a ? b : c }}'))
           .toContain(
-              '(((ctx).a /*3,4*/) /*3,4*/ ? ((ctx).b /*7,8*/) /*7,8*/ : ((ctx).c /*11,12*/) /*11,12*/) /*3,12*/');
+              '(((ctx).a /*3,4*/) /*3,4*/ ? ((ctx).b /*7,8*/) /*7,8*/ : (((ctx).c /*11,12*/) /*11,12*/)) /*3,12*/');
     });
 
     it('should annotate interpolations', () => {
       expect(tcbWithSpans('{{ hello }} {{ world }}'))
-          .toContain('"" + ((ctx).hello /*3,8*/) /*3,8*/ + ((ctx).world /*15,20*/) /*15,20*/');
+          .toContain('"" + (((ctx).hello /*3,8*/) /*3,8*/) + (((ctx).world /*15,20*/) /*15,20*/)');
     });
 
     it('should annotate literal map expressions', () => {
@@ -43,7 +43,7 @@ describe('type check blocks diagnostics', () => {
 
     it('should annotate literals', () => {
       const TEMPLATE = '{{ 123 }}';
-      expect(tcbWithSpans(TEMPLATE)).toContain('123 /*3,6*/;');
+      expect(tcbWithSpans(TEMPLATE)).toContain('123 /*3,6*/');
     });
 
     it('should annotate non-null assertions', () => {
@@ -53,7 +53,7 @@ describe('type check blocks diagnostics', () => {
 
     it('should annotate prefix not', () => {
       const TEMPLATE = `{{ !a }}`;
-      expect(tcbWithSpans(TEMPLATE)).toContain('!(((ctx).a /*4,5*/) /*4,5*/) /*3,5*/;');
+      expect(tcbWithSpans(TEMPLATE)).toContain('!(((ctx).a /*4,5*/) /*4,5*/) /*3,5*/');
     });
 
     it('should annotate method calls', () => {
@@ -137,7 +137,7 @@ describe('type check blocks diagnostics', () => {
       }];
       const block = tcbWithSpans(TEMPLATE, PIPES);
       expect(block).toContain(
-          '(null as TestPipe).transform(((ctx).a /*3,4*/) /*3,4*/, ((ctx).b /*12,13*/) /*12,13*/) /*3,13*/;');
+          '((null as TestPipe).transform(((ctx).a /*3,4*/) /*3,4*/, ((ctx).b /*12,13*/) /*12,13*/) /*3,13*/);');
     });
 
     describe('attaching multiple comments for multiple references', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -126,10 +126,8 @@ export function ngForDeclaration(): TestDeclaration {
   };
 }
 
-export function ngForDts(): TestFile {
-  return {
-    name: absoluteFrom('/ngfor.d.ts'),
-    contents: `
+export function ngForDts(): TestFile&TypeCheckingTarget {
+  const contents = `
     export declare class NgForOf<T> {
       ngForOf: T[];
       ngForTrackBy: TrackByFunction<T>;
@@ -148,7 +146,14 @@ export function ngForDts(): TestFile {
       readonly even: boolean;
       readonly first: boolean;
       readonly last: boolean;
-    }`,
+    }`;
+  const name = absoluteFrom('/ngfor.d.ts');
+  return {
+    name,
+    fileName: name,
+    contents,
+    source: contents,
+    templates: {},
   };
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -13,33 +13,33 @@ import {ALL_ENABLED_CONFIG, tcb, TestDeclaration, TestDirective} from './test_ut
 
 describe('type check blocks', () => {
   it('should generate a basic block for a binding', () => {
-    expect(tcb('{{hello}} {{world}}')).toContain('"" + ((ctx).hello) + ((ctx).world);');
+    expect(tcb('{{hello}} {{world}}')).toContain('"" + (((ctx).hello)) + (((ctx).world));');
   });
 
   it('should generate literal map expressions', () => {
     const TEMPLATE = '{{ method({foo: a, bar: b}) }}';
-    expect(tcb(TEMPLATE)).toContain('(ctx).method({ "foo": ((ctx).a), "bar": ((ctx).b) });');
+    expect(tcb(TEMPLATE)).toContain('(ctx).method({ "foo": ((ctx).a), "bar": ((ctx).b) })');
   });
 
   it('should generate literal array expressions', () => {
     const TEMPLATE = '{{ method([a, b]) }}';
-    expect(tcb(TEMPLATE)).toContain('(ctx).method([((ctx).a), ((ctx).b)]);');
+    expect(tcb(TEMPLATE)).toContain('(ctx).method([((ctx).a), ((ctx).b)])');
   });
 
   it('should handle non-null assertions', () => {
     const TEMPLATE = `{{a!}}`;
-    expect(tcb(TEMPLATE)).toContain('((((ctx).a))!);');
+    expect(tcb(TEMPLATE)).toContain('((((ctx).a))!)');
   });
 
   it('should handle keyed property access', () => {
     const TEMPLATE = `{{a[b]}}`;
-    expect(tcb(TEMPLATE)).toContain('(((ctx).a))[((ctx).b)];');
+    expect(tcb(TEMPLATE)).toContain('(((ctx).a))[((ctx).b)]');
   });
 
   it('should handle nested ternary expressions', () => {
     const TEMPLATE = `{{a ? b : c ? d : e}}`;
     expect(tcb(TEMPLATE))
-        .toContain('(((ctx).a) ? ((ctx).b) : (((ctx).c) ? ((ctx).d) : ((ctx).e)))');
+        .toContain('(((ctx).a) ? ((ctx).b) : ((((ctx).c) ? ((ctx).d) : (((ctx).e)))))');
   });
 
   it('should handle quote expressions as any type', () => {
@@ -101,7 +101,7 @@ describe('type check blocks', () => {
   it('should handle method calls of template variables', () => {
     const TEMPLATE = `<ng-template let-a>{{a(1)}}</ng-template>`;
     expect(tcb(TEMPLATE)).toContain('var _t2 = _t1.$implicit;');
-    expect(tcb(TEMPLATE)).toContain('(_t2).a(1);');
+    expect(tcb(TEMPLATE)).toContain('(_t2).a(1)');
   });
 
   it('should handle implicit vars when using microsyntax', () => {
@@ -259,7 +259,7 @@ describe('type check blocks', () => {
       <input #i>
     `;
     expect(tcb(TEMPLATE))
-        .toContain('var _t1 = document.createElement("input"); "" + ((_t1).value);');
+        .toContain('var _t1 = document.createElement("input"); "" + (((_t1).value));');
   });
 
   it('should generate a forward directive reference correctly', () => {
@@ -275,7 +275,7 @@ describe('type check blocks', () => {
     }];
     expect(tcb(TEMPLATE, DIRECTIVES))
         .toContain(
-            'var _t1: Dir = (null!); "" + ((_t1).value); var _t2 = document.createElement("div");');
+            'var _t1: Dir = (null!); "" + (((_t1).value)); var _t2 = document.createElement("div");');
   });
 
   it('should handle style and class bindings specially', () => {
@@ -504,7 +504,7 @@ describe('type check blocks', () => {
   it('should handle $any casts', () => {
     const TEMPLATE = `{{$any(a)}}`;
     const block = tcb(TEMPLATE);
-    expect(block).toContain('(((ctx).a) as any);');
+    expect(block).toContain('(((ctx).a) as any)');
   });
 
   describe('experimental DOM checking via lib.dom.d.ts', () => {
@@ -644,12 +644,12 @@ describe('type check blocks', () => {
 
       it('should descend into template bodies when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('((ctx).a);');
+        expect(block).toContain('((ctx).a)');
       });
       it('should not descend into template bodies when disabled', () => {
         const DISABLED_CONFIG: TypeCheckingConfig = {...BASE_CONFIG, checkTemplateBodies: false};
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).not.toContain('((ctx).a);');
+        expect(block).not.toContain('((ctx).a)');
       });
     });
 
@@ -836,12 +836,12 @@ describe('type check blocks', () => {
 
       it('should check types of pipes when enabled', () => {
         const block = tcb(TEMPLATE, PIPES);
-        expect(block).toContain('(null as TestPipe).transform(((ctx).a), ((ctx).b), ((ctx).c));');
+        expect(block).toContain('(null as TestPipe).transform(((ctx).a), ((ctx).b), ((ctx).c))');
       });
       it('should not check types of pipes when disabled', () => {
         const DISABLED_CONFIG: TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfPipes: false};
         const block = tcb(TEMPLATE, PIPES, DISABLED_CONFIG);
-        expect(block).toContain('(null as any).transform(((ctx).a), ((ctx).b), ((ctx).c));');
+        expect(block).toContain('(null as any).transform(((ctx).a), ((ctx).b), ((ctx).c))');
       });
     });
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_expression.spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_expression.spec.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import {ASTWithSource, Binary, BindingPipe, Conditional, Interpolation, PropertyRead, TmplAstBoundAttribute, TmplAstBoundText, TmplAstElement, TmplAstNode, TmplAstTemplate,} from '@angular/compiler';
 import * as ts from 'typescript';
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_expression.spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_expression.spec.ts
@@ -1,0 +1,380 @@
+import {ASTWithSource, Binary, BindingPipe, Conditional, Interpolation, PropertyRead, TmplAstBoundAttribute, TmplAstBoundText, TmplAstElement, TmplAstNode, TmplAstTemplate,} from '@angular/compiler';
+import * as ts from 'typescript';
+
+import {absoluteFrom, getSourceFileOrError} from '../../file_system';
+import {runInEachFileSystem} from '../../file_system/testing';
+import {ClassDeclaration} from '../../reflection';
+import {TemplateTypeChecker} from '../api';
+
+import {getClass, ngForDeclaration, ngForDts, setup, TestDeclaration} from './test_utils';
+
+runInEachFileSystem(() => {
+  describe('templateTypeChecker.getSymbolOfTemplateExpression()', () => {
+    it('should get a symbol for just a component property used in an input binding', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const templateString = `<div [inputA]="helloWorld"></div>`;
+      const {program, templateTypeChecker} = setup(
+          [
+            {
+              fileName,
+              templates: {'Cmp': templateString},
+              source: `export class Cmp {helloWorld: string;}`,
+            },
+          ],
+          {inlining: false});
+      const sf = getSourceFileOrError(program, fileName);
+      const cmp = getClass(sf, 'Cmp');
+
+      const nodes = getAstElements(templateTypeChecker, cmp, templateString);
+
+      const symbol =
+          templateTypeChecker.getSymbolOfTemplateExpression(nodes[0].inputs[0].value, cmp)!;
+      expect(symbol.escapedName.toString()).toEqual('helloWorld');
+    });
+
+    it('should get a symbol for properties several levels deep', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const templateString = `<div [inputA]="person.address.street"></div>`;
+      const {program, templateTypeChecker} = setup(
+          [
+            {
+              fileName,
+              templates: {'Cmp': templateString},
+              source: `
+              interface Address {
+                street: string;
+              }
+
+              interface Person {
+                address: Address;
+              }
+              export class Cmp {person?: Person;}
+            `,
+            },
+          ],
+          {inlining: false});
+      const sf = getSourceFileOrError(program, fileName);
+      const cmp = getClass(sf, 'Cmp');
+
+      const nodes = getAstElements(templateTypeChecker, cmp, templateString);
+
+      const symbol =
+          templateTypeChecker.getSymbolOfTemplateExpression(nodes[0].inputs[0].value, cmp)!;
+      expect(symbol.escapedName.toString()).toEqual('street');
+      expect((symbol.declarations[0] as ts.PropertyDeclaration).parent.name!.getText())
+          .toEqual('Address');
+    });
+
+    it('should get a symbol for conditionals', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const templateString = `
+        <div [inputA]="person?.address?.street"></div>
+        <div [inputA]="person ? person.address : noPersonError"></div>
+      `;
+      const {program, templateTypeChecker} = setup(
+          [
+            {
+              fileName,
+              templates: {'Cmp': templateString},
+              source: `
+              interface Address {
+                street: string;
+              }
+
+              interface Person {
+                address: Address;
+              }
+              export class Cmp {person?: Person; noPersonError = 'no person'}
+            `,
+            },
+          ],
+          {inlining: false});
+      const sf = getSourceFileOrError(program, fileName);
+      const cmp = getClass(sf, 'Cmp');
+
+      const nodes = getAstElements(templateTypeChecker, cmp, templateString);
+
+      const safePropertyRead = nodes[0].inputs[0].value as ASTWithSource;
+      const symbol = templateTypeChecker.getSymbolOfTemplateExpression(safePropertyRead, cmp)!;
+      expect(symbol.escapedName.toString()).toEqual('street');
+      expect((symbol.declarations[0] as ts.PropertyDeclaration).parent.name!.getText())
+          .toEqual('Address');
+
+      const ternary = (nodes[1].inputs[0].value as ASTWithSource).ast as Conditional;
+      expect(templateTypeChecker.getSymbolOfTemplateExpression(ternary, cmp)).toBeNull();
+
+      const addrSymbol = templateTypeChecker.getSymbolOfTemplateExpression(ternary.trueExp, cmp)!;
+      expect(addrSymbol.escapedName.toString()).toEqual('address');
+
+      const noPersonSymbol =
+          templateTypeChecker.getSymbolOfTemplateExpression(ternary.falseExp, cmp)!;
+      expect(noPersonSymbol.escapedName.toString()).toEqual('noPersonError');
+    });
+
+    it('should get a symbol for function on a component used in an input binding', () => {
+      const functionName = 'helloWorld';
+      const fileName = absoluteFrom('/main.ts');
+      const templateString = `<div [inputA]="${functionName}"></div>`;
+      const {program, templateTypeChecker} = setup(
+          [
+            {
+              fileName,
+              templates: {'Cmp': templateString},
+              source: `
+            export class Cmp {
+              ${functionName}() { return ''; }
+            }`,
+            },
+          ],
+          {inlining: false});
+      const sf = getSourceFileOrError(program, fileName);
+      const cmp = getClass(sf, 'Cmp');
+
+      const nodes = getAstElements(templateTypeChecker, cmp, templateString);
+
+      const symbol =
+          templateTypeChecker.getSymbolOfTemplateExpression(nodes[0].inputs[0].value, cmp)!;
+      expect(symbol.escapedName.toString()).toEqual(functionName);
+    });
+
+    it('should return null when requesting a symbol for an entire binary expression', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const templateString = `<div [inputA]="a + b"></div>`;
+      const {program, templateTypeChecker} = setup(
+          [
+            {
+              fileName,
+              templates: {'Cmp': templateString},
+              source: `
+            export class Cmp {
+              a!: number;
+              b!: number;
+            }`,
+            },
+          ],
+          {inlining: false});
+      const sf = getSourceFileOrError(program, fileName);
+      const cmp = getClass(sf, 'Cmp');
+
+      const {nodes} = templateTypeChecker.overrideComponentTemplate(cmp, templateString);
+
+      const symbol = templateTypeChecker.getSymbolOfTemplateExpression(
+          (nodes[0] as TmplAstElement).inputs[0].value, cmp);
+      expect(symbol).toBeNull();
+    });
+
+    it('should get a symbol for a component property in a binary expression', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const templateString = `<div [inputA]="a + b"></div>`;
+      const {program, templateTypeChecker} = setup(
+          [
+            {
+              fileName,
+              templates: {'Cmp': templateString},
+              source: `
+            export class Cmp {
+              a!: number;
+              b!: number;
+            }`,
+            },
+          ],
+          {inlining: false});
+      const sf = getSourceFileOrError(program, fileName);
+      const cmp = getClass(sf, 'Cmp');
+
+      const nodes = getAstElements(templateTypeChecker, cmp, templateString);
+      const valueAssignment = nodes[0].inputs[0].value as ASTWithSource;
+
+      const aSymbol = templateTypeChecker.getSymbolOfTemplateExpression(
+          (valueAssignment.ast as Binary).left, cmp)!;
+      expect(aSymbol.escapedName.toString()).toBe('a');
+      const bSymbol = templateTypeChecker.getSymbolOfTemplateExpression(
+          (valueAssignment.ast as Binary).right, cmp)!;
+      expect(bSymbol.escapedName.toString()).toBe('b');
+    });
+
+    it('should return member on directive bound with template var', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const dirFile = absoluteFrom('/dir.ts');
+      const templateString = `
+        <div dir #myDir="dir"></div>
+        <div [inputA]="myDir.dirValue" [inputB]="myDir"></div>
+        `;
+      const {program, templateTypeChecker} = setup(
+          [
+            {
+              fileName,
+              templates: {'Cmp': templateString},
+              declarations: [{
+                name: 'TestDir',
+                selector: '[dir]',
+                file: dirFile,
+                type: 'directive',
+                exportAs: ['dir'],
+              }]
+            },
+            {
+              fileName: dirFile,
+              source: `export class TestDir { dirValue = 'helloWorld' }`,
+              templates: {}
+            }
+          ],
+          {inlining: false});
+      const sf = getSourceFileOrError(program, fileName);
+      const cmp = getClass(sf, 'Cmp');
+
+      const nodes = getAstElements(templateTypeChecker, cmp, templateString);
+
+      const dirValueSymbol =
+          templateTypeChecker.getSymbolOfTemplateExpression(nodes[1].inputs[0].value, cmp)!;
+      expect(dirValueSymbol.escapedName.toString()).toBe('dirValue');
+      const dirSymbol =
+          templateTypeChecker.getSymbolOfTemplateExpression(nodes[1].inputs[1].value, cmp)!;
+      expect(dirSymbol.escapedName.toString()).toBe('TestDir');
+    });
+  });
+
+  describe('AST Templates', () => {
+    let templateTypeChecker: TemplateTypeChecker;
+    let cmp: ClassDeclaration<ts.ClassDeclaration>;
+    let templateNode: TmplAstTemplate;
+
+    beforeEach(() => {
+      const fileName = absoluteFrom('/main.ts');
+      const templateString = `
+              <div *ngFor="let user of users; let i = index;">
+                {{user.name}} {{user.address}}
+                <div [tabIndex]="i"></div>
+              </div>`;
+      const testValues = setup(
+          [
+            {
+              fileName,
+              templates: {'Cmp': templateString},
+              source: `
+            export interface User {
+              name: string;
+              address: string;
+            }
+            export class Cmp { users: User[]; }
+            `,
+              declarations: [ngForDeclaration()],
+            },
+            ngForDts(),
+          ],
+          {inlining: false});
+      templateTypeChecker = testValues.templateTypeChecker;
+      const sf = getSourceFileOrError(testValues.program, fileName);
+      cmp = getClass(sf, 'Cmp');
+      templateNode = getAstTemplates(templateTypeChecker, cmp, templateString)[0];
+    });
+
+    it('should retrieve a symbol for an expression inside structural binding', () => {
+      const ngForOfBinding =
+          templateNode.templateAttrs.find(a => a.name === 'ngForOf')! as TmplAstBoundAttribute;
+      const symbol = templateTypeChecker.getSymbolOfTemplateExpression(ngForOfBinding.value, cmp)!;
+      expect(symbol.escapedName.toString()).toEqual('users');
+    });
+
+    it('should retrieve a symbol for property reads of implicit variable inside structural binding',
+       () => {
+         const boundText =
+             (templateNode.children[0] as TmplAstElement).children[0] as TmplAstBoundText;
+         const interpolation = (boundText.value as ASTWithSource).ast as Interpolation;
+         const namePropRead = interpolation.expressions[0] as PropertyRead;
+         const addressPropRead = interpolation.expressions[1] as PropertyRead;
+
+         const nameSymbol = templateTypeChecker.getSymbolOfTemplateExpression(namePropRead, cmp)!;
+         expect(nameSymbol.escapedName.toString()).toEqual('name');
+         const addressSymbol =
+             templateTypeChecker.getSymbolOfTemplateExpression(addressPropRead, cmp)!;
+         expect(addressSymbol.escapedName.toString()).toEqual('address');
+         const userSymbol =
+             templateTypeChecker.getSymbolOfTemplateExpression(namePropRead.receiver, cmp)!;
+         expect(userSymbol.escapedName).toContain('$implicit');
+         expect(userSymbol.declarations[0].parent!.getText()).toContain('NgForOfContext');
+       });
+
+    it('finds symbol when using a template variable', () => {
+      const innerElementNodes =
+          onlyAstElements((templateNode.children[0] as TmplAstElement).children);
+      const indexSymbol = templateTypeChecker.getSymbolOfTemplateExpression(
+          innerElementNodes[0].inputs[0].value, cmp)!;
+      expect(indexSymbol.escapedName).toContain('index');
+      expect(indexSymbol.declarations[0].parent!.getText()).toContain('NgForOfContext');
+    });
+  });
+
+  describe('pipes', () => {
+    let templateTypeChecker: TemplateTypeChecker;
+    let cmp: ClassDeclaration<ts.ClassDeclaration>;
+    let binding: BindingPipe;
+
+    beforeEach(() => {
+      const fileName = absoluteFrom('/main.ts');
+      const templateString = `<div [inputA]="a | test:b:c"></div>`;
+      const testValues = setup(
+          [
+            {
+              fileName,
+              templates: {'Cmp': templateString},
+              source: `
+            export class Cmp { a: string; b: number; c: boolean }
+            export class TestPipe {
+              transform(value: string, repeat: number, commaSeparate: boolean) {
+              }
+            }
+            `,
+              declarations: [{
+                type: 'pipe',
+                name: 'TestPipe',
+                pipeName: 'test',
+              }],
+            },
+          ],
+          {inlining: false});
+      templateTypeChecker = testValues.templateTypeChecker;
+      const sf = getSourceFileOrError(testValues.program, fileName);
+      cmp = getClass(sf, 'Cmp');
+      binding = (getAstElements(templateTypeChecker, cmp, templateString)[0].inputs[0].value as
+                 ASTWithSource)
+                    .ast as BindingPipe;
+    });
+
+    it('should get symbol for pipe', () => {
+      const pipeSymbol = templateTypeChecker.getSymbolOfTemplateExpression(binding, cmp)!;
+      expect(pipeSymbol.escapedName.toString()).toEqual('transform');
+      expect((pipeSymbol.declarations[0].parent as ts.ClassDeclaration).name!.getText())
+          .toEqual('TestPipe');
+    });
+
+    it('should get symbols for pipe expression and args', () => {
+      const aSymbol = templateTypeChecker.getSymbolOfTemplateExpression(binding.exp, cmp)!;
+      expect(aSymbol.escapedName.toString()).toEqual('a');
+      const bSymbol = templateTypeChecker.getSymbolOfTemplateExpression(binding.args[0], cmp)!;
+      expect(bSymbol.escapedName.toString()).toEqual('b');
+      const cSymbol = templateTypeChecker.getSymbolOfTemplateExpression(binding.args[1], cmp)!;
+      expect(cSymbol.escapedName.toString()).toEqual('c');
+    });
+  });
+});
+
+function onlyAstTemplates(nodes: TmplAstNode[]): TmplAstTemplate[] {
+  return nodes.filter((n): n is TmplAstTemplate => n instanceof TmplAstTemplate);
+}
+
+function onlyAstElements(nodes: TmplAstNode[]): TmplAstElement[] {
+  return nodes.filter((n): n is TmplAstElement => n instanceof TmplAstElement);
+}
+
+function getAstElements(
+    templateTypeChecker: TemplateTypeChecker, cmp: ts.ClassDeclaration&{name: ts.Identifier},
+    templateString: string) {
+  return onlyAstElements(templateTypeChecker.overrideComponentTemplate(cmp, templateString).nodes);
+}
+
+function getAstTemplates(
+    templateTypeChecker: TemplateTypeChecker, cmp: ts.ClassDeclaration&{name: ts.Identifier},
+    templateString: string) {
+  return onlyAstTemplates(templateTypeChecker.overrideComponentTemplate(cmp, templateString).nodes);
+}


### PR DESCRIPTION
Add `TemplateTypeChecker` operation to retrieve the `ts.Symbol` of an AST expression
from a template. Not all expressions will have symbols (e.g. there is no symbol
associated with the expression a + b, but there are symbols for both the a and b
nodes individually).

Sometimes we need to traverse an intermediate variable declaration to arrive at
the correct `ts.Symbol`. For example, loop variables are declared using an intermediate:
```
<div *ngFor="let user of users">
  {{user.name}}
</div>
```
Getting the symbol of user here (from the expression) is tricky, because the TCB looks like:

```
var _t0 = ...; // type of NgForOf
var _t1: any; // context of embedded view for NgForOf structural directive
if (NgForOf.ngTemplateContextGuard(_t0, _t1)) {
  // _t1 is now NgForOfContext<...>
  var _t2 = _t1.$implicit; // let user = '$implicit'
  _t2.name; // user.name expression
}
```
Just getting the `ts.Expression` for the `AST` node `PropRead(ImplicitReceiver, 'user')`
via the sourcemaps will yield the `_t2` expression.  This function recognizes that `_t2`
is an aliasing variable declared locally in the TCB, and actually fetch the `ts.Symbol` of its initializer.

There is also similar special case handling for `#ref` local references
as well.

Resolves #38064
