### PR TITLE
WIP test(language-service): [Ivy] add test for type guard

### DIFF
--- a/packages/language-service/ivy/test/diagnostic_spec.ts
+++ b/packages/language-service/ivy/test/diagnostic_spec.ts
@@ -35,4 +35,17 @@ describe('diagnostic', () => {
     expect(text.substring(start!, start! + length!)).toBe('nope');
     expect(messageText).toBe(`Property 'nope' does not exist on type 'AppComponent'.`);
   });
+
+  it('should not produce error on type guards', () => {
+    service.overwriteInlineTemplate(APP_COMPONENT, `
+      <ng-container *ngIf="user.type === 'user1'; else user2">
+        {{ user.name }}
+      </ng-container>
+      <ng-template #user2>
+        {{ user.address }}
+      </ng-template>
+    `);
+    const diags = ngLS.getSemanticDiagnostics(APP_COMPONENT);
+    expect(diags.length).toBe(0);
+  });
 });

--- a/packages/language-service/ivy/test/language_service_spec.ts
+++ b/packages/language-service/ivy/test/language_service_spec.ts
@@ -17,7 +17,7 @@ describe('parseNgCompilerOptions', () => {
     const options = parseNgCompilerOptions(project);
     expect(options).toEqual(jasmine.objectContaining({
       enableIvy: true,  // default for ivy is true
-      fullTemplateTypeCheck: true,
+      strictTemplates: true,
       strictInjectionParameters: true,
     }));
   });

--- a/packages/language-service/test/project/app/app.component.ts
+++ b/packages/language-service/test/project/app/app.component.ts
@@ -13,6 +13,16 @@ export interface Hero {
   name: string;
 }
 
+interface User1 {
+  type: 'user1';
+  name: string;
+}
+
+interface User2 {
+  type: 'user2';
+  address: string;
+}
+
 @Component({
   selector: 'my-app',
   template: `
@@ -23,6 +33,10 @@ export interface Hero {
 export class AppComponent {
   title = 'Tour of Heroes';
   hero: Hero = {id: 1, name: 'Windstorm'};
+  user: User1|User2 = {
+    type: 'user1',
+    name: 'John',
+  };
   private internal: string = 'internal';
   setTitle(newTitle: string) {
     this.title = newTitle;

--- a/packages/language-service/test/project/tsconfig.json
+++ b/packages/language-service/test/project/tsconfig.json
@@ -12,7 +12,7 @@
     }
   },
   "angularCompilerOptions": {
-    "fullTemplateTypeCheck": true,
+    "strictTemplates": true,
     "strictInjectionParameters": true
   }
 }


### PR DESCRIPTION
This commit adds a test for type guard. It does not work in View Engine,
but with Ivy there should not be any diagnostics when used correctly.

https://github.com/angular/vscode-ng-language-service/issues/843

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
