### PR TITLE
fix(dev-infra): skip husky git commit hooks while merging pull requests

### DIFF
--- a/dev-infra/pr/merge/index.ts
+++ b/dev-infra/pr/merge/index.ts
@@ -33,6 +33,10 @@ import {MergeResult, MergeStatus, PullRequestMergeTask} from './task';
 export async function mergePullRequest(
     prNumber: number, githubToken: string, projectRoot: string = getRepoBaseDir(),
     config?: MergeConfigWithRemote) {
+  // Set an environment variable for the duration of the process to skip all git commit hooks
+  // triggered by husky.
+  process.env['HUSKY_SKIP_HOOKS'] = '1';
+
   const api = await createPullRequestMergeTask(githubToken, projectRoot, config);
 
   // Perform the merge. Force mode can be activated through a command line flag.

--- a/dev-infra/pr/merge/index.ts
+++ b/dev-infra/pr/merge/index.ts
@@ -33,8 +33,8 @@ import {MergeResult, MergeStatus, PullRequestMergeTask} from './task';
 export async function mergePullRequest(
     prNumber: number, githubToken: string, projectRoot: string = getRepoBaseDir(),
     config?: MergeConfigWithRemote) {
-  // Set an environment variable for the duration of the process to skip all git commit hooks
-  // triggered by husky.
+  // Set the environment variable to skip all git commit hooks triggered by husky. We are unable to
+  // rely on `---no-verify` as some hooks still run, notably the `prepare-commit-msg` hook.
   process.env['HUSKY_SKIP_HOOKS'] = '1';
 
   const api = await createPullRequestMergeTask(githubToken, projectRoot, config);


### PR DESCRIPTION
During the merge process, all validations have already been completed so git commit
hooks can be safely skipped.  This additionally, prevents errors from occuring which
would be caused the commit hooks executing, such as when yarn updates and then yarn
commands are unable to run within the same process.
