### PR TITLE
fix(compiler): source span for microsyntax bindings should be the bin…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -101,11 +101,13 @@ class ExpressionVisitor extends RecursiveAstVisitor {
     // The compiler's expression parser records the location of some expressions in a manner not
     // useful to the indexer. For example, a `MethodCall` `foo(a, b)` will record the span of the
     // entire method call, but the indexer is interested only in the method identifier.
-    const localExpression = this.expressionStr.substr(ast.span.start);
-    if (!localExpression.includes(ast.name)) {
-      throw new Error(`Impossible state: "${ast.name}" not found in "${localExpression}"`);
+
+    // The source span of the requested AST starts at a location that is offset from the expression.
+    const identifierStart = ast.sourceSpan.start - this.absoluteOffset;
+    if (!this.expressionStr.substring(identifierStart).startsWith(ast.name)) {
+      throw new Error(`Impossible state: "${ast.name}" not found in "${
+          this.expressionStr}" at location ${identifierStart}`);
     }
-    const identifierStart = ast.span.start + localExpression.indexOf(ast.name);
 
     // Join the relative position of the expression within a node with the absolute position
     // of the node to get the absolute position of the expression in the source code.
@@ -191,25 +193,13 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
     this.visitAll(template.references);
   }
   visitBoundAttribute(attribute: TmplAstBoundAttribute) {
-    // A BoundAttribute's value (the parent AST) may have subexpressions (children ASTs) that have
-    // recorded spans extending past the recorded span of the parent. The most common example of
-    // this is with `*ngFor`.
-    // To resolve this, use the information on the BoundAttribute Template AST, which is always
-    // correct, to determine locations of identifiers in the expression.
-    //
-    // TODO(ayazhafiz): Remove this when https://github.com/angular/angular/pull/31813 lands.
-    const attributeSrc = attribute.sourceSpan.toString();
-    const attributeAbsolutePosition = attribute.sourceSpan.start.offset;
-
-    // Skip the bytes of the attribute name so that there are no collisions between the attribute
-    // name and expression identifier names later.
-    const nameSkipOffet = attributeSrc.indexOf(attribute.name) + attribute.name.length;
-    const expressionSrc = attributeSrc.substring(nameSkipOffet);
-    const expressionAbsolutePosition = attributeAbsolutePosition + nameSkipOffet;
+    if (attribute.valueSpan === undefined) {
+      return;
+    }
 
     const identifiers = ExpressionVisitor.getIdentifiers(
-        attribute.value, expressionSrc, expressionAbsolutePosition, this.boundTemplate,
-        this.targetToIdentifier.bind(this));
+        attribute.value, attribute.valueSpan.toString(), attribute.valueSpan.start.offset,
+        this.boundTemplate, this.targetToIdentifier.bind(this));
     identifiers.forEach(id => this.identifiers.add(id));
   }
   visitBoundEvent(attribute: TmplAstBoundEvent) {

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -189,6 +189,33 @@ runInEachFileSystem(() => {
           target: null,
         });
       });
