### PR TITLE
fix(compiler): incorrectly encapsulating @import containing colons and semicolons

### DIFF
--- a/packages/compiler/test/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css_spec.ts
@@ -340,6 +340,18 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
       const css = s(styleStr, 'contenta');
       expect(css).toEqual('div[contenta] {background-image:url("a.jpg"); color:red;}');
     });
+
+    it('should shim rules with an escaped quote inside quoted content', () => {
+      const styleStr = 'div::after { content: "\\"" }';
+      const css = s(styleStr, 'contenta');
+      expect(css).toEqual('div[contenta]::after { content:"\\""}');
+    });
+
+    it('should shim rules with curly braces inside quoted content', () => {
+      const styleStr = 'div::after { content: "{}" }';
+      const css = s(styleStr, 'contenta');
+      expect(css).toEqual('div[contenta]::after { content:"{}"}');
+    });
   });
 
   describe('processRules', () => {

--- a/packages/compiler/test/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css_spec.ts
@@ -283,6 +283,28 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
       expect(css).toEqual('@import url("a"); div[contenta] {}');
     });
 
+    it('should shim rules with quoted content after @import', () => {
+      const styleStr = '@import url("a"); div {background-image: url("a.jpg"); color: red;}';
+      const css = s(styleStr, 'contenta');
+      expect(css).toEqual(
+          '@import url("a"); div[contenta] {background-image:url("a.jpg"); color:red;}');
+    });
+
+    it('should pass through @import directives whose URL contains colons and semicolons', () => {
+      const styleStr =
+          '@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap");';
+      const css = s(styleStr, 'contenta');
+      expect(css).toEqual(styleStr);
+    });
+
+    it('should shim rules after @import with colons and semicolons', () => {
+      const styleStr =
+          '@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap"); div {}';
+      const css = s(styleStr, 'contenta');
+      expect(css).toEqual(
+          '@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap"); div[contenta] {}');
+    });
+
     it('should leave calc() unchanged', () => {
       const styleStr = 'div {height:calc(100% - 55px);}';
       const css = s(styleStr, 'contenta');
@@ -311,6 +333,12 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
     it('should keep sourceURL comments', () => {
       expect(s('/*# sourceMappingURL=data:x */b {c}/*# sourceURL=xxx */', 'contenta'))
           .toEqual('b[contenta] {c}/*# sourceMappingURL=data:x *//*# sourceURL=xxx */');
+    });
+
+    it('should shim rules with quoted content', () => {
+      const styleStr = 'div {background-image: url("a.jpg"); color: red;}';
+      const css = s(styleStr, 'contenta');
+      expect(css).toEqual('div[contenta] {background-image:url("a.jpg"); color:red;}');
     });
   });
 


### PR DESCRIPTION
At a high level, the current shadow DOM shim logic works by escaping the content of a CSS rule (e.g. `div {color: red;}` becomes `div {%BLOCK%}`), using a regex to parse out things like the  selector and the rule body, and then re-adding the content after the selector has been modified.  

The problem is that the regex has to be very broad in order capture all of the different use cases, which can cause it to match strings suffixed with a semi-colon in some places where it shouldn't, like this URL from Google Fonts `https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap`. Most of the time this is fine, because the logic that escapes the rule content to `%BLOCK%` will have converted it to something that won't be matched by the regex. However, it breaks down for rules like `@import` which don't have a body, but can still have quoted content with characters that can match the regex.

These changes resolve the issue by making a second pass over the escaped string and replacing all of the remaining quoted content with `%QUOTED%` before parsing it with the regex. Once everything has been processed, we make a final pass where we restore the quoted content.

In a previous iteration of this PR, I went with a shorter approach which narrowed down the regex so that it doesn't capture rules without a body. It fixed the issue, but it also ended up breaking some of the more contrived unit test cases. I decided not to pursue it further, because we would've ended up with a very long and brittle regex that likely would've broken in even weirder
ways.

Fixes #38587.