### PR TITLE
fix(core): reset `tView` between tests in Ivy TestBed

### DIFF
--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -379,6 +379,11 @@ export class R3TestBedCompiler {
       const moduleScope = getScopeOfModule(moduleType);
       this.storeFieldOfDefOnType(componentType, NG_COMP_DEF, 'directiveDefs');
       this.storeFieldOfDefOnType(componentType, NG_COMP_DEF, 'pipeDefs');
+      // `tView` that is stored on component def contains information about directives and pipes
+      // that are in the scope of this component. Patching component scope will cause `tView` to be
+      // changed. Store original `tView` before patching scope, so the `tView` (including scope
+      // information) is restored back to its previous/original state before running next test.
+      this.storeFieldOfDefOnType(componentType, NG_COMP_DEF, 'tView');
       patchComponentDefWithScope((componentType as any).ɵcmp, moduleScope);
     });
 


### PR DESCRIPTION
`tView` that is stored on a component def contains information about directives and pipes that are available in the scope of this component. Patching component scope causes `tView` to be updated. Prior to this commit, the `tView` information was not restored/reset in case component class is not declared in the `declarations` field while calling `TestBed.configureTestingModule`, thus causing `tView` to be reused between tests (thus preserving scopes information between tests). This commit updates TestBed logic to preserve `tView` value before applying scope changes and reset it back to the previous state between tests.

Closes #38600.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No