### PR TITLE
feat(dev-infra): update to latest benchpress version

### DIFF
--- a/dev-infra/tmpl-package.json
+++ b/dev-infra/tmpl-package.json
@@ -9,7 +9,7 @@
     "ts-circular-deps": "./ts-circular-dependencies/index.js"
   },
   "dependencies": {
-    "@angular/benchpress": "0.2.0",
+    "@angular/benchpress": "0.2.1",
     "@octokit/graphql": "<from-root>",
     "@octokit/types": "<from-root>",
     "brotli": "<from-root>",


### PR DESCRIPTION
We recently updated the benchpress package to have a more loose
Angular core peer dependency, and less other unused dependencies.

We should make sure to use that in the dev-infra package so that
peer dependencies can be satisfied in consumer projects, and so
that less unused dependencies are brought into projects.