### PR TITLE
refactor(compiler): always return a mutable clone from `Scope#resolve`

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -165,6 +165,22 @@ describe('type check blocks diagnostics', () => {
             .toContain('((_t1 /*23,24*/) || (_t1 /*28,29*/) /*23,29*/);');
       });
     });
+
+    describe('attaching comments for generic directive inputs', () => {
+      it('should be correct for directive refs', () => {
+        const DIRECTIVES: TestDeclaration[] = [{
+          type: 'directive',
+          name: 'MyComponent',
+          selector: 'my-cmp',
+          isComponent: true,
+          isGeneric: true,
+          inputs: {'inputA': 'inputA'},
+        }];
+        const TEMPLATE = `<my-cmp [inputA]="''"></my-cmp>`;
+        expect(tcbWithSpans(TEMPLATE, DIRECTIVES))
+            .toContain('_t1.inputA = ("" /*18,20*/) /*8,21*/;');
+      });
+    });
   });
 });
 


### PR DESCRIPTION
This change prevents comments from a resolved node from appearing at
each location the resolved expression is used and also prevents callers
of `Scope#resolve` from accidentally modifying / adding comments to the
declaration site.


Note: This is targeting `major` because it modifies the `TcbReferenceOp` which was merged only to `major`.