### PR TITLE
fix(forms): ngModel select [multiple=false] should return a value

### DIFF
--- a/packages/forms/src/directives/select_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_control_value_accessor.ts
@@ -85,7 +85,7 @@ function _extractId(valueString: string): string {
  */
 @Directive({
   selector:
-      'select:not([multiple])[formControlName],select:not([multiple])[formControl],select:not([multiple])[ngModel]',
+      'select:not([multiple])[formControlName],select:not([multiple])[formControl],select:not([multiple])[ngModel],select[multiple=false][ngModel]',
   host: {'(change)': 'onChange($event.target.value)', '(blur)': 'onTouched()'},
   providers: [SELECT_VALUE_ACCESSOR]
 })

--- a/packages/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -77,7 +77,7 @@ abstract class HTMLCollection {
  */
 @Directive({
   selector:
-      'select[multiple][formControlName],select[multiple][formControl],select[multiple][ngModel]',
+      'select[multiple][formControlName],select[multiple][formControl],select[multiple]:not([multiple=false])[ngModel]',
   host: {'(change)': 'onChange($event.target)', '(blur)': 'onTouched()'},
   providers: [SELECT_MULTIPLE_VALUE_ACCESSOR]
 })


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When `ngModel` is added to a select element with `multiple` attribute value set to false [SelectMultipleControlValueAccessor](https://github.com/angular/angular/blob/master/packages/forms/src/directives/select_multiple_control_value_accessor.ts#L84)
is used instead of [SelectControlValueAccessor](https://github.com/angular/angular/blob/master/packages/forms/src/directives/select_control_value_accessor.ts#L92), therefore an array is returned instead of a value.

Issue Number: [#12585](https://github.com/angular/angular/issues/12585)


## What is the new behavior?
When `ngModel` is added to a select element with `multiple` attribute value set to false [SelectControlValueAccessor](https://github.com/angular/angular/blob/master/packages/forms/src/directives/select_control_value_accessor.ts#L92), therefore  a value is returned.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
There might be applications/libraries that already depend on this behavior as this issue was reported for version 2.1.2. These changes should be reviewed by project maintainers manually.

## Other information
I hoped to fix this issue by modifying selectors for previously mentioned directives, however I was surprised to find out that `multiple` attribute selector is not working with values.

Any guidance on how to proceed with this PR would be appreciated.