### PR TITLE
refactor(compiler-cli): setup compilation mode to enable generating linker code

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/ngcc_trait_compiler.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/ngcc_trait_compiler.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 import {IncrementalBuild} from '../../../src/ngtsc/incremental/api';
 import {NOOP_PERF_RECORDER} from '../../../src/ngtsc/perf';
 import {ClassDeclaration, Decorator} from '../../../src/ngtsc/reflection';
-import {DecoratorHandler, DtsTransformRegistry, HandlerFlags, Trait, TraitCompiler} from '../../../src/ngtsc/transform';
+import {CompilationMode, DecoratorHandler, DtsTransformRegistry, HandlerFlags, Trait, TraitCompiler} from '../../../src/ngtsc/transform';
 import {NgccReflectionHost} from '../host/ngcc_host';
 import {isDefined} from '../utils';
 
@@ -26,7 +26,7 @@ export class NgccTraitCompiler extends TraitCompiler {
       private ngccReflector: NgccReflectionHost) {
     super(
         handlers, ngccReflector, NOOP_PERF_RECORDER, new NoIncrementalBuild(),
-        /* compileNonExportedClasses */ true, new DtsTransformRegistry());
+        /* compileNonExportedClasses */ true, CompilationMode.FULL, new DtsTransformRegistry());
   }
 
   get analyzedFiles(): ts.SourceFile[] {

--- a/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
@@ -48,7 +48,7 @@ runInEachFileSystem(() => {
           'analyze',
           'register',
           'resolve',
-          'compile',
+          'compileFull',
         ]);
         // Only detect the Component and Directive decorators
         handler.detect.and.callFake(
@@ -95,7 +95,7 @@ runInEachFileSystem(() => {
         });
         // The "test" compilation result is just the name of the decorator being compiled
         // (suffixed with `(compiled)`)
-        (handler.compile as any).and.callFake((decl: ts.Declaration, analysis: any) => {
+        (handler.compileFull as any).and.callFake((decl: ts.Declaration, analysis: any) => {
           logs.push(`compile: ${(decl as any).name.text}@${analysis.decoratorName} (resolved: ${
               analysis.resolved})`);
           return `@${analysis.decoratorName} (compiled)`;
@@ -414,7 +414,7 @@ runInEachFileSystem(() => {
           expect(testHandler.analyze).toHaveBeenCalled();
           expect(testHandler.register).not.toHaveBeenCalled();
           expect(testHandler.resolve).not.toHaveBeenCalled();
-          expect(testHandler.compile).not.toHaveBeenCalled();
+          expect(testHandler.compileFull).not.toHaveBeenCalled();
         });
 
         it('should report resolve diagnostics to the `diagnosticHandler` callback', () => {
@@ -436,7 +436,7 @@ runInEachFileSystem(() => {
           expect(testHandler.analyze).toHaveBeenCalled();
           expect(testHandler.register).toHaveBeenCalled();
           expect(testHandler.resolve).toHaveBeenCalled();
-          expect(testHandler.compile).not.toHaveBeenCalled();
+          expect(testHandler.compileFull).not.toHaveBeenCalled();
         });
       });
 
@@ -452,7 +452,7 @@ runInEachFileSystem(() => {
             analyze(): AnalysisOutput<unknown> {
               throw new Error('analyze should not have been called');
             }
-            compile(): CompileResult {
+            compileFull(): CompileResult {
               throw new Error('compile should not have been called');
             }
           }

--- a/packages/compiler-cli/ngcc/test/analysis/migration_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/migration_host_spec.ts
@@ -209,7 +209,7 @@ class DetectDecoratorHandler implements DecoratorHandler<unknown, unknown, unkno
     return {};
   }
 
-  compile(node: ClassDeclaration): CompileResult|CompileResult[] {
+  compileFull(node: ClassDeclaration): CompileResult|CompileResult[] {
     return [];
   }
 }
@@ -227,7 +227,7 @@ class DiagnosticProducingHandler implements DecoratorHandler<unknown, unknown, u
     return {diagnostics: [makeDiagnostic(9999, node, 'test diagnostic')]};
   }
 
-  compile(node: ClassDeclaration): CompileResult|CompileResult[] {
+  compileFull(node: ClassDeclaration): CompileResult|CompileResult[] {
     return [];
   }
 }

--- a/packages/compiler-cli/ngcc/test/analysis/ngcc_trait_compiler_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/ngcc_trait_compiler_spec.ts
@@ -309,7 +309,7 @@ class TestHandler implements DecoratorHandler<unknown, unknown, unknown> {
     return {};
   }
 
-  compile(node: ClassDeclaration): CompileResult|CompileResult[] {
+  compileFull(node: ClassDeclaration): CompileResult|CompileResult[] {
     this.log.push(this.name + ':compile:' + node.name.text);
     return [];
   }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -580,7 +580,7 @@ export class ComponentDecoratorHandler implements
     return {data};
   }
 
-  compile(
+  compileFull(
       node: ClassDeclaration, analysis: Readonly<ComponentAnalysisData>,
       resolution: Readonly<ComponentResolutionData>, pool: ConstantPool): CompileResult[] {
     const meta: R3ComponentMetadata = {...analysis.meta, ...resolution};

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -151,7 +151,7 @@ export class DirectiveDecoratorHandler implements
     return {diagnostics: diagnostics.length > 0 ? diagnostics : undefined};
   }
 
-  compile(
+  compileFull(
       node: ClassDeclaration, analysis: Readonly<DirectiveHandlerData>,
       resolution: Readonly<unknown>, pool: ConstantPool): CompileResult[] {
     const meta = analysis.meta;

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -87,7 +87,7 @@ export class InjectableDecoratorHandler implements
     this.injectableRegistry.registerInjectable(node);
   }
 
-  compile(node: ClassDeclaration, analysis: Readonly<InjectableHandlerData>): CompileResult[] {
+  compileFull(node: ClassDeclaration, analysis: Readonly<InjectableHandlerData>): CompileResult[] {
     const res = compileIvyInjectable(analysis.meta);
     const statements = res.statements;
     const results: CompileResult[] = [];

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -371,7 +371,7 @@ export class NgModuleDecoratorHandler implements
     }
   }
 
-  compile(
+  compileFull(
       node: ClassDeclaration, analysis: Readonly<NgModuleAnalysis>,
       resolution: Readonly<NgModuleResolution>): CompileResult[] {
     //  Merge the injector imports (which are 'exports' that were later found to be NgModules)

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -133,7 +133,7 @@ export class PipeDecoratorHandler implements DecoratorHandler<Decorator, PipeHan
     return {};
   }
 
-  compile(node: ClassDeclaration, analysis: Readonly<PipeHandlerData>): CompileResult[] {
+  compileFull(node: ClassDeclaration, analysis: Readonly<PipeHandlerData>): CompileResult[] {
     const meta = analysis.meta;
     const res = compilePipeFromMetadata(meta);
     const factoryRes = compileNgFactoryDefField({

--- a/packages/compiler-cli/src/ngtsc/annotations/test/injectable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/injectable_spec.ts
@@ -22,7 +22,7 @@ runInEachFileSystem(() => {
            const {handler, TestClass, ɵprov, analysis} =
                setupHandler(/* errorOnDuplicateProv */ true);
            try {
-             handler.compile(TestClass, analysis);
+             handler.compileFull(TestClass, analysis);
              return fail('Compilation should have failed');
            } catch (err) {
              if (!(err instanceof FatalDiagnosticError)) {
@@ -39,7 +39,7 @@ runInEachFileSystem(() => {
          () => {
            const {handler, TestClass, ɵprov, analysis} =
                setupHandler(/* errorOnDuplicateProv */ false);
-           const res = handler.compile(TestClass, analysis);
+           const res = handler.compileFull(TestClass, analysis);
            expect(res).not.toContain(jasmine.objectContaining({name: 'ɵprov'}));
          });
     });

--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -49,6 +49,22 @@ export interface TestOnlyOptions {
 }
 
 /**
+ * Options that specify compilation target.
+ */
+export interface TargetOptions {
+  /**
+   * Specifies the compilation mode to use. The following modes are available:
+   * - 'full': generates fully AOT compiled code using Ivy instructions.
+   * - 'partial': generates code in a stable, but intermediate form suitable to be published to NPM.
+   *
+   * To become public once the linker is ready.
+   *
+   * @internal
+   */
+  compilationMode?: 'full'|'partial';
+}
+
+/**
  * A merged interface of all of the various Angular compiler options, as well as the standard
  * `ts.CompilerOptions`.
  *
@@ -56,4 +72,5 @@ export interface TestOnlyOptions {
  */
 export interface NgCompilerOptions extends ts.CompilerOptions, LegacyNgcOptions, BazelAndG3Options,
                                            NgcCompatibilityOptions, StrictTemplateOptions,
-                                           TestOnlyOptions, I18nOptions, MiscOptions {}
+                                           TestOnlyOptions, I18nOptions, TargetOptions,
+                                           MiscOptions {}

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -27,7 +27,7 @@ import {entryPointKeyFor, NgModuleRouteAnalyzer} from '../../routing';
 import {ComponentScopeReader, LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../scope';
 import {generatedFactoryTransform} from '../../shims';
 import {ivySwitchTransform} from '../../switch';
-import {aliasTransformFactory, declarationTransformFactory, DecoratorHandler, DtsTransformRegistry, ivyTransformFactory, TraitCompiler} from '../../transform';
+import {aliasTransformFactory, CompilationMode, declarationTransformFactory, DecoratorHandler, DtsTransformRegistry, ivyTransformFactory, TraitCompiler} from '../../transform';
 import {TemplateTypeCheckerImpl} from '../../typecheck';
 import {OptimizeFor, TemplateTypeChecker, TypeCheckingConfig, TypeCheckingProgramStrategy} from '../../typecheck/api';
 import {isTemplateDiagnostic} from '../../typecheck/diagnostics';
@@ -747,9 +747,11 @@ export class NgCompiler {
           this.closureCompilerEnabled, injectableRegistry, this.options.i18nInLocale),
     ];
 
+    const compilationMode =
+        this.options.compilationMode === 'partial' ? CompilationMode.PARTIAL : CompilationMode.FULL;
     const traitCompiler = new TraitCompiler(
         handlers, reflector, this.perfRecorder, this.incrementalDriver,
-        this.options.compileNonExportedClasses !== false, dtsTransforms);
+        this.options.compileNonExportedClasses !== false, compilationMode, dtsTransforms);
 
     const templateTypeChecker = new TemplateTypeCheckerImpl(
         this.tsProgram, this.typeCheckingProgramStrategy, traitCompiler,

--- a/packages/compiler-cli/src/ngtsc/transform/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/api.ts
@@ -15,6 +15,21 @@ import {ClassDeclaration, Decorator} from '../../reflection';
 import {ImportManager} from '../../translator';
 import {TypeCheckContext} from '../../typecheck/api';
 
+/**
+ * Specifies the compilation mode that is used for the compilation.
+ */
+export enum CompilationMode {
+  /**
+   * Generates fully AOT compiled code using Ivy instructions.
+   */
+  FULL,
+
+  /**
+   * Generates code using a stable, but intermediate format suitable to be published to NPM.
+   */
+  PARTIAL,
+}
+
 export enum HandlerPrecedence {
   /**
    * Handler with PRIMARY precedence cannot overlap - there can only be one on a given class.
@@ -147,10 +162,25 @@ export interface DecoratorHandler<D, A, R> {
   /**
    * Generate a description of the field which should be added to the class, including any
    * initialization code to be generated.
+   *
+   * If the compilation mode is configured as partial, and an implementation of `compilePartial` is
+   * provided, then this method is not called.
    */
-  compile(
+  compileFull(
       node: ClassDeclaration, analysis: Readonly<A>, resolution: Readonly<R>,
       constantPool: ConstantPool): CompileResult|CompileResult[];
+
+  /**
+   * Generates code for the decorator using a stable, but intermediate format suitable to be
+   * published to NPM. This code is meant to be processed by the linker to achieve the final AOT
+   * compiled code.
+   *
+   * If present, this method is used if the compilation mode is configured as partial, otherwise
+   * `compileFull` is.
+   */
+  compilePartial?
+      (node: ClassDeclaration, analysis: Readonly<A>, resolution: Readonly<R>): CompileResult
+      |CompileResult[];
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -17,7 +17,7 @@ import {ClassDeclaration, Decorator, ReflectionHost} from '../../reflection';
 import {ProgramTypeCheckAdapter, TypeCheckContext} from '../../typecheck/api';
 import {getSourceFile, isExported} from '../../util/src/typescript';
 
-import {AnalysisOutput, CompileResult, DecoratorHandler, HandlerFlags, HandlerPrecedence, ResolveResult} from './api';
+import {AnalysisOutput, CompilationMode, CompileResult, DecoratorHandler, HandlerFlags, HandlerPrecedence, ResolveResult} from './api';
 import {DtsTransformRegistry} from './declaration';
 import {PendingTrait, Trait, TraitState} from './trait';
 
@@ -88,7 +88,8 @@ export class TraitCompiler implements ProgramTypeCheckAdapter {
       private handlers: DecoratorHandler<unknown, unknown, unknown>[],
       private reflector: ReflectionHost, private perf: PerfRecorder,
       private incrementalBuild: IncrementalBuild<ClassRecord, unknown>,
-      private compileNonExportedClasses: boolean, private dtsTransforms: DtsTransformRegistry) {
+      private compileNonExportedClasses: boolean, private compilationMode: CompilationMode,
+      private dtsTransforms: DtsTransformRegistry) {
     for (const handler of handlers) {
       this.handlersByName.set(handler.name, handler);
     }
@@ -479,8 +480,17 @@ export class TraitCompiler implements ProgramTypeCheckAdapter {
       }
 
       const compileSpan = this.perf.start('compileClass', original);
-      const compileMatchRes =
-          trait.handler.compile(clazz, trait.analysis, trait.resolution, constantPool);
+
+      let compileRes: CompileResult|CompileResult[];
+      if (this.compilationMode === CompilationMode.PARTIAL &&
+          trait.handler.compilePartial !== undefined) {
+        compileRes = trait.handler.compilePartial(clazz, trait.analysis, trait.resolution);
+      } else {
+        compileRes =
+            trait.handler.compileFull(clazz, trait.analysis, trait.resolution, constantPool);
+      }
+
+      const compileMatchRes = compileRes;
       this.perf.stop(compileSpan);
       if (Array.isArray(compileMatchRes)) {
         for (const result of compileMatchRes) {

--- a/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
@@ -5,13 +5,16 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {ConstantPool} from '@angular/compiler';
+import * as o from '@angular/compiler/src/output/output_ast';
+
 import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {NOOP_INCREMENTAL_BUILD} from '../../incremental';
 import {NOOP_PERF_RECORDER} from '../../perf';
-import {TypeScriptReflectionHost} from '../../reflection';
-import {makeProgram} from '../../testing';
-import {DtsTransformRegistry, TraitCompiler} from '../../transform';
+import {ClassDeclaration, Decorator, isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
+import {getDeclaration, makeProgram} from '../../testing';
+import {CompilationMode, DetectResult, DtsTransformRegistry, TraitCompiler} from '../../transform';
 import {AnalysisOutput, CompileResult, DecoratorHandler, HandlerPrecedence} from '../src/api';
 
 runInEachFileSystem(() => {
@@ -30,7 +33,7 @@ runInEachFileSystem(() => {
         analyze(): AnalysisOutput<unknown> {
           throw new Error('analyze should not have been called');
         }
-        compile(): CompileResult {
+        compileFull(): CompileResult {
           throw new Error('compile should not have been called');
         }
       }
@@ -43,12 +46,133 @@ runInEachFileSystem(() => {
       const reflectionHost = new TypeScriptReflectionHost(checker);
       const compiler = new TraitCompiler(
           [new FakeDecoratorHandler()], reflectionHost, NOOP_PERF_RECORDER, NOOP_INCREMENTAL_BUILD,
-          true, new DtsTransformRegistry());
+          true, CompilationMode.FULL, new DtsTransformRegistry());
       const sourceFile = program.getSourceFile('lib.d.ts')!;
       const analysis = compiler.analyzeSync(sourceFile);
 
       expect(sourceFile.isDeclarationFile).toBe(true);
       expect(analysis).toBeFalsy();
+    });
+
+    describe('compilation mode', () => {
+      class PartialDecoratorHandler implements DecoratorHandler<{}, {}, unknown> {
+        name = 'PartialDecoratorHandler';
+        precedence = HandlerPrecedence.PRIMARY;
+
+        detect(node: ClassDeclaration, decorators: Decorator[]|null): DetectResult<{}>|undefined {
+          if (node.name.text !== 'Partial') {
+            return undefined;
+          }
+          return {trigger: node, decorator: null, metadata: {}};
+        }
+
+        analyze(): AnalysisOutput<unknown> {
+          return {analysis: {}};
+        }
+
+        compileFull(): CompileResult {
+          return {
+            name: 'compileFull',
+            initializer: o.literal(true),
+            statements: [],
+            type: o.BOOL_TYPE
+          };
+        }
+
+        compilePartial(): CompileResult {
+          return {
+            name: 'compilePartial',
+            initializer: o.literal(true),
+            statements: [],
+            type: o.BOOL_TYPE
+          };
+        }
+      }
+
+      class FullDecoratorHandler implements DecoratorHandler<{}, {}, unknown> {
+        name = 'FullDecoratorHandler';
+        precedence = HandlerPrecedence.PRIMARY;
+
+        detect(node: ClassDeclaration, decorators: Decorator[]|null): DetectResult<{}>|undefined {
+          if (node.name.text !== 'Full') {
+            return undefined;
+          }
+          return {trigger: node, decorator: null, metadata: {}};
+        }
+
+        analyze(): AnalysisOutput<unknown> {
+          return {analysis: {}};
+        }
+
+        compileFull(): CompileResult {
+          return {
+            name: 'compileFull',
+            initializer: o.literal(true),
+            statements: [],
+            type: o.BOOL_TYPE
+          };
+        }
+      }
+
+      it('should run partial compilation when implemented if compilation mode is partial', () => {
+        const {program} = makeProgram([{
+          name: _('/test.ts'),
+          contents: `
+            export class Full {}
+            export class Partial {}
+          `,
+        }]);
+        const checker = program.getTypeChecker();
+        const reflectionHost = new TypeScriptReflectionHost(checker);
+        const compiler = new TraitCompiler(
+            [new PartialDecoratorHandler(), new FullDecoratorHandler()], reflectionHost,
+            NOOP_PERF_RECORDER, NOOP_INCREMENTAL_BUILD, true, CompilationMode.PARTIAL,
+            new DtsTransformRegistry());
+        const sourceFile = program.getSourceFile('test.ts')!;
+        compiler.analyzeSync(sourceFile);
+        compiler.resolve();
+
+        const partialDecl =
+            getDeclaration(program, _('/test.ts'), 'Partial', isNamedClassDeclaration);
+        const partialResult = compiler.compile(partialDecl, new ConstantPool())!;
+        expect(partialResult.length).toBe(1);
+        expect(partialResult[0].name).toBe('compilePartial');
+
+        const fullDecl = getDeclaration(program, _('/test.ts'), 'Full', isNamedClassDeclaration);
+        const fullResult = compiler.compile(fullDecl, new ConstantPool())!;
+        expect(fullResult.length).toBe(1);
+        expect(fullResult[0].name).toBe('compileFull');
+      });
+
+      it('should run full compilation if compilation mode is full', () => {
+        const {program} = makeProgram([{
+          name: _('/test.ts'),
+          contents: `
+            export class Full {}
+            export class Partial {}
+          `,
+        }]);
+        const checker = program.getTypeChecker();
+        const reflectionHost = new TypeScriptReflectionHost(checker);
+        const compiler = new TraitCompiler(
+            [new PartialDecoratorHandler(), new FullDecoratorHandler()], reflectionHost,
+            NOOP_PERF_RECORDER, NOOP_INCREMENTAL_BUILD, true, CompilationMode.FULL,
+            new DtsTransformRegistry());
+        const sourceFile = program.getSourceFile('test.ts')!;
+        compiler.analyzeSync(sourceFile);
+        compiler.resolve();
+
+        const partialDecl =
+            getDeclaration(program, _('/test.ts'), 'Partial', isNamedClassDeclaration);
+        const partialResult = compiler.compile(partialDecl, new ConstantPool())!;
+        expect(partialResult.length).toBe(1);
+        expect(partialResult[0].name).toBe('compileFull');
+
+        const fullDecl = getDeclaration(program, _('/test.ts'), 'Full', isNamedClassDeclaration);
+        const fullResult = compiler.compile(fullDecl, new ConstantPool())!;
+        expect(fullResult.length).toBe(1);
+        expect(fullResult[0].name).toBe('compileFull');
+      });
     });
   });
 });

--- a/packages/compiler-cli/test/compliance/BUILD.bazel
+++ b/packages/compiler-cli/test/compliance/BUILD.bazel
@@ -10,6 +10,7 @@ ts_library(
         "//packages:types",
         "//packages/compiler",
         "//packages/compiler-cli",
+        "//packages/compiler-cli/src/ngtsc/core:api",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler/test:test_utils",
         "@npm//typescript",

--- a/packages/compiler-cli/test/compliance/mock_compile.ts
+++ b/packages/compiler-cli/test/compliance/mock_compile.ts
@@ -5,11 +5,11 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AotCompilerOptions} from '@angular/compiler';
 import {escapeRegExp} from '@angular/compiler/src/util';
 import {arrayToMockDir, MockCompilerHost, MockData, MockDirectory, toMockFileArray} from '@angular/compiler/test/aot/test_util';
 import * as ts from 'typescript';
 
+import {NgCompilerOptions} from '../../src/ngtsc/core/api';
 import {NodeJSFileSystem, setFileSystem} from '../../src/ngtsc/file_system';
 import {NgtscProgram} from '../../src/ngtsc/program';
 
@@ -198,10 +198,7 @@ function buildMatcher(pieces: (string|RegExp)[]): {regexp: RegExp, groups: Map<s
 
 
 export function compile(
-    data: MockDirectory, angularFiles: MockData, options: AotCompilerOptions = {},
-    errorCollector: (error: any, fileName?: string) => void = error => {
-      throw error;
-    }): {
+    data: MockDirectory, angularFiles: MockData, options: NgCompilerOptions = {}): {
   source: string,
 } {
   setFileSystem(new NodeJSFileSystem());
@@ -225,4 +222,10 @@ export function compile(
       scripts.map(script => mockCompilerHost.readFile(script.replace(/\.ts$/, '.js'))).join('\n');
 
   return {source};
+}
+
+export function createCompileFn(compilationMode: 'full'|'partial'): typeof compile {
+  return (data, angularFiles, options: NgCompilerOptions = {}) => {
+    return compile(data, angularFiles, {...options, compilationMode});
+  };
 }

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -8,25 +8,29 @@
 
 import {AttributeMarker} from '@angular/compiler/src/core';
 import {setup} from '@angular/compiler/test/aot/test_util';
-import {compile, expectEmit} from './mock_compile';
+import {createCompileFn, expectEmit} from './mock_compile';
+import {runInEachCompilationMode} from './test_runner';
 
 
 /**
  * These tests are codified version of the tests in compiler_canonical_spec.ts. Every
  * test in compiler_canonical_spec.ts should have a corresponding test here.
  */
-describe('compiler compliance', () => {
-  const angularFiles = setup({
-    compileAngular: false,
-    compileAnimations: false,
-    compileFakeCore: true,
-  });
+runInEachCompilationMode(compilationMode => {
+  const compile = createCompileFn(compilationMode);
 
-  describe('elements', () => {
-    it('should handle SVG', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+  describe('compiler compliance', () => {
+    const angularFiles = setup({
+      compileAngular: false,
+      compileAnimations: false,
+      compileFakeCore: true,
+    });
+
+    describe('elements', () => {
+      it('should handle SVG', () => {
+        const files = {
+          app: {
+            'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -38,18 +42,18 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      // The factory should look like this:
-      const factory =
-          'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+        // The factory should look like this:
+        const factory =
+            'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
-      // The template should look like this (where IDENT is a wild card for an identifier):
-      const template = `
+        // The template should look like this (where IDENT is a wild card for an identifier):
+        const template = `
         …
         consts: [["title", "Hello", ${
-          AttributeMarker.Classes}, "my-app"], ["cx", "20", "cy", "30", "r", "50"]],
+            AttributeMarker.Classes}, "my-app"], ["cx", "20", "cy", "30", "r", "50"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
@@ -67,16 +71,16 @@ describe('compiler compliance', () => {
       `;
 
 
-      const result = compile(files, angularFiles);
+        const result = compile(files, angularFiles);
 
-      expectEmit(result.source, factory, 'Incorrect factory');
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, factory, 'Incorrect factory');
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should handle MathML', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should handle MathML', () => {
+        const files = {
+          app: {
+            'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -88,15 +92,15 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      // The factory should look like this:
-      const factory =
-          'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+        // The factory should look like this:
+        const factory =
+            'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
-      // The template should look like this (where IDENT is a wild card for an identifier):
-      const template = `
+        // The template should look like this (where IDENT is a wild card for an identifier):
+        const template = `
         …
         consts: [["title", "Hello", ${AttributeMarker.Classes}, "my-app"]],
         template: function MyComponent_Template(rf, ctx) {
@@ -116,15 +120,15 @@ describe('compiler compliance', () => {
       `;
 
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, factory, 'Incorrect factory');
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, factory, 'Incorrect factory');
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should translate DOM structure', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should translate DOM structure', () => {
+        const files = {
+          app: {
+            'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -136,15 +140,15 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      // The factory should look like this:
-      const factory =
-          'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+        // The factory should look like this:
+        const factory =
+            'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
-      // The template should look like this (where IDENT is a wild card for an identifier):
-      const template = `
+        // The template should look like this (where IDENT is a wild card for an identifier):
+        const template = `
         …
         consts: [["title", "Hello", ${AttributeMarker.Classes}, "my-app"]],
         template: function MyComponent_Template(rf, ctx) {
@@ -161,18 +165,18 @@ describe('compiler compliance', () => {
       `;
 
 
-      const result = compile(files, angularFiles);
+        const result = compile(files, angularFiles);
 
-      expectEmit(result.source, factory, 'Incorrect factory');
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, factory, 'Incorrect factory');
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    // TODO(https://github.com/angular/angular/issues/24426): We need to support the parser actually
-    // building the proper attributes based off of xmlns attributes.
-    xit('should support namespaced attributes', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      // TODO(https://github.com/angular/angular/issues/24426): We need to support the parser
+      // actually building the proper attributes based off of xmlns attributes.
+      xit('should support namespaced attributes', () => {
+        const files = {
+          app: {
+            'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -184,15 +188,15 @@ describe('compiler compliance', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-        }
-      };
+          }
+        };
 
-      // The factory should look like this:
-      const factory =
-          'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+        // The factory should look like this:
+        const factory =
+            'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
-      // The template should look like this (where IDENT is a wild card for an identifier):
-      const template = `
+        // The template should look like this (where IDENT is a wild card for an identifier):
+        const template = `
           …
           consts: [["class", "my-app", 0, "http://someuri/foo", "foo:bar", "baz", "title", "Hello", 0, "http://someuri/foo", "foo:qux", "quacks"]],
           template: function MyComponent_Template(rf, ctx) {
@@ -209,16 +213,16 @@ describe('compiler compliance', () => {
         `;
 
 
-      const result = compile(files, angularFiles);
+        const result = compile(files, angularFiles);
 
-      expectEmit(result.source, factory, 'Incorrect factory');
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, factory, 'Incorrect factory');
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should support <ng-container>', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should support <ng-container>', () => {
+        const files = {
+          app: {
+            'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -230,11 +234,11 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      // The template should look like this (where IDENT is a wild card for an identifier):
-      const template = `
+        // The template should look like this (where IDENT is a wild card for an identifier):
+        const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
@@ -248,14 +252,15 @@ describe('compiler compliance', () => {
           }
         `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should generate self-closing elementContainer instruction for empty <ng-container>', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should generate self-closing elementContainer instruction for empty <ng-container>',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -267,11 +272,11 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-        }
-      };
+             }
+           };
 
-      // The template should look like this (where IDENT is a wild card for an identifier):
-      const template = `
+           // The template should look like this (where IDENT is a wild card for an identifier):
+           const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
@@ -280,14 +285,14 @@ describe('compiler compliance', () => {
           }
         `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should bind to element properties', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should bind to element properties', () => {
+        const files = {
+          app: {
+            'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -301,12 +306,12 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const factory =
-          'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
-      const template = `
+        const factory =
+            'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+        const template = `
         …
         consts: [[${AttributeMarker.Bindings}, "id"]],
         template: function MyComponent_Template(rf, ctx) {
@@ -320,16 +325,16 @@ describe('compiler compliance', () => {
       `;
 
 
-      const result = compile(files, angularFiles);
+        const result = compile(files, angularFiles);
 
-      expectEmit(result.source, factory, 'Incorrect factory');
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, factory, 'Incorrect factory');
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should reserve slots for pure functions', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should reserve slots for pure functions', () => {
+        const files = {
+          app: {
+            'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -348,20 +353,20 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      ///////////////
-      // TODO(FW-1273): The code generated below is adding extra parens, and we need to stop
-      // generating those.
-      //
-      // For example:
-      // `$r3$.ɵɵproperty("ternary", (ctx.cond ? $r3$.ɵɵpureFunction1(8, $c0$, ctx.a): $c1$));`
-      ///////////////
+        ///////////////
+        // TODO(FW-1273): The code generated below is adding extra parens, and we need to stop
+        // generating those.
+        //
+        // For example:
+        // `$r3$.ɵɵproperty("ternary", (ctx.cond ? $r3$.ɵɵpureFunction1(8, $c0$, ctx.a): $c1$));`
+        ///////////////
 
-      const factory =
-          'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
-      const template = `
+        const factory =
+            'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+        const template = `
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelement(0, "div", 0);
@@ -374,16 +379,16 @@ describe('compiler compliance', () => {
       `;
 
 
-      const result = compile(files, angularFiles);
+        const result = compile(files, angularFiles);
 
-      expectEmit(result.source, factory, 'Incorrect factory');
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, factory, 'Incorrect factory');
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should reserve slots for pure functions in host binding function', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should reserve slots for pure functions in host binding function', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, NgModule, Input} from '@angular/core';
 
             @Component({
@@ -423,10 +428,10 @@ describe('compiler compliance', () => {
             })
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const hostBindingsDef = `
+        const hostBindingsDef = `
         const $_c0$ = function (a0, a1) { return { collapsedHeight: a0, expandedHeight: a1 }; };
         const $_c1$ = function (a0, a1) { return { value: a0, params: a1 }; };
         const $_c2$ = function (a0, a1) { return { collapsedWidth: a0, expandedWidth: a1 }; };
@@ -447,14 +452,14 @@ describe('compiler compliance', () => {
         },
         …
       `;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, hostBindingsDef, 'Incorrect "hostBindings" function');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, hostBindingsDef, 'Incorrect "hostBindings" function');
+      });
 
-    it('should bind to class and style names', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should bind to class and style names', () => {
+        const files = {
+          app: {
+            'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -469,12 +474,12 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const factory =
-          'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
-      const template = `
+        const factory =
+            'MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
+        const template = `
         MyComponent.ɵcmp = i0.ɵɵdefineComponent({type:MyComponent,selectors:[["my-component"]],
             decls: 1,
             vars: 4,
@@ -492,16 +497,16 @@ describe('compiler compliance', () => {
       `;
 
 
-      const result = compile(files, angularFiles);
+        const result = compile(files, angularFiles);
 
-      expectEmit(result.source, factory, 'Incorrect factory');
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, factory, 'Incorrect factory');
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should de-duplicate attribute arrays', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should de-duplicate attribute arrays', () => {
+        const files = {
+          app: {
+            'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -517,10 +522,10 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
         …
         consts: [["title", "hi"]],
         template: function MyComponent_Template(rf, ctx) {
@@ -533,16 +538,16 @@ describe('compiler compliance', () => {
       `;
 
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
     });
-  });
 
-  describe('components & directives', () => {
-    it('should instantiate directives', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+    describe('components & directives', () => {
+      it('should instantiate directives', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, Directive, NgModule} from '@angular/core';
 
             @Component({selector: 'child', template: 'child-view'})
@@ -557,11 +562,11 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [ChildComponent, SomeDirective, MyComponent]})
             export class MyModule{}
           `
-        }
-      };
+          }
+        };
 
-      // ChildComponent definition should be:
-      const ChildComponentDefinition = `
+        // ChildComponent definition should be:
+        const ChildComponentDefinition = `
         ChildComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           type: ChildComponent,
           selectors: [["child"]],
@@ -575,22 +580,22 @@ describe('compiler compliance', () => {
           encapsulation: 2
         });`;
 
-      const ChildComponentFactory =
-          `ChildComponent.ɵfac = function ChildComponent_Factory(t) { return new (t || ChildComponent)(); };`;
+        const ChildComponentFactory =
+            `ChildComponent.ɵfac = function ChildComponent_Factory(t) { return new (t || ChildComponent)(); };`;
 
-      // SomeDirective definition should be:
-      const SomeDirectiveDefinition = `
+        // SomeDirective definition should be:
+        const SomeDirectiveDefinition = `
         SomeDirective.ɵdir = $r3$.ɵɵdefineDirective({
           type: SomeDirective,
           selectors: [["", "some-directive", ""]]
         });
       `;
 
-      const SomeDirectiveFactory =
-          `SomeDirective.ɵfac = function SomeDirective_Factory(t) {return new (t || SomeDirective)(); };`;
+        const SomeDirectiveFactory =
+            `SomeDirective.ɵfac = function SomeDirective_Factory(t) {return new (t || SomeDirective)(); };`;
 
-      // MyComponent definition should be:
-      const MyComponentDefinition = `
+        // MyComponent definition should be:
+        const MyComponentDefinition = `
         …
         MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           type: MyComponent,
@@ -609,24 +614,24 @@ describe('compiler compliance', () => {
         });
       `;
 
-      const MyComponentFactory =
-          `MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };`;
+        const MyComponentFactory =
+            `MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };`;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, ChildComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
-      expectEmit(source, ChildComponentFactory, 'Incorrect ChildComponent.ɵfac');
-      expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeDirective.ɵdir');
-      expectEmit(source, SomeDirectiveFactory, 'Incorrect SomeDirective.ɵfac');
-      expectEmit(source, MyComponentDefinition, 'Incorrect MyComponentDefinition.ɵcmp');
-      expectEmit(source, MyComponentFactory, 'Incorrect MyComponentDefinition.ɵfac');
-    });
+        expectEmit(source, ChildComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
+        expectEmit(source, ChildComponentFactory, 'Incorrect ChildComponent.ɵfac');
+        expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeDirective.ɵdir');
+        expectEmit(source, SomeDirectiveFactory, 'Incorrect SomeDirective.ɵfac');
+        expectEmit(source, MyComponentDefinition, 'Incorrect MyComponentDefinition.ɵcmp');
+        expectEmit(source, MyComponentFactory, 'Incorrect MyComponentDefinition.ɵfac');
+      });
 
-    it('should support complex selectors', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should support complex selectors', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Directive, NgModule} from '@angular/core';
 
             @Directive({selector: 'div.foo[some-directive]:not([title]):not(.baz)'})
@@ -638,44 +643,44 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [SomeDirective, OtherDirective]})
             export class MyModule{}
           `
-        }
-      };
+          }
+        };
 
-      // SomeDirective definition should be:
-      const SomeDirectiveDefinition = `
+        // SomeDirective definition should be:
+        const SomeDirectiveDefinition = `
         SomeDirective.ɵdir = $r3$.ɵɵdefineDirective({
           type: SomeDirective,
           selectors: [["div", "some-directive", "", 8, "foo", 3, "title", "", 9, "baz"]]
         });
       `;
 
-      const SomeDirectiveFactory =
-          `SomeDirective.ɵfac = function SomeDirective_Factory(t) {return new (t || SomeDirective)(); };`;
+        const SomeDirectiveFactory =
+            `SomeDirective.ɵfac = function SomeDirective_Factory(t) {return new (t || SomeDirective)(); };`;
 
-      // OtherDirective definition should be:
-      const OtherDirectiveDefinition = `
+        // OtherDirective definition should be:
+        const OtherDirectiveDefinition = `
         OtherDirective.ɵdir = $r3$.ɵɵdefineDirective({
           type: OtherDirective,
           selectors: [["", 5, "span", "title", "", 9, "baz"]]
         });
       `;
 
-      const OtherDirectiveFactory =
-          `OtherDirective.ɵfac = function OtherDirective_Factory(t) {return new (t || OtherDirective)(); };`;
+        const OtherDirectiveFactory =
+            `OtherDirective.ɵfac = function OtherDirective_Factory(t) {return new (t || OtherDirective)(); };`;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeDirective.ɵdir');
-      expectEmit(source, SomeDirectiveFactory, 'Incorrect SomeDirective.ɵfac');
-      expectEmit(source, OtherDirectiveDefinition, 'Incorrect OtherDirective.ɵdir');
-      expectEmit(source, OtherDirectiveFactory, 'Incorrect OtherDirective.ɵfac');
-    });
+        expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeDirective.ɵdir');
+        expectEmit(source, SomeDirectiveFactory, 'Incorrect SomeDirective.ɵfac');
+        expectEmit(source, OtherDirectiveDefinition, 'Incorrect OtherDirective.ɵdir');
+        expectEmit(source, OtherDirectiveFactory, 'Incorrect OtherDirective.ɵfac');
+      });
 
-    it('should convert #my-app selector to ["", "id", "my-app"]', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should convert #my-app selector to ["", "id", "my-app"]', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, NgModule} from '@angular/core';
 
             @Component({selector: '#my-app', template: ''})
@@ -684,11 +689,11 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [SomeComponent]})
             export class MyModule{}
           `
-        }
-      };
+          }
+        };
 
-      // SomeDirective definition should be:
-      const SomeDirectiveDefinition = `
+        // SomeDirective definition should be:
+        const SomeDirectiveDefinition = `
         SomeComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           type: SomeComponent,
           selectors: [["", "id", "my-app"]],
@@ -696,15 +701,15 @@ describe('compiler compliance', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeComponent.ɵcomp');
-    });
-    it('should support components without selector', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+        expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeComponent.ɵcomp');
+      });
+      it('should support components without selector', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, Directive, NgModule} from '@angular/core';
 
             @Component({template: '<router-outlet></router-outlet>'})
@@ -713,11 +718,11 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [EmptyOutletComponent]})
             export class MyModule{}
           `
-        }
-      };
+          }
+        };
 
-      // EmptyOutletComponent definition should be:
-      const EmptyOutletComponentDefinition = `
+        // EmptyOutletComponent definition should be:
+        const EmptyOutletComponentDefinition = `
         …
         EmptyOutletComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           type: EmptyOutletComponent,
@@ -733,21 +738,21 @@ describe('compiler compliance', () => {
         });
       `;
 
-      const EmptyOutletComponentFactory =
-          `EmptyOutletComponent.ɵfac = function EmptyOutletComponent_Factory(t) { return new (t || EmptyOutletComponent)(); };`;
+        const EmptyOutletComponentFactory =
+            `EmptyOutletComponent.ɵfac = function EmptyOutletComponent_Factory(t) { return new (t || EmptyOutletComponent)(); };`;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, EmptyOutletComponentDefinition, 'Incorrect EmptyOutletComponent.ɵcmp');
-      expectEmit(source, EmptyOutletComponentFactory, 'Incorrect EmptyOutletComponent.ɵfac');
-    });
+        expectEmit(source, EmptyOutletComponentDefinition, 'Incorrect EmptyOutletComponent.ɵcmp');
+        expectEmit(source, EmptyOutletComponentFactory, 'Incorrect EmptyOutletComponent.ɵfac');
+      });
 
-    it('should not treat ElementRef, ViewContainerRef, or ChangeDetectorRef specially when injecting',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should not treat ElementRef, ViewContainerRef, or ChangeDetectorRef specially when injecting',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
             import {Component, NgModule, ElementRef, ChangeDetectorRef, ViewContainerRef} from '@angular/core';
 
             @Component({
@@ -761,10 +766,10 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
             `
-           }
-         };
+             }
+           };
 
-         const MyComponentDefinition = `
+           const MyComponentDefinition = `
         …
         MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           type: MyComponent,
@@ -775,23 +780,23 @@ describe('compiler compliance', () => {
           encapsulation: 2
         });`;
 
-         const MyComponentFactory = `MyComponent.ɵfac = function MyComponent_Factory(t) {
+           const MyComponentFactory = `MyComponent.ɵfac = function MyComponent_Factory(t) {
             return new (t || MyComponent)(
               $r3$.ɵɵdirectiveInject($i$.ElementRef), $r3$.ɵɵdirectiveInject($i$.ViewContainerRef),
               $r3$.ɵɵdirectiveInject($i$.ChangeDetectorRef));
           };`;
 
-         const result = compile(files, angularFiles);
-         const source = result.source;
+           const result = compile(files, angularFiles);
+           const source = result.source;
 
-         expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ɵcmp');
-         expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ɵfac');
-       });
+           expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ɵcmp');
+           expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ɵfac');
+         });
 
-    it('should support structural directives', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should support structural directives', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, Directive, NgModule, TemplateRef} from '@angular/core';
 
             @Directive({selector: '[if]'})
@@ -810,18 +815,18 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [IfDirective, MyComponent]})
             export class MyModule {}
             `
-        }
-      };
+          }
+        };
 
-      const IfDirectiveDefinition = `
+        const IfDirectiveDefinition = `
         IfDirective.ɵdir = $r3$.ɵɵdefineDirective({
           type: IfDirective,
           selectors: [["", "if", ""]]
         });`;
-      const IfDirectiveFactory =
-          `IfDirective.ɵfac = function IfDirective_Factory(t) { return new (t || IfDirective)($r3$.ɵɵdirectiveInject($i$.TemplateRef)); };`;
+        const IfDirectiveFactory =
+            `IfDirective.ɵfac = function IfDirective_Factory(t) { return new (t || IfDirective)($r3$.ɵɵdirectiveInject($i$.TemplateRef)); };`;
 
-      const MyComponentDefinition = `
+        const MyComponentDefinition = `
         function MyComponent_li_2_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "li");
@@ -853,23 +858,23 @@ describe('compiler compliance', () => {
           encapsulation: 2
         });`;
 
-      const MyComponentFactory =
-          `MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };`;
+        const MyComponentFactory =
+            `MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };`;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, IfDirectiveDefinition, 'Incorrect IfDirective.ɵdir');
-      expectEmit(source, IfDirectiveFactory, 'Incorrect IfDirective.ɵfac');
-      expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ɵcmp');
-      expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ɵfac');
-    });
+        expectEmit(source, IfDirectiveDefinition, 'Incorrect IfDirective.ɵdir');
+        expectEmit(source, IfDirectiveFactory, 'Incorrect IfDirective.ɵfac');
+        expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ɵcmp');
+        expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ɵfac');
+      });
 
-    describe('value composition', () => {
-      it('should support array literals', () => {
-        const files = {
-          app: {
-            'spec.ts': `
+      describe('value composition', () => {
+        it('should support array literals', () => {
+          const files = {
+            app: {
+              'spec.ts': `
               import {Component, Input, NgModule} from '@angular/core';
 
               @Component({
@@ -896,10 +901,10 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyComp, MyApp]})
               export class MyModule { }
             `
-          }
-        };
+            }
+          };
 
-        const MyAppDeclaration = `
+          const MyAppDeclaration = `
           const $e0_ff$ = function ($v$) { return ["Nancy", $v$]; };
           …
           MyApp.ɵcmp = $r3$.ɵɵdefineComponent({
@@ -921,16 +926,16 @@ describe('compiler compliance', () => {
           });
         `;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, MyAppDeclaration, 'Invalid array emit');
-      });
+          expectEmit(source, MyAppDeclaration, 'Invalid array emit');
+        });
 
-      it('should support 9+ bindings in array literals', () => {
-        const files = {
-          app: {
-            'spec.ts': `
+        it('should support 9+ bindings in array literals', () => {
+          const files = {
+            app: {
+              'spec.ts': `
               import {Component, Input, NgModule} from '@angular/core';
 
               @Component({
@@ -975,10 +980,10 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyComp, MyApp]})
               export class MyModule {}
               `
-          }
-        };
+            }
+          };
 
-        const MyAppDefinition = `
+          const MyAppDefinition = `
           const $e0_ff$ = function ($v0$, $v1$, $v2$, $v3$, $v4$, $v5$, $v6$, $v7$, $v8$) {
             return ["start-", $v0$, $v1$, $v2$, $v3$, $v4$, "-middle-", $v5$, $v6$, $v7$, $v8$, "-end"];
           }
@@ -1003,16 +1008,16 @@ describe('compiler compliance', () => {
           });
         `;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, MyAppDefinition, 'Invalid array binding');
-      });
+          expectEmit(source, MyAppDefinition, 'Invalid array binding');
+        });
 
-      it('should support object literals', () => {
-        const files = {
-          app: {
-            'spec.ts': `
+        it('should support object literals', () => {
+          const files = {
+            app: {
+              'spec.ts': `
                 import {Component, Input, NgModule} from '@angular/core';
 
                 @Component({
@@ -1039,10 +1044,10 @@ describe('compiler compliance', () => {
                 @NgModule({declarations: [ObjectComp, MyApp]})
                 export class MyModule {}
               `
-          }
-        };
+            }
+          };
 
-        const MyAppDefinition = `
+          const MyAppDefinition = `
           const $e0_ff$ = function ($v$) { return {"duration": 500, animation: $v$}; };
           …
           MyApp.ɵcmp = $r3$.ɵɵdefineComponent({
@@ -1064,16 +1069,16 @@ describe('compiler compliance', () => {
           });
         `;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, MyAppDefinition, 'Invalid object literal binding');
-      });
+          expectEmit(source, MyAppDefinition, 'Invalid object literal binding');
+        });
 
-      it('should support expressions nested deeply in object/array literals', () => {
-        const files = {
-          app: {
-            'spec.ts': `
+        it('should support expressions nested deeply in object/array literals', () => {
+          const files = {
+            app: {
+              'spec.ts': `
               import {Component, Input, NgModule} from '@angular/core';
 
               @Component({
@@ -1103,10 +1108,10 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [NestedComp, MyApp]})
               export class MyModule {}
               `
-          }
-        };
+            }
+          };
 
-        const MyAppDefinition = `
+          const MyAppDefinition = `
           const $c0$ = function () { return {opacity: 0, duration: 0}; };
           const $e0_ff$ = function ($v$) { return {opacity: 1, duration: $v$}; };
           const $e0_ff_1$ = function ($v1$, $v2$) { return [$v1$, $v2$]; };
@@ -1133,18 +1138,18 @@ describe('compiler compliance', () => {
         `;
 
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, MyAppDefinition, 'Invalid array/object literal binding');
+          expectEmit(source, MyAppDefinition, 'Invalid array/object literal binding');
+        });
       });
-    });
 
-    describe('content projection', () => {
-      it('should support content projection in root template', () => {
-        const files = {
-          app: {
-            'spec.ts': `
+      describe('content projection', () => {
+        it('should support content projection in root template', () => {
+          const files = {
+            app: {
+              'spec.ts': `
               import {Component, Directive, NgModule, TemplateRef} from '@angular/core';
 
               @Component({selector: 'simple', template: '<div><ng-content></ng-content></div>'})
@@ -1167,10 +1172,10 @@ describe('compiler compliance', () => {
               })
               export class MyApp {}
             `
-          }
-        };
+            }
+          };
 
-        const SimpleComponentDefinition = `
+          const SimpleComponentDefinition = `
           SimpleComponent.ɵcmp = $r3$.ɵɵdefineComponent({
             type: SimpleComponent,
             selectors: [["simple"]],
@@ -1188,7 +1193,7 @@ describe('compiler compliance', () => {
             encapsulation: 2
           });`;
 
-        const ComplexComponentDefinition = `
+          const ComplexComponentDefinition = `
           const $c1$ = [[["span", "title", "tofirst"]], [["span", "title", "tosecond"]]];
           …
           ComplexComponent.ɵcmp = $r3$.ɵɵdefineComponent({
@@ -1213,19 +1218,19 @@ describe('compiler compliance', () => {
           });
         `;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(
-            result.source, SimpleComponentDefinition, 'Incorrect SimpleComponent definition');
-        expectEmit(
-            result.source, ComplexComponentDefinition, 'Incorrect ComplexComponent definition');
-      });
+          expectEmit(
+              result.source, SimpleComponentDefinition, 'Incorrect SimpleComponent definition');
+          expectEmit(
+              result.source, ComplexComponentDefinition, 'Incorrect ComplexComponent definition');
+        });
 
-      it('should support multi-slot content projection with multiple wildcard slots', () => {
-        const files = {
-          app: {
-            'spec.ts': `
+        it('should support multi-slot content projection with multiple wildcard slots', () => {
+          const files = {
+            app: {
+              'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -1240,10 +1245,10 @@ describe('compiler compliance', () => {
               @NgModule({ declarations: [Cmp] })
               class Module {}
             `,
-          }
-        };
+            }
+          };
 
-        const output = `
+          const output = `
           const $c0$ = ["*", [["", "spacer", ""]], "*"];
           const $c1$ = ["*", "[spacer]", "*"];
           …
@@ -1265,14 +1270,14 @@ describe('compiler compliance', () => {
           });
         `;
 
-        const {source} = compile(files, angularFiles);
-        expectEmit(source, output, 'Invalid content projection instructions generated');
-      });
+          const {source} = compile(files, angularFiles);
+          expectEmit(source, output, 'Invalid content projection instructions generated');
+        });
 
-      it('should support content projection in nested templates', () => {
-        const files = {
-          app: {
-            'spec.ts': `
+        it('should support content projection in nested templates', () => {
+          const files = {
+            app: {
+              'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -1293,9 +1298,9 @@ describe('compiler compliance', () => {
               @NgModule({ declarations: [Cmp] })
               class Module {}
             `
-          }
-        };
-        const output = `
+            }
+          };
+          const output = `
           function Cmp_div_0_Template(rf, ctx) { if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 2);
             $r3$.ɵɵprojection(1);
@@ -1317,7 +1322,7 @@ describe('compiler compliance', () => {
           const $_c4$ = [[["span", "title", "tofirst"]], "*"];
           …
           consts: [["id", "second", ${AttributeMarker.Template}, "ngIf"], ["id", "third", ${
-            AttributeMarker.Template}, "ngIf"], ["id", "second"], ["id", "third"]],
+              AttributeMarker.Template}, "ngIf"], ["id", "second"], ["id", "third"]],
           template: function Cmp_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵprojectionDef($_c4$);
@@ -1333,14 +1338,14 @@ describe('compiler compliance', () => {
           }
         `;
 
-        const {source} = compile(files, angularFiles);
-        expectEmit(source, output, 'Invalid content projection instructions generated');
-      });
+          const {source} = compile(files, angularFiles);
+          expectEmit(source, output, 'Invalid content projection instructions generated');
+        });
 
-      it('should support content projection in both the root and nested templates', () => {
-        const files = {
-          app: {
-            'spec.ts': `
+        it('should support content projection in both the root and nested templates', () => {
+          const files = {
+            app: {
+              'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -1363,10 +1368,10 @@ describe('compiler compliance', () => {
               @NgModule({ declarations: [Cmp] })
               class Module {}
             `
-          }
-        };
+            }
+          };
 
-        const output = `
+          const output = `
           function Cmp_ng_template_1_ng_template_1_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵɵprojection(0, 3);
@@ -1398,14 +1403,14 @@ describe('compiler compliance', () => {
           }
         `;
 
-        const {source} = compile(files, angularFiles);
-        expectEmit(source, output, 'Invalid content projection instructions generated');
-      });
+          const {source} = compile(files, angularFiles);
+          expectEmit(source, output, 'Invalid content projection instructions generated');
+        });
 
-      it('should parse the selector that is passed into ngProjectAs', () => {
-        const files = {
-          app: {
-            'spec.ts': `
+        it('should parse the selector that is passed into ngProjectAs', () => {
+          const files = {
+            app: {
+              'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -1423,12 +1428,12 @@ describe('compiler compliance', () => {
               })
               export class MyApp {}
             `
-          }
-        };
+            }
+          };
 
-        // Note that the c0 and c1 constants aren't being used in this particular test,
-        // but they are used in some of the logic that is folded under the ellipsis.
-        const SimpleComponentDefinition = `
+          // Note that the c0 and c1 constants aren't being used in this particular test,
+          // but they are used in some of the logic that is folded under the ellipsis.
+          const SimpleComponentDefinition = `
           const $_c0$ = [[["", "title", ""]]];
           const $_c1$ = ["[title]"];
           …
@@ -1448,16 +1453,16 @@ describe('compiler compliance', () => {
             encapsulation: 2
         })`;
 
-        const result = compile(files, angularFiles);
+          const result = compile(files, angularFiles);
 
-        expectEmit(
-            result.source, SimpleComponentDefinition, 'Incorrect SimpleComponent definition');
-      });
+          expectEmit(
+              result.source, SimpleComponentDefinition, 'Incorrect SimpleComponent definition');
+        });
 
-      it('should take the first selector if multiple values are passed into ngProjectAs', () => {
-        const files = {
-          app: {
-            'spec.ts': `
+        it('should take the first selector if multiple values are passed into ngProjectAs', () => {
+          const files = {
+            app: {
+              'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -1475,12 +1480,12 @@ describe('compiler compliance', () => {
               })
               export class MyApp {}
             `
-          }
-        };
+            }
+          };
 
-        // Note that the c0 and c1 constants aren't being used in this particular test,
-        // but they are used in some of the logic that is folded under the ellipsis.
-        const SimpleComponentDefinition = `
+          // Note that the c0 and c1 constants aren't being used in this particular test,
+          // but they are used in some of the logic that is folded under the ellipsis.
+          const SimpleComponentDefinition = `
           const $_c0$ = [[["", "title", ""]]];
           const $_c1$ = ["[title]"];
           …
@@ -1500,16 +1505,16 @@ describe('compiler compliance', () => {
             encapsulation: 2
         })`;
 
-        const result = compile(files, angularFiles);
+          const result = compile(files, angularFiles);
 
-        expectEmit(
-            result.source, SimpleComponentDefinition, 'Incorrect SimpleComponent definition');
-      });
+          expectEmit(
+              result.source, SimpleComponentDefinition, 'Incorrect SimpleComponent definition');
+        });
 
-      it('should include parsed ngProjectAs selectors into template attrs', () => {
-        const files = {
-          app: {
-            'spec.ts': `
+        it('should include parsed ngProjectAs selectors into template attrs', () => {
+          const files = {
+            app: {
+              'spec.ts': `
               import {Component} from '@angular/core';
 
               @Component({
@@ -1520,10 +1525,10 @@ describe('compiler compliance', () => {
                 show = true;
               }
             `
-          }
-        };
+            }
+          };
 
-        const SimpleComponentDefinition = `
+          const SimpleComponentDefinition = `
           MyApp.ɵcmp = i0.ɵɵdefineComponent({
             type: MyApp,
             selectors: [
@@ -1533,7 +1538,7 @@ describe('compiler compliance', () => {
             vars: 1,
             consts: [
                 ["ngProjectAs", ".someclass", ${AttributeMarker.ProjectAs}, ["", 8, "someclass"], ${
-            AttributeMarker.Template}, "ngIf"],
+              AttributeMarker.Template}, "ngIf"],
                 ["ngProjectAs", ".someclass", ${AttributeMarker.ProjectAs}, ["", 8, "someclass"]]
             ],
             template: function MyApp_Template(rf, ctx) {
@@ -1548,23 +1553,23 @@ describe('compiler compliance', () => {
           });
         `;
 
-        const result = compile(files, angularFiles);
-        expectEmit(result.source, SimpleComponentDefinition, 'Incorrect MyApp definition');
-      });
+          const result = compile(files, angularFiles);
+          expectEmit(result.source, SimpleComponentDefinition, 'Incorrect MyApp definition');
+        });
 
-      it('should capture the node name of ng-content with a structural directive', () => {
-        const files = {
-          app: {
-            'spec.ts': `
+        it('should capture the node name of ng-content with a structural directive', () => {
+          const files = {
+            app: {
+              'spec.ts': `
               import {Component, Directive, NgModule, TemplateRef} from '@angular/core';
 
               @Component({selector: 'simple', template: '<ng-content *ngIf="showContent"></ng-content>'})
               export class SimpleComponent {}
             `
-          }
-        };
+            }
+          };
 
-        const SimpleComponentDefinition = `
+          const SimpleComponentDefinition = `
           SimpleComponent.ɵcmp = $r3$.ɵɵdefineComponent({
             type: SimpleComponent,
             selectors: [["simple"]],
@@ -1584,15 +1589,15 @@ describe('compiler compliance', () => {
             encapsulation: 2
           });`;
 
-        const result = compile(files, angularFiles);
-        expectEmit(
-            result.source, SimpleComponentDefinition, 'Incorrect SimpleComponent definition');
+          const result = compile(files, angularFiles);
+          expectEmit(
+              result.source, SimpleComponentDefinition, 'Incorrect SimpleComponent definition');
+        });
       });
-    });
 
-    describe('queries', () => {
-      const directive = {
-        'some.directive.ts': `
+      describe('queries', () => {
+        const directive = {
+          'some.directive.ts': `
           import {Directive} from '@angular/core';
 
           @Directive({
@@ -1600,13 +1605,13 @@ describe('compiler compliance', () => {
           })
           export class SomeDirective { }
         `
-      };
+        };
 
-      it('should support view queries with directives', () => {
-        const files = {
-          app: {
-            ...directive,
-            'view_query.component.ts': `
+        it('should support view queries with directives', () => {
+          const files = {
+            app: {
+              ...directive,
+              'view_query.component.ts': `
             import {Component, NgModule, ViewChild, ViewChildren} from '@angular/core';
             import {SomeDirective} from './some.directive';
 
@@ -1624,10 +1629,10 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [SomeDirective, ViewQueryComponent]})
             export class MyModule {}
             `
-          }
-        };
+            }
+          };
 
-        const ViewQueryComponentDefinition = `
+          const ViewQueryComponentDefinition = `
           …
           ViewQueryComponent.ɵcmp = $r3$.ɵɵdefineComponent({
             type: ViewQueryComponent,
@@ -1655,16 +1660,16 @@ describe('compiler compliance', () => {
             encapsulation: 2
           });`;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, ViewQueryComponentDefinition, 'Invalid ViewQuery declaration');
-      });
+          expectEmit(source, ViewQueryComponentDefinition, 'Invalid ViewQuery declaration');
+        });
 
-      it('should support view queries with local refs', () => {
-        const files = {
-          app: {
-            'view_query.component.ts': `
+        it('should support view queries with local refs', () => {
+          const files = {
+            app: {
+              'view_query.component.ts': `
             import {Component, NgModule, ViewChild, ViewChildren, QueryList} from '@angular/core';
 
             @Component({
@@ -1682,10 +1687,10 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [ViewQueryComponent]})
             export class MyModule {}
             `
-          }
-        };
+            }
+          };
 
-        const ViewQueryComponentDefinition = `
+          const ViewQueryComponentDefinition = `
           const $e0_attrs$ = ["myRef"];
           const $e1_attrs$ = ["myRef1", "myRef2", "myRef3"];
           …
@@ -1705,17 +1710,17 @@ describe('compiler compliance', () => {
             …
           });`;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, ViewQueryComponentDefinition, 'Invalid ViewQuery declaration');
-      });
+          expectEmit(source, ViewQueryComponentDefinition, 'Invalid ViewQuery declaration');
+        });
 
-      it('should support static view queries', () => {
-        const files = {
-          app: {
-            ...directive,
-            'view_query.component.ts': `
+        it('should support static view queries', () => {
+          const files = {
+            app: {
+              ...directive,
+              'view_query.component.ts': `
             import {Component, NgModule, ViewChild} from '@angular/core';
             import {SomeDirective} from './some.directive';
 
@@ -1733,10 +1738,10 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [SomeDirective, ViewQueryComponent]})
             export class MyModule {}
             `
-          }
-        };
+            }
+          };
 
-        const ViewQueryComponentDefinition = `
+          const ViewQueryComponentDefinition = `
           const $refs$ = ["foo"];
           …
           ViewQueryComponent.ɵcmp = $r3$.ɵɵdefineComponent({
@@ -1765,17 +1770,17 @@ describe('compiler compliance', () => {
             encapsulation: 2
           });`;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, ViewQueryComponentDefinition, 'Invalid ViewQuery declaration');
-      });
+          expectEmit(source, ViewQueryComponentDefinition, 'Invalid ViewQuery declaration');
+        });
 
-      it('should support view queries with read tokens specified', () => {
-        const files = {
-          app: {
-            ...directive,
-            'view_query.component.ts': `
+        it('should support view queries with read tokens specified', () => {
+          const files = {
+            app: {
+              ...directive,
+              'view_query.component.ts': `
             import {Component, NgModule, ViewChild, ViewChildren, QueryList, ElementRef, TemplateRef} from '@angular/core';
             import {SomeDirective} from './some.directive';
 
@@ -1797,10 +1802,10 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [ViewQueryComponent]})
             export class MyModule {}
             `
-          }
-        };
+            }
+          };
 
-        const ViewQueryComponentDefinition = `
+          const ViewQueryComponentDefinition = `
           const $e0_attrs$ = ["myRef"];
           const $e1_attrs$ = ["myRef1", "myRef2", "myRef3"];
           …
@@ -1824,17 +1829,17 @@ describe('compiler compliance', () => {
             …
           });`;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, ViewQueryComponentDefinition, 'Invalid ViewQuery declaration');
-      });
+          expectEmit(source, ViewQueryComponentDefinition, 'Invalid ViewQuery declaration');
+        });
 
-      it('should support content queries with directives', () => {
-        const files = {
-          app: {
-            ...directive,
-            'content_query.ts': `
+        it('should support content queries with directives', () => {
+          const files = {
+            app: {
+              ...directive,
+              'content_query.ts': `
             import {Component, ContentChild, ContentChildren, NgModule, QueryList} from '@angular/core';
             import {SomeDirective} from './some.directive';
 
@@ -1862,10 +1867,10 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [SomeDirective, ContentQueryComponent, MyApp]})
             export class MyModule { }
             `
-          }
-        };
+            }
+          };
 
-        const ContentQueryComponentDefinition = `
+          const ContentQueryComponentDefinition = `
           ContentQueryComponent.ɵcmp = $r3$.ɵɵdefineComponent({
             type: ContentQueryComponent,
             selectors: [["content-query-component"]],
@@ -1894,16 +1899,16 @@ describe('compiler compliance', () => {
             encapsulation: 2
           });`;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, ContentQueryComponentDefinition, 'Invalid ContentQuery declaration');
-      });
+          expectEmit(source, ContentQueryComponentDefinition, 'Invalid ContentQuery declaration');
+        });
 
-      it('should support content queries with local refs', () => {
-        const files = {
-          app: {
-            'content_query.component.ts': `
+        it('should support content queries with local refs', () => {
+          const files = {
+            app: {
+              'content_query.component.ts': `
             import {Component, ContentChild, ContentChildren, NgModule, QueryList} from '@angular/core';
 
             @Component({
@@ -1920,10 +1925,10 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [ContentQueryComponent]})
             export class MyModule {}
           `
-          }
-        };
+            }
+          };
 
-        const ContentQueryComponentDefinition = `
+          const ContentQueryComponentDefinition = `
           const $e0_attrs$ = ["myRef"];
           const $e1_attrs$ = ["myRef1", "myRef2", "myRef3"];
           …
@@ -1943,17 +1948,17 @@ describe('compiler compliance', () => {
             …
           });`;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, ContentQueryComponentDefinition, 'Invalid ContentQuery declaration');
-      });
+          expectEmit(source, ContentQueryComponentDefinition, 'Invalid ContentQuery declaration');
+        });
 
-      it('should support static content queries', () => {
-        const files = {
-          app: {
-            ...directive,
-            'content_query.ts': `
+        it('should support static content queries', () => {
+          const files = {
+            app: {
+              ...directive,
+              'content_query.ts': `
             import {Component, ContentChild, NgModule} from '@angular/core';
             import {SomeDirective} from './some.directive';
 
@@ -1981,10 +1986,10 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [SomeDirective, ContentQueryComponent, MyApp]})
             export class MyModule { }
             `
-          }
-        };
+            }
+          };
 
-        const ContentQueryComponentDefinition = `
+          const ContentQueryComponentDefinition = `
           ContentQueryComponent.ɵcmp = $r3$.ɵɵdefineComponent({
             type: ContentQueryComponent,
             selectors: [["content-query-component"]],
@@ -2013,17 +2018,17 @@ describe('compiler compliance', () => {
             encapsulation: 2
           });`;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, ContentQueryComponentDefinition, 'Invalid ContentQuery declaration');
-      });
+          expectEmit(source, ContentQueryComponentDefinition, 'Invalid ContentQuery declaration');
+        });
 
-      it('should support content queries with read tokens specified', () => {
-        const files = {
-          app: {
-            ...directive,
-            'content_query.component.ts': `
+        it('should support content queries with read tokens specified', () => {
+          const files = {
+            app: {
+              ...directive,
+              'content_query.component.ts': `
             import {Component, ContentChild, ContentChildren, NgModule, QueryList, ElementRef, TemplateRef} from '@angular/core';
             import {SomeDirective} from './some.directive';
 
@@ -2044,10 +2049,10 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [ContentQueryComponent]})
             export class MyModule {}
           `
-          }
-        };
+            }
+          };
 
-        const ContentQueryComponentDefinition = `
+          const ContentQueryComponentDefinition = `
           const $e0_attrs$ = ["myRef"];
           const $e1_attrs$ = ["myRef1", "myRef2", "myRef3"];
           …
@@ -2071,18 +2076,18 @@ describe('compiler compliance', () => {
             …
           });`;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, ContentQueryComponentDefinition, 'Invalid ContentQuery declaration');
+          expectEmit(source, ContentQueryComponentDefinition, 'Invalid ContentQuery declaration');
+        });
       });
-    });
 
-    describe('pipes', () => {
-      it('should render pipes', () => {
-        const files = {
-          app: {
-            'spec.ts': `
+      describe('pipes', () => {
+        it('should render pipes', () => {
+          const files = {
+            app: {
+              'spec.ts': `
                 import {Component, NgModule, Pipe, PipeTransform, OnDestroy} from '@angular/core';
 
                 @Pipe({
@@ -2115,10 +2120,10 @@ describe('compiler compliance', () => {
                 @NgModule({declarations:[MyPipe, MyPurePipe, MyApp]})
                 export class MyModule {}
             `
-          }
-        };
+            }
+          };
 
-        const MyPipeDefinition = `
+          const MyPipeDefinition = `
             MyPipe.ɵpipe = $r3$.ɵɵdefinePipe({
               name: "myPipe",
               type: MyPipe,
@@ -2126,22 +2131,22 @@ describe('compiler compliance', () => {
             });
         `;
 
-        const MyPipeFactoryDef = `
+          const MyPipeFactoryDef = `
           MyPipe.ɵfac = function MyPipe_Factory(t) { return new (t || MyPipe)(); };
         `;
 
-        const MyPurePipeDefinition = `
+          const MyPurePipeDefinition = `
             MyPurePipe.ɵpipe = $r3$.ɵɵdefinePipe({
               name: "myPurePipe",
               type: MyPurePipe,
               pure: true
             });`;
 
-        const MyPurePipeFactoryDef = `
+          const MyPurePipeFactoryDef = `
           MyPurePipe.ɵfac = function MyPurePipe_Factory(t) { return new (t || MyPurePipe)(); };
         `;
 
-        const MyAppDefinition = `
+          const MyAppDefinition = `
             const $c0$ = function ($a0$) {
               return [$a0$, 1, 2, 3, 4, 5];
             };
@@ -2172,20 +2177,20 @@ describe('compiler compliance', () => {
               encapsulation: 2
             });`;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, MyPipeDefinition, 'Invalid pipe definition');
-        expectEmit(source, MyPipeFactoryDef, 'Invalid pipe factory function');
-        expectEmit(source, MyPurePipeDefinition, 'Invalid pure pipe definition');
-        expectEmit(source, MyPurePipeFactoryDef, 'Invalid pure pipe factory function');
-        expectEmit(source, MyAppDefinition, 'Invalid MyApp definition');
-      });
+          expectEmit(source, MyPipeDefinition, 'Invalid pipe definition');
+          expectEmit(source, MyPipeFactoryDef, 'Invalid pipe factory function');
+          expectEmit(source, MyPurePipeDefinition, 'Invalid pure pipe definition');
+          expectEmit(source, MyPurePipeFactoryDef, 'Invalid pure pipe factory function');
+          expectEmit(source, MyAppDefinition, 'Invalid MyApp definition');
+        });
 
-      it('should use appropriate function for a given no of pipe arguments', () => {
-        const files = {
-          app: {
-            'spec.ts': `
+        it('should use appropriate function for a given no of pipe arguments', () => {
+          const files = {
+            app: {
+              'spec.ts': `
                 import {Component, NgModule, Pipe, PipeTransform, OnDestroy} from '@angular/core';
 
                 @Pipe({
@@ -2208,10 +2213,10 @@ describe('compiler compliance', () => {
                 @NgModule({declarations:[MyPipe, MyApp]})
                 export class MyModule {}
             `
-          }
-        };
+            }
+          };
 
-        const MyAppDefinition = `
+          const MyAppDefinition = `
             // ...
             MyApp.ɵcmp = $r3$.ɵɵdefineComponent({
               type: MyApp,
@@ -2242,17 +2247,17 @@ describe('compiler compliance', () => {
               encapsulation: 2
             });`;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, MyAppDefinition, 'Invalid MyApp definition');
-      });
+          expectEmit(source, MyAppDefinition, 'Invalid MyApp definition');
+        });
 
-      it('should generate the proper instruction when injecting ChangeDetectorRef into a pipe',
-         () => {
-           const files = {
-             app: {
-               'spec.ts': `
+        it('should generate the proper instruction when injecting ChangeDetectorRef into a pipe',
+           () => {
+             const files = {
+               app: {
+                 'spec.ts': `
                   import {Component, NgModule, Pipe, PipeTransform, ChangeDetectorRef, Optional} from '@angular/core';
 
                   @Pipe({name: 'myPipe'})
@@ -2280,10 +2285,10 @@ describe('compiler compliance', () => {
                   @NgModule({declarations:[MyPipe, MyOtherPipe, MyApp]})
                   export class MyModule {}
                 `
-             }
-           };
+               }
+             };
 
-           const MyPipeDefinition = `
+             const MyPipeDefinition = `
               MyPipe.ɵpipe = $r3$.ɵɵdefinePipe({
                 name: "myPipe",
                 type: MyPipe,
@@ -2291,35 +2296,35 @@ describe('compiler compliance', () => {
               });
             `;
 
-           const MyPipeFactory = `
+             const MyPipeFactory = `
               MyPipe.ɵfac = function MyPipe_Factory(t) { return new (t || MyPipe)($r3$.ɵɵinjectPipeChangeDetectorRef()); };
             `;
 
-           const MyOtherPipeDefinition = `
+             const MyOtherPipeDefinition = `
               MyOtherPipe.ɵpipe = $r3$.ɵɵdefinePipe({
                 name: "myOtherPipe",
                 type: MyOtherPipe,
                 pure: true
               });`;
 
-           const MyOtherPipeFactory = `
+             const MyOtherPipeFactory = `
               MyOtherPipe.ɵfac = function MyOtherPipe_Factory(t) { return new (t || MyOtherPipe)($r3$.ɵɵinjectPipeChangeDetectorRef(8)); };
             `;
 
-           const result = compile(files, angularFiles);
-           const source = result.source;
+             const result = compile(files, angularFiles);
+             const source = result.source;
 
-           expectEmit(source, MyPipeDefinition, 'Invalid pipe definition');
-           expectEmit(source, MyPipeFactory, 'Invalid pipe factory function');
-           expectEmit(source, MyOtherPipeDefinition, 'Invalid alternate pipe definition');
-           expectEmit(source, MyOtherPipeFactory, 'Invalid alternate pipe factory function');
-         });
-    });
+             expectEmit(source, MyPipeDefinition, 'Invalid pipe definition');
+             expectEmit(source, MyPipeFactory, 'Invalid pipe factory function');
+             expectEmit(source, MyOtherPipeDefinition, 'Invalid alternate pipe definition');
+             expectEmit(source, MyOtherPipeFactory, 'Invalid alternate pipe factory function');
+           });
+      });
 
-    it('local reference', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('local reference', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, NgModule} from '@angular/core';
 
             @Component({selector: 'my-component', template: '<input #user>Hello {{user.value}}!'})
@@ -2328,10 +2333,10 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const MyComponentDefinition = `
+        const MyComponentDefinition = `
         …
         MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           type: MyComponent,
@@ -2354,16 +2359,16 @@ describe('compiler compliance', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ɵcmp');
-    });
+        expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ɵcmp');
+      });
 
-    it('local references in nested views', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('local references in nested views', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, Directive, NgModule, TemplateRef} from '@angular/core';
 
             @Directive({selector: '[if]'})
@@ -2389,10 +2394,10 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [IfDirective, MyComponent]})
             export class MyModule {}
             `
-        }
-      };
+          }
+        };
 
-      const MyComponentDefinition = `
+        const MyComponentDefinition = `
         function MyComponent_div_3_span_2_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "span");
@@ -2449,15 +2454,15 @@ describe('compiler compliance', () => {
           encapsulation: 2
         });`;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
-      expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ɵcmp');
-    });
+        const result = compile(files, angularFiles);
+        const source = result.source;
+        expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ɵcmp');
+      });
 
-    it('should support local refs mixed with context assignments', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should support local refs mixed with context assignments', () => {
+        const files = {
+          app: {
+            'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -2475,10 +2480,10 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
       function MyComponent_div_0_span_3_Template(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵɵelementStart(0, "span");
@@ -2509,7 +2514,7 @@ describe('compiler compliance', () => {
 
       // ...
       consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], ["foo", ""], [${
-          AttributeMarker.Template}, "ngIf"]],
+            AttributeMarker.Template}, "ngIf"]],
       template:function MyComponent_Template(rf, ctx){
         if (rf & 1) {
           $i0$.ɵɵtemplate(0, MyComponent_div_0_Template, 4, 1, "div", 0);
@@ -2519,15 +2524,15 @@ describe('compiler compliance', () => {
         }
       }`;
 
-      const result = compile(files, angularFiles);
+        const result = compile(files, angularFiles);
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    describe('lifecycle hooks', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      describe('lifecycle hooks', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, Input, NgModule} from '@angular/core';
 
             let events: string[] = [];
@@ -2565,11 +2570,11 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [LifecycleComp, SimpleLayout]})
             export class LifecycleModule {}
           `
-        }
-      };
+          }
+        };
 
-      it('should gen hooks with a few simple components', () => {
-        const LifecycleCompDefinition = `
+        it('should gen hooks with a few simple components', () => {
+          const LifecycleCompDefinition = `
           LifecycleComp.ɵcmp = $r3$.ɵɵdefineComponent({
             type: LifecycleComp,
             selectors: [["lifecycle-comp"]],
@@ -2581,7 +2586,7 @@ describe('compiler compliance', () => {
             encapsulation: 2
           });`;
 
-        const SimpleLayoutDefinition = `
+          const SimpleLayoutDefinition = `
           SimpleLayout.ɵcmp = $r3$.ɵɵdefineComponent({
             type: SimpleLayout,
             selectors: [["simple-layout"]],
@@ -2603,18 +2608,18 @@ describe('compiler compliance', () => {
            encapsulation: 2
           });`;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        expectEmit(source, LifecycleCompDefinition, 'Invalid LifecycleComp definition');
-        expectEmit(source, SimpleLayoutDefinition, 'Invalid SimpleLayout definition');
+          expectEmit(source, LifecycleCompDefinition, 'Invalid LifecycleComp definition');
+          expectEmit(source, SimpleLayoutDefinition, 'Invalid SimpleLayout definition');
+        });
       });
-    });
 
-    describe('template variables', () => {
-      const shared = {
-        shared: {
-          'for_of.ts': `
+      describe('template variables', () => {
+        const shared = {
+          shared: {
+            'for_of.ts': `
             import {Directive, Input, SimpleChanges, TemplateRef, ViewContainerRef} from '@angular/core';
 
             export interface ForOfContext {
@@ -2662,14 +2667,14 @@ describe('compiler compliance', () => {
               }
             }
           `
-        }
-      };
+          }
+        };
 
-      it('should support embedded views in the SVG namespace', () => {
-        const files = {
-          app: {
-            ...shared,
-            'spec.ts': `
+        it('should support embedded views in the SVG namespace', () => {
+          const files = {
+            app: {
+              ...shared,
+              'spec.ts': `
                   import {Component, NgModule} from '@angular/core';
                   import {ForOfDirective} from './shared/for_of';
 
@@ -2686,11 +2691,11 @@ describe('compiler compliance', () => {
                   })
                   export class MyModule {}
                 `
-          }
-        };
+            }
+          };
 
-        // TODO(benlesh): Enforce this when the directives are specified
-        const ForDirectiveDefinition = `
+          // TODO(benlesh): Enforce this when the directives are specified
+          const ForDirectiveDefinition = `
               ForOfDirective.ɵdir = $r3$.ɵɵdefineDirective({
                 type: ForOfDirective,
                 selectors: [["", "forOf", ""]],
@@ -2699,11 +2704,11 @@ describe('compiler compliance', () => {
               });
             `;
 
-        const ForDirectiveFactory = `ForOfDirective.ɵfac = function ForOfDirective_Factory(t) {
+          const ForDirectiveFactory = `ForOfDirective.ɵfac = function ForOfDirective_Factory(t) {
             return new (t || ForOfDirective)($r3$.ɵɵdirectiveInject(ViewContainerRef), $r3$.ɵɵdirectiveInject(TemplateRef));
           };`;
 
-        const MyComponentDefinition = `
+          const MyComponentDefinition = `
               function MyComponent__svg_g_1_Template(rf, ctx) {
                 if (rf & 1) {
                   $r3$.ɵɵnamespaceSVG();
@@ -2736,20 +2741,20 @@ describe('compiler compliance', () => {
               });
             `;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        // TODO(benlesh): Enforce this when the directives are specified
-        // expectEmit(source, ForDirectiveDefinition, 'Invalid directive definition');
-        // expectEmit(source, ForDirectiveFactory, 'Invalid directive factory');
-        expectEmit(source, MyComponentDefinition, 'Invalid component definition');
-      });
+          // TODO(benlesh): Enforce this when the directives are specified
+          // expectEmit(source, ForDirectiveDefinition, 'Invalid directive definition');
+          // expectEmit(source, ForDirectiveFactory, 'Invalid directive factory');
+          expectEmit(source, MyComponentDefinition, 'Invalid component definition');
+        });
 
-      it('should support a let variable and reference', () => {
-        const files = {
-          app: {
-            ...shared,
-            'spec.ts': `
+        it('should support a let variable and reference', () => {
+          const files = {
+            app: {
+              ...shared,
+              'spec.ts': `
               import {Component, NgModule} from '@angular/core';
               import {ForOfDirective} from './shared/for_of';
 
@@ -2766,11 +2771,11 @@ describe('compiler compliance', () => {
               })
               export class MyModule {}
             `
-          }
-        };
+            }
+          };
 
-        // TODO(chuckj): Enforce this when the directives are specified
-        const ForDirectiveDefinition = `
+          // TODO(chuckj): Enforce this when the directives are specified
+          const ForDirectiveDefinition = `
           ForOfDirective.ɵdir = $r3$.ɵɵdefineDirective({
             type: ForOfDirective,
             selectors: [["", "forOf", ""]],
@@ -2779,13 +2784,13 @@ describe('compiler compliance', () => {
           });
         `;
 
-        const ForDirectiveFactory = `
+          const ForDirectiveFactory = `
           ForOfDirective.ɵfac = function ForOfDirective_Factory(t) {
             return new (t || ForOfDirective)($r3$.ɵɵdirectiveInject(ViewContainerRef), $r3$.ɵɵdirectiveInject(TemplateRef));
           };
         `;
 
-        const MyComponentDefinition = `
+          const MyComponentDefinition = `
           function MyComponent_li_1_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵelementStart(0, "li");
@@ -2821,20 +2826,20 @@ describe('compiler compliance', () => {
           });
         `;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
+          const result = compile(files, angularFiles);
+          const source = result.source;
 
-        // TODO(chuckj): Enforce this when the directives are specified
-        // expectEmit(source, ForDirectiveDefinition, 'Invalid directive definition');
-        // expectEmit(source, ForDirectiveFactory, 'Invalid directive factory');
-        expectEmit(source, MyComponentDefinition, 'Invalid component definition');
-      });
+          // TODO(chuckj): Enforce this when the directives are specified
+          // expectEmit(source, ForDirectiveDefinition, 'Invalid directive definition');
+          // expectEmit(source, ForDirectiveFactory, 'Invalid directive factory');
+          expectEmit(source, MyComponentDefinition, 'Invalid component definition');
+        });
 
-      it('should support accessing parent template variables', () => {
-        const files = {
-          app: {
-            ...shared,
-            'spec.ts': `
+        it('should support accessing parent template variables', () => {
+          const files = {
+            app: {
+              ...shared,
+              'spec.ts': `
               import {Component, NgModule} from '@angular/core';
               import {ForOfDirective} from './shared/for_of';
 
@@ -2864,10 +2869,10 @@ describe('compiler compliance', () => {
               })
               export class MyModule {}
             `
-          }
-        };
+            }
+          };
 
-        const MyComponentDefinition = `
+          const MyComponentDefinition = `
           function MyComponent_li_1_li_4_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵelementStart(0, "li");
@@ -2924,16 +2929,16 @@ describe('compiler compliance', () => {
             encapsulation: 2
           });`;
 
-        const result = compile(files, angularFiles);
-        const source = result.source;
-        expectEmit(source, MyComponentDefinition, 'Invalid component definition');
+          const result = compile(files, angularFiles);
+          const source = result.source;
+          expectEmit(source, MyComponentDefinition, 'Invalid component definition');
+        });
       });
-    });
 
-    it('should instantiate directives in a closure when they are forward referenced', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should instantiate directives in a closure when they are forward referenced', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, NgModule, Directive} from '@angular/core';
 
             @Component({
@@ -2953,24 +2958,24 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [HostBindingComp, MyForwardDirective]})
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const MyAppDefinition = `
+        const MyAppDefinition = `
         …
         directives: function () { return [MyForwardDirective]; }
         …
       `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
-      expectEmit(source, MyAppDefinition, 'Invalid component definition');
-    });
+        const result = compile(files, angularFiles);
+        const source = result.source;
+        expectEmit(source, MyAppDefinition, 'Invalid component definition');
+      });
 
-    it('should instantiate pipes in a closure when they are forward referenced', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should instantiate pipes in a closure when they are forward referenced', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, NgModule, Pipe} from '@angular/core';
 
             @Component({
@@ -2990,24 +2995,24 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [HostBindingComp, MyForwardPipe]})
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const MyAppDefinition = `
+        const MyAppDefinition = `
         …
         pipes: function () { return [MyForwardPipe]; }
         …
       `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
-      expectEmit(source, MyAppDefinition, 'Invalid component definition');
-    });
+        const result = compile(files, angularFiles);
+        const source = result.source;
+        expectEmit(source, MyAppDefinition, 'Invalid component definition');
+      });
 
-    it('should split multiple `exportAs` values into an array', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should split multiple `exportAs` values into an array', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Directive, NgModule} from '@angular/core';
 
             @Directive({selector: '[some-directive]', exportAs: 'someDir, otherDir'})
@@ -3016,11 +3021,11 @@ describe('compiler compliance', () => {
             @NgModule({declarations: [SomeDirective]})
             export class MyModule{}
           `
-        }
-      };
+          }
+        };
 
-      // SomeDirective definition should be:
-      const SomeDirectiveDefinition = `
+        // SomeDirective definition should be:
+        const SomeDirectiveDefinition = `
         SomeDirective.ɵdir = $r3$.ɵɵdefineDirective({
           type: SomeDirective,
           selectors: [["", "some-directive", ""]],
@@ -3028,16 +3033,16 @@ describe('compiler compliance', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeDirective.ɵdir');
-    });
+        expectEmit(source, SomeDirectiveDefinition, 'Incorrect SomeDirective.ɵdir');
+      });
 
-    it('should not throw for empty property bindings on ng-template', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should not throw for empty property bindings on ng-template', () => {
+        const files = {
+          app: {
+            'example.ts': `
           import {Component, NgModule} from '@angular/core';
 
           @Component({
@@ -3049,39 +3054,39 @@ describe('compiler compliance', () => {
 
           @NgModule({declarations: [MyComponent]})
           export class MyModule {}`
-        }
-      };
+          }
+        };
 
-      expect(() => compile(files, angularFiles)).not.toThrow();
-    });
+        expect(() => compile(files, angularFiles)).not.toThrow();
+      });
 
-    it('should not generate a selectors array if the directive does not have a selector', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should not generate a selectors array if the directive does not have a selector', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Directive} from '@angular/core';
 
             @Directive()
             export class AbstractDirective {
             }
           `
-        }
-      };
-      const expectedOutput = `
+          }
+        };
+        const expectedOutput = `
       // ...
       AbstractDirective.ɵdir = $r3$.ɵɵdefineDirective({
         type: AbstractDirective
       });
       // ...
       `;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, expectedOutput, 'Invalid directive definition');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, expectedOutput, 'Invalid directive definition');
+      });
 
-    it('should generate a pure function for constant object literals', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should generate a pure function for constant object literals', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -3090,10 +3095,10 @@ describe('compiler compliance', () => {
             export class MyApp {
             }
           `
-        }
-      };
+          }
+        };
 
-      const MyAppDeclaration = `
+        const MyAppDeclaration = `
         const $c0$ = function () { return {}; };
         const $c1$ = function () { return { a: 1, b: 2 }; };
         …
@@ -3115,14 +3120,14 @@ describe('compiler compliance', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, MyAppDeclaration, 'Invalid component definition');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, MyAppDeclaration, 'Invalid component definition');
+      });
 
-    it('should generate a pure function for constant array literals', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should generate a pure function for constant array literals', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -3131,10 +3136,10 @@ describe('compiler compliance', () => {
             export class MyApp {
             }
           `
-        }
-      };
+          }
+        };
 
-      const MyAppDeclaration = `
+        const MyAppDeclaration = `
         const $c0$ = function () { return []; };
         const $c1$ = function () { return [0, 1, 2]; };
         …
@@ -3156,14 +3161,14 @@ describe('compiler compliance', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, MyAppDeclaration, 'Invalid component definition');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, MyAppDeclaration, 'Invalid component definition');
+      });
 
-    it('should not share pure functions between null and object literals', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should not share pure functions between null and object literals', () => {
+        const files = {
+          app: {
+            'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -3177,10 +3182,10 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyApp]})
               export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const MyAppDeclaration = `
+        const MyAppDeclaration = `
         const $c0$ = function () { return { foo: null }; };
         const $c1$ = function () { return {}; };
         const $c2$ = function (a0) { return { foo: a0 }; };
@@ -3206,14 +3211,14 @@ describe('compiler compliance', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, MyAppDeclaration, 'Invalid component definition');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, MyAppDeclaration, 'Invalid component definition');
+      });
 
-    it('should not share pure functions between null and array literals', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should not share pure functions between null and array literals', () => {
+        const files = {
+          app: {
+            'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -3227,10 +3232,10 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyApp]})
               export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const MyAppDeclaration = `
+        const MyAppDeclaration = `
         const $c0$ = function () { return { foo: null }; };
         const $c1$ = function () { return []; };
         const $c2$ = function (a0) { return { foo: a0 }; };
@@ -3256,14 +3261,14 @@ describe('compiler compliance', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, MyAppDeclaration, 'Invalid component definition');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, MyAppDeclaration, 'Invalid component definition');
+      });
 
-    it('should not share pure functions between null and function calls', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should not share pure functions between null and function calls', () => {
+        const files = {
+          app: {
+            'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -3281,10 +3286,10 @@ describe('compiler compliance', () => {
               @NgModule({declarations: [MyApp]})
               export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const MyAppDeclaration = `
+        const MyAppDeclaration = `
         const $c0$ = function () { return { foo: null }; };
         const $c1$ = function (a0) { return { foo: a0 }; };
         …
@@ -3309,8 +3314,9 @@ describe('compiler compliance', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, MyAppDeclaration, 'Invalid component definition');
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, MyAppDeclaration, 'Invalid component definition');
+      });
     });
   });
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -7,20 +7,24 @@
  */
 import {AttributeMarker} from '@angular/compiler/src/core';
 import {MockDirectory, setup} from '@angular/compiler/test/aot/test_util';
-import {compile, expectEmit} from './mock_compile';
+import {createCompileFn, expectEmit} from './mock_compile';
+import {runInEachCompilationMode} from './test_runner';
 
-describe('compiler compliance: bindings', () => {
-  const angularFiles = setup({
-    compileAngular: false,
-    compileFakeCore: true,
-    compileAnimations: false,
-  });
+runInEachCompilationMode(compilationMode => {
+  const compile = createCompileFn(compilationMode);
 
-  describe('text bindings', () => {
-    it('should generate interpolation instruction', () => {
-      const files: MockDirectory = {
-        app: {
-          'example.ts': `
+  describe('compiler compliance: bindings', () => {
+    const angularFiles = setup({
+      compileAngular: false,
+      compileFakeCore: true,
+      compileAnimations: false,
+    });
+
+    describe('text bindings', () => {
+      it('should generate interpolation instruction', () => {
+        const files: MockDirectory = {
+          app: {
+            'example.ts': `
           import {Component, NgModule} from '@angular/core';
           @Component({
             selector: 'my-component',
@@ -33,10 +37,10 @@ describe('compiler compliance: bindings', () => {
           @NgModule({declarations: [MyComponent]})
           export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
       template:function MyComponent_Template(rf, $ctx$){
         if (rf & 1) {
           $i0$.ɵɵelementStart(0, "div");
@@ -48,16 +52,16 @@ describe('compiler compliance: bindings', () => {
           $i0$.ɵɵtextInterpolate1("Hello ", $ctx$.name, "");
         }
       }`;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect interpolated text binding');
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect interpolated text binding');
+      });
     });
-  });
 
-  describe('property bindings', () => {
-    it('should generate bind instruction', () => {
-      const files: MockDirectory = {
-        app: {
-          'example.ts': `
+    describe('property bindings', () => {
+      it('should generate bind instruction', () => {
+        const files: MockDirectory = {
+          app: {
+            'example.ts': `
           import {Component, NgModule} from '@angular/core';
 
           @Component({
@@ -70,10 +74,10 @@ describe('compiler compliance: bindings', () => {
 
           @NgModule({declarations: [MyComponent]})
           export class MyModule {}`
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
       …
       consts: [[${AttributeMarker.Bindings}, "title"]],
       template:function MyComponent_Template(rf, $ctx$){
@@ -84,14 +88,14 @@ describe('compiler compliance: bindings', () => {
           $i0$.ɵɵproperty("title", $ctx$.title);
         }
       }`;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect property binding');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect property binding');
+      });
 
-    it('should generate interpolation instruction for {{...}} bindings', () => {
-      const files: MockDirectory = {
-        app: {
-          'example.ts': `
+      it('should generate interpolation instruction for {{...}} bindings', () => {
+        const files: MockDirectory = {
+          app: {
+            'example.ts': `
           import {Component, NgModule} from '@angular/core';
           @Component({
             selector: 'my-component',
@@ -104,10 +108,10 @@ describe('compiler compliance: bindings', () => {
           @NgModule({declarations: [MyComponent]})
           export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
       …
       consts: [[${AttributeMarker.Bindings}, "title"]],
       template:function MyComponent_Template(rf, $ctx$){
@@ -118,14 +122,14 @@ describe('compiler compliance: bindings', () => {
           $i0$.ɵɵpropertyInterpolate1("title", "Hello ", $ctx$.name, "");
         }
       }`;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect interpolated property binding');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect interpolated property binding');
+      });
 
-    it('should ignore empty bindings', () => {
-      const files: MockDirectory = {
-        app: {
-          'example.ts': `
+      it('should ignore empty bindings', () => {
+        const files: MockDirectory = {
+          app: {
+            'example.ts': `
             import {Component} from '@angular/core';
             @Component({
               selector: 'test',
@@ -133,17 +137,17 @@ describe('compiler compliance: bindings', () => {
             })
             class FooCmp {}
           `
-        }
-      };
-      const result = compile(files, angularFiles);
-      expect(result.source).not.toContain('i0.ɵɵproperty');
-    });
+          }
+        };
+        const result = compile(files, angularFiles);
+        expect(result.source).not.toContain('i0.ɵɵproperty');
+      });
 
-    it('should not remap property names whose names do not correspond to their attribute names',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should not remap property names whose names do not correspond to their attribute names',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -158,10 +162,10 @@ describe('compiler compliance: bindings', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-           }
-         };
+             }
+           };
 
-         const template = `
+           const template = `
       consts: [[${AttributeMarker.Bindings}, "for"]]
 
       // ...
@@ -175,22 +179,22 @@ describe('compiler compliance: bindings', () => {
         }
       }`;
 
-         const result = compile(files, angularFiles);
+           const result = compile(files, angularFiles);
 
-         expectEmit(result.source, template, 'Incorrect template');
-       });
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should emit temporary evaluation within the binding expression for in-order execution',
-       () => {
-         // https://github.com/angular/angular/issues/37194
-         // Verifies that temporary expressions used for expressions with potential side-effects in
-         // the LHS of a safe navigation access are emitted within the binding expression itself, to
-         // ensure that these temporaries are evaluated during the evaluation of the binding. This
-         // is important for when the LHS contains a pipe, as pipe evaluation depends on the current
-         // binding index.
-         const files = {
-           app: {
-             'example.ts': `
+      it('should emit temporary evaluation within the binding expression for in-order execution',
+         () => {
+           // https://github.com/angular/angular/issues/37194
+           // Verifies that temporary expressions used for expressions with potential side-effects
+           // in the LHS of a safe navigation access are emitted within the binding expression
+           // itself, to ensure that these temporaries are evaluated during the evaluation of the
+           // binding. This is important for when the LHS contains a pipe, as pipe evaluation
+           // depends on the current binding index.
+           const files = {
+             app: {
+               'example.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -200,11 +204,11 @@ describe('compiler compliance: bindings', () => {
               myTitle = 'hello';
               auth?: () => { identity(): any; };
             }`
-           }
-         };
+             }
+           };
 
-         const result = compile(files, angularFiles);
-         const template = `
+           const result = compile(files, angularFiles);
+           const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             …
@@ -215,13 +219,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-         expectEmit(result.source, template, 'Incorrect template');
-       });
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should chain multiple property bindings into a single instruction', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple property bindings into a single instruction', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -231,11 +235,11 @@ describe('compiler compliance: bindings', () => {
               myTitle = 'hello';
               buttonId = 'special-button';
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             …
@@ -245,24 +249,24 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain property bindings in the presence of other bindings', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain property bindings in the presence of other bindings', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Component} from '@angular/core';
 
             @Component({
               template: '<button [title]="1" [attr.id]="2" [tabindex]="3" aria-label="{{1 + 3}}"></button>'
             })
             export class MyComponent {}`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             …
@@ -274,24 +278,24 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should not add interpolated properties to the property instruction chain', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should not add interpolated properties to the property instruction chain', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Component} from '@angular/core';
 
             @Component({
               template: '<button [title]="1" [id]="2" tabindex="{{0 + 3}}" aria-label="hello-{{1 + 3}}-{{2 + 3}}"></button>'
             })
             export class MyComponent {}`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             …
@@ -303,13 +307,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain synthetic property bindings together with regular property bindings', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain synthetic property bindings together with regular property bindings', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -324,11 +328,11 @@ describe('compiler compliance: bindings', () => {
             export class MyComponent {
               expansionState = 'expanded';
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             …
@@ -338,13 +342,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain multiple property bindings on an ng-template', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple property bindings on an ng-template', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -354,11 +358,11 @@ describe('compiler compliance: bindings', () => {
               myTitle = 'hello';
               buttonId = 'custom-id';
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             …
@@ -368,13 +372,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain multiple property bindings when there are multiple elements', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple property bindings when there are multiple elements', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -388,11 +392,11 @@ describe('compiler compliance: bindings', () => {
               myTitle = 'hello';
               buttonId = 'special-button';
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             …
@@ -406,13 +410,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain multiple property bindings when there are child elements', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple property bindings when there are child elements', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -425,11 +429,11 @@ describe('compiler compliance: bindings', () => {
               myTitle = 'hello';
               buttonId = 'special-button';
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             …
@@ -441,15 +445,15 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
+        expectEmit(result.source, template, 'Incorrect template');
+      });
     });
-  });
 
-  describe('attribute bindings', () => {
-    it('should chain multiple attribute bindings into a single instruction', () => {
-      const files = {
-        app: {
-          'example.ts': `
+    describe('attribute bindings', () => {
+      it('should chain multiple attribute bindings into a single instruction', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -461,11 +465,11 @@ describe('compiler compliance: bindings', () => {
               myTitle = 'hello';
               buttonId = 'special-button';
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             …
@@ -475,13 +479,14 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain multiple single-interpolation attribute bindings into one instruction', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple single-interpolation attribute bindings into one instruction',
+         () => {
+           const files = {
+             app: {
+               'example.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -493,11 +498,11 @@ describe('compiler compliance: bindings', () => {
               myTitle = 'hello';
               buttonId = 'special-button';
             }`
-        }
-      };
+             }
+           };
 
-      const result = compile(files, angularFiles);
-      const template = `
+           const result = compile(files, angularFiles);
+           const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             …
@@ -507,13 +512,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should chain attribute bindings in the presence of other bindings', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain attribute bindings in the presence of other bindings', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -523,11 +528,11 @@ describe('compiler compliance: bindings', () => {
               \`
             })
             export class MyComponent {}`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             …
@@ -539,13 +544,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should not add interpolated attributes to the attribute instruction chain', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should not add interpolated attributes to the attribute instruction chain', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -557,11 +562,11 @@ describe('compiler compliance: bindings', () => {
                   attr.aria-label="hello-{{1 + 3}}-{{2 + 3}}"></button>\`
             })
             export class MyComponent {}`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             …
@@ -573,13 +578,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain multiple attribute bindings when there are multiple elements', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple attribute bindings when there are multiple elements', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -593,11 +598,11 @@ describe('compiler compliance: bindings', () => {
               myTitle = 'hello';
               buttonId = 'special-button';
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             …
@@ -611,13 +616,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain multiple attribute bindings when there are child elements', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple attribute bindings when there are child elements', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -630,11 +635,11 @@ describe('compiler compliance: bindings', () => {
               myTitle = 'hello';
               buttonId = 'special-button';
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           template: function MyComponent_Template(rf, ctx) {
             …
@@ -646,13 +651,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should exclude attribute bindings from the attributes array', () => {
-      const files: MockDirectory = {
-        app: {
-          'example.ts': `
+      it('should exclude attribute bindings from the attributes array', () => {
+        const files: MockDirectory = {
+          app: {
+            'example.ts': `
           import {Component, NgModule} from '@angular/core';
 
           @Component({
@@ -673,24 +678,24 @@ describe('compiler compliance: bindings', () => {
 
           @NgModule({declarations: [MyComponent]})
           export class MyModule {}`
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
         consts: [["target", "_blank", "aria-label", "link", ${
-          AttributeMarker.Bindings}, "title", "id", "customEvent"]],
+            AttributeMarker.Bindings}, "title", "id", "customEvent"]],
         …
       `;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect attribute array');
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect attribute array');
+      });
     });
-  });
 
-  describe('host bindings', () => {
-    it('should support host bindings', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+    describe('host bindings', () => {
+      it('should support host bindings', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Directive, HostBinding, NgModule} from '@angular/core';
 
             @Directive({selector: '[hostBindingDir]'})
@@ -701,10 +706,10 @@ describe('compiler compliance: bindings', () => {
             @NgModule({declarations: [HostBindingDir]})
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const HostBindingDirDeclaration = `
+        const HostBindingDirDeclaration = `
       HostBindingDir.ɵdir = $r3$.ɵɵdefineDirective({
         type: HostBindingDir,
         selectors: [["", "hostBindingDir", ""]],
@@ -717,16 +722,16 @@ describe('compiler compliance: bindings', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, HostBindingDirDeclaration, 'Invalid host binding code');
-    });
+        expectEmit(source, HostBindingDirDeclaration, 'Invalid host binding code');
+      });
 
-    it('should support host bindings with temporary expressions', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should support host bindings with temporary expressions', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Directive, NgModule} from '@angular/core';
 
             @Directive({
@@ -740,10 +745,10 @@ describe('compiler compliance: bindings', () => {
             @NgModule({declarations: [HostBindingDir]})
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const HostBindingDirDeclaration = `
+        const HostBindingDirDeclaration = `
       HostBindingDir.ɵdir = $r3$.ɵɵdefineDirective({
         type: HostBindingDir,
         selectors: [["", "hostBindingDir", ""]],
@@ -757,16 +762,16 @@ describe('compiler compliance: bindings', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, HostBindingDirDeclaration, 'Invalid host binding code');
-    });
+        expectEmit(source, HostBindingDirDeclaration, 'Invalid host binding code');
+      });
 
-    it('should support host bindings with pure functions', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should support host bindings with pure functions', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, NgModule} from '@angular/core';
 
             @Component({
@@ -783,10 +788,10 @@ describe('compiler compliance: bindings', () => {
             @NgModule({declarations: [HostBindingComp]})
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const HostBindingCompDeclaration = `
+        const HostBindingCompDeclaration = `
         const $ff$ = function ($v$) { return ["red", $v$]; };
         …
         HostBindingComp.ɵcmp = $r3$.ɵɵdefineComponent({
@@ -805,16 +810,16 @@ describe('compiler compliance: bindings', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, HostBindingCompDeclaration, 'Invalid host binding code');
-    });
+        expectEmit(source, HostBindingCompDeclaration, 'Invalid host binding code');
+      });
 
-    it('should support host attribute bindings', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should support host attribute bindings', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Directive, NgModule} from '@angular/core';
 
             @Directive({
@@ -830,10 +835,10 @@ describe('compiler compliance: bindings', () => {
             @NgModule({declarations: [HostAttributeDir]})
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const HostAttributeDirDeclaration = `
+        const HostAttributeDirDeclaration = `
         HostAttributeDir.ɵdir = $r3$.ɵɵdefineDirective({
           type: HostAttributeDir,
           selectors: [["", "hostAttributeDir", ""]],
@@ -846,16 +851,16 @@ describe('compiler compliance: bindings', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, HostAttributeDirDeclaration, 'Invalid host attribute code');
-    });
+        expectEmit(source, HostAttributeDirDeclaration, 'Invalid host attribute code');
+      });
 
-    it('should support host attributes', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should support host attributes', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Directive, NgModule} from '@angular/core';
 
             @Directive({
@@ -870,10 +875,10 @@ describe('compiler compliance: bindings', () => {
             @NgModule({declarations: [HostAttributeDir]})
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const HostAttributeDirDeclaration = `
+        const HostAttributeDirDeclaration = `
         HostAttributeDir.ɵdir = $r3$.ɵɵdefineDirective({
           type: HostAttributeDir,
           selectors: [["", "hostAttributeDir", ""]],
@@ -881,16 +886,16 @@ describe('compiler compliance: bindings', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, HostAttributeDirDeclaration, 'Invalid host attribute code');
-    });
+        expectEmit(source, HostAttributeDirDeclaration, 'Invalid host attribute code');
+      });
 
-    it('should support host attributes together with host classes and styles', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should support host attributes together with host classes and styles', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, Directive, NgModule} from '@angular/core';
 
             @Component({
@@ -920,37 +925,37 @@ describe('compiler compliance: bindings', () => {
             @NgModule({declarations: [HostAttributeComp, HostAttributeDir]})
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const CompAndDirDeclaration = `
+        const CompAndDirDeclaration = `
         HostAttributeComp.ɵcmp = $r3$.ɵɵdefineComponent({
           type: HostAttributeComp,
           selectors: [["my-host-attribute-component"]],
           hostAttrs: ["title", "hello there from component", ${
-          AttributeMarker.Styles}, "opacity", "1"],
+            AttributeMarker.Styles}, "opacity", "1"],
         …
         HostAttributeDir.ɵdir = $r3$.ɵɵdefineDirective({
           type: HostAttributeDir,
           selectors: [["", "hostAttributeDir", ""]],
           hostAttrs: ["title", "hello there from directive", ${
-          AttributeMarker.Classes}, "one", "two", ${
-          AttributeMarker.Styles}, "width", "200px", "height", "500px"],
+            AttributeMarker.Classes}, "one", "two", ${
+            AttributeMarker.Styles}, "width", "200px", "height", "500px"],
           hostVars: 4,
           hostBindings: function HostAttributeDir_HostBindings(rf, ctx) {
             …
           }
     `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
-      expectEmit(source, CompAndDirDeclaration, 'Invalid host attribute code');
-    });
+        const result = compile(files, angularFiles);
+        const source = result.source;
+        expectEmit(source, CompAndDirDeclaration, 'Invalid host attribute code');
+      });
 
-    it('should chain multiple host property bindings into a single instruction', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple host property bindings into a single instruction', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Directive} from '@angular/core';
 
             @Directive({
@@ -965,11 +970,11 @@ describe('compiler compliance: bindings', () => {
               myTitle = 'hello';
               myId = 'special-directive';
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           hostBindings: function MyDirective_HostBindings(rf, ctx) {
             …
@@ -979,13 +984,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain both host properties in the decorator and on the class', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain both host properties in the decorator and on the class', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Directive, HostBinding} from '@angular/core';
 
             @Directive({
@@ -1001,11 +1006,11 @@ describe('compiler compliance: bindings', () => {
               @HostBinding('id')
               myId = 'special-directive';
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           hostBindings: function MyDirective_HostBindings(rf, ctx) {
             …
@@ -1015,13 +1020,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain multiple host property bindings in the presence of other bindings', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple host property bindings in the presence of other bindings', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Directive} from '@angular/core';
 
             @Directive({
@@ -1033,11 +1038,11 @@ describe('compiler compliance: bindings', () => {
               }
             })
             export class MyDirective {}`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           hostBindings: function MyDirective_HostBindings(rf, ctx) {
             …
@@ -1048,13 +1053,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain multiple synthetic properties into a single instruction call', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple synthetic properties into a single instruction call', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Directive} from '@angular/core';
 
             @Directive({
@@ -1069,11 +1074,11 @@ describe('compiler compliance: bindings', () => {
               expandedState = 'collapsed';
               isSmall = true;
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
         …
         hostBindings: function MyDirective_HostBindings(rf, ctx) {
           …
@@ -1083,13 +1088,13 @@ describe('compiler compliance: bindings', () => {
         }
       `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain multiple host attribute bindings into a single instruction', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple host attribute bindings into a single instruction', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Directive} from '@angular/core';
 
             @Directive({
@@ -1104,11 +1109,11 @@ describe('compiler compliance: bindings', () => {
               myTitle = 'hello';
               myId = 'special-directive';
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           hostBindings: function MyDirective_HostBindings(rf, ctx) {
             …
@@ -1118,13 +1123,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain both host attributes in the decorator and on the class', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain both host attributes in the decorator and on the class', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Directive, HostBinding} from '@angular/core';
 
             @Directive({
@@ -1140,11 +1145,11 @@ describe('compiler compliance: bindings', () => {
               @HostBinding('attr.id')
               myId = 'special-directive';
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           hostBindings: function MyDirective_HostBindings(rf, ctx) {
             …
@@ -1154,13 +1159,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain multiple host attribute bindings in the presence of other bindings', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple host attribute bindings in the presence of other bindings', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Directive} from '@angular/core';
 
             @Directive({
@@ -1172,11 +1177,11 @@ describe('compiler compliance: bindings', () => {
               }
             })
             export class MyDirective {}`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
             …
             hostBindings: function MyDirective_HostBindings(rf, ctx) {
               …
@@ -1187,13 +1192,13 @@ describe('compiler compliance: bindings', () => {
             }
           `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain multiple host listeners into a single instruction', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple host listeners into a single instruction', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Directive, HostListener} from '@angular/core';
 
             @Directive({
@@ -1210,11 +1215,11 @@ describe('compiler compliance: bindings', () => {
               @HostListener('click')
               click() {}
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           hostBindings: function MyDirective_HostBindings(rf, ctx) {
             if (rf & 1) {
@@ -1223,13 +1228,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain multiple synthetic host listeners into a single instruction', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple synthetic host listeners into a single instruction', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Component, HostListener} from '@angular/core';
 
             @Component({
@@ -1243,11 +1248,11 @@ describe('compiler compliance: bindings', () => {
               @HostListener('@animation.start')
               start() {}
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
           …
           hostBindings: function MyComponent_HostBindings(rf, ctx) {
             if (rf & 1) {
@@ -1256,13 +1261,13 @@ describe('compiler compliance: bindings', () => {
           }
         `;
 
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain multiple regular and synthetic host listeners into two instructions', () => {
-      const files = {
-        app: {
-          'example.ts': `
+      it('should chain multiple regular and synthetic host listeners into two instructions', () => {
+        const files = {
+          app: {
+            'example.ts': `
             import {Component, HostListener} from '@angular/core';
 
             @Component({
@@ -1281,11 +1286,11 @@ describe('compiler compliance: bindings', () => {
               @HostListener('click')
               click() {}
             }`
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      const template = `
+        const result = compile(files, angularFiles);
+        const template = `
         …
         hostBindings: function MyComponent_HostBindings(rf, ctx) {
           if (rf & 1) {
@@ -1294,14 +1299,14 @@ describe('compiler compliance: bindings', () => {
           }
         }
       `;
-      expectEmit(result.source, template, 'Incorrect template');
+        expectEmit(result.source, template, 'Incorrect template');
+      });
     });
-  });
 
-  describe('non bindable behavior', () => {
-    const getAppFiles = (template: string = ''): MockDirectory => ({
-      app: {
-        'example.ts': `
+    describe('non bindable behavior', () => {
+      const getAppFiles = (template: string = ''): MockDirectory => ({
+        app: {
+          'example.ts': `
           import {Component, NgModule} from '@angular/core';
 
           @Component({
@@ -1314,11 +1319,11 @@ describe('compiler compliance: bindings', () => {
 
           @NgModule({declarations: [MyComponent]})
           export class MyModule {}`
-      }
-    });
+        }
+      });
 
-    it('should generate the proper update instructions for interpolated properties', () => {
-      const files: MockDirectory = getAppFiles(`
+      it('should generate the proper update instructions for interpolated properties', () => {
+        const files: MockDirectory = getAppFiles(`
         <div title="a{{one}}b{{two}}c{{three}}d{{four}}e{{five}}f{{six}}g{{seven}}h{{eight}}i{{nine}}j"></div>
         <div title="a{{one}}b{{two}}c{{three}}d{{four}}e{{five}}f{{six}}g{{seven}}h{{eight}}i"></div>
         <div title="a{{one}}b{{two}}c{{three}}d{{four}}e{{five}}f{{six}}g{{seven}}h"></div>
@@ -1331,7 +1336,7 @@ describe('compiler compliance: bindings', () => {
         <div title="{{one}}"></div>
       `);
 
-      const template = `
+        const template = `
       …
         if (rf & 2) {
           i0.ɵɵpropertyInterpolateV("title", ["a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i", ctx.nine, "j"]);
@@ -1356,13 +1361,13 @@ describe('compiler compliance: bindings', () => {
       }
       …
       `;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect handling of interpolated properties');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect handling of interpolated properties');
+      });
 
 
-    it('should generate the proper update instructions for interpolated attributes', () => {
-      const files: MockDirectory = getAppFiles(`
+      it('should generate the proper update instructions for interpolated attributes', () => {
+        const files: MockDirectory = getAppFiles(`
         <div attr.title="a{{one}}b{{two}}c{{three}}d{{four}}e{{five}}f{{six}}g{{seven}}h{{eight}}i{{nine}}j"></div>
         <div attr.title="a{{one}}b{{two}}c{{three}}d{{four}}e{{five}}f{{six}}g{{seven}}h{{eight}}i"></div>
         <div attr.title="a{{one}}b{{two}}c{{three}}d{{four}}e{{five}}f{{six}}g{{seven}}h"></div>
@@ -1375,7 +1380,7 @@ describe('compiler compliance: bindings', () => {
         <div attr.title="{{one}}"></div>
       `);
 
-      const template = `
+        const template = `
       …
         if (rf & 2) {
           i0.ɵɵattributeInterpolateV("title", ["a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i", ctx.nine, "j"]);
@@ -1400,19 +1405,19 @@ describe('compiler compliance: bindings', () => {
       }
       …
       `;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect handling of interpolated properties');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect handling of interpolated properties');
+      });
 
-    it('should keep local ref for host element', () => {
-      const files: MockDirectory = getAppFiles(`
+      it('should keep local ref for host element', () => {
+        const files: MockDirectory = getAppFiles(`
         <b ngNonBindable #myRef id="my-id">
           <i>Hello {{ name }}!</i>
         </b>
         {{ myRef.id }}
       `);
 
-      const template = `
+        const template = `
         …
         consts: [["id", "my-id"], ["myRef", ""]],
         template:function MyComponent_Template(rf, $ctx$){
@@ -1433,18 +1438,18 @@ describe('compiler compliance: bindings', () => {
           }
         }
       `;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect handling of local refs for host element');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect handling of local refs for host element');
+      });
 
-    it('should not have local refs for nested elements', () => {
-      const files: MockDirectory = getAppFiles(`
+      it('should not have local refs for nested elements', () => {
+        const files: MockDirectory = getAppFiles(`
        <div ngNonBindable>
          <input value="one" #myInput> {{ myInput.value }}
        </div>
       `);
 
-      const template = `
+        const template = `
         …
         consts: [["value", "one", "#myInput", ""]],
         template:function MyComponent_Template(rf, $ctx$){
@@ -1457,18 +1462,18 @@ describe('compiler compliance: bindings', () => {
             $i0$.ɵɵelementEnd();
         }
       `;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect handling of local refs for nested elements');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect handling of local refs for nested elements');
+      });
 
-    it('should not process property bindings and listeners', () => {
-      const files: MockDirectory = getAppFiles(`
+      it('should not process property bindings and listeners', () => {
+        const files: MockDirectory = getAppFiles(`
         <div ngNonBindable>
           <div [id]="my-id" (click)="onclick"></div>
         </div>
       `);
 
-      const template = `
+        const template = `
         …
         consts: [["[id]", "my-id", "(click)", "onclick"]],
         template:function MyComponent_Template(rf, $ctx$){
@@ -1480,24 +1485,26 @@ describe('compiler compliance: bindings', () => {
             $i0$.ɵɵelementEnd();
         }
       `;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect handling of property bindings and listeners');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(
+            result.source, template, 'Incorrect handling of property bindings and listeners');
+      });
 
-    it('should not generate extra instructions for elements with no children', () => {
-      const files: MockDirectory = getAppFiles(`
+      it('should not generate extra instructions for elements with no children', () => {
+        const files: MockDirectory = getAppFiles(`
         <div ngNonBindable></div>
       `);
 
-      const template = `
+        const template = `
         template:function MyComponent_Template(rf, $ctx$){
           if (rf & 1) {
             $i0$.ɵɵelement(0, "div");
           }
         }
       `;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect handling of elements with no children');
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect handling of elements with no children');
+      });
     });
   });
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
@@ -7,20 +7,24 @@
  */
 import {AttributeMarker} from '@angular/compiler/src/core';
 import {setup} from '@angular/compiler/test/aot/test_util';
-import {compile, expectEmit} from './mock_compile';
+import {createCompileFn, expectEmit} from './mock_compile';
+import {runInEachCompilationMode} from './test_runner';
 
-describe('compiler compliance: directives', () => {
-  const angularFiles = setup({
-    compileAngular: false,
-    compileAnimations: false,
-    compileFakeCore: true,
-  });
+runInEachCompilationMode(compilationMode => {
+  const compile = createCompileFn(compilationMode);
 
-  describe('matching', () => {
-    it('should not match directives on i18n attribute', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+  describe('compiler compliance: directives', () => {
+    const angularFiles = setup({
+      compileAngular: false,
+      compileAnimations: false,
+      compileFakeCore: true,
+    });
+
+    describe('matching', () => {
+      it('should not match directives on i18n attribute', () => {
+        const files = {
+          app: {
+            'spec.ts': `
                 import {Component, Directive, NgModule} from '@angular/core';
 
                 @Directive({selector: '[i18n]'})
@@ -31,11 +35,11 @@ describe('compiler compliance: directives', () => {
 
                 @NgModule({declarations: [I18nDirective, MyComponent]})
                 export class MyModule{}`
-        }
-      };
+          }
+        };
 
-      // MyComponent definition should be:
-      const MyComponentDefinition = `
+        // MyComponent definition should be:
+        const MyComponentDefinition = `
             MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
                 type: MyComponent,
                 selectors: [["my-component"]],
@@ -50,21 +54,21 @@ describe('compiler compliance: directives', () => {
             });
         `;
 
-      const MyComponentFactory = `
+        const MyComponentFactory = `
         MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
       `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
-      expectEmit(source, MyComponentFactory, 'Incorrect ChildComponent.ɵfac');
-    });
+        expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
+        expectEmit(source, MyComponentFactory, 'Incorrect ChildComponent.ɵfac');
+      });
 
-    it('should not match directives on i18n-prefixed attributes', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should not match directives on i18n-prefixed attributes', () => {
+        const files = {
+          app: {
+            'spec.ts': `
                 import {Component, Directive, NgModule} from '@angular/core';
 
                 @Directive({selector: '[i18n]'})
@@ -81,11 +85,11 @@ describe('compiler compliance: directives', () => {
 
                 @NgModule({declarations: [I18nDirective, I18nFooDirective, FooDirective, MyComponent]})
                 export class MyModule{}`
-        }
-      };
+          }
+        };
 
-      // MyComponent definition should be:
-      const MyComponentDefinition = `
+        // MyComponent definition should be:
+        const MyComponentDefinition = `
             MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
                 type: MyComponent,
                 selectors: [["my-component"]],
@@ -100,21 +104,21 @@ describe('compiler compliance: directives', () => {
             });
         `;
 
-      const MyComponentFactory = `
+        const MyComponentFactory = `
         MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
       `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
-      expectEmit(source, MyComponentFactory, 'Incorrect ChildComponent.ɵfac');
-    });
+        expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
+        expectEmit(source, MyComponentFactory, 'Incorrect ChildComponent.ɵfac');
+      });
 
-    it('should match directives on element bindings', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should match directives on element bindings', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, Directive, Input, NgModule} from '@angular/core';
 
             @Directive({selector: '[someDirective]'})
@@ -128,12 +132,12 @@ describe('compiler compliance: directives', () => {
             @NgModule({declarations: [SomeDirective, MyComponent]})
             export class MyModule{}
           `
-        }
-      };
+          }
+        };
 
 
-      // MyComponent definition should be:
-      const MyComponentDefinition = `
+        // MyComponent definition should be:
+        const MyComponentDefinition = `
           …
           MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
               …
@@ -152,16 +156,16 @@ describe('compiler compliance: directives', () => {
           });
       `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
-    });
+        expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
+      });
 
-    it('should match directives on ng-templates', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should match directives on ng-templates', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, Directive, NgModule, TemplateRef} from '@angular/core';
 
             @Directive({
@@ -182,10 +186,10 @@ describe('compiler compliance: directives', () => {
             @NgModule({declarations: [DirectiveA, MyComponent]})
             export class MyModule{}
           `
-        }
-      };
+          }
+        };
 
-      const MyComponentDefinition = `
+        const MyComponentDefinition = `
         …
         function MyComponent_ng_template_0_Template(rf, ctx) {
           if (rf & 1) {
@@ -207,14 +211,14 @@ describe('compiler compliance: directives', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
+      });
 
-    it('should match directives on ng-container', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should match directives on ng-container', () => {
+        const files = {
+          app: {
+            'spec.ts': `
               import {Component, Directive, NgModule, TemplateRef} from '@angular/core';
 
               @Directive({
@@ -235,10 +239,10 @@ describe('compiler compliance: directives', () => {
               @NgModule({declarations: [DirectiveA, MyComponent]})
               export class MyModule{}
             `
-        }
-      };
+          }
+        };
 
-      const MyComponentDefinition = `
+        const MyComponentDefinition = `
         …
         function MyComponent_ng_container_0_Template(rf, ctx) {
           if (rf & 1) {
@@ -265,14 +269,14 @@ describe('compiler compliance: directives', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
+      });
 
-    it('should match directives on ng-template bindings', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should match directives on ng-template bindings', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, Directive, Input, NgModule} from '@angular/core';
 
             @Directive({selector: '[someDirective]'})
@@ -286,12 +290,12 @@ describe('compiler compliance: directives', () => {
             @NgModule({declarations: [SomeDirective, MyComponent]})
             export class MyModule{}
           `
-        }
-      };
+          }
+        };
 
 
-      // MyComponent definition should be:
-      const MyComponentDefinition = `
+        // MyComponent definition should be:
+        const MyComponentDefinition = `
         …
         MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
             …
@@ -310,16 +314,16 @@ describe('compiler compliance: directives', () => {
         });
     `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
-    });
+        expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
+      });
 
-    it('should match structural directives', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should match structural directives', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, Directive, Input, NgModule} from '@angular/core';
 
             @Directive({selector: '[someDirective]'})
@@ -333,11 +337,11 @@ describe('compiler compliance: directives', () => {
             @NgModule({declarations: [SomeDirective, MyComponent]})
             export class MyModule{}
           `
-        }
-      };
+          }
+        };
 
-      // MyComponent definition should be:
-      const MyComponentDefinition = `
+        // MyComponent definition should be:
+        const MyComponentDefinition = `
           …
           MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
               …
@@ -353,16 +357,16 @@ describe('compiler compliance: directives', () => {
           });
       `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
-    });
+        expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
+      });
 
-    it('should match directives on element outputs', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should match directives on element outputs', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, Directive, Output, EventEmitter, NgModule} from '@angular/core';
 
             @Directive({selector: '[someDirective]'})
@@ -378,12 +382,12 @@ describe('compiler compliance: directives', () => {
             @NgModule({declarations: [SomeDirective, MyComponent]})
             export class MyModule{}
           `
-        }
-      };
+          }
+        };
 
 
-      // MyComponent definition should be:
-      const MyComponentDefinition = `
+        // MyComponent definition should be:
+        const MyComponentDefinition = `
         …
         MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
             …
@@ -401,10 +405,11 @@ describe('compiler compliance: directives', () => {
         });
     `;
 
-      const result = compile(files, angularFiles);
-      const source = result.source;
+        const result = compile(files, angularFiles);
+        const source = result.source;
 
-      expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
+        expectEmit(source, MyComponentDefinition, 'Incorrect ChildComponent.ɵcmp');
+      });
     });
   });
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_input_outputs_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_input_outputs_spec.ts
@@ -7,19 +7,23 @@
  */
 
 import {MockDirectory, setup} from '@angular/compiler/test/aot/test_util';
-import {compile, expectEmit} from './mock_compile';
+import {createCompileFn, expectEmit} from './mock_compile';
+import {runInEachCompilationMode} from './test_runner';
 
-describe('compiler compliance: listen()', () => {
-  const angularFiles = setup({
-    compileAngular: false,
-    compileFakeCore: true,
-    compileAnimations: false,
-  });
+runInEachCompilationMode(compilationMode => {
+  const compile = createCompileFn(compilationMode);
 
-  it('should declare inputs/outputs', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+  describe('compiler compliance: listen()', () => {
+    const angularFiles = setup({
+      compileAngular: false,
+      compileFakeCore: true,
+      compileAnimations: false,
+    });
+
+    it('should declare inputs/outputs', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, Directive, NgModule, Input, Output} from '@angular/core';
 
               @Component({
@@ -48,10 +52,10 @@ describe('compiler compliance: listen()', () => {
               @NgModule({declarations: [MyComponent, MyDirective]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const componentDef = `
+      const componentDef = `
       MyComponent.ɵcmp = IDENT.ɵɵdefineComponent({
           …
           inputs:{
@@ -65,7 +69,7 @@ describe('compiler compliance: listen()', () => {
           …
         });`;
 
-    const directiveDef = `
+      const directiveDef = `
       MyDirective.ɵdir = IDENT.ɵɵdefineDirective({
         …
         inputs:{
@@ -80,9 +84,10 @@ describe('compiler compliance: listen()', () => {
       });`;
 
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, componentDef, 'Incorrect component definition');
-    expectEmit(result.source, directiveDef, 'Incorrect directive definition');
+      expectEmit(result.source, componentDef, 'Incorrect component definition');
+      expectEmit(result.source, directiveDef, 'Incorrect directive definition');
+    });
   });
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -7,22 +7,26 @@
  */
 import {AttributeMarker} from '@angular/compiler/src/core';
 import {setup} from '@angular/compiler/test/aot/test_util';
-import {compile, expectEmit} from './mock_compile';
+import {createCompileFn, expectEmit} from './mock_compile';
+import {runInEachCompilationMode} from './test_runner';
 
 /* These tests are codified version of the tests in compiler_canonical_spec.ts. Every
  * test in compiler_canonical_spec.ts should have a corresponding test here.
  */
-describe('compiler compliance: listen()', () => {
-  const angularFiles = setup({
-    compileAngular: false,
-    compileFakeCore: true,
-    compileAnimations: false,
-  });
+runInEachCompilationMode(compilationMode => {
+  const compile = createCompileFn(compilationMode);
 
-  it('should create listener instruction on element', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+  describe('compiler compliance: listen()', () => {
+    const angularFiles = setup({
+      compileAngular: false,
+      compileFakeCore: true,
+      compileAnimations: false,
+    });
+
+    it('should create listener instruction on element', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -36,11 +40,11 @@ describe('compiler compliance: listen()', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    // The template should look like this (where IDENT is a wild card for an identifier):
-    const template = `
+      // The template should look like this (where IDENT is a wild card for an identifier):
+      const template = `
         …
         consts: [[${AttributeMarker.Bindings}, "click"]],
         template: function MyComponent_Template(rf, ctx) {
@@ -55,15 +59,15 @@ describe('compiler compliance: listen()', () => {
         }
         `;
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should create listener instruction on other components', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should create listener instruction on other components', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -83,10 +87,10 @@ describe('compiler compliance: listen()', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
         …
         consts: [[${AttributeMarker.Bindings}, "click"]],
         template: function MyComponent_Template(rf, ctx) {
@@ -100,15 +104,15 @@ describe('compiler compliance: listen()', () => {
         }
         `;
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should create multiple listener instructions that share a view snapshot', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should create multiple listener instructions that share a view snapshot', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -129,10 +133,10 @@ describe('compiler compliance: listen()', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
         function MyComponent_div_0_Template(rf, ctx) {
           if (rf & 1) {
             const $s$ = $r3$.ɵɵgetCurrentView();
@@ -166,15 +170,15 @@ describe('compiler compliance: listen()', () => {
         }
         `;
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('local refs in listeners defined before the local refs', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('local refs in listeners defined before the local refs', () => {
+      const files = {
+        app: {
+          'spec.ts': `
             import {Component, NgModule} from '@angular/core';
 
             @Component({
@@ -189,10 +193,10 @@ describe('compiler compliance: listen()', () => {
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const MyComponentDefinition = `
+      const MyComponentDefinition = `
         …
         MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           type: MyComponent,
@@ -218,21 +222,21 @@ describe('compiler compliance: listen()', () => {
         });
       `;
 
-    const MyComponentFactory = `
+      const MyComponentFactory = `
       MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
     `;
 
-    const result = compile(files, angularFiles);
-    const source = result.source;
+      const result = compile(files, angularFiles);
+      const source = result.source;
 
-    expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ɵcmp');
-    expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ɵfac');
-  });
+      expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ɵcmp');
+      expectEmit(source, MyComponentFactory, 'Incorrect MyComponent.ɵfac');
+    });
 
-  it('should chain multiple listeners on the same element', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should chain multiple listeners on the same element', () => {
+      const files = {
+        app: {
+          'spec.ts': `
             import {Component, NgModule} from '@angular/core';
 
             @Component({
@@ -245,10 +249,10 @@ describe('compiler compliance: listen()', () => {
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
         …
         consts: [[${AttributeMarker.Bindings}, "click", "change"]],
         template: function MyComponent_Template(rf, ctx) {
@@ -264,14 +268,14 @@ describe('compiler compliance: listen()', () => {
         }
         `;
 
-    const result = compile(files, angularFiles);
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should chain multiple listeners across elements', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should chain multiple listeners across elements', () => {
+      const files = {
+        app: {
+          'spec.ts': `
             import {Component, NgModule} from '@angular/core';
 
             @Component({
@@ -287,13 +291,13 @@ describe('compiler compliance: listen()', () => {
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
         …
         consts: [[${AttributeMarker.Bindings}, "click", "change"], [${
-        AttributeMarker.Bindings}, "update", "delete"]],
+          AttributeMarker.Bindings}, "update", "delete"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵelementStart(0, "div", 0);
@@ -306,14 +310,14 @@ describe('compiler compliance: listen()', () => {
         }
         `;
 
-    const result = compile(files, angularFiles);
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should chain multiple listeners on the same template', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should chain multiple listeners on the same template', () => {
+      const files = {
+        app: {
+          'spec.ts': `
             import {Component, NgModule} from '@angular/core';
 
             @Component({
@@ -326,10 +330,10 @@ describe('compiler compliance: listen()', () => {
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
         …
         consts: [[${AttributeMarker.Bindings}, "click", "change"]],
         template: function MyComponent_Template(rf, ctx) {
@@ -340,14 +344,14 @@ describe('compiler compliance: listen()', () => {
         }
         `;
 
-    const result = compile(files, angularFiles);
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should not generate the $event argument if it is not being used in a template', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should not generate the $event argument if it is not being used in a template', () => {
+      const files = {
+        app: {
+          'spec.ts': `
           import {Component} from '@angular/core';
 
           @Component({
@@ -357,10 +361,10 @@ describe('compiler compliance: listen()', () => {
             onClick() {}
           }
         `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
       …
       consts: [[${AttributeMarker.Bindings}, "click"]],
       template: function MyComponent_Template(rf, ctx) {
@@ -374,15 +378,15 @@ describe('compiler compliance: listen()', () => {
       }
     `;
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should not generate the $event argument if it is not being used in a host listener', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should not generate the $event argument if it is not being used in a host listener', () => {
+      const files = {
+        app: {
+          'spec.ts': `
           import {Component, HostListener} from '@angular/core';
 
           @Component({
@@ -398,10 +402,10 @@ describe('compiler compliance: listen()', () => {
             click() {}
           }
         `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
       …
       hostBindings: function MyComponent_HostBindings(rf, ctx) {
         if (rf & 1) {
@@ -414,14 +418,14 @@ describe('compiler compliance: listen()', () => {
       }
     `;
 
-    const result = compile(files, angularFiles);
-    expectEmit(result.source, template, 'Incorrect host bindings');
-  });
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect host bindings');
+    });
 
-  it('should generate the $event argument if it is being used in a host listener', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should generate the $event argument if it is being used in a host listener', () => {
+      const files = {
+        app: {
+          'spec.ts': `
           import {Directive, HostListener} from '@angular/core';
 
           @Directive()
@@ -430,10 +434,10 @@ describe('compiler compliance: listen()', () => {
             click(t: EventTarget) {}
           }
         `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
       …
       hostBindings: function MyComponent_HostBindings(rf, ctx) {
         if (rf & 1) {
@@ -444,7 +448,8 @@ describe('compiler compliance: listen()', () => {
       }
     `;
 
-    const result = compile(files, angularFiles);
-    expectEmit(result.source, template, 'Incorrect host bindings');
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect host bindings');
+    });
   });
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_providers_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_providers_spec.ts
@@ -7,19 +7,23 @@
  */
 
 import {setup} from '@angular/compiler/test/aot/test_util';
-import {compile, expectEmit} from './mock_compile';
+import {createCompileFn, expectEmit} from './mock_compile';
+import {runInEachCompilationMode} from './test_runner';
 
-describe('compiler compliance: providers', () => {
-  const angularFiles = setup({
-    compileAngular: false,
-    compileFakeCore: true,
-    compileAnimations: false,
-  });
+runInEachCompilationMode(compilationMode => {
+  const compile = createCompileFn(compilationMode);
 
-  it('should emit the ProvidersFeature feature when providers and viewProviders', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+  describe('compiler compliance: providers', () => {
+    const angularFiles = setup({
+      compileAngular: false,
+      compileFakeCore: true,
+      compileAnimations: false,
+    });
+
+    it('should emit the ProvidersFeature feature when providers and viewProviders', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               abstract class Greeter { abstract greet(): string; }
@@ -40,20 +44,20 @@ describe('compiler compliance: providers', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const result = compile(files, angularFiles);
-    expectEmit(
-        result.source,
-        'features: [i0.ɵɵProvidersFeature([GreeterEN, {provide: Greeter, useClass: GreeterEN}], [GreeterEN])],',
-        'Incorrect features');
-  });
+      const result = compile(files, angularFiles);
+      expectEmit(
+          result.source,
+          'features: [i0.ɵɵProvidersFeature([GreeterEN, {provide: Greeter, useClass: GreeterEN}], [GreeterEN])],',
+          'Incorrect features');
+    });
 
-  it('should emit the ProvidersFeature feature when providers only', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should emit the ProvidersFeature feature when providers only', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               abstract class Greeter { abstract greet(): string; }
@@ -73,20 +77,20 @@ describe('compiler compliance: providers', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const result = compile(files, angularFiles);
-    expectEmit(
-        result.source,
-        'features: [i0.ɵɵProvidersFeature([GreeterEN, {provide: Greeter, useClass: GreeterEN}])],',
-        'Incorrect features');
-  });
+      const result = compile(files, angularFiles);
+      expectEmit(
+          result.source,
+          'features: [i0.ɵɵProvidersFeature([GreeterEN, {provide: Greeter, useClass: GreeterEN}])],',
+          'Incorrect features');
+    });
 
-  it('should emit the ProvidersFeature feature when viewProviders only', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should emit the ProvidersFeature feature when viewProviders only', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               abstract class Greeter { abstract greet(): string; }
@@ -106,18 +110,19 @@ describe('compiler compliance: providers', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const result = compile(files, angularFiles);
-    expectEmit(
-        result.source, 'features: [i0.ɵɵProvidersFeature([], [GreeterEN])],', 'Incorrect features');
-  });
+      const result = compile(files, angularFiles);
+      expectEmit(
+          result.source, 'features: [i0.ɵɵProvidersFeature([], [GreeterEN])],',
+          'Incorrect features');
+    });
 
-  it('should not emit the ProvidersFeature feature when no providers', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should not emit the ProvidersFeature feature when no providers', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               abstract class Greeter { abstract greet(): string; }
@@ -136,12 +141,12 @@ describe('compiler compliance: providers', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const result = compile(files, angularFiles);
-    expectEmit(
-        result.source, `
+      const result = compile(files, angularFiles);
+      expectEmit(
+          result.source, `
         export class MyComponent {
         }
         MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
@@ -157,6 +162,7 @@ describe('compiler compliance: providers', () => {
           },
           encapsulation: 2
         });`,
-        'Incorrect features');
+          'Incorrect features');
+    });
   });
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_spec.ts
@@ -7,20 +7,24 @@
  */
 
 import {MockDirectory, setup} from '@angular/compiler/test/aot/test_util';
-import {compile, expectEmit} from './mock_compile';
+import {createCompileFn, expectEmit} from './mock_compile';
+import {runInEachCompilationMode} from './test_runner';
 
-describe('r3_view_compiler', () => {
-  const angularFiles = setup({
-    compileAngular: false,
-    compileFakeCore: true,
-    compileAnimations: false,
-  });
+runInEachCompilationMode(compilationMode => {
+  const compile = createCompileFn(compilationMode);
 
-  describe('hello world', () => {
-    it('should be able to generate the hello world component', () => {
-      const files: MockDirectory = {
-        app: {
-          'hello.ts': `
+  describe('r3_view_compiler', () => {
+    const angularFiles = setup({
+      compileAngular: false,
+      compileFakeCore: true,
+      compileAnimations: false,
+    });
+
+    describe('hello world', () => {
+      it('should be able to generate the hello world component', () => {
+        const files: MockDirectory = {
+          app: {
+            'hello.ts': `
            import {Component, NgModule} from '@angular/core';
 
            @Component({
@@ -36,16 +40,16 @@ describe('r3_view_compiler', () => {
            })
            export class HelloWorldModule {}
         `
-        }
-      };
-      compile(files, angularFiles);
+          }
+        };
+        compile(files, angularFiles);
+      });
     });
-  });
 
-  it('should be able to generate the example', () => {
-    const files: MockDirectory = {
-      app: {
-        'example.ts': `
+    it('should be able to generate the example', () => {
+      const files: MockDirectory = {
+        app: {
+          'example.ts': `
         import {Component, OnInit, OnDestroy, ElementRef, Input, NgModule} from '@angular/core';
 
         @Component({
@@ -85,18 +89,19 @@ describe('r3_view_compiler', () => {
         })
         export class TodoModule{}
         `
-      }
-    };
-    const result = compile(files, angularFiles);
-    expect(result.source).toContain('@angular/core');
-  });
+        }
+      };
+      const result = compile(files, angularFiles);
+      expect(result.source).toContain('@angular/core');
+    });
 
-  describe('interpolations', () => {
-    // Regression #21927
-    it('should generate a correct call to textInterpolateV with more than 8 interpolations', () => {
-      const files: MockDirectory = {
-        app: {
-          'example.ts': `
+    describe('interpolations', () => {
+      // Regression #21927
+      it('should generate a correct call to textInterpolateV with more than 8 interpolations',
+         () => {
+           const files: MockDirectory = {
+             app: {
+               'example.ts': `
           import {Component, NgModule} from '@angular/core';
 
           @Component({
@@ -109,10 +114,10 @@ describe('r3_view_compiler', () => {
 
           @NgModule({declarations: [MyApp]})
           export class MyModule {}`
-        }
-      };
+             }
+           };
 
-      const bV_call = `
+           const bV_call = `
       …
       function MyApp_Template(rf, ctx) {
         if (rf & 1) {
@@ -124,16 +129,16 @@ describe('r3_view_compiler', () => {
       }
       …
       `;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, bV_call, 'Incorrect bV call');
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, bV_call, 'Incorrect bV call');
+         });
     });
-  });
 
-  describe('animations', () => {
-    it('should not register any @attr attributes as static attributes', () => {
-      const files: MockDirectory = {
-        app: {
-          'example.ts': `
+    describe('animations', () => {
+      it('should not register any @attr attributes as static attributes', () => {
+        const files: MockDirectory = {
+          app: {
+            'example.ts': `
           import {Component, NgModule} from '@angular/core';
 
           @Component({
@@ -145,10 +150,10 @@ describe('r3_view_compiler', () => {
 
           @NgModule({declarations: [MyApp]})
           export class MyModule {}`
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
       template: function MyApp_Template(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵɵelement(0, "div");
@@ -157,14 +162,14 @@ describe('r3_view_compiler', () => {
           $i0$.ɵɵproperty("@attr", …)("@binding", …);
         }
       }`;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect initialization attributes');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect initialization attributes');
+      });
 
-    it('should dedup multiple [@event] listeners', () => {
-      const files: MockDirectory = {
-        app: {
-          'example.ts': `
+      it('should dedup multiple [@event] listeners', () => {
+        const files: MockDirectory = {
+          app: {
+            'example.ts': `
           import {Component, NgModule} from '@angular/core';
 
           @Component({
@@ -176,10 +181,10 @@ describe('r3_view_compiler', () => {
 
           @NgModule({declarations: [MyApp]})
           export class MyModule {}`
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
       template: function MyApp_Template(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵɵelementStart(0, "div");
@@ -187,8 +192,9 @@ describe('r3_view_compiler', () => {
           $i0$.ɵɵproperty("@mySelector", …);
         }
       }`;
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect initialization attributes');
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect initialization attributes');
+      });
     });
   });
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -8,21 +8,25 @@
 
 import {AttributeMarker} from '@angular/compiler/src/core';
 import {setup} from '@angular/compiler/test/aot/test_util';
-import {compile, expectEmit} from './mock_compile';
+import {createCompileFn, expectEmit} from './mock_compile';
+import {runInEachCompilationMode} from './test_runner';
 
-describe('compiler compliance: styling', () => {
-  const angularFiles = setup({
-    compileAngular: false,
-    compileFakeCore: true,
-    compileAnimations: false,
-  });
+runInEachCompilationMode(compilationMode => {
+  const compile = createCompileFn(compilationMode);
 
-  describe('@Component.styles', () => {
-    it('should pass in the component metadata styles into the component definition and shim them using style encapsulation',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+  describe('compiler compliance: styling', () => {
+    const angularFiles = setup({
+      compileAngular: false,
+      compileFakeCore: true,
+      compileAnimations: false,
+    });
+
+    describe('@Component.styles', () => {
+      it('should pass in the component metadata styles into the component definition and shim them using style encapsulation',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -36,20 +40,20 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-           }
-         };
+             }
+           };
 
-         const template =
-             'styles: ["div.foo[_ngcontent-%COMP%] { color: red; }", "[_nghost-%COMP%]   p[_ngcontent-%COMP%]:nth-child(even) { --webkit-transition: 1s linear all; }"]';
-         const result = compile(files, angularFiles);
-         expectEmit(result.source, template, 'Incorrect template');
-       });
+           const template =
+               'styles: ["div.foo[_ngcontent-%COMP%] { color: red; }", "[_nghost-%COMP%]   p[_ngcontent-%COMP%]:nth-child(even) { --webkit-transition: 1s linear all; }"]';
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should pass in styles, but skip shimming the styles if the view encapsulation signals not to',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should pass in styles, but skip shimming the styles if the view encapsulation signals not to',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
                 import {Component, NgModule, ViewEncapsulation} from '@angular/core';
 
                 @Component({
@@ -64,19 +68,19 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-           }
-         };
+             }
+           };
 
-         const template = 'div.tall { height: 123px; }", ":host.small p { height:5px; }';
-         const result = compile(files, angularFiles);
-         expectEmit(result.source, template, 'Incorrect template');
-       });
+           const template = 'div.tall { height: 123px; }", ":host.small p { height:5px; }';
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should pass in the component metadata styles into the component definition but skip shimming when style encapsulation is set to native',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should pass in the component metadata styles into the component definition but skip shimming when style encapsulation is set to native',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
                 import {Component, NgModule, ViewEncapsulation} from '@angular/core';
 
                 @Component({
@@ -91,26 +95,26 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-           }
-         };
+             }
+           };
 
-         const template = `
+           const template = `
          MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
            …
            styles: ["div.cool { color: blue; }", ":host.nice p { color: gold; }"],
            encapsulation: 1
          })
          `;
-         const result = compile(files, angularFiles);
-         expectEmit(result.source, template, 'Incorrect template');
-       });
-  });
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, template, 'Incorrect template');
+         });
+    });
 
-  describe('@Component.animations', () => {
-    it('should pass in the component metadata animations into the component definition', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+    describe('@Component.animations', () => {
+      it('should pass in the component metadata animations into the component definition', () => {
+        const files = {
+          app: {
+            'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -124,10 +128,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
         MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           type: MyComponent,
           selectors:[["my-component"]],
@@ -142,14 +146,14 @@ describe('compiler compliance: styling', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should include animations even if the provided array is empty', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should include animations even if the provided array is empty', () => {
+        const files = {
+          app: {
+            'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -163,10 +167,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
         MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           type: MyComponent,
           selectors:[["my-component"]],
@@ -181,14 +185,14 @@ describe('compiler compliance: styling', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should generate any animation triggers into the component template', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should generate any animation triggers into the component template', () => {
+        const files = {
+          app: {
+            'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -204,10 +208,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
         …
         MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           …
@@ -231,14 +235,14 @@ describe('compiler compliance: styling', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should generate animation listeners', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should generate animation listeners', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, NgModule} from '@angular/core';
 
             @Component({
@@ -265,10 +269,10 @@ describe('compiler compliance: styling', () => {
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
         …
         MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           …
@@ -288,14 +292,14 @@ describe('compiler compliance: styling', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should generate animation host binding and listener code for directives', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should generate animation host binding and listener code for directives', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Directive, Component, NgModule} from '@angular/core';
 
             @Directive({
@@ -327,10 +331,10 @@ describe('compiler compliance: styling', () => {
             @NgModule({declarations: [MyComponent, MyAnimDir]})
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
         MyAnimDir.ɵdir = $r3$.ɵɵdefineDirective({
           …
           hostVars: 1,
@@ -346,16 +350,16 @@ describe('compiler compliance: styling', () => {
         });
       `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
     });
-  });
 
-  describe('[style] and [style.prop]', () => {
-    it('should create style instructions on the element', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+    describe('[style] and [style.prop]', () => {
+      it('should create style instructions on the element', () => {
+        const files = {
+          app: {
+            'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -369,10 +373,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
           template: function MyComponent_Template(rf, $ctx$) {
             if (rf & 1) {
               $r3$.ɵɵelement(0, "div");
@@ -383,15 +387,15 @@ describe('compiler compliance: styling', () => {
           }
           `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should correctly count the total slots required when style/class bindings include interpolation',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should correctly count the total slots required when style/class bindings include interpolation',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -428,10 +432,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponentWithInterpolation, MyComponentWithMuchosInterpolation, MyComponentWithoutInterpolation]})
                 export class MyModule {}
             `
-           }
-         };
+             }
+           };
 
-         const template = `
+           const template = `
         …
           decls: 1,
           vars: 3,
@@ -467,15 +471,15 @@ describe('compiler compliance: styling', () => {
           }
           `;
 
-         const result = compile(files, angularFiles);
-         expectEmit(result.source, template, 'Incorrect template');
-       });
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should place initial, multi, singular and application followed by attribute style instructions in the template code in that order',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should place initial, multi, singular and application followed by attribute style instructions in the template code in that order',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -495,10 +499,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-           }
-         };
+             }
+           };
 
-         const template = `
+           const template = `
           …
           MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
               type: MyComponent,
@@ -520,15 +524,15 @@ describe('compiler compliance: styling', () => {
             });
         `;
 
-         const result = compile(files, angularFiles);
-         expectEmit(result.source, template, 'Incorrect template');
-       });
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should assign a sanitizer instance to the element style allocation instruction if any url-based properties are detected',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should assign a sanitizer instance to the element style allocation instruction if any url-based properties are detected',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -542,10 +546,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-           }
-         };
+             }
+           };
 
-         const template = `
+           const template = `
           MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
             type: MyComponent,
             selectors: [["my-component"]],
@@ -563,14 +567,14 @@ describe('compiler compliance: styling', () => {
           });
         `;
 
-         const result = compile(files, angularFiles);
-         expectEmit(result.source, template, 'Incorrect template');
-       });
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should support [style.foo.suffix] style bindings with a suffix', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should support [style.foo.suffix] style bindings with a suffix', () => {
+        const files = {
+          app: {
+            'spec.ts': `
              import {Component, NgModule} from '@angular/core';
 
              @Component({
@@ -583,10 +587,10 @@ describe('compiler compliance: styling', () => {
              @NgModule({declarations: [MyComponent]})
              export class MyModule {}
          `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
           template:  function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵɵelement(0, "div");
@@ -597,14 +601,14 @@ describe('compiler compliance: styling', () => {
           }
      `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should not create instructions for empty style bindings', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should not create instructions for empty style bindings', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, NgModule} from '@angular/core';
 
             @Component({
@@ -617,19 +621,19 @@ describe('compiler compliance: styling', () => {
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      expect(result.source).not.toContain('styling');
+        const result = compile(files, angularFiles);
+        expect(result.source).not.toContain('styling');
+      });
     });
-  });
 
-  describe('[class]', () => {
-    it('should create class styling instructions on the element', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+    describe('[class]', () => {
+      it('should create class styling instructions on the element', () => {
+        const files = {
+          app: {
+            'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -643,10 +647,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
           template: function MyComponent_Template(rf, $ctx$) {
             if (rf & 1) {
               $r3$.ɵɵelement(0, "div");
@@ -657,15 +661,15 @@ describe('compiler compliance: styling', () => {
           }
           `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should place initial, multi, singular and application followed by attribute class instructions in the template code in that order',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should place initial, multi, singular and application followed by attribute class instructions in the template code in that order',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -685,10 +689,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-           }
-         };
+             }
+           };
 
-         const template = `
+           const template = `
           …
           MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
               type: MyComponent,
@@ -710,15 +714,15 @@ describe('compiler compliance: styling', () => {
             });
         `;
 
-         const result = compile(files, angularFiles);
-         expectEmit(result.source, template, 'Incorrect template');
-       });
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should not generate the styling apply instruction if there are only static style/class attributes',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should not generate the styling apply instruction if there are only static style/class attributes',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -733,10 +737,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-           }
-         };
+             }
+           };
 
-         const template = `
+           const template = `
           …
           MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
               type: MyComponent,
@@ -744,7 +748,7 @@ describe('compiler compliance: styling', () => {
               decls: 1,
               vars: 2,
               consts: [[${AttributeMarker.Classes}, "foo", ${
-             AttributeMarker.Styles}, "width", "100px"]],
+               AttributeMarker.Styles}, "width", "100px"]],
               template:  function MyComponent_Template(rf, $ctx$) {
                 if (rf & 1) {
                   $r3$.ɵɵelement(0, "div", 0);
@@ -757,14 +761,14 @@ describe('compiler compliance: styling', () => {
             });
         `;
 
-         const result = compile(files, angularFiles);
-         expectEmit(result.source, template, 'Incorrect template');
-       });
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should not create instructions for empty class bindings', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should not create instructions for empty class bindings', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, NgModule} from '@angular/core';
 
             @Component({
@@ -777,19 +781,19 @@ describe('compiler compliance: styling', () => {
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const result = compile(files, angularFiles);
-      expect(result.source).not.toContain('styling');
+        const result = compile(files, angularFiles);
+        expect(result.source).not.toContain('styling');
+      });
     });
-  });
 
-  describe('[style] mixed with [class]', () => {
-    it('should split [style] and [class] bindings into a separate instructions', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+    describe('[style] mixed with [class]', () => {
+      it('should split [style] and [class] bindings into a separate instructions', () => {
+        const files = {
+          app: {
+            'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -804,10 +808,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
           template: function MyComponent_Template(rf, $ctx$) {
             if (rf & 1) {
               $r3$.ɵɵelement(0, "div");
@@ -819,15 +823,15 @@ describe('compiler compliance: styling', () => {
           }
           `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should stamp out pipe definitions in the creation block if used by styling bindings',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should stamp out pipe definitions in the creation block if used by styling bindings',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -842,10 +846,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-           }
-         };
+             }
+           };
 
-         const template = `
+           const template = `
           template: function MyComponent_Template(rf, $ctx$) {
             if (rf & 1) {
               $r3$.ɵɵelementStart(0, "div");
@@ -860,14 +864,14 @@ describe('compiler compliance: styling', () => {
           }
           `;
 
-         const result = compile(files, angularFiles);
-         expectEmit(result.source, template, 'Incorrect template');
-       });
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should properly offset multiple style pipe references for styling bindings', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should properly offset multiple style pipe references for styling bindings', () => {
+        const files = {
+          app: {
+            'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -891,10 +895,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
           template: function MyComponent_Template(rf, $ctx$) {
             if (rf & 1) {
               $r3$.ɵɵelementStart(0, "div");
@@ -916,14 +920,14 @@ describe('compiler compliance: styling', () => {
           }
           `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should always generate select() statements before any styling instructions', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should always generate select() statements before any styling instructions', () => {
+        const files = {
+          app: {
+            'spec.ts': `
                 import {Component, NgModule} from '@angular/core';
 
                 @Component({
@@ -945,10 +949,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
           …
           template: function MyComponent_Template(rf, $ctx$) {
             …
@@ -964,16 +968,17 @@ describe('compiler compliance: styling', () => {
           }
           `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
     });
-  });
 
-  describe('@Component host styles/classes', () => {
-    it('should generate style/class instructions for a host component creation definition', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+    describe('@Component host styles/classes', () => {
+      it('should generate style/class instructions for a host component creation definition',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
                 import {Component, NgModule, HostBinding} from '@angular/core';
 
                 @Component({
@@ -1001,12 +1006,12 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-        }
-      };
+             }
+           };
 
-      const template = `
+           const template = `
           hostAttrs: [${AttributeMarker.Classes}, "foo", "baz", ${
-          AttributeMarker.Styles}, "width", "200px", "height", "500px"],
+               AttributeMarker.Styles}, "width", "200px", "height", "500px"],
           hostVars: 8,
           hostBindings: function MyComponent_HostBindings(rf, ctx) {
             if (rf & 2) {
@@ -1020,14 +1025,14 @@ describe('compiler compliance: styling', () => {
           vars: 0,
           `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should generate style/class instructions for multiple host binding definitions', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should generate style/class instructions for multiple host binding definitions', () => {
+        const files = {
+          app: {
+            'spec.ts': `
                 import {Component, NgModule, HostBinding} from '@angular/core';
 
                 @Component({
@@ -1058,10 +1063,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
           hostVars: 12,
           hostBindings: function MyComponent_HostBindings(rf, ctx) {
             if (rf & 2) {
@@ -1075,15 +1080,15 @@ describe('compiler compliance: styling', () => {
           vars: 0,
           `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should generate override instructions for only single-level styling bindings when !important is present',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should generate override instructions for only single-level styling bindings when !important is present',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
                 import {Component, NgModule, HostBinding} from '@angular/core';
 
                 @Component({
@@ -1113,10 +1118,10 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent]})
                 export class MyModule {}
             `
-           }
-         };
+             }
+           };
 
-         const template = `
+           const template = `
             function MyComponent_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵɵelement(0, "div");
@@ -1130,7 +1135,7 @@ describe('compiler compliance: styling', () => {
             },
           `;
 
-         const hostBindings = `
+           const hostBindings = `
             hostVars: 8,
             hostBindings: function MyComponent_HostBindings(rf, ctx) {
               if (rf & 2) {
@@ -1142,15 +1147,15 @@ describe('compiler compliance: styling', () => {
             },
           `;
 
-         const result = compile(files, angularFiles);
-         expectEmit(result.source, hostBindings, 'Incorrect template');
-         expectEmit(result.source, template, 'Incorrect template');
-       });
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, hostBindings, 'Incorrect template');
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should support class interpolation', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should support class interpolation', () => {
+        const files = {
+          app: {
+            'spec.ts': `
                   import {Component, NgModule, HostBinding} from '@angular/core';
 
                   @Component({
@@ -1183,10 +1188,10 @@ describe('compiler compliance: styling', () => {
                   @NgModule({declarations: [MyComponent]})
                   export class MyModule {}
               `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
               function MyComponent_Template(rf, ctx) {
                 if (rf & 1) {
                   …
@@ -1213,14 +1218,14 @@ describe('compiler compliance: styling', () => {
               },
             `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should support style interpolation', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should support style interpolation', () => {
+        const files = {
+          app: {
+            'spec.ts': `
                   import {Component, NgModule, HostBinding} from '@angular/core';
 
                   @Component({
@@ -1253,10 +1258,10 @@ describe('compiler compliance: styling', () => {
                   @NgModule({declarations: [MyComponent]})
                   export class MyModule {}
               `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
               function MyComponent_Template(rf, ctx) {
                 if (rf & 1) {
                   …
@@ -1283,15 +1288,15 @@ describe('compiler compliance: styling', () => {
               },
             `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should generate styling instructions for multiple directives that contain host binding definitions',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should generate styling instructions for multiple directives that contain host binding definitions',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
                 import {Directive, Component, NgModule, HostBinding} from '@angular/core';
 
                 @Directive({selector: '[myClassDir]'})
@@ -1328,12 +1333,12 @@ describe('compiler compliance: styling', () => {
                 @NgModule({declarations: [MyComponent, WidthDirective, HeightDirective, ClassDirective]})
                 export class MyModule {}
             `
-           }
-         };
+             }
+           };
 
-         // NOTE: IF YOU ARE CHANGING THIS COMPILER SPEC, YOU MAY NEED TO CHANGE THE DIRECTIVE
-         // DEF THAT'S HARD-CODED IN `ng_class.ts`.
-         const template = `
+           // NOTE: IF YOU ARE CHANGING THIS COMPILER SPEC, YOU MAY NEED TO CHANGE THE DIRECTIVE
+           // DEF THAT'S HARD-CODED IN `ng_class.ts`.
+           const template = `
           …
           hostVars: 2,
           hostBindings: function ClassDirective_HostBindings(rf, ctx) {
@@ -1360,16 +1365,16 @@ describe('compiler compliance: styling', () => {
           …
           `;
 
-         const result = compile(files, angularFiles);
-         expectEmit(result.source, template, 'Incorrect template');
-       });
-  });
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, template, 'Incorrect template');
+         });
+    });
 
-  describe('interpolations', () => {
-    it('should generate the proper update instructions for interpolated classes', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+    describe('interpolations', () => {
+      it('should generate the proper update instructions for interpolated classes', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -1389,10 +1394,10 @@ describe('compiler compliance: styling', () => {
             export class MyComponent {
             }
           `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
       …
         if (rf & 2) {
           $r3$.ɵɵclassMapInterpolateV(["a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i", ctx.nine, "j"]);
@@ -1417,15 +1422,15 @@ describe('compiler compliance: styling', () => {
       }
       …
       `;
-      const result = compile(files, angularFiles);
+        const result = compile(files, angularFiles);
 
-      expectEmit(result.source, template, 'Incorrect handling of interpolated classes');
-    });
+        expectEmit(result.source, template, 'Incorrect handling of interpolated classes');
+      });
 
-    it('should throw for interpolations inside individual class bindings', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should throw for interpolations inside individual class bindings', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -1434,16 +1439,16 @@ describe('compiler compliance: styling', () => {
             export class MyComponent {
             }
           `
-        }
-      };
+          }
+        };
 
-      expect(() => compile(files, angularFiles)).toThrowError(/Unexpected interpolation/);
-    });
+        expect(() => compile(files, angularFiles)).toThrowError(/Unexpected interpolation/);
+      });
 
-    it('should generate the proper update instructions for interpolated style properties', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should generate the proper update instructions for interpolated style properties', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -1463,10 +1468,10 @@ describe('compiler compliance: styling', () => {
             export class MyComponent {
             }
           `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
       …
         if (rf & 2) {
           $r3$.ɵɵstylePropInterpolateV("color", ["a", ctx.one, "b", ctx.two, "c", ctx.three, "d", ctx.four, "e", ctx.five, "f", ctx.six, "g", ctx.seven, "h", ctx.eight, "i", ctx.nine, "j"]);
@@ -1491,16 +1496,16 @@ describe('compiler compliance: styling', () => {
       }
       …
       `;
-      const result = compile(files, angularFiles);
+        const result = compile(files, angularFiles);
 
-      expectEmit(result.source, template, 'Incorrect handling of interpolated style properties');
-    });
+        expectEmit(result.source, template, 'Incorrect handling of interpolated style properties');
+      });
 
-    it('should generate update instructions for interpolated style properties with a suffix',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should generate update instructions for interpolated style properties with a suffix',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -1511,26 +1516,27 @@ describe('compiler compliance: styling', () => {
             export class MyComponent {
             }
           `
-           }
-         };
+             }
+           };
 
-         const template = `
+           const template = `
             …
             if (rf & 2) {
               $r3$.ɵɵstylePropInterpolate2("width", "a", ctx.one, "b", ctx.two, "c", "px");
             }
             …
           `;
-         const result = compile(files, angularFiles);
+           const result = compile(files, angularFiles);
 
-         expectEmit(result.source, template, 'Incorrect handling of interpolated style properties');
-       });
+           expectEmit(
+               result.source, template, 'Incorrect handling of interpolated style properties');
+         });
 
-    it('should generate update instructions for interpolated style properties with a sanitizer',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should generate update instructions for interpolated style properties with a sanitizer',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -1549,10 +1555,10 @@ describe('compiler compliance: styling', () => {
               myRepeat = 'no-repeat';
             }
           `
-           }
-         };
+             }
+           };
 
-         const template = `
+           const template = `
             …
             if (rf & 2) {
               $r3$.ɵɵstylePropInterpolate1("background", "url(", ctx.myUrl1, ")");
@@ -1561,16 +1567,17 @@ describe('compiler compliance: styling', () => {
             }
             …
           `;
-         const result = compile(files, angularFiles);
+           const result = compile(files, angularFiles);
 
-         expectEmit(result.source, template, 'Incorrect handling of interpolated style properties');
-       });
+           expectEmit(
+               result.source, template, 'Incorrect handling of interpolated style properties');
+         });
 
-    it('should generate update instructions for interpolated style properties with !important',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should generate update instructions for interpolated style properties with !important',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
             import {Component} from '@angular/core';
 
             @Component({
@@ -1581,27 +1588,28 @@ describe('compiler compliance: styling', () => {
             export class MyComponent {
             }
           `
-           }
-         };
+             }
+           };
 
-         const template = `
+           const template = `
             …
             if (rf & 2) {
               $r3$.ɵɵstylePropInterpolate2("width", "a", ctx.one, "b", ctx.two, "c");
             }
             …
           `;
-         const result = compile(files, angularFiles);
+           const result = compile(files, angularFiles);
 
-         expectEmit(result.source, template, 'Incorrect handling of interpolated style properties');
-       });
-  });
+           expectEmit(
+               result.source, template, 'Incorrect handling of interpolated style properties');
+         });
+    });
 
-  describe('instruction chaining', () => {
-    it('should chain classProp instruction calls', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+    describe('instruction chaining', () => {
+      it('should chain classProp instruction calls', () => {
+        const files = {
+          app: {
+            'spec.ts': `
              import {Component} from '@angular/core';
 
              @Component({
@@ -1615,10 +1623,10 @@ describe('compiler compliance: styling', () => {
                tesToTomato = false;
              }
          `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
        …
        MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
         …
@@ -1632,14 +1640,14 @@ describe('compiler compliance: styling', () => {
       });
      `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain styleProp instruction calls', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should chain styleProp instruction calls', () => {
+        const files = {
+          app: {
+            'spec.ts': `
              import {Component} from '@angular/core';
 
              @Component({
@@ -1653,10 +1661,10 @@ describe('compiler compliance: styling', () => {
                transition = 'all 1337ms ease';
              }
          `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
        …
        MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
         …
@@ -1670,14 +1678,14 @@ describe('compiler compliance: styling', () => {
       });
      `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain mixed styleProp and classProp calls', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should chain mixed styleProp and classProp calls', () => {
+        const files = {
+          app: {
+            'spec.ts': `
              import {Component} from '@angular/core';
 
              @Component({
@@ -1698,10 +1706,10 @@ describe('compiler compliance: styling', () => {
                tesToTomato = false;
              }
          `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
        …
        MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
         …
@@ -1716,14 +1724,14 @@ describe('compiler compliance: styling', () => {
       });
      `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain style interpolations of the same kind', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should chain style interpolations of the same kind', () => {
+        const files = {
+          app: {
+            'spec.ts': `
              import {Component} from '@angular/core';
 
              @Component({
@@ -1735,10 +1743,10 @@ describe('compiler compliance: styling', () => {
              export class MyComponent {
              }
          `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
        …
        MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
         …
@@ -1752,14 +1760,14 @@ describe('compiler compliance: styling', () => {
       });
      `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should chain style interpolations of multiple kinds', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should chain style interpolations of multiple kinds', () => {
+        const files = {
+          app: {
+            'spec.ts': `
              import {Component} from '@angular/core';
 
              @Component({
@@ -1774,10 +1782,10 @@ describe('compiler compliance: styling', () => {
              export class MyComponent {
              }
          `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
        …
        MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
         …
@@ -1793,15 +1801,15 @@ describe('compiler compliance: styling', () => {
       });
      `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
 
-    it('should break into multiple chains if there are other styling instructions in between',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should break into multiple chains if there are other styling instructions in between',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
                   import {Component} from '@angular/core';
 
                   @Component({
@@ -1822,10 +1830,10 @@ describe('compiler compliance: styling', () => {
                     yesToOrange = true;
                   }
               `
-           }
-         };
+             }
+           };
 
-         const template = `
+           const template = `
             …
             MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
               …
@@ -1842,15 +1850,15 @@ describe('compiler compliance: styling', () => {
             });
           `;
 
-         const result = compile(files, angularFiles);
-         expectEmit(result.source, template, 'Incorrect template');
-       });
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should break into multiple chains if there are other styling interpolation instructions in between',
-       () => {
-         const files = {
-           app: {
-             'spec.ts': `
+      it('should break into multiple chains if there are other styling interpolation instructions in between',
+         () => {
+           const files = {
+             app: {
+               'spec.ts': `
                   import {Component} from '@angular/core';
 
                   @Component({
@@ -1867,10 +1875,10 @@ describe('compiler compliance: styling', () => {
                     width = '42px';
                   }
               `
-           }
-         };
+             }
+           };
 
-         const template = `
+           const template = `
             …
             MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
               …
@@ -1887,14 +1895,14 @@ describe('compiler compliance: styling', () => {
             });
           `;
 
-         const result = compile(files, angularFiles);
-         expectEmit(result.source, template, 'Incorrect template');
-       });
+           const result = compile(files, angularFiles);
+           expectEmit(result.source, template, 'Incorrect template');
+         });
 
-    it('should chain styling instructions inside host bindings', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+      it('should chain styling instructions inside host bindings', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, HostBinding} from '@angular/core';
 
             @Component({
@@ -1919,10 +1927,10 @@ describe('compiler compliance: styling', () => {
               yesToOrange = true;
             }
            `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
          …
          MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
           …
@@ -1937,15 +1945,15 @@ describe('compiler compliance: styling', () => {
         });
        `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
     });
-  });
 
-  it('should count only non-style and non-class host bindings on Components', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should count only non-style and non-class host bindings on Components', () => {
+      const files = {
+        app: {
+          'spec.ts': `
           import {Component, NgModule, HostBinding} from '@angular/core';
 
           @Component({
@@ -1977,12 +1985,12 @@ describe('compiler compliance: styling', () => {
           @NgModule({declarations: [MyComponent]})
           export class MyModule {}
         `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
       hostAttrs: ["title", "foo title", ${AttributeMarker.Classes}, "foo", "baz", ${
-        AttributeMarker.Styles}, "width", "200px", "height", "500px"],
+          AttributeMarker.Styles}, "width", "200px", "height", "500px"],
       hostVars: 6,
       hostBindings: function MyComponent_HostBindings(rf, ctx) {
         if (rf & 2) {
@@ -1993,14 +2001,14 @@ describe('compiler compliance: styling', () => {
       }
     `;
 
-    const result = compile(files, angularFiles);
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should count only non-style and non-class host bindings on Directives', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should count only non-style and non-class host bindings on Directives', () => {
+      const files = {
+        app: {
+          'spec.ts': `
           import {Directive, Component, NgModule, HostBinding} from '@angular/core';
 
           @Directive({selector: '[myWidthDir]'})
@@ -2018,10 +2026,10 @@ describe('compiler compliance: styling', () => {
             title = 'some title';
           }
         `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
     hostVars: 6,
     hostBindings: function WidthDirective_HostBindings(rf, ctx) {
         if (rf & 2) {
@@ -2032,15 +2040,15 @@ describe('compiler compliance: styling', () => {
       }
     `;
 
-    const result = compile(files, angularFiles);
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  describe('new styling refactor', () => {
-    it('should generate the correct amount of host bindings when styling is present', () => {
-      const files = {
-        app: {
-          'spec.ts': `
+    describe('new styling refactor', () => {
+      it('should generate the correct amount of host bindings when styling is present', () => {
+        const files = {
+          app: {
+            'spec.ts': `
             import {Component, Directive, NgModule} from '@angular/core';
 
             @Directive({
@@ -2076,10 +2084,10 @@ describe('compiler compliance: styling', () => {
             @NgModule({declarations: [MyAppComp, MyDir]})
             export class MyModule {}
           `
-        }
-      };
+          }
+        };
 
-      const template = `
+        const template = `
           hostVars: 10,
           hostBindings: function MyDir_HostBindings(rf, ctx) {
             if (rf & 2) {
@@ -2092,8 +2100,9 @@ describe('compiler compliance: styling', () => {
           }
       `;
 
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template');
+        const result = compile(files, angularFiles);
+        expectEmit(result.source, template, 'Incorrect template');
+      });
     });
   });
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -7,19 +7,23 @@
  */
 import {AttributeMarker} from '@angular/compiler/src/core';
 import {setup} from '@angular/compiler/test/aot/test_util';
-import {compile, expectEmit} from './mock_compile';
+import {createCompileFn, expectEmit} from './mock_compile';
+import {runInEachCompilationMode} from './test_runner';
 
-describe('compiler compliance: template', () => {
-  const angularFiles = setup({
-    compileAngular: false,
-    compileFakeCore: true,
-    compileAnimations: false,
-  });
+runInEachCompilationMode(compilationMode => {
+  const compile = createCompileFn(compilationMode);
 
-  it('should correctly bind to context in nested template', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+  describe('compiler compliance: template', () => {
+    const angularFiles = setup({
+      compileAngular: false,
+      compileFakeCore: true,
+      compileAnimations: false,
+    });
+
+    it('should correctly bind to context in nested template', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -45,11 +49,11 @@ describe('compiler compliance: template', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    // The template should look like this (where IDENT is a wild card for an identifier):
-    const template = `
+      // The template should look like this (where IDENT is a wild card for an identifier):
+      const template = `
       function MyComponent_ul_0_li_1_div_1_Template(rf, ctx) {
         if (rf & 1) {
           const $s$ = $i0$.ɵɵgetCurrentView();
@@ -104,9 +108,9 @@ describe('compiler compliance: template', () => {
       }
       // ...
       consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${
-        AttributeMarker.Bindings}, "title", "click", ${
-        AttributeMarker.Template}, "ngFor", "ngForOf"], [${
-        AttributeMarker.Bindings}, "title", "click"]],
+          AttributeMarker.Bindings}, "title", "click", ${
+          AttributeMarker.Template}, "ngFor", "ngForOf"], [${
+          AttributeMarker.Bindings}, "title", "click"]],
       template:function MyComponent_Template(rf, ctx){
         if (rf & 1) {
           $i0$.ɵɵtemplate(0, MyComponent_ul_0_Template, 2, 1, "ul", 0);
@@ -116,15 +120,15 @@ describe('compiler compliance: template', () => {
         }
       }`;
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should correctly bind to context in nested template with many bindings', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should correctly bind to context in nested template with many bindings', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -141,10 +145,10 @@ describe('compiler compliance: template', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
         function MyComponent_div_0_Template(rf, ctx) {
           if (rf & 1) {
             const $s$ = $r3$.ɵɵgetCurrentView();
@@ -161,7 +165,7 @@ describe('compiler compliance: template', () => {
         }
         // ...
         consts: [[${AttributeMarker.Bindings}, "click", ${
-        AttributeMarker.Template}, "ngFor", "ngForOf"], [${AttributeMarker.Bindings}, "click"]],
+          AttributeMarker.Template}, "ngFor", "ngForOf"], [${AttributeMarker.Bindings}, "click"]],
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵɵtemplate(0, MyComponent_div_0_Template, 1, 0, "div", 0);
@@ -172,15 +176,15 @@ describe('compiler compliance: template', () => {
         }
         `;
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should correctly bind to implicit receiver in template', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should correctly bind to implicit receiver in template', () => {
+      const files = {
+        app: {
+          'spec.ts': `
           import {Component, NgModule} from '@angular/core';
 
           @Component({
@@ -197,10 +201,10 @@ describe('compiler compliance: template', () => {
           @NgModule({declarations: [MyComponent]})
           export class MyModule {}
         `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
       function MyComponent_div_0_Template(rf, ctx) {
         if (rf & 1) {
           const $_r2$ = i0.ɵɵgetCurrentView();
@@ -224,15 +228,15 @@ describe('compiler compliance: template', () => {
       }
     `;
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should support ngFor context variables', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should support ngFor context variables', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -247,10 +251,10 @@ describe('compiler compliance: template', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
       function MyComponent_span_0_Template(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵɵelementStart(0, "span");
@@ -275,15 +279,15 @@ describe('compiler compliance: template', () => {
         }
       }`;
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should support ngFor context variables in parent views', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should support ngFor context variables in parent views', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -300,10 +304,10 @@ describe('compiler compliance: template', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
       function MyComponent_div_0_span_1_Template(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵɵelementStart(0, "span");
@@ -334,7 +338,7 @@ describe('compiler compliance: template', () => {
 
       // ...
       consts: [[${AttributeMarker.Template}, "ngFor", "ngForOf"], [${
-        AttributeMarker.Template}, "ngIf"]],
+          AttributeMarker.Template}, "ngIf"]],
       template:function MyComponent_Template(rf, ctx){
         if (rf & 1) {
           $i0$.ɵɵtemplate(0, MyComponent_div_0_Template, 2, 1, "div", 0);
@@ -344,15 +348,15 @@ describe('compiler compliance: template', () => {
         }
       }`;
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should correctly skip contexts as needed', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should correctly skip contexts as needed', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -371,11 +375,11 @@ describe('compiler compliance: template', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    // The template should look like this (where IDENT is a wild card for an identifier):
-    const template = `
+      // The template should look like this (where IDENT is a wild card for an identifier):
+      const template = `
       function MyComponent_div_0_div_1_div_1_Template(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵɵelementStart(0, "div");
@@ -426,15 +430,15 @@ describe('compiler compliance: template', () => {
         }
       }`;
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should support <ng-template>', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should support <ng-template>', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -449,10 +453,10 @@ describe('compiler compliance: template', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
       function MyComponent_ng_template_0_Template(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵɵtext(0, " some-content ");
@@ -471,15 +475,15 @@ describe('compiler compliance: template', () => {
         }
       }`;
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should support local refs on <ng-template>', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should support local refs on <ng-template>', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -491,10 +495,10 @@ describe('compiler compliance: template', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
       function MyComponent_ng_template_0_Template(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵɵtext(0, "some-content");
@@ -509,15 +513,15 @@ describe('compiler compliance: template', () => {
         }
       }`;
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should support directive outputs on <ng-template>', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should support directive outputs on <ng-template>', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -529,10 +533,10 @@ describe('compiler compliance: template', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
       function MyComponent_ng_template_0_Template(rf, ctx) { }
 
       // ...
@@ -545,15 +549,15 @@ describe('compiler compliance: template', () => {
         }
       }`;
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should allow directive inputs as an interpolated prop on <ng-template>', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should allow directive inputs as an interpolated prop on <ng-template>', () => {
+      const files = {
+        app: {
+          'spec.ts': `
           import {Component, Directive, Input} from '@angular/core';
 
           @Directive({selector: '[dir]'})
@@ -569,10 +573,10 @@ describe('compiler compliance: template', () => {
             message = 'Hello';
           }
         `
-      }
-    };
-    const result = compile(files, angularFiles);
-    const expectedTemplate = `
+        }
+      };
+      const result = compile(files, angularFiles);
+      const expectedTemplate = `
       consts: [[${AttributeMarker.Bindings}, "dir"]],
       template: function TestComp_Template(rf, ctx) {
         if (rf & 1) {
@@ -583,14 +587,14 @@ describe('compiler compliance: template', () => {
         }
       },
     `;
-    expectEmit(result.source, expectedTemplate, 'Incorrect template');
-  });
+      expectEmit(result.source, expectedTemplate, 'Incorrect template');
+    });
 
-  it('should allow directive inputs as an interpolated prop on <ng-template> (with structural directives)',
-     () => {
-       const files = {
-         app: {
-           'spec.ts': `
+    it('should allow directive inputs as an interpolated prop on <ng-template> (with structural directives)',
+       () => {
+         const files = {
+           app: {
+             'spec.ts': `
               import {Component, Directive, Input} from '@angular/core';
 
               @Directive({selector: '[dir]'})
@@ -606,12 +610,12 @@ describe('compiler compliance: template', () => {
                 message = 'Hello';
               }
             `
-         }
-       };
-       const result = compile(files, angularFiles);
+           }
+         };
+         const result = compile(files, angularFiles);
 
-       // Expect that `ɵɵpropertyInterpolate` is generated in the inner template function.
-       const expectedInnerTemplate = `
+         // Expect that `ɵɵpropertyInterpolate` is generated in the inner template function.
+         const expectedInnerTemplate = `
           function $TestComp_0_Template$(rf, ctx) {
             if (rf & 1) {
               $i0$.ɵɵtemplate(0, $TestComp_0_ng_template_0_Template$, 0, 0, "ng-template", 1);
@@ -622,10 +626,10 @@ describe('compiler compliance: template', () => {
             }
           }
         `;
-       expectEmit(result.source, expectedInnerTemplate, 'Incorrect template');
+         expectEmit(result.source, expectedInnerTemplate, 'Incorrect template');
 
-       // Main template should just contain *ngIf property.
-       const expectedMainTemplate = `
+         // Main template should just contain *ngIf property.
+         const expectedMainTemplate = `
           consts: [[4, "ngIf"], [3, "dir"]],
           template: function TestComp_Template(rf, ctx) {
             if (rf & 1) {
@@ -636,14 +640,14 @@ describe('compiler compliance: template', () => {
             }
           },
         `;
-       expectEmit(result.source, expectedMainTemplate, 'Incorrect template');
-     });
+         expectEmit(result.source, expectedMainTemplate, 'Incorrect template');
+       });
 
-  it('should create unique template function names even for similar nested template structures',
-     () => {
-       const files = {
-         app: {
-           'spec1.ts': `
+    it('should create unique template function names even for similar nested template structures',
+       () => {
+         const files = {
+           app: {
+             'spec1.ts': `
           import {Component, NgModule} from '@angular/core';
 
           @Component({
@@ -665,7 +669,7 @@ describe('compiler compliance: template', () => {
           @NgModule({declarations: [AComponent]})
           export class AModule {}
         `,
-           'spec2.ts': `
+             'spec2.ts': `
           import {Component, NgModule} from '@angular/core';
 
           @Component({
@@ -697,29 +701,29 @@ describe('compiler compliance: template', () => {
           @NgModule({declarations: [BComponent]})
           export class BModule {}
         `,
-         },
-       };
+           },
+         };
 
-       const result = compile(files, angularFiles);
+         const result = compile(files, angularFiles);
 
-       const allTemplateFunctionsNames = (result.source.match(/function ([^\s(]+)/g) || [])
-                                             .map(x => x.slice(9))
-                                             .filter(x => x.includes('Template'))
-                                             .sort();
-       const uniqueTemplateFunctionNames = Array.from(new Set(allTemplateFunctionsNames));
+         const allTemplateFunctionsNames = (result.source.match(/function ([^\s(]+)/g) || [])
+                                               .map(x => x.slice(9))
+                                               .filter(x => x.includes('Template'))
+                                               .sort();
+         const uniqueTemplateFunctionNames = Array.from(new Set(allTemplateFunctionsNames));
 
-       // Expected template function:
-       // - 5 for AComponent's template.
-       // - 9 for BComponent's template.
-       // - 2 for the two components.
-       expect(allTemplateFunctionsNames.length).toBe(5 + 9 + 2);
-       expect(allTemplateFunctionsNames).toEqual(uniqueTemplateFunctionNames);
-     });
+         // Expected template function:
+         // - 5 for AComponent's template.
+         // - 9 for BComponent's template.
+         // - 2 for the two components.
+         expect(allTemplateFunctionsNames.length).toBe(5 + 9 + 2);
+         expect(allTemplateFunctionsNames).toEqual(uniqueTemplateFunctionNames);
+       });
 
-  it('should create unique template function names for ng-content templates', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should create unique template function names for ng-content templates', () => {
+      const files = {
+        app: {
+          'spec.ts': `
           import {Component, NgModule} from '@angular/core';
 
           @Component({
@@ -745,30 +749,30 @@ describe('compiler compliance: template', () => {
           @NgModule({declarations: [AComponent, BComponent]})
           export class AModule {}
         `
-      },
-    };
+        },
+      };
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    const allTemplateFunctionsNames = (result.source.match(/function ([^\s(]+)/g) || [])
-                                          .map(x => x.slice(9))
-                                          .filter(x => x.includes('Template'))
-                                          .sort();
-    const uniqueTemplateFunctionNames = Array.from(new Set(allTemplateFunctionsNames));
+      const allTemplateFunctionsNames = (result.source.match(/function ([^\s(]+)/g) || [])
+                                            .map(x => x.slice(9))
+                                            .filter(x => x.includes('Template'))
+                                            .sort();
+      const uniqueTemplateFunctionNames = Array.from(new Set(allTemplateFunctionsNames));
 
-    // Expected template function:
-    // - 1 for AComponent's template.
-    // - 1 for BComponent's template.
-    // - 2 for the two components.
-    expect(allTemplateFunctionsNames.length).toBe(1 + 1 + 2);
-    expect(allTemplateFunctionsNames).toEqual(uniqueTemplateFunctionNames);
-  });
+      // Expected template function:
+      // - 1 for AComponent's template.
+      // - 1 for BComponent's template.
+      // - 2 for the two components.
+      expect(allTemplateFunctionsNames.length).toBe(1 + 1 + 2);
+      expect(allTemplateFunctionsNames).toEqual(uniqueTemplateFunctionNames);
+    });
 
-  it('should create unique listener function names even for similar nested template structures',
-     () => {
-       const files = {
-         app: {
-           'spec.ts': `
+    it('should create unique listener function names even for similar nested template structures',
+       () => {
+         const files = {
+           app: {
+             'spec.ts': `
           import {Component, NgModule} from '@angular/core';
 
           @Component({
@@ -790,25 +794,25 @@ describe('compiler compliance: template', () => {
           @NgModule({declarations: [MyComponent]})
           export class MyModule {}
         `,
-         },
-       };
+           },
+         };
 
-       const result = compile(files, angularFiles);
+         const result = compile(files, angularFiles);
 
-       const allListenerFunctionsNames = (result.source.match(/function ([^\s(]+)/g) || [])
-                                             .map(x => x.slice(9))
-                                             .filter(x => x.includes('listener'))
-                                             .sort();
-       const uniqueListenerFunctionNames = Array.from(new Set(allListenerFunctionsNames));
+         const allListenerFunctionsNames = (result.source.match(/function ([^\s(]+)/g) || [])
+                                               .map(x => x.slice(9))
+                                               .filter(x => x.includes('listener'))
+                                               .sort();
+         const uniqueListenerFunctionNames = Array.from(new Set(allListenerFunctionsNames));
 
-       expect(allListenerFunctionsNames.length).toBe(3);
-       expect(allListenerFunctionsNames).toEqual(uniqueListenerFunctionNames);
-     });
+         expect(allListenerFunctionsNames.length).toBe(3);
+         expect(allListenerFunctionsNames).toEqual(uniqueListenerFunctionNames);
+       });
 
-  it('should support pipes in template bindings', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should support pipes in template bindings', () => {
+      const files = {
+        app: {
+          'spec.ts': `
               import {Component, NgModule} from '@angular/core';
 
               @Component({
@@ -821,10 +825,10 @@ describe('compiler compliance: template', () => {
               @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
-      }
-    };
+        }
+      };
 
-    const template = `
+      const template = `
       function MyComponent_div_0_Template(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵɵelement(0, "div");
@@ -842,15 +846,15 @@ describe('compiler compliance: template', () => {
         }
       }`;
 
-    const result = compile(files, angularFiles);
+      const result = compile(files, angularFiles);
 
-    expectEmit(result.source, template, 'Incorrect template');
-  });
+      expectEmit(result.source, template, 'Incorrect template');
+    });
 
-  it('should safely nest ternary operations', () => {
-    const files = {
-      app: {
-        'spec.ts': `
+    it('should safely nest ternary operations', () => {
+      const files = {
+        app: {
+          'spec.ts': `
             import {Component, NgModule} from '@angular/core';
 
             @Component({
@@ -863,12 +867,13 @@ describe('compiler compliance: template', () => {
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
         `
-      }
-    };
+        }
+      };
 
-    const template = `i0.ɵɵtextInterpolate1(" ", (ctx.a == null ? null : ctx.a.b) ? 1 : 2, "")`;
+      const template = `i0.ɵɵtextInterpolate1(" ", (ctx.a == null ? null : ctx.a.b) ? 1 : 2, "")`;
 
-    const result = compile(files, angularFiles);
-    expectEmit(result.source, template, 'Incorrect template');
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect template');
+    });
   });
 });

--- a/packages/compiler-cli/test/compliance/test_runner.ts
+++ b/packages/compiler-cli/test/compliance/test_runner.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export type CompilationModeRunner = (compilationMode: 'full'|'partial') => void;
+
+export interface RunInEachCompilationModeFn {
+  (callback: CompilationModeRunner): void;
+  full(callback: CompilationModeRunner): void;
+  partial(callback: CompilationModeRunner): void;
+}
+
+function runInEachCompilationModeFn(callback: CompilationModeRunner) {
+  runCompilationMode('full', callback, false);
+  runCompilationMode('partial', callback, false);
+}
+
+function runCompilationMode(
+    compilationMode: 'full'|'partial', callback: CompilationModeRunner, error: boolean) {
+  describe(`<<CompilationMode: ${compilationMode}>>`, () => {
+    callback(compilationMode);
+    if (error) {
+      afterAll(() => {
+        throw new Error(`runCompilationMode limited to ${compilationMode}, cannot pass`);
+      });
+    }
+  });
+}
+
+export const runInEachCompilationMode = runInEachCompilationModeFn as RunInEachCompilationModeFn;
+
+runInEachCompilationMode.full = (callback: CompilationModeRunner) =>
+    runCompilationMode('full', callback, true);
+runInEachCompilationMode.partial = (callback: CompilationModeRunner) =>
+    runCompilationMode('partial', callback, true);


### PR DESCRIPTION
This is a precursor to introducing the Angular linker. As an initial
step, a compiler option to configure the compilation model is introduced.
This option is initially internal until the linker is considered ready.