### PR TITLE
build: remove usage of blacklist in benchmark tooling

### DIFF
--- a/modules/benchmarks/src/expanding_rows/expanding_row.ts
+++ b/modules/benchmarks/src/expanding_rows/expanding_row.ts
@@ -45,10 +45,10 @@ export interface ExpandingRowHostBase {
   handleRowSummaryClick(row: ExpandingRow): void;
 
   /**
-   * Check if element is blacklisted.  Blacklisted elements will not collapse an
+   * Check if element is collapsible.  Elements marked as uncollapsible will not collapse an
    * open row when clicked.
    */
-  isBlacklisted(element: HTMLElement|null): boolean;
+  isCollapsible(element: HTMLElement|null): boolean;
 
   /**
    * Handles caption element click on a cfc-expanding-row component. Note
@@ -247,16 +247,15 @@ export class ExpandingRow {
    * notify click on its host element. Note that caption is only shown when
    * the row is expanded. Hence this will collapse this row and put the focus
    * on it.
-   * If a blacklisted element exists in the caption, clicking that element will
+   * If an uncollapsible element exists in the caption, clicking that element will
    * not trigger the row collapse.
    */
   handleCaptionClick(event: MouseEvent): void {
-    if (this.expandingRowHost.isBlacklisted(event.target as {} as HTMLElement)) {
-      return;
+    if (this.expandingRowHost.isCollapsible(event.target as {} as HTMLElement)) {
+      this.expandingRowHost.handleRowCaptionClick(this);
+      this.collapse();
+      this.focus();
     }
-    this.expandingRowHost.handleRowCaptionClick(this);
-    this.collapse();
-    this.focus();
   }
 
   /**

--- a/modules/benchmarks/src/expanding_rows/expanding_row_host.ts
+++ b/modules/benchmarks/src/expanding_rows/expanding_row_host.ts
@@ -315,18 +315,18 @@ export class ExpandingRowHost implements AfterViewInit, OnDestroy, ExpandingRowH
   }
 
   /**
-   * Check if element is blacklisted.  Blacklisted elements will not collapse an
+   * Check if element is collapsible.  Elements marked as uncollapsible will not collapse an
    * open row when clicked.
    */
-  isBlacklisted(element: HTMLElement|null): boolean {
+  isCollapsible(element: HTMLElement|null): boolean {
     const clickRoot = this.getClickRootElement();
     while (element && element !== clickRoot) {
-      if (element.hasAttribute('cfcexpandingrowblacklist')) {
-        return true;
+      if (element.hasAttribute('cfcUncollapsible')) {
+        return false;
       }
       element = element.parentElement;
     }
-    return false;
+    return true;
   }
 
   /**

--- a/modules/benchmarks/src/expanding_rows/expanding_row_module.ts
+++ b/modules/benchmarks/src/expanding_rows/expanding_row_module.ts
@@ -10,11 +10,11 @@ import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 
 import {ExpandingRow} from './expanding_row';
-import {ExpandingRowBlacklist} from './expanding_row_blacklist';
 import {ExpandingRowDetailsCaption} from './expanding_row_details_caption';
 import {ExpandingRowDetailsContent} from './expanding_row_details_content';
 import {ExpandingRowHost} from './expanding_row_host';
 import {ExpandingRowSummary} from './expanding_row_summary';
+import {ExpandingRowUncollapsible} from './expanding_row_uncollapsible';
 
 /** The main module for the cfc-expanding-row component. */
 @NgModule({
@@ -24,7 +24,7 @@ import {ExpandingRowSummary} from './expanding_row_summary';
     ExpandingRowDetailsContent,
     ExpandingRowHost,
     ExpandingRowSummary,
-    ExpandingRowBlacklist,
+    ExpandingRowUncollapsible,
   ],
   exports: [
     ExpandingRow,
@@ -32,7 +32,7 @@ import {ExpandingRowSummary} from './expanding_row_summary';
     ExpandingRowDetailsContent,
     ExpandingRowHost,
     ExpandingRowSummary,
-    ExpandingRowBlacklist,
+    ExpandingRowUncollapsible,
   ],
   imports: [
     CommonModule,

--- a/modules/benchmarks/src/expanding_rows/expanding_row_uncollapsible.ts
+++ b/modules/benchmarks/src/expanding_rows/expanding_row_uncollapsible.ts
@@ -14,7 +14,7 @@ import {Directive} from '@angular/core';
  * expanded row
  */
 @Directive({
-  selector: '[cfcExpandingRowBlacklist]',
+  selector: '[cfcUncollapsible]',
 })
-export class ExpandingRowBlacklist {
+export class ExpandingRowUncollapsible {
 }


### PR DESCRIPTION
Removes the usage of blacklist in benchmark tooling, instead using more
specificity to indicate whether a row is collapsible.
