### PR TITLE
fix(localize): install `@angular/localize` in `devDependencies` by default

### DIFF
--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -16,6 +16,9 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
+  "ng-add": {
+    "save": "devDependencies"
+  },
   "sideEffects": [
     "**/init/index.js",
     "**/init.js",

--- a/packages/localize/schematics/ng-add/README.md
+++ b/packages/localize/schematics/ng-add/README.md
@@ -4,3 +4,7 @@ This schematic will be executed when an Angular CLI user runs `ng add @angular/l
 
 It will search their `angular.json` file, and find polyfills and main files for server builders.
 Then it will add the `@angular/localize/init` polyfill that `@angular/localize` needs to work.
+
+If the user specifies that they want to use `$localize` at runtime then the dependency will be
+added to the `depdendencies` section of `package.json` rather than in the `devDependencies` which
+is the default.

--- a/packages/localize/schematics/ng-add/index.ts
+++ b/packages/localize/schematics/ng-add/index.ts
@@ -10,6 +10,8 @@
 
 import {virtualFs, workspaces} from '@angular-devkit/core';
 import {chain, Rule, SchematicsException, Tree} from '@angular-devkit/schematics';
+import {NodePackageInstallTask} from '@angular-devkit/schematics/tasks';
+import {addPackageJsonDependency, NodeDependencyType, removePackageJsonDependency} from '@schematics/angular/utility/dependencies';
 import {getWorkspace} from '@schematics/angular/utility/workspace';
 import {Builders} from '@schematics/angular/utility/workspace-models';
 
@@ -95,6 +97,22 @@ function prependToTargetFiles(
   };
 }
 
+function moveToDependencyType(type: NodeDependencyType): Rule {
+  return (host, context) => {
+    debugger;
+    if (host.exists('package.json')) {
+      // Remove the previous dependency and add in a new one under the desired type.
+      removePackageJsonDependency(host, '@angular/localize');
+      addPackageJsonDependency(
+          host, {name: '@angular/localize', type, version: `^0.0.0-PLACEHOLDER`});
+
+      // Add a task to run the package manager. This is necessary because we updated
+      // "package.json" and we want lock files to reflect this.
+      context.addTask(new NodePackageInstallTask());
+    };
+  };
+}
+
 export default function(options: Schema): Rule {
   return async (host: Tree) => {
     if (!options.name) {
@@ -114,9 +132,15 @@ export default function(options: Schema): Rule {
 ${localizePolyfill}
 `;
 
+    // If `$localize` will not be used at runtime then we can install `@angular/localize` as a
+    // devDependency.
+    const dependencyType =
+        options.useAtRuntime ? NodeDependencyType.Default : NodeDependencyType.Dev;
+
     return chain([
       prependToTargetFiles(project, Builders.Browser, 'polyfills', localizeStr),
       prependToTargetFiles(project, Builders.Server, 'main', localizeStr),
+      moveToDependencyType(dependencyType),
     ]);
   };
 }

--- a/packages/localize/schematics/ng-add/index.ts
+++ b/packages/localize/schematics/ng-add/index.ts
@@ -9,7 +9,7 @@
  */
 
 import {virtualFs, workspaces} from '@angular-devkit/core';
-import {chain, Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
+import {chain, noop, Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
 import {NodePackageInstallTask} from '@angular-devkit/schematics/tasks';
 import {addPackageJsonDependency, NodeDependencyType, removePackageJsonDependency} from '@schematics/angular/utility/dependencies';
 import {getWorkspace} from '@schematics/angular/utility/workspace';
@@ -113,8 +113,6 @@ function moveToDependencies(host: Tree, context: SchematicContext) {
   }
 }
 
-function noop() {}
-
 export default function(options: Schema): Rule {
   return async (host: Tree) => {
     if (!options.name) {
@@ -139,7 +137,7 @@ ${localizePolyfill}
       prependToTargetFiles(project, Builders.Server, 'main', localizeStr),
       // If `$localize` will be used at runtime then must install `@angular/localize`
       // into `dependencies`, rather than the default of `devDependencies`.
-      options.useAtRuntime ? moveToDependencies : noop
+      options.useAtRuntime ? moveToDependencies : noop()
     ]);
   };
 }

