### PR TITLE
fix(zone.js): add missing types field in package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -749,6 +749,8 @@ jobs:
              cp dist/bin/packages/zone.js/npm_package/bundles/zone-patch-electron.umd.js ./packages/zone.js/test/extra/ &&
              yarn --cwd packages/zone.js electrontest
       - run: yarn --cwd packages/zone.js jesttest
+      - run: yarn --cwd packages/zone.js/test/typings install --frozen-lockfile --non-interactive
+      - run: yarn --cwd packages/zone.js/test/typings test
 
   # Windows jobs
   # Docs: https://circleci.com/docs/2.0/hello-world-windows/

--- a/packages/zone.js/BUILD.bazel
+++ b/packages/zone.js/BUILD.bazel
@@ -34,32 +34,13 @@ genrule(
 
 genrule(
     name = "zone_js_d_ts",
-    srcs = ["//packages/zone.js/lib:zone_d_ts"],
-    outs = ["zone.js.d.ts"],
-    cmd = "cp $< $@",
-)
-
-genrule(
-    name = "zone_extensions_d_ts",
-    srcs = ["//packages/zone.js/lib:zone.api.extensions.ts"],
-    outs = ["zone.api.extensions.ts"],
-    cmd = "cp $< $@",
-)
-
-genrule(
-    name = "zone_configurations_d_ts",
-    srcs = ["//packages/zone.js/lib:zone.configurations.api.ts"],
-    outs = ["zone.configurations.api.ts"],
-    cmd = "cp $< $@",
-)
-
-filegroup(
-    name = "zone_d_ts",
     srcs = [
-        ":zone_configurations_d_ts",
-        ":zone_extensions_d_ts",
-        ":zone_js_d_ts",
+        "//packages/zone.js/lib:zone_d_ts",
+        "//packages/zone.js/lib:zone.api.extensions.ts",
+        "//packages/zone.js/lib:zone.configurations.api.ts",
     ],
+    outs = ["zone.d.ts"],
+    cmd = "cat $(SRCS) > $@",
 )
 
 generate_rollup_bundle(
@@ -95,5 +76,5 @@ pkg_npm(
     ] + [
         "//packages/zone.js/fesm2015:" + b + "-es2015.min.dist"
         for b in BUNDLES_ENTRY_POINTS.keys()
-    ] + [":zone_d_ts"],
+    ] + [":zone_js_d_ts"],
 )

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -6,6 +6,7 @@
   "module": "./fesm2015/zone.js",
   "es2015": "./fesm2015/zone.js",
   "fesm2015": "./fesm2015/zone.js",
+  "typings": "./zone.d.ts",
   "dependencies": {
     "tslib": "^2.0.0"
   },

--- a/packages/zone.js/test/npm_package/npm_package.spec.ts
+++ b/packages/zone.js/test/npm_package/npm_package.spec.ts
@@ -40,20 +40,18 @@ describe('Zone.js npm_package', () => {
     it('should contain module resolution mappings', () => {
       expect(shx.grep('"main":', packageJson)).toContain(`zone.umd.js`);
     });
+
+    it('should contain typings', () => {
+      expect(shx.grep('"typings":', packageJson)).toContain(`./zone.d.ts`);
+    });
   });
 
   describe('check npm_package root folder', () => {
     describe('typescript support', () => {
-      it('should have an zone.js.d.ts file', () => {
-        expect(shx.cat('zone.js.d.ts')).toContain('declare const');
-      });
-
-      it('should have an zone.api.extensions.ts file', () => {
-        expect(shx.cat('zone.api.extensions.ts')).toContain('EventTarget');
-      });
-
-      it('should have an zone.configurations.api.ts file', () => {
-        expect(shx.cat('zone.configurations.api.ts')).toContain('ZoneGlobalConfigurations');
+      it('should have an zone.d.ts file', () => {
+        expect(shx.cat('zone.d.ts')).toContain('declare const');
+        expect(shx.cat('zone.d.ts')).toContain('interface EventTarget');
+        expect(shx.cat('zone.d.ts')).toContain('ZoneGlobalConfigurations');
       });
     });
 

--- a/packages/zone.js/test/typings/.gitignore
+++ b/packages/zone.js/test/typings/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+build
+*.log

--- a/packages/zone.js/test/typings/package.json
+++ b/packages/zone.js/test/typings/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "typings",
+  "version": "1.0.0",
+  "description": "typing test package to test zone.js.d.ts",
+  "scripts": {
+    "test": "tsc -p ."
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@types/node": "12.11.1",
+    "domino": "^2.1.6",
+    "zone.js": "file:../../../../dist/bin/packages/zone.js/npm_package"
+  },
+  "devDependencies": {
+    "typescript": "~4.0.2"
+  }
+}

--- a/packages/zone.js/test/typings/tsconfig.json
+++ b/packages/zone.js/test/typings/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "experimentalDecorators": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "./build",
+    "rootDir": ".",
+    "target": "es5",
+    "noEmitOnError": false,
+    "stripInternal": false,
+    "strict": true,
+    "lib": [
+      "es5",
+      "dom",
+      "es2015.collection",
+      "es2015.iterable",
+      "es2015.promise",
+    ],
+  },
+  "files": [
+    "./type.test.ts",
+    "./node_modules/zone.js/zone.d.ts"
+  ],
+}

--- a/packages/zone.js/test/typings/type.test.ts
+++ b/packages/zone.js/test/typings/type.test.ts
@@ -1,0 +1,18 @@
+import * as domino from 'domino';
+require('zone.js/bundles/zone.umd');
+
+// Zone public API should be included
+Zone.current.fork({name: 'testZone'}).run(() => {});
+
+// Zone extra APIs for EventTarget should be available
+const w = domino.createWindow('<h1>Hello zone.js</h1>');
+const h1 = w.document.querySelector('h1');
+const listener = () => {};
+h1!.addEventListener('click', listener);
+const clickListeners = h1!.eventListeners!('click');
+if (!clickListeners || clickListeners.length === 0 || clickListeners[0] !== listener) {
+  throw new Error('eventListeners not work!!!');
+}
+
+const globalZoneConfig = w as ZoneGlobalConfigurations;
+globalZoneConfig.__Zone_disable_EventEmitter = true;


### PR DESCRIPTION
Close #38584

In zone.js 0.11.1, the `types` field is missing in the `package.json`,
the reason is in zone.js 0.11.0, the `files` field is used to specify the
types, but it cause the npm package not contain any bundles issue, so zone.js
0.11.1 remove the `files` field, which cause the `type` definition gone.

This PR concat the `zone.js.d.ts`, `zone.configurations.api.ts`, `zone.api.extensions.ts`
types into a single `zone.js.d.ts` file.
