### PR TITLE
fix(dev-infra): ignore comments when validating commit messages

### DIFF
--- a/dev-infra/commit-message/parse.spec.ts
+++ b/dev-infra/commit-message/parse.spec.ts
@@ -82,4 +82,24 @@ describe('commit message parsing:', () => {
     const message2 = buildCommitMessage({prefix: 'squash! '});
     expect(parseCommitMessage(message2).isSquash).toBe(true);
   });
+
+  it('ignores comment lines', () => {
+    const message = buildCommitMessage({
+      prefix: '# This is a comment line before the header.\n' +
+          '## This is another comment line before the headers.\n',
+      body: '# This is a comment line befor the body.\n' +
+          'This is line 1 of the actual body.\n' +
+          '## This is another comment line inside the body.\n' +
+          'This is line 2 of the actual body (and it also contains a # but it not a comment).\n' +
+          '### This is yet another comment line after the body.\n',
+    });
+    const parsedMessage = parseCommitMessage(message);
+
+    expect(parsedMessage.header)
+        .toBe(`${commitValues.type}(${commitValues.scope}): ${commitValues.summary}`);
+    expect(parsedMessage.body)
+        .toBe(
+            'This is line 1 of the actual body.\n' +
+            'This is line 2 of the actual body (and it also contains a # but it not a comment).\n');
+  });
 });

--- a/dev-infra/commit-message/parse.ts
+++ b/dev-infra/commit-message/parse.ts
@@ -36,6 +36,10 @@ const COMMIT_BODY_RE = /^.*\n\n([\s\S]*)$/;
 
 /** Parse a full commit message into its composite parts. */
 export function parseCommitMessage(commitMsg: string): ParsedCommitMessage {
+  // Ignore comments (i.e. lines starting with `#`). Comments are automatically removed by git and
+  // should not be considered part of the final commit message.
+  commitMsg = commitMsg.split('\n').filter(line => !line.startsWith('#')).join('\n');
+
   let header = '';
   let body = '';
   let bodyWithoutLinking = '';

--- a/dev-infra/commit-message/validate-file.ts
+++ b/dev-infra/commit-message/validate-file.ts
@@ -16,7 +16,13 @@ import {validateCommitMessage} from './validate';
 
 /** Validate commit message at the provided file path. */
 export function validateFile(filePath: string) {
-  const commitMessage = readFileSync(resolve(getRepoBaseDir(), filePath), 'utf8');
+  // Read the commit message from the specified file and remove any comments (i.e. lines starting
+  // with `#`). Comments are automatically removed by git and are not part of the final commit
+  // message.
+  const commitMessage = readFileSync(resolve(getRepoBaseDir(), filePath), 'utf8')
+                            .split('\n')
+                            .filter(line => !line.startsWith('#'))
+                            .join('\n');
   if (validateCommitMessage(commitMessage)) {
     info('√  Valid commit message');
     deleteCommitMessageDraft(filePath);

--- a/dev-infra/commit-message/validate-file.ts
+++ b/dev-infra/commit-message/validate-file.ts
@@ -16,13 +16,7 @@ import {validateCommitMessage} from './validate';
 
 /** Validate commit message at the provided file path. */
 export function validateFile(filePath: string) {
-  // Read the commit message from the specified file and remove any comments (i.e. lines starting
-  // with `#`). Comments are automatically removed by git and are not part of the final commit
-  // message.
-  const commitMessage = readFileSync(resolve(getRepoBaseDir(), filePath), 'utf8')
-                            .split('\n')
-                            .filter(line => !line.startsWith('#'))
-                            .join('\n');
+  const commitMessage = readFileSync(resolve(getRepoBaseDir(), filePath), 'utf8');
   if (validateCommitMessage(commitMessage)) {
     info('√  Valid commit message');
     deleteCommitMessageDraft(filePath);


### PR DESCRIPTION
When creating a commit with the git cli, git pre-populates the editor used to enter the commit message with some comments (i.e. lines starting with `#`). These comments contain helpful instructions or information regarding the changes that are part of the commit. As happens with all commit message comments, they are removed by git and do not end up in the final commit message.

However, the file that is passed to the `commit-msg` to be validated still contains these comments. This may affect the outcome of the commit message validation. In such cases, the author will not realize that the commit message is not in the desired format until the linting checks fail on CI (which validates the final commit messages and is not affected by this issue), usually several minutes later.

Possible ways in which the commit message validation outcome can be affected:
- The minimum body length check may pass incorrectly, even if there is no actual body, because the comments are counted as part of the body.
- The maximum line length check may fail incorrectly due to a very long line in the comments.

This commit fixes the problem by removing comment lines before validating a commit message that comes from a file.

Fixes #37865.
