### PR TITLE
docs: remove outdated CircleCI link from `DEVELOPER.md`

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -154,9 +154,7 @@ available as a long-term distribution mechanism, but they are guaranteed to be a
 time of the build.
 
 You can access the artifacts for a specific CI run by going to the workflow page, clicking on the
-`publish_packages_as_artifacts` job and then switching to the "Artifacts" tab.
-(If you happen to know the build number of the job, the URL will be something like:
-`https://circleci.com/gh/angular/angular/<build-number>#artifacts`)
+`publish_packages_as_artifacts` job and then switching to the "ARTIFACTS" tab.
 
 #### Archives for each Package
 On the "Artifacts" tab, there is a list of links to compressed archives for Angular packages. The


### PR DESCRIPTION
CircleCI updated their UI and now the URLs are different (and cannot be constructed based on the build number alone). This commit removes a reference of the obsolete URL pattern to avoid confusion.

Example old URL: https://circleci.com/gh/angular/angular/<build-number>#artifacts

Example new URL: https://app.circleci.com/pipelines/github/angular/angular/<build-number>/workflows/<workflow-id>/jobs/<job-id>/artifacts
