### PR TITLE
fix(core): stricter event emitter type

### DIFF
--- a/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.ts
+++ b/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.ts
@@ -12,5 +12,5 @@ import { Product } from '../products';
 // #docregion input-output
 export class ProductAlertsComponent {
   @Input() product: Product | undefined;
-  @Output() notify = new EventEmitter();
+  @Output() notify = new EventEmitter<void>();
 }

--- a/aio/content/start/index.md
+++ b/aio/content/start/index.md
@@ -250,6 +250,15 @@ The `ProductAlertsComponent` needs to emit an event when the user clicks **Notif
 
   <code-example path="getting-started/src/app/product-alerts/product-alerts.component.ts" header="src/app/product-alerts/product-alerts.component.ts" region="input-output"></code-example>
 
+  You use the `void` type to specify that `notify.emit()` doesn't accept an argument.
+
+  <div class="alert is-helpful">
+
+  In new components, the Angular Generator includes an empty `constructor()`, the `OnInit` interface, and the `ngOnInit()` method.
+  Since these steps don't use them, the following code example omits them for brevity.
+
+  </div>
+
 1. In `product-alerts.component.html`, update the **Notify Me** button with an event binding to call the `notify.emit()` method.
 
     <code-example header="src/app/product-alerts/product-alerts.component.html" path="getting-started/src/app/product-alerts/product-alerts.component.html"></code-example>

--- a/goldens/public-api/core/core.md
+++ b/goldens/public-api/core/core.md
@@ -452,7 +452,7 @@ export class ErrorHandler {
 // @public
 export interface EventEmitter<T> extends Subject<T> {
     new (isAsync?: boolean): EventEmitter<T>;
-    emit(value?: T): void;
+    emit(value: T): void;
     subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
     subscribe(observerOrNext?: any, error?: any, complete?: any): Subscription;
 }

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -15,5 +15,6 @@ pkg_npm(
     deps = [
         "//packages/core/schematics/migrations/entry-components",
         "//packages/core/schematics/migrations/typed-forms",
+        "//packages/core/schematics/migrations/void-event-emitter",
     ],
 )

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -9,6 +9,11 @@
       "version": "9999.0.0",
       "description": "Experimental migration that adds <any>s for Typed Forms.",
       "factory": "./migrations/typed-forms/index"
+    },
+    "migration-v14-void-event-emitter": {
+      "version": "14.0.0-beta",
+      "description": "Adds `<void>` type parameter to `EventEmitter` constructor calls if `.emit()` is used without an argument",
+      "factory": "./migrations/void-event-emitter/index"
     }
   }
 }

--- a/packages/core/schematics/migrations/void-event-emitter/BUILD.bazel
+++ b/packages/core/schematics/migrations/void-event-emitter/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//tools:defaults.bzl", "ts_library")
+
+ts_library(
+    name = "void-event-emitter",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+    deps = [
+        "//packages/compiler",
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)

--- a/packages/core/schematics/migrations/void-event-emitter/README.md
+++ b/packages/core/schematics/migrations/void-event-emitter/README.md
@@ -1,0 +1,27 @@
+## Void EventEmitter migration
+
+Updates type parameter for `EventEmitter` constructor call in scenarios where the emitter is used without arguments.
+
+It analyzes both `.emit` and `.next` method calls. Method calls are tracked in the class itself and in its template, if any. 
+
+#### Before
+```ts
+class MyComponent {
+ @Output() myEvent = new EventEmitter();
+ 
+ onClick() {
+     this.myEvent.emit();
+ }
+}
+```
+
+#### After
+```ts
+class MyComponent {
+  @Output() myEvent = new EventEmitter<void>();
+
+  onClick() {
+    this.myEvent.emit();
+  }
+}
+```

--- a/packages/core/schematics/migrations/void-event-emitter/component-templates-resolver.ts
+++ b/packages/core/schematics/migrations/void-event-emitter/component-templates-resolver.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Tree} from '@angular-devkit/schematics';
+import ts from 'typescript';
+
+import {NgComponentTemplateVisitor} from '../../utils/ng_component_template';
+
+// Use it instead of individually passing all 3 arguments down the call stack
+export class ComponentTemplatesResolver {
+  constructor(private typeChecker: ts.TypeChecker, private tree: Tree, private basePath: string) {}
+
+  resolveTemplates(classDeclaration: ts.ClassDeclaration) {
+    const templateVisitor =
+        new NgComponentTemplateVisitor(this.typeChecker, this.basePath, this.tree);
+    templateVisitor.visitNode(classDeclaration);
+    return templateVisitor.resolvedTemplates;
+  }
+}

