### PR TITLE
ci: do not require g3 checks for the changes in `packages/zone.js/dist` folder

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -68,6 +68,7 @@ merge:
       - "packages/**/integrationtest/**"
       - "packages/**/test/**"
       - "packages/zone.js/*"
+      - "packages/zone.js/dist/**"
       - "packages/zone.js/doc/**"
       - "packages/zone.js/example/**"
       - "packages/zone.js/scripts/**"


### PR DESCRIPTION
This commit updates ngbot config to avoid requesting google3 presubmit for the changes in
the `packages/zone.js/dist` folder (which is not synced into google3).

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No