### PR TITLE
refactor(compiler-cli): cleanup after TS 4.0 changes

### DIFF
--- a/packages/compiler-cli/src/ngtsc/reflection/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/reflection/BUILD.bazel
@@ -7,5 +7,8 @@ ts_library(
     srcs = ["index.ts"] + glob([
         "src/**/*.ts",
     ]),
-    deps = ["@npm//typescript"],
+    deps = [
+        "//packages/compiler-cli/src/ngtsc/util",
+        "@npm//typescript",
+    ],
 )

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -8,6 +8,8 @@
 
 import * as ts from 'typescript';
 
+import {isLiteralNullTypeNode} from '../../util/src/typescript';
+
 import {ClassDeclaration, ClassMember, ClassMemberKind, CtorParameter, Declaration, Decorator, FunctionDefinition, Import, isDecoratorIdentifier, ReflectionHost} from './host';
 import {typeToValue} from './type_to_value';
 import {isNamedClassDeclaration} from './util';
@@ -63,12 +65,8 @@ export class TypeScriptReflectionHost implements ReflectionHost {
       // We also don't need to support `foo: Foo|undefined` because Angular's DI injects `null` for
       // optional tokes that don't have providers.
       if (typeNode && ts.isUnionTypeNode(typeNode)) {
-        let childTypeNodes = typeNode.types.filter(
-            // TODO(alan-agius4): remove `childTypeNode.kind !== ts.SyntaxKind.NullKeyword` when
-            // TS 3.9 support is dropped. In TS 4.0 NullKeyword is a child of LiteralType.
-            childTypeNode => childTypeNode.kind !== ts.SyntaxKind.NullKeyword &&
-                !(ts.isLiteralTypeNode(childTypeNode) &&
-                  childTypeNode.literal.kind === ts.SyntaxKind.NullKeyword));
+        let childTypeNodes =
+            typeNode.types.filter(childTypeNode => !isLiteralNullTypeNode(childTypeNode));
 
         if (childTypeNodes.length === 1) {
           typeNode = childTypeNodes[0];

--- a/packages/compiler-cli/src/ngtsc/transform/src/declaration.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/declaration.ts
@@ -240,8 +240,8 @@ export class ReturnTypeTransform implements DtsTransform {
 
   transformClassElement(element: ts.ClassElement, imports: ImportManager): ts.ClassElement {
     // // TODO(alan-agius4): Remove when we no longer support TS 3.9
-    // TS <= 3.9
     if (ts.isMethodSignature(element)) {
+      // TS <= 3.9
       const original = ts.getOriginalNode(element) as ts.MethodDeclaration;
       if (!this.typeReplacements.has(original)) {
         return element;
@@ -263,10 +263,8 @@ export class ReturnTypeTransform implements DtsTransform {
       // `ts.ClassElement`. Since `element` was a `ts.MethodSignature` already, transforming it into
       // this type is actually correct.
       return methodSignature as unknown as ts.ClassElement;
-    }
-
-    // TS 4.0 +
-    if (ts.isMethodDeclaration(element)) {
+    } else if (ts.isMethodDeclaration(element)) {
+      // TS 4.0 +
       const original = ts.getOriginalNode(element, ts.isMethodDeclaration);
       if (!this.typeReplacements.has(original)) {
         return element;
@@ -275,9 +273,16 @@ export class ReturnTypeTransform implements DtsTransform {
       const tsReturnType = translateType(returnType, imports);
 
       return ts.updateMethod(
-          element, element.decorators, element.modifiers, element.asteriskToken, element.name,
-          element.questionToken, element.typeParameters, element.parameters, tsReturnType,
-          element.body);
+          /* node */ element,
+          /* decorators */ element.decorators,
+          /* modifiers */ element.modifiers,
+          /* asteriskToken */ element.asteriskToken,
+          /* name */ element.name,
+          /* questionToken */ element.questionToken,
+          /* typeParameters */ element.typeParameters,
+          /* parameters */ element.parameters,
+          /* type */ tsReturnType,
+          /* body */ element.body);
     }
 
     return element;

--- a/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
@@ -12,6 +12,7 @@ import * as ts from 'typescript';
 import {DefaultImportRecorder, ImportRewriter} from '../../imports';
 import {Decorator, ReflectionHost} from '../../reflection';
 import {ImportManager, translateExpression, translateStatement} from '../../translator';
+import {setNodeArraySourceMapRange} from '../../util/src/typescript';
 import {visit, VisitListEntryResult, Visitor} from '../../util/src/visitor';
 
 import {CompileResult} from './api';
@@ -187,8 +188,7 @@ class IvyTransformationVisitor extends Visitor {
 
     // Create a new `NodeArray` with the filtered decorators that sourcemaps back to the original.
     const array = ts.createNodeArray(filtered);
-    (array.pos as number) = node.decorators.pos;
-    (array.end as number) = node.decorators.end;
+    setNodeArraySourceMapRange(array, node.decorators.pos, node.decorators.end);
     return array;
   }
 

--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -11,6 +11,7 @@ import {LocalizedString, UnaryOperator, UnaryOperatorExpr} from '@angular/compil
 import * as ts from 'typescript';
 
 import {DefaultImportRecorder, ImportRewriter, NOOP_DEFAULT_IMPORT_RECORDER, NoopImportRewriter} from '../../imports';
+import {createNullTypeNode} from '../../util/src/typescript';
 
 export class Context {
   constructor(readonly isStatement: boolean) {}
@@ -526,11 +527,7 @@ export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
 
   visitLiteralExpr(ast: LiteralExpr, context: Context): ts.TypeNode {
     if (ast.value === null) {
-      // TODO(alan-agius4): Remove when we no longer support TS 3.9
-      // Use: return ts.createLiteralTypeNode(ts.createNull()) directly.
-      return ts.versionMajorMinor.charAt(0) === '4' ?
-          ts.createLiteralTypeNode(ts.createNull() as any) :
-          ts.createKeywordTypeNode(ts.SyntaxKind.NullKeyword as any);
+      return createNullTypeNode();
     } else if (ast.value === undefined) {
       return ts.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword);
     } else if (typeof ast.value === 'boolean') {

--- a/packages/compiler-cli/src/ngtsc/util/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/util/BUILD.bazel
@@ -10,7 +10,6 @@ ts_library(
     deps = [
         "//packages:types",
         "//packages/compiler-cli/src/ngtsc/file_system",
-        "//packages/compiler-cli/src/ngtsc/incremental:api",
         "@npm//@types/node",
         "@npm//typescript",
     ],


### PR DESCRIPTION
This commit extracts some TS 4.0 sensitive operations into utility functions
to better isolate them from the rest of the code base. This way, support for
3.9-specific functionality is isolated to a single location, and cleanup
after removal of 3.9 support will be much more straightforward.