--- a/packages/core/schematics/migrations/void-event-emitter/index.ts
+++ b/packages/core/schematics/migrations/void-event-emitter/index.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
+import {relative} from 'path';
+import ts from 'typescript';
+
+import {loadEsmModule} from '../../utils/load_esm';
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
+import {getImportSpecifier} from '../../utils/typescript/imports';
+
+import {ComponentTemplatesResolver} from './component-templates-resolver';
+import {getEventEmitterTypeParam, withCompilerModule} from './util';
+
+export default function(): Rule {
+  return async (tree: Tree, ctx: SchematicContext) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+    const allPaths = [...buildPaths, ...testPaths];
+
+    if (!allPaths.length) {
+      throw new SchematicsException(
+          'Could not find any tsconfig file. Cannot migrate argument-less (void) EventEmitter declarations.');
+    }
+
+    let compilerModule;
+    try {
+      // Load ESM `@angular/compiler` using the TypeScript dynamic import workaround.
+      // Once TypeScript provides support for keeping the dynamic import this workaround can be
+      // changed to a direct dynamic import.
+      compilerModule = await loadEsmModule<typeof import('@angular/compiler')>('@angular/compiler');
+    } catch (e) {
+      throw new SchematicsException(
+          `Unable to load the '@angular/compiler' package. Details: ${(e as Error).message}`);
+    }
+
+    const failures: string[] = [];
+    for (const tsconfigPath of allPaths) {
+      const thisFailures =
+          runVoidEventEmitterMigration(tree, tsconfigPath, basePath, compilerModule);
+      failures.push(...thisFailures);
+    }
+
+    if (failures.length) {
+      ctx.logger.info('Could not migrate all event emitters automatically. Please');
+      ctx.logger.info('manually migrate the following instances:');
+      failures.forEach(message => ctx.logger.warn(`⮑   ${message}`));
+    }
+  };
+}
+
+function runVoidEventEmitterMigration(
+    tree: Tree, tsconfigPath: string, basePath: string,
+    compilerModule: typeof import('@angular/compiler')): string[] {
+  const {program} = createMigrationProgram(tree, tsconfigPath, basePath);
+  const failures: string[] = [];
+  const typeChecker = program.getTypeChecker();
+  const printer = ts.createPrinter();
+  const sourceFiles =
+      program.getSourceFiles().filter(sourceFile => canMigrateFile(basePath, sourceFile, program));
+
+  sourceFiles.forEach(sourceFile => {
+    const eventEmitterImportSpecifier =
+        getImportSpecifier(sourceFile, '@angular/core', 'EventEmitter');
+
+    // If there are no imports for the `EventEmitter`, we can exit early.
+    if (!eventEmitterImportSpecifier) {
+      return;
+    }
+
+    const componentTemplatesResolver = new ComponentTemplatesResolver(typeChecker, tree, basePath);
+
+    const emitterUsages =
+        withCompilerModule(compilerModule)
+            .findEventEmitterReferences(
+                sourceFile, typeChecker, eventEmitterImportSpecifier, componentTemplatesResolver);
+
+    const update = tree.beginUpdate(relative(basePath, sourceFile.fileName));
+    let hasUpdates = false;
+
+    for (let [declaration, calls] of emitterUsages.entries()) {
+      const typeParam = getEventEmitterTypeParam(declaration);
+
+      if (typeParam === 'void') {
+        continue;
+      }
+
+      const voidCalls = calls.filter(emitterCall => !emitterCall.hasArguments);
+      const nonVoidCalls = calls.filter(emitterCall => emitterCall.hasArguments);
+
+      // in case of typed or mixed usage, display a warning for each void call instead of
+      // auto-migrating
+      if (typeParam === 'typed' || nonVoidCalls.length > 0) {
+        for (let voidCall of voidCalls) {
+          const method = voidCall.methodName;
+          const {line, character} = voidCall.pos;
+          const relativeFilePath = relative(basePath, voidCall.filePath);
+          failures.push(`${relativeFilePath}@${line + 1}:${character + 1}: .${
+              method}() call requires an argument`);
+        }
+        continue;
+      }
+
+      // findEventEmitterReferences() only tracked declarations initialized with a NewExpression
+      const newExpr = declaration.initializer as ts.NewExpression;
+
+      const updatedNewExpr = ts.factory.createNewExpression(
+          newExpr.expression, [ts.factory.createToken(ts.SyntaxKind.VoidKeyword)],
+          newExpr.arguments);
+
+      update.remove(newExpr.getStart(), newExpr.getWidth());
+      update.insertRight(
+          newExpr.getStart(),
+          printer.printNode(ts.EmitHint.Unspecified, updatedNewExpr, sourceFile));
+
+      hasUpdates = true;
+    }
+
+    if (hasUpdates) {
+      tree.commitUpdate(update);
+    }
+  });
+
+
+  return failures;
+}

