### PR TITLE
refactor(core): remove deprecated `ɵɵselect` instruction

### DIFF
--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -29,7 +29,6 @@ export class Identifiers {
 
   static elementEnd: o.ExternalReference = {name: 'ɵɵelementEnd', moduleName: CORE};
 
-  static select: o.ExternalReference = {name: 'ɵɵselect', moduleName: CORE};
   static advance: o.ExternalReference = {name: 'ɵɵadvance', moduleName: CORE};
 
   static syntheticHostProperty:

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -201,7 +201,6 @@ export {
   ɵɵresolveWindow,
   ɵɵrestoreView,
 
-  ɵɵselect,
   ɵɵsetComponentScope,
   ɵɵsetNgModuleScope,
   ɵɵstaticContentQuery,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -88,8 +88,6 @@ export {
 
   ɵɵreference,
 
-  // TODO: remove `select` once we've refactored all of the tests not to use it.
-  ɵɵselect,
   ɵɵstyleMap,
   ɵɵstyleMapInterpolate1,
   ɵɵstyleMapInterpolate2,

--- a/packages/core/src/render3/instructions/advance.ts
+++ b/packages/core/src/render3/instructions/advance.ts
@@ -39,16 +39,6 @@ export function ɵɵadvance(delta: number): void {
   selectIndexInternal(getTView(), getLView(), getSelectedIndex() + delta, getCheckNoChangesMode());
 }
 
-/**
- * Selects an element for later binding instructions.
- * @deprecated No longer being generated, but still used in unit tests.
- * @codeGenApi
- */
-export function ɵɵselect(index: number): void {
-  // TODO(misko): Remove this function as it is no longer being used.
-  selectIndexInternal(getTView(), getLView(), index, getCheckNoChangesMode());
-}
-
 export function selectIndexInternal(
     tView: TView, lView: LView, index: number, checkNoChangesMode: boolean) {
   ngDevMode && assertGreaterThan(index, -1, 'Invalid index');

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -134,7 +134,6 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵstylePropInterpolate8': r3.ɵɵstylePropInterpolate8,
        'ɵɵstylePropInterpolateV': r3.ɵɵstylePropInterpolateV,
        'ɵɵclassProp': r3.ɵɵclassProp,
-       'ɵɵselect': r3.ɵɵselect,
        'ɵɵadvance': r3.ɵɵadvance,
        'ɵɵtemplate': r3.ɵɵtemplate,
        'ɵɵtext': r3.ɵɵtext,

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -10,7 +10,7 @@ import {NgForOfContext} from '@angular/common';
 import {getSortedClassName} from '@angular/core/testing/src/styling';
 
 import {ɵɵdefineComponent} from '../../src/render3/definition';
-import {RenderFlags, ɵɵattribute, ɵɵclassMap, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵproperty, ɵɵselect, ɵɵstyleMap, ɵɵstyleProp, ɵɵtemplate, ɵɵtext, ɵɵtextInterpolate1} from '../../src/render3/index';
+import {RenderFlags, ɵɵattribute, ɵɵclassMap, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵproperty, ɵɵstyleMap, ɵɵstyleProp, ɵɵtemplate, ɵɵtext, ɵɵtextInterpolate1} from '../../src/render3/index';
 import {AttributeMarker} from '../../src/render3/interfaces/node';
 import {bypassSanitizationTrustHtml, bypassSanitizationTrustResourceUrl, bypassSanitizationTrustScript, bypassSanitizationTrustStyle, bypassSanitizationTrustUrl, getSanitizationBypassType, SafeValue, unwrapSafeValue} from '../../src/sanitization/bypass';
 import {ɵɵsanitizeHtml, ɵɵsanitizeResourceUrl, ɵɵsanitizeScript, ɵɵsanitizeStyle, ɵɵsanitizeUrl} from '../../src/sanitization/sanitization';
@@ -32,23 +32,6 @@ describe('instructions', () => {
   function createScript() {
     ɵɵelement(0, 'script');
   }
-
-  describe('ɵɵselect', () => {
-    it('should error in DevMode if index is out of range', () => {
-      // Only one constant added, meaning only index `0` is valid.
-      const t = new TemplateFixture(createDiv, () => {}, 1, 0);
-      expect(() => {
-        t.update(() => {
-          ɵɵselect(-1);
-        });
-      }).toThrow();
-      expect(() => {
-        t.update(() => {
-          ɵɵselect(1);
-        });
-      }).toThrow();
-    });
-  });
 
   describe('bind', () => {
     it('should update bindings when value changes with the correct perf counters', () => {
@@ -225,7 +208,6 @@ describe('instructions', () => {
         }
         if (rf & RenderFlags.Update) {
           const row_r2 = ctx0.$implicit;
-          ɵɵselect(1);
           ɵɵproperty('ngForOf', row_r2);
         }
       }
@@ -239,7 +221,6 @@ describe('instructions', () => {
         }
         if (rf & RenderFlags.Update) {
           const col_r3 = ctx1.$implicit;
-          ɵɵselect(1);
           ɵɵtextInterpolate1('', col_r3, '');
         }
       }

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -10,7 +10,7 @@ import {NgForOfContext} from '@angular/common';
 import {getSortedClassName} from '@angular/core/testing/src/styling';
 
 import {ɵɵdefineComponent} from '../../src/render3/definition';
-import {RenderFlags, ɵɵattribute, ɵɵclassMap, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵproperty, ɵɵstyleMap, ɵɵstyleProp, ɵɵtemplate, ɵɵtext, ɵɵtextInterpolate1} from '../../src/render3/index';
+import {RenderFlags, ɵɵadvance, ɵɵattribute, ɵɵclassMap, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵproperty, ɵɵstyleMap, ɵɵstyleProp, ɵɵtemplate, ɵɵtext, ɵɵtextInterpolate1} from '../../src/render3/index';
 import {AttributeMarker} from '../../src/render3/interfaces/node';
 import {bypassSanitizationTrustHtml, bypassSanitizationTrustResourceUrl, bypassSanitizationTrustScript, bypassSanitizationTrustStyle, bypassSanitizationTrustUrl, getSanitizationBypassType, SafeValue, unwrapSafeValue} from '../../src/sanitization/bypass';
 import {ɵɵsanitizeHtml, ɵɵsanitizeResourceUrl, ɵɵsanitizeScript, ɵɵsanitizeStyle, ɵɵsanitizeUrl} from '../../src/sanitization/sanitization';
@@ -32,6 +32,23 @@ describe('instructions', () => {
   function createScript() {
     ɵɵelement(0, 'script');
   }
+
+  describe('ɵɵadvance', () => {
+    it('should error in DevMode if index is out of range', () => {
+      // Only one constant added, meaning only index `0` is valid.
+      const t = new TemplateFixture(createDiv, () => {}, 1, 0);
+      expect(() => {
+        t.update(() => {
+          ɵɵadvance(-1);
+        });
+      }).toThrow();
+      expect(() => {
+        t.update(() => {
+          ɵɵadvance(1);
+        });
+      }).toThrow();
+    });
+  });
 
   describe('bind', () => {
     it('should update bindings when value changes with the correct perf counters', () => {
@@ -208,6 +225,7 @@ describe('instructions', () => {
         }
         if (rf & RenderFlags.Update) {
           const row_r2 = ctx0.$implicit;
+          ɵɵadvance(1);
           ɵɵproperty('ngForOf', row_r2);
         }
       }
@@ -221,6 +239,7 @@ describe('instructions', () => {
         }
         if (rf & RenderFlags.Update) {
           const col_r3 = ctx1.$implicit;
+          ɵɵadvance(1);
           ɵɵtextInterpolate1('', col_r3, '');
         }
       }


### PR DESCRIPTION
This instruction was deprecated in 664e0015d4de720216c52b13b808f9ba41b7da38
and is no longer referenced in any meaningful
way, so it can be removed.
