### PR TITLE
feat(dev-infra): tooling to check out pending PR

### DIFF
--- a/dev-infra/pr/BUILD.bazel
+++ b/dev-infra/pr/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
     module_name = "@angular/dev-infra-private/pr",
     visibility = ["//dev-infra:__subpackages__"],
     deps = [
+        "//dev-infra/pr/checkout",
         "//dev-infra/pr/discover-new-conflicts",
         "//dev-infra/pr/merge",
         "//dev-infra/pr/rebase",

--- a/dev-infra/pr/checkout/BUILD.bazel
+++ b/dev-infra/pr/checkout/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
+
+ts_library(
+    name = "checkout",
+    srcs = glob(["*.ts"]),
+    module_name = "@angular/dev-infra-private/pr/checkout",
+    visibility = ["//dev-infra:__subpackages__"],
+    deps = [
+        "//dev-infra/pr/common",
+        "//dev-infra/utils",
+        "@npm//@types/yargs",
+    ],
+)

--- a/dev-infra/pr/checkout/cli.ts
+++ b/dev-infra/pr/checkout/cli.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Arguments, Argv, CommandModule} from 'yargs';
+
+import {error} from '../../utils/console';
+import {checkOutPrLocally} from '../common/checkout-pr';
+
+export interface CheckoutOptions {
+  prNumber: number;
+  'github-token'?: string;
+}
+
+/** URL to the Github page where personal access tokens can be generated. */
+export const GITHUB_TOKEN_GENERATE_URL = `https://github.com/settings/tokens`;
+
+/** Builds the checkout pull request command. */
+function builder(yargs: Argv) {
+  return yargs.positional('prNumber', {type: 'number', demandOption: true}).option('github-token', {
+    type: 'string',
+    description: 'Github token. If not set, token is retrieved from the environment variables.'
+  });
+}
+
+/** Handles the checkout pull request command. */
+async function handler({prNumber, 'github-token': token}: Arguments<CheckoutOptions>) {
+  const githubToken = token || process.env.GITHUB_TOKEN || process.env.TOKEN;
+  if (!githubToken) {
+    error('No Github token set. Please set the `GITHUB_TOKEN` environment variable.');
+    error('Alternatively, pass the `--github-token` command line flag.');
+    error(`You can generate a token here: ${GITHUB_TOKEN_GENERATE_URL}`);
+    process.exitCode = 1;
+    return;
+  }
+  const prCheckoutOptions = {allowIfMaintainerCannotModify: true, branchName: `pr-${prNumber}`};
+  await checkOutPrLocally(prNumber, githubToken, prCheckoutOptions);
+}
+
+/** yargs command module for checking out a PR  */
+export const CheckoutCommandModule: CommandModule<{}, CheckoutOptions> = {
+  handler,
+  builder,
+  command: 'checkout <pr-number>',
+  describe: 'Checkout a PR from the upstream repo',
+};

--- a/dev-infra/pr/checkout/cli.ts
+++ b/dev-infra/pr/checkout/cli.ts
@@ -9,7 +9,7 @@
 import {Arguments, Argv, CommandModule} from 'yargs';
 
 import {error} from '../../utils/console';
-import {checkOutPrLocally} from '../common/checkout-pr';
+import {checkOutPullRequestLocally} from '../common/checkout-pr';
 
 export interface CheckoutOptions {
   prNumber: number;
@@ -38,7 +38,7 @@ async function handler({prNumber, 'github-token': token}: Arguments<CheckoutOpti
     return;
   }
   const prCheckoutOptions = {allowIfMaintainerCannotModify: true, branchName: `pr-${prNumber}`};
-  await checkOutPrLocally(prNumber, githubToken, prCheckoutOptions);
+  await checkOutPullRequestLocally(prNumber, githubToken, prCheckoutOptions);
 }
 
 /** yargs command module for checking out a PR  */

--- a/dev-infra/pr/cli.ts
+++ b/dev-infra/pr/cli.ts
@@ -8,6 +8,7 @@
 
 import * as yargs from 'yargs';
 
+import {CheckoutCommandModule} from './checkout/cli';
 import {buildDiscoverNewConflictsCommand, handleDiscoverNewConflictsCommand} from './discover-new-conflicts/cli';
 import {buildMergeCommand, handleMergeCommand} from './merge/cli';
 import {buildRebaseCommand, handleRebaseCommand} from './rebase/cli';
