### PR TITLE
fix(compiler-cli): ignoring useFactory as method declaration in Injectable

### DIFF
--- a/goldens/public-api/core/core.d.ts
+++ b/goldens/public-api/core/core.d.ts
@@ -337,7 +337,7 @@ export declare interface FactoryProvider extends FactorySansProvider {
 
 export declare interface FactorySansProvider {
     deps?: any[];
-    useFactory: (this: never, ...args: any[]) => any;
+    useFactory: (this: void, ...args: any[]) => any;
 }
 
 export declare function forwardRef(forwardRefFn: ForwardRefFn): Type<any>;

--- a/goldens/public-api/core/core.d.ts
+++ b/goldens/public-api/core/core.d.ts
@@ -337,7 +337,7 @@ export declare interface FactoryProvider extends FactorySansProvider {
 
 export declare interface FactorySansProvider {
     deps?: any[];
-    useFactory: Function;
+    useFactory: (this: never, ...args: any[]) => any;
 }
 
 export declare function forwardRef(forwardRefFn: ForwardRefFn): Type<any>;

--- a/goldens/public-api/core/testing/testing.d.ts
+++ b/goldens/public-api/core/testing/testing.d.ts
@@ -72,14 +72,14 @@ export declare interface TestBed {
     overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): void;
     overridePipe(pipe: Type<any>, override: MetadataOverride<Pipe>): void;
     overrideProvider(token: any, provider: {
-        useFactory: (this: never, ...args: any[]) => any;
+        useFactory: (this: void, ...args: any[]) => any;
         deps: any[];
     }): void;
     overrideProvider(token: any, provider: {
         useValue: any;
     }): void;
     overrideProvider(token: any, provider: {
-        useFactory?: (this: never, ...args: any[]) => any;
+        useFactory?: (this: void, ...args: any[]) => any;
         useValue?: any;
         deps?: any[];
     }): void;
@@ -109,14 +109,14 @@ export declare interface TestBedStatic {
     overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): TestBedStatic;
     overridePipe(pipe: Type<any>, override: MetadataOverride<Pipe>): TestBedStatic;
     overrideProvider(token: any, provider: {
-        useFactory: (this: never, ...args: any[]) => any;
+        useFactory: (this: void, ...args: any[]) => any;
         deps: any[];
     }): TestBedStatic;
     overrideProvider(token: any, provider: {
         useValue: any;
     }): TestBedStatic;
     overrideProvider(token: any, provider: {
-        useFactory?: (this: never, ...args: any[]) => any;
+        useFactory?: (this: void, ...args: any[]) => any;
         useValue?: any;
         deps?: any[];
     }): TestBedStatic;

--- a/goldens/public-api/core/testing/testing.d.ts
+++ b/goldens/public-api/core/testing/testing.d.ts
@@ -72,14 +72,14 @@ export declare interface TestBed {
     overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): void;
     overridePipe(pipe: Type<any>, override: MetadataOverride<Pipe>): void;
     overrideProvider(token: any, provider: {
-        useFactory: Function;
+        useFactory: (this: never, ...args: any[]) => any;
         deps: any[];
     }): void;
     overrideProvider(token: any, provider: {
         useValue: any;
     }): void;
     overrideProvider(token: any, provider: {
-        useFactory?: Function;
+        useFactory?: (this: never, ...args: any[]) => any;
         useValue?: any;
         deps?: any[];
     }): void;
@@ -109,14 +109,14 @@ export declare interface TestBedStatic {
     overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): TestBedStatic;
     overridePipe(pipe: Type<any>, override: MetadataOverride<Pipe>): TestBedStatic;
     overrideProvider(token: any, provider: {
-        useFactory: Function;
+        useFactory: (this: never, ...args: any[]) => any;
         deps: any[];
     }): TestBedStatic;
     overrideProvider(token: any, provider: {
         useValue: any;
     }): TestBedStatic;
     overrideProvider(token: any, provider: {
-        useFactory?: Function;
+        useFactory?: (this: never, ...args: any[]) => any;
         useValue?: any;
         deps?: any[];
     }): TestBedStatic;

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -513,6 +513,16 @@ export function reflectObjectLiteral(node: ts.ObjectLiteralExpression): Map<stri
       map.set(name, prop.initializer);
     } else if (ts.isShorthandPropertyAssignment(prop)) {
       map.set(prop.name.text, prop.name);
+    } else if (ts.isMethodDeclaration(prop) && prop.body !== undefined) {
+      const name = propertyNameToString(prop.name);
+      if (name === null) {
+        return;
+      }
+      map.set(
+          name,
+          ts.createFunctionExpression(
+              undefined, prop.asteriskToken, name, prop.typeParameters, prop.parameters, prop.type,
+              prop.body));
     } else {
       return;
     }

--- a/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
@@ -65,7 +65,10 @@ export class TypeScriptAstFactory implements AstFactory<ts.Statement, ts.Express
   }
 
   createCallExpression(callee: ts.Expression, args: ts.Expression[], pure: boolean): ts.Expression {
-    const call = ts.createCall(callee, undefined, args);
+    const expression = (ts.isFunctionExpression(callee) || ts.isArrowFunction(callee)) ?
+        ts.createParen(callee) :
+        callee;
+    const call = ts.createCall(expression, undefined, args);
     if (pure) {
       ts.addSyntheticLeadingComment(
           call, ts.SyntaxKind.MultiLineCommentTrivia, '@__PURE__', /* trailing newline */ false);

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -217,7 +217,7 @@ function resolveProvider(provider: SupportedProvider): Record {
   if (USE_VALUE in provider) {
     // We need to use USE_VALUE in provider since provider.useValue could be defined as undefined.
     value = (provider as ValueProvider).useValue;
-  } else if ((provider as FactoryProvider).useFactory) {
+  } else if ((provider as FactoryProvider).useFactory!) {
     fn = (provider as FactoryProvider).useFactory;
   } else if ((provider as ExistingProvider).useExisting) {
     // Just use IDENT

--- a/packages/core/src/di/interface/provider.ts
+++ b/packages/core/src/di/interface/provider.ts
@@ -206,7 +206,7 @@ export interface FactorySansProvider {
    * A function to invoke to create a value for this `token`. The function is invoked with
    * resolved values of `token`s in the `deps` field.
    */
-  useFactory: (this: never, ...args: any[]) => any;
+  useFactory: (this: void, ...args: any[]) => any;
 
   /**
    * A list of `token`s to be resolved by the injector. The list of values is then

--- a/packages/core/src/di/interface/provider.ts
+++ b/packages/core/src/di/interface/provider.ts
@@ -206,7 +206,7 @@ export interface FactorySansProvider {
    * A function to invoke to create a value for this `token`. The function is invoked with
    * resolved values of `token`s in the `deps` field.
    */
-  useFactory: Function;
+  useFactory: (this: never, ...args: any[]) => any;
 
   /**
    * A list of `token`s to be resolved by the injector. The list of values is then

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -504,7 +504,7 @@ export function providerToFactory(
     if (isValueProvider(provider)) {
       factory = () => resolveForwardRef(provider.useValue);
     } else if (isFactoryProvider(provider)) {
-      factory = () => provider.useFactory(...injectArgs(provider.deps || []));
+      factory = () => (provider as any).useFactory(...injectArgs(provider.deps || []));
     } else if (isExistingProvider(provider)) {
       factory = () => ɵɵinject(resolveForwardRef(provider.useExisting));
     } else {

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -504,7 +504,7 @@ export function providerToFactory(
     if (isValueProvider(provider)) {
       factory = () => resolveForwardRef(provider.useValue);
     } else if (isFactoryProvider(provider)) {
-      factory = () => (provider as any).useFactory(...injectArgs(provider.deps || []));
+      factory = () => provider.useFactory(...injectArgs(provider.deps || []));
     } else if (isExistingProvider(provider)) {
       factory = () => ɵɵinject(resolveForwardRef(provider.useExisting));
     } else {

--- a/packages/core/src/di/util.ts
+++ b/packages/core/src/di/util.ts
@@ -37,8 +37,7 @@ export function convertInjectableProviderToFactory(
     return () => ɵɵinject(resolveForwardRef(existingProvider.useExisting));
   } else if ((provider as FactorySansProvider).useFactory!) {
     const factoryProvider = (provider as FactorySansProvider);
-    return () => (factoryProvider as any)
-                     .useFactory(...injectArgs(factoryProvider.deps || EMPTY_ARRAY));
+    return () => factoryProvider.useFactory(...injectArgs(factoryProvider.deps || EMPTY_ARRAY));
   } else if ((provider as StaticClassSansProvider | ClassSansProvider).useClass) {
     const classProvider = (provider as StaticClassSansProvider | ClassSansProvider);
     let deps = (provider as StaticClassSansProvider).deps;

--- a/packages/core/src/di/util.ts
+++ b/packages/core/src/di/util.ts
@@ -35,9 +35,10 @@ export function convertInjectableProviderToFactory(
   } else if ((provider as ExistingSansProvider).useExisting) {
     const existingProvider = (provider as ExistingSansProvider);
     return () => ɵɵinject(resolveForwardRef(existingProvider.useExisting));
-  } else if ((provider as FactorySansProvider).useFactory) {
+  } else if ((provider as FactorySansProvider).useFactory!) {
     const factoryProvider = (provider as FactorySansProvider);
-    return () => factoryProvider.useFactory(...injectArgs(factoryProvider.deps || EMPTY_ARRAY));
+    return () => (factoryProvider as any)
+                     .useFactory(...injectArgs(factoryProvider.deps || EMPTY_ARRAY));
   } else if ((provider as StaticClassSansProvider | ClassSansProvider).useClass) {
     const classProvider = (provider as StaticClassSansProvider | ClassSansProvider);
     let deps = (provider as StaticClassSansProvider).deps;

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -143,12 +143,12 @@ export class TestBedRender3 implements TestBed {
   }
 
   static overrideProvider(token: any, provider: {
-    useFactory: (this: never, ...args: any[]) => any,
+    useFactory: (this: void, ...args: any[]) => any,
     deps: any[],
   }): TestBedStatic;
   static overrideProvider(token: any, provider: {useValue: any;}): TestBedStatic;
   static overrideProvider(token: any, provider: {
-    useFactory?: (this: never, ...args: any[]) => any,
+    useFactory?: (this: void, ...args: any[]) => any,
     useValue?: any,
     deps?: any[],
   }): TestBedStatic {
@@ -326,7 +326,7 @@ export class TestBedRender3 implements TestBed {
    * Overwrites all providers for the given token with the given provider definition.
    */
   overrideProvider(token: any, provider: {
-    useFactory?: (this: never, ...args: any[]) => any,
+    useFactory?: (this: void, ...args: any[]) => any,
     useValue?: any,
     deps?: any[]
   }): void {

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -143,12 +143,12 @@ export class TestBedRender3 implements TestBed {
   }
 
   static overrideProvider(token: any, provider: {
-    useFactory: Function,
+    useFactory: (this: never, ...args: any[]) => any,
     deps: any[],
   }): TestBedStatic;
   static overrideProvider(token: any, provider: {useValue: any;}): TestBedStatic;
   static overrideProvider(token: any, provider: {
-    useFactory?: Function,
+    useFactory?: (this: never, ...args: any[]) => any,
     useValue?: any,
     deps?: any[],
   }): TestBedStatic {
@@ -325,8 +325,11 @@ export class TestBedRender3 implements TestBed {
   /**
    * Overwrites all providers for the given token with the given provider definition.
    */
-  overrideProvider(token: any, provider: {useFactory?: Function, useValue?: any, deps?: any[]}):
-      void {
+  overrideProvider(token: any, provider: {
+    useFactory?: (this: never, ...args: any[]) => any,
+    useValue?: any,
+    deps?: any[]
+  }): void {
     this.assertNotInstantiated('overrideProvider', 'override provider');
     this.compiler.overrideProvider(token, provider);
   }

--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -157,9 +157,12 @@ export class R3TestBedCompiler {
     this.pendingPipes.add(pipe);
   }
 
-  overrideProvider(
-      token: any,
-      provider: {useFactory?: Function, useValue?: any, deps?: any[], multi?: boolean}): void {
+  overrideProvider(token: any, provider: {
+    useFactory?: (this: never, ...args: any[]) => any,
+    useValue?: any,
+    deps?: any[],
+    multi?: boolean
+  }): void {
     let providerDef: Provider;
     if (provider.useFactory !== undefined) {
       providerDef = {

--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -158,7 +158,7 @@ export class R3TestBedCompiler {
   }
 
   overrideProvider(token: any, provider: {
-    useFactory?: (this: never, ...args: any[]) => any,
+    useFactory?: (this: void, ...args: any[]) => any,
     useValue?: any,
     deps?: any[],
     multi?: boolean

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -78,12 +78,15 @@ export interface TestBed {
    * Overwrites all providers for the given token with the given provider definition.
    */
   overrideProvider(token: any, provider: {
-    useFactory: Function,
+    useFactory: (this: never, ...args: any[]) => any,
     deps: any[],
   }): void;
   overrideProvider(token: any, provider: {useValue: any;}): void;
-  overrideProvider(token: any, provider: {useFactory?: Function, useValue?: any, deps?: any[]}):
-      void;
+  overrideProvider(token: any, provider: {
+    useFactory?: (this: never, ...args: any[]) => any,
+    useValue?: any,
+    deps?: any[]
+  }): void;
 
   overrideTemplateUsingTestingModule(component: Type<any>, template: string): void;
 
@@ -203,12 +206,12 @@ export class TestBedViewEngine implements TestBed {
    * Note: This works for JIT and AOTed components as well.
    */
   static overrideProvider(token: any, provider: {
-    useFactory: Function,
+    useFactory: (this: never, ...args: any[]) => any,
     deps: any[],
   }): TestBedStatic;
   static overrideProvider(token: any, provider: {useValue: any;}): TestBedStatic;
   static overrideProvider(token: any, provider: {
-    useFactory?: Function,
+    useFactory?: (this: never, ...args: any[]) => any,
     useValue?: any,
     deps?: any[],
   }): TestBedStatic {
@@ -529,19 +532,22 @@ export class TestBedViewEngine implements TestBed {
    * Overwrites all providers for the given token with the given provider definition.
    */
   overrideProvider(token: any, provider: {
-    useFactory: Function,
+    useFactory: (this: never, ...args: any[]) => any,
     deps: any[],
   }): void;
   overrideProvider(token: any, provider: {useValue: any;}): void;
-  overrideProvider(token: any, provider: {useFactory?: Function, useValue?: any, deps?: any[]}):
-      void {
+  overrideProvider(token: any, provider: {
+    useFactory?: (this: never, ...args: any[]) => any,
+    useValue?: any,
+    deps?: any[]
+  }): void {
     this._assertNotInstantiated('overrideProvider', 'override provider');
     this.overrideProviderImpl(token, provider);
   }
 
   private overrideProviderImpl(
       token: any, provider: {
-        useFactory?: Function,
+        useFactory?: (this: never, ...args: any[]) => any,
         useValue?: any,
         deps?: any[],
       },

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -78,12 +78,12 @@ export interface TestBed {
    * Overwrites all providers for the given token with the given provider definition.
    */
   overrideProvider(token: any, provider: {
-    useFactory: (this: never, ...args: any[]) => any,
+    useFactory: (this: void, ...args: any[]) => any,
     deps: any[],
   }): void;
   overrideProvider(token: any, provider: {useValue: any;}): void;
   overrideProvider(token: any, provider: {
-    useFactory?: (this: never, ...args: any[]) => any,
+    useFactory?: (this: void, ...args: any[]) => any,
     useValue?: any,
     deps?: any[]
   }): void;
@@ -206,12 +206,12 @@ export class TestBedViewEngine implements TestBed {
    * Note: This works for JIT and AOTed components as well.
    */
   static overrideProvider(token: any, provider: {
-    useFactory: (this: never, ...args: any[]) => any,
+    useFactory: (this: void, ...args: any[]) => any,
     deps: any[],
   }): TestBedStatic;
   static overrideProvider(token: any, provider: {useValue: any;}): TestBedStatic;
   static overrideProvider(token: any, provider: {
-    useFactory?: (this: never, ...args: any[]) => any,
+    useFactory?: (this: void, ...args: any[]) => any,
     useValue?: any,
     deps?: any[],
   }): TestBedStatic {
@@ -532,12 +532,12 @@ export class TestBedViewEngine implements TestBed {
    * Overwrites all providers for the given token with the given provider definition.
    */
   overrideProvider(token: any, provider: {
-    useFactory: (this: never, ...args: any[]) => any,
+    useFactory: (this: void, ...args: any[]) => any,
     deps: any[],
   }): void;
   overrideProvider(token: any, provider: {useValue: any;}): void;
   overrideProvider(token: any, provider: {
-    useFactory?: (this: never, ...args: any[]) => any,
+    useFactory?: (this: void, ...args: any[]) => any,
     useValue?: any,
     deps?: any[]
   }): void {
@@ -547,7 +547,7 @@ export class TestBedViewEngine implements TestBed {
 
   private overrideProviderImpl(
       token: any, provider: {
-        useFactory?: (this: never, ...args: any[]) => any,
+        useFactory?: (this: void, ...args: any[]) => any,
         useValue?: any,
         deps?: any[],
       },

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -104,12 +104,12 @@ export interface TestBedStatic {
    * Note: This works for JIT and AOTed components as well.
    */
   overrideProvider(token: any, provider: {
-    useFactory: (this: never, ...args: any[]) => any,
+    useFactory: (this: void, ...args: any[]) => any,
     deps: any[],
   }): TestBedStatic;
   overrideProvider(token: any, provider: {useValue: any;}): TestBedStatic;
   overrideProvider(token: any, provider: {
-    useFactory?: (this: never, ...args: any[]) => any,
+    useFactory?: (this: void, ...args: any[]) => any,
     useValue?: any,
     deps?: any[],
   }): TestBedStatic;

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -104,12 +104,12 @@ export interface TestBedStatic {
    * Note: This works for JIT and AOTed components as well.
    */
   overrideProvider(token: any, provider: {
-    useFactory: Function,
+    useFactory: (this: never, ...args: any[]) => any,
     deps: any[],
   }): TestBedStatic;
   overrideProvider(token: any, provider: {useValue: any;}): TestBedStatic;
   overrideProvider(token: any, provider: {
-    useFactory?: Function,
+    useFactory?: (this: never, ...args: any[]) => any,
     useValue?: any,
     deps?: any[],
   }): TestBedStatic;


### PR DESCRIPTION
Currently when we're analyzing an object literal that is passed into an Angular decorator, we only look for property assignments, which covers most cases, but breaks down if something is defined as a method declaration, e.g.

```ts
@Injectable({
  // Won't be picked up
  useFactory() {
    return new Service();
  }
})
class Service {}
```

These changes make it so that we pick up method declarations too.

In the process of working on this issue, I found another one: we were generating invalid code when emitting a call to a `FunctionExpression`. The problem was that we'd create a `CallExpression` directly from the `FunctionExpression` which would result an expression like `function foo() {}()`. I've added some code so that we wrap the function in parentheses: `(function foo() {})()`.

Fixes #38578.

**Note:** I didn't add any equivalent tests for the runtime, because the runtime tests are in JIT mode which doesn't have the problem.