--- a/packages/localize/schematics/ng-add/index_spec.ts
+++ b/packages/localize/schematics/ng-add/index_spec.ts
@@ -33,11 +33,13 @@ export { renderModule, renderModuleFactory } from '@angular/platform-server';`;
 
   beforeEach(() => {
     host = new UnitTestTree(new HostTree());
-    host.create('package.json', `{
-      "dependencies": {
-        "@angular/localize": "old-version"
+    host.create('package.json', JSON.stringify({
+      'devDependencies': {
+        // The default (according to `ng-add` in its package.json) is for `@angular/localize` to be
+        // saved to `devDependencies`.
+        '@angular/localize': '~0.0.0-PLACEHOLDER',
       }
-    }`);
+    }));
     host.create('src/polyfills.ts', polyfillsContent);
     host.create('src/another-polyfills.ts', polyfillsContent);
     host.create('src/unrelated-polyfills.ts', polyfillsContent);
@@ -176,7 +178,7 @@ export { renderModule, renderModuleFactory } from '@angular/platform-server';`;
     host = await schematicRunner.runSchematicAsync('ng-add', defaultOptions, host).toPromise();
     const packageJsonText = host.readContent('/package.json');
     expect(JSON.parse(packageJsonText).devDependencies?.['@angular/localize'])
-        .toBe('^0.0.0-PLACEHOLDER');
+        .toBe('~0.0.0-PLACEHOLDER');
     expect(JSON.parse(packageJsonText).dependencies?.['@angular/localize']).toBeUndefined();
   });
 
@@ -186,7 +188,7 @@ export { renderModule, renderModuleFactory } from '@angular/platform-server';`;
                .toPromise();
     const packageJsonText = host.readContent('/package.json');
     expect(JSON.parse(packageJsonText).dependencies?.['@angular/localize'])
-        .toBe('^0.0.0-PLACEHOLDER');
+        .toBe('~0.0.0-PLACEHOLDER');
     expect(JSON.parse(packageJsonText).devDependencies?.['@angular/localize']).toBeUndefined();
   });
 });

--- a/packages/localize/schematics/ng-add/schema.d.ts
+++ b/packages/localize/schematics/ng-add/schema.d.ts
@@ -11,4 +11,11 @@ export interface Schema {
    * The name of the project.
    */
   name?: string;
+  /**
+   * Will this project use $localize at runtime?
+   *
+   * If true then the dependency is included in the `dependencies` section of packge.json, rather
+   * than `devDependencies`.
+   */
+  useAtRuntime?: boolean;
 }

--- a/packages/localize/schematics/ng-add/schema.json
+++ b/packages/localize/schematics/ng-add/schema.json
@@ -10,8 +10,12 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "useAtRuntime": {
+      "type": "boolean",
+      "description": "If true then the dependency is included in the `dependencies` section of packge.json, rather than `devDependencies`.",
+      "x-prompt": "Will this project use $localize at runtime?"
     }
   },
-  "required": [
-  ]
+  "required": []
 }

--- a/packages/localize/schematics/ng-add/schema.json
+++ b/packages/localize/schematics/ng-add/schema.json
@@ -13,8 +13,8 @@
     },
     "useAtRuntime": {
       "type": "boolean",
-      "description": "If true then the dependency is included in the `dependencies` section of packge.json, rather than `devDependencies`.",
-      "x-prompt": "Will this project use $localize at runtime?"
+      "description": "If set then `@angular/localize` is included in the `dependencies` section of `package.json`, rather than `devDependencies`, which is the default.",
+      "default": false
     }
   },
   "required": []


### PR DESCRIPTION
Previously this package was installed in the default `dependencies` section
of `package.json`, but this meant that its dependencies are treated as
dependencies of the main project - Babel, for example.

Generally, $localize` is not used at runtime - it is compiled out by the
translation tooling, so there is no need for it to be a full dependency.

This commit changes the default location of the package to be the
`devDependencies` section, but gives the user a prompt to choose
otherwise.

Fixes #38329

