### PR TITLE
docs(localize): fix angular.json syntax

### DIFF
--- a/aio/content/guide/i18n.md
+++ b/aio/content/guide/i18n.md
@@ -766,8 +766,10 @@ The HTML `base` tag with the `href` attribute specifies the base URI, or URL, fo
     "i18n": {
       "sourceLocale": "en-US",
       "locales": {
-        "fr": "src/locale/messages.fr.xlf"
-        "baseHref": ""
+        "fr": {
+          "translation": "src/locale/messages.fr.xlf",
+          "baseHref": "" 
+        }
       }
     },
     "architect": {


### PR DESCRIPTION
In the chapter internationalization (i18n) at section "Deploy multiple locales" the syntax for the angular.json is wrong.
This commit fixes the angular.json, when specifying the translation file and the baseHref for a locale.

## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
In the chapter internationalization (i18n) at section "Deploy multiple locales" the syntax for the angular.json is wrong.

## What is the new behavior?
This commit fixes the angular.json in the docs at section "Deploy multiple locales", when specifying the translation file and the baseHref for a locale.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
