### PR TITLE
fix(router): preload router should use loaded config #38557

### DIFF
--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -15,7 +15,6 @@ import {Event, NavigationEnd, RouteConfigLoadEnd, RouteConfigLoadStart} from './
 import {Router} from './router';
 import {RouterConfigLoader} from './router_config_loader';
 
-
 /**
  * @description
  *
@@ -128,7 +127,10 @@ export class RouterPreloader implements OnDestroy {
     return this.preloadingStrategy.preload(route, () => {
       const loaded$ = this.loader.load(ngModule.injector, route);
       return loaded$.pipe(mergeMap((config: LoadedRouterConfig) => {
-        route._loadedConfig = config;
+        // should use loaded config
+        if (!route._loadedConfig) {
+          route._loadedConfig = config;
+        }
         return this.processRoutes(config.module, config.routes);
       }));
     });


### PR DESCRIPTION
Router preloading use asynchronous calculation, but if we navigate to target route when that calculation not complete.
This may cause applyRedirect create config for that route.
After a while, preload procedure got its _loadedConfig and override the one created by applyRedirect.
This is naturally not we want, it may cause page component destroy and rebuild unintentional.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 38557


## What is the new behavior?

Async prelad will use Loadedconfig, not create new one

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
