### PR TITLE
fix(dev-infra): handle no caretaker config being defined

### DIFF
--- a/dev-infra/caretaker/check/github.ts
+++ b/dev-infra/caretaker/check/github.ts
@@ -13,15 +13,9 @@ import {GitClient} from '../../utils/git';
 import {CaretakerConfig} from '../config';
 
 
-interface GithubInfoQuery {
-  [key: string]: {
-    issueCount: number,
-  };
-}
-
 /** Retrieve the number of matching issues for each github query. */
-export async function printGithubTasks(git: GitClient, config: CaretakerConfig) {
-  if (!config.githubQueries?.length) {
+export async function printGithubTasks(git: GitClient, config?: CaretakerConfig) {
+  if (!config?.githubQueries?.length) {
     debug('No github queries defined in the configuration, skipping.');
     return;
   }


### PR DESCRIPTION
Properly handle cases where no caretaker config is provided to ng-dev commands
