### PR TITLE
refactor(core): use isObservable provided by rxjs 6.1+

### DIFF
--- a/integration/side-effects/snapshots/common/esm2015.js
+++ b/integration/side-effects/snapshots/common/esm2015.js
@@ -1,1 +1,3 @@
 import "@angular/core";
+
+import "rxjs";

--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, EventEmitter, OnDestroy, Pipe, PipeTransform, ɵisObservable, ɵisPromise} from '@angular/core';
-import {Observable, SubscriptionLike} from 'rxjs';
+import {ChangeDetectorRef, EventEmitter, OnDestroy, Pipe, PipeTransform, ɵisPromise} from '@angular/core';
+import {isObservable, Observable, SubscriptionLike} from 'rxjs';
+
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
 interface SubscriptionStrategy {
@@ -126,7 +127,7 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
       return _promiseStrategy;
     }
 
-    if (ɵisObservable(obj)) {
+    if (isObservable(obj)) {
       return _observableStrategy;
     }
 

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -29,7 +29,7 @@ export {_sanitizeHtml as ɵ_sanitizeHtml} from './sanitization/html_sanitizer';
 export {_sanitizeUrl as ɵ_sanitizeUrl} from './sanitization/url_sanitizer';
 export {makeDecorator as ɵmakeDecorator} from './util/decorators';
 export {global as ɵglobal} from './util/global';
-export {isObservable as ɵisObservable, isPromise as ɵisPromise} from './util/lang';
+export {isPromise as ɵisPromise} from './util/lang';
 export {stringify as ɵstringify} from './util/stringify';
 export {clearOverrides as ɵclearOverrides, initServicesIfNeeded as ɵinitServicesIfNeeded, overrideComponentView as ɵoverrideComponentView, overrideProvider as ɵoverrideProvider} from './view/index';
 export {NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from './view/provider';

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -7,8 +7,8 @@
  */
 
 
+import {isObservable} from 'rxjs';
 import {assertIndexInRange} from '../../util/assert';
-import {isObservable} from '../../util/lang';
 import {EMPTY_OBJ} from '../empty';
 import {PropertyAliasValue, TNode, TNodeFlags, TNodeType} from '../interfaces/node';
 import {GlobalTargetResolver, isProceduralRenderer, RElement, Renderer3} from '../interfaces/renderer';

--- a/packages/core/src/util/BUILD.bazel
+++ b/packages/core/src/util/BUILD.bazel
@@ -15,6 +15,5 @@ ts_library(
     deps = [
         "//packages:types",
         "//packages/core/src/interface",
-        "@npm//rxjs",
     ],
 )

--- a/packages/core/src/util/lang.ts
+++ b/packages/core/src/util/lang.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Observable} from 'rxjs';
-
 /**
  * Determine if the argument is shaped like a Promise
  */
@@ -15,13 +13,4 @@ export function isPromise<T = any>(obj: any): obj is Promise<T> {
   // allow any Promise/A+ compliant thenable.
   // It's up to the caller to ensure that obj.then conforms to the spec
   return !!obj && typeof obj.then === 'function';
-}
-
-/**
- * Determine if the argument is an Observable
- */
-export function isObservable(obj: any|Observable<any>): obj is Observable<any> {
-  // TODO: use isObservable once we update pass rxjs 6.1
-  // https://github.com/ReactiveX/rxjs/blob/master/CHANGELOG.md#610-2018-05-03
-  return !!obj && typeof obj.subscribe === 'function';
 }

--- a/packages/core/src/view/provider.ts
+++ b/packages/core/src/view/provider.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {isObservable} from 'rxjs';
 import {ChangeDetectorRef, SimpleChange, SimpleChanges, WrappedValue} from '../change_detection/change_detection';
 import {INJECTOR, Injector, resolveForwardRef} from '../di';
 import {ElementRef} from '../linker/element_ref';
 import {TemplateRef} from '../linker/template_ref';
 import {ViewContainerRef} from '../linker/view_container_ref';
 import {Renderer2} from '../render/api';
-import {isObservable} from '../util/lang';
 import {stringify} from '../util/stringify';
 
 import {createChangeDetectorRef, createInjector} from './refs';

--- a/packages/core/test/util/lang_spec.ts
+++ b/packages/core/test/util/lang_spec.ts
@@ -5,43 +5,22 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {isObservable, isPromise} from '@angular/core/src/util/lang';
-import {of} from 'rxjs';
+import {isPromise} from '@angular/core/src/util/lang';
 
-{
-  describe('isPromise', () => {
-    it('should be true for native Promises',
-       () => expect(isPromise(Promise.resolve(true))).toEqual(true));
+describe('isPromise', () => {
+  it('should be true for native Promises',
+     () => expect(isPromise(Promise.resolve(true))).toEqual(true));
 
-    it('should be true for thenables', () => expect(isPromise({then: () => {}})).toEqual(true));
+  it('should be true for thenables', () => expect(isPromise({then: () => {}})).toEqual(true));
 
-    it('should be false if "then" is not a function',
-       () => expect(isPromise({then: 0})).toEqual(false));
+  it('should be false if "then" is not a function',
+     () => expect(isPromise({then: 0})).toEqual(false));
 
-    it('should be false if the argument has no "then" function',
-       () => expect(isPromise({})).toEqual(false));
+  it('should be false if the argument has no "then" function',
+     () => expect(isPromise({})).toEqual(false));
 
-    it('should be false if the argument is undefined or null', () => {
-      expect(isPromise(undefined)).toEqual(false);
-      expect(isPromise(null)).toEqual(false);
-    });
+  it('should be false if the argument is undefined or null', () => {
+    expect(isPromise(undefined)).toEqual(false);
+    expect(isPromise(null)).toEqual(false);
   });
-
-  describe('isObservable', () => {
-    it('should be true for an Observable', () => expect(isObservable(of(true))).toEqual(true));
-
-    it('should be true if the argument is the object with subscribe function',
-       () => expect(isObservable({subscribe: () => {}})).toEqual(true));
-
-    it('should be false if the argument is undefined',
-       () => expect(isObservable(undefined)).toEqual(false));
-
-    it('should be false if the argument is null', () => expect(isObservable(null)).toEqual(false));
-
-    it('should be false if the argument is an object',
-       () => expect(isObservable({})).toEqual(false));
-
-    it('should be false if the argument is a function',
-       () => expect(isObservable(() => {})).toEqual(false));
-  });
-}
+});

--- a/packages/core/test/view/provider_spec.ts
+++ b/packages/core/test/view/provider_spec.ts
@@ -360,7 +360,8 @@ import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, compViewDef, compViewDefFacto
               const subscription = emitter.subscribe(callback);
               unsubscribeSpy = spyOn(subscription, 'unsubscribe').and.callThrough();
               return subscription;
-            }
+            },
+            lift: () => ({...this.emitter})
           };
         }
 

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectionToken, ɵisObservable as isObservable, ɵisPromise as isPromise} from '@angular/core';
-import {forkJoin, from, Observable} from 'rxjs';
+import {InjectionToken, ɵisPromise as isPromise} from '@angular/core';
+import {forkJoin, from, isObservable, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 
 import {AsyncValidator, AsyncValidatorFn, ValidationErrors, Validator, ValidatorFn} from './directives/validators';

--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵisObservable as isObservable, ɵisPromise as isPromise} from '@angular/core';
-import {from, Observable, of} from 'rxjs';
+import {ɵisPromise as isPromise} from '@angular/core';
+import {from, isObservable, Observable, of} from 'rxjs';
 import {concatAll, last as lastValue, map} from 'rxjs/operators';
 
 import {Params, PRIMARY_OUTLET} from '../shared';


### PR DESCRIPTION
Refactor common, core, forms, router to use the isObservable method from rxjs 6.1+.
Remove the isObservable method from core.