### PR TITLE
docs: correct link to chrome status in component style guide

### DIFF
--- a/aio/content/guide/component-styles.md
+++ b/aio/content/guide/component-styles.md
@@ -125,7 +125,7 @@ Emulated is the default and most commonly used view encapsulation. For more info
 
 <div class="alert is-important">
 
-The shadow-piercing descendant combinator is deprecated and [support is being removed from major browsers](https://www.chromestatus.com/features/6750456638341120) and tools.
+The shadow-piercing descendant combinator is deprecated and [support is being removed from major browsers](https://www.chromestatus.com/feature/6750456638341120) and tools.
 As such we plan to drop support in Angular (for all 3 of `/deep/`, `>>>` and `::ng-deep`).
 Until then `::ng-deep` should be preferred for a broader compatibility with the tools.
 


### PR DESCRIPTION
Corrects the link to the chromestatus page which errantly linked to features
rather than feature (singular).
