### PR TITLE
fix(core): ensure TestBed is not instantiated before override provider

### DIFF
--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -327,6 +327,7 @@ export class TestBedRender3 implements TestBed {
    */
   overrideProvider(token: any, provider: {useFactory?: Function, useValue?: any, deps?: any[]}):
       void {
+    this.assertNotInstantiated('overrideProvider', 'override provider');
     this.compiler.overrideProvider(token, provider);
   }
 

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -535,6 +535,7 @@ export class TestBedViewEngine implements TestBed {
   overrideProvider(token: any, provider: {useValue: any;}): void;
   overrideProvider(token: any, provider: {useFactory?: Function, useValue?: any, deps?: any[]}):
       void {
+    this._assertNotInstantiated('overrideProvider', 'override provider');
     this.overrideProviderImpl(token, provider);
   }
 

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -774,18 +774,6 @@ const bTok = new InjectionToken<string>('b');
           expect(testDir!.test).toBe('some prop');
         });
 
-        it('should throw if the TestBed is already created', () => {
-          @Component({selector: 'comp', template: 'a'})
-          class MyComponent {
-          }
-
-          TestBed.inject(Injector);
-
-          expect(() => TestBed.overrideTemplateUsingTestingModule(MyComponent, 'b'))
-              .toThrowError(
-                  /Cannot override template when the test module has already been instantiated/);
-        });
-
         it('should reset overrides when the testing module is resetted', () => {
           @Component({selector: 'comp', template: 'a'})
           class MyComponent {
@@ -1070,6 +1058,70 @@ Did you run and wait for 'resolveComponentResources()'?` :
            componentFixture.detectChanges();
            expect(componentFixture.nativeElement).toHaveText('Parent(Mock)');
          }));
+    });
+
+    describe('calling override methods after TestBed initialization', () => {
+      const getExpectedErrorMessage = (methodName: string, methodDescription: string) => `Cannot ${
+          methodDescription} when the test module has already been instantiated. Make sure you are not using \`inject\` before \`${
+          methodName}\`.`;
+
+      it('should throw if TestBed.overrideProvider is called after TestBed initialization', () => {
+        TestBed.inject(Injector);
+
+        expect(() => TestBed.overrideProvider(aTok, {
+          useValue: 'mockValue'
+        })).toThrowError(getExpectedErrorMessage('overrideProvider', 'override provider'));
+      });
+
+      it('should throw if TestBed.overrideModule is called after TestBed initialization', () => {
+        @NgModule()
+        class MyModule {
+        }
+
+        TestBed.inject(Injector);
+
+        expect(() => TestBed.overrideModule(MyModule, {}))
+            .toThrowError(getExpectedErrorMessage('overrideModule', 'override module metadata'));
+      });
+
+      it('should throw if TestBed.overridePipe is called after TestBed initialization', () => {
+        @Pipe({name: 'myPipe'})
+        class MyPipe {
+          transform(value: any) {
+            return value;
+          }
+        }
+
+        TestBed.inject(Injector);
+
+        expect(() => TestBed.overridePipe(MyPipe, {}))
+            .toThrowError(getExpectedErrorMessage('overridePipe', 'override pipe metadata'));
+      });
+
+      it('should throw if TestBed.overrideDirective is called after TestBed initialization', () => {
+        @Directive()
+        class MyDirective {
+        }
+
+        TestBed.inject(Injector);
+
+        expect(() => TestBed.overrideDirective(MyDirective, {}))
+            .toThrowError(
+                getExpectedErrorMessage('overrideDirective', 'override directive metadata'));
+      });
+
+      it('should throw if TestBed.overrideTemplateUsingTestingModule is called after TestBed initialization',
+         () => {
+           @Component({selector: 'comp', template: 'a'})
+           class MyComponent {
+           }
+
+           TestBed.inject(Injector);
+
+           expect(() => TestBed.overrideTemplateUsingTestingModule(MyComponent, 'b'))
+               .toThrowError(
+                   /Cannot override template when the test module has already been instantiated/);
+         });
     });
   });
 }


### PR DESCRIPTION
There is an inconsistency in overrideProvider behaviour. Testing documentation says (https://angular.io/guide/testing-components-basics#createcomponent, https://angular.io/guide/testing-components-scenarios#the-async-beforeeach) that all override...
methods throw error if TestBed is already instantiated. However overrideProvider doesn't throw any error, but (same as
other override... methods) doesn't replace providers if TestBed is instantiated. Add TestBed instantiation check to
overrideProvider method to make it consistent.

Issue mentioned here: https://github.com/angular/angular/issues/13460#issuecomment-636005966

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
overrideProvider doesn't replace provider if TestBed is instantiated (same as other override... methods) but it doesn't give any feedback (other override... methods throw error)


## What is the new behavior?
overrideProvider throws error if TestBed is instantiated.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

If you call `TestBed.overrideProvider` after TestBed initialization, provider overrides are not applied. This behavior is 
consistent with other override methods (such as `TestBed.overrideDirective`, etc) but they throw an error to indicate that, 
when the check was missing in the `TestBed.overrideProvider` function. Now calling `TestBed.overrideProvider` after 
TestBed initialization also triggers an error, thus there is a chance that some tests (where `TestBed.overrideProvider` is 
called after TestBed initialization) will start to fail and require updates to move `TestBed.overrideProvider` calls before 
TestBed initialization is completed.

## Other information
This inconsistency is confusing for users. I have seen open issues in some other repositories which are related to this issue like https://github.com/ngneat/spectator/issues/337
Documentation https://angular.io/guide/testing-components-basics#createcomponent
Documentation https://angular.io/guide/testing-components-scenarios#the-async-beforeeach