### PR TITLE
docs: mention setUpLocationSync with $locationShim

### DIFF
--- a/aio/content/guide/upgrade.md
+++ b/aio/content/guide/upgrade.md
@@ -952,10 +952,17 @@ For usage of the `$location` service as a provider in AngularJS, you need to dow
 ```ts
 // Other imports ...
 import { $locationShim } from '@angular/common/upgrade';
+import { setUpLocationSync } from '@angular/router/upgrade';
 import { downgradeInjectable } from '@angular/upgrade/static';
 
 angular.module('myHybridApp', [...])
   .factory('$location', downgradeInjectable($locationShim));
+
+...
+// if running in hybrid routing mode (optional):
+// call setUpLocationSync after bootstrap or routing won't be synced.
+this.upgrade.bootstrap(...);
+setUpLocationSync(this.upgrade);
 ```
 
 Once you introduce the Angular Router, using the Angular Router triggers navigations through the unified location service, still providing a single source for navigating with AngularJS and Angular.


### PR DESCRIPTION
#38415  PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
upgrade documentation for `$locationShim` doesn't mention `setUpLocationSync`

$locationShim doesn't seem to connect to the Location service at all
if you don't call `setUpLocationSync` from @angular/router/upgrade

Issue Number: N/A


## What is the new behavior?

Add a mention of `setUpLocationSync` which is required for hybrid routing to work

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
