### PR TITLE
ci: update payload size limit for integration tests

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 245885,
+        "main-es2015": 245303,
         "polyfills-es2015": 36938,
         "5-es2015": 751
       }
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 222476,
+        "main-es2015": 221887,
         "polyfills-es2015": 36723,
         "5-es2015": 781
       }


### PR DESCRIPTION
This commit updates (reduces) the payload size limit for a couple test apps. This is a result of
adding the `ngDevMode` to tree-shake more dev-mode-only error messages from the core package within
https://github.com/angular/angular/commit/11506491393d33ac808da78a3bbb3a8bc9fb5588.


## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No