### PR TITLE
build(docs-infra): upgrade cli command docs sources to a5c13d29e

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -23,7 +23,7 @@
     "build-local-with-viewengine": "yarn ~~build",
     "prebuild-local-with-viewengine-ci": "node scripts/switch-to-viewengine && yarn setup-local-ci",
     "build-local-with-viewengine-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js b0b27361d",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js a5c13d29e",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#master](https://github.com/angular/angular/tree/master) from [cli-builds#master](https://github.com/angular/cli-builds/tree/master).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/b0b27361d...a5c13d29e):

**Modified**
- help/build.json
- help/generate.json
- help/test.json
- help/xi18n.json

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/05b670ec8...a5c13d29e) since PR #38509:

**Modified**
- help/xi18n.json

##
Closes #38443
Closes #38509