### PR TITLE
feat: remove ViewEncapsulation.Native

### DIFF
--- a/aio/content/examples/component-styles/src/app/quest-summary.component.ts
+++ b/aio/content/examples/component-styles/src/app/quest-summary.component.ts
@@ -13,8 +13,8 @@ import { Component, ViewEncapsulation } from '@angular/core';
 export class QuestSummaryComponent { }
 // #enddocregion
 /*
-  // #docregion encapsulation.native
+  // #docregion encapsulation.shadow
   // warning: few browsers support shadow DOM encapsulation at this time
-  encapsulation: ViewEncapsulation.Native
-  // #enddocregion encapsulation.native
+  encapsulation: ViewEncapsulation.ShadowDom
+  // #enddocregion encapsulation.shadow
 */

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -41,7 +41,6 @@ v9 - v12
 | `@angular/core`               | [`DefaultIterableDiffer`](#core)                                              | <!--v7--> v11 |
 | `@angular/core`               | [`ReflectiveKey`](#core)                                                      | <!--v8--> v11 |
 | `@angular/core`               | [`RenderComponentType`](#core)                                                | <!--v7--> v11 |
-| `@angular/core`               | [`ViewEncapsulation.Native`](#core)                                           | <!--v6--> v11 |
 | `@angular/core`               | [`WrappedValue`](#core)                                                       | <!--v10--> v12 |
 | `@angular/forms`              | [`ngModel` with reactive forms](#ngmodel-reactive)                            | <!--v6--> v11 |
 | `@angular/router`             | [`preserveQueryParams`](#router)                                              | <!--v7--> v11 |
@@ -89,7 +88,6 @@ Tip: In the [API reference section](api) of this doc site, deprecated APIs are i
 | [`DefaultIterableDiffer`](api/core/DefaultIterableDiffer) | n/a | v4 | Not part of public API. |
 | [`ReflectiveInjector`](api/core/ReflectiveInjector) | [`Injector.create`](api/core/Injector#create)  | v5 | See [`ReflectiveInjector`](#reflectiveinjector) |
 | [`ReflectiveKey`](api/core/ReflectiveKey) | none | v5 | none |
-| [`ViewEncapsulation.Native`](api/core/ViewEncapsulation#Native) | [`ViewEncapsulation.ShadowDom`](api/core/ViewEncapsulation#ShadowDom) | v6 | Use the native encapsulation mechanism of the renderer. See [view.ts](https://github.com/angular/angular/blob/3e992e18ebf51d6036818f26c3d77b52d3ec48eb/packages/core/src/metadata/view.ts#L32).
 | [`defineInjectable`](api/core/defineInjectable) | `ɵɵdefineInjectable` | v8 | Used only in generated code. No source code should depend on this API. |
 | [`entryComponents`](api/core/NgModule#entryComponents) | none | v9 | See [`entryComponents`](#entryComponents) |
 | [`ANALYZE_FOR_ENTRY_COMPONENTS`](api/core/ANALYZE_FOR_ENTRY_COMPONENTS) | none | v9 | See [`ANALYZE_FOR_ENTRY_COMPONENTS`](#entryComponents) |

--- a/aio/content/guide/view-encapsulation.md
+++ b/aio/content/guide/view-encapsulation.md
@@ -13,8 +13,6 @@ Choose from the following modes:
   to attach a shadow DOM to the component's host element, and then puts the component
   view inside that shadow DOM. The component's styles are included within the shadow DOM.
 
-* `Native` view encapsulation uses a now deprecated version of the browser's native shadow DOM implementation - [learn about the changes](https://hayato.io/2016/shadowdomv1/).
-
 * `Emulated` view encapsulation (the default) emulates the behavior of shadow DOM by preprocessing
   (and renaming) the CSS code to effectively scope the CSS to the component's view.
   For details, see [Inspecting generated CSS](guide/view-encapsulation#inspect-generated-css) below.
@@ -26,7 +24,7 @@ Choose from the following modes:
 
 To set the components encapsulation mode, use the `encapsulation` property in the component metadata:
 
-<code-example path="component-styles/src/app/quest-summary.component.ts" region="encapsulation.native" header="src/app/quest-summary.component.ts"></code-example>
+<code-example path="component-styles/src/app/quest-summary.component.ts" region="encapsulation.shadow" header="src/app/quest-summary.component.ts"></code-example>
 
 `ShadowDom` view encapsulation only works on browsers that have native support
 for shadow DOM (see [Shadow DOM v1](https://caniuse.com/#feat=shadowdomv1) on the

--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.ts
@@ -21,7 +21,7 @@ const initialDocViewerContent = initialDocViewerElement ? initialDocViewerElemen
   selector: 'aio-doc-viewer',
   template: ''
   // TODO(robwormald): shadow DOM and emulated don't work here (?!)
-  // encapsulation: ViewEncapsulation.Native
+  // encapsulation: ViewEncapsulation.ShadowDom
 })
 export class DocViewerComponent implements OnDestroy {
   // Enable/Disable view transition animations.

--- a/goldens/public-api/core/core.d.ts
+++ b/goldens/public-api/core/core.d.ts
@@ -1032,7 +1032,6 @@ export declare abstract class ViewContainerRef {
 
 export declare enum ViewEncapsulation {
     Emulated = 0,
-    Native = 1,
     None = 2,
     ShadowDom = 3
 }

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -30,7 +30,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 134891,
+        "main-es2015": 135003,
         "polyfills-es2015": 37248
       }
     }

--- a/packages/bazel/src/schematics/ng-new/schema.d.ts
+++ b/packages/bazel/src/schematics/ng-new/schema.d.ts
@@ -107,7 +107,6 @@ export declare enum Style {
  */
 export declare enum ViewEncapsulation {
   Emulated = 'Emulated',
-  Native = 'Native',
   None = 'None',
   ShadowDom = 'ShadowDom'
 }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -72,7 +72,7 @@ describe('compiler compliance: styling', () => {
          expectEmit(result.source, template, 'Incorrect template');
        });
 
-    it('should pass in the component metadata styles into the component definition but skip shimming when style encapsulation is set to native',
+    it('should pass in the component metadata styles into the component definition but skip shimming when style encapsulation is set to shadow dom',
        () => {
          const files = {
            app: {
@@ -80,7 +80,7 @@ describe('compiler compliance: styling', () => {
                 import {Component, NgModule, ViewEncapsulation} from '@angular/core';
 
                 @Component({
-                  encapsulation: ViewEncapsulation.Native,
+                  encapsulation: ViewEncapsulation.ShadowDom,
                   selector: "my-component",
                   styles: ["div.cool { color: blue; }", ":host.nice p { color: gold; }"],
                   template: "..."
@@ -98,7 +98,7 @@ describe('compiler compliance: styling', () => {
          MyComponent.ɵcmp = $r3$.ɵɵdefineComponent({
            …
            styles: ["div.cool { color: blue; }", ":host.nice p { color: gold; }"],
-           encapsulation: 1
+           encapsulation: 3
          })
          `;
          const result = compile(files, angularFiles);

--- a/packages/compiler-cli/test/ngtsc/fake_core/index.ts
+++ b/packages/compiler-cli/test/ngtsc/fake_core/index.ts
@@ -77,7 +77,7 @@ export type ɵɵPipeDefWithMeta<PipeT, NameT> = any;
 
 export enum ViewEncapsulation {
   Emulated = 0,
-  Native = 1,
+  // Historically the 1 value was for `Native` encapsulation which has been removed as of v11.
   None = 2,
   ShadowDom = 3
 }

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -173,7 +173,7 @@ export interface R3FactoryDefMetadataFacade {
 
 export enum ViewEncapsulation {
   Emulated = 0,
-  Native = 1,
+  // Historically the 1 value was for `Native` encapsulation which has been removed as of v11.
   None = 2,
   ShadowDom = 3
 }

--- a/packages/compiler/src/core.ts
+++ b/packages/compiler/src/core.ts
@@ -82,7 +82,7 @@ export interface Component extends Directive {
 }
 export enum ViewEncapsulation {
   Emulated = 0,
-  Native = 1,
+  // Historically the 1 value was for `Native` encapsulation which has been removed as of v11.
   None = 2,
   ShadowDom = 3
 }

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -163,8 +163,6 @@ export interface R3ComponentMetadata extends R3DirectiveMetadata {
 
   /**
    * An encapsulation policy for the template and CSS styles. One of:
-   * - `ViewEncapsulation.Native`: Use shadow roots. This works only if natively available on the
-   *   platform (note that this is marked the as the "deprecated shadow DOM" as of Angular v6.1.
    * - `ViewEncapsulation.Emulated`: Use shimmed CSS that emulates the native behavior.
    * - `ViewEncapsulation.None`: Use global CSS without any encapsulation.
    * - `ViewEncapsulation.ShadowDom`: Use the latest ShadowDOM API to natively encapsulate styles

--- a/packages/compiler/test/directive_normalizer_spec.ts
+++ b/packages/compiler/test/directive_normalizer_spec.ts
@@ -226,7 +226,7 @@ function normalizeTemplate(normalizer: DirectiveNormalizer, o: {
     describe('normalizeLoadedTemplate', () => {
       it('should store the viewEncapsulation in the result',
          inject([DirectiveNormalizer], (normalizer: DirectiveNormalizer) => {
-           const viewEncapsulation = ViewEncapsulation.Native;
+           const viewEncapsulation = ViewEncapsulation.ShadowDom;
            const template = <CompileTemplateMetadata>normalizeTemplate(normalizer, {
              encapsulation: viewEncapsulation,
              template: '',

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -15,6 +15,7 @@ pkg_npm(
         "//packages/core/schematics/migrations/missing-injectable",
         "//packages/core/schematics/migrations/module-with-providers",
         "//packages/core/schematics/migrations/move-document",
+        "//packages/core/schematics/migrations/native-view-encapsulation",
         "//packages/core/schematics/migrations/navigation-extras-omissions",
         "//packages/core/schematics/migrations/relative-link-resolution",
         "//packages/core/schematics/migrations/renderer-to-renderer2",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -59,6 +59,11 @@
       "version": "11.0.0-beta",
       "description": "In Angular version 11, the type of `AbstractControl.parent` can be `null` to reflect the runtime value more accurately. This migration automatically adds non-null assertions to existing accesses of the `parent` property on types like `FormControl`, `FormArray` and `FormGroup`.",
       "factory": "./migrations/abstract-control-parent/index"
+    },
+    "migration-v11-native-view-encapsulation": {
+      "version": "11.0.0-beta",
+      "description": "ViewEncapsulation.Native has been removed as of Angular version 11. This migration replaces any usages with ViewEncapsulation.ShadowDom.",
+      "factory": "./migrations/native-view-encapsulation/index"
     }
   }
 }

--- a/packages/core/schematics/migrations/native-view-encapsulation/BUILD.bazel
+++ b/packages/core/schematics/migrations/native-view-encapsulation/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//tools:defaults.bzl", "ts_library")
+
+ts_library(
+    name = "native-view-encapsulation",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+    deps = [
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)

--- a/packages/core/schematics/migrations/native-view-encapsulation/README.md
+++ b/packages/core/schematics/migrations/native-view-encapsulation/README.md
@@ -1,0 +1,34 @@
+## `ViewEncapsulation.Native` migration
+
+Automatically migrates usages of `ViewEncapsulation.Native` to `ViewEncapsulation.ShadowDom`.
+For most practical purposes the `Native` mode is compatible with the `ShadowDom` mode.
+
+The migration covers any reference to the `Native` value that can be traced to `@angular/core`.
+Some examples:
+* Inside the `encapsulation` property of `Component` decorators.
+* In property assignments for the `COMPILER_OPTIONS` provider.
+* In variables.
+
+#### Before
+```ts
+import { Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  template: '...',
+  encapsulation: ViewEncapsulation.Native
+})
+export class App {
+}
+```
+
+#### After
+```ts
+import { Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  template: '...',
+  encapsulation: ViewEncapsulation.ShadowDom
+})
+export class App {
+}
+```

--- a/packages/core/schematics/migrations/native-view-encapsulation/index.ts
+++ b/packages/core/schematics/migrations/native-view-encapsulation/index.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule, SchematicsException, Tree} from '@angular-devkit/schematics';
+import {relative} from 'path';
+
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {createMigrationProgram} from '../../utils/typescript/compiler_host';
+import {findNativeEncapsulationNodes} from './util';
+
+
+/** Migration that switches from `ViewEncapsulation.Native` to `ViewEncapsulation.ShadowDom`. */
+export default function(): Rule {
+  return (tree: Tree) => {
+    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+    const allPaths = [...buildPaths, ...testPaths];
+
+    if (!allPaths.length) {
+      throw new SchematicsException(
+          'Could not find any tsconfig file. Cannot migrate away from Native view encapsulation.');
+    }
+
+    for (const tsconfigPath of allPaths) {
+      runNativeViewEncapsulationMigration(tree, tsconfigPath, basePath);
+    }
+  };
+}
+
+function runNativeViewEncapsulationMigration(tree: Tree, tsconfigPath: string, basePath: string) {
+  const {program} = createMigrationProgram(tree, tsconfigPath, basePath);
+  const typeChecker = program.getTypeChecker();
+  const sourceFiles = program.getSourceFiles().filter(
+      f => !f.isDeclarationFile && !program.isSourceFileFromExternalLibrary(f));
+
+  sourceFiles.forEach(sourceFile => {
+    const update = tree.beginUpdate(relative(basePath, sourceFile.fileName));
+    const identifiers = findNativeEncapsulationNodes(typeChecker, sourceFile);
+
+    identifiers.forEach(node => {
+      update.remove(node.getStart(), node.getWidth());
+      update.insertRight(node.getStart(), 'ShadowDom');
+    });
+
+    tree.commitUpdate(update);
+  });
+}

--- a/packages/core/schematics/migrations/native-view-encapsulation/util.ts
+++ b/packages/core/schematics/migrations/native-view-encapsulation/util.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {getImportOfIdentifier} from '../../utils/typescript/imports';
+
+/** Finds all the Identifier nodes in a file that refer to `Native` view encapsulation. */
+export function findNativeEncapsulationNodes(
+    typeChecker: ts.TypeChecker, sourceFile: ts.SourceFile): Set<ts.Identifier> {
+  const results = new Set<ts.Identifier>();
+
+  sourceFile.forEachChild(function walkNode(node: ts.Node) {
+    // Note that we look directly for nodes in the form of `<something>.Native`, rather than going
+    // for `Component` class decorators, because it's much simpler and it allows us to handle cases
+    // where `ViewEncapsulation.Native` might be used in a different context (e.g. a variable).
+    // Using the encapsulation outside of a decorator is an edge case, but we do have public APIs
+    // where it can be passed in (see the `defaultViewEncapsulation` property on the
+    // `COMPILER_OPTIONS` provider).
+    if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.name) &&
+        node.name.text === 'Native' && ts.isIdentifier(node.expression)) {
+      const expressionImport = getImportOfIdentifier(typeChecker, node.expression);
+      if (expressionImport && expressionImport.name === 'ViewEncapsulation' &&
+          expressionImport.importModule === '@angular/core') {
+        results.add(node.name);
+      }
+    } else {
+      node.forEachChild(walkNode);
+    }
+  });
+
+  return results;
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
         "//packages/core/schematics/migrations/missing-injectable",
         "//packages/core/schematics/migrations/module-with-providers",
         "//packages/core/schematics/migrations/move-document",
+        "//packages/core/schematics/migrations/native-view-encapsulation",
         "//packages/core/schematics/migrations/navigation-extras-omissions",
         "//packages/core/schematics/migrations/relative-link-resolution",
         "//packages/core/schematics/migrations/renderer-to-renderer2",

--- a/packages/core/schematics/test/native_view_encapsulation_migration_spec.ts
+++ b/packages/core/schematics/test/native_view_encapsulation_migration_spec.ts
@@ -1,0 +1,169 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import * as shx from 'shelljs';
+
+describe('ViewEncapsulation.Native migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', require.resolve('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile('/tsconfig.json', JSON.stringify({
+      compilerOptions: {
+        lib: ['es2015'],
+        strictNullChecks: true,
+      },
+    }));
+    writeFile('/angular.json', JSON.stringify({
+      projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
+    }));
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  it('should change Native view encapsulation usages to ShadowDom', async () => {
+    writeFile('/index.ts', `
+      import {Component, ViewEncapsulation} from '@angular/core';
+
+      @Component({
+        template: 'hello',
+        encapsulation: ViewEncapsulation.Native
+      })
+      class App {}
+    `);
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain('encapsulation: ViewEncapsulation.ShadowDom');
+  });
+
+  it('should change Native view encapsulation usages if the enum is aliased', async () => {
+    writeFile('/index.ts', `
+      import {Component, ViewEncapsulation as Encapsulation} from '@angular/core';
+
+      @Component({
+        template: 'hello',
+        encapsulation: Encapsulation.Native
+      })
+      class App {}
+    `);
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain('encapsulation: Encapsulation.ShadowDom');
+  });
+
+  it('should change Native view encapsulation usages inside a variable', async () => {
+    writeFile('/index.ts', `
+      import {Component, ViewEncapsulation} from '@angular/core';
+
+      const encapsulation = ViewEncapsulation.Native;
+
+      @Component({template: 'hello', encapsulation})
+      class App {}
+
+      @Component({template: 'click me', encapsulation})
+      class Button {}
+    `);
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain('const encapsulation = ViewEncapsulation.ShadowDom;');
+  });
+
+  it('should not change components that do not set an encapsulation', async () => {
+    const source = `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: 'hello'
+      })
+      class App {}
+    `;
+
+    writeFile('/index.ts', source);
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toBe(source);
+  });
+
+  it('should not change components that use an encapsulation different from Native', async () => {
+    const source = `
+      import {Component, ViewEncapsulation} from '@angular/core';
+
+      @Component({
+        template: 'hello',
+        encapsulation: ViewEncapsulation.None
+      })
+      class App {}
+    `;
+
+    writeFile('/index.ts', source);
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toBe(source);
+  });
+
+  it('should not change cases where ViewEncapsulation does not come from @angular/core',
+     async () => {
+       const source = `
+        import {Component} from '@angular/core';
+        import {ViewEncapsulation} from '@not-angular/core';
+
+        @Component({
+          template: 'hello',
+          encapsulation: ViewEncapsulation.Native
+        })
+        class App {}
+      `;
+
+       writeFile('/index.ts', source);
+
+       await runMigration();
+
+       const content = tree.readContent('/index.ts');
+       expect(content).toBe(source);
+     });
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematicAsync('migration-v11-native-view-encapsulation', {}, tree)
+        .toPromise();
+  }
+});

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -173,7 +173,7 @@ export interface R3FactoryDefMetadataFacade {
 
 export enum ViewEncapsulation {
   Emulated = 0,
-  Native = 1,
+  // Historically the 1 value was for `Native` encapsulation which has been removed as of v11.
   None = 2,
   ShadowDom = 3
 }

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -518,7 +518,6 @@ export interface Component extends Directive {
 
   /**
    * An encapsulation policy for the template and CSS styles. One of:
-   * - `ViewEncapsulation.Native`: Deprecated. Use `ViewEncapsulation.ShadowDom` instead.
    * - `ViewEncapsulation.Emulated`: Use shimmed CSS that
    * emulates the native behavior.
    * - `ViewEncapsulation.None`: Use global CSS without any

--- a/packages/core/src/metadata/view.ts
+++ b/packages/core/src/metadata/view.ts
@@ -28,15 +28,9 @@ export enum ViewEncapsulation {
    * This is the default option.
    */
   Emulated = 0,
-  /**
-   * @deprecated v6.1.0 - use {ViewEncapsulation.ShadowDom} instead.
-   * Use the native encapsulation mechanism of the renderer.
-   *
-   * For the DOM this means using the deprecated [Shadow DOM
-   * v0](https://w3c.github.io/webcomponents/spec/shadow/) and
-   * creating a ShadowRoot for Component's Host Element.
-   */
-  Native = 1,
+
+  // Historically the 1 value was for `Native` encapsulation which has been removed as of v11.
+
   /**
    * Don't provide any template or style encapsulation.
    */

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -517,8 +517,8 @@ function getRenderParent(tView: TView, tNode: TNode, currentView: LView): REleme
       // Since the projection would then move it to its final destination. Note that we can't
       // make this assumption when using the Shadow DOM, because the native projection placeholders
       // (<content> or <slot>) have to be in place as elements are being inserted.
-      if (encapsulation !== ViewEncapsulation.ShadowDom &&
-          encapsulation !== ViewEncapsulation.Native) {
+      if (encapsulation === ViewEncapsulation.None ||
+          encapsulation === ViewEncapsulation.Emulated) {
         return null;
       }
     }

--- a/packages/core/src/view/util.ts
+++ b/packages/core/src/view/util.ts
@@ -230,7 +230,10 @@ export function getParentRenderElement(view: ViewData, renderHost: any, def: Nod
     if ((renderParent.flags & NodeFlags.TypeElement) === 0 ||
         (renderParent.flags & NodeFlags.ComponentView) === 0 ||
         (renderParent.element!.componentRendererType &&
-         renderParent.element!.componentRendererType!.encapsulation === ViewEncapsulation.Native)) {
+         (renderParent.element!.componentRendererType!.encapsulation ===
+              ViewEncapsulation.ShadowDom ||
+          // TODO(FW-2290): remove the `encapsulation === 1` fallback logic in v12.
+          renderParent.element!.componentRendererType!.encapsulation === 1))) {
       // only children of non components, or children of components with native encapsulation should
       // be attached.
       return asElementData(view, def.renderParent!.nodeIndex).renderElement;

--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -490,13 +490,13 @@ describe('projection', () => {
     expect(main.nativeElement).toHaveText('TREE(0:TREE2(1:TREE(2:)))');
   });
 
-  if (supportsNativeShadowDOM()) {
-    it('should support native content projection and isolate styles per component', () => {
-      TestBed.configureTestingModule({declarations: [SimpleNative1, SimpleNative2]});
+  if (supportsShadowDOM()) {
+    it('should support shadow dom content projection and isolate styles per component', () => {
+      TestBed.configureTestingModule({declarations: [SimpleShadowDom1, SimpleShadowDom2]});
       TestBed.overrideComponent(MainComp, {
         set: {
-          template: '<simple-native1><div>A</div></simple-native1>' +
-              '<simple-native2><div>B</div></simple-native2>'
+          template: '<simple-shadow-dom1><div>A</div></simple-shadow-dom1>' +
+              '<simple-shadow-dom2><div>B</div></simple-shadow-dom2>'
         }
       });
       const main = TestBed.createComponent(MainComp);
@@ -857,21 +857,21 @@ class Simple {
 }
 
 @Component({
-  selector: 'simple-native1',
-  template: 'SIMPLE1(<content></content>)',
-  encapsulation: ViewEncapsulation.Native,
+  selector: 'simple-shadow-dom1',
+  template: 'SIMPLE1(<slot></slot>)',
+  encapsulation: ViewEncapsulation.ShadowDom,
   styles: ['div {color: red}']
 })
-class SimpleNative1 {
+class SimpleShadowDom1 {
 }
 
 @Component({
-  selector: 'simple-native2',
-  template: 'SIMPLE2(<content></content>)',
-  encapsulation: ViewEncapsulation.Native,
+  selector: 'simple-shadow-dom2',
+  template: 'SIMPLE2(<slot></slot>)',
+  encapsulation: ViewEncapsulation.ShadowDom,
   styles: ['div {color: blue}']
 })
-class SimpleNative2 {
+class SimpleShadowDom2 {
 }
 
 @Component({selector: 'empty', template: ''})
@@ -1043,6 +1043,6 @@ class CmpA1 {
 class CmpA2 {
 }
 
-function supportsNativeShadowDOM(): boolean {
-  return typeof (<any>document.body).createShadowRoot === 'function';
+function supportsShadowDOM(): boolean {
+  return typeof (<any>document.body).attachShadow !== 'undefined';
 }

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -20,8 +20,8 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
     beforeEach(() => {
       TestBed.configureTestingModule({
         declarations: [
-          TestCmp, SomeApp, CmpEncapsulationEmulated, CmpEncapsulationNative, CmpEncapsulationNone,
-          CmpEncapsulationNative
+          TestCmp, SomeApp, CmpEncapsulationEmulated, CmpEncapsulationShadow, CmpEncapsulationNone,
+          CmpEncapsulationShadow
         ]
       });
       renderer = TestBed.createComponent(TestCmp).componentInstance.renderer;
@@ -98,16 +98,14 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       });
     });
 
-    if (browserDetection.supportsDeprecatedShadowDomV0) {
+    if (browserDetection.supportsShadowDom) {
       it('should allow to style components with emulated encapsulation and no encapsulation inside of components with shadow DOM',
          () => {
            const fixture = TestBed.createComponent(SomeApp);
+           const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
+           const shadow = cmp.shadowRoot.querySelector('.shadow');
 
-           const cmp = fixture.debugElement.query(By.css('cmp-native')).nativeElement;
-
-
-           const native = cmp.shadowRoot.querySelector('.native');
-           expect(window.getComputedStyle(native).color).toEqual('rgb(255, 0, 0)');
+           expect(window.getComputedStyle(shadow).color).toEqual('rgb(255, 0, 0)');
 
            const emulated = cmp.shadowRoot.querySelector('.emulated');
            expect(window.getComputedStyle(emulated).color).toEqual('rgb(0, 0, 255)');
@@ -117,15 +115,6 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
          });
     }
   });
-}
-
-@Component({
-  selector: 'cmp-native',
-  template: `<div class="native"></div><cmp-emulated></cmp-emulated><cmp-none></cmp-none>`,
-  styles: [`.native { color: red; }`],
-  encapsulation: ViewEncapsulation.Native
-})
-class CmpEncapsulationNative {
 }
 
 @Component({
@@ -149,7 +138,7 @@ class CmpEncapsulationNone {
 @Component({
   selector: 'cmp-shadow',
   template: `<div class="shadow"></div><cmp-emulated></cmp-emulated><cmp-none></cmp-none>`,
-  styles: [`.native { color: red; }`],
+  styles: [`.shadow { color: red; }`],
   encapsulation: ViewEncapsulation.ShadowDom
 })
 class CmpEncapsulationShadow {
@@ -158,7 +147,7 @@ class CmpEncapsulationShadow {
 @Component({
   selector: 'some-app',
   template: `
-	  <cmp-native></cmp-native>
+	  <cmp-shadow></cmp-shadow>
 	  <cmp-emulated></cmp-emulated>
 	  <cmp-none></cmp-none>
   `,

--- a/packages/platform-browser/test/dom/shadow_dom_spec.ts
+++ b/packages/platform-browser/test/dom/shadow_dom_spec.ts
@@ -15,13 +15,11 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 if (browserDetection.supportsShadowDom) {
   describe('ShadowDOM Support', () => {
-    let testContainer: HTMLDivElement;
-
     beforeEach(() => {
       TestBed.configureTestingModule({imports: [TestModule]});
     });
 
-    it('should attach and use a shadowRoot when ViewEncapsulation.Native is set', () => {
+    it('should attach and use a shadowRoot when ViewEncapsulation.ShadowDom is set', () => {
       const compEl = TestBed.createComponent(ShadowComponent).nativeElement;
       expect(compEl.shadowRoot!.textContent).toEqual('Hello World');
     });

--- a/packages/platform-browser/testing/src/matchers.ts
+++ b/packages/platform-browser/testing/src/matchers.ts
@@ -305,8 +305,14 @@ function elementText(n: any): string {
     return '';
   }
 
-  if (getDOM().isElementNode(n) && (n as Element).tagName == 'CONTENT') {
-    return elementText(Array.prototype.slice.apply((<any>n).getDistributedNodes()));
+  if (getDOM().isElementNode(n)) {
+    const tagName = (n as Element).tagName;
+
+    if (tagName === 'CONTENT') {
+      return elementText(Array.prototype.slice.apply((<any>n).getDistributedNodes()));
+    } else if (tagName === 'SLOT') {
+      return elementText(Array.prototype.slice.apply((<any>n).assignedNodes()));
+    }
   }
 
   if (hasShadowRoot(n)) {

--- a/packages/platform-server/src/server_renderer.ts
+++ b/packages/platform-server/src/server_renderer.ts
@@ -32,7 +32,6 @@ export class ServerRendererFactory2 implements RendererFactory2 {
       return this.defaultRenderer;
     }
     switch (type.encapsulation) {
-      case ViewEncapsulation.Native:
       case ViewEncapsulation.Emulated: {
         let renderer = this.rendererByCompId.get(type.id);
         if (!renderer) {

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -272,19 +272,19 @@ class ImageExampleModule {
 
 @Component({
   selector: 'app',
-  template: 'Native works',
-  encapsulation: ViewEncapsulation.Native,
+  template: 'Shadow DOM works',
+  encapsulation: ViewEncapsulation.ShadowDom,
   styles: [':host { color: red; }']
 })
-class NativeEncapsulationApp {
+class ShadowDomEncapsulationApp {
 }
 
 @NgModule({
-  declarations: [NativeEncapsulationApp],
+  declarations: [ShadowDomEncapsulationApp],
   imports: [BrowserModule.withServerTransition({appId: 'test'}), ServerModule],
-  bootstrap: [NativeEncapsulationApp]
+  bootstrap: [ShadowDomEncapsulationApp]
 })
-class NativeExampleModule {
+class ShadowDomExampleModule {
 }
 
 @Component({selector: 'my-child', template: 'Works!'})
@@ -666,8 +666,8 @@ describe('platform-server integration', () => {
          });
        }));
 
-    it('should handle ViewEncapsulation.Native', waitForAsync(() => {
-         renderModule(NativeExampleModule, {document: doc}).then(output => {
+    it('should handle ViewEncapsulation.ShadowDom', waitForAsync(() => {
+         renderModule(ShadowDomExampleModule, {document: doc}).then(output => {
            expect(output).not.toBe('');
            expect(output).toContain('color: red');
            called = true;


### PR DESCRIPTION
See the individual commits for more context, but the high-level overview is:
1. Adds an automated migration that will replace any usages of `ViewEncapsulation.Native` with `ViewEncapsulation.ShadowDom`.
2. Removes the `Native` value from `ViewEncapsulation` and replaces any usages in tests and docs with `ShadowDom`.