### PR TITLE
fix(common): Allow scrolling when browser supports scrollTo

### DIFF
--- a/packages/common/src/viewport_scroller.ts
+++ b/packages/common/src/viewport_scroller.ts
@@ -88,7 +88,7 @@ export class BrowserViewportScroller implements ViewportScroller {
    * @returns The position in screen coordinates.
    */
   getScrollPosition(): [number, number] {
-    if (this.supportScrollRestoration()) {
+    if (this.supportsScrolling()) {
       return [this.window.scrollX, this.window.scrollY];
     } else {
       return [0, 0];
@@ -100,7 +100,7 @@ export class BrowserViewportScroller implements ViewportScroller {
    * @param position The new position in screen coordinates.
    */
   scrollToPosition(position: [number, number]): void {
-    if (this.supportScrollRestoration()) {
+    if (this.supportsScrolling()) {
       this.window.scrollTo(position[0], position[1]);
     }
   }
@@ -110,7 +110,7 @@ export class BrowserViewportScroller implements ViewportScroller {
    * @param anchor The ID of the anchor element.
    */
   scrollToAnchor(anchor: string): void {
-    if (this.supportScrollRestoration()) {
+    if (this.supportsScrolling()) {
       const elSelected =
           this.document.getElementById(anchor) || this.document.getElementsByName(anchor)[0];
       if (elSelected) {
@@ -159,6 +159,14 @@ export class BrowserViewportScroller implements ViewportScroller {
       // setter function.
       return !!scrollRestorationDescriptor &&
           !!(scrollRestorationDescriptor.writable || scrollRestorationDescriptor.set);
+    } catch {
+      return false;
+    }
+  }
+
+  private supportsScrolling(): boolean {
+    try {
+      return !!this.window.scrollTo;
     } catch {
       return false;
     }

--- a/packages/common/test/viewport_scroller_spec.ts
+++ b/packages/common/test/viewport_scroller_spec.ts
@@ -15,20 +15,29 @@ describe('BrowserViewportScroller', () => {
   let windowSpy: any;
 
   beforeEach(() => {
-    windowSpy = jasmine.createSpyObj('window', ['history']);
-    windowSpy.scrollTo = 1;
+    windowSpy = jasmine.createSpyObj('window', ['history', 'scrollTo']);
     windowSpy.history.scrollRestoration = 'auto';
     documentSpy = jasmine.createSpyObj('document', ['getElementById', 'getElementsByName']);
     scroller = new BrowserViewportScroller(documentSpy, windowSpy, null!);
   });
 
   describe('setHistoryScrollRestoration', () => {
-    it('should not crash when scrollRestoration is not writable', () => {
+    function createNonWritableScrollRestoration() {
       Object.defineProperty(windowSpy.history, 'scrollRestoration', {
         value: 'auto',
         configurable: true,
       });
+    }
+
+    it('should not crash when scrollRestoration is not writable', () => {
+      createNonWritableScrollRestoration();
       expect(() => scroller.setHistoryScrollRestoration('manual')).not.toThrow();
+    });
+
+    it('should still allow scrolling if scrollRestoration is not writable', () => {
+      createNonWritableScrollRestoration();
+      scroller.scrollToPosition([10, 10]);
+      expect(windowSpy.scrollTo as jasmine.Spy).toHaveBeenCalledWith(10, 10);
     });
   });
 


### PR DESCRIPTION
This commit fixes a regression from "fix(common): ensure
scrollRestoration is writable (#30630)" that caused scrolling to not
happen at all in browsers that do not support scroll restoration. The
issue was that `supportScrollRestoration` was updated to return `false`
if a browser did not have a writable `scrollRestoration`. However, the
previous behavior was that the function would return `true` if
`window.scrollTo` was defined. Every scrolling function in the
`ViewportScroller` used `supportScrollRestoration` and, with the update
in bb88c9fa3daac80086efbda951d81c159e3840f4, no scrolling would be
performed if a browser did not have writable `scrollRestoration` but
_did_ have `window.scrollTo`.

Note, that this failure was detected in the saucelabs tests. IE does not
support scroll restoration so IE tests were failing.
* https://app.circleci.com/pipelines/github/angular/angular/20061/workflows/7e16b250-f9d5-4d1b-a07d-e1cad8f366f9/jobs/788037
* https://github.com/angular/angular/blob/ca798804b244a380875abc1da5f0cff99164f539/packages/router/test/bootstrap.spec.ts#L257