### PR TITLE
test(compiler): Add back tests for renamed inputs and outputs

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
@@ -690,11 +690,10 @@ runInEachFileSystem(() => {
 
         const inputBbinding = (nodes[0] as TmplAstElement).inputs[1];
         const bSymbol = templateTypeChecker.getSymbolOfNode(inputBbinding, cmp)!;
-        // TODO(atscott): The BoundTarget is not assigning renamed properties correctly
-        // assertInputBindingSymbol(bSymbol);
-        // expect((bSymbol.bindings[0].tsSymbol!.declarations[0] as ts.PropertyDeclaration)
-        //            .name.getText())
-        //     .toEqual('inputB');
+        assertInputBindingSymbol(bSymbol);
+        expect((bSymbol.bindings[0].tsSymbol!.declarations[0] as ts.PropertyDeclaration)
+                   .name.getText())
+            .toEqual('inputB');
       });
 
       it('does not retrieve a symbol for an input when undeclared', () => {
@@ -983,11 +982,10 @@ runInEachFileSystem(() => {
 
         const outputBBinding = (nodes[0] as TmplAstElement).outputs[1];
         const bSymbol = templateTypeChecker.getSymbolOfNode(outputBBinding, cmp)!;
-        // TODO(atscott): The BoundTarget is not assigning renamed properties correctly
-        // assertOutputBindingSymbol(bSymbol);
-        // expect((bSymbol.bindings[0].tsSymbol!.declarations[0] as ts.PropertyDeclaration)
-        //            .name.getText())
-        //     .toEqual('outputB');
+        assertOutputBindingSymbol(bSymbol);
+        expect((bSymbol.bindings[0].tsSymbol!.declarations[0] as ts.PropertyDeclaration)
+                   .name.getText())
+            .toEqual('outputB');
       });
 
       it('should find symbol for output binding when there are multiple directives', () => {


### PR DESCRIPTION
#38685 corrected the confusion between field and property names so the consumer can
now be determined correctly.
