### PR TITLE
build: run browsers tests on chromium locally

### DIFF
--- a/browser-providers.conf.js
+++ b/browser-providers.conf.js
@@ -12,8 +12,10 @@
 // If a category becomes empty (e.g. BS and required), then the corresponding job must be commented
 // out in the CI configuration.
 var CIconfiguration = {
-  'Chrome': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
-  'Firefox': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
+  // Chrome and Firefox run as part of the Bazel browser tests, so we do not run them as
+  // part of the legacy Saucelabs tests.
+  'Chrome': {unitTest: {target: null, required: false}, e2e: {target: null, required: true}},
+  'Firefox': {unitTest: {target: null, required: false}, e2e: {target: null, required: true}},
   // Set ESR as a not required browser as it fails for Ivy acceptance tests.
   'FirefoxESR': {unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
   // Disabled because using the "beta" channel of Chrome can cause non-deterministic CI results.

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -245,7 +245,10 @@ def karma_web_test_suite(name, **kwargs):
         runtime_deps = runtime_deps,
         bootstrap = bootstrap,
         deps = deps,
-        browsers = ["//dev-infra/browsers/firefox:firefox"],
+        browsers = [
+            "//dev-infra/browsers/chromium:chromium",
+            "//dev-infra/browsers/firefox:firefox",
+        ],
         data = data,
         tags = tags,
         **kwargs


### PR DESCRIPTION
Previously we added a browser target for `firefox` into the
dev-infra package. It looks like as part of this change, we
accidentally switched the local web testing target to `firefox`.

Web tests are not commonly run locally as we use Domino and
NodeJS tests for primary development. Sometimes though we intend
to run tests in a browser. This would currently work with Firefox
but not on Windows (as Firefox is a noop there in Bazel).

This commit switches the primary browser back to `chromium`. Also
Firefox has been added as a second browser to web testing targets.

This allows us to reduce browsers in the legacy Saucelabs job. i.e.
not running Chrome and Firefox there. This should increase stability
and potentially speed up the legacy job (+ reduced rate limit for Saucelabs).
Also we get incremental/cache test results for Firefox.