+
+      it('should discover properties in template expressions and resist collisions', () => {
+        const template = '<div *ngFor="let foo of (foos ? foos : foos)"></div>';
+        const refs = getTemplateIdentifiers(bind(template));
+
+        const refArr = Array.from(refs);
+        expect(refArr).toEqual(jasmine.arrayContaining([
+          {
+            name: 'foos',
+            kind: IdentifierKind.Property,
+            span: new AbsoluteSourceSpan(25, 29),
+            target: null,
+          },
+          {
+            name: 'foos',
+            kind: IdentifierKind.Property,
+            span: new AbsoluteSourceSpan(32, 36),
+            target: null,
+          },
+          {
+            name: 'foos',
+            kind: IdentifierKind.Property,
+            span: new AbsoluteSourceSpan(39, 43),
+            target: null,
+          },
+        ]));
+      });
     });
 
     describe('generates identifiers for PropertyWrites', () => {

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -155,7 +155,7 @@ export class BindingParser {
       } else if (binding.value) {
         const valueSpan = moveParseSourceSpan(sourceSpan, binding.value.ast.sourceSpan);
         this._parsePropertyAst(
-            key, binding.value, sourceSpan, valueSpan, targetMatchableAttrs, targetProps);
+            key, binding.value, bindingSpan, valueSpan, targetMatchableAttrs, targetProps);
       } else {
         targetMatchableAttrs.push([key, '' /* value */]);
         // Since this is a literal attribute with no RHS, source span should be

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -251,9 +251,17 @@ describe('R3 AST source spans', () => {
       // </ng-template>
       expectFromHtml('<div *ngFor="item of items"></div>').toEqual([
         ['Template', '0:34', '0:28', '28:34'],
-        ['BoundAttribute', '5:27', '13:17'],  // ngFor="item of items" -> item
-        ['BoundAttribute', '5:27', '21:26'],  // ngFor="item of items" -> items
+        ['BoundAttribute', '6:18', '13:17'],   // ngFor="item -> item
+        ['BoundAttribute', '18:26', '21:26'],  // of items -> items
         ['Element', '0:34', '0:28', '28:34'],
+      ]);
+
+      expectFromHtml('<div *ngFor="item of items; trackBy: trackByFn"></div>').toEqual([
+        ['Template', '0:54', '0:48', '48:54'],
+        ['BoundAttribute', '6:18', '13:17'],   // ngFor="item -> item
+        ['BoundAttribute', '18:28', '21:26'],  // of items;  -> items
+        ['BoundAttribute', '28:46', '37:46'],  // trackBy: trackByFn -> trackByFn
+        ['Element', '0:54', '0:48', '48:54'],
       ]);
     });
 

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -238,7 +238,7 @@ describe('R3 AST source spans', () => {
       expectFromHtml('<div *ngFor="let item of items"></div>').toEqual([
         ['Template', '0:38', '0:32', '32:38'],
         ['TextAttribute', '6:11', '<empty>'],  // ngFor
-        ['BoundAttribute', '5:31', '25:30'],   // *ngFor="let item of items" -> items
+        ['BoundAttribute', '22:30', '25:30'],  // of items -> items
         ['Variable', '13:22', '<empty>'],      // let item
         ['Element', '0:38', '0:32', '32:38'],
       ]);
@@ -256,12 +256,13 @@ describe('R3 AST source spans', () => {
         ['Element', '0:34', '0:28', '28:34'],
       ]);
 
-      expectFromHtml('<div *ngFor="item of items; trackBy: trackByFn"></div>').toEqual([
-        ['Template', '0:54', '0:48', '48:54'],
-        ['BoundAttribute', '6:18', '13:17'],   // ngFor="item -> item
-        ['BoundAttribute', '18:28', '21:26'],  // of items;  -> items
-        ['BoundAttribute', '28:46', '37:46'],  // trackBy: trackByFn -> trackByFn
-        ['Element', '0:54', '0:48', '48:54'],
+      expectFromHtml('<div *ngFor="let item of items; trackBy: trackByFn"></div>').toEqual([
+        ['Template', '0:58', '0:52', '52:58'],
+        ['TextAttribute', '6:11', '<empty>'],  // ngFor
+        ['BoundAttribute', '22:32', '25:30'],  // of items;  -> item
+        ['BoundAttribute', '32:50', '41:50'],  // trackBy: trackByFn -> trackByFn
+        ['Variable', '13:22', '<empty>'],      // let item
+        ['Element', '0:58', '0:52', '52:58'],
       ]);
     });
 
@@ -277,9 +278,18 @@ describe('R3 AST source spans', () => {
     it('is correct for variables via as ...', () => {
       expectFromHtml('<div *ngIf="expr as local"></div>').toEqual([
         ['Template', '0:33', '0:27', '27:33'],
-        ['BoundAttribute', '5:26', '12:16'],  // ngIf="expr as local" -> expr
+        ['BoundAttribute', '6:17', '12:16'],  // ngIf="expr -> expr
         ['Variable', '6:25', '6:10'],         // ngIf="expr as local -> ngIf
         ['Element', '0:33', '0:27', '27:33'],
+      ]);
+
+      expectFromHtml('<div *ngFor="let item of items | async as items"></div>').toEqual([
+        ['Template', '0:55', '0:49', '49:55'],
+        ['TextAttribute', '6:11', '<empty>'],  // ngFor
+        ['BoundAttribute', '22:39', '25:38'],  // `of items | async` -> `items | async`
+        ['Variable', '13:22', '<empty>'],      // let item
+        ['Variable', '22:47', '22:24'],        // `of items | async as items` -> `of`
+        ['Element', '0:55', '0:49', '49:55'],
       ]);
     });
   });


### PR DESCRIPTION
…ding span

In a microsyntax expression, the source spans of the individual bindings should
to be distinguished from each other and only contain the relavent parts.

```
<div *ngFor="let item of items; trackBy: trackByFn">
</div>
```

In this example, the current source span for `ngForTrackBy` and
`ngForOf` are both the entire span `*ngFor="let item of items; trackBy: trackByFn"`.
With this change, the source span for `ngForOf` would be `of items; `
and the source span for `ngForTrackBy` would be `trackBy: trackByFn`.
