### PR TITLE
fix(zone.js): zone.js package.json should not include files/directories fields

### DIFF
--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -6,17 +6,8 @@
   "module": "./fesm2015/zone.js",
   "es2015": "./fesm2015/zone.js",
   "fesm2015": "./fesm2015/zone.js",
-  "files": [
-    "./zone.js.d.ts",
-    "./zone.api.extensions.ts",
-    "./zone.configurations.api.ts"
-  ],
   "dependencies": {
     "tslib": "^2.0.0"
-  },
-  "directories": {
-    "lib": "lib",
-    "test": "test"
   },
   "devDependencies": {
     "@types/node": "^10.9.4",


### PR DESCRIPTION
Close #38526, #38516, #38517

After update to `APF`, the `directories` and `files` options are not compatible,
so we need to remove those fileds to make sure everything work as expected.
