### PR TITLE
fix(dev-infra): remove ANSI escape codes from log file outputs

### DIFF
--- a/dev-infra/utils/console.ts
+++ b/dev-infra/utils/console.ts
@@ -196,6 +196,9 @@ export function captureLogOutputForCommand(argv: Arguments) {
     /** Path to the log file location. */
     const logFilePath = join(getRepoBaseDir(), '.ng-dev.log');
 
+    // Strip ANSI escape codes from log outputs.
+    LOGGED_TEXT = LOGGED_TEXT.replace(/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]/g, '');
+
     writeFileSync(logFilePath, LOGGED_TEXT);
 
     // For failure codes greater than 1, the new logged lines should be written to a specific log


### PR DESCRIPTION
Remove the ANSI codes from the log file outputs to make the ng-dev log files
more readable.
