### PR TITLE
refactor(migrations): remove rxjs usage within static queries migration

### DIFF
--- a/packages/core/schematics/migrations/static-queries/index.ts
+++ b/packages/core/schematics/migrations/static-queries/index.ts
@@ -9,7 +9,6 @@
 import {logging} from '@angular-devkit/core';
 import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
 import {relative} from 'path';
-import {from} from 'rxjs';
 import * as ts from 'typescript';
 
 import {NgComponentTemplateVisitor} from '../../utils/ng_component_template';
@@ -41,11 +40,7 @@ interface AnalyzedProject {
 
 /** Entry point for the V8 static-query migration. */
 export default function(): Rule {
-  return (tree: Tree, context: SchematicContext) => {
-    // We need to cast the returned "Observable" to "any" as there is a
-    // RxJS version mismatch that breaks the TS compilation.
-    return from(runMigration(tree, context).then(() => tree)) as any;
-  };
+  return runMigration;
 }
 
 /** Runs the V8 migration static-query migration for all determined TypeScript projects. */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

rxjs was only used within one location within the static queries migration to workaround a previous limitation that schematics could not directly use a promise.  However, promise support has been available since 8.0.


## What is the new behavior?

This change removes the observable promise wrapping.  It also removes an any cast that was previously needed to workaround rxjs version mismatches during compilation.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
