### PR TITLE
refactor(dev-infra): use a mixin to require a `github-token` for an ng-dev command

### DIFF
--- a/dev-infra/pr/checkout/cli.ts
+++ b/dev-infra/pr/checkout/cli.ts
@@ -8,12 +8,12 @@
 
 import {Arguments, Argv, CommandModule} from 'yargs';
 
-import {error} from '../../utils/console';
+import {addGithubTokenFlag} from '../../utils/yargs';
 import {checkOutPullRequestLocally} from '../common/checkout-pr';
 
 export interface CheckoutOptions {
   prNumber: number;
-  'github-token'?: string;
+  'github-token': string;
 }
 
 /** URL to the Github page where personal access tokens can be generated. */
@@ -21,24 +21,13 @@ export const GITHUB_TOKEN_GENERATE_URL = `https://github.com/settings/tokens`;
 
 /** Builds the checkout pull request command. */
 function builder(yargs: Argv) {
-  return yargs.positional('prNumber', {type: 'number', demandOption: true}).option('github-token', {
-    type: 'string',
-    description: 'Github token. If not set, token is retrieved from the environment variables.'
-  });
+  return addGithubTokenFlag(yargs).positional('prNumber', {type: 'number', demandOption: true});
 }
 
 /** Handles the checkout pull request command. */
 async function handler({prNumber, 'github-token': token}: Arguments<CheckoutOptions>) {
-  const githubToken = token || process.env.GITHUB_TOKEN || process.env.TOKEN;
-  if (!githubToken) {
-    error('No Github token set. Please set the `GITHUB_TOKEN` environment variable.');
-    error('Alternatively, pass the `--github-token` command line flag.');
-    error(`You can generate a token here: ${GITHUB_TOKEN_GENERATE_URL}`);
-    process.exitCode = 1;
-    return;
-  }
   const prCheckoutOptions = {allowIfMaintainerCannotModify: true, branchName: `pr-${prNumber}`};
-  await checkOutPullRequestLocally(prNumber, githubToken, prCheckoutOptions);
+  await checkOutPullRequestLocally(prNumber, token, prCheckoutOptions);
 }
 
 /** yargs command module for checking out a PR  */

--- a/dev-infra/pr/checkout/cli.ts
+++ b/dev-infra/pr/checkout/cli.ts
@@ -13,11 +13,8 @@ import {checkOutPullRequestLocally} from '../common/checkout-pr';
 
 export interface CheckoutOptions {
   prNumber: number;
-  'github-token': string;
+  githubToken: string;
 }
