### PR TITLE
fix(router): preload router should use loaded config #38557

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -483,6 +483,11 @@ export interface Route {
    * @internal
    */
   _loadedConfig?: LoadedRouterConfig;
+  /**
+   * Filled for routes with `loadChildren` during load
+   * @internal
+   */
+  _loader$?: Observable<LoadedRouterConfig>;
 }
 
 export class LoadedRouterConfig {

--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -126,9 +126,12 @@ export class RouterPreloader implements OnDestroy {
 
   private preloadConfig(ngModule: NgModuleRef<any>, route: Route): Observable<void> {
     return this.preloadingStrategy.preload(route, () => {
-      const loaded$ = this.loader.load(ngModule.injector, route);
+      const loaded$ = route._loadedConfig ? of(route._loadedConfig) :
+                                            this.loader.load(ngModule.injector, route);
       return loaded$.pipe(mergeMap((config: LoadedRouterConfig) => {
-        route._loadedConfig = config;
+        if (!route._loadedConfig) {
+          route._loadedConfig = config;
+        }
         return this.processRoutes(config.module, config.routes);
       }));
     });

--- a/packages/router/test/router_preloader.spec.ts
+++ b/packages/router/test/router_preloader.spec.ts
@@ -8,10 +8,13 @@
 
 import {Compiler, Component, NgModule, NgModuleFactoryLoader, NgModuleRef} from '@angular/core';
 import {fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
-import {PreloadAllModules, PreloadingStrategy, RouterPreloader} from '@angular/router';
+import {DefaultUrlSerializer, PreloadAllModules, PreloadingStrategy, RouterPreloader, UrlTree} from '@angular/router';
+import {Observable, of, timer} from 'rxjs';
+import {catchError, switchMapTo} from 'rxjs/operators';
 
 import {Route, RouteConfigLoadEnd, RouteConfigLoadStart, Router, RouterModule} from '../index';
-import {LoadedRouterConfig} from '../src/config';
+import {applyRedirects} from '../src/apply_redirects';
+import {LoadedRouterConfig, Routes} from '../src/config';
 import {RouterTestingModule, SpyNgModuleFactoryLoader} from '../testing';
 
 describe('RouterPreloader', () => {
@@ -261,4 +264,62 @@ describe('RouterPreloader', () => {
              expect(c[0]._loadedConfig!.routes[0].component).toBe(configs[0].component);
            })));
   });
+});
+
+describe('should use loaded configs when preload not done but navigate works', () => {
+  class PreloadAllModulesAsync implements PreloadingStrategy {
+    preload(_: Route, fn: () => Observable<any>): Observable<any> {
+      return timer(3000).pipe(switchMapTo(fn()), catchError(() => of(null)));
+    }
+  }
+
+  @NgModule({imports: [RouterModule.forChild([])]})
+  class LoadedModule {
+  }
+
+  const routeConfig: Routes = [{path: 'loadedModule1', loadChildren: 'expected'}];
+  const serializer = new DefaultUrlSerializer();
+  let testModule: NgModuleRef<any>;
+
+  function tree(url: string): UrlTree {
+    return new DefaultUrlSerializer().parse(url);
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule.withRoutes(routeConfig)],
+      providers: [{provide: PreloadingStrategy, useClass: PreloadAllModulesAsync}]
+    });
+    testModule = TestBed.inject(NgModuleRef);
+  });
+
+
+  it('should work',
+     fakeAsync(inject(
+         [
+           NgModuleFactoryLoader,
+           RouterPreloader,
+           Router,
+         ],
+         (lazyLoader: SpyNgModuleFactoryLoader, preloader: RouterPreloader, router: Router) => {
+           const loadedConfig = new LoadedRouterConfig(routeConfig, testModule);
+           const loader = {load: () => of(loadedConfig)};
+           const c = router.config as {_loadedConfig: LoadedRouterConfig}[];
+
+           lazyLoader.stubbedModules = {expected: LoadedModule};
+           preloader.preload().subscribe(() => {});
+
+           tick(500);
+           expect(c[0]._loadedConfig).not.toBeDefined();
+           applyRedirects(
+               testModule.injector, <any>loader, serializer, tree('loadedModule1'), router.config)
+               .forEach(r => {
+                 expect((c[0] as any)._loadedConfig).toBe(loadedConfig);
+               });
+
+           tick(2500);
+
+           expect(c[0]._loadedConfig).toBeDefined();
+           expect(c[0]._loadedConfig).toBe(loadedConfig);
+         })));
 });


### PR DESCRIPTION
Router preloading use asynchronous calculation, but if we navigate to target route when that calculation not complete.
This may cause applyRedirect create config for that route.
After a while, preload procedure got its _loadedConfig and override the one created by applyRedirect.
This is naturally not we want, it may cause page component destroy and rebuild unintentional.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
