### PR TITLE
refactor(compiler-cli): make the output AST translator generic

### DIFF
--- a/packages/compiler-cli/ngcc/src/rendering/commonjs_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/commonjs_rendering_formatter.ts
@@ -55,7 +55,7 @@ export class CommonJsRenderingFormatter extends Esm5RenderingFormatter {
       const namedImport = entryPointBasePath !== basePath ?
           importManager.generateNamedImport(relativePath, e.identifier) :
           {symbol: e.identifier, moduleImport: null};
-      const importNamespace = namedImport.moduleImport ? `${namedImport.moduleImport}.` : '';
+      const importNamespace = namedImport.moduleImport ? `${namedImport.moduleImport.text}.` : '';
       const exportStr = `\nexports.${e.identifier} = ${importNamespace}${namedImport.symbol};`;
       output.append(exportStr);
     });
@@ -66,7 +66,7 @@ export class CommonJsRenderingFormatter extends Esm5RenderingFormatter {
       file: ts.SourceFile): void {
     for (const e of exports) {
       const namedImport = importManager.generateNamedImport(e.fromModule, e.symbolName);
-      const importNamespace = namedImport.moduleImport ? `${namedImport.moduleImport}.` : '';
+      const importNamespace = namedImport.moduleImport ? `${namedImport.moduleImport.text}.` : '';
       const exportStr = `\nexports.${e.asAlias} = ${importNamespace}${namedImport.symbol};`;
       output.append(exportStr);
     }

--- a/packages/compiler-cli/ngcc/src/rendering/esm5_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/esm5_rendering_formatter.ts
@@ -9,7 +9,6 @@ import {Statement} from '@angular/compiler';
 import MagicString from 'magic-string';
 import * as ts from 'typescript';
 
-import {NOOP_DEFAULT_IMPORT_RECORDER} from '../../../src/ngtsc/imports';
 import {ImportManager, translateStatement} from '../../../src/ngtsc/translator';
 import {CompiledClass} from '../analysis/types';
 import {getContainingStatement} from '../host/esm2015_host';
@@ -65,8 +64,9 @@ export class Esm5RenderingFormatter extends EsmRenderingFormatter {
    * @return The JavaScript code corresponding to `stmt` (in the appropriate format).
    */
   printStatement(stmt: Statement, sourceFile: ts.SourceFile, importManager: ImportManager): string {
-    const node =
-        translateStatement(stmt, importManager, NOOP_DEFAULT_IMPORT_RECORDER, ts.ScriptTarget.ES5);
+    const node = translateStatement(
+        stmt, importManager,
+        {downlevelLocalizedStrings: true, downlevelVariableDeclarations: true});
     const code = this.printer.printNode(ts.EmitHint.Unspecified, node, sourceFile);
 
     return code;

--- a/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
@@ -10,7 +10,7 @@ import MagicString from 'magic-string';
 import * as ts from 'typescript';
 
 import {absoluteFromSourceFile, AbsoluteFsPath, dirname, relative, toRelativeImport} from '../../../src/ngtsc/file_system';
-import {NOOP_DEFAULT_IMPORT_RECORDER, Reexport} from '../../../src/ngtsc/imports';
+import {Reexport} from '../../../src/ngtsc/imports';
 import {Import, ImportManager, translateStatement} from '../../../src/ngtsc/translator';
 import {isDtsPath} from '../../../src/ngtsc/util/src/typescript';
 import {ModuleWithProvidersInfo} from '../analysis/module_with_providers_analyzer';
@@ -247,8 +247,7 @@ export class EsmRenderingFormatter implements RenderingFormatter {
    * @return The JavaScript code corresponding to `stmt` (in the appropriate format).
    */
   printStatement(stmt: Statement, sourceFile: ts.SourceFile, importManager: ImportManager): string {
-    const node = translateStatement(
-        stmt, importManager, NOOP_DEFAULT_IMPORT_RECORDER, ts.ScriptTarget.ES2015);
+    const node = translateStatement(stmt, importManager);
     const code = this.printer.printNode(ts.EmitHint.Unspecified, node, sourceFile);
 
     return code;
@@ -263,8 +262,6 @@ export class EsmRenderingFormatter implements RenderingFormatter {
     }
     return 0;
   }
-
-
 
   /**
    * Check whether the given type is the core Angular `ModuleWithProviders` interface.
@@ -292,7 +289,8 @@ function findStatement(node: ts.Node): ts.Statement|undefined {
 function generateImportString(
     importManager: ImportManager, importPath: string|null, importName: string) {
   const importAs = importPath ? importManager.generateNamedImport(importPath, importName) : null;
-  return importAs ? `${importAs.moduleImport}.${importAs.symbol}` : `${importName}`;
+  return importAs && importAs.moduleImport ? `${importAs.moduleImport.text}.${importAs.symbol}` :
+                                             `${importName}`;
 }
 
 function getNextSiblingInArray<T extends ts.Node>(node: T, array: ts.NodeArray<T>): T|null {

--- a/packages/compiler-cli/ngcc/src/rendering/umd_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/umd_rendering_formatter.ts
@@ -91,7 +91,7 @@ export class UmdRenderingFormatter extends Esm5RenderingFormatter {
       const namedImport = entryPointBasePath !== basePath ?
           importManager.generateNamedImport(relativePath, e.identifier) :
           {symbol: e.identifier, moduleImport: null};
-      const importNamespace = namedImport.moduleImport ? `${namedImport.moduleImport}.` : '';
+      const importNamespace = namedImport.moduleImport ? `${namedImport.moduleImport.text}.` : '';
       const exportStr = `\nexports.${e.identifier} = ${importNamespace}${namedImport.symbol};`;
       output.appendRight(insertionPoint, exportStr);
     });
@@ -111,7 +111,7 @@ export class UmdRenderingFormatter extends Esm5RenderingFormatter {
         lastStatement ? lastStatement.getEnd() : factoryFunction.body.getEnd() - 1;
     for (const e of exports) {
       const namedImport = importManager.generateNamedImport(e.fromModule, e.symbolName);
-      const importNamespace = namedImport.moduleImport ? `${namedImport.moduleImport}.` : '';
+      const importNamespace = namedImport.moduleImport ? `${namedImport.moduleImport.text}.` : '';
       const exportStr = `\nexports.${e.asAlias} = ${importNamespace}${namedImport.symbol};`;
       output.appendRight(insertionPoint, exportStr);
     }

--- a/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
@@ -69,7 +69,7 @@ B.decorators = [
   { type: OtherB },
   { type: Directive, args: [{ selector: '[b]' }] }
 ];
-var C_1;
+let C_1;
 let C = C_1 = class C {};
 C.decorators = [
   { type: Directive, args: [{ selector: '[c]' }] },
@@ -111,7 +111,7 @@ B.decorators = [
 ];
 return B;
 })();
-var C_1;
+let C_1;
 let C = C_1 = /** @class */ (() => {
 class C {}
 C.decorators = [
@@ -432,7 +432,7 @@ A.decorators = [
             name: _('/node_modules/test-package/some/file.js'),
             contents: `
 import * as tslib_1 from "tslib";
-var D_1;
+let D_1;
 /* A copyright notice */
 import { Directive } from '@angular/core';
 const OtherA = () => (node) => { };
@@ -681,9 +681,9 @@ export { D };
           const stmt3 = new DeclareVarStmt('baz', new LiteralExpr('qux'), undefined, []);
 
           expect(renderer.printStatement(stmt1, sourceFile, importManager)).toBe('const foo = 42;');
-          expect(renderer.printStatement(stmt2, sourceFile, importManager)).toBe('var bar = true;');
+          expect(renderer.printStatement(stmt2, sourceFile, importManager)).toBe('let bar = true;');
           expect(renderer.printStatement(stmt3, sourceFile, importManager))
-              .toBe('var baz = "qux";');
+              .toBe('let baz = "qux";');
         });
       });
     });

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -13,7 +13,7 @@ import * as ts from 'typescript';
 
 import {absoluteFrom, getFileSystem} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
-import {NOOP_DEFAULT_IMPORT_RECORDER, Reexport} from '../../../src/ngtsc/imports';
+import {Reexport} from '../../../src/ngtsc/imports';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
 import {Import, ImportManager, translateStatement} from '../../../src/ngtsc/translator';
 import {loadTestFiles} from '../../../test/helpers';
@@ -65,8 +65,8 @@ class TestRenderingFormatter implements RenderingFormatter {
   }
   printStatement(stmt: Statement, sourceFile: ts.SourceFile, importManager: ImportManager): string {
     const node = translateStatement(
-        stmt, importManager, NOOP_DEFAULT_IMPORT_RECORDER,
-        this.isEs5 ? ts.ScriptTarget.ES5 : ts.ScriptTarget.ES2015);
+        stmt, importManager,
+        {downlevelLocalizedStrings: this.isEs5, downlevelVariableDeclarations: this.isEs5});
     const code = this.printer.printNode(ts.EmitHint.Unspecified, node, sourceFile);
 
     return `// TRANSPILED\n${code}`;

--- a/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/renderer_spec.ts
@@ -32,6 +32,8 @@ import {getRootFiles, makeTestEntryPointBundle} from '../helpers/utils';
 class TestRenderingFormatter implements RenderingFormatter {
   private printer = ts.createPrinter({newLine: ts.NewLineKind.LineFeed});
 
+  constructor(private isEs5: boolean) {}
+
   addImports(output: MagicString, imports: Import[], sf: ts.SourceFile) {
     output.prepend('\n// ADD IMPORTS\n');
   }
@@ -63,7 +65,8 @@ class TestRenderingFormatter implements RenderingFormatter {
   }
   printStatement(stmt: Statement, sourceFile: ts.SourceFile, importManager: ImportManager): string {
     const node = translateStatement(
-        stmt, importManager, NOOP_DEFAULT_IMPORT_RECORDER, ts.ScriptTarget.ES2015);
+        stmt, importManager, NOOP_DEFAULT_IMPORT_RECORDER,
+        this.isEs5 ? ts.ScriptTarget.ES5 : ts.ScriptTarget.ES2015);
     const code = this.printer.printNode(ts.EmitHint.Unspecified, node, sourceFile);
 
     return `// TRANSPILED\n${code}`;
@@ -94,7 +97,7 @@ function createTestRenderer(
                                    .analyzeProgram(bundle.src.program);
   const privateDeclarationsAnalyses =
       new PrivateDeclarationsAnalyzer(host, referencesRegistry).analyzeProgram(bundle.src.program);
-  const testFormatter = new TestRenderingFormatter();
+  const testFormatter = new TestRenderingFormatter(isEs5);
   spyOn(testFormatter, 'addExports').and.callThrough();
   spyOn(testFormatter, 'addImports').and.callThrough();
   spyOn(testFormatter, 'addDefinitions').and.callThrough();
@@ -569,7 +572,7 @@ UndecoratedBase.ɵfac = function UndecoratedBase_Factory(t) { return new (t || U
 UndecoratedBase.ɵdir = ɵngcc0.ɵɵdefineDirective({ type: UndecoratedBase, viewQuery: function UndecoratedBase_Query(rf, ctx) { if (rf & 1) {
         ɵngcc0.ɵɵstaticViewQuery(_c0, true);
     } if (rf & 2) {
-        var _t;
+        let _t;
         ɵngcc0.ɵɵqueryRefresh(_t = ɵngcc0.ɵɵloadQuery()) && (ctx.test = _t.first);
     } } });`);
         });

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
 import {ErrorCode, FatalDiagnosticError, makeDiagnostic, makeRelatedInformation} from '../../diagnostics';
 import {DefaultImportRecorder, Reference, ReferenceEmitter} from '../../imports';
 import {InjectableClassRegistry, MetadataReader, MetadataRegistry} from '../../metadata';
-import {PartialEvaluator, ResolvedValue, ResolvedValueArray} from '../../partial_evaluator';
+import {PartialEvaluator, ResolvedValue} from '../../partial_evaluator';
 import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral, typeNodeToValueExpr} from '../../reflection';
 import {NgModuleRouteAnalyzer} from '../../routing';
 import {LocalModuleScopeRegistry, ScopeData} from '../../scope';

--- a/packages/compiler-cli/src/ngtsc/annotations/test/metadata_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/metadata_spec.ts
@@ -133,8 +133,7 @@ runInEachFileSystem(() => {
     }
     const sf = getSourceFileOrError(program, _('/index.ts'));
     const im = new ImportManager(new NoopImportRewriter(), 'i');
-    const tsStatement =
-        translateStatement(call, im, NOOP_DEFAULT_IMPORT_RECORDER, ts.ScriptTarget.ES2015);
+    const tsStatement = translateStatement(call, im);
     const res = ts.createPrinter().printNode(ts.EmitHint.Unspecified, tsStatement, sf);
     return res.replace(/\s+/g, ' ');
   }

--- a/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
@@ -9,7 +9,7 @@ import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {NOOP_INCREMENTAL_BUILD} from '../../incremental';
 import {NOOP_PERF_RECORDER} from '../../perf';
-import {ClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
+import {TypeScriptReflectionHost} from '../../reflection';
 import {makeProgram} from '../../testing';
 import {DtsTransformRegistry, TraitCompiler} from '../../transform';
 import {AnalysisOutput, CompileResult, DecoratorHandler, HandlerPrecedence} from '../src/api';

--- a/packages/compiler-cli/src/ngtsc/translator/index.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/index.ts
@@ -6,4 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {attachComments, Import, ImportManager, NamedImport, translateExpression, translateStatement, translateType} from './src/translator';
+export {Import, ImportManager, NamedImport} from './src/import_manager';
+export {attachComments, translateExpression, translateStatement} from './src/translator';
+export {translateType} from './src/type_translator';

--- a/packages/compiler-cli/src/ngtsc/translator/index.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/index.ts
@@ -6,6 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {Import, ImportManager, NamedImport} from './src/import_manager';
-export {attachComments, translateExpression, translateStatement} from './src/translator';
+export {AstFactory, BinaryOperator, LeadingComment, ObjectLiteralProperty, SourceMapLocation, SourceMapRange, TemplateElement, TemplateLiteral, UnaryOperator} from './src/api/ast_factory';
+export {Import, ImportGenerator, NamedImport} from './src/api/import_generator';
+export {ImportManager} from './src/import_manager';
+export {RecordWrappedNodeExprFn} from './src/translator';
 export {translateType} from './src/type_translator';
+export {attachComments, TypeScriptAstFactory} from './src/typescript_ast_factory';
+export {translateExpression, translateStatement} from './src/typescript_translator';

--- a/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
@@ -1,0 +1,320 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Used to create transpiler specific AST nodes from Angular Output AST nodes in an abstract way.
+ *
+ * Note that the `AstFactory` makes no assumptions about the target language being generated.
+ * It is up to the caller to do this - e.g. only call `createTaggedTemplate()` or pass `let`|`const`
+ * to `createVariableDeclaration()` if the final JS will allow it.
+ */
+export interface AstFactory<TStatement, TExpression> {
+  /**
+   * Attach the `leadingComments` to the given `statement` node.
+   *
+   * @param statement the statement where the comment is to be attached.
+   * @param leadingComments the comments to attach.
+   * @returns the node passed in as `statement` with the comments attached.
+   */
+  attachComments(statement: TStatement, leadingComments?: LeadingComment[]): TStatement;
+
+  /**
+   * Create a literal array expresion (e.g. `[expr1, expr2]`).
+   *
+   * @param elements a collection of the expressions to appear in each array slot.
+   */
+  createArrayLiteral(elements: TExpression[]): TExpression;
+
+  /**
+   * Create an assignment expression (e.g. `lhsExpr = rhsExpr`).
+   *
+   * @param target an expression that evaluates to the left side of the assignment.
+   * @param value an expression that evaluates to the right side of the assignment.
+   */
+  createAssignment(target: TExpression, value: TExpression): TExpression;
+
+  /**
+   * Create a binary expression (e.g. `lhs && rhs`).
+   *
+   * @param leftOperand an expression that will appear on the left of the operator.
+   * @param operator the binary operator that will be applied.
+   * @param rightOperand an expression that will appear on the right of the operator.
+   */
+  createBinaryExpression(
+      leftOperand: TExpression, operator: BinaryOperator, rightOperand: TExpression): TExpression;
+
+  /**
+   * Create a block of statements (e.g. `{ stmt1; stmt2; }`).
+   *
+   * @param body an array of statements to be wrapped in a block.
+   */
+  createBlock(body: TStatement[]): TStatement;
+
+  /**
+   * Create an expression that is calling the `callee` with the given `args`.
+   *
+   * @param callee an expression that evaluates to a function to be called.
+   * @param args the arugments to be passed to the call.
+   * @param pure whether to mark the call as pure (having no side-effects).
+   */
+  createCallExpression(callee: TExpression, args: TExpression[], pure: boolean): TExpression;
+
+  /**
+   * Create a ternary expression (e.g. `testExpr ? trueExpr : falseExpr`).
+   *
+   * @param condition an expression that will be tested for truthiness.
+   * @param thenExpression an expression that is executed if `condition` is truthy.
+   * @param elseExpression an expression that is executed if `condition` is falsy.
+   */
+  createConditional(
+      condition: TExpression, thenExpression: TExpression,
+      elseExpression: TExpression): TExpression;
+
+  /**
+   * Create an element access (e.g. `obj[expr]`).
+   *
+   * @param expression an expression that evaluates to the object to be accessed.
+   * @param element an expression that evaluates to the element on the object.
+   */
+  createElementAccess(expression: TExpression, element: TExpression): TExpression;
+
+  /**
+   * Create a statement that is simply executing the given `expression` (e.g. `x = 10;`).
+   *
+   * @param expression the expression to be converted to a statement.
+   */
+  createExpressionStatement(expression: TExpression): TStatement;
+
+  /**
+   * Create a statement that declares a function (e.g. `function foo(param1, param2) { stmt; }`).
+   *
+   * @param functionName the name of the function.
+   * @param parameters the names of the function's parameters.
+   * @param body a statement (or a block of statements) that are the body of the function.
+   */
+  createFunctionDeclaration(functionName: string|null, parameters: string[], body: TStatement):
+      TStatement;
+
+  /**
+   * Create an expression that represents a function
+   * (e.g. `function foo(param1, param2) { stmt; }`).
+   *
+   * @param functionName the name of the function.
+   * @param parameters the names of the function's parameters.
+   * @param body a statement (or a block of statements) that are the body of the function.
+   */
+  createFunctionExpression(functionName: string|null, parameters: string[], body: TStatement):
+      TExpression;
+
+  /**
+   * Create an identifier.
+   *
+   * @param name the name of the identifier.
+   */
+  createIdentifier(name: string): TExpression;
+
+  /**
+   * Create an if statement (e.g. `if (testExpr) { trueStmt; } else { falseStmt; }`).
+   *
+   * @param condition an expression that will be tested for truthiness.
+   * @param thenStatement a statement (or block of statements) that is executed if `condition` is
+   *     truthy.
+   * @param elseStatement a statement (or block of statements) that is executed if `condition` is
+   *     falsy.
+   */
+  createIfStatement(
+      condition: TExpression, thenStatement: TStatement,
+      elseStatement: TStatement|null): TStatement;
+
+  /**
+   * Create a simple literal (e.g. `"string"`, `123`, `false`, etc).
+   *
+   * @param value the value of the literal.
+   */
+  createLiteral(value: string|number|boolean|null|undefined): TExpression;
+
+  /**
+   * Create an expression that is instantiating the `expression` as a class.
+   *
+   * @param expression an expression that evaluates to a constructor to be instantiated.
+   * @param args the arguments to be passed to the constructor.
+   */
+  createNewExpression(expression: TExpression, args: TExpression[]): TExpression;
+
+  /**
+   * Create a literal object expression (e.g. `{ prop1: expr1, prop2: expr2 }`).
+   *
+   * @param properties the properties (key and value) to appear in the object.
+   */
+  createObjectLiteral(properties: ObjectLiteralProperty<TExpression>[]): TExpression;
+
+  /**
+   * Wrap an expression in parentheses.
+   *
+   * @param expression the expression to wrap in parentheses.
+   */
+  createParenthesizedExpression(expression: TExpression): TExpression;
+
+  /**
+   * Create a property access (e.g. `obj.prop`).
+   *
+   * @param expression an expression that evaluates to the object to be accessed.
+   * @param propertyName the name of the property to access.
+   */
+  createPropertyAccess(expression: TExpression, propertyName: string): TExpression;
+
+  /**
+   * Create a return statement (e.g `return expr;`).
+   *
+   * @param expression the expression to be returned.
+   */
+  createReturnStatement(expression: TExpression|null): TStatement;
+
+  /**
+   * Create a tagged template literal string. E.g.
+   *
+   * ```
+   * tag`str1${expr1}str2${expr2}str3`
+   * ```
+   *
+   * @param tag an expression that is applied as a tag handler for this template string.
+   * @param template the collection of strings and expressions that constitute an interpolated
+   *     template literal.
+   */
+  createTaggedTemplate(tag: TExpression, template: TemplateLiteral<TExpression>): TExpression;
+
+  /**
+   * Create a throw statement (e.g. `throw expr;`).
+   *
+   * @param expression the expression to be thrown.
+   */
+  createThrowStatement(expression: TExpression): TStatement;
+
+  /**
+   * Create an expression that extracts the type of an expression (e.g. `typeof expr`).
+   *
+   * @param expression the expression whose type we want.
+   */
+  createTypeOfExpression(expression: TExpression): TExpression;
+
+  /**
+   * Prefix the `operand` with the given `operator` (e.g. `-expr`).
+   *
+   * @param operator the text of the operator to apply (e.g. `+`, `-` or `!`).
+   * @param operand the expression that the operator applies to.
+   */
+  createUnaryExpression(operator: UnaryOperator, operand: TExpression): TExpression;
+
+  /**
+   * Create an expression that declares a new variable, possibly initialized to `initializer`.
+   *
+   * @param variableName the name of the variable.
+   * @param initializer if not `null` then this expression is assigned to the declared variable.
+   * @param type whether this variable should be declared as `var`, `let` or `const`.
+   */
+  createVariableDeclaration(
+      variableName: string, initializer: TExpression|null,
+      type: VariableDeclarationType): TStatement;
+
+  /**
+   * Attach a source map range to the given node.
+   *
+   * @param node the node to which the range should be attached.
+   * @param sourceMapRange the range to attach to the node, or null if there is no range to attach.
+   * @returns the `node` with the `sourceMapRange` attached.
+   */
+  setSourceMapRange<T extends TStatement|TExpression>(node: T, sourceMapRange: SourceMapRange|null):
+      T;
+}
+
+/**
+ * The type of a variable declaration.
+ */
+export type VariableDeclarationType = 'const'|'let'|'var';
+
+/**
+ * The unary operators supported by the `AstFactory`.
+ */
+export type UnaryOperator = '+'|'-'|'!';
+
+/**
+ * The binary operators supported by the `AstFactory`.
+ */
+export type BinaryOperator =
+    '&&'|'>'|'>='|'&'|'/'|'=='|'==='|'<'|'<='|'-'|'%'|'*'|'!='|'!=='|'||'|'+';
+
+/**
+ * The original location of the start or end of a node created by the `AstFactory`.
+ */
+export interface SourceMapLocation {
+  /** 0-based character position of the location in the original source file. */
+  offset: number;
+  /** 0-based line index of the location in the original source file. */
+  line: number;
+  /** 0-based column position of the location in the original source file. */
+  column: number;
+}
+
+/**
+ * The original range of a node created by the `AstFactory`.
+ */
+export interface SourceMapRange {
+  url: string;
+  content: string;
+  start: SourceMapLocation;
+  end: SourceMapLocation;
+}
+
+/**
+ * Information used by the `AstFactory` to create a property on an object literal expression.
+ */
+export interface ObjectLiteralProperty<TExpression> {
+  propertyName: string;
+  value: TExpression;
+  /**
+   * Whether the `propertyName` should be enclosed in quotes.
+   */
+  quoted: boolean;
+}
+
+/**
+ * Information used by the `AstFactory` to create a template literal string (i.e. a back-ticked
+ * string with interpolations).
+ */
+export interface TemplateLiteral<TExpression> {
+  /**
+   * A collection of the static string pieces of the interpolated template literal string.
+   */
+  elements: TemplateElement[];
+  /**
+   * A collection of the interpolated expressions that are interleaved between the elements.
+   */
+  expressions: TExpression[];
+}
+
+/**
+ * Information about a static string piece of an interpolated template literal string.
+ */
+export interface TemplateElement {
+  /** The raw string as it was found in the original source code. */
+  raw: string;
+  /** The parsed string, with escape codes etc processed. */
+  cooked: string;
+  /** The original location of this piece of the template literal string. */
+  range: SourceMapRange|null;
+}
+
+/**
+ * Information used by the `AstFactory` to prepend a comment to a statement that was created by the
+ * `AstFactory`.
+ */
+export interface LeadingComment {
+  toString(): string;
+  multiline: boolean;
+  trailingNewline: boolean;
+}

--- a/packages/compiler-cli/src/ngtsc/translator/src/api/import_generator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/api/import_generator.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Information about an import that has been added to a module.
+ */
+export interface Import {
+  /** The name of the module that has been imported. */
+  specifier: string;
+  /** The alias of the imported module. */
+  qualifier: string;
+}
+
+/**
+ * The symbol name and import namespace of an imported symbol,
+ * which has been registered through the ImportGenerator.
+ */
+export interface NamedImport<TExpression> {
+  /** The import namespace containing this imported symbol. */
+  moduleImport: TExpression|null;
+  /** The (possibly rewritten) name of the imported symbol. */
+  symbol: string;
+}
+
+/**
+ * Generate import information based on the context of the code being generated.
+ *
+ * Implementations of these methods return a specific identifier that corresponds to the imported
+ * module.
+ */
+export interface ImportGenerator<TExpression> {
+  generateNamespaceImport(moduleName: string): TExpression;
+  generateNamedImport(moduleName: string, originalSymbol: string): NamedImport<TExpression>;
+}

--- a/packages/compiler-cli/src/ngtsc/translator/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/context.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * The current context of a translator visitor as it traverses the AST tree.
+ *
+ * It tracks whether we are in the process of outputting a statement or an expression.
+ */
+export class Context {
+  constructor(readonly isStatement: boolean) {}
+
+  get withExpressionMode(): Context {
+    return this.isStatement ? new Context(false) : this;
+  }
+
+  get withStatementMode(): Context {
+    return !this.isStatement ? new Context(true) : this;
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/translator/src/import_manager.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/import_manager.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {ImportRewriter, NoopImportRewriter} from '../../imports/src/core';
+
+/**
+ * Information about an import that has been added to a module.
+ */
+export interface Import {
+  /** The name of the module that has been imported. */
+  specifier: string;
+  /** The alias of the imported module. */
+  qualifier: string;
+}
+
+/**
+ * The symbol name and import namespace of an imported symbol,
+ * which has been registered through the ImportManager.
+ */
+export interface NamedImport {
+  /** The import namespace containing this imported symbol. */
+  moduleImport: string|null;
+  /** The (possibly rewritten) name of the imported symbol. */
+  symbol: string;
+}
+
+export class ImportManager {
+  private specifierToIdentifier = new Map<string, string>();
+  private nextIndex = 0;
+
+  constructor(protected rewriter: ImportRewriter = new NoopImportRewriter(), private prefix = 'i') {
+  }
+
+  generateNamedImport(moduleName: string, originalSymbol: string): NamedImport {
+    // First, rewrite the symbol name.
+    const symbol = this.rewriter.rewriteSymbol(originalSymbol, moduleName);
+
+    // Ask the rewriter if this symbol should be imported at all. If not, it can be referenced
+    // directly (moduleImport: null).
+    if (!this.rewriter.shouldImportSymbol(symbol, moduleName)) {
+      // The symbol should be referenced directly.
+      return {moduleImport: null, symbol};
+    }
+
+    // If not, this symbol will be imported. Allocate a prefix for the imported module if needed.
+
+    if (!this.specifierToIdentifier.has(moduleName)) {
+      this.specifierToIdentifier.set(moduleName, `${this.prefix}${this.nextIndex++}`);
+    }
+    const moduleImport = this.specifierToIdentifier.get(moduleName)!;
+
+    return {moduleImport, symbol};
+  }
+
+  getAllImports(contextPath: string): Import[] {
+    const imports: {specifier: string, qualifier: string}[] = [];
+    this.specifierToIdentifier.forEach((qualifier, specifier) => {
+      specifier = this.rewriter.rewriteSpecifier(specifier, contextPath);
+      imports.push({specifier, qualifier});
+    });
+    return imports;
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -134,15 +134,16 @@ class ExpressionTranslatorVisitor implements ExpressionVisitor, StatementVisitor
       private scriptTarget: Exclude<ts.ScriptTarget, ts.ScriptTarget.JSON>) {}
 
   visitDeclareVarStmt(stmt: DeclareVarStmt, context: Context): ts.VariableStatement {
-    const isConst =
-        this.scriptTarget >= ts.ScriptTarget.ES2015 && stmt.hasModifier(StmtModifier.Final);
+    const varType = this.scriptTarget < ts.ScriptTarget.ES2015 ?
+        ts.NodeFlags.None :
+        stmt.hasModifier(StmtModifier.Final) ? ts.NodeFlags.Const : ts.NodeFlags.Let;
     const varDeclaration = ts.createVariableDeclaration(
         /* name */ stmt.name,
         /* type */ undefined,
         /* initializer */ stmt.value?.visitExpression(this, context.withExpressionMode));
     const declarationList = ts.createVariableDeclarationList(
         /* declarations */[varDeclaration],
-        /* flags */ isConst ? ts.NodeFlags.Const : ts.NodeFlags.None);
+        /* flags */ varType);
     const varStatement = ts.createVariableStatement(undefined, declarationList);
     return attachComments(varStatement, stmt.leadingComments);
   }

--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -6,23 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ArrayType, AssertNotNull, BinaryOperator, BinaryOperatorExpr, BuiltinType, BuiltinTypeName, CastExpr, ClassStmt, CommaExpr, ConditionalExpr, DeclareFunctionStmt, DeclareVarStmt, Expression, ExpressionStatement, ExpressionType, ExpressionVisitor, ExternalExpr, FunctionExpr, IfStmt, InstantiateExpr, InvokeFunctionExpr, InvokeMethodExpr, LeadingComment, LiteralArrayExpr, LiteralExpr, LiteralMapExpr, MapType, NotExpr, ParseSourceSpan, ReadKeyExpr, ReadPropExpr, ReadVarExpr, ReturnStatement, Statement, StatementVisitor, StmtModifier, ThrowStmt, TryCatchStmt, Type, TypeofExpr, TypeVisitor, WrappedNodeExpr, WriteKeyExpr, WritePropExpr, WriteVarExpr} from '@angular/compiler';
+import {AssertNotNull, BinaryOperator, BinaryOperatorExpr, CastExpr, ClassStmt, CommaExpr, ConditionalExpr, DeclareFunctionStmt, DeclareVarStmt, Expression, ExpressionStatement, ExpressionVisitor, ExternalExpr, FunctionExpr, IfStmt, InstantiateExpr, InvokeFunctionExpr, InvokeMethodExpr, LeadingComment, LiteralArrayExpr, LiteralExpr, LiteralMapExpr, NotExpr, ParseSourceSpan, ReadKeyExpr, ReadPropExpr, ReadVarExpr, ReturnStatement, Statement, StatementVisitor, StmtModifier, ThrowStmt, TryCatchStmt, TypeofExpr, WrappedNodeExpr, WriteKeyExpr, WritePropExpr, WriteVarExpr} from '@angular/compiler';
 import {LocalizedString, UnaryOperator, UnaryOperatorExpr} from '@angular/compiler/src/output/output_ast';
 import * as ts from 'typescript';
 
-import {DefaultImportRecorder, ImportRewriter, NOOP_DEFAULT_IMPORT_RECORDER, NoopImportRewriter} from '../../imports';
-
-export class Context {
-  constructor(readonly isStatement: boolean) {}
-
-  get withExpressionMode(): Context {
-    return this.isStatement ? new Context(false) : this;
-  }
-
-  get withStatementMode(): Context {
-    return !this.isStatement ? new Context(true) : this;
-  }
-}
+import {DefaultImportRecorder} from '../../imports';
+import {Context} from './context';
+import {ImportManager} from './import_manager';
 
 const UNARY_OPERATORS = new Map<UnaryOperator, ts.PrefixUnaryOperator>([
   [UnaryOperator.Minus, ts.SyntaxKind.MinusToken],
@@ -48,65 +38,6 @@ const BINARY_OPERATORS = new Map<BinaryOperator, ts.BinaryOperator>([
   [BinaryOperator.Plus, ts.SyntaxKind.PlusToken],
 ]);
 
-/**
- * Information about an import that has been added to a module.
- */
-export interface Import {
-  /** The name of the module that has been imported. */
-  specifier: string;
-  /** The alias of the imported module. */
-  qualifier: string;
-}
-
-/**
- * The symbol name and import namespace of an imported symbol,
- * which has been registered through the ImportManager.
- */
-export interface NamedImport {
-  /** The import namespace containing this imported symbol. */
-  moduleImport: string|null;
-  /** The (possibly rewritten) name of the imported symbol. */
-  symbol: string;
-}
-
-export class ImportManager {
-  private specifierToIdentifier = new Map<string, string>();
-  private nextIndex = 0;
-
-  constructor(protected rewriter: ImportRewriter = new NoopImportRewriter(), private prefix = 'i') {
-  }
-
-  generateNamedImport(moduleName: string, originalSymbol: string): NamedImport {
-    // First, rewrite the symbol name.
-    const symbol = this.rewriter.rewriteSymbol(originalSymbol, moduleName);
-
-    // Ask the rewriter if this symbol should be imported at all. If not, it can be referenced
-    // directly (moduleImport: null).
-    if (!this.rewriter.shouldImportSymbol(symbol, moduleName)) {
-      // The symbol should be referenced directly.
-      return {moduleImport: null, symbol};
-    }
-
-    // If not, this symbol will be imported. Allocate a prefix for the imported module if needed.
-
-    if (!this.specifierToIdentifier.has(moduleName)) {
-      this.specifierToIdentifier.set(moduleName, `${this.prefix}${this.nextIndex++}`);
-    }
-    const moduleImport = this.specifierToIdentifier.get(moduleName)!;
-
-    return {moduleImport, symbol};
-  }
-
-  getAllImports(contextPath: string): Import[] {
-    const imports: {specifier: string, qualifier: string}[] = [];
-    this.specifierToIdentifier.forEach((qualifier, specifier) => {
-      specifier = this.rewriter.rewriteSpecifier(specifier, contextPath);
-      imports.push({specifier, qualifier});
-    });
-    return imports;
-  }
-}
-
 export function translateExpression(
     expression: Expression, imports: ImportManager, defaultImportRecorder: DefaultImportRecorder,
     scriptTarget: Exclude<ts.ScriptTarget, ts.ScriptTarget.JSON>): ts.Expression {
@@ -123,9 +54,6 @@ export function translateStatement(
       new Context(true));
 }
 
-export function translateType(type: Type, imports: ImportManager): ts.TypeNode {
-  return type.visitType(new TypeTranslatorVisitor(imports), new Context(false));
-}
 
 class ExpressionTranslatorVisitor implements ExpressionVisitor, StatementVisitor {
   private externalSourceFiles = new Map<string, ts.SourceMapSource>();
@@ -541,232 +469,6 @@ class ExpressionTranslatorVisitor implements ExpressionVisitor, StatementVisitor
     const literal = ts.createStringLiteral(text);
     this.setSourceMapRange(literal, span);
     return literal;
-  }
-}
-
-export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
-  constructor(private imports: ImportManager) {}
-
-  visitBuiltinType(type: BuiltinType, context: Context): ts.KeywordTypeNode {
-    switch (type.name) {
-      case BuiltinTypeName.Bool:
-        return ts.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
-      case BuiltinTypeName.Dynamic:
-        return ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
-      case BuiltinTypeName.Int:
-      case BuiltinTypeName.Number:
-        return ts.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
-      case BuiltinTypeName.String:
-        return ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
-      case BuiltinTypeName.None:
-        return ts.createKeywordTypeNode(ts.SyntaxKind.NeverKeyword);
-      default:
-        throw new Error(`Unsupported builtin type: ${BuiltinTypeName[type.name]}`);
-    }
-  }
-
-  visitExpressionType(type: ExpressionType, context: Context): ts.TypeNode {
-    const typeNode = this.translateExpression(type.value, context);
-    if (type.typeParams === null) {
-      return typeNode;
-    }
-
-    if (!ts.isTypeReferenceNode(typeNode)) {
-      throw new Error(
-          'An ExpressionType with type arguments must translate into a TypeReferenceNode');
-    } else if (typeNode.typeArguments !== undefined) {
-      throw new Error(
-          `An ExpressionType with type arguments cannot have multiple levels of type arguments`);
-    }
-
-    const typeArgs = type.typeParams.map(param => this.translateType(param, context));
-    return ts.createTypeReferenceNode(typeNode.typeName, typeArgs);
-  }
-
-  visitArrayType(type: ArrayType, context: Context): ts.ArrayTypeNode {
-    return ts.createArrayTypeNode(this.translateType(type.of, context));
-  }
-
-  visitMapType(type: MapType, context: Context): ts.TypeLiteralNode {
-    const parameter = ts.createParameter(
-        undefined, undefined, undefined, 'key', undefined,
-        ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword));
-    const typeArgs = type.valueType !== null ?
-        this.translateType(type.valueType, context) :
-        ts.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
-    const indexSignature = ts.createIndexSignature(undefined, undefined, [parameter], typeArgs);
-    return ts.createTypeLiteralNode([indexSignature]);
-  }
-
-  visitReadVarExpr(ast: ReadVarExpr, context: Context): ts.TypeQueryNode {
-    if (ast.name === null) {
-      throw new Error(`ReadVarExpr with no variable name in type`);
-    }
-    return ts.createTypeQueryNode(ts.createIdentifier(ast.name));
-  }
-
-  visitWriteVarExpr(expr: WriteVarExpr, context: Context): never {
-    throw new Error('Method not implemented.');
-  }
-
-  visitWriteKeyExpr(expr: WriteKeyExpr, context: Context): never {
-    throw new Error('Method not implemented.');
-  }
-
-  visitWritePropExpr(expr: WritePropExpr, context: Context): never {
-    throw new Error('Method not implemented.');
-  }
-
-  visitInvokeMethodExpr(ast: InvokeMethodExpr, context: Context): never {
-    throw new Error('Method not implemented.');
-  }
-
-  visitInvokeFunctionExpr(ast: InvokeFunctionExpr, context: Context): never {
-    throw new Error('Method not implemented.');
-  }
-
-  visitInstantiateExpr(ast: InstantiateExpr, context: Context): never {
-    throw new Error('Method not implemented.');
-  }
-
-  visitLiteralExpr(ast: LiteralExpr, context: Context): ts.TypeNode {
-    if (ast.value === null) {
-      // TODO(alan-agius4): Remove when we no longer support TS 3.9
-      // Use: return ts.createLiteralTypeNode(ts.createNull()) directly.
-      return ts.versionMajorMinor.charAt(0) === '4' ?
-          ts.createLiteralTypeNode(ts.createNull() as any) :
-          ts.createKeywordTypeNode(ts.SyntaxKind.NullKeyword as any);
-    } else if (ast.value === undefined) {
-      return ts.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword);
-    } else if (typeof ast.value === 'boolean') {
-      return ts.createLiteralTypeNode(ts.createLiteral(ast.value));
-    } else if (typeof ast.value === 'number') {
-      return ts.createLiteralTypeNode(ts.createLiteral(ast.value));
-    } else {
-      return ts.createLiteralTypeNode(ts.createLiteral(ast.value));
-    }
-  }
-
-  visitLocalizedString(ast: LocalizedString, context: Context): never {
-    throw new Error('Method not implemented.');
-  }
-
-  visitExternalExpr(ast: ExternalExpr, context: Context): ts.EntityName|ts.TypeReferenceNode {
-    if (ast.value.moduleName === null || ast.value.name === null) {
-      throw new Error(`Import unknown module or symbol`);
-    }
-    const {moduleImport, symbol} =
-        this.imports.generateNamedImport(ast.value.moduleName, ast.value.name);
-    const symbolIdentifier = ts.createIdentifier(symbol);
-
-    const typeName = moduleImport ?
-        ts.createQualifiedName(ts.createIdentifier(moduleImport), symbolIdentifier) :
-        symbolIdentifier;
-
-    const typeArguments = ast.typeParams !== null ?
-        ast.typeParams.map(type => this.translateType(type, context)) :
-        undefined;
-    return ts.createTypeReferenceNode(typeName, typeArguments);
-  }
-
-  visitConditionalExpr(ast: ConditionalExpr, context: Context) {
-    throw new Error('Method not implemented.');
-  }
-
-  visitNotExpr(ast: NotExpr, context: Context) {
-    throw new Error('Method not implemented.');
-  }
-
-  visitAssertNotNullExpr(ast: AssertNotNull, context: Context) {
-    throw new Error('Method not implemented.');
-  }
-
-  visitCastExpr(ast: CastExpr, context: Context) {
-    throw new Error('Method not implemented.');
-  }
-
-  visitFunctionExpr(ast: FunctionExpr, context: Context) {
-    throw new Error('Method not implemented.');
-  }
-
-  visitUnaryOperatorExpr(ast: UnaryOperatorExpr, context: Context) {
-    throw new Error('Method not implemented.');
-  }
-
-  visitBinaryOperatorExpr(ast: BinaryOperatorExpr, context: Context) {
-    throw new Error('Method not implemented.');
-  }
-
-  visitReadPropExpr(ast: ReadPropExpr, context: Context) {
-    throw new Error('Method not implemented.');
-  }
-
-  visitReadKeyExpr(ast: ReadKeyExpr, context: Context) {
-    throw new Error('Method not implemented.');
-  }
-
-  visitLiteralArrayExpr(ast: LiteralArrayExpr, context: Context): ts.TupleTypeNode {
-    const values = ast.entries.map(expr => this.translateExpression(expr, context));
-    return ts.createTupleTypeNode(values);
-  }
-
-  visitLiteralMapExpr(ast: LiteralMapExpr, context: Context): ts.TypeLiteralNode {
-    const entries = ast.entries.map(entry => {
-      const {key, quoted} = entry;
-      const type = this.translateExpression(entry.value, context);
-      return ts.createPropertySignature(
-          /* modifiers */ undefined,
-          /* name */ quoted ? ts.createStringLiteral(key) : key,
-          /* questionToken */ undefined,
-          /* type */ type,
-          /* initializer */ undefined);
-    });
-    return ts.createTypeLiteralNode(entries);
-  }
-
-  visitCommaExpr(ast: CommaExpr, context: Context) {
-    throw new Error('Method not implemented.');
-  }
-
-  visitWrappedNodeExpr(ast: WrappedNodeExpr<any>, context: Context): ts.TypeNode {
-    const node: ts.Node = ast.node;
-    if (ts.isEntityName(node)) {
-      return ts.createTypeReferenceNode(node, /* typeArguments */ undefined);
-    } else if (ts.isTypeNode(node)) {
-      return node;
-    } else if (ts.isLiteralExpression(node)) {
-      return ts.createLiteralTypeNode(node);
-    } else {
-      throw new Error(
-          `Unsupported WrappedNodeExpr in TypeTranslatorVisitor: ${ts.SyntaxKind[node.kind]}`);
-    }
-  }
-
-  visitTypeofExpr(ast: TypeofExpr, context: Context): ts.TypeQueryNode {
-    const typeNode = this.translateExpression(ast.expr, context);
-    if (!ts.isTypeReferenceNode(typeNode)) {
-      throw new Error(`The target of a typeof expression must be a type reference, but it was
-          ${ts.SyntaxKind[typeNode.kind]}`);
-    }
-    return ts.createTypeQueryNode(typeNode.typeName);
-  }
-
-  private translateType(type: Type, context: Context): ts.TypeNode {
-    const typeNode = type.visitType(this, context);
-    if (!ts.isTypeNode(typeNode)) {
-      throw new Error(
-          `A Type must translate to a TypeNode, but was ${ts.SyntaxKind[typeNode.kind]}`);
-    }
-    return typeNode;
-  }
-
-  private translateExpression(expr: Expression, context: Context): ts.TypeNode {
-    const typeNode = expr.visitExpression(this, context);
-    if (!ts.isTypeNode(typeNode)) {
-      throw new Error(
-          `An Expression must translate to a TypeNode, but was ${ts.SyntaxKind[typeNode.kind]}`);
-    }
-    return typeNode;
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -742,9 +742,12 @@ export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
   }
 
   visitTypeofExpr(ast: TypeofExpr, context: Context): ts.TypeQueryNode {
-    let expr = translateExpression(
-        ast.expr, this.imports, NOOP_DEFAULT_IMPORT_RECORDER, ts.ScriptTarget.ES2015);
-    return ts.createTypeQueryNode(expr as ts.Identifier);
+    const typeNode = this.translateExpression(ast.expr, context);
+    if (!ts.isTypeReferenceNode(typeNode)) {
+      throw new Error(`The target of a typeof expression must be a type reference, but it was
+          ${ts.SyntaxKind[typeNode.kind]}`);
+    }
+    return ts.createTypeQueryNode(typeNode.typeName);
   }
 
   private translateType(type: Type, context: Context): ts.TypeNode {

--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -5,214 +5,249 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import * as o from '@angular/compiler';
 
-import {AssertNotNull, BinaryOperator, BinaryOperatorExpr, CastExpr, ClassStmt, CommaExpr, ConditionalExpr, DeclareFunctionStmt, DeclareVarStmt, Expression, ExpressionStatement, ExpressionVisitor, ExternalExpr, FunctionExpr, IfStmt, InstantiateExpr, InvokeFunctionExpr, InvokeMethodExpr, LeadingComment, LiteralArrayExpr, LiteralExpr, LiteralMapExpr, NotExpr, ParseSourceSpan, ReadKeyExpr, ReadPropExpr, ReadVarExpr, ReturnStatement, Statement, StatementVisitor, StmtModifier, ThrowStmt, TryCatchStmt, TypeofExpr, WrappedNodeExpr, WriteKeyExpr, WritePropExpr, WriteVarExpr} from '@angular/compiler';
-import {LocalizedString, UnaryOperator, UnaryOperatorExpr} from '@angular/compiler/src/output/output_ast';
-import * as ts from 'typescript';
-
-import {DefaultImportRecorder} from '../../imports';
+import {AstFactory, BinaryOperator, ObjectLiteralProperty, SourceMapRange, TemplateElement, TemplateLiteral, UnaryOperator} from './api/ast_factory';
+import {ImportGenerator} from './api/import_generator';
 import {Context} from './context';
-import {ImportManager} from './import_manager';
 
-const UNARY_OPERATORS = new Map<UnaryOperator, ts.PrefixUnaryOperator>([
-  [UnaryOperator.Minus, ts.SyntaxKind.MinusToken],
-  [UnaryOperator.Plus, ts.SyntaxKind.PlusToken],
+const UNARY_OPERATORS = new Map<o.UnaryOperator, UnaryOperator>([
+  [o.UnaryOperator.Minus, '-'],
+  [o.UnaryOperator.Plus, '+'],
 ]);
 
-const BINARY_OPERATORS = new Map<BinaryOperator, ts.BinaryOperator>([
-  [BinaryOperator.And, ts.SyntaxKind.AmpersandAmpersandToken],
-  [BinaryOperator.Bigger, ts.SyntaxKind.GreaterThanToken],
-  [BinaryOperator.BiggerEquals, ts.SyntaxKind.GreaterThanEqualsToken],
-  [BinaryOperator.BitwiseAnd, ts.SyntaxKind.AmpersandToken],
-  [BinaryOperator.Divide, ts.SyntaxKind.SlashToken],
-  [BinaryOperator.Equals, ts.SyntaxKind.EqualsEqualsToken],
-  [BinaryOperator.Identical, ts.SyntaxKind.EqualsEqualsEqualsToken],
-  [BinaryOperator.Lower, ts.SyntaxKind.LessThanToken],
-  [BinaryOperator.LowerEquals, ts.SyntaxKind.LessThanEqualsToken],
-  [BinaryOperator.Minus, ts.SyntaxKind.MinusToken],
-  [BinaryOperator.Modulo, ts.SyntaxKind.PercentToken],
-  [BinaryOperator.Multiply, ts.SyntaxKind.AsteriskToken],
-  [BinaryOperator.NotEquals, ts.SyntaxKind.ExclamationEqualsToken],
-  [BinaryOperator.NotIdentical, ts.SyntaxKind.ExclamationEqualsEqualsToken],
-  [BinaryOperator.Or, ts.SyntaxKind.BarBarToken],
-  [BinaryOperator.Plus, ts.SyntaxKind.PlusToken],
+const BINARY_OPERATORS = new Map<o.BinaryOperator, BinaryOperator>([
+  [o.BinaryOperator.And, '&&'],
+  [o.BinaryOperator.Bigger, '>'],
+  [o.BinaryOperator.BiggerEquals, '>='],
+  [o.BinaryOperator.BitwiseAnd, '&'],
+  [o.BinaryOperator.Divide, '/'],
+  [o.BinaryOperator.Equals, '=='],
+  [o.BinaryOperator.Identical, '==='],
+  [o.BinaryOperator.Lower, '<'],
+  [o.BinaryOperator.LowerEquals, '<='],
+  [o.BinaryOperator.Minus, '-'],
+  [o.BinaryOperator.Modulo, '%'],
+  [o.BinaryOperator.Multiply, '*'],
+  [o.BinaryOperator.NotEquals, '!='],
+  [o.BinaryOperator.NotIdentical, '!=='],
+  [o.BinaryOperator.Or, '||'],
+  [o.BinaryOperator.Plus, '+'],
 ]);
 
-export function translateExpression(
-    expression: Expression, imports: ImportManager, defaultImportRecorder: DefaultImportRecorder,
-    scriptTarget: Exclude<ts.ScriptTarget, ts.ScriptTarget.JSON>): ts.Expression {
-  return expression.visitExpression(
-      new ExpressionTranslatorVisitor(imports, defaultImportRecorder, scriptTarget),
-      new Context(false));
+export type RecordWrappedNodeExprFn<TExpression> = (expr: TExpression) => void;
+
+export interface TranslatorOptions<TExpression> {
+  downlevelLocalizedStrings?: boolean;
+  downlevelVariableDeclarations?: boolean;
+  recordWrappedNodeExpr?: RecordWrappedNodeExprFn<TExpression>;
 }
 
-export function translateStatement(
-    statement: Statement, imports: ImportManager, defaultImportRecorder: DefaultImportRecorder,
-    scriptTarget: Exclude<ts.ScriptTarget, ts.ScriptTarget.JSON>): ts.Statement {
-  return statement.visitStatement(
-      new ExpressionTranslatorVisitor(imports, defaultImportRecorder, scriptTarget),
-      new Context(true));
-}
+export class ExpressionTranslatorVisitor<TStatement, TExpression> implements o.ExpressionVisitor,
+                                                                             o.StatementVisitor {
+  private downlevelLocalizedStrings: boolean;
+  private downlevelVariableDeclarations: boolean;
+  private recordWrappedNodeExpr: RecordWrappedNodeExprFn<TExpression>;
 
-
-class ExpressionTranslatorVisitor implements ExpressionVisitor, StatementVisitor {
-  private externalSourceFiles = new Map<string, ts.SourceMapSource>();
   constructor(
-      private imports: ImportManager, private defaultImportRecorder: DefaultImportRecorder,
-      private scriptTarget: Exclude<ts.ScriptTarget, ts.ScriptTarget.JSON>) {}
-
-  visitDeclareVarStmt(stmt: DeclareVarStmt, context: Context): ts.VariableStatement {
-    const varType = this.scriptTarget < ts.ScriptTarget.ES2015 ?
-        ts.NodeFlags.None :
-        stmt.hasModifier(StmtModifier.Final) ? ts.NodeFlags.Const : ts.NodeFlags.Let;
-    const varDeclaration = ts.createVariableDeclaration(
-        /* name */ stmt.name,
-        /* type */ undefined,
-        /* initializer */ stmt.value?.visitExpression(this, context.withExpressionMode));
-    const declarationList = ts.createVariableDeclarationList(
-        /* declarations */[varDeclaration],
-        /* flags */ varType);
-    const varStatement = ts.createVariableStatement(undefined, declarationList);
-    return attachComments(varStatement, stmt.leadingComments);
+      private factory: AstFactory<TStatement, TExpression>,
+      private imports: ImportGenerator<TExpression>, options: TranslatorOptions<TExpression>) {
+    this.downlevelLocalizedStrings = options.downlevelLocalizedStrings === true;
+    this.downlevelVariableDeclarations = options.downlevelVariableDeclarations === true;
+    this.recordWrappedNodeExpr = options.recordWrappedNodeExpr || (() => {});
   }
 
-  visitDeclareFunctionStmt(stmt: DeclareFunctionStmt, context: Context): ts.FunctionDeclaration {
-    const fnDeclaration = ts.createFunctionDeclaration(
-        /* decorators */ undefined,
-        /* modifiers */ undefined,
-        /* asterisk */ undefined,
-        /* name */ stmt.name,
-        /* typeParameters */ undefined,
-        /* parameters */
-        stmt.params.map(param => ts.createParameter(undefined, undefined, undefined, param.name)),
-        /* type */ undefined,
-        /* body */
-        ts.createBlock(
-            stmt.statements.map(child => child.visitStatement(this, context.withStatementMode))));
-    return attachComments(fnDeclaration, stmt.leadingComments);
-  }
-
-  visitExpressionStmt(stmt: ExpressionStatement, context: Context): ts.ExpressionStatement {
-    return attachComments(
-        ts.createStatement(stmt.expr.visitExpression(this, context.withStatementMode)),
+  visitDeclareVarStmt(stmt: o.DeclareVarStmt, context: Context): TStatement {
+    const varType = this.downlevelVariableDeclarations ?
+        'var' :
+        stmt.hasModifier(o.StmtModifier.Final) ? 'const' : 'let';
+    return this.factory.attachComments(
+        this.factory.createVariableDeclaration(
+            stmt.name, stmt.value?.visitExpression(this, context.withExpressionMode), varType),
         stmt.leadingComments);
   }
 
-  visitReturnStmt(stmt: ReturnStatement, context: Context): ts.ReturnStatement {
-    return attachComments(
-        ts.createReturn(stmt.value.visitExpression(this, context.withExpressionMode)),
+  visitDeclareFunctionStmt(stmt: o.DeclareFunctionStmt, context: Context): TStatement {
+    return this.factory.attachComments(
+        this.factory.createFunctionDeclaration(
+            stmt.name, stmt.params.map(param => param.name),
+            this.factory.createBlock(
+                this.visitStatements(stmt.statements, context.withStatementMode))),
         stmt.leadingComments);
   }
 
-  visitDeclareClassStmt(stmt: ClassStmt, context: Context) {
-    if (this.scriptTarget < ts.ScriptTarget.ES2015) {
-      throw new Error(
-          `Unsupported mode: Visiting a "declare class" statement (class ${stmt.name}) while ` +
-          `targeting ${ts.ScriptTarget[this.scriptTarget]}.`);
-    }
+  visitExpressionStmt(stmt: o.ExpressionStatement, context: Context): TStatement {
+    return this.factory.attachComments(
+        this.factory.createExpressionStatement(
+            stmt.expr.visitExpression(this, context.withStatementMode)),
+        stmt.leadingComments);
+  }
+
+  visitReturnStmt(stmt: o.ReturnStatement, context: Context): TStatement {
+    return this.factory.attachComments(
+        this.factory.createReturnStatement(
+            stmt.value.visitExpression(this, context.withExpressionMode)),
+        stmt.leadingComments);
+  }
+
+  visitDeclareClassStmt(_stmt: o.ClassStmt, _context: Context): never {
     throw new Error('Method not implemented.');
   }
 
-  visitIfStmt(stmt: IfStmt, context: Context): ts.IfStatement {
-    const thenBlock = ts.createBlock(
-        stmt.trueCase.map(child => child.visitStatement(this, context.withStatementMode)));
-    const elseBlock = stmt.falseCase.length > 0 ?
-        ts.createBlock(
-            stmt.falseCase.map(child => child.visitStatement(this, context.withStatementMode))) :
-        undefined;
-    const ifStatement =
-        ts.createIf(stmt.condition.visitExpression(this, context), thenBlock, elseBlock);
-    return attachComments(ifStatement, stmt.leadingComments);
-  }
-
-  visitTryCatchStmt(stmt: TryCatchStmt, context: Context) {
-    throw new Error('Method not implemented.');
-  }
-
-  visitThrowStmt(stmt: ThrowStmt, context: Context): ts.ThrowStatement {
-    return attachComments(
-        ts.createThrow(stmt.error.visitExpression(this, context.withExpressionMode)),
+  visitIfStmt(stmt: o.IfStmt, context: Context): TStatement {
+    return this.factory.attachComments(
+        this.factory.createIfStatement(
+            stmt.condition.visitExpression(this, context),
+            this.factory.createBlock(
+                this.visitStatements(stmt.trueCase, context.withStatementMode)),
+            stmt.falseCase.length > 0 ? this.factory.createBlock(this.visitStatements(
+                                            stmt.falseCase, context.withStatementMode)) :
+                                        null),
         stmt.leadingComments);
   }
 
-  visitReadVarExpr(ast: ReadVarExpr, context: Context): ts.Identifier {
-    const identifier = ts.createIdentifier(ast.name!);
+  visitTryCatchStmt(_stmt: o.TryCatchStmt, _context: Context): never {
+    throw new Error('Method not implemented.');
+  }
+
+  visitThrowStmt(stmt: o.ThrowStmt, context: Context): TStatement {
+    return this.factory.attachComments(
+        this.factory.createThrowStatement(
+            stmt.error.visitExpression(this, context.withExpressionMode)),
+        stmt.leadingComments);
+  }
+
+  visitReadVarExpr(ast: o.ReadVarExpr, _context: Context): TExpression {
+    const identifier = this.factory.createIdentifier(ast.name!);
     this.setSourceMapRange(identifier, ast.sourceSpan);
     return identifier;
   }
 
-  visitWriteVarExpr(expr: WriteVarExpr, context: Context): ts.Expression {
-    const result: ts.Expression = ts.createBinary(
-        ts.createIdentifier(expr.name), ts.SyntaxKind.EqualsToken,
-        expr.value.visitExpression(this, context));
-    return context.isStatement ? result : ts.createParen(result);
+  visitWriteVarExpr(expr: o.WriteVarExpr, context: Context): TExpression {
+    const assignment = this.factory.createAssignment(
+        this.setSourceMapRange(this.factory.createIdentifier(expr.name), expr.sourceSpan),
+        expr.value.visitExpression(this, context),
+    );
+    return context.isStatement ? assignment :
+                                 this.factory.createParenthesizedExpression(assignment);
   }
 
-  visitWriteKeyExpr(expr: WriteKeyExpr, context: Context): ts.Expression {
+  visitWriteKeyExpr(expr: o.WriteKeyExpr, context: Context): TExpression {
     const exprContext = context.withExpressionMode;
-    const lhs = ts.createElementAccess(
+    const target = this.factory.createElementAccess(
         expr.receiver.visitExpression(this, exprContext),
-        expr.index.visitExpression(this, exprContext));
-    const rhs = expr.value.visitExpression(this, exprContext);
-    const result: ts.Expression = ts.createBinary(lhs, ts.SyntaxKind.EqualsToken, rhs);
-    return context.isStatement ? result : ts.createParen(result);
+        expr.index.visitExpression(this, exprContext),
+    );
+    const assignment =
+        this.factory.createAssignment(target, expr.value.visitExpression(this, exprContext));
+    return context.isStatement ? assignment :
+                                 this.factory.createParenthesizedExpression(assignment);
   }
 
-  visitWritePropExpr(expr: WritePropExpr, context: Context): ts.BinaryExpression {
-    return ts.createBinary(
-        ts.createPropertyAccess(expr.receiver.visitExpression(this, context), expr.name),
-        ts.SyntaxKind.EqualsToken, expr.value.visitExpression(this, context));
+  visitWritePropExpr(expr: o.WritePropExpr, context: Context): TExpression {
+    const target =
+        this.factory.createPropertyAccess(expr.receiver.visitExpression(this, context), expr.name);
+    return this.factory.createAssignment(target, expr.value.visitExpression(this, context));
   }
 
-  visitInvokeMethodExpr(ast: InvokeMethodExpr, context: Context): ts.CallExpression {
+  visitInvokeMethodExpr(ast: o.InvokeMethodExpr, context: Context): TExpression {
     const target = ast.receiver.visitExpression(this, context);
-    const call = ts.createCall(
-        ast.name !== null ? ts.createPropertyAccess(target, ast.name) : target, undefined,
-        ast.args.map(arg => arg.visitExpression(this, context)));
-    this.setSourceMapRange(call, ast.sourceSpan);
-    return call;
+    return this.setSourceMapRange(
+        this.factory.createCallExpression(
+            ast.name !== null ? this.factory.createPropertyAccess(target, ast.name) : target,
+            ast.args.map(arg => arg.visitExpression(this, context)),
+            /* pure */ false),
+        ast.sourceSpan);
   }
 
-  visitInvokeFunctionExpr(ast: InvokeFunctionExpr, context: Context): ts.CallExpression {
-    const expr = ts.createCall(
-        ast.fn.visitExpression(this, context), undefined,
+  visitInvokeFunctionExpr(ast: o.InvokeFunctionExpr, context: Context): TExpression {
+    return this.setSourceMapRange(
+        this.factory.createCallExpression(
+            ast.fn.visitExpression(this, context),
+            ast.args.map(arg => arg.visitExpression(this, context)), ast.pure),
+        ast.sourceSpan);
+  }
+
+  visitInstantiateExpr(ast: o.InstantiateExpr, context: Context): TExpression {
+    return this.factory.createNewExpression(
+        ast.classExpr.visitExpression(this, context),
         ast.args.map(arg => arg.visitExpression(this, context)));
-    if (ast.pure) {
-      ts.addSyntheticLeadingComment(expr, ts.SyntaxKind.MultiLineCommentTrivia, '@__PURE__', false);
+  }
+
+  visitLiteralExpr(ast: o.LiteralExpr, _context: Context): TExpression {
+    return this.setSourceMapRange(this.factory.createLiteral(ast.value), ast.sourceSpan);
+  }
+
+  visitLocalizedString(ast: o.LocalizedString, context: Context): TExpression {
+    // A `$localize` message consists of `messageParts` and `expressions`, which get interleaved
+    // together. The interleaved pieces look like:
+    // `[messagePart0, expression0, messagePart1, expression1, messagePart2]`
+    //
+    // Note that there is always a message part at the start and end, and so therefore
+    // `messageParts.length === expressions.length + 1`.
+    //
+    // Each message part may be prefixed with "metadata", which is wrapped in colons (:) delimiters.
+    // The metadata is attached to the first and subsequent message parts by calls to
+    // `serializeI18nHead()` and `serializeI18nTemplatePart()` respectively.
+    //
+    // The first message part (i.e. `ast.messageParts[0]`) is used to initialize `messageParts`
+    // array.
+    const elements: TemplateElement[] = [createTemplateElement(ast.serializeI18nHead())];
+    const expressions: TExpression[] = [];
+    for (let i = 0; i < ast.expressions.length; i++) {
+      const placeholder = this.setSourceMapRange(
+          ast.expressions[i].visitExpression(this, context), ast.getPlaceholderSourceSpan(i));
+      expressions.push(placeholder);
+      elements.push(createTemplateElement(ast.serializeI18nTemplatePart(i + 1)));
     }
-    this.setSourceMapRange(expr, ast.sourceSpan);
-    return expr;
+
+    const localizeTag = this.factory.createIdentifier('$localize');
+
+    // Now choose which implementation to use to actually create the necessary AST nodes.
+    const localizeCall = this.downlevelLocalizedStrings ?
+        this.createES5TaggedTemplateFunctionCall(localizeTag, {elements, expressions}) :
+        this.factory.createTaggedTemplate(localizeTag, {elements, expressions});
+
+    return this.setSourceMapRange(localizeCall, ast.sourceSpan);
   }
 
-  visitInstantiateExpr(ast: InstantiateExpr, context: Context): ts.NewExpression {
-    return ts.createNew(
-        ast.classExpr.visitExpression(this, context), undefined,
-        ast.args.map(arg => arg.visitExpression(this, context)));
-  }
+  /**
+   * Translate the tagged template literal into a call that is compatible with ES5, using the
+   * imported `__makeTemplateObject` helper for ES5 formatted output.
+   */
+  private createES5TaggedTemplateFunctionCall(
+      tagHandler: TExpression, {elements, expressions}: TemplateLiteral<TExpression>): TExpression {
+    // Ensure that the `__makeTemplateObject()` helper has been imported.
+    const {moduleImport, symbol} =
+        this.imports.generateNamedImport('tslib', '__makeTemplateObject');
+    const __makeTemplateObjectHelper = (moduleImport === null) ?
+        this.factory.createIdentifier(symbol) :
+        this.factory.createPropertyAccess(moduleImport, symbol);
 
-  visitLiteralExpr(ast: LiteralExpr, context: Context): ts.Expression {
-    let expr: ts.Expression;
-    if (ast.value === undefined) {
-      expr = ts.createIdentifier('undefined');
-    } else if (ast.value === null) {
-      expr = ts.createNull();
-    } else {
-      expr = ts.createLiteral(ast.value);
+    // Collect up the cooked and raw strings into two separate arrays.
+    const cooked: TExpression[] = [];
+    const raw: TExpression[] = [];
+    for (const element of elements) {
+      cooked.push(this.factory.setSourceMapRange(
+          this.factory.createLiteral(element.cooked), element.range));
+      raw.push(
+          this.factory.setSourceMapRange(this.factory.createLiteral(element.raw), element.range));
     }
-    this.setSourceMapRange(expr, ast.sourceSpan);
-    return expr;
+
+    // Generate the helper call in the form: `__makeTemplateObject([cooked], [raw]);`
+    const templateHelperCall = this.factory.createCallExpression(
+        __makeTemplateObjectHelper,
+        [this.factory.createArrayLiteral(cooked), this.factory.createArrayLiteral(raw)],
+        /* pure */ false);
+
+    // Finally create the tagged handler call in the form:
+    // `tag(__makeTemplateObject([cooked], [raw]), ...expressions);`
+    return this.factory.createCallExpression(
+        tagHandler, [templateHelperCall, ...expressions],
+        /* pure */ false);
   }
 
-  visitLocalizedString(ast: LocalizedString, context: Context): ts.Expression {
-    const localizedString = this.scriptTarget >= ts.ScriptTarget.ES2015 ?
-        this.createLocalizedStringTaggedTemplate(ast, context) :
-        this.createLocalizedStringFunctionCall(ast, context);
-    this.setSourceMapRange(localizedString, ast.sourceSpan);
-    return localizedString;
-  }
-
-  visitExternalExpr(ast: ExternalExpr, context: Context): ts.PropertyAccessExpression
-      |ts.Identifier {
+  visitExternalExpr(ast: o.ExternalExpr, _context: Context): TExpression {
     if (ast.value.name === null) {
       throw new Error(`Import unknown module or symbol ${ast.value}`);
     }
@@ -224,19 +259,18 @@ class ExpressionTranslatorVisitor implements ExpressionVisitor, StatementVisitor
           this.imports.generateNamedImport(ast.value.moduleName, ast.value.name);
       if (moduleImport === null) {
         // The symbol was ambient after all.
-        return ts.createIdentifier(symbol);
+        return this.factory.createIdentifier(symbol);
       } else {
-        return ts.createPropertyAccess(
-            ts.createIdentifier(moduleImport), ts.createIdentifier(symbol));
+        return this.factory.createPropertyAccess(moduleImport, symbol);
       }
     } else {
       // The symbol is ambient, so just reference it.
-      return ts.createIdentifier(ast.value.name);
+      return this.factory.createIdentifier(ast.value.name);
     }
   }
 
-  visitConditionalExpr(ast: ConditionalExpr, context: Context): ts.ConditionalExpression {
-    let cond: ts.Expression = ast.condition.visitExpression(this, context);
+  visitConditionalExpr(ast: o.ConditionalExpr, context: Context): TExpression {
+    let cond: TExpression = ast.condition.visitExpression(this, context);
 
     // Ordinarily the ternary operator is right-associative. The following are equivalent:
     //   `a ? b : c ? d : e` => `a ? b : (c ? d : e)`
@@ -258,259 +292,128 @@ class ExpressionTranslatorVisitor implements ExpressionVisitor, StatementVisitor
     // conditional expression is directly used as the condition of another.
     //
     // TODO(alxhub): investigate better logic for precendence of conditional operators
-    if (ast.condition instanceof ConditionalExpr) {
+    if (ast.condition instanceof o.ConditionalExpr) {
       // The condition of this ternary needs to be wrapped in parentheses to maintain
       // left-associativity.
-      cond = ts.createParen(cond);
+      cond = this.factory.createParenthesizedExpression(cond);
     }
 
-    return ts.createConditional(
+    return this.factory.createConditional(
         cond, ast.trueCase.visitExpression(this, context),
         ast.falseCase!.visitExpression(this, context));
   }
 
-  visitNotExpr(ast: NotExpr, context: Context): ts.PrefixUnaryExpression {
-    return ts.createPrefix(
-        ts.SyntaxKind.ExclamationToken, ast.condition.visitExpression(this, context));
+  visitNotExpr(ast: o.NotExpr, context: Context): TExpression {
+    return this.factory.createUnaryExpression('!', ast.condition.visitExpression(this, context));
   }
 
-  visitAssertNotNullExpr(ast: AssertNotNull, context: Context): ts.NonNullExpression {
+  visitAssertNotNullExpr(ast: o.AssertNotNull, context: Context): TExpression {
     return ast.condition.visitExpression(this, context);
   }
 
-  visitCastExpr(ast: CastExpr, context: Context): ts.Expression {
+  visitCastExpr(ast: o.CastExpr, context: Context): TExpression {
     return ast.value.visitExpression(this, context);
   }
 
-  visitFunctionExpr(ast: FunctionExpr, context: Context): ts.FunctionExpression {
-    return ts.createFunctionExpression(
-        undefined, undefined, ast.name || undefined, undefined,
-        ast.params.map(
-            param => ts.createParameter(
-                undefined, undefined, undefined, param.name, undefined, undefined, undefined)),
-        undefined, ts.createBlock(ast.statements.map(stmt => stmt.visitStatement(this, context))));
+  visitFunctionExpr(ast: o.FunctionExpr, context: Context): TExpression {
+    return this.factory.createFunctionExpression(
+        ast.name ?? null, ast.params.map(param => param.name),
+        this.factory.createBlock(this.visitStatements(ast.statements, context)));
   }
 
-  visitUnaryOperatorExpr(ast: UnaryOperatorExpr, context: Context): ts.Expression {
-    if (!UNARY_OPERATORS.has(ast.operator)) {
-      throw new Error(`Unknown unary operator: ${UnaryOperator[ast.operator]}`);
-    }
-    return ts.createPrefix(
-        UNARY_OPERATORS.get(ast.operator)!, ast.expr.visitExpression(this, context));
-  }
-
-  visitBinaryOperatorExpr(ast: BinaryOperatorExpr, context: Context): ts.Expression {
+  visitBinaryOperatorExpr(ast: o.BinaryOperatorExpr, context: Context): TExpression {
     if (!BINARY_OPERATORS.has(ast.operator)) {
-      throw new Error(`Unknown binary operator: ${BinaryOperator[ast.operator]}`);
+      throw new Error(`Unknown binary operator: ${o.BinaryOperator[ast.operator]}`);
     }
-    return ts.createBinary(
-        ast.lhs.visitExpression(this, context), BINARY_OPERATORS.get(ast.operator)!,
-        ast.rhs.visitExpression(this, context));
+    return this.factory.createBinaryExpression(
+        ast.lhs.visitExpression(this, context),
+        BINARY_OPERATORS.get(ast.operator)!,
+        ast.rhs.visitExpression(this, context),
+    );
   }
 
-  visitReadPropExpr(ast: ReadPropExpr, context: Context): ts.PropertyAccessExpression {
-    return ts.createPropertyAccess(ast.receiver.visitExpression(this, context), ast.name);
+  visitReadPropExpr(ast: o.ReadPropExpr, context: Context): TExpression {
+    return this.factory.createPropertyAccess(ast.receiver.visitExpression(this, context), ast.name);
   }
 
-  visitReadKeyExpr(ast: ReadKeyExpr, context: Context): ts.ElementAccessExpression {
-    return ts.createElementAccess(
+  visitReadKeyExpr(ast: o.ReadKeyExpr, context: Context): TExpression {
+    return this.factory.createElementAccess(
         ast.receiver.visitExpression(this, context), ast.index.visitExpression(this, context));
   }
 
-  visitLiteralArrayExpr(ast: LiteralArrayExpr, context: Context): ts.ArrayLiteralExpression {
-    const expr =
-        ts.createArrayLiteral(ast.entries.map(expr => expr.visitExpression(this, context)));
-    this.setSourceMapRange(expr, ast.sourceSpan);
-    return expr;
+  visitLiteralArrayExpr(ast: o.LiteralArrayExpr, context: Context): TExpression {
+    return this.factory.createArrayLiteral(ast.entries.map(
+        expr => this.setSourceMapRange(expr.visitExpression(this, context), ast.sourceSpan)));
   }
 
-  visitLiteralMapExpr(ast: LiteralMapExpr, context: Context): ts.ObjectLiteralExpression {
-    const entries = ast.entries.map(
-        entry => ts.createPropertyAssignment(
-            entry.quoted ? ts.createLiteral(entry.key) : ts.createIdentifier(entry.key),
-            entry.value.visitExpression(this, context)));
-    const expr = ts.createObjectLiteral(entries);
-    this.setSourceMapRange(expr, ast.sourceSpan);
-    return expr;
+  visitLiteralMapExpr(ast: o.LiteralMapExpr, context: Context): TExpression {
+    const properties: ObjectLiteralProperty<TExpression>[] = ast.entries.map(entry => {
+      return {
+        propertyName: entry.key,
+        quoted: entry.quoted,
+        value: entry.value.visitExpression(this, context)
+      };
+    });
+    return this.setSourceMapRange(this.factory.createObjectLiteral(properties), ast.sourceSpan);
   }
 
-  visitCommaExpr(ast: CommaExpr, context: Context): never {
+  visitCommaExpr(ast: o.CommaExpr, context: Context): never {
     throw new Error('Method not implemented.');
   }
 
-  visitWrappedNodeExpr(ast: WrappedNodeExpr<any>, context: Context): any {
-    if (ts.isIdentifier(ast.node)) {
-      this.defaultImportRecorder.recordUsedIdentifier(ast.node);
-    }
+  visitWrappedNodeExpr(ast: o.WrappedNodeExpr<any>, _context: Context): any {
+    this.recordWrappedNodeExpr(ast.node);
     return ast.node;
   }
 
-  visitTypeofExpr(ast: TypeofExpr, context: Context): ts.TypeOfExpression {
-    return ts.createTypeOf(ast.expr.visitExpression(this, context));
+  visitTypeofExpr(ast: o.TypeofExpr, context: Context): TExpression {
+    return this.factory.createTypeOfExpression(ast.expr.visitExpression(this, context));
   }
 
-  /**
-   * Translate the `LocalizedString` node into a `TaggedTemplateExpression` for ES2015 formatted
-   * output.
-   */
-  private createLocalizedStringTaggedTemplate(ast: LocalizedString, context: Context):
-      ts.TaggedTemplateExpression {
-    let template: ts.TemplateLiteral;
-    const length = ast.messageParts.length;
-    const metaBlock = ast.serializeI18nHead();
-    if (length === 1) {
-      template = ts.createNoSubstitutionTemplateLiteral(metaBlock.cooked, metaBlock.raw);
-      this.setSourceMapRange(template, ast.getMessagePartSourceSpan(0));
-    } else {
-      // Create the head part
-      const head = ts.createTemplateHead(metaBlock.cooked, metaBlock.raw);
-      this.setSourceMapRange(head, ast.getMessagePartSourceSpan(0));
-      const spans: ts.TemplateSpan[] = [];
-      // Create the middle parts
-      for (let i = 1; i < length - 1; i++) {
-        const resolvedExpression = ast.expressions[i - 1].visitExpression(this, context);
-        this.setSourceMapRange(resolvedExpression, ast.getPlaceholderSourceSpan(i - 1));
-        const templatePart = ast.serializeI18nTemplatePart(i);
-        const templateMiddle = createTemplateMiddle(templatePart.cooked, templatePart.raw);
-        this.setSourceMapRange(templateMiddle, ast.getMessagePartSourceSpan(i));
-        const templateSpan = ts.createTemplateSpan(resolvedExpression, templateMiddle);
-        spans.push(templateSpan);
-      }
-      // Create the tail part
-      const resolvedExpression = ast.expressions[length - 2].visitExpression(this, context);
-      this.setSourceMapRange(resolvedExpression, ast.getPlaceholderSourceSpan(length - 2));
-      const templatePart = ast.serializeI18nTemplatePart(length - 1);
-      const templateTail = createTemplateTail(templatePart.cooked, templatePart.raw);
-      this.setSourceMapRange(templateTail, ast.getMessagePartSourceSpan(length - 1));
-      spans.push(ts.createTemplateSpan(resolvedExpression, templateTail));
-      // Put it all together
-      template = ts.createTemplateExpression(head, spans);
+  visitUnaryOperatorExpr(ast: o.UnaryOperatorExpr, context: Context): TExpression {
+    if (!UNARY_OPERATORS.has(ast.operator)) {
+      throw new Error(`Unknown unary operator: ${o.UnaryOperator[ast.operator]}`);
     }
-    const expression = ts.createTaggedTemplate(ts.createIdentifier('$localize'), template);
-    this.setSourceMapRange(expression, ast.sourceSpan);
-    return expression;
+    return this.factory.createUnaryExpression(
+        UNARY_OPERATORS.get(ast.operator)!, ast.expr.visitExpression(this, context));
   }
 
-  /**
-   * Translate the `LocalizedString` node into a `$localize` call using the imported
-   * `__makeTemplateObject` helper for ES5 formatted output.
-   */
-  private createLocalizedStringFunctionCall(ast: LocalizedString, context: Context) {
-    // A `$localize` message consists `messageParts` and `expressions`, which get interleaved
-    // together. The interleaved pieces look like:
-    // `[messagePart0, expression0, messagePart1, expression1, messagePart2]`
-    //
-    // Note that there is always a message part at the start and end, and so therefore
-    // `messageParts.length === expressions.length + 1`.
-    //
-    // Each message part may be prefixed with "metadata", which is wrapped in colons (:) delimiters.
-    // The metadata is attached to the first and subsequent message parts by calls to
-    // `serializeI18nHead()` and `serializeI18nTemplatePart()` respectively.
-
-    // The first message part (i.e. `ast.messageParts[0]`) is used to initialize `messageParts`
-    // array.
-    const messageParts = [ast.serializeI18nHead()];
-    const expressions: any[] = [];
-
-    // The rest of the `ast.messageParts` and each of the expressions are `ast.expressions` pushed
-    // into the arrays. Note that `ast.messagePart[i]` corresponds to `expressions[i-1]`
-    for (let i = 1; i < ast.messageParts.length; i++) {
-      expressions.push(ast.expressions[i - 1].visitExpression(this, context));
-      messageParts.push(ast.serializeI18nTemplatePart(i));
-    }
-
-    // The resulting downlevelled tagged template string uses a call to the `__makeTemplateObject()`
-    // helper, so we must ensure it has been imported.
-    const {moduleImport, symbol} =
-        this.imports.generateNamedImport('tslib', '__makeTemplateObject');
-    const __makeTemplateObjectHelper = (moduleImport === null) ?
-        ts.createIdentifier(symbol) :
-        ts.createPropertyAccess(ts.createIdentifier(moduleImport), ts.createIdentifier(symbol));
-
-    // Generate the call in the form:
-    // `$localize(__makeTemplateObject(cookedMessageParts, rawMessageParts), ...expressions);`
-    const cookedLiterals = messageParts.map(
-        (messagePart, i) =>
-            this.createLiteral(messagePart.cooked, ast.getMessagePartSourceSpan(i)));
-    const rawLiterals = messageParts.map(
-        (messagePart, i) => this.createLiteral(messagePart.raw, ast.getMessagePartSourceSpan(i)));
-    return ts.createCall(
-        /* expression */ ts.createIdentifier('$localize'),
-        /* typeArguments */ undefined,
-        /* argumentsArray */[
-          ts.createCall(
-              /* expression */ __makeTemplateObjectHelper,
-              /* typeArguments */ undefined,
-              /* argumentsArray */
-              [
-                ts.createArrayLiteral(cookedLiterals),
-                ts.createArrayLiteral(rawLiterals),
-              ]),
-          ...expressions,
-        ]);
+  private visitStatements(statements: o.Statement[], context: Context): TStatement[] {
+    return statements.map(stmt => stmt.visitStatement(this, context))
+        .filter(stmt => stmt !== undefined);
   }
 
-
-  private setSourceMapRange(expr: ts.Node, sourceSpan: ParseSourceSpan|null) {
-    if (sourceSpan) {
-      const {start, end} = sourceSpan;
-      const {url, content} = start.file;
-      if (url) {
-        if (!this.externalSourceFiles.has(url)) {
-          this.externalSourceFiles.set(url, ts.createSourceMapSource(url, content, pos => pos));
-        }
-        const source = this.externalSourceFiles.get(url);
-        ts.setSourceMapRange(expr, {pos: start.offset, end: end.offset, source});
-      }
-    }
+  private setSourceMapRange<T extends TExpression|TStatement>(ast: T, span: o.ParseSourceSpan|null):
+      T {
+    return this.factory.setSourceMapRange(ast, createRange(span));
   }
-
-  private createLiteral(text: string, span: ParseSourceSpan|null) {
-    const literal = ts.createStringLiteral(text);
-    this.setSourceMapRange(literal, span);
-    return literal;
-  }
-}
-
-// HACK: Use this in place of `ts.createTemplateMiddle()`.
-// Revert once https://github.com/microsoft/TypeScript/issues/35374 is fixed
-function createTemplateMiddle(cooked: string, raw: string): ts.TemplateMiddle {
-  const node: ts.TemplateLiteralLikeNode = ts.createTemplateHead(cooked, raw);
-  (node.kind as ts.SyntaxKind) = ts.SyntaxKind.TemplateMiddle;
-  return node as ts.TemplateMiddle;
-}
-
-// HACK: Use this in place of `ts.createTemplateTail()`.
-// Revert once https://github.com/microsoft/TypeScript/issues/35374 is fixed
-function createTemplateTail(cooked: string, raw: string): ts.TemplateTail {
-  const node: ts.TemplateLiteralLikeNode = ts.createTemplateHead(cooked, raw);
-  (node.kind as ts.SyntaxKind) = ts.SyntaxKind.TemplateTail;
-  return node as ts.TemplateTail;
 }
 
 /**
- * Attach the given `leadingComments` to the `statement` node.
- *
- * @param statement The statement that will have comments attached.
- * @param leadingComments The comments to attach to the statement.
+ * Convert a cooked-raw string object into one that can be used by the AST factories.
  */
-export function attachComments<T extends ts.Statement>(
-    statement: T, leadingComments?: LeadingComment[]): T {
-  if (leadingComments === undefined) {
-    return statement;
-  }
+function createTemplateElement(
+    {cooked, raw, range}: {cooked: string, raw: string, range: o.ParseSourceSpan|null}):
+    TemplateElement {
+  return {cooked, raw, range: createRange(range)};
+}
 
-  for (const comment of leadingComments) {
-    const commentKind = comment.multiline ? ts.SyntaxKind.MultiLineCommentTrivia :
-                                            ts.SyntaxKind.SingleLineCommentTrivia;
-    if (comment.multiline) {
-      ts.addSyntheticLeadingComment(
-          statement, commentKind, comment.toString(), comment.trailingNewline);
-    } else {
-      for (const line of comment.text.split('\n')) {
-        ts.addSyntheticLeadingComment(statement, commentKind, line, comment.trailingNewline);
-      }
-    }
+/**
+ * Convert an OutputAST source-span into a range that can be used by the AST factories.
+ */
+function createRange(span: o.ParseSourceSpan|null): SourceMapRange|null {
+  if (span === null) {
+    return null;
   }
-  return statement;
+  const {start, end} = span;
+  const {url, content} = start.file;
+  if (!url) {
+    return null;
+  }
+  return {
+    url,
+    content,
+    start: {offset: start.offset, line: start.line, column: start.col},
+    end: {offset: end.offset, line: end.line, column: end.col},
+  };
 }

--- a/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
@@ -1,0 +1,244 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ArrayType, AssertNotNull, BinaryOperatorExpr, BuiltinType, BuiltinTypeName, CastExpr, CommaExpr, ConditionalExpr, Expression, ExpressionType, ExpressionVisitor, ExternalExpr, FunctionExpr, InstantiateExpr, InvokeFunctionExpr, InvokeMethodExpr, LiteralArrayExpr, LiteralExpr, LiteralMapExpr, LocalizedString, MapType, NotExpr, ReadKeyExpr, ReadPropExpr, ReadVarExpr, Type, TypeofExpr, TypeVisitor, UnaryOperatorExpr, WrappedNodeExpr, WriteKeyExpr, WritePropExpr, WriteVarExpr} from '@angular/compiler';
+import * as ts from 'typescript';
+
+import {Context} from './context';
+import {ImportManager} from './import_manager';
+
+
+export function translateType(type: Type, imports: ImportManager): ts.TypeNode {
+  return type.visitType(new TypeTranslatorVisitor(imports), new Context(false));
+}
+
+export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
+  constructor(private imports: ImportManager) {}
+
+  visitBuiltinType(type: BuiltinType, context: Context): ts.KeywordTypeNode {
+    switch (type.name) {
+      case BuiltinTypeName.Bool:
+        return ts.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
+      case BuiltinTypeName.Dynamic:
+        return ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
+      case BuiltinTypeName.Int:
+      case BuiltinTypeName.Number:
+        return ts.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
+      case BuiltinTypeName.String:
+        return ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+      case BuiltinTypeName.None:
+        return ts.createKeywordTypeNode(ts.SyntaxKind.NeverKeyword);
+      default:
+        throw new Error(`Unsupported builtin type: ${BuiltinTypeName[type.name]}`);
+    }
+  }
+
+  visitExpressionType(type: ExpressionType, context: Context): ts.TypeNode {
+    const typeNode = this.translateExpression(type.value, context);
+    if (type.typeParams === null) {
+      return typeNode;
+    }
+
+    if (!ts.isTypeReferenceNode(typeNode)) {
+      throw new Error(
+          'An ExpressionType with type arguments must translate into a TypeReferenceNode');
+    } else if (typeNode.typeArguments !== undefined) {
+      throw new Error(
+          `An ExpressionType with type arguments cannot have multiple levels of type arguments`);
+    }
+
+    const typeArgs = type.typeParams.map(param => this.translateType(param, context));
+    return ts.createTypeReferenceNode(typeNode.typeName, typeArgs);
+  }
+
+  visitArrayType(type: ArrayType, context: Context): ts.ArrayTypeNode {
+    return ts.createArrayTypeNode(this.translateType(type.of, context));
+  }
+
+  visitMapType(type: MapType, context: Context): ts.TypeLiteralNode {
+    const parameter = ts.createParameter(
+        undefined, undefined, undefined, 'key', undefined,
+        ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword));
+    const typeArgs = type.valueType !== null ?
+        this.translateType(type.valueType, context) :
+        ts.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
+    const indexSignature = ts.createIndexSignature(undefined, undefined, [parameter], typeArgs);
+    return ts.createTypeLiteralNode([indexSignature]);
+  }
+
+  visitReadVarExpr(ast: ReadVarExpr, context: Context): ts.TypeQueryNode {
+    if (ast.name === null) {
+      throw new Error(`ReadVarExpr with no variable name in type`);
+    }
+    return ts.createTypeQueryNode(ts.createIdentifier(ast.name));
+  }
+
+  visitWriteVarExpr(expr: WriteVarExpr, context: Context): never {
+    throw new Error('Method not implemented.');
+  }
+
+  visitWriteKeyExpr(expr: WriteKeyExpr, context: Context): never {
+    throw new Error('Method not implemented.');
+  }
+
+  visitWritePropExpr(expr: WritePropExpr, context: Context): never {
+    throw new Error('Method not implemented.');
+  }
+
+  visitInvokeMethodExpr(ast: InvokeMethodExpr, context: Context): never {
+    throw new Error('Method not implemented.');
+  }
+
+  visitInvokeFunctionExpr(ast: InvokeFunctionExpr, context: Context): never {
+    throw new Error('Method not implemented.');
+  }
+
+  visitInstantiateExpr(ast: InstantiateExpr, context: Context): never {
+    throw new Error('Method not implemented.');
+  }
+
+  visitLiteralExpr(ast: LiteralExpr, context: Context): ts.TypeNode {
+    if (ast.value === null) {
+      // TODO(alan-agius4): Remove when we no longer support TS 3.9
+      // Use: return ts.createLiteralTypeNode(ts.createNull()) directly.
+      return ts.versionMajorMinor.charAt(0) === '4' ?
+          ts.createLiteralTypeNode(ts.createNull() as any) :
+          ts.createKeywordTypeNode(ts.SyntaxKind.NullKeyword as any);
+    } else if (ast.value === undefined) {
+      return ts.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword);
+    } else if (typeof ast.value === 'boolean') {
+      return ts.createLiteralTypeNode(ts.createLiteral(ast.value));
+    } else if (typeof ast.value === 'number') {
+      return ts.createLiteralTypeNode(ts.createLiteral(ast.value));
+    } else {
+      return ts.createLiteralTypeNode(ts.createLiteral(ast.value));
+    }
+  }
+
+  visitLocalizedString(ast: LocalizedString, context: Context): never {
+    throw new Error('Method not implemented.');
+  }
+
+  visitExternalExpr(ast: ExternalExpr, context: Context): ts.EntityName|ts.TypeReferenceNode {
+    if (ast.value.moduleName === null || ast.value.name === null) {
+      throw new Error(`Import unknown module or symbol`);
+    }
+    const {moduleImport, symbol} =
+        this.imports.generateNamedImport(ast.value.moduleName, ast.value.name);
+    const symbolIdentifier = ts.createIdentifier(symbol);
+
+    const typeName = moduleImport ?
+        ts.createQualifiedName(ts.createIdentifier(moduleImport), symbolIdentifier) :
+        symbolIdentifier;
+
+    const typeArguments = ast.typeParams !== null ?
+        ast.typeParams.map(type => this.translateType(type, context)) :
+        undefined;
+    return ts.createTypeReferenceNode(typeName, typeArguments);
+  }
+
+  visitConditionalExpr(ast: ConditionalExpr, context: Context) {
+    throw new Error('Method not implemented.');
+  }
+
+  visitNotExpr(ast: NotExpr, context: Context) {
+    throw new Error('Method not implemented.');
+  }
+
+  visitAssertNotNullExpr(ast: AssertNotNull, context: Context) {
+    throw new Error('Method not implemented.');
+  }
+
+  visitCastExpr(ast: CastExpr, context: Context) {
+    throw new Error('Method not implemented.');
+  }
+
+  visitFunctionExpr(ast: FunctionExpr, context: Context) {
+    throw new Error('Method not implemented.');
+  }
+
+  visitUnaryOperatorExpr(ast: UnaryOperatorExpr, context: Context) {
+    throw new Error('Method not implemented.');
+  }
+
+  visitBinaryOperatorExpr(ast: BinaryOperatorExpr, context: Context) {
+    throw new Error('Method not implemented.');
+  }
+
+  visitReadPropExpr(ast: ReadPropExpr, context: Context) {
+    throw new Error('Method not implemented.');
+  }
+
+  visitReadKeyExpr(ast: ReadKeyExpr, context: Context) {
+    throw new Error('Method not implemented.');
+  }
+
+  visitLiteralArrayExpr(ast: LiteralArrayExpr, context: Context): ts.TupleTypeNode {
+    const values = ast.entries.map(expr => this.translateExpression(expr, context));
+    return ts.createTupleTypeNode(values);
+  }
+
+  visitLiteralMapExpr(ast: LiteralMapExpr, context: Context): ts.TypeLiteralNode {
+    const entries = ast.entries.map(entry => {
+      const {key, quoted} = entry;
+      const type = this.translateExpression(entry.value, context);
+      return ts.createPropertySignature(
+          /* modifiers */ undefined,
+          /* name */ quoted ? ts.createStringLiteral(key) : key,
+          /* questionToken */ undefined,
+          /* type */ type,
+          /* initializer */ undefined);
+    });
+    return ts.createTypeLiteralNode(entries);
+  }
+
+  visitCommaExpr(ast: CommaExpr, context: Context) {
+    throw new Error('Method not implemented.');
+  }
+
+  visitWrappedNodeExpr(ast: WrappedNodeExpr<any>, context: Context): ts.TypeNode {
+    const node: ts.Node = ast.node;
+    if (ts.isEntityName(node)) {
+      return ts.createTypeReferenceNode(node, /* typeArguments */ undefined);
+    } else if (ts.isTypeNode(node)) {
+      return node;
+    } else if (ts.isLiteralExpression(node)) {
+      return ts.createLiteralTypeNode(node);
+    } else {
+      throw new Error(
+          `Unsupported WrappedNodeExpr in TypeTranslatorVisitor: ${ts.SyntaxKind[node.kind]}`);
+    }
+  }
+
+  visitTypeofExpr(ast: TypeofExpr, context: Context): ts.TypeQueryNode {
+    const typeNode = this.translateExpression(ast.expr, context);
+    if (!ts.isTypeReferenceNode(typeNode)) {
+      throw new Error(`The target of a typeof expression must be a type reference, but it was
+          ${ts.SyntaxKind[typeNode.kind]}`);
+    }
+    return ts.createTypeQueryNode(typeNode.typeName);
+  }
+
+  private translateType(type: Type, context: Context): ts.TypeNode {
+    const typeNode = type.visitType(this, context);
+    if (!ts.isTypeNode(typeNode)) {
+      throw new Error(
+          `A Type must translate to a TypeNode, but was ${ts.SyntaxKind[typeNode.kind]}`);
+    }
+    return typeNode;
+  }
+
+  private translateExpression(expr: Expression, context: Context): ts.TypeNode {
+    const typeNode = expr.visitExpression(this, context);
+    if (!ts.isTypeNode(typeNode)) {
+      throw new Error(
+          `An Expression must translate to a TypeNode, but was ${ts.SyntaxKind[typeNode.kind]}`);
+    }
+    return typeNode;
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
@@ -6,39 +6,39 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ArrayType, AssertNotNull, BinaryOperatorExpr, BuiltinType, BuiltinTypeName, CastExpr, CommaExpr, ConditionalExpr, Expression, ExpressionType, ExpressionVisitor, ExternalExpr, FunctionExpr, InstantiateExpr, InvokeFunctionExpr, InvokeMethodExpr, LiteralArrayExpr, LiteralExpr, LiteralMapExpr, LocalizedString, MapType, NotExpr, ReadKeyExpr, ReadPropExpr, ReadVarExpr, Type, TypeofExpr, TypeVisitor, UnaryOperatorExpr, WrappedNodeExpr, WriteKeyExpr, WritePropExpr, WriteVarExpr} from '@angular/compiler';
+import * as o from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {Context} from './context';
 import {ImportManager} from './import_manager';
 
 
-export function translateType(type: Type, imports: ImportManager): ts.TypeNode {
+export function translateType(type: o.Type, imports: ImportManager): ts.TypeNode {
   return type.visitType(new TypeTranslatorVisitor(imports), new Context(false));
 }
 
-export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
+export class TypeTranslatorVisitor implements o.ExpressionVisitor, o.TypeVisitor {
   constructor(private imports: ImportManager) {}
 
-  visitBuiltinType(type: BuiltinType, context: Context): ts.KeywordTypeNode {
+  visitBuiltinType(type: o.BuiltinType, context: Context): ts.KeywordTypeNode {
     switch (type.name) {
-      case BuiltinTypeName.Bool:
+      case o.BuiltinTypeName.Bool:
         return ts.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
-      case BuiltinTypeName.Dynamic:
+      case o.BuiltinTypeName.Dynamic:
         return ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
-      case BuiltinTypeName.Int:
-      case BuiltinTypeName.Number:
+      case o.BuiltinTypeName.Int:
+      case o.BuiltinTypeName.Number:
         return ts.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
-      case BuiltinTypeName.String:
+      case o.BuiltinTypeName.String:
         return ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
-      case BuiltinTypeName.None:
+      case o.BuiltinTypeName.None:
         return ts.createKeywordTypeNode(ts.SyntaxKind.NeverKeyword);
       default:
-        throw new Error(`Unsupported builtin type: ${BuiltinTypeName[type.name]}`);
+        throw new Error(`Unsupported builtin type: ${o.BuiltinTypeName[type.name]}`);
     }
   }
 
-  visitExpressionType(type: ExpressionType, context: Context): ts.TypeNode {
+  visitExpressionType(type: o.ExpressionType, context: Context): ts.TypeNode {
     const typeNode = this.translateExpression(type.value, context);
     if (type.typeParams === null) {
       return typeNode;
@@ -56,11 +56,11 @@ export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
     return ts.createTypeReferenceNode(typeNode.typeName, typeArgs);
   }
 
-  visitArrayType(type: ArrayType, context: Context): ts.ArrayTypeNode {
+  visitArrayType(type: o.ArrayType, context: Context): ts.ArrayTypeNode {
     return ts.createArrayTypeNode(this.translateType(type.of, context));
   }
 
-  visitMapType(type: MapType, context: Context): ts.TypeLiteralNode {
+  visitMapType(type: o.MapType, context: Context): ts.TypeLiteralNode {
     const parameter = ts.createParameter(
         undefined, undefined, undefined, 'key', undefined,
         ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword));
@@ -71,38 +71,38 @@ export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
     return ts.createTypeLiteralNode([indexSignature]);
   }
 
-  visitReadVarExpr(ast: ReadVarExpr, context: Context): ts.TypeQueryNode {
+  visitReadVarExpr(ast: o.ReadVarExpr, context: Context): ts.TypeQueryNode {
     if (ast.name === null) {
       throw new Error(`ReadVarExpr with no variable name in type`);
     }
     return ts.createTypeQueryNode(ts.createIdentifier(ast.name));
   }
 
-  visitWriteVarExpr(expr: WriteVarExpr, context: Context): never {
+  visitWriteVarExpr(expr: o.WriteVarExpr, context: Context): never {
     throw new Error('Method not implemented.');
   }
 
-  visitWriteKeyExpr(expr: WriteKeyExpr, context: Context): never {
+  visitWriteKeyExpr(expr: o.WriteKeyExpr, context: Context): never {
     throw new Error('Method not implemented.');
   }
 
-  visitWritePropExpr(expr: WritePropExpr, context: Context): never {
+  visitWritePropExpr(expr: o.WritePropExpr, context: Context): never {
     throw new Error('Method not implemented.');
   }
 
-  visitInvokeMethodExpr(ast: InvokeMethodExpr, context: Context): never {
+  visitInvokeMethodExpr(ast: o.InvokeMethodExpr, context: Context): never {
     throw new Error('Method not implemented.');
   }
 
-  visitInvokeFunctionExpr(ast: InvokeFunctionExpr, context: Context): never {
+  visitInvokeFunctionExpr(ast: o.InvokeFunctionExpr, context: Context): never {
     throw new Error('Method not implemented.');
   }
 
-  visitInstantiateExpr(ast: InstantiateExpr, context: Context): never {
+  visitInstantiateExpr(ast: o.InstantiateExpr, context: Context): never {
     throw new Error('Method not implemented.');
   }
 
-  visitLiteralExpr(ast: LiteralExpr, context: Context): ts.TypeNode {
+  visitLiteralExpr(ast: o.LiteralExpr, context: Context): ts.TypeNode {
     if (ast.value === null) {
       // TODO(alan-agius4): Remove when we no longer support TS 3.9
       // Use: return ts.createLiteralTypeNode(ts.createNull()) directly.
@@ -120,11 +120,11 @@ export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
     }
   }
 
-  visitLocalizedString(ast: LocalizedString, context: Context): never {
+  visitLocalizedString(ast: o.LocalizedString, context: Context): never {
     throw new Error('Method not implemented.');
   }
 
-  visitExternalExpr(ast: ExternalExpr, context: Context): ts.EntityName|ts.TypeReferenceNode {
+  visitExternalExpr(ast: o.ExternalExpr, context: Context): ts.EntityName|ts.TypeReferenceNode {
     if (ast.value.moduleName === null || ast.value.name === null) {
       throw new Error(`Import unknown module or symbol`);
     }
@@ -132,9 +132,8 @@ export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
         this.imports.generateNamedImport(ast.value.moduleName, ast.value.name);
     const symbolIdentifier = ts.createIdentifier(symbol);
 
-    const typeName = moduleImport ?
-        ts.createQualifiedName(ts.createIdentifier(moduleImport), symbolIdentifier) :
-        symbolIdentifier;
+    const typeName =
+        moduleImport ? ts.createQualifiedName(moduleImport, symbolIdentifier) : symbolIdentifier;
 
     const typeArguments = ast.typeParams !== null ?
         ast.typeParams.map(type => this.translateType(type, context)) :
@@ -142,48 +141,48 @@ export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
     return ts.createTypeReferenceNode(typeName, typeArguments);
   }
 
-  visitConditionalExpr(ast: ConditionalExpr, context: Context) {
+  visitConditionalExpr(ast: o.ConditionalExpr, context: Context) {
     throw new Error('Method not implemented.');
   }
 
-  visitNotExpr(ast: NotExpr, context: Context) {
+  visitNotExpr(ast: o.NotExpr, context: Context) {
     throw new Error('Method not implemented.');
   }
 
-  visitAssertNotNullExpr(ast: AssertNotNull, context: Context) {
+  visitAssertNotNullExpr(ast: o.AssertNotNull, context: Context) {
     throw new Error('Method not implemented.');
   }
 
-  visitCastExpr(ast: CastExpr, context: Context) {
+  visitCastExpr(ast: o.CastExpr, context: Context) {
     throw new Error('Method not implemented.');
   }
 
-  visitFunctionExpr(ast: FunctionExpr, context: Context) {
+  visitFunctionExpr(ast: o.FunctionExpr, context: Context) {
     throw new Error('Method not implemented.');
   }
 
-  visitUnaryOperatorExpr(ast: UnaryOperatorExpr, context: Context) {
+  visitUnaryOperatorExpr(ast: o.UnaryOperatorExpr, context: Context) {
     throw new Error('Method not implemented.');
   }
 
-  visitBinaryOperatorExpr(ast: BinaryOperatorExpr, context: Context) {
+  visitBinaryOperatorExpr(ast: o.BinaryOperatorExpr, context: Context) {
     throw new Error('Method not implemented.');
   }
 
-  visitReadPropExpr(ast: ReadPropExpr, context: Context) {
+  visitReadPropExpr(ast: o.ReadPropExpr, context: Context) {
     throw new Error('Method not implemented.');
   }
 
-  visitReadKeyExpr(ast: ReadKeyExpr, context: Context) {
+  visitReadKeyExpr(ast: o.ReadKeyExpr, context: Context) {
     throw new Error('Method not implemented.');
   }
 
-  visitLiteralArrayExpr(ast: LiteralArrayExpr, context: Context): ts.TupleTypeNode {
+  visitLiteralArrayExpr(ast: o.LiteralArrayExpr, context: Context): ts.TupleTypeNode {
     const values = ast.entries.map(expr => this.translateExpression(expr, context));
     return ts.createTupleTypeNode(values);
   }
 
-  visitLiteralMapExpr(ast: LiteralMapExpr, context: Context): ts.TypeLiteralNode {
+  visitLiteralMapExpr(ast: o.LiteralMapExpr, context: Context): ts.TypeLiteralNode {
     const entries = ast.entries.map(entry => {
       const {key, quoted} = entry;
       const type = this.translateExpression(entry.value, context);
@@ -197,11 +196,11 @@ export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
     return ts.createTypeLiteralNode(entries);
   }
 
-  visitCommaExpr(ast: CommaExpr, context: Context) {
+  visitCommaExpr(ast: o.CommaExpr, context: Context) {
     throw new Error('Method not implemented.');
   }
 
-  visitWrappedNodeExpr(ast: WrappedNodeExpr<any>, context: Context): ts.TypeNode {
+  visitWrappedNodeExpr(ast: o.WrappedNodeExpr<any>, context: Context): ts.TypeNode {
     const node: ts.Node = ast.node;
     if (ts.isEntityName(node)) {
       return ts.createTypeReferenceNode(node, /* typeArguments */ undefined);
@@ -215,7 +214,7 @@ export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
     }
   }
 
-  visitTypeofExpr(ast: TypeofExpr, context: Context): ts.TypeQueryNode {
+  visitTypeofExpr(ast: o.TypeofExpr, context: Context): ts.TypeQueryNode {
     const typeNode = this.translateExpression(ast.expr, context);
     if (!ts.isTypeReferenceNode(typeNode)) {
       throw new Error(`The target of a typeof expression must be a type reference, but it was
@@ -224,7 +223,7 @@ export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
     return ts.createTypeQueryNode(typeNode.typeName);
   }
 
-  private translateType(type: Type, context: Context): ts.TypeNode {
+  private translateType(type: o.Type, context: Context): ts.TypeNode {
     const typeNode = type.visitType(this, context);
     if (!ts.isTypeNode(typeNode)) {
       throw new Error(
@@ -233,7 +232,7 @@ export class TypeTranslatorVisitor implements ExpressionVisitor, TypeVisitor {
     return typeNode;
   }
 
-  private translateExpression(expr: Expression, context: Context): ts.TypeNode {
+  private translateExpression(expr: o.Expression, context: Context): ts.TypeNode {
     const typeNode = expr.visitExpression(this, context);
     if (!ts.isTypeNode(typeNode)) {
       throw new Error(

--- a/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
@@ -1,0 +1,256 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+
+import {AstFactory, BinaryOperator, LeadingComment, ObjectLiteralProperty, SourceMapRange, TemplateLiteral, UnaryOperator, VariableDeclarationType} from './api/ast_factory';
+
+const UNARY_OPERATORS: Record<UnaryOperator, ts.PrefixUnaryOperator> = {
+  '+': ts.SyntaxKind.PlusToken,
+  '-': ts.SyntaxKind.MinusToken,
+  '!': ts.SyntaxKind.ExclamationToken,
+};
+
+const BINARY_OPERATORS: Record<BinaryOperator, ts.BinaryOperator> = {
+  '&&': ts.SyntaxKind.AmpersandAmpersandToken,
+  '>': ts.SyntaxKind.GreaterThanToken,
+  '>=': ts.SyntaxKind.GreaterThanEqualsToken,
+  '&': ts.SyntaxKind.AmpersandToken,
+  '/': ts.SyntaxKind.SlashToken,
+  '==': ts.SyntaxKind.EqualsEqualsToken,
+  '===': ts.SyntaxKind.EqualsEqualsEqualsToken,
+  '<': ts.SyntaxKind.LessThanToken,
+  '<=': ts.SyntaxKind.LessThanEqualsToken,
+  '-': ts.SyntaxKind.MinusToken,
+  '%': ts.SyntaxKind.PercentToken,
+  '*': ts.SyntaxKind.AsteriskToken,
+  '!=': ts.SyntaxKind.ExclamationEqualsToken,
+  '!==': ts.SyntaxKind.ExclamationEqualsEqualsToken,
+  '||': ts.SyntaxKind.BarBarToken,
+  '+': ts.SyntaxKind.PlusToken,
+};
+
+const VAR_TYPES: Record<VariableDeclarationType, ts.NodeFlags> = {
+  'const': ts.NodeFlags.Const,
+  'let': ts.NodeFlags.Let,
+  'var': ts.NodeFlags.None,
+};
+
+/**
+ * A TypeScript flavoured implementation of the AstFactory.
+ */
+export class TypeScriptAstFactory implements AstFactory<ts.Statement, ts.Expression> {
+  private externalSourceFiles = new Map<string, ts.SourceMapSource>();
+
+  attachComments = attachComments;
+
+  createArrayLiteral = ts.createArrayLiteral;
+
+  createAssignment(target: ts.Expression, value: ts.Expression): ts.Expression {
+    return ts.createBinary(target, ts.SyntaxKind.EqualsToken, value);
+  }
+
+  createBinaryExpression(
+      leftOperand: ts.Expression, operator: BinaryOperator,
+      rightOperand: ts.Expression): ts.Expression {
+    return ts.createBinary(leftOperand, BINARY_OPERATORS[operator], rightOperand);
+  }
+
+  createBlock(body: ts.Statement[]): ts.Statement {
+    return ts.createBlock(body);
+  }
+
+  createCallExpression(callee: ts.Expression, args: ts.Expression[], pure: boolean): ts.Expression {
+    const call = ts.createCall(callee, undefined, args);
+    if (pure) {
+      ts.addSyntheticLeadingComment(
+          call, ts.SyntaxKind.MultiLineCommentTrivia, '@__PURE__', /* trailing newline */ false);
+    }
+    return call;
+  }
+
+  createConditional = ts.createConditional;
+
+  createElementAccess = ts.createElementAccess;
+
+  createExpressionStatement = ts.createExpressionStatement;
+
+  createFunctionDeclaration(functionName: string|null, parameters: string[], body: ts.Statement):
+      ts.Statement {
+    if (!ts.isBlock(body)) {
+      throw new Error(`Invalid syntax, expected a block, but got ${ts.SyntaxKind[body.kind]}.`);
+    }
+    return ts.createFunctionDeclaration(
+        undefined, undefined, undefined, functionName ?? undefined, undefined,
+        parameters.map(param => ts.createParameter(undefined, undefined, undefined, param)),
+        undefined, body);
+  }
+
+  createFunctionExpression(functionName: string|null, parameters: string[], body: ts.Statement):
+      ts.Expression {
+    if (!ts.isBlock(body)) {
+      throw new Error(`Invalid syntax, expected a block, but got ${ts.SyntaxKind[body.kind]}.`);
+    }
+    return ts.createFunctionExpression(
+        undefined, undefined, functionName ?? undefined, undefined,
+        parameters.map(param => ts.createParameter(undefined, undefined, undefined, param)),
+        undefined, body);
+  }
+
+  createIdentifier = ts.createIdentifier;
+
+  createIfStatement(
+      condition: ts.Expression, thenStatement: ts.Statement,
+      elseStatement: ts.Statement|null): ts.Statement {
+    return ts.createIf(condition, thenStatement, elseStatement ?? undefined);
+  }
+
+  createLiteral(value: string|number|boolean|null|undefined): ts.Expression {
+    if (value === undefined) {
+      return ts.createIdentifier('undefined');
+    } else if (value === null) {
+      return ts.createNull();
+    } else {
+      return ts.createLiteral(value);
+    }
+  }
+
+  createNewExpression(expression: ts.Expression, args: ts.Expression[]): ts.Expression {
+    return ts.createNew(expression, undefined, args);
+  }
+
+  createObjectLiteral(properties: ObjectLiteralProperty<ts.Expression>[]): ts.Expression {
+    return ts.createObjectLiteral(properties.map(
+        prop => ts.createPropertyAssignment(
+            prop.quoted ? ts.createLiteral(prop.propertyName) :
+                          ts.createIdentifier(prop.propertyName),
+            prop.value)));
+  }
+
+  createParenthesizedExpression = ts.createParen;
+
+  createPropertyAccess = ts.createPropertyAccess;
+
+  createReturnStatement(expression: ts.Expression|null): ts.Statement {
+    return ts.createReturn(expression ?? undefined);
+  }
+
+  createTaggedTemplate(tag: ts.Expression, template: TemplateLiteral<ts.Expression>):
+      ts.Expression {
+    let templateLiteral: ts.TemplateLiteral;
+    const length = template.elements.length;
+    const head = template.elements[0];
+    if (length === 1) {
+      templateLiteral = ts.createNoSubstitutionTemplateLiteral(head.cooked, head.raw);
+    } else {
+      const spans: ts.TemplateSpan[] = [];
+      // Create the middle parts
+      for (let i = 1; i < length - 1; i++) {
+        const {cooked, raw, range} = template.elements[i];
+        const middle = createTemplateMiddle(cooked, raw);
+        if (range !== null) {
+          this.setSourceMapRange(middle, range);
+        }
+        spans.push(ts.createTemplateSpan(template.expressions[i - 1], middle));
+      }
+      // Create the tail part
+      const resolvedExpression = template.expressions[length - 2];
+      const templatePart = template.elements[length - 1];
+      const templateTail = createTemplateTail(templatePart.cooked, templatePart.raw);
+      if (templatePart.range !== null) {
+        this.setSourceMapRange(templateTail, templatePart.range);
+      }
+      spans.push(ts.createTemplateSpan(resolvedExpression, templateTail));
+      // Put it all together
+      templateLiteral =
+          ts.createTemplateExpression(ts.createTemplateHead(head.cooked, head.raw), spans);
+    }
+    if (head.range !== null) {
+      this.setSourceMapRange(templateLiteral, head.range);
+    }
+    return ts.createTaggedTemplate(tag, templateLiteral);
+  }
+
+  createThrowStatement = ts.createThrow;
+
+  createTypeOfExpression = ts.createTypeOf;
+
+
+  createUnaryExpression(operator: UnaryOperator, operand: ts.Expression): ts.Expression {
+    return ts.createPrefix(UNARY_OPERATORS[operator], operand);
+  }
+
+  createVariableDeclaration(
+      variableName: string, initializer: ts.Expression|null,
+      type: VariableDeclarationType): ts.Statement {
+    return ts.createVariableStatement(
+        undefined,
+        ts.createVariableDeclarationList(
+            [ts.createVariableDeclaration(variableName, undefined, initializer ?? undefined)],
+            VAR_TYPES[type]),
+    );
+  }
+
+  setSourceMapRange<T extends ts.Node>(node: T, sourceMapRange: SourceMapRange|null): T {
+    if (sourceMapRange === null) {
+      return node;
+    }
+
+    const url = sourceMapRange.url;
+    if (!this.externalSourceFiles.has(url)) {
+      this.externalSourceFiles.set(
+          url, ts.createSourceMapSource(url, sourceMapRange.content, pos => pos));
+    }
+    const source = this.externalSourceFiles.get(url);
+    ts.setSourceMapRange(
+        node, {pos: sourceMapRange.start.offset, end: sourceMapRange.end.offset, source});
+    return node;
+  }
+}
+
+// HACK: Use this in place of `ts.createTemplateMiddle()`.
+// Revert once https://github.com/microsoft/TypeScript/issues/35374 is fixed.
+export function createTemplateMiddle(cooked: string, raw: string): ts.TemplateMiddle {
+  const node: ts.TemplateLiteralLikeNode = ts.createTemplateHead(cooked, raw);
+  (node.kind as ts.SyntaxKind) = ts.SyntaxKind.TemplateMiddle;
+  return node as ts.TemplateMiddle;
+}
+
+// HACK: Use this in place of `ts.createTemplateTail()`.
+// Revert once https://github.com/microsoft/TypeScript/issues/35374 is fixed.
+export function createTemplateTail(cooked: string, raw: string): ts.TemplateTail {
+  const node: ts.TemplateLiteralLikeNode = ts.createTemplateHead(cooked, raw);
+  (node.kind as ts.SyntaxKind) = ts.SyntaxKind.TemplateTail;
+  return node as ts.TemplateTail;
+}
+
+/**
+ * Attach the given `leadingComments` to the `statement` node.
+ *
+ * @param statement The statement that will have comments attached.
+ * @param leadingComments The comments to attach to the statement.
+ */
+export function attachComments<T extends ts.Statement>(
+    statement: T, leadingComments?: LeadingComment[]): T {
+  if (leadingComments === undefined) {
+    return statement;
+  }
+
+  for (const comment of leadingComments) {
+    const commentKind = comment.multiline ? ts.SyntaxKind.MultiLineCommentTrivia :
+                                            ts.SyntaxKind.SingleLineCommentTrivia;
+    if (comment.multiline) {
+      ts.addSyntheticLeadingComment(
+          statement, commentKind, comment.toString(), comment.trailingNewline);
+    } else {
+      for (const line of comment.toString().split('\n')) {
+        ts.addSyntheticLeadingComment(statement, commentKind, line, comment.trailingNewline);
+      }
+    }
+  }
+  return statement;
+}

--- a/packages/compiler-cli/src/ngtsc/translator/src/typescript_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/typescript_translator.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '@angular/compiler';
+import * as ts from 'typescript';
+
+import {ImportGenerator} from './api/import_generator';
+import {Context} from './context';
+import {ExpressionTranslatorVisitor, TranslatorOptions} from './translator';
+import {TypeScriptAstFactory} from './typescript_ast_factory';
+
+export function translateExpression(
+    expression: o.Expression, imports: ImportGenerator<ts.Expression>,
+    options: TranslatorOptions<ts.Expression> = {}): ts.Expression {
+  return expression.visitExpression(
+      new ExpressionTranslatorVisitor(new TypeScriptAstFactory(), imports, options),
+      new Context(false));
+}
+
+export function translateStatement(
+    statement: o.Statement, imports: ImportGenerator<ts.Expression>,
+    options: TranslatorOptions<ts.Expression> = {}): ts.Statement {
+  return statement.visitStatement(
+      new ExpressionTranslatorVisitor(new TypeScriptAstFactory(), imports, options),
+      new Context(true));
+}

--- a/packages/compiler-cli/src/ngtsc/translator/src/typescript_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/typescript_translator.ts
@@ -18,7 +18,8 @@ export function translateExpression(
     expression: o.Expression, imports: ImportGenerator<ts.Expression>,
     options: TranslatorOptions<ts.Expression> = {}): ts.Expression {
   return expression.visitExpression(
-      new ExpressionTranslatorVisitor(new TypeScriptAstFactory(), imports, options),
+      new ExpressionTranslatorVisitor<ts.Statement, ts.Expression>(
+          new TypeScriptAstFactory(), imports, options),
       new Context(false));
 }
 
@@ -26,6 +27,7 @@ export function translateStatement(
     statement: o.Statement, imports: ImportGenerator<ts.Expression>,
     options: TranslatorOptions<ts.Expression> = {}): ts.Statement {
   return statement.visitStatement(
-      new ExpressionTranslatorVisitor(new TypeScriptAstFactory(), imports, options),
+      new ExpressionTranslatorVisitor<ts.Statement, ts.Expression>(
+          new TypeScriptAstFactory(), imports, options),
       new Context(true));
 }

--- a/packages/compiler-cli/src/ngtsc/translator/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/translator/test/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob([
+        "**/*.ts",
+    ]),
+    deps = [
+        "//packages:types",
+        "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/translator",
+        "@npm//typescript",
+    ],
+)
+
+jasmine_node_test(
+    name = "test",
+    bootstrap = ["//tools/testing:node_no_angular_es5"],
+    deps = [
+        ":test_lib",
+    ],
+)

--- a/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
@@ -1,0 +1,389 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {leadingComment} from '@angular/compiler';
+import * as ts from 'typescript';
+
+import {TypeScriptAstFactory} from '../src/typescript_ast_factory';
+
+describe('TypeScriptAstFactory', () => {
+  let factory: TypeScriptAstFactory;
+  beforeEach(() => factory = new TypeScriptAstFactory());
+
+  describe('attachComments()', () => {
+    it('should add the comments to the given statement', () => {
+      const {items: [stmt], generate} = setupStatements('x = 10;');
+      factory.attachComments(
+          stmt, [leadingComment('comment 1', true), leadingComment('comment 2', false)]);
+
+      expect(generate(stmt)).toEqual([
+        '/* comment 1 */',
+        '//comment 2',
+        'x = 10;',
+      ].join('\n'));
+    });
+  });
+
+  describe('createArrayLiteral()', () => {
+    it('should create an array node containing the provided expressions', () => {
+      const {items: [expr1, expr2], generate} = setupExpressions(`42`, '"moo"');
+      const array = factory.createArrayLiteral([expr1, expr2]);
+      expect(generate(array)).toEqual('[42, "moo"]');
+    });
+  });
+
+  describe('createAssignment()', () => {
+    it('should create an assignment node using the target and value expressions', () => {
+      const {items: [target, value], generate} = setupExpressions(`x`, `42`);
+      const assignment = factory.createAssignment(target, value);
+      expect(generate(assignment)).toEqual('x = 42');
+    });
+  });
+
+  describe('createBinaryExpression()', () => {
+    it('should create a binary operation node using the left and right expressions', () => {
+      const {items: [left, right], generate} = setupExpressions(`17`, `42`);
+      const assignment = factory.createBinaryExpression(left, '+', right);
+      expect(generate(assignment)).toEqual('17 + 42');
+    });
+  });
+
+  describe('createBlock()', () => {
+    it('should create a block statement containing the given statements', () => {
+      const {items: stmts, generate} = setupStatements('x = 10; y = 20;');
+      const block = factory.createBlock(stmts);
+      expect(generate(block)).toEqual([
+        '{',
+        '    x = 10;',
+        '    y = 20;',
+        '}',
+      ].join('\n'));
+    });
+  });
+
+  describe('createCallExpression()', () => {
+    it('should create a call on the `callee` with the given `args`', () => {
+      const {items: [callee, arg1, arg2], generate} = setupExpressions('foo', '42', '"moo"');
+      const call = factory.createCallExpression(callee, [arg1, arg2], false);
+      expect(generate(call)).toEqual('foo(42, "moo")');
+    });
+
+    it('should create a call marked with a PURE comment if `pure` is true', () => {
+      const {items: [callee, arg1, arg2], generate} = setupExpressions(`foo`, `42`, `"moo"`);
+      const call = factory.createCallExpression(callee, [arg1, arg2], true);
+      expect(generate(call)).toEqual('/*@__PURE__*/ foo(42, "moo")');
+    });
+  });
+
+  describe('createConditional()', () => {
+    it('should create a condition expression', () => {
+      const {items: [test, thenExpr, elseExpr], generate} =
+          setupExpressions(`!test`, `42`, `"moo"`);
+      const conditional = factory.createConditional(test, thenExpr, elseExpr);
+      expect(generate(conditional)).toEqual('!test ? 42 : "moo"');
+    });
+  });
+
+  describe('createElementAccess()', () => {
+    it('should create an expression accessing the element of an array/object', () => {
+      const {items: [expr, element], generate} = setupExpressions(`obj`, `"moo"`);
+      const access = factory.createElementAccess(expr, element);
+      expect(generate(access)).toEqual('obj["moo"]');
+    });
+  });
+
+  describe('createExpressionStatement()', () => {
+    it('should create a statement node from the given expression', () => {
+      const {items: [expr], generate} = setupExpressions(`x = 10`);
+      const stmt = factory.createExpressionStatement(expr);
+      expect(ts.isExpressionStatement(stmt)).toBe(true);
+      expect(generate(stmt)).toEqual('x = 10;');
+    });
+  });
+
+  describe('createFunctionDeclaration()', () => {
+    it('should create a function declaration node with the given name, parameters and body statements',
+       () => {
+         const {items: [body], generate} = setupStatements('{x = 10; y = 20;}');
+         const fn = factory.createFunctionDeclaration('foo', ['arg1', 'arg2'], body);
+         expect(generate(fn))
+             .toEqual(
+                 'function foo(arg1, arg2) { x = 10; y = 20; }',
+             );
+       });
+  });
+
+  describe('createFunctionExpression()', () => {
+    it('should create a function expression node with the given name, parameters and body statements',
+       () => {
+         const {items: [body], generate} = setupStatements('{x = 10; y = 20;}');
+         const fn = factory.createFunctionExpression('foo', ['arg1', 'arg2'], body);
+         expect(ts.isExpressionStatement(fn)).toBe(false);
+         expect(generate(fn)).toEqual('function foo(arg1, arg2) { x = 10; y = 20; }');
+       });
+
+    it('should create an anonymous function expression node if the name is null', () => {
+      const {items: [body], generate} = setupStatements('{x = 10; y = 20;}');
+      const fn = factory.createFunctionExpression(null, ['arg1', 'arg2'], body);
+      expect(generate(fn)).toEqual('function (arg1, arg2) { x = 10; y = 20; }');
+    });
+  });
+
+  describe('createIdentifier()', () => {
+    it('should create an identifier with the given name', () => {
+      const id = factory.createIdentifier('someId') as ts.Identifier;
+      expect(ts.isIdentifier(id)).toBe(true);
+      expect(id.text).toEqual('someId');
+    });
+  });
+
+  describe('createIfStatement()', () => {
+    it('should create an if-else statement', () => {
+      const {items: [testStmt, thenStmt, elseStmt], generate} =
+          setupStatements('!test;x = 10;x = 42;');
+      const test = (testStmt as ts.ExpressionStatement).expression;
+      const ifStmt = factory.createIfStatement(test, thenStmt, elseStmt);
+      expect(generate(ifStmt)).toEqual([
+        'if (!test)',
+        '    x = 10;',
+        'else',
+        '    x = 42;',
+      ].join('\n'));
+    });
+
+    it('should create an if statement if the else expression is null', () => {
+      const {items: [testStmt, thenStmt], generate} = setupStatements('!test;x = 10;');
+      const test = (testStmt as ts.ExpressionStatement).expression;
+      const ifStmt = factory.createIfStatement(test, thenStmt, null);
+      expect(generate(ifStmt)).toEqual([
+        'if (!test)',
+        '    x = 10;',
+      ].join('\n'));
+    });
+  });
+
+  describe('createLiteral()', () => {
+    it('should create a string literal', () => {
+      const {generate} = setupStatements();
+      const literal = factory.createLiteral('moo');
+      expect(ts.isStringLiteral(literal)).toBe(true);
+      expect(generate(literal)).toEqual('"moo"');
+    });
+
+    it('should create a number literal', () => {
+      const {generate} = setupStatements();
+      const literal = factory.createLiteral(42);
+      expect(ts.isNumericLiteral(literal)).toBe(true);
+      expect(generate(literal)).toEqual('42');
+    });
+
+    it('should create a number literal for `NaN`', () => {
+      const {generate} = setupStatements();
+      const literal = factory.createLiteral(NaN);
+      expect(ts.isNumericLiteral(literal)).toBe(true);
+      expect(generate(literal)).toEqual('NaN');
+    });
+
+    it('should create a boolean literal', () => {
+      const {generate} = setupStatements();
+      const literal = factory.createLiteral(true);
+      expect(ts.isToken(literal)).toBe(true);
+      expect(generate(literal)).toEqual('true');
+    });
+
+    it('should create an `undefined` literal', () => {
+      const {generate} = setupStatements();
+      const literal = factory.createLiteral(undefined);
+      expect(ts.isIdentifier(literal)).toBe(true);
+      expect(generate(literal)).toEqual('undefined');
+    });
+
+    it('should create a `null` literal', () => {
+      const {generate} = setupStatements();
+      const literal = factory.createLiteral(null);
+      expect(ts.isToken(literal)).toBe(true);
+      expect(generate(literal)).toEqual('null');
+    });
+  });
+
+  describe('createNewExpression()', () => {
+    it('should create a `new` operation on the constructor `expression` with the given `args`',
+       () => {
+         const {items: [expr, arg1, arg2], generate} = setupExpressions('Foo', '42', '"moo"');
+         const call = factory.createNewExpression(expr, [arg1, arg2]);
+         expect(generate(call)).toEqual('new Foo(42, "moo")');
+       });
+  });
+
+  describe('createObjectLiteral()', () => {
+    it('should create an object literal node, with the given properties', () => {
+      const {items: [prop1, prop2], generate} = setupExpressions('42', '"moo"');
+      const obj = factory.createObjectLiteral([
+        {propertyName: 'prop1', value: prop1, quoted: false},
+        {propertyName: 'prop2', value: prop2, quoted: true},
+      ]);
+      expect(generate(obj)).toEqual('{ prop1: 42, "prop2": "moo" }');
+    });
+  });
+
+  describe('createParenthesizedExpression()', () => {
+    it('should add parentheses around the given expression', () => {
+      const {items: [expr], generate} = setupExpressions(`a + b`);
+      const paren = factory.createParenthesizedExpression(expr);
+      expect(generate(paren)).toEqual('(a + b)');
+    });
+  });
+
+  describe('createPropertyAccess()', () => {
+    it('should create a property access expression node', () => {
+      const {items: [expr], generate} = setupExpressions(`obj`);
+      const access = factory.createPropertyAccess(expr, 'moo');
+      expect(generate(access)).toEqual('obj.moo');
+    });
+  });
+
+  describe('createReturnStatement()', () => {
+    it('should create a return statement returning the given expression', () => {
+      const {items: [expr], generate} = setupExpressions(`42`);
+      const returnStmt = factory.createReturnStatement(expr);
+      expect(generate(returnStmt)).toEqual('return 42;');
+    });
+
+    it('should create a void return statement if the expression is null', () => {
+      const {generate} = setupStatements();
+      const returnStmt = factory.createReturnStatement(null);
+      expect(generate(returnStmt)).toEqual('return;');
+    });
+  });
+
+  describe('createTaggedTemplate()', () => {
+    it('should create a tagged template node from the tag, elements and expressions', () => {
+      const elements = [
+        {raw: 'raw\\n1', cooked: 'raw\n1', range: null},
+        {raw: 'raw\\n2', cooked: 'raw\n2', range: null},
+        {raw: 'raw\\n3', cooked: 'raw\n3', range: null},
+      ];
+      const {items: [tag, ...expressions], generate} = setupExpressions('tagFn', '42', '"moo"');
+      const template = factory.createTaggedTemplate(tag, {elements, expressions});
+      expect(generate(template)).toEqual('tagFn `raw\\n1${42}raw\\n2${"moo"}raw\\n3`');
+    });
+  });
+
+  describe('createThrowStatement()', () => {
+    it('should create a throw statement, throwing the given expression', () => {
+      const {items: [expr], generate} = setupExpressions(`new Error("bad")`);
+      const throwStmt = factory.createThrowStatement(expr);
+      expect(generate(throwStmt)).toEqual('throw new Error("bad");');
+    });
+  });
+
+  describe('createTypeOfExpression()', () => {
+    it('should create a typeof expression node', () => {
+      const {items: [expr], generate} = setupExpressions(`42`);
+      const typeofExpr = factory.createTypeOfExpression(expr);
+      expect(generate(typeofExpr)).toEqual('typeof 42');
+    });
+  });
+
+  describe('createUnaryExpression()', () => {
+    it('should create a unary expression with the operator and operand', () => {
+      const {items: [expr], generate} = setupExpressions(`value`);
+      const unaryExpr = factory.createUnaryExpression('!', expr);
+      expect(generate(unaryExpr)).toEqual('!value');
+    });
+  });
+
+  describe('createVariableDeclaration()', () => {
+    it('should create a variable declaration statement node for the given variable name and initializer',
+       () => {
+         const {items: [initializer], generate} = setupExpressions(`42`);
+         const varDecl = factory.createVariableDeclaration('foo', initializer, 'let');
+         expect(generate(varDecl)).toEqual('let foo = 42;');
+       });
+
+    it('should create a constant declaration statement node for the given variable name and initializer',
+       () => {
+         const {items: [initializer], generate} = setupExpressions(`42`);
+         const varDecl = factory.createVariableDeclaration('foo', initializer, 'const');
+         expect(generate(varDecl)).toEqual('const foo = 42;');
+       });
+
+    it('should create a downleveled declaration statement node for the given variable name and initializer',
+       () => {
+         const {items: [initializer], generate} = setupExpressions(`42`);
+         const varDecl = factory.createVariableDeclaration('foo', initializer, 'var');
+         expect(generate(varDecl)).toEqual('var foo = 42;');
+       });
+
+    it('should create an uninitialized variable declaration statement node for the given variable name and a null initializer',
+       () => {
+         const {generate} = setupStatements();
+         const varDecl = factory.createVariableDeclaration('foo', null, 'let');
+         expect(generate(varDecl)).toEqual('let foo;');
+       });
+  });
+
+  describe('setSourceMapRange()', () => {
+    it('should attach the `sourceMapRange` to the given `node`', () => {
+      const {items: [expr]} = setupExpressions(`42`);
+
+      factory.setSourceMapRange(expr, {
+        start: {line: 0, column: 1, offset: 1},
+        end: {line: 2, column: 3, offset: 15},
+        content: '-****\n*****\n****',
+        url: 'original.ts'
+      });
+
+      const range = ts.getSourceMapRange(expr);
+      expect(range.pos).toEqual(1);
+      expect(range.end).toEqual(15);
+      expect(range.source?.getLineAndCharacterOfPosition(range.pos))
+          .toEqual({line: 0, character: 1});
+      expect(range.source?.getLineAndCharacterOfPosition(range.end))
+          .toEqual({line: 2, character: 3});
+    });
+  });
+});
+
+/**
+ * Setup some statements to use in a test, along with a generate function to print the created nodes
+ * out.
+ *
+ * The TypeScript printer requires access to the original source of non-synthesized nodes.
+ * It uses the source content to output things like text between parts of nodes, which it doesn't
+ * store in the AST node itself.
+ *
+ * So this helper (and its sister `setupExpressions()`) capture the original source file used to
+ * provide the original statements/expressions that are used in the tests so that the printing will
+ * work via the returned `generate()` function.
+ */
+function setupStatements(stmts: string = ''): SetupResult<ts.Statement> {
+  const printer = ts.createPrinter();
+  const sf = ts.createSourceFile('test.ts', stmts, ts.ScriptTarget.ES2015, true);
+  return {
+    items: Array.from(sf.statements),
+    generate: (node: ts.Node) => printer.printNode(ts.EmitHint.Unspecified, node, sf),
+  };
+}
+
+/**
+ * Setup some statements to use in a test, along with a generate function to print the created nodes
+ * out.
+ *
+ * See `setupStatements()` for more information about this helper function.
+ */
+function setupExpressions(...exprs: string[]): SetupResult<ts.Expression> {
+  const {items: [arrayStmt], generate} = setupStatements(`[${exprs.join(',')}];`);
+  const expressions = Array.from(
+      ((arrayStmt as ts.ExpressionStatement).expression as ts.ArrayLiteralExpression).elements);
+  return {items: expressions, generate};
+}
+
+interface SetupResult<TNode extends ts.Node> {
+  items: TNode[];
+  generate(node: ts.Node): string;
+}

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
@@ -9,7 +9,7 @@
 import {ExpressionType, ExternalExpr, Type, WrappedNodeExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {ImportFlags, NOOP_DEFAULT_IMPORT_RECORDER, Reference, ReferenceEmitter} from '../../imports';
+import {ImportFlags, Reference, ReferenceEmitter} from '../../imports';
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
 import {ImportManager, translateExpression, translateType} from '../../translator';
 import {TypeCheckableDirectiveMeta, TypeCheckingConfig, TypeCtorMetadata} from '../api';
@@ -213,8 +213,7 @@ export class Environment {
     const ngExpr = this.refEmitter.emit(ref, this.contextFile, ImportFlags.NoAliasing);
 
     // Use `translateExpression` to convert the `Expression` into a `ts.Expression`.
-    return translateExpression(
-        ngExpr, this.importManager, NOOP_DEFAULT_IMPORT_RECORDER, ts.ScriptTarget.ES2015);
+    return translateExpression(ngExpr, this.importManager);
   }
 
   /**

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -1638,7 +1638,7 @@ describe('compiler compliance', () => {
                 $r3$.ɵɵviewQuery(SomeDirective, true);
               }
               if (rf & 2) {
-                var $tmp$;
+                let $tmp$;
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDir = $tmp$.first);
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDirs = $tmp$);
               }
@@ -1697,7 +1697,7 @@ describe('compiler compliance', () => {
                 $r3$.ɵɵviewQuery($e1_attrs$, true);
               }
               if (rf & 2) {
-                var $tmp$;
+                let $tmp$;
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.myRef = $tmp$.first);
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.myRefs = $tmp$);
               }
@@ -1748,7 +1748,7 @@ describe('compiler compliance', () => {
                 $r3$.ɵɵviewQuery($refs$, true);
               }
               if (rf & 2) {
-                var $tmp$;
+                let $tmp$;
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDir = $tmp$.first);
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.foo = $tmp$.first);
               }
@@ -1814,7 +1814,7 @@ describe('compiler compliance', () => {
                 $r3$.ɵɵviewQuery(SomeDirective, true, TemplateRef);
               }
               if (rf & 2) {
-                var $tmp$;
+                let $tmp$;
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.myRef = $tmp$.first);
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDir = $tmp$.first);
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.myRefs = $tmp$);
@@ -1875,7 +1875,7 @@ describe('compiler compliance', () => {
               $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, false);
               }
               if (rf & 2) {
-              var $tmp$;
+              let $tmp$;
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDir = $tmp$.first);
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDirList = $tmp$);
               }
@@ -1935,7 +1935,7 @@ describe('compiler compliance', () => {
               $r3$.ɵɵcontentQuery(dirIndex, $e1_attrs$, false);
               }
               if (rf & 2) {
-              var $tmp$;
+              let $tmp$;
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.myRef = $tmp$.first);
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.myRefs = $tmp$);
               }
@@ -1994,7 +1994,7 @@ describe('compiler compliance', () => {
               $r3$.ɵɵcontentQuery(dirIndex, $ref0$, true);
               }
               if (rf & 2) {
-              var $tmp$;
+              let $tmp$;
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDir = $tmp$.first);
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.foo = $tmp$.first);
               }
@@ -2061,7 +2061,7 @@ describe('compiler compliance', () => {
               $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, false, TemplateRef);
               }
               if (rf & 2) {
-              var $tmp$;
+              let $tmp$;
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.myRef = $tmp$.first);
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDir = $tmp$.first);
                 $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.myRefs = $tmp$);

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -209,7 +209,7 @@ describe('compiler compliance: bindings', () => {
           template: function MyComponent_Template(rf, ctx) {
             …
             if (rf & 2) {
-              var $tmp0$ = null;
+              let $tmp0$ = null;
               $r3$.ɵɵproperty("title", ctx.myTitle)("id", ($tmp0$ = $r3$.ɵɵpipeBind1(1, 3, ($tmp0$ = ctx.auth()) == null ? null : $tmp0$.identity())) == null ? null : $tmp0$.id)("tabindex", 1);
             }
           }
@@ -750,7 +750,7 @@ describe('compiler compliance: bindings', () => {
           hostVars: 1,
           hostBindings: function HostBindingDir_HostBindings(rf, ctx) {
             if (rf & 2) {
-              var $tmp0$ = null;
+              let $tmp0$ = null;
               $r3$.ɵɵhostProperty("id", ($tmp0$ = ctx.getData()) == null ? null : $tmp0$.id);
             }
           }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
@@ -212,7 +212,7 @@ describe('compiler compliance: dependency injection', () => {
           MyService.ɵprov = $r3$.ɵɵdefineInjectable({
             token: MyService,
             factory: function MyService_Factory(t) {
-              var r = null;
+              let r = null;
               if (t) {
                 r = new t();
               } else {
@@ -285,7 +285,7 @@ describe('compiler compliance: dependency injection', () => {
           MyService.ɵprov = $r3$.ɵɵdefineInjectable({
             token: MyService,
             factory: function MyService_Factory(t) {
-              var r = null;
+              let r = null;
               if (t) {
                 r = new t();
               } else {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -251,7 +251,7 @@ const i18nMsg = (message: string, placeholders: Placeholder[] = [], meta?: Meta)
   const closurePlaceholders = i18nPlaceholdersToString(placeholders);
   const locMessageWithPlaceholders = i18nMsgInsertLocalizePlaceholders(message, placeholders);
   return String.raw`
-    var ${varName};
+    let ${varName};
     if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
         ${i18nMsgClosureMeta(meta)}
         const $MSG_EXTERNAL_${msgIndex}$ = goog.getMsg("${message}"${closurePlaceholders});
@@ -304,7 +304,7 @@ describe('i18n support in the template compiler', () => {
 
       // Keeping this block as a raw string, since it checks escaping of special chars.
       const i18n_6 = String.raw`
-        var $i18n_23$;
+        let $i18n_23$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           /**
            * @desc [BACKUP_$` +
@@ -321,7 +321,7 @@ describe('i18n support in the template compiler', () => {
 
       // Keeping this block as a raw string, since it checks escaping of special chars.
       const i18n_7 = String.raw`
-        var $i18n_7$;
+        let $i18n_7$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           /**
            * @desc Some text \' [BACKUP_MESSAGE_ID: xxx]
@@ -780,7 +780,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-              var $tmp_0_0$ = null;
+              let $tmp_0_0$ = null;
               $r3$.ɵɵi18nExp(($tmp_0_0$ = ctx.valueA.getRawValue()) == null ? null : $tmp_0_0$.getTitle());
               $r3$.ɵɵi18nApply(1);
           }
@@ -942,7 +942,7 @@ describe('i18n support in the template compiler', () => {
       verify(input, output);
     });
 
-    it('should sanitize ids and generate proper var names', () => {
+    it('should sanitize ids and generate proper variable names', () => {
       const input = `
         <div i18n="@@ID.WITH.INVALID.CHARS.2" i18n-title="@@ID.WITH.INVALID.CHARS" title="Element title">
           Some content
@@ -951,7 +951,7 @@ describe('i18n support in the template compiler', () => {
 
       // Keeping raw content (avoiding `i18nMsg`) to illustrate message id sanitization.
       const output = String.raw`
-        var $I18N_0$;
+        let $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_ID_WITH_INVALID_CHARS$$APP_SPEC_TS_1$ = goog.getMsg("Element title");
             $I18N_0$ = $MSG_EXTERNAL_ID_WITH_INVALID_CHARS$$APP_SPEC_TS_1$;
@@ -960,7 +960,7 @@ describe('i18n support in the template compiler', () => {
             $I18N_0$ = $localize \`:@@ID.WITH.INVALID.CHARS:Element title\`;
         }
         …
-        var $I18N_2$;
+        let $I18N_2$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_ID_WITH_INVALID_CHARS_2$$APP_SPEC_TS_4$ = goog.getMsg(" Some content ");
             $I18N_2$ = $MSG_EXTERNAL_ID_WITH_INVALID_CHARS_2$$APP_SPEC_TS_4$;
@@ -1018,7 +1018,7 @@ describe('i18n support in the template compiler', () => {
 
       // Keeping raw content (avoiding `i18nMsg`) to illustrate quotes escaping.
       const output = String.raw`
-        var $I18N_0$;
+        let $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_4924931801512133405$$APP_SPEC_TS_0$ = goog.getMsg("Some text 'with single quotes', \"with double quotes\", ` +
           '`with backticks`' + String.raw` and without quotes.");
@@ -1036,7 +1036,7 @@ describe('i18n support in the template compiler', () => {
       const input = '<div i18n>`{{ count }}`</div>';
       // Keeping raw content (avoiding `i18nMsg`) to illustrate backticks escaping.
       const output = String.raw`
-      var $I18N_0$;
+      let $I18N_0$;
       if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           const $MSG_APP_SPEC_TS_1$ = goog.getMsg("` +
           '`{$interpolation}`' + String.raw`", { "interpolation": "\uFFFD0\uFFFD" });
@@ -1108,7 +1108,7 @@ describe('i18n support in the template compiler', () => {
       // Keeping raw content (avoiding `i18nMsg`) to illustrate how named interpolations are
       // generated.
       const i18n_0 = String.raw`
-        var $I18N_0$;
+        let $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_7597881511811528589$$APP_SPEC_TS_0$ = goog.getMsg(" Named interpolation: {$phA} Named interpolation with spaces: {$phB} ", {
               "phA": "\uFFFD0\uFFFD",
@@ -1209,7 +1209,7 @@ describe('i18n support in the template compiler', () => {
             $r3$.ɵɵelementEnd();
           }
           if (rf & 2) {
-            var $tmp_2_0$ = null;
+            let $tmp_2_0$ = null;
             $r3$.ɵɵadvance(2);
             $r3$.ɵɵi18nExp($r3$.ɵɵpipeBind1(2, 3, ctx.valueA))
                           (ctx.valueA == null ? null : ctx.valueA.a == null ? null : ctx.valueA.a.b)
@@ -2487,7 +2487,7 @@ describe('i18n support in the template compiler', () => {
       // Keeping raw content (avoiding `i18nMsg`) to illustrate message layout
       // in case of whitespace preserving mode.
       const i18n_0 = String.raw`
-        var $I18N_0$;
+        let $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_963542717423364282$$APP_SPEC_TS_0$ = goog.getMsg("\n          Some text\n          {$startTagSpan}Text inside span{$closeTagSpan}\n        ", {
               "startTagSpan": "\uFFFD#3\uFFFD",
@@ -2571,7 +2571,7 @@ describe('i18n support in the template compiler', () => {
       `;
 
       const output = String.raw`
-        var $I18N_0$;
+        let $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_EXTERNAL_4166854826696768832$$APP_SPEC_TS_0$ = goog.getMsg("{VAR_SELECT, select, single {'single quotes'} double {\"double quotes\"} other {other}}");
             $I18N_0$ = $MSG_EXTERNAL_4166854826696768832$$APP_SPEC_TS_0$;
@@ -2914,7 +2914,7 @@ describe('i18n support in the template compiler', () => {
       // Keeping raw content here to illustrate the difference in placeholders generated for
       // goog.getMsg and $localize calls (see last i18n block).
       const i18n_0 = String.raw`
-        var $I18N_1$;
+        let $I18N_1$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_APP_SPEC_TS_1$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
             $I18N_1$ = $MSG_APP_SPEC_TS_1$;
@@ -2925,7 +2925,7 @@ describe('i18n support in the template compiler', () => {
         $I18N_1$ = $r3$.ɵɵi18nPostprocess($I18N_1$, {
           "VAR_SELECT": "\uFFFD0\uFFFD"
         });
-        var $I18N_2$;
+        let $I18N_2$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_APP_SPEC_TS_2$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
             $I18N_2$ = $MSG_APP_SPEC_TS_2$;
@@ -2936,7 +2936,7 @@ describe('i18n support in the template compiler', () => {
         $I18N_2$ = $r3$.ɵɵi18nPostprocess($I18N_2$, {
           "VAR_SELECT": "\uFFFD1\uFFFD"
         });
-        var $I18N_4$;
+        let $I18N_4$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_APP_SPEC_TS__4$ = goog.getMsg("{VAR_SELECT, select, male {male} female {female} other {other}}");
             $I18N_4$ = $MSG_APP_SPEC_TS__4$;
@@ -2947,7 +2947,7 @@ describe('i18n support in the template compiler', () => {
         $I18N_4$ = $r3$.ɵɵi18nPostprocess($I18N_4$, {
           "VAR_SELECT": "\uFFFD0:1\uFFFD"
         });
-        var $I18N_0$;
+        let $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
             const $MSG_APP_SPEC_TS_0$ = goog.getMsg(" {$icu} {$startTagDiv} {$icu} {$closeTagDiv}{$startTagDiv_1} {$icu} {$closeTagDiv}", {
               "startTagDiv": "\uFFFD#2\uFFFD",
@@ -3345,7 +3345,7 @@ describe('i18n support in the template compiler', () => {
       const input = `<div i18n>Some Message</div>`;
 
       const output = String.raw`
-        var $I18N_0$;
+        let $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) { … }
         else {
             $I18N_0$ = $localize \`:␟ec93160d6d6a8822214060dd7938bf821c22b226␟6795333002533525253:Some Message\`;
@@ -3360,7 +3360,7 @@ describe('i18n support in the template compiler', () => {
       const input = `<div i18n>Some Message</div>`;
 
       const output = String.raw`
-        var $I18N_0$;
+        let $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) { … }
         else {
             $I18N_0$ = $localize \`:␟ec93160d6d6a8822214060dd7938bf821c22b226␟6795333002533525253:Some Message\`;
@@ -3523,7 +3523,7 @@ $` + String.raw`{$I18N_4$}:ICU:\`;
       `;
 
       const i18n_0 = String.raw`
-        var $I18N_0$;
+        let $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           const $MSG_EXTERNAL_7128002169381370313$$APP_SPEC_TS_1$ = goog.getMsg("{$startTagXhtmlDiv} Count: {$startTagXhtmlSpan}5{$closeTagXhtmlSpan}{$closeTagXhtmlDiv}", {
             "startTagXhtmlDiv": "\uFFFD#3\uFFFD",
@@ -3584,7 +3584,7 @@ $` + String.raw`{$I18N_4$}:ICU:\`;
       `;
 
       const i18n_0 = String.raw`
-        var $I18N_0$;
+        let $I18N_0$;
         if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
           const $MSG_EXTERNAL_7428861019045796010$$APP_SPEC_TS_1$ = goog.getMsg(" Count: {$startTagXhtmlSpan}5{$closeTagXhtmlSpan}", {
             "startTagXhtmlSpan": "\uFFFD#4\uFFFD",

--- a/packages/compiler/test/render3/view/i18n_spec.ts
+++ b/packages/compiler/test/render3/view/i18n_spec.ts
@@ -223,76 +223,107 @@ describe('Utils', () => {
 
     it('serializeI18nHead()', () => {
       expect(o.localizedString(meta(), [literal('')], [], []).serializeI18nHead())
-          .toEqual({cooked: '', raw: ''});
+          .toEqual({cooked: '', raw: '', range: jasmine.any(ParseSourceSpan)});
       expect(o.localizedString(meta('', '', 'desc'), [literal('')], [], []).serializeI18nHead())
-          .toEqual({cooked: ':desc:', raw: ':desc:'});
+          .toEqual({cooked: ':desc:', raw: ':desc:', range: jasmine.any(ParseSourceSpan)});
       expect(o.localizedString(meta('id', '', 'desc'), [literal('')], [], []).serializeI18nHead())
-          .toEqual({cooked: ':desc@@id:', raw: ':desc@@id:'});
+          .toEqual({cooked: ':desc@@id:', raw: ':desc@@id:', range: jasmine.any(ParseSourceSpan)});
       expect(
           o.localizedString(meta('', 'meaning', 'desc'), [literal('')], [], []).serializeI18nHead())
-          .toEqual({cooked: ':meaning|desc:', raw: ':meaning|desc:'});
+          .toEqual({
+            cooked: ':meaning|desc:',
+            raw: ':meaning|desc:',
+            range: jasmine.any(ParseSourceSpan)
+          });
       expect(o.localizedString(meta('id', 'meaning', 'desc'), [literal('')], [], [])
                  .serializeI18nHead())
-          .toEqual({cooked: ':meaning|desc@@id:', raw: ':meaning|desc@@id:'});
+          .toEqual({
+            cooked: ':meaning|desc@@id:',
+            raw: ':meaning|desc@@id:',
+            range: jasmine.any(ParseSourceSpan)
+          });
       expect(o.localizedString(meta('id', '', ''), [literal('')], [], []).serializeI18nHead())
-          .toEqual({cooked: ':@@id:', raw: ':@@id:'});
+          .toEqual({cooked: ':@@id:', raw: ':@@id:', range: jasmine.any(ParseSourceSpan)});
 
       // Escaping colons (block markers)
       expect(o.localizedString(meta('id:sub_id', 'meaning', 'desc'), [literal('')], [], [])
                  .serializeI18nHead())
-          .toEqual({cooked: ':meaning|desc@@id:sub_id:', raw: ':meaning|desc@@id\\:sub_id:'});
+          .toEqual({
+            cooked: ':meaning|desc@@id:sub_id:',
+            raw: ':meaning|desc@@id\\:sub_id:',
+            range: jasmine.any(ParseSourceSpan)
+          });
       expect(o.localizedString(meta('id', 'meaning:sub_meaning', 'desc'), [literal('')], [], [])
                  .serializeI18nHead())
-          .toEqual(
-              {cooked: ':meaning:sub_meaning|desc@@id:', raw: ':meaning\\:sub_meaning|desc@@id:'});
+          .toEqual({
+            cooked: ':meaning:sub_meaning|desc@@id:',
+            raw: ':meaning\\:sub_meaning|desc@@id:',
+            range: jasmine.any(ParseSourceSpan)
+          });
       expect(o.localizedString(meta('id', 'meaning', 'desc:sub_desc'), [literal('')], [], [])
                  .serializeI18nHead())
-          .toEqual({cooked: ':meaning|desc:sub_desc@@id:', raw: ':meaning|desc\\:sub_desc@@id:'});
+          .toEqual({
+            cooked: ':meaning|desc:sub_desc@@id:',
+            raw: ':meaning|desc\\:sub_desc@@id:',
+            range: jasmine.any(ParseSourceSpan)
+          });
       expect(o.localizedString(meta('id', 'meaning', 'desc'), [literal('message source')], [], [])
                  .serializeI18nHead())
           .toEqual({
             cooked: ':meaning|desc@@id:message source',
-            raw: ':meaning|desc@@id:message source'
+            raw: ':meaning|desc@@id:message source',
+            range: jasmine.any(ParseSourceSpan)
           });
       expect(o.localizedString(meta('id', 'meaning', 'desc'), [literal(':message source')], [], [])
                  .serializeI18nHead())
           .toEqual({
             cooked: ':meaning|desc@@id::message source',
-            raw: ':meaning|desc@@id::message source'
+            raw: ':meaning|desc@@id::message source',
+            range: jasmine.any(ParseSourceSpan)
           });
       expect(o.localizedString(meta('', '', ''), [literal('message source')], [], [])
                  .serializeI18nHead())
-          .toEqual({cooked: 'message source', raw: 'message source'});
+          .toEqual({
+            cooked: 'message source',
+            raw: 'message source',
+            range: jasmine.any(ParseSourceSpan)
+          });
       expect(o.localizedString(meta('', '', ''), [literal(':message source')], [], [])
                  .serializeI18nHead())
-          .toEqual({cooked: ':message source', raw: '\\:message source'});
+          .toEqual({
+            cooked: ':message source',
+            raw: '\\:message source',
+            range: jasmine.any(ParseSourceSpan)
+          });
     });
 
     it('serializeI18nPlaceholderBlock()', () => {
       expect(o.localizedString(meta('', '', ''), [literal(''), literal('')], [literal('')], [])
                  .serializeI18nTemplatePart(1))
-          .toEqual({cooked: '', raw: ''});
+          .toEqual({cooked: '', raw: '', range: jasmine.any(ParseSourceSpan)});
       expect(o.localizedString(
                   meta('', '', ''), [literal(''), literal('')],
                   [new o.LiteralPiece('abc', {} as any)], [])
                  .serializeI18nTemplatePart(1))
-          .toEqual({cooked: ':abc:', raw: ':abc:'});
+          .toEqual({cooked: ':abc:', raw: ':abc:', range: jasmine.any(ParseSourceSpan)});
       expect(
           o.localizedString(meta('', '', ''), [literal(''), literal('message')], [literal('')], [])
               .serializeI18nTemplatePart(1))
-          .toEqual({cooked: 'message', raw: 'message'});
+          .toEqual({cooked: 'message', raw: 'message', range: jasmine.any(ParseSourceSpan)});
       expect(o.localizedString(
                   meta('', '', ''), [literal(''), literal('message')], [literal('abc')], [])
                  .serializeI18nTemplatePart(1))
-          .toEqual({cooked: ':abc:message', raw: ':abc:message'});
+          .toEqual(
+              {cooked: ':abc:message', raw: ':abc:message', range: jasmine.any(ParseSourceSpan)});
       expect(
           o.localizedString(meta('', '', ''), [literal(''), literal(':message')], [literal('')], [])
               .serializeI18nTemplatePart(1))
-          .toEqual({cooked: ':message', raw: '\\:message'});
+          .toEqual({cooked: ':message', raw: '\\:message', range: jasmine.any(ParseSourceSpan)});
       expect(o.localizedString(
                   meta('', '', ''), [literal(''), literal(':message')], [literal('abc')], [])
                  .serializeI18nTemplatePart(1))
-          .toEqual({cooked: ':abc::message', raw: ':abc::message'});
+          .toEqual(
+              {cooked: ':abc::message', raw: ':abc::message', range: jasmine.any(ParseSourceSpan)});
     });
 
     function meta(customId?: string, meaning?: string, description?: string): I18nMeta {


### PR DESCRIPTION
This commit refactors the `ExpressionTranslatorVisitor` so that it
is not tied directly to the TypeScript AST. Instead it uses generic
`TExpression` and `TStatement` types that are then converted
to concrete types by the `TypeScriptAstFactory`.

This paves the way for a `BabelAstFactory` that can be used to
generate Babel AST nodes instead of TypeScript, which will be
part of the new linker tool.
