### PR TITLE
docs(forms): fix first sentence of reset function doc

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1579,7 +1579,7 @@ export class FormGroup extends AbstractControl {
   }
 
   /**
-   * Resets the `FormGroup`, marks all descendants are marked `pristine` and `untouched`, and
+   * Resets the `FormGroup` by marking all descendants `pristine` and `untouched` and setting
    * the value of all descendants to null.
    *
    * You reset to a specific form state by passing in a map of states


### PR DESCRIPTION
Fixed the structure of the first sentence in the documentation of the `reset` function in the `FormGroup` class (forms package).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
