### PR TITLE
docs: Update titles to getting started topics

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -61,27 +61,27 @@
             "children": [
               {
                 "url": "start",
-                "title": "A Sample App",
+                "title": "Getting started",
                 "tooltip": "Take a look at Angular's component model, template syntax, and component communication."
               },
               {
                 "url": "start/start-routing",
-                "title": "In-app Navigation",
+                "title": "Adding navigation",
                 "tooltip": "Navigate among different page views using the browser's URL."
               },
               {
                 "url": "start/start-data",
-                "title": "Manage Data",
+                "title": "Managing Data",
                 "tooltip": "Use services and access external data via HTTP."
               },
               {
                 "url": "start/start-forms",
-                "title": "Forms for User Input",
+                "title": "Using Forms for User Input",
                 "tooltip": "Learn about fetching and managing data from users with forms."
               },
               {
                 "url": "start/start-deployment",
-                "title": "Deployment",
+                "title": "Deploying an application",
                 "tooltip": "Move to local development, or deploy your application to Firebase or your own server."
               }
             ]

--- a/aio/content/start/index.md
+++ b/aio/content/start/index.md
@@ -1,4 +1,4 @@
-# Part 1: Getting started with a basic Angular app
+# Getting started with a basic Angular app
 
 Welcome to Angular!
 

--- a/aio/content/start/start-data.md
+++ b/aio/content/start/start-data.md
@@ -1,4 +1,4 @@
-# Try it: Manage data
+# Managing data
 
 At the end of [In-app Navigation](start/start-routing "Try it: In-app Navigation"), the online store application has a product catalog with two views: a product list and product details.
 Users can click on a product name from the list to see details in a new view, with a distinct URL, or route.

--- a/aio/content/start/start-deployment.md
+++ b/aio/content/start/start-deployment.md
@@ -1,4 +1,4 @@
-# Try it: Deployment
+# Deploying an application
 
 
 To deploy your application, you have to compile it, and then host the JavaScript, CSS, and HTML on a web server. Built Angular applications are very portable and can live in any environment or served by any technology, such as Node, Java, .NET, PHP, and many others.

--- a/aio/content/start/start-forms.md
+++ b/aio/content/start/start-forms.md
@@ -1,4 +1,4 @@
-# Try it: Use forms for user input
+# Using forms for user input
 
 At the end of [Managing Data](start/start-data "Try it: Managing Data"), the online store application has a product catalog and a shopping cart.
 

--- a/aio/content/start/start-routing.md
+++ b/aio/content/start/start-routing.md
@@ -1,4 +1,4 @@
-# In-app navigation
+# Adding navigation
 
 At the end of [part 1](start "Get started with a basic Angular app"), the online store application has a basic product catalog.
 The app doesn't have any variable states or navigation.


### PR DESCRIPTION
The topics for our getting started tutorial are inconsistent.
This change makes the titles consistent and easier to read.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The titles for our getting started topics are inconsistent. Some say "Part 1" some say "Try it" etc.

Issue Number: N/A


## What is the new behavior?
The titles are now consistent.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
