### PR TITLE
docs(router): Add annotations to correct Router documentation 

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -202,6 +202,7 @@ export class RouterLink {
     this.preserve = value;
   }
 
+  /** @nodoc */
   @HostListener('click')
   onClick(): boolean {
     const extras = {
@@ -334,13 +335,16 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
     this.preserve = value;
   }
 
+  /** @nodoc */
   ngOnChanges(changes: {}): any {
     this.updateTargetUrlAndHref();
   }
+  /** @nodoc */
   ngOnDestroy(): any {
     this.subscription.unsubscribe();
   }
 
+  /** @nodoc */
   @HostListener('click', ['$event.button', '$event.ctrlKey', '$event.metaKey', '$event.shiftKey'])
   onClick(button: number, ctrlKey: boolean, metaKey: boolean, shiftKey: boolean): boolean {
     if (button !== 0 || ctrlKey || metaKey || shiftKey) {

--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -102,7 +102,7 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
     });
   }
 
-
+  /** @nodoc */
   ngAfterContentInit(): void {
     this.links.changes.subscribe(_ => this.update());
     this.linksWithHrefs.changes.subscribe(_ => this.update());
@@ -115,9 +115,11 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
     this.classes = classes.filter(c => !!c);
   }
 
+  /** @nodoc */
   ngOnChanges(changes: SimpleChanges): void {
     this.update();
   }
+  /** @nodoc */
   ngOnDestroy(): void {
     this.subscription.unsubscribe();
   }

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -76,10 +76,12 @@ export class RouterOutlet implements OnDestroy, OnInit {
     parentContexts.onChildOutletCreated(this.name, this);
   }
 
+  /** @nodoc */
   ngOnDestroy(): void {
     this.parentContexts.onChildOutletDestroyed(this.name);
   }
 
+  /** @nodoc */
   ngOnInit(): void {
     if (!this.activated) {
       // If the outlet was not instantiated at the time the route got activated we need to populate

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1010,7 +1010,7 @@ export class Router {
     this.lastSuccessfulId = -1;
   }
 
-  /** @docsNotRequired */
+  /** @nodoc */
   ngOnDestroy(): void {
     this.dispose();
   }

--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -97,6 +97,7 @@ export class RouterPreloader implements OnDestroy {
     return this.processRoutes(ngModule, this.router.config);
   }
 
+  /** @nodoc */
   ngOnDestroy(): void {
     if (this.subscription) {
       this.subscription.unsubscribe();

--- a/packages/router/src/router_scroller.ts
+++ b/packages/router/src/router_scroller.ts
@@ -87,6 +87,7 @@ export class RouterScroller implements OnDestroy {
         routerEvent, this.lastSource === 'popstate' ? this.store[this.restoredId] : null, anchor));
   }
 
+  /** @nodoc */
   ngOnDestroy() {
     if (this.routerEventsSubscription) {
       this.routerEventsSubscription.unsubscribe();


### PR DESCRIPTION
The `@HostListener` functions and lifecycle hooks aren't intended to be public API but
do need to appear in the `.d.ts` files or type checking will break. Adding the
nodoc annotation will correctly hide this function on the docs site.

Again, note that `@internal` cannot be used because the result would be
that the functions then do not appear in the `.d.ts` files. This would
break lifecycle hooks because the class would be seen as not
implementing the interface correctly. This would also break
`HostListener` because the compiled templates would attempt to call the
`onClick` functions, but those would also not appear in the `d.ts` and
would produce errors like "Property 'onClick' does not exist on type 'RouterLinkWithHref'".