### PR TITLE
fix(localize): ensure required XLIFF parameters are serialized

### DIFF
--- a/packages/localize/src/tools/src/extract/translation_files/xliff1_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/xliff1_translation_serializer.ts
@@ -32,7 +32,18 @@ export class Xliff1TranslationSerializer implements TranslationSerializer {
     const ids = new Set<string>();
     const xml = new XmlFile();
     xml.startTag('xliff', {'version': '1.2', 'xmlns': 'urn:oasis:names:tc:xliff:document:1.2'});
-    xml.startTag('file', {'source-language': this.sourceLocale, 'datatype': 'plaintext'});
+    // NOTE: the `original` property is set to the legacy `ng2.template` value for backward
+    // compatibility.
+    // We could compute the file from the `message.location` property, but there could
+    // be multiple values for this in the collection of `messages`. In that case we would probably
+    // need to change the serializer to output a new `<file>` element for each collection of
+    // messages that come from a particular original file, and the translation file parsers may not
+    // be able to cope with this.
+    xml.startTag('file', {
+      'source-language': this.sourceLocale,
+      'datatype': 'plaintext',
+      'original': 'ng2.template',
+    });
     xml.startTag('body');
     for (const message of messages) {
       const id = this.getMessageId(message);

--- a/packages/localize/src/tools/src/extract/translation_files/xliff2_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/xliff2_translation_serializer.ts
@@ -36,7 +36,13 @@ export class Xliff2TranslationSerializer implements TranslationSerializer {
       'xmlns': 'urn:oasis:names:tc:xliff:document:2.0',
       'srcLang': this.sourceLocale
     });
-    xml.startTag('file');
+    // NOTE: the `original` property is set to the legacy `ng.template` value for backward
+    // compatibility.
+    // We could compute the file from the `message.location` property, but there could
+    // be multiple values for this in the collection of `messages`. In that case we would probably
+    // need to change the serializer to output a new `<file>` element for each collection of
+    // messages that come from a particular original file, and the translation file parsers may not
+    xml.startTag('file', {'id': 'ngi18n', 'original': 'ng.template'});
     for (const message of messages) {
       const id = this.getMessageId(message);
       if (ids.has(id)) {

--- a/packages/localize/src/tools/test/extract/integration/main_spec.ts
+++ b/packages/localize/src/tools/test/extract/integration/main_spec.ts
@@ -146,7 +146,7 @@ runInEachFileSystem(() => {
           expect(fs.readFile(outputPath)).toEqual([
             `<?xml version="1.0" encoding="UTF-8" ?>`,
             `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-            `  <file source-language="en-CA" datatype="plaintext">`,
+            `  <file source-language="en-CA" datatype="plaintext" original="ng2.template">`,
             `    <body>`,
             `      <trans-unit id="3291030485717846467" datatype="html">`,
             `        <source>Hello, <x id="PH"/>!</source>`,
@@ -206,7 +206,7 @@ runInEachFileSystem(() => {
           expect(fs.readFile(outputPath)).toEqual([
             `<?xml version="1.0" encoding="UTF-8" ?>`,
             `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-AU">`,
-            `  <file>`,
+            `  <file id="ngi18n" original="ng.template">`,
             `    <unit id="3291030485717846467">`,
             `      <segment>`,
             `        <source>Hello, <ph id="0" equiv="PH"/>!</source>`,
@@ -257,7 +257,7 @@ runInEachFileSystem(() => {
            expect(fs.readFile(outputPath)).toEqual([
              `<?xml version="1.0" encoding="UTF-8" ?>`,
              `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-             `  <file source-language="en-CA" datatype="plaintext">`,
+             `  <file source-language="en-CA" datatype="plaintext" original="ng2.template">`,
              `    <body>`,
              `      <trans-unit id="157258427077572998" datatype="html">`,
              `        <source>Message in <x id="a-file"/>!</source>`,

--- a/packages/localize/src/tools/test/extract/translation_files/xliff1_translation_serializer_spec.ts
+++ b/packages/localize/src/tools/test/extract/translation_files/xliff1_translation_serializer_spec.ts
@@ -58,7 +58,7 @@ runInEachFileSystem(() => {
           expect(output).toEqual([
             `<?xml version="1.0" encoding="UTF-8" ?>`,
             `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-            `  <file source-language="xx" datatype="plaintext">`,
+            `  <file source-language="xx" datatype="plaintext" original="ng2.template">`,
             `    <body>`,
             `      <trans-unit id="${
                 useLegacyIds ? '1234567890ABCDEF1234567890ABCDEF12345678' :

--- a/packages/localize/src/tools/test/extract/translation_files/xliff2_translation_serializer_spec.ts
+++ b/packages/localize/src/tools/test/extract/translation_files/xliff2_translation_serializer_spec.ts
@@ -64,7 +64,7 @@ runInEachFileSystem(() => {
           expect(output).toEqual([
             `<?xml version="1.0" encoding="UTF-8" ?>`,
             `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="xx">`,
-            `  <file>`,
+            `  <file id="ngi18n" original="ng.template">`,
             `    <unit id="${useLegacyIds ? '615790887472569365' : '12345'}">`,
             `      <notes>`,
             `        <note category="location">file.ts:6</note>`,


### PR DESCRIPTION
When extracting i18n messages from source code, the XLIFF
serializers were missing some required attributes on the `<file>`
element.

This commit re-introduces the `original` property to each of XLIFF 1.2
and 2.0 serializers. Also it adds in the required `id` property for the
XLIFF 2.0 seralizer.

Fixes #38570