### PR TITLE
perf(core): use `ngDevMode` to tree-shake error messages

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 147573,
+        "main-es2015": 146989,
         "polyfills-es2015": 36571
       }
     }

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -384,7 +384,7 @@ export class R3Injector {
       let multiRecord = this.records.get(token);
       if (multiRecord) {
         // It has. Throw a nice error if
-        if (multiRecord.multi === undefined) {
+        if (ngDevMode && multiRecord.multi === undefined) {
           throwMixedMultiProviderError();
         }
       } else {
@@ -396,7 +396,7 @@ export class R3Injector {
       multiRecord.multi!.push(provider);
     } else {
       const existing = this.records.get(token);
-      if (existing && existing.multi !== undefined) {
+      if (ngDevMode && existing && existing.multi !== undefined) {
         throwMixedMultiProviderError();
       }
     }
@@ -404,7 +404,7 @@ export class R3Injector {
   }
 
   private hydrate<T>(token: Type<T>|InjectionToken<T>, record: Record<T>): T {
-    if (record.value === CIRCULAR) {
+    if (ngDevMode && record.value === CIRCULAR) {
       throwCyclicDependencyError(stringify(token));
     } else if (record.value === NOT_YET) {
       record.value = CIRCULAR;
@@ -511,7 +511,7 @@ export function providerToFactory(
       const classRef = resolveForwardRef(
           provider &&
           ((provider as StaticClassProvider | ClassProvider).useClass || provider.provide));
-      if (!classRef) {
+      if (ngDevMode && !classRef) {
         throwInvalidProviderError(ngModuleType, providers, provider);
       }
       if (hasDeps(provider)) {

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1375,6 +1375,7 @@ function findDirectiveDefMatches(
   ngDevMode &&
       assertNodeOfPossibleTypes(
           tNode, [TNodeType.Element, TNodeType.ElementContainer, TNodeType.Container]);
+
   const registry = tView.directiveRegistry;
   let matches: any[]|null = null;
   if (registry) {
@@ -1385,13 +1386,14 @@ function findDirectiveDefMatches(
         diPublicInInjector(getOrCreateNodeInjectorForNode(tNode, viewData), tView, def.type);
 
         if (isComponentDef(def)) {
-          ngDevMode &&
-              assertNodeOfPossibleTypes(
-                  tNode, [TNodeType.Element],
-                  `"${tNode.tagName}" tags cannot be used as component hosts. ` +
-                      `Please use a different tag to activate the ${
-                          stringify(def.type)} component.`);
-          if (tNode.flags & TNodeFlags.isComponentHost) throwMultipleComponentError(tNode);
+          if (ngDevMode) {
+            assertNodeOfPossibleTypes(
+                tNode, [TNodeType.Element],
+                `"${tNode.tagName}" tags cannot be used as component hosts. ` +
+                    `Please use a different tag to activate the ${stringify(def.type)} component.`);
+
+            if (tNode.flags & TNodeFlags.isComponentHost) throwMultipleComponentError(tNode);
+          }
           markAsComponentHost(tView, tNode);
           // The component is always stored first with directives after.
           matches.unshift(def);

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -351,9 +351,6 @@
     "name": "setUpAttributes"
   },
   {
-    "name": "throwMultipleComponentError"
-  },
-  {
     "name": "unwrapRNode"
   },
   {

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -1587,12 +1587,6 @@
     "name": "syncPendingControls"
   },
   {
-    "name": "throwMixedMultiProviderError"
-  },
-  {
-    "name": "throwMultipleComponentError"
-  },
-  {
     "name": "toObservable"
   },
   {

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -129,9 +129,6 @@
     "name": "stringify"
   },
   {
-    "name": "throwMixedMultiProviderError"
-  },
-  {
     "name": "ɵɵdefineInjectable"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -714,9 +714,6 @@
     "name": "stringifyForError"
   },
   {
-    "name": "throwMultipleComponentError"
-  },
-  {
     "name": "toTStylingRange"
   },
   {


### PR DESCRIPTION
This commit adds `ngDevMode` guard to throw some errors only in dev mode
(similar to how things work in other parts of Ivy runtime code). The
`ngDevMode` flag helps to tree-shake these error messages from production
builds (in dev mode everything will work as it works right now) to decrease
production bundle size.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
