### PR TITLE
release: cut the zone.js-0.11.2 release

### DIFF
--- a/packages/zone.js/CHANGELOG.md
+++ b/packages/zone.js/CHANGELOG.md
@@ -1,3 +1,32 @@
+<a name="0.11.2"></a>
+## [0.11.2](https://github.com/angular/angular/compare/zone.js-0.11.0...zone.js-0.11.2) (2020-09-19)
+
+
+### Bug Fixes
+
+* **zone.js:** add missing types field in package.json ([#38585](https://github.com/angular/angular/issues/38585)) ([27cc56b](https://github.com/angular/angular/commit/27cc56b)), closes [#38584](https://github.com/angular/angular/issues/38584)
+* **zone.js:** defineProperty patch should not swallow error ([#37582](https://github.com/angular/angular/issues/37582)) ([45a73dd](https://github.com/angular/angular/commit/45a73dd)), closes [#37432](https://github.com/angular/angular/issues/37432)
+* **zone.js:** run tests in umd format ([#37582](https://github.com/angular/angular/issues/37582)) ([40096be](https://github.com/angular/angular/commit/40096be))
+* **zone.js:** should have better backward compatibilities ([#38797](https://github.com/angular/angular/issues/38797)) ([a33d630](https://github.com/angular/angular/commit/a33d630)), closes [#38561](https://github.com/angular/angular/issues/38561) [#38669](https://github.com/angular/angular/issues/38669)
+* **zone.js:** should invoke xhr send task when no response error occurs ([#38836](https://github.com/angular/angular/issues/38836)) ([d92a0dd](https://github.com/angular/angular/commit/d92a0dd)), closes [#38795](https://github.com/angular/angular/issues/38795)
+* **zone.js:** zone.js toString patch should check typeof Promise is function ([#38350](https://github.com/angular/angular/issues/38350)) ([18e474f](https://github.com/angular/angular/commit/18e474f)), closes [#38361](https://github.com/angular/angular/issues/38361)
+
+
+### BREAKING CHANGES
+
+* **zone.js:** ZoneJS no longer swallows errors produced by `Object.defineProperty` calls.
+
+Prior to this change, ZoneJS monkey patched `Object.defineProperty` and if there is an error
+(such as the property is not configurable or not writable) the patched logic swallowed it
+and only console.log was produced. This behavior used to hide real errors,
+so the logic is now updated to trigger original errors (if any). One exception
+where the patch remains in place is `document.registerElement`
+(to allow smooth transition for code/polyfills that rely on old behavior in legacy browsers).
+If your code relies on the old behavior (where errors were not thrown before),
+you may need to update the logic to handle the errors that are no longer masked by ZoneJS patch.
+
+
+
 <a name="0.11.1"></a>
 ## [0.11.1](https://github.com/angular/angular/compare/zone.js-0.11.0...zone.js-0.11.1) (2020-08-19)
 
@@ -11,7 +40,7 @@
 
 Prior to `v0.11.1`, Zone.js provided two distribution bundle formats in the `dist` folder.
 They were (1) `ES5` bundle distributed as `zone.js` and (2) `ES2015` bundle distributed as `zone-evergreen.js`.
-These bundles are used for Angular's differential-loading mechanism. 
+These bundles are used for Angular's differential-loading mechanism.
 
 Prior to `v0.11.11` the following code
 

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zone.js",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Zones for JavaScript",
   "main": "./bundles/zone.umd.js",
   "module": "./fesm2015/zone.js",


### PR DESCRIPTION
Since this PR https://github.com/angular/angular/pull/38649 to test the `tgz` of `npm_package.pack` rule still need some updates ( currently the `bazel run npm_package.pack` fails in the Windows environment), so it will need some time to be merged, so I am testing the result manually and we can release this version first. 
