### PR TITLE
Add format of ISO week-numbering year

### DIFF
--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -394,6 +394,14 @@ function weekGetter(size: number, monthBased = false): DateFormatter {
   };
 }
 
+function weekNumberingYearGetter(size: number, trim: boolean): DateFormatter {
+  return function(date: Date, locale: string) {
+    const thisThurs = getThursdayThisWeek(date);
+    const result = thisThurs.getFullYear();
+    return padNumber(result, size, getLocaleNumberSymbol(locale, NumberSymbol.MinusSign), trim);
+  };
+}
+
 type DateFormatter = (date: Date, locale: string, offset: number) => string;
 
 const DATE_FORMATS: {[format: string]: DateFormatter} = {};
@@ -429,13 +437,27 @@ function getDateFormatter(format: string): DateFormatter|null {
     case 'yy':
       formatter = dateGetter(DateType.FullYear, 2, 0, true, true);
       break;
-    // 3 digit representation of the year, padded (000-999). (e.g. AD 2001 => 01, AD 2010 => 10)
+    // 3 digit representation of the year, padded (000-999). (e.g. AD 1 => 001, AD 2010 => 2010)
     case 'yyy':
       formatter = dateGetter(DateType.FullYear, 3, 0, false, true);
       break;
     // 4 digit representation of the year (e.g. AD 1 => 0001, AD 2010 => 2010)
     case 'yyyy':
       formatter = dateGetter(DateType.FullYear, 4, 0, false, true);
+      break;
+
+    // ISO week-numbering year
+    case 'r':
+      formatter = weekNumberingYearGetter(1, false);
+      break;
+    case 'rr':
+      formatter = weekNumberingYearGetter(2, true);
+      break;
+    case 'rrr':
+      formatter = weekNumberingYearGetter(3, false);
+      break;
+    case 'rrrr':
+      formatter = weekNumberingYearGetter(4, false);
       break;
 
     // Month of the year (1-12), numeric

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -65,6 +65,10 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  *  |                    | yy          | Numeric: 2 digits + zero padded                               | 02, 20, 01, 17, 73                                         |
  *  |                    | yyy         | Numeric: 3 digits + zero padded                               | 002, 020, 201, 2017, 20173                                 |
  *  |                    | yyyy        | Numeric: 4 digits or more + zero padded                       | 0002, 0020, 0201, 2017, 20173                              |
+ *  | Week-numbering year| r           | Numeric: minimum digits                                       | 2, 20, 201, 2017, 20173                                    |
+ *  |                    | rr          | Numeric: 2 digits + zero padded                               | 02, 20, 01, 17, 73                                         |
+ *  |                    | rrr         | Numeric: 3 digits + zero padded                               | 002, 020, 201, 2017, 20173                                 |
+ *  |                    | rrrr        | Numeric: 4 digits or more + zero padded                       | 0002, 0020, 0201, 2017, 20173                              |
  *  | Month              | M           | Numeric: 1 digit                                              | 9, 12                                                      |
  *  |                    | MM          | Numeric: 2 digits + zero padded                               | 09, 12                                                     |
  *  |                    | MMM         | Abbreviated                                                   | Sep                                                        |

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -361,5 +361,14 @@ describe('Format date', () => {
       expect(formatDate(3001, 'm:ss.SS', 'en')).toEqual('0:03.00');
       expect(formatDate(3001, 'm:ss.SSS', 'en')).toEqual('0:03.001');
     });
+
+    // https://github.com/angular/angular/issues/38739
+    it('should format correctly for iso week-numbering year', () => {
+      const date = new Date(2018, 11, 31);
+      expect(formatDate(date, 'r', 'en')).toEqual('2019');
+      expect(formatDate(date, 'rr', 'en')).toEqual('19');
+      expect(formatDate(date, 'rrr', 'en')).toEqual('2019');
+      expect(formatDate(date, 'rrrr', 'en')).toEqual('2019');
+    });
   });
 });


### PR DESCRIPTION
Add support to format iso week-numbering year with 'r' in dateFormat
string template.

PR angular#38739

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #38739 


## What is the new behavior?

support formating date as ISO week-numbering year with symbol 'r'.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
