### PR TITLE
fix(core): do not call the hook if it is undefined

### DIFF
--- a/packages/core/src/render3/hooks.ts
+++ b/packages/core/src/render3/hooks.ts
@@ -258,6 +258,8 @@ function callHook(currentView: LView, initPhase: InitPhaseState, arr: HookData, 
       hook.call(directive);
     }
   } else {
-    hook.call(directive);
+    if (hook) {
+      hook.call(directive);
+    }
   }
 }


### PR DESCRIPTION
This fix prevents the Angular framework from throwing an exception
when the value of a hook is undefined. Normally the hook can never
be null of undefined but due to a bug in the framework, this situation can happen.

More details can be found in the following GitHub issue:
https://github.com/angular/angular/issues/38611#issuecomment-683277944

refs #38611

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [38611](https://github.com/angular/angular/issues/38611)
## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
