### PR TITLE
docs: Marking the `entryComponents` array as deprecated

### DIFF
--- a/aio/content/guide/entry-components.md
+++ b/aio/content/guide/entry-components.md
@@ -76,6 +76,12 @@ All router components must be entry components. Because this would require you t
 
 ## The `entryComponents` array
 
+<div class="alert is-helpful">
+   
+Since 9.0.0 with Ivy, the `entryComponents` property is no longer necessary. See [deprecations guide](guide/deprecations#entryComponents).
+   
+</div>
+
 Though the `@NgModule` decorator has an `entryComponents` array, most of the time
 you won't have to explicitly set any entry components because Angular adds components listed in `@NgModule.bootstrap` and those in route definitions to entry components automatically. Though these two mechanisms account for most entry components, if your app happens to bootstrap or dynamically load a component by type imperatively,
 you must add it to `entryComponents` explicitly.


### PR DESCRIPTION
Since the `entryComponents` array is now deprecated (per https://angular.io/api/core/NgModule#entryComponents and https://angular.io/guide/deprecations#entryComponents), it would be great to reflect that information the official docs as the information there was still elated to the pre-v9 behavior.

## PR Checklist

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The current docs are out of date.

Issue Number: N/A


## What is the new behavior?
Describes that the `entryComponents` array is now deprecated

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

