### PR TITLE
feat(dev-infra): add `style` type to commit parser tool

### DIFF
--- a/dev-infra/commit-message/config.ts
+++ b/dev-infra/commit-message/config.ts
@@ -86,6 +86,12 @@ export const COMMIT_TYPES: {[key: string]: CommitType} = {
     description: 'A release point in the repository',
     scope: ScopeRequirement.Forbidden,
   },
+  style: {
+    name: 'style',
+    description:
+        'Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)',
+    scope: ScopeRequirement.Required,
+  },
   test: {
     name: 'test',
     description: 'Improvements or corrections made to the project\'s test suite',


### PR DESCRIPTION
According to the documentation (see: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type),
there is a type called `styled`, but this is not present on the commit parser.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The commit parser will allow to commit with type `style` as documented.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
