### PR TITLE
fix(dev-infra): set build commit message type to allow an optional scope

### DIFF
--- a/dev-infra/commit-message/config.ts
+++ b/dev-infra/commit-message/config.ts
@@ -49,7 +49,7 @@ export const COMMIT_TYPES: {[key: string]: CommitType} = {
   build: {
     name: 'build',
     description: 'Changes to local repository build system and tooling',
-    scope: ScopeRequirement.Forbidden,
+    scope: ScopeRequirement.Optional,
   },
   ci: {
     name: 'ci',


### PR DESCRIPTION
Allow, optionally, a scope to be used with the build type commit message.
