### PR TITLE
feat(dev-infra): create tooling to edit commit messages for an upstream pr

### DIFF
--- a/dev-infra/commit-message/parse.ts
+++ b/dev-infra/commit-message/parse.ts
@@ -19,6 +19,8 @@ export interface ParsedCommitMessage {
   isFixup: boolean;
   isSquash: boolean;
   isRevert: boolean;
+  raw: string;
+  message: string;
 }
 
 /** Regex determining if a commit is a fixup. */
@@ -37,10 +39,10 @@ const COMMIT_HEADER_RE = /^(.*)/i;
 const COMMIT_BODY_RE = /^.*\n\n([\s\S]*)$/;
 
 /** Parse a full commit message into its composite parts. */
-export function parseCommitMessage(commitMsg: string): ParsedCommitMessage {
+export function parseCommitMessage(rawCommitMsg: string): ParsedCommitMessage {
   // Ignore comments (i.e. lines starting with `#`). Comments are automatically removed by git and
   // should not be considered part of the final commit message.
-  commitMsg = commitMsg.split('\n').filter(line => !line.startsWith('#')).join('\n');
+  const commitMsg = rawCommitMsg.split('\n').filter(line => !line.startsWith('#')).join('\n');
 
   let header = '';
   let body = '';
@@ -72,6 +74,8 @@ export function parseCommitMessage(commitMsg: string): ParsedCommitMessage {
     type,
     scope,
     subject,
+    raw: rawCommitMsg,
+    message: commitMsg,
     isFixup: FIXUP_PREFIX_RE.test(commitMsg),
     isSquash: SQUASH_PREFIX_RE.test(commitMsg),
     isRevert: REVERT_PREFIX_RE.test(commitMsg),

--- a/dev-infra/pr/BUILD.bazel
+++ b/dev-infra/pr/BUILD.bazel
@@ -9,6 +9,7 @@ ts_library(
         "//dev-infra/pr/check-target-branches",
         "//dev-infra/pr/checkout",
         "//dev-infra/pr/discover-new-conflicts",
+        "//dev-infra/pr/fixup-commits",
         "//dev-infra/pr/merge",
         "//dev-infra/pr/rebase",
         "@npm//@types/yargs",

--- a/dev-infra/pr/cli.ts
+++ b/dev-infra/pr/cli.ts
@@ -12,6 +12,7 @@ import {CheckTargetBranchesModule} from './check-target-branches/cli';
 import {CheckoutCommandModule} from './checkout/cli';
 import {buildDiscoverNewConflictsCommand, handleDiscoverNewConflictsCommand} from './discover-new-conflicts/cli';
 import {MergeCommandModule} from './merge/cli';
+import {FixupCommitsCommandModule} from './fixup-commits/cli';
 import {buildRebaseCommand, handleRebaseCommand} from './rebase/cli';
 
 /** Build the parser for pull request commands. */
@@ -28,5 +29,6 @@ export function buildPrParser(localYargs: yargs.Argv) {
           buildRebaseCommand, handleRebaseCommand)
       .command(MergeCommandModule)
       .command(CheckoutCommandModule)
-      .command(CheckTargetBranchesModule);
+      .command(CheckTargetBranchesModule)
+      .command(FixupCommitsCommandModule);
 }

--- a/dev-infra/pr/fixup-commits/BUILD.bazel
+++ b/dev-infra/pr/fixup-commits/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
+
+ts_library(
+    name = "fixup-commits",
+    srcs = glob(["*.ts"]),
+    module_name = "@angular/dev-infra-private/pr/fixup-commits",
+    visibility = ["//dev-infra:__subpackages__"],
+    deps = [
+        "//dev-infra/commit-message",
+        "//dev-infra/pr/common",
+        "//dev-infra/utils",
+        "@npm//@types/cli-progress",
+        "@npm//@types/node",
+        "@npm//@types/shelljs",
+        "@npm//@types/yargs",
+        "@npm//external-editor",
+    ],
+)

--- a/dev-infra/pr/fixup-commits/cli.ts
+++ b/dev-infra/pr/fixup-commits/cli.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Arguments, Argv, CommandModule} from 'yargs';
+
+import {error} from '../../utils/console';
+
+import {fixupCommits} from './fixup-commits';
+
+/** The options available to the fixup-commits command via CLI. */
+export interface FixupCommitsOptions {
+  'github-token'?: string;
+  prNumber: number;
+}
+
+/** URL to the Github page where personal access tokens can be generated. */
+export const GITHUB_TOKEN_GENERATE_URL = `https://github.com/settings/tokens`;
+
+/** Builds the fixup-commits pull request command. */
+function builder(yargs: Argv) {
+  return yargs
+      .option('github-token', {
+        type: 'string',
+        description: 'Github token. If not set, token is retrieved from the environment variables.'
+      })
+      .positional('prNumber', {type: 'number', demandOption: true});
+}
+
+/** Handles the fixup-commits pull request command. */
+async function handler({prNumber, 'github-token': token}: Arguments<FixupCommitsOptions>) {
+  const githubToken = token || process.env.GITHUB_TOKEN || process.env.TOKEN;
+  if (!githubToken) {
+    error('No Github token set. Please set the `GITHUB_TOKEN` environment variable.');
+    error('Alternatively, pass the `--github-token` command line flag.');
+    error(`You can generate a token here: ${GITHUB_TOKEN_GENERATE_URL}`);
+    process.exit(1);
+  }
+
+  try {
+    await fixupCommits(prNumber, githubToken);
+  } catch (e) {
+    error(e);
+    process.exitCode = 1;
+  }
+}
+
+export const FixupCommitsCommandModule: CommandModule<{}, FixupCommitsOptions> = {
+  handler,
+  builder,
+  command: 'fixup-commits <pr-number>',
+  describe: 'Amend commits for a PR and push back to the upstream repository'
+};

--- a/dev-infra/pr/fixup-commits/fixup-commits.ts
+++ b/dev-infra/pr/fixup-commits/fixup-commits.ts
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {edit} from 'external-editor';
+import {moveCursor} from 'readline';
+
+import {parseCommitMessage, ParsedCommitMessage} from '../../commit-message/parse';
+import {green, info, promptConfirm, yellow} from '../../utils/console';
+import {GitClient} from '../../utils/git';
+import {checkOutPullRequestLocally} from '../common/checkout-pr';
+
+/** Fixup the commits  */
+export async function fixupCommits(pr: number, githubToken: string) {
+  /** Client for interacting with Git and Github */
+  const git = new GitClient(githubToken);
+  git.printGitCommands = false;
+  /** The commits contained in the PR. */
+  const commits = await getCommitsForPr(git, pr);
+  /** Total number of commits which have been ammended. */
+  let ammendedCommitCount = 0;
+  const {
+    /** Push the local changes back to the PR upstream. */
+    pushToUpstream,
+    /** Reset the local repository back to the state before the command was run. */
+    resetGitState
+  } = await checkOutPullRequestLocally(pr, githubToken);
+  /** The SHA of the commit/ref immediately before the PR. */
+  const shaBeforePr = git.run(['rev-parse', `${commits[0].sha}~1`]).stdout.trim();
+
+  info(`PR #${pr} contains ${commits.length} commit message(s)`);
+
+  // Reset the git environment to the sha before the PR
+  git.run(['reset', '--hard', shaBeforePr]);
+
+  for (const commit of commits) {
+    /** The parsed commit information from the commit message. */
+    const parsedCommit = parseCommitMessage(commit.commit.message);
+    /** The commit message diff as a patch string. */
+    const commitAsPatch = git.run(['format-patch', '-1', commit.sha, '--stdout']).stdout;
+    // Apply the commit patch
+    git.run(['am'], {input: commitAsPatch});
+
+    // All commits which are fixups should be skipped as they will be squashed anyway.
+    if (parsedCommit.isFixup) {
+      continue;
+    }
+
+    // Ask the user via command prompt if the commit should be ammended.
+    if (await presentCommitForAmendment(parsedCommit)) {
+      /** The text of the new commit message. */
+      const commitMessage = await ammendCommit(parsedCommit);
+      if (commitMessage.raw !== parsedCommit.raw) {
+        // Ammend the commit message with the new commit message text, using --no-verify to skip
+        // commit message validation checks.
+        git.run(['commit', '--amend', '--no-verify', '-m', commitMessage.raw]);
+        ammendedCommitCount++;
+      }
+    }
+  }
+
+  // Rebase the PR to resolve all fixup commits.
+  git.run(['rebase', '-i', shaBeforePr], {env: {GIT_SEQUENCE_EDITOR: ':'}});
+
+  // Only push changes to upstream if a commit has actually been ammended
+  if (ammendedCommitCount > 0) {
+    info(`${ammendedCommitCount} commit message(s) ammended, pushing to upstream.`);
+    pushToUpstream();
+  } else {
+    info('No commit messages were ammended, skipping push to upstream.');
+  }
+
+  // Reset the git repository back the state before the command was run.
+  resetGitState();
+}
+
+/** Retrieves all commits for a specified PR. */
+async function getCommitsForPr(git: GitClient, pr: number) {
+  const {owner, name: repo} = git.remoteConfig;
+  return (await git.github.pulls.listCommits({pull_number: pr, owner, repo})).data;
+}
+
+/** Ask the user via command prompt if the provided commit should be ammended. */
+async function presentCommitForAmendment(commit: ParsedCommitMessage) {
+  /**
+   * Print a message in the console, returning a function to clear the printed message from
+   * the console, replacing it with a new message if provided.
+   */
+  function writeCommitMsg(message: string): (message?: string) => void {
+    /** The number of lines the message uses. */
+    const lineCount = message.split('\n').length + 1;
+    info(message);
+
+    return (newMessage?: string) => {
+      // Move the cursor back to the position before the original message was written.
+      moveCursor(process.stdout, -1000, -lineCount);
+      process.stdout.clearScreenDown();
+      if (newMessage) {
+        info(newMessage);
+      }
+    };
+  }
+
+  /**
+   * Function to rewrite the contents of stdout, after it has printed the commit message provided.
+   */
+  const writeResultInStdOut = writeCommitMsg(`\n${commit.message}\n`);
+  /** Whether the user would like to modify this commit message.  */
+  const promptResult = await promptConfirm(`Would you like to modify the commit message?`, true);
+  /**
+   * The string to prepend to the commit message header line, based on whether the commit is
+   * being ammended.
+   */
+  const resultPrepend = promptResult ? green('Updated:') : yellow('Skipped:');
+
+  writeResultInStdOut(`${resultPrepend} ${commit.header}`);
+  return promptResult;
+}
+
+/** Amend the procided commit message */
+async function ammendCommit(commit: ParsedCommitMessage): Promise<ParsedCommitMessage> {
+  // TODO(josephperrott): run commit message validation on new commit message text.
+  const newCommitMessage = edit(commit.raw);
+  return parseCommitMessage(newCommitMessage);
+}

--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
     "cli-progress": "^3.7.0",
     "conventional-changelog": "^2.0.3",
     "entities": "1.1.1",
+    "external-editor": "^3.0.3",
     "firebase-tools": "^7.11.0",
     "firefox-profile": "1.0.3",
     "glob": "7.1.2",


### PR DESCRIPTION
To better allow for team members, particularly caretakers, to be able to amend
commit messages on behalf of PR authors this tool automates the local checkout,
amendment of commit messages and push back to github.  This allows for any team
member to fixup the commit messages of any PR which allows for edits by
maintainers.
