### PR TITLE
Event emitter throws an error when no "next" callback is provided

### DIFF
--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -105,7 +105,7 @@ class EventEmitter_ extends Subject<any> {
   }
 
   subscribe(generatorOrNext?: any, error?: any, complete?: any): Subscription {
-    let schedulerFn: (t: any) => any;
+    let schedulerFn = (t: any) => {};
     let errorFn = (err: any): any => null;
     let completeFn = (): any => null;
 
@@ -120,7 +120,9 @@ class EventEmitter_ extends Subject<any> {
         completeFn = this.createHanlder(() => generatorOrNext.complete());
       }
     } else {
-      schedulerFn = this.createHanlder(value => generatorOrNext(value));
+      if (generatorOrNext) {
+        schedulerFn = this.createHanlder(value => generatorOrNext(value));
+      }
 
       if (error) {
         errorFn = this.createHanlder(err => error(err));

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -110,48 +110,24 @@ class EventEmitter_ extends Subject<any> {
     let completeFn = (): any => null;
 
     if (generatorOrNext && typeof generatorOrNext === 'object') {
-      schedulerFn = this.__isAsync ? (value: any) => {
-        setTimeout(() => generatorOrNext.next(value));
-      } : (value: any) => {
-        generatorOrNext.next(value);
-      };
+      schedulerFn = this.createHanlder(value => generatorOrNext.next(value));
 
       if (generatorOrNext.error) {
-        errorFn = this.__isAsync ? (err) => {
-          setTimeout(() => generatorOrNext.error(err));
-        } : (err) => {
-          generatorOrNext.error(err);
-        };
+        errorFn = this.createHanlder(err => generatorOrNext.error(err));
       }
 
       if (generatorOrNext.complete) {
-        completeFn = this.__isAsync ? () => {
-          setTimeout(() => generatorOrNext.complete());
-        } : () => {
-          generatorOrNext.complete();
-        };
+        completeFn = this.createHanlder(() => generatorOrNext.complete());
       }
     } else {
-      schedulerFn = this.__isAsync ? (value: any) => {
-        setTimeout(() => generatorOrNext(value));
-      } : (value: any) => {
-        generatorOrNext(value);
-      };
+      schedulerFn = this.createHanlder(value => generatorOrNext(value));
 
       if (error) {
-        errorFn = this.__isAsync ? (err) => {
-          setTimeout(() => error(err));
-        } : (err) => {
-          error(err);
-        };
+        errorFn = this.createHanlder(err => error(err));
       }
 
       if (complete) {
-        completeFn = this.__isAsync ? () => {
-          setTimeout(() => complete());
-        } : () => {
-          complete();
-        };
+        completeFn = this.createHanlder(() => complete());
       }
     }
 
@@ -162,6 +138,17 @@ class EventEmitter_ extends Subject<any> {
     }
 
     return sink;
+  }
+
+  private createHanlder(callback: (...args: any) => void) {
+    if (this.__isAsync) {
+      return (...args: any) => {
+        setTimeout(() => callback(...args));
+      };
+    }
+    return (...args: any) => {
+      callback(...args);
+    };
   }
 }
 

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -110,26 +110,26 @@ class EventEmitter_ extends Subject<any> {
     let completeFn = (): any => null;
 
     if (generatorOrNext && typeof generatorOrNext === 'object') {
-      schedulerFn = this.createHanlder(value => generatorOrNext.next(value));
+      schedulerFn = this.createHandler(value => generatorOrNext.next(value));
 
       if (generatorOrNext.error) {
-        errorFn = this.createHanlder(err => generatorOrNext.error(err));
+        errorFn = this.createHandler(err => generatorOrNext.error(err));
       }
 
       if (generatorOrNext.complete) {
-        completeFn = this.createHanlder(() => generatorOrNext.complete());
+        completeFn = this.createHandler(() => generatorOrNext.complete());
       }
     } else {
       if (generatorOrNext) {
-        schedulerFn = this.createHanlder(value => generatorOrNext(value));
+        schedulerFn = this.createHandler(value => generatorOrNext(value));
       }
 
       if (error) {
-        errorFn = this.createHanlder(err => error(err));
+        errorFn = this.createHandler(err => error(err));
       }
 
       if (complete) {
-        completeFn = this.createHanlder(() => complete());
+        completeFn = this.createHandler(() => complete());
       }
     }
 
@@ -142,15 +142,13 @@ class EventEmitter_ extends Subject<any> {
     return sink;
   }
 
-  private createHanlder(callback: (...args: any) => void) {
+  private createHandler(callback: (...args: any) => void) {
     if (this.__isAsync) {
       return (...args: any) => {
         setTimeout(() => callback(...args));
       };
     }
-    return (...args: any) => {
-      callback(...args);
-    };
+    return callback;
   }
 }
 

--- a/packages/core/test/event_emitter_spec.ts
+++ b/packages/core/test/event_emitter_spec.ts
@@ -30,6 +30,12 @@ import {EventEmitter} from '../src/event_emitter';
          emitter.emit(99);
        }));
 
+    it('shouldn\'t throw an error when no next callback is provided', () => {
+      emitter.subscribe();
+      emitter.next('something');
+      expect(true).toBeTruthy();
+    });
+
     it('should call the throw callback',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          emitter.subscribe({

--- a/packages/core/test/event_emitter_spec.ts
+++ b/packages/core/test/event_emitter_spec.ts
@@ -39,7 +39,6 @@ import {EventEmitter} from '../src/event_emitter';
     it('should call the throw callback',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          emitter.subscribe({
-           next: () => {},
            error: (error: any) => {
              expect(error).toEqual('Boom');
              async.done();
@@ -51,7 +50,6 @@ import {EventEmitter} from '../src/event_emitter';
     it('should work when no throw callback is provided',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          emitter.subscribe({
-           next: () => {},
            error: (_: any) => {
              async.done();
            }
@@ -62,8 +60,6 @@ import {EventEmitter} from '../src/event_emitter';
     it('should call the return callback',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          emitter.subscribe({
-           next: () => {},
-           error: (_: any) => {},
            complete: () => {
              async.done();
            }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently it throws an error when the next callback is not provided
```ts
const emitter = new EventEmitter();
emitter.subscribe();
emitter.next();
```

## What is the new behavior?
Doesn't throw an error

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Also moved repeated functionality into a separate function