@@ -24,7 +25,8 @@ export function buildPrParser(localYargs: yargs.Argv) {
           buildDiscoverNewConflictsCommand, handleDiscoverNewConflictsCommand)
       .command(
           'rebase <pr-number>', 'Rebase a pending PR and push the rebased commits back to Github',
-          buildRebaseCommand, handleRebaseCommand);
+          buildRebaseCommand, handleRebaseCommand)
+      .command(CheckoutCommandModule);
 }
 
 if (require.main === module) {

--- a/dev-infra/pr/common/BUILD.bazel
+++ b/dev-infra/pr/common/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
+
+ts_library(
+    name = "common",
+    srcs = glob(["*.ts"]),
+    visibility = ["//dev-infra:__subpackages__"],
+    deps = [
+        "//dev-infra/utils",
+        "@npm//@types/node",
+        "@npm//typed-graphqlify",
+    ],
+)

--- a/dev-infra/pr/common/checkout-pr.ts
+++ b/dev-infra/pr/common/checkout-pr.ts
@@ -9,12 +9,11 @@
 import {types as graphQLTypes} from 'typed-graphqlify';
 import {URL} from 'url';
 
-import {getConfig, NgDevConfig} from '../../utils/config';
-import {error, info, promptConfirm} from '../../utils/console';
+import {info} from '../../utils/console';
 import {GitClient} from '../../utils/git';
 import {getPr} from '../../utils/github';
 
-/* GraphQL schema for the response body for each pending PR. */
+/* GraphQL schema for the response body for a pending PR. */
 const PR_SCHEMA = {
   state: graphQLTypes.string,
   maintainerCanModify: graphQLTypes.boolean,
@@ -36,17 +35,39 @@ const PR_SCHEMA = {
   },
 };
 
+export class HasLocalChangesError extends Error {
+  constructor(msg: string) {
+    super(msg);
+  }
+}
+
+export class MaintainerModifyAccessError extends Error {
+  constructor(msg: string) {
+    super(msg);
+  }
+}
+
+/** Options for checking out a PR */
+export interface PrCheckoutOptions {
+  /** The local name for the branch when checking out a pr. */
+  branchName?: string;
+  /** Whether the PR should be checked out if the maintainer cannot modify. */
+  allowIfMaintainerCannotModify?: boolean;
+}
+
 /**
  * Rebase the provided PR onto its merge target branch, and push up the resulting
  * commit to the PRs repository.
  */
-export async function rebasePr(
-    prNumber: number, githubToken: string, config: Pick<NgDevConfig, 'github'> = getConfig()) {
+export async function checkOutPrLocally(
+    prNumber: number, githubToken: string, opts: PrCheckoutOptions = {}) {
+  /** Authenticated Git client for git and Github interactions. */
   const git = new GitClient(githubToken);
-  // TODO: Rely on a common assertNoLocalChanges function.
+
+  // In order to preserve local changes, checkouts cannot occur if local changes are present in the
+  // git environment.  Checked before retrieving the PR to fail fast.
   if (git.hasLocalChanges()) {
-    error('Cannot perform rebase of PR with local changes.');
-    process.exit(1);
+    throw new HasLocalChangesError('Cannot checkout requested PR because of local changes in git');
   }
 
   /**
@@ -54,81 +75,52 @@ export async function rebasePr(
    * any Git operations that may change the working branch.
    */
   const previousBranchOrRevision = git.getCurrentBranchOrRevision();
-  /* Get the PR information from Github. */
+  /* The PR information from Github. */
   const pr = await getPr(PR_SCHEMA, prNumber, git);
-
+  /** The branch name of the PR from the repository the PR came from. */
   const headRefName = pr.headRef.name;
-  const baseRefName = pr.baseRef.name;
+  /** The full ref for the repository and branch the PR came from. */
   const fullHeadRef = `${pr.headRef.repository.nameWithOwner}:${headRefName}`;
-  const fullBaseRef = `${pr.baseRef.repository.nameWithOwner}:${baseRefName}`;
+  /** The full URL path of the repository the PR came from with github token as authentication. */
   const headRefUrl = addAuthenticationToUrl(pr.headRef.repository.url, githubToken);
-  const baseRefUrl = addAuthenticationToUrl(pr.baseRef.repository.url, githubToken);
-
   // Note: Since we use a detached head for rebasing the PR and therefore do not have
   // remote-tracking branches configured, we need to set our expected ref and SHA. This
   // allows us to use `--force-with-lease` for the detached head while ensuring that we
   // never accidentally override upstream changes that have been pushed in the meanwhile.
   // See:
   // https://git-scm.com/docs/git-push#Documentation/git-push.txt---force-with-leaseltrefnamegtltexpectgt
+  /** Flag for a force push with leage back to upstream. */
   const forceWithLeaseFlag = `--force-with-lease=${headRefName}:${pr.headRefOid}`;
 
   // If the PR does not allow maintainers to modify it, exit as the rebased PR cannot
   // be pushed up.
-  if (!pr.maintainerCanModify && !pr.viewerDidAuthor) {
-    error(
-        `Cannot rebase as you did not author the PR and the PR does not allow maintainers` +
-        `to modify the PR`);
-    process.exit(1);
+  if (!pr.maintainerCanModify && !pr.viewerDidAuthor && !opts.allowIfMaintainerCannotModify) {
+    throw new MaintainerModifyAccessError('PR is not set to allow maintainers to modify the PR');
   }
 
   try {
     // Fetch the branch at the commit of the PR, and check it out in a detached state.
     info(`Checking out PR #${prNumber} from ${fullHeadRef}`);
     git.run(['fetch', headRefUrl, headRefName]);
-    git.run(['checkout', '--detach', 'FETCH_HEAD']);
-
-    // Fetch the PRs target branch and rebase onto it.
-    info(`Fetching ${fullBaseRef} to rebase #${prNumber} on`);
-    git.run(['fetch', baseRefUrl, baseRefName]);
-    info(`Attempting to rebase PR #${prNumber} on ${fullBaseRef}`);
-    const rebaseResult = git.runGraceful(['rebase', 'FETCH_HEAD']);
-
-    // If the rebase was clean, push the rebased PR up to the authors fork.
-    if (rebaseResult.status === 0) {
-      info(`Rebase was able to complete automatically without conflicts`);
-      info(`Pushing rebased PR #${prNumber} to ${fullHeadRef}`);
-      git.run(['push', headRefUrl, `HEAD:${headRefName}`, forceWithLeaseFlag]);
-      info(`Rebased and updated PR #${prNumber}`);
-      cleanUpGitState();
-      process.exit(0);
+    if (opts.branchName) {
+      git.run(['checkout', '-b', opts.branchName, 'FETCH_HEAD']);
+    } else {
+      git.run(['checkout', '--detach', 'FETCH_HEAD']);
     }
   } catch (err) {
-    error(err.message);
     cleanUpGitState();
-    process.exit(1);
+    throw Error('git didnt work');
   }
 
-  // On automatic rebase failures, prompt to choose if the rebase should be continued
-  // manually or aborted now.
-  info(`Rebase was unable to complete automatically without conflicts.`);
-  // If the command is run in a non-CI environment, prompt to format the files immediately.
-  const continueRebase =
-      process.env['CI'] === undefined && await promptConfirm('Manually complete rebase?');
-
-  if (continueRebase) {
-    info(`After manually completing rebase, run the following command to update PR #${prNumber}:`);
-    info(` $ git push ${pr.headRef.repository.url} HEAD:${headRefName} ${forceWithLeaseFlag}`);
-    info();
-    info(`To abort the rebase and return to the state of the repository before this command`);
-    info(`run the following command:`);
-    info(` $ git rebase --abort && git reset --hard && git checkout ${previousBranchOrRevision}`);
-    process.exit(1);
-  } else {
-    info(`Cleaning up git state, and restoring previous state.`);
-  }
-
-  cleanUpGitState();
-  process.exit(1);
+  return {
+    pushToUpstream: () => {
+      git.run(['push', headRefUrl, `HEAD:${headRefName}`, forceWithLeaseFlag]);
+      cleanUpGitState();
+    },
+    reset: () => {
+      cleanUpGitState();
+    }
+  };
 
   /** Reset git back to the original branch. */
   function cleanUpGitState() {
@@ -138,6 +130,10 @@ export async function rebasePr(
     git.runGraceful(['reset', '--hard'], {stdio: 'ignore'});
     // Checkout the original branch from before the run began.
     git.runGraceful(['checkout', previousBranchOrRevision], {stdio: 'ignore'});
+    // If a named branch was created, delete the branch.
+    if (opts.branchName) {
+      git.runGraceful(['branch', '-D', opts.branchName]);
+    }
   }
 }
 

--- a/dev-infra/pr/common/checkout-pr.ts
+++ b/dev-infra/pr/common/checkout-pr.ts
@@ -105,7 +105,7 @@ export async function checkOutPullRequestLocally(
     git.run(['fetch', headRefUrl, headRefName]);
     git.run(['checkout', '--detach', 'FETCH_HEAD']);
   } catch (e) {
-    resetGitState();
+    git.checkout(previousBranchOrRevision, true);
     throw e;
   }
 
@@ -121,22 +121,10 @@ export async function checkOutPullRequestLocally(
       return true;
     },
     /** Restores the state of the local repository to before the PR checkout occured. */
-    resetGitState
+    resetGitState: (): boolean => {
+      return git.checkout(previousBranchOrRevision, true);
+    }
   };
-
-  /** Restores the state of the local repository to before the PR checkout occured. */
-  function resetGitState() {
-    // Ensure that any outstanding ams are aborted.
-    git.runGraceful(['am', '--abort'], {stdio: 'ignore'});
-    // Ensure that any outstanding cherry-picks are aborted.
-    git.runGraceful(['cherry-pick', '--abort'], {stdio: 'ignore'});
-    // Ensure that any outstanding rebases are aborted.
-    git.runGraceful(['rebase', '--abort'], {stdio: 'ignore'});
-    // Ensure that any changes in the current repo state are cleared.
-    git.runGraceful(['reset', '--hard'], {stdio: 'ignore'});
-    // Checkout the original branch from before the run began.
-    git.runGraceful(['checkout', previousBranchOrRevision], {stdio: 'ignore'});
-  }
 }
 
 /** Adds the provided token as username to the provided url. */

--- a/dev-infra/pr/discover-new-conflicts/index.ts
+++ b/dev-infra/pr/discover-new-conflicts/index.ts
@@ -72,7 +72,7 @@ export async function discoverNewConflictsForPr(
 
   info(`Requesting pending PRs from Github`);
   /** List of PRs from github currently known as mergable. */
-  const allPendingPRs = (await getPendingPrs(PR_SCHEMA, config.github)).map(processPr);
+  const allPendingPRs = (await getPendingPrs(PR_SCHEMA, git)).map(processPr);
   /** The PR which is being checked against. */
   const requestedPr = allPendingPRs.find(pr => pr.number === newPrNumber);
   if (requestedPr === undefined) {

--- a/dev-infra/utils/git/github.ts
+++ b/dev-infra/utils/git/github.ts
@@ -26,7 +26,7 @@ export class GithubApiRequestError extends Error {
  **/
 export class GithubClient extends Octokit {
   /** The Github GraphQL (v4) API. */
-  graqhql: GithubGraphqlClient;
+  graphql: GithubGraphqlClient;
 
   /** The current user based on checking against the Github API. */
   private _currentUser: string|null = null;
@@ -42,7 +42,7 @@ export class GithubClient extends Octokit {
     });
 
     // Create authenticated graphql client.
-    this.graqhql = new GithubGraphqlClient(token);
+    this.graphql = new GithubGraphqlClient(token);
   }
 
   /** Retrieve the login of the current user from Github. */
@@ -51,7 +51,7 @@ export class GithubClient extends Octokit {
     if (this._currentUser !== null) {
       return this._currentUser;
     }
-    const result = await this.graqhql.query({
+    const result = await this.graphql.query({
       viewer: {
         login: types.string,
       }
@@ -80,7 +80,7 @@ class GithubGraphqlClient {
     // Set the default headers to include authorization with the provided token for all
     // graphQL calls.
     if (token) {
-      this.graqhql.defaults({headers: {authorization: `token ${token}`}});
+      this.graqhql = this.graqhql.defaults({headers: {authorization: `token ${token}`}});
     }
   }
 

--- a/dev-infra/utils/git/index.ts
+++ b/dev-infra/utils/git/index.ts
@@ -151,6 +151,25 @@ export class GitClient {
   }
 
   /**
+   * Checks out a requested branch or revision, optionally cleaning the state of the repository
+   * before attempting the checking. Returns a boolean indicating whether the branch or revision
+   * was cleanly checked out.
+   */
+  checkout(branchOrRevision: string, cleanState: boolean): boolean {
+    if (cleanState) {
+      // Abort any outstanding ams.
+      this.runGraceful(['am', '--abort'], {stdio: 'ignore'});
+      // Abort any outstanding cherry-picks.
+      this.runGraceful(['cherry-pick', '--abort'], {stdio: 'ignore'});
+      // Abort any outstanding rebases.
+      this.runGraceful(['rebase', '--abort'], {stdio: 'ignore'});
+      // Clear any changes in the current repo.
+      this.runGraceful(['reset', '--hard'], {stdio: 'ignore'});
+    }
+    return this.runGraceful(['checkout', branchOrRevision], {stdio: 'ignore'}).status === 0;
+  }
+
+  /**
    * Assert the GitClient instance is using a token with permissions for the all of the
    * provided OAuth scopes.
    */

--- a/dev-infra/utils/github.ts
+++ b/dev-infra/utils/github.ts
@@ -6,29 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {graphql as unauthenticatedGraphql} from '@octokit/graphql';
+import {params, types} from 'typed-graphqlify';
 
-import {params, query as graphqlQuery, types} from 'typed-graphqlify';
-import {NgDevConfig} from './config';
-
-/** The configuration required for github interactions. */
-type GithubConfig = NgDevConfig['github'];
-
-/**
- * Authenticated instance of Github GraphQl API service, relies on a
- * personal access token being available in the TOKEN environment variable.
- */
-const graphql = unauthenticatedGraphql.defaults({
-  headers: {
-    // TODO(josephperrott): Remove reference to TOKEN environment variable as part of larger
-    // effort to migrate to expecting tokens via GITHUB_ACCESS_TOKEN environment variables.
-    authorization: `token ${process.env.TOKEN || process.env.GITHUB_ACCESS_TOKEN}`,
-  }
-});
+import {GitClient} from './git';
 
 /** Get a PR from github  */
-export async function getPr<PrSchema>(
-    prSchema: PrSchema, prNumber: number, {owner, name}: GithubConfig) {
+export async function getPr<PrSchema>(prSchema: PrSchema, prNumber: number, git: GitClient) {
+  /** The owner and name of the repository */
+  const {owner, name} = git.remoteConfig;
+  /** The GraphQL query object to get a the PR */
   const PR_QUERY = params(
       {
         $number: 'Int!',    // The PR number
@@ -41,14 +27,15 @@ export async function getPr<PrSchema>(
         })
       });
 
-  const result =
-      await graphql(graphqlQuery(PR_QUERY), {number: prNumber, owner, name}) as typeof PR_QUERY;
+  const result = (await git.github.graphql.query(PR_QUERY, {number: prNumber, owner, name}));
   return result.repository.pullRequest;
 }
 
 /** Get all pending PRs from github  */
-export async function getPendingPrs<PrSchema>(prSchema: PrSchema, {owner, name}: GithubConfig) {
-  // The GraphQL query object to get a page of pending PRs
+export async function getPendingPrs<PrSchema>(prSchema: PrSchema, git: GitClient) {
+  /** The owner and name of the repository */
+  const {owner, name} = git.remoteConfig;
+  /** The GraphQL query object to get a page of pending PRs */
   const PRS_QUERY = params(
       {
         $first: 'Int',      // How many entries to get with each request
@@ -73,36 +60,22 @@ export async function getPendingPrs<PrSchema>(prSchema: PrSchema, {owner, name}:
               }),
         })
       });
-  const query = graphqlQuery('members', PRS_QUERY);
-
-  /**
-   * Gets the query and queryParams for a specific page of entries.
-   */
-  const queryBuilder = (count: number, cursor?: string) => {
-    return {
-      query,
-      params: {
-        after: cursor || null,
-        first: count,
-        owner,
-        name,
-      },
-    };
-  };
-
-  // The current cursor
+  /** The current cursor */
   let cursor: string|undefined;
-  // If an additional page of members is expected
+  /** If an additional page of members is expected */
   let hasNextPage = true;
-  // Array of pending PRs
+  /** Array of pending PRs */
   const prs: Array<PrSchema> = [];
 
-  // For each page of the response, get the page and add it to the
-  // list of PRs
+  // For each page of the response, get the page and add it to the list of PRs
   while (hasNextPage) {
-    const {query, params} = queryBuilder(100, cursor);
-    const results = await graphql(query, params) as typeof PRS_QUERY;
-
+    const params = {
+      after: cursor || null,
+      first: 100,
+      owner,
+      name,
+    };
+    const results = await git.github.graphql.query(PRS_QUERY, params) as typeof PRS_QUERY;
     prs.push(...results.repository.pullRequests.nodes);
     hasNextPage = results.repository.pullRequests.pageInfo.hasNextPage;
     cursor = results.repository.pullRequests.pageInfo.endCursor;


### PR DESCRIPTION
Creates a tool within ng-dev to checkout a pending PR from the upstream repository.  This automates
an action that many developers on the Angular team need to do periodically in the process of testing
and reviewing incoming PRs.
