### PR TITLE
fix(bazel): substitute local labels with `@npm//@angular/bazel` for NPM version

### DIFF
--- a/packages/bazel/BUILD.bazel
+++ b/packages/bazel/BUILD.bazel
@@ -18,7 +18,8 @@ pkg_npm(
     substitutions = {
         "(#|\/\/)\\s+BEGIN-DEV-ONLY[\\w\W]+?(#|\/\/)\\s+END-DEV-ONLY": "",
         "//packages/bazel/src/ngc-wrapped": "@npm//@angular/bazel/bin:ngc-wrapped",
-        "//packages/bazel/": "//",
+        "//packages/bazel/src/ng_package:": "@npm//@angular//bazel:src/ng_package/",
+        "//packages/bazel/src:": "@npm//@angular//bazel:src/",
         "angular/packages/bazel/": "npm_angular_bazel/",
     },
     tags = ["release-with-framework"],


### PR DESCRIPTION

The fixes the below error when used with the NodeJS rules 2:

```
ERROR: in /defaults.bzl: in /1bbbf98caa40fd7ceccd451948ced2e0/
external/npm/@angular/bazel/index.bzl:
Label '@npm//src:ng_module.bzl' is invalid because 'src' is not a package;
 perhaps you meant to put the colon here: '@npm//:src/ng_module.bzl'?
```

Output before
```
# Copyright Google LLC All Rights Reserved.
#
# Use of this source code is governed by an MIT-style license that can be
# found in the LICENSE file at https://angular.io/license
""" Public API surface is re-exported here.

Users should not load files under "/src"
"""

load("//src/ng_package:ng_package.bzl", _ng_package = "ng_package")
load("//src:ng_module.bzl", _ng_module = "ng_module_macro")

ng_module = _ng_module
ng_package = _ng_package
# DO NOT ADD PUBLIC API without including in the documentation generation
# Run `yarn bazel build //docs` to verify
```

Output now
```
# Copyright Google LLC All Rights Reserved.
#
# Use of this source code is governed by an MIT-style license that can be
# found in the LICENSE file at https://angular.io/license
""" Public API surface is re-exported here.

Users should not load files under "/src"
"""

load("@npm//@angular/bazel/src/ng_package:ng_package.bzl", _ng_package = "ng_package")
load("@npm//@angular/bazel/src:ng_module.bzl", _ng_module = "ng_module_macro")

ng_module = _ng_module
ng_package = _ng_package
# DO NOT ADD PUBLIC API without including in the documentation generation
# Run `yarn bazel build @npm//@angular/bazel/docs` to verify
```