### PR TITLE
build(docs-infra): upgrade cli command docs sources to 05b670ec8

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -23,7 +23,7 @@
     "build-local-with-viewengine": "yarn ~~build",
     "prebuild-local-with-viewengine-ci": "node scripts/switch-to-viewengine && yarn setup-local-ci",
     "build-local-with-viewengine-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js b0b27361d",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 05b670ec8",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#master](https://github.com/angular/angular/tree/master) from [cli-builds#master](https://github.com/angular/cli-builds/tree/master).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/b0b27361d...05b670ec8):

**Modified**
- help/build.json
- help/generate.json
- help/test.json
- help/xi18n.json

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/4a2761606...05b670ec8) since PR #38443:

**Modified**
- help/build.json
- help/generate.json
- help/test.json
- help/xi18n.json

##
Closes #38443