### PR TITLE
fix(ngcc): fix compilation of `ChangeDetectorRef` in pipe constructors

### DIFF
--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -1211,7 +1211,7 @@ exports.MissingClass2 = MissingClass2;
       });
 
       describe('getConstructorParameters', () => {
-        it('should always specify LOCAL type value references for decorated constructor parameter types',
+        it('should retain imported name for type value references for decorated constructor parameter types',
            () => {
              const files = [
                {
@@ -1271,7 +1271,7 @@ exports.MissingClass2 = MissingClass2;
 
              expect(parameters.map(p => p.name)).toEqual(['arg1', 'arg2', 'arg3']);
              expectTypeValueReferencesForParameters(
-                 parameters, ['shared.Baz', 'local.External', 'SameFile']);
+                 parameters, ['Baz', 'External', 'SameFile'], ['shared-lib', './local', null]);
            });
 
         it('should find the decorated constructor parameters', () => {

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
@@ -1140,7 +1140,7 @@ runInEachFileSystem(() => {
     });
 
     describe('getConstructorParameters()', () => {
-      it('should always specify LOCAL type value references for decorated constructor parameter types',
+      it('should retain imported name for type value references for decorated constructor parameter types',
          () => {
            const files = [
              {
@@ -1188,7 +1188,8 @@ runInEachFileSystem(() => {
            const parameters = host.getConstructorParameters(classNode)!;
 
            expect(parameters.map(p => p.name)).toEqual(['arg1', 'arg2', 'arg3']);
-           expectTypeValueReferencesForParameters(parameters, ['Baz', 'External', 'SameFile']);
+           expectTypeValueReferencesForParameters(
+               parameters, ['Baz', 'External', 'SameFile'], ['shared-lib', './local', null]);
          });
 
       it('should find the decorated constructor parameters', () => {
@@ -1205,7 +1206,8 @@ runInEachFileSystem(() => {
           '_viewContainer', '_template', 'injected'
         ]);
         expectTypeValueReferencesForParameters(
-            parameters, ['ViewContainerRef', 'TemplateRef', null]);
+            parameters, ['ViewContainerRef', 'TemplateRef', null],
+            ['@angular/core', '@angular/core', null]);
       });
 
       it('should accept `ctorParameters` as an array', () => {

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -1252,7 +1252,7 @@ runInEachFileSystem(() => {
     });
 
     describe('getConstructorParameters()', () => {
-      it('should always specify LOCAL type value references for decorated constructor parameter types',
+      it('should retain imported name for type value references for decorated constructor parameter types',
          () => {
            const files = [
              {
@@ -1310,7 +1310,8 @@ runInEachFileSystem(() => {
            const parameters = host.getConstructorParameters(classNode)!;
 
            expect(parameters.map(p => p.name)).toEqual(['arg1', 'arg2', 'arg3']);
-           expectTypeValueReferencesForParameters(parameters, ['Baz', 'External', 'SameFile']);
+           expectTypeValueReferencesForParameters(
+               parameters, ['Baz', 'External', 'SameFile'], ['shared-lib', './local', null]);
          });
 
       it('should find the decorated constructor parameters', () => {

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -1332,7 +1332,7 @@ runInEachFileSystem(() => {
     });
 
     describe('getConstructorParameters', () => {
-      it('should always specify LOCAL type value references for decorated constructor parameter types',
+      it('should retain imported name for type value references for decorated constructor parameter types',
          () => {
            const files = [
              {
@@ -1369,7 +1369,7 @@ runInEachFileSystem(() => {
                name: _('/main.js'),
                contents: `
   (function (global, factory) {
-    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('shared-lib), require('./local')) :
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('shared-lib'), require('./local')) :
     typeof define === 'function' && define.amd ? define('main', ['exports', 'shared-lib', './local'], factory) :
     (factory(global.main, global.shared, global.local));
   }(this, (function (exports, shared, local) { 'use strict';
@@ -1401,7 +1401,7 @@ runInEachFileSystem(() => {
 
            expect(parameters.map(p => p.name)).toEqual(['arg1', 'arg2', 'arg3']);
            expectTypeValueReferencesForParameters(
-               parameters, ['shared.Baz', 'local.External', 'SameFile']);
+               parameters, ['Baz', 'External', 'SameFile'], ['shared-lib', './local', null]);
          });
 
       it('should find the decorated constructor parameters', () => {

--- a/packages/compiler-cli/ngcc/test/integration/util.ts
+++ b/packages/compiler-cli/ngcc/test/integration/util.ts
@@ -99,7 +99,14 @@ function compileIntoFlatPackage(
     program.emit();
   };
 
-  emit({declaration: true, module: options.module, target: options.target, lib: []});
+  emit({
+    declaration: true,
+    emitDecoratorMetadata: true,
+    moduleResolution: ts.ModuleResolutionKind.NodeJs,
+    module: options.module,
+    target: options.target,
+    lib: [],
+  });
 
   // Copy over the JS and .d.ts files, and add a .metadata.json for each .d.ts file.
   for (const file of rootNames) {
@@ -152,7 +159,9 @@ export function compileIntoApf(
   compileFs.ensureDir(compileFs.resolve('esm2015'));
   emit({
     declaration: true,
+    emitDecoratorMetadata: true,
     outDir: './esm2015',
+    moduleResolution: ts.ModuleResolutionKind.NodeJs,
     module: ts.ModuleKind.ESNext,
     target: ts.ScriptTarget.ES2015,
     lib: [],
@@ -178,7 +187,9 @@ export function compileIntoApf(
   compileFs.ensureDir(compileFs.resolve('esm5'));
   emit({
     declaration: false,
+    emitDecoratorMetadata: true,
     outDir: './esm5',
+    moduleResolution: ts.ModuleResolutionKind.NodeJs,
     module: ts.ModuleKind.ESNext,
     target: ts.ScriptTarget.ES5,
     lib: [],


### PR DESCRIPTION
In #38666 we changed how ngcc deals with type expressions, where it
would now always emit the original type expression into the generated
code as a "local" type value reference instead of synthesizing new
imports using an "imported" type value reference. This was done as a fix
to properly deal with renamed symbols, however it turns out that the
compiler has special handling for certain imported symbols, e.g.
`ChangeDetectorRef` from `@angular/core`. The "local" type value
reference prevented this special logic from being hit, resulting in
incorrect compilation of pipe factories.

This commit fixes the issue by manually inspecting the import of the
type expression, in order to return an "imported" type value reference.
By manually inspecting the import we continue to handle renamed symbols.

Fixes #38883