-
-/** URL to the Github page where personal access tokens can be generated. */
-export const GITHUB_TOKEN_GENERATE_URL = `https://github.com/settings/tokens`;
 
 /** Builds the checkout pull request command. */
 function builder(yargs: Argv) {
@@ -25,9 +22,9 @@ function builder(yargs: Argv) {
 }
 
 /** Handles the checkout pull request command. */
-async function handler({prNumber, 'github-token': token}: Arguments<CheckoutOptions>) {
+async function handler({prNumber, githubToken}: Arguments<CheckoutOptions>) {
   const prCheckoutOptions = {allowIfMaintainerCannotModify: true, branchName: `pr-${prNumber}`};
-  await checkOutPullRequestLocally(prNumber, token, prCheckoutOptions);
+  await checkOutPullRequestLocally(prNumber, githubToken, prCheckoutOptions);
 }
 
 /** yargs command module for checking out a PR  */

--- a/dev-infra/pr/merge/cli.ts
+++ b/dev-infra/pr/merge/cli.ts
@@ -8,36 +8,24 @@
 
 import {Arguments, Argv} from 'yargs';
 
-import {error, red, yellow} from '../../utils/console';
+import {addGithubTokenFlag} from '../../utils/yargs';
 
-import {GITHUB_TOKEN_GENERATE_URL, mergePullRequest} from './index';
+import {mergePullRequest} from './index';
 
 /** The options available to the merge command via CLI. */
 export interface MergeCommandOptions {
-  'github-token'?: string;
+  'github-token': string;
   'pr-number': number;
 }
 
 /** Builds the options for the merge command. */
 export function buildMergeCommand(yargs: Argv): Argv<MergeCommandOptions> {
-  return yargs.help()
-      .strict()
-      .positional('pr-number', {demandOption: true, type: 'number'})
-      .option('github-token', {
-        type: 'string',
-        description: 'Github token. If not set, token is retrieved from the environment variables.'
-      });
+  return addGithubTokenFlag(yargs).help().strict().positional(
+      'pr-number', {demandOption: true, type: 'number'});
 }
 
 /** Handles the merge command. i.e. performs the merge of a specified pull request. */
-export async function handleMergeCommand(args: Arguments<MergeCommandOptions>) {
-  const githubToken = args['github-token'] || process.env.GITHUB_TOKEN || process.env.TOKEN;
-  if (!githubToken) {
-    error(red('No Github token set. Please set the `GITHUB_TOKEN` environment variable.'));
-    error(red('Alternatively, pass the `--github-token` command line flag.'));
-    error(yellow(`You can generate a token here: ${GITHUB_TOKEN_GENERATE_URL}`));
-    process.exit(1);
-  }
-
-  await mergePullRequest(args['pr-number'], githubToken);
+export async function handleMergeCommand(
+    {'pr-number': pr, 'github-token': token}: Arguments<MergeCommandOptions>) {
+  await mergePullRequest(pr, token);
 }

--- a/dev-infra/pr/merge/cli.ts
+++ b/dev-infra/pr/merge/cli.ts
@@ -14,7 +14,7 @@ import {mergePullRequest} from './index';
 
 /** The options available to the merge command via CLI. */
 export interface MergeCommandOptions {
-  'github-token': string;
+  githubToken: string;
   'pr-number': number;
 }
 
@@ -26,6 +26,6 @@ export function buildMergeCommand(yargs: Argv): Argv<MergeCommandOptions> {
 
 /** Handles the merge command. i.e. performs the merge of a specified pull request. */
 export async function handleMergeCommand(
-    {'pr-number': pr, 'github-token': token}: Arguments<MergeCommandOptions>) {
-  await mergePullRequest(pr, token);
+    {'pr-number': pr, githubToken}: Arguments<MergeCommandOptions>) {
+  await mergePullRequest(pr, githubToken);
 }

--- a/dev-infra/pr/merge/index.ts
+++ b/dev-infra/pr/merge/index.ts
@@ -11,12 +11,10 @@ import {getConfig, getRepoBaseDir} from '../../utils/config';
 import {error, green, info, promptConfirm, red, yellow} from '../../utils/console';
 import {GitClient} from '../../utils/git';
 import {GithubApiRequestError} from '../../utils/git/github';
+import {GITHUB_TOKEN_GENERATE_URL} from '../../utils/yargs';
 
-import {loadAndValidateConfig, MergeConfig, MergeConfigWithRemote} from './config';
+import {loadAndValidateConfig, MergeConfigWithRemote} from './config';
 import {MergeResult, MergeStatus, PullRequestMergeTask} from './task';
-
-/** URL to the Github page where personal access tokens can be generated. */
-export const GITHUB_TOKEN_GENERATE_URL = `https://github.com/settings/tokens`;
 
 
 /**

--- a/dev-infra/pr/rebase/cli.ts
+++ b/dev-infra/pr/rebase/cli.ts
@@ -8,7 +8,7 @@
 
 import {Arguments, Argv} from 'yargs';
 
-import {error} from '../../utils/console';
+import {addGithubTokenFlag} from '../../utils/yargs';
 
 import {rebasePr} from './index';
 
@@ -17,30 +17,18 @@ export const GITHUB_TOKEN_GENERATE_URL = `https://github.com/settings/tokens`;
 
 /** The options available to the rebase command via CLI. */
 export interface RebaseCommandOptions {
-  'github-token'?: string;
+  'github-token': string;
   prNumber: number;
 }
 
 /** Builds the rebase pull request command. */
 export function buildRebaseCommand(yargs: Argv): Argv<RebaseCommandOptions> {
-  return yargs
-      .option('github-token', {
-        type: 'string',
-        description: 'Github token. If not set, token is retrieved from the environment variables.'
-      })
-      .positional('prNumber', {type: 'number', demandOption: true});
+  return addGithubTokenFlag(yargs).positional('prNumber', {type: 'number', demandOption: true});
 }
 
 
 /** Handles the rebase pull request command. */
-export async function handleRebaseCommand(args: Arguments<RebaseCommandOptions>) {
-  const githubToken = args['github-token'] || process.env.GITHUB_TOKEN || process.env.TOKEN;
-  if (!githubToken) {
-    error('No Github token set. Please set the `GITHUB_TOKEN` environment variable.');
-    error('Alternatively, pass the `--github-token` command line flag.');
-    error(`You can generate a token here: ${GITHUB_TOKEN_GENERATE_URL}`);
-    process.exit(1);
-  }
-
-  await rebasePr(args.prNumber, githubToken);
+export async function handleRebaseCommand(
+    {prNumber, 'github-token': token}: Arguments<RebaseCommandOptions>) {
+  await rebasePr(prNumber, token);
 }

--- a/dev-infra/pr/rebase/cli.ts
+++ b/dev-infra/pr/rebase/cli.ts
@@ -12,12 +12,9 @@ import {addGithubTokenFlag} from '../../utils/yargs';
 
 import {rebasePr} from './index';
 
-/** URL to the Github page where personal access tokens can be generated. */
-export const GITHUB_TOKEN_GENERATE_URL = `https://github.com/settings/tokens`;
-
 /** The options available to the rebase command via CLI. */
 export interface RebaseCommandOptions {
-  'github-token': string;
+  githubToken: string;
   prNumber: number;
 }
 
@@ -26,9 +23,8 @@ export function buildRebaseCommand(yargs: Argv): Argv<RebaseCommandOptions> {
   return addGithubTokenFlag(yargs).positional('prNumber', {type: 'number', demandOption: true});
 }
 
-
 /** Handles the rebase pull request command. */
 export async function handleRebaseCommand(
-    {prNumber, 'github-token': token}: Arguments<RebaseCommandOptions>) {
-  await rebasePr(prNumber, token);
+    {prNumber, githubToken}: Arguments<RebaseCommandOptions>) {
+  await rebasePr(prNumber, githubToken);
 }

--- a/dev-infra/utils/yargs.ts
+++ b/dev-infra/utils/yargs.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Argv, Omit} from 'yargs';
+import {error} from './console';
+
+export type ArgvWithGithubToken = Argv < Omit<{'github-token': string;}, 'github-token'>&{
+  'github-token': string;
+}
+> ;
+
+export function addGithubTokenFlag(yargs: Argv): ArgvWithGithubToken {
+  return yargs
+      .option('github-token', {
+        type: 'string',
+        description: 'Github token. If not set, token is retrieved from the environment variables.',
+        coerce: (token: string) => {
+          const githubToken = token || process.env.GITHUB_TOKEN || process.env.TOKEN;
+          if (!githubToken) {
+            error('No Github token set. Please set the `GITHUB_TOKEN` environment variable.');
+            error('Alternatively, pass the `--github-token` command line flag.');
+            error(`You can generate a token here: https://github.com/settings/tokens`);
+            process.exit(1);
+          }
+          return githubToken;
+        },
+      })
+      .default('github-token', '', '<LOCAL TOKEN>');
+}

--- a/dev-infra/utils/yargs.ts
+++ b/dev-infra/utils/yargs.ts
@@ -6,29 +6,32 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Argv, Omit} from 'yargs';
-import {error} from './console';
+import {Argv} from 'yargs';
+import {error, red, yellow} from './console';
 
-export type ArgvWithGithubToken = Argv < Omit<{'github-token': string;}, 'github-token'>&{
-  'github-token': string;
-}
-> ;
+export type ArgvWithGithubToken = Argv<{githubToken: string}>;
 
 export function addGithubTokenFlag(yargs: Argv): ArgvWithGithubToken {
   return yargs
-      .option('github-token', {
+      // 'github-token' is casted to 'githubToken' to properly set up typings to reflect the key in
+      // the Argv object being camelCase rather than kebob case due to the `camel-case-expansion`
+      // config: https://github.com/yargs/yargs-parser#camel-case-expansion
+      .option('github-token' as 'githubToken', {
         type: 'string',
         description: 'Github token. If not set, token is retrieved from the environment variables.',
         coerce: (token: string) => {
           const githubToken = token || process.env.GITHUB_TOKEN || process.env.TOKEN;
           if (!githubToken) {
-            error('No Github token set. Please set the `GITHUB_TOKEN` environment variable.');
-            error('Alternatively, pass the `--github-token` command line flag.');
-            error(`You can generate a token here: https://github.com/settings/tokens`);
+            error(red('No Github token set. Please set the `GITHUB_TOKEN` environment variable.'));
+            error(red('Alternatively, pass the `--github-token` command line flag.'));
+            error(yellow(`You can generate a token here: ${GITHUB_TOKEN_GENERATE_URL}`));
             process.exit(1);
           }
           return githubToken;
         },
       })
-      .default('github-token', '', '<LOCAL TOKEN>');
+      .default('github-token' as 'githubToken', '', '<LOCAL TOKEN>');
 }
+
+/** URL to the Github page where personal access tokens can be generated. */
+export const GITHUB_TOKEN_GENERATE_URL = 'https://github.com/settings/tokens/new';


### PR DESCRIPTION
Creates a mixin for requiring a github token to be provided to a command.  This mixin
allows for a centralized management of the requirement and handling of the github-token.
