### PR TITLE
fix(core): clear the `RefreshTransplantedView` when detached

### DIFF
--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -300,6 +300,7 @@ function detachMovedView(declarationContainer: LContainer, lView: LView) {
   // would be cleared and the counter decremented), we need to decrement the view counter here
   // instead.
   if (lView[FLAGS] & LViewFlags.RefreshTransplantedView) {
+    lView[FLAGS] &= ~LViewFlags.RefreshTransplantedView;
     updateTransplantedViewCount(insertionLContainer, -1);
   }
 


### PR DESCRIPTION
The `RefreshTransplantedView` flag is used to indicate that the view or one of its children
is transplanted and dirty, so it should still be refreshed as part of change detection.
This flag is set on the transplanted view itself as well setting a
counter on as its parents.
When a transplanted view is detached and still has this flag, it means
it got detached before it was refreshed. This can happen for "backwards
references" or transplanted views that are inserted at a location that
was already checked. In this case, we should decrement the parent
counters _and_ clear the flag on the detached view so it's not seen as
"transplanted" anymore (it is detached and has no parent counters to
adjust).

fixes #38619
