### PR TITLE
build: update the package.json to 10.2.0-next.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "10.1.0-rc.0",
+  "version": "10.2.0-next.0",
   "private": true,
   "description": "Angular - a web framework for modern web apps",
   "homepage": "https://github.com/angular/angular",


### PR DESCRIPTION
When the rc was cut for 10.1.0-rc.0, the package.json for master should be updated
to to the following next version, in this case 10.2.0-next.0.