--- a/packages/core/schematics/migrations/void-event-emitter/util.ts
+++ b/packages/core/schematics/migrations/void-event-emitter/util.ts
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import type {Call, TmplAstBoundEvent, TmplAstElement} from '@angular/compiler';
+import ts from 'typescript';
+
+import {parseHtmlGracefully} from '../../utils/parse_html';
+import {TemplateAstVisitor} from '../../utils/template_ast_visitor';
+import {isReferenceToImport} from '../../utils/typescript/symbol';
+
+import type {ComponentTemplatesResolver} from './component-templates-resolver';
+import {ResolvedTemplate} from '../../utils/ng_component_template';
+
+type EventEmitterCall = {
+  hasArguments: boolean,
+  methodName: 'emit'|'next',
+  pos: ts.LineAndCharacter,
+  filePath: string
+};
+
+type EventEmitterUsages = Map<ts.PropertyDeclaration, EventEmitterCall[]>;
+
+function isEmitMethod(methodName: string|ts.__String): methodName is 'emit'|'next' {
+  return methodName === 'emit' || methodName === 'next';
+}
+
+type EventEmitterTypeParam = 'typed'|'void'|'missing';
+
+export function getEventEmitterTypeParam(node: ts.PropertyDeclaration): EventEmitterTypeParam {
+  const initializedTypeParams =
+      node.initializer && ts.isNewExpression(node.initializer) && node.initializer.typeArguments;
+
+  const declaredTypeParams =
+      node.type && ts.isTypeReferenceNode(node.type) && node.type.typeArguments;
+
+  const typeParams = declaredTypeParams || initializedTypeParams;
+
+  if (!typeParams || !typeParams.length) {
+    return 'missing';
+  }
+
+  if (typeParams[0].kind === ts.SyntaxKind.VoidKeyword) {
+    return 'void';
+  }
+
+  return 'typed';
+}
+
+// Wrap everything in a function, so that we could use compilerModule freely
+// (primarily, extend RecursiveAstVisitor)
+export function withCompilerModule(compilerModule: typeof import('@angular/compiler')) {
+  class EmitterTemplateVisitor extends TemplateAstVisitor {
+    constructor(private usages: EventEmitterUsages, private template: ResolvedTemplate) {
+      super(compilerModule);
+    }
+    override visitElement(element: TmplAstElement) {
+      this.visitAll(element.outputs);
+      super.visitElement(element);
+    }
+
+    override visitBoundEvent(attribute: TmplAstBoundEvent) {
+      const astVisitor = new EmitterAstVisitor(this.usages, this.template);
+      attribute.handler.visit(astVisitor);
+    }
+  }
+
+  class EmitterAstVisitor extends compilerModule.RecursiveAstVisitor {
+    constructor(private usages: EventEmitterUsages, private template: ResolvedTemplate) {
+      super();
+    }
+
+    override visitCall(ast: Call, context: any): any {
+      // E.g. (click)="myEmitter.emit(123)"
+      // ast.receiver: "emit" property
+      // ast.receiver.receiver: "myEmitter" property
+      // ast.receiver.receiver.receiver: "this" context (implicit)
+
+      if (ast.receiver instanceof compilerModule.PropertyRead && isEmitMethod(ast.receiver.name) &&
+          ast.receiver.receiver instanceof compilerModule.PropertyRead &&
+          ast.receiver.receiver.receiver instanceof compilerModule.ImplicitReceiver) {
+        for (let [declaration, calls] of this.usages.entries()) {
+          if (ts.isMemberName(declaration.name) &&
+              declaration.name.escapedText === ast.receiver.receiver.name) {
+            const pos = this.template.getCharacterAndLineOfPosition(ast.sourceSpan.start);
+            calls.push({
+              hasArguments: !!ast.args.length,
+              methodName: ast.receiver.name,
+              pos: pos,
+              filePath: this.template.filePath
+            });
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Find class properties initialized with `new EventEmitter()` as well as .emit() methods calls on
+   * such properties.
+   */
+  function findEventEmitterReferences(
+      sourceFile: ts.SourceFile, typeChecker: ts.TypeChecker,
+      eventEmitterImportSpecifier: ts.ImportSpecifier,
+      componentTemplatesResolver: ComponentTemplatesResolver) {
+    const usagesInFile: EventEmitterUsages = new Map();
+
+    ts.forEachChild(sourceFile, function visitNode(node) {
+      if (ts.isClassDeclaration(node)) {
+        const usagesInClass = findUsagesInClass(
+            typeChecker, node, eventEmitterImportSpecifier, componentTemplatesResolver);
+        for (let [declaration, calls] of usagesInClass.entries()) {
+          usagesInFile.set(declaration, calls);
+        }
+      } else {
+        ts.forEachChild(node, visitNode);
+      }
+    });
+
+    return usagesInFile;
+  }
+
+
+  function findUsagesInClass(
+      typeChecker: ts.TypeChecker, classDeclaration: ts.ClassDeclaration,
+      eventEmitterImportSpecifier: ts.ImportSpecifier,
+      componentTemplatesResolver: ComponentTemplatesResolver) {
+    const usages: EventEmitterUsages = new Map();
+
+    // Find all property declarations of type EventEmitter
+    ts.forEachChild(classDeclaration, function visitNode(node: ts.Node) {
+      if (ts.isPropertyDeclaration(node) &&
+          isReferenceToImport(typeChecker, node, eventEmitterImportSpecifier)) {
+        usages.set(node, []);
+      }
+
+      ts.forEachChild(node, visitNode);
+    });
+
+    // Find all .emit method calls on the emitters from the previous step
+    ts.forEachChild(classDeclaration, function visitNode(node: ts.Node) {
+      if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression) &&
+          isEmitMethod(node.expression.name.escapedText)) {
+        const symbol = typeChecker.getSymbolAtLocation(node.expression.expression);
+        const declaration = symbol?.declarations?.[0];
+        const trackedCalls =
+            declaration && ts.isPropertyDeclaration(declaration) && usages.get(declaration);
+        const pos = ts.getLineAndCharacterOfPosition(node.getSourceFile(), node.getStart());
+        trackedCalls && trackedCalls.push({
+          hasArguments: !!node.arguments.length,
+          methodName: node.expression.name.escapedText,
+          pos: pos,
+          filePath: node.getSourceFile().fileName
+        });
+      }
+      ts.forEachChild(node, visitNode);
+    });
+
+    // Find all .emit method calls inside the component template
+    const templates = componentTemplatesResolver.resolveTemplates(classDeclaration);
+
+    templates.forEach(template => {
+      const emitterTemplateVisitor = new EmitterTemplateVisitor(usages, template);
+      const templateNodes =
+          parseHtmlGracefully(template.content, template.filePath, compilerModule) || [];
+      emitterTemplateVisitor.visitAll(templateNodes);
+    });
+
+    return usages;
+  }
+
+  return {findEventEmitterReferences};
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -10,6 +10,7 @@ ts_library(
     deps = [
         "//packages/core/schematics/migrations/entry-components",
         "//packages/core/schematics/migrations/typed-forms",
+        "//packages/core/schematics/migrations/void-event-emitter",
         "//packages/core/schematics/utils",
         "@npm//@angular-devkit/core",
         "@npm//@angular-devkit/schematics",

--- a/packages/core/schematics/test/void_event_emitter_migration_spec.ts
+++ b/packages/core/schematics/test/void_event_emitter_migration_spec.ts
@@ -1,0 +1,323 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import * as shx from 'shelljs';
+
+describe('EventEmitter<void> migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+  let warnOutput: string[];
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', require.resolve('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile('/tsconfig.json', JSON.stringify({
+      compilerOptions: {
+        lib: ['es2015'],
+        strictNullChecks: true,
+      },
+    }));
+    writeFile('/angular.json', JSON.stringify({
+      version: 1,
+      projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
+    }));
+
+    // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.
+    writeFile('/node_modules/@angular/core/index.d.ts', `
+      export declare class EventEmitter<T = any> {}
+    `);
+
+    warnOutput = [];
+    runner.logger.subscribe(logEntry => {
+      if (logEntry.level === 'warn') {
+        warnOutput.push(logEntry.message);
+      }
+    });
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+
+  it('should add <void> when .emit() without an argument is called in the component', async () => {
+    writeFile('/index.ts', `
+      import { EventEmitter, Component } from '@angular/core';
+
+      @Component({template: ''})
+      export class MyComponent {
+        change = new EventEmitter();
+
+        onClick() {
+          this.change.emit();
+        }
+      }
+    `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toContain(`change = new EventEmitter<void>()`);
+    expect(warnOutput.length).toBe(0);
+  });
+
+  it('should treat .next() method of event emitter the same as .emit', async () => {
+    writeFile('/index.ts', `
+      import { EventEmitter, Component } from '@angular/core';
+
+      @Component({template: ''})
+      export class MyComponent {
+        alwaysVoid = new EventEmitter();
+        mixed = new EventEmitter();
+
+        onClick() {
+          this.alwaysVoid.next();
+
+          this.mixed.next();
+          this.mixed.emit(999);
+        }
+      }
+    `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toContain(`alwaysVoid = new EventEmitter<void>()`);
+    expect(tree.readContent('/index.ts')).toContain(`mixed = new EventEmitter()`);
+
+    expect(warnOutput.length).toBe(1);
+    expect(warnOutput[0]).toMatch(/\s+index\.ts@12:11: .next\(\) call requires an argument/);
+  });
+
+  it('should keep a property as is if it already has type parameter on the constructor call',
+     async () => {
+       const originalContents = `
+      import { EventEmitter, Component } from '@angular/core';
+
+      @Component({template: ''})
+      export class MyComponent {
+        change = new EventEmitter<number>();
+
+        onClick() {
+          this.change.emit();
+        }
+      }
+    `;
+       writeFile('/index.ts', originalContents);
+
+       await runMigration();
+       expect(tree.readContent('/index.ts')).toEqual(originalContents);
+
+       expect(warnOutput.length).toBe(1);
+       expect(warnOutput[0]).toMatch(/\s+index\.ts@9:11: .emit\(\) call requires an argument/);
+     });
+
+  it('should keep a property as is if used with both void and non-void calls', async () => {
+    const originalContents = `
+      import { EventEmitter, Component } from '@angular/core';
+
+      @Component({template: ''})
+      export class MyComponent {
+        change = new EventEmitter();
+
+        onClick() {
+          this.change.emit();
+          this.change.emit(666);
+        }
+      }
+    `;
+    writeFile('/index.ts', originalContents);
+
+
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toEqual(originalContents);
+
+    expect(warnOutput.length).toBe(1);
+    expect(warnOutput[0]).toMatch(/\s+index\.ts@9:11: .emit\(\) call requires an argument/);
+  });
+
+  it('should keep a property as is if it has explicit type', async () => {
+    const originalContents = `
+      import { EventEmitter, Component } from '@angular/core';
+
+      @Component({template: ''})
+      export class MyComponent {
+        change: EventEmitter<void> = new EventEmitter();
+
+        onClick() {
+          this.change.emit();
+        }
+      }
+    `;
+    writeFile('/index.ts', originalContents);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toEqual(originalContents);
+    expect(warnOutput.length).toBe(0);
+  });
+
+  it('should analyze .emit calls in an inline component template', async () => {
+    writeFile('/index.ts', `
+      import { EventEmitter, Component } from '@angular/core';
+
+      @Component({template: '<button (click)="change.emit()"></button>'})
+      export class MyComponent {
+        change = new EventEmitter();
+      }
+    `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toContain(`change = new EventEmitter<void>()`);
+    expect(warnOutput.length).toBe(0);
+  });
+
+  it('should analyze .emit calls in a template references via templateUrl', async () => {
+    writeFile('/my.component.html', '<button (click)="change.emit()"></button>');
+    writeFile('/index.ts', `
+      import { EventEmitter, Component } from '@angular/core';
+
+      @Component({templateUrl: './my.component.html'})
+      export class MyComponent {
+        change = new EventEmitter();
+      }
+    `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toContain(`change = new EventEmitter<void>()`);
+    expect(warnOutput.length).toBe(0);
+  });
+
+  it('should keep a property as is if .emit is called with an argument in a template', async () => {
+    const originalContents = `
+      import { EventEmitter, Component } from '@angular/core';
+
+      @Component({template: '<button (click)="change.emit(777)"></button>'})
+      export class MyComponent {
+        change = new EventEmitter();
+      }
+    `;
+    writeFile('/index.ts', originalContents);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toEqual(originalContents);
+    expect(warnOutput.length).toBe(0);
+  });
+
+  it('should handle a file with multiple classes and multiple event emitters', async () => {
+    const originalContents = `
+      import { EventEmitter, Component } from '@angular/core';
+
+      @Component({template: '<button (click)="emitInTemplate.emit()"></button>'})
+      export class AComponent {
+        emitInTemplate = new EventEmitter();
+        emitInClass = new EventEmitter();
+        emitWithArg = new EventEmitter();
+
+        emitEvents() {
+          this.emitInClass.emit();
+          this.emitWithArg.emit(123);
+        }
+      }
+
+      @Component({template: ''})
+      export class BComponent {
+        emitInClass = new EventEmitter();
+
+        emitEvent() {
+          this.emitInClass.emit(777);
+        }
+      }
+    `;
+
+    const expectedOutput = `
+      import { EventEmitter, Component } from '@angular/core';
+
+      @Component({template: '<button (click)="emitInTemplate.emit()"></button>'})
+      export class AComponent {
+        emitInTemplate = new EventEmitter<void>();
+        emitInClass = new EventEmitter<void>();
+        emitWithArg = new EventEmitter();
+
+        emitEvents() {
+          this.emitInClass.emit();
+          this.emitWithArg.emit(123);
+        }
+      }
+
+      @Component({template: ''})
+      export class BComponent {
+        emitInClass = new EventEmitter();
+
+        emitEvent() {
+          this.emitInClass.emit(777);
+        }
+      }
+    `;
+
+    writeFile('/index.ts', originalContents);
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toEqual(expectedOutput);
+    expect(warnOutput.length).toBe(0);
+  });
+
+
+  it('should print correct line/character in warnings for inline template', async () => {
+    writeFile('/index.ts', `
+      import { EventEmitter, Component } from '@angular/core';
+
+      @Component({template: '<button (click)="change.emit()"></button>'})
+      export class MyComponent {
+        change = new EventEmitter<number>();
+      }
+    `);
+
+    await runMigration();
+    expect(warnOutput.length).toBe(1);
+    expect(warnOutput[0]).toMatch(/\s+index\.ts@4:47: .emit\(\) call requires an argument/);
+  });
+
+
+  it('should print correct line/character in warnings for template references via templateUrl',
+     async () => {
+       writeFile('/my.component.html', '<button (click)="change.emit()"></button>');
+       writeFile('/index.ts', `
+      import { EventEmitter, Component } from '@angular/core';
+
+      @Component({templateUrl: './my.component.html'})
+      export class MyComponent {
+        change = new EventEmitter<number>();
+      }
+    `);
+
+       await runMigration();
+       expect(warnOutput.length).toBe(1);
+       expect(warnOutput[0])
+           .toMatch(/\s+my\.component\.html@1:18: .emit\(\) call requires an argument/);
+     });
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematicAsync('migration-v14-void-event-emitter', {}, tree).toPromise();
+  }
+});

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -80,7 +80,7 @@ export interface EventEmitter<T> extends Subject<T> {
    * Emits an event containing a given value.
    * @param value The value to emit.
    */
-  emit(value?: T): void;
+  emit(value: T): void;
 
   /**
    * Registers handlers for events emitted by this instance.

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -511,7 +511,7 @@ describe('directives', () => {
   describe('outputs', () => {
     @Directive({selector: '[out]'})
     class TestDir {
-      @Output() out = new EventEmitter();
+      @Output() out = new EventEmitter<void>();
     }
 
     it('should allow outputs of directive on ng-template', () => {

--- a/packages/core/test/acceptance/profiler_spec.ts
+++ b/packages/core/test/acceptance/profiler_spec.ts
@@ -158,7 +158,7 @@ describe('profiler', () => {
     it('should invoke the profiler on output handler execution', async () => {
       @Component({selector: 'child', template: ''})
       class Child {
-        @Output() childEvent = new EventEmitter();
+        @Output() childEvent = new EventEmitter<void>();
       }
 
       @Component({selector: 'my-comp', template: '<child (childEvent)="onEvent()"></child>'})

--- a/packages/examples/upgrade/static/ts/full/module.ts
+++ b/packages/examples/upgrade/static/ts/full/module.ts
@@ -41,8 +41,8 @@ export class TextFormatter {
 })
 export class Ng2HeroesComponent {
   @Input() heroes!: Hero[];
-  @Output() addHero = new EventEmitter();
-  @Output() removeHero = new EventEmitter();
+  @Output() addHero = new EventEmitter<void>();
+  @Output() removeHero = new EventEmitter<Hero>();
 }
 // #enddocregion
 


### PR DESCRIPTION
This completes the work from this original PR: https://github.com/angular/angular/pull/35300 (no longer maintained).

However, I discarded the original idea to default `new EventEmitter()` to `EventEmitter<void>`, instead sticking to the existing type of `EventEmitter<any>`. That would be yet another breaking change with way too many cascading changes to make in tests.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: Fixes #35119

This error is not caught and can cause a runtime exception, since a subscriber only expects values of type `number` to be emitted.
```
const em = new EventEmitter<number>;
em.next(); // <- No value provided will feed `undefined` where `number` is expected
```

## What is the new behavior?

This error is caught by TypeScript
```
const em = new EventEmitter<number>;
em.next(); // <- Expected 1 argument to `next()` but 0 arguments provided
```

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

It's no longer possible to have an event emitter type which sometimes accepts arguments and sometimes not. It's either one but not both:
```
const em = new EventEmitter<void>();
em.next(); // OK
em.next(something); // Not OK

const em2 = new EventEmitter<any>();
em2.next(); // Not OK
em2.next(undefined); // OK
em2.next(something); // OK
```
This could be overcome if `emit` is defined as a typed property rather than a method. [Example in TS Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAogtgS2AHgCoD4oF4oCgoFSpQQAewEAdgCYDOUAbgPYLX6EcD8UAFAJTZMzVuw4EAXFACuNCADMElCNRLkqdIqLFdeDAIYAbKRE6TUArEJZtt2yT31GIZi1ZG5QkWAyrB4SCgAnNEwcAG8tCERgSX8UDABuXABfXFwDCGASOABCWJ9KP2ig5D1KEHQkqIA6KKR+IA). However, I'm reluctant with such an approach - announcing it as "property" - might be confusing to some users.

Any feedback on this subject is welcome!

## Broken consumer in angular/components

The breaking change described above currently breaks an example in material-experimental: https://github.com/angular/components/blob/master/src/components-examples/material-experimental/popover-edit/popover-edit-mat-table/popover-edit-mat-table-example.html#L100

What is a proper way to proceed with it? Should a separate PR be filed for angular/components ? 

## Other information
Original PR: https://github.com/angular/angular/pull/35300
Related PR in rxjs: https://github.com/ReactiveX/rxjs/pull/5307