### PR TITLE
test(docs-infra): remove usage of blacklist in test naming

### DIFF
--- a/aio/tools/transforms/angular-base-package/processors/createSitemap.spec.js
+++ b/aio/tools/transforms/angular-base-package/processors/createSitemap.spec.js
@@ -47,7 +47,7 @@ describe('createSitemap processor', () => {
         expect(docs.pop().urls).toEqual(['abc', 'fgh']);
       });
 
-      it('ignoring blacklisted doc types', () => {
+      it('ignoring excluded doc types', () => {
         const docs = [
           { path: 'abc', outputPath: 'abc', docType: 'good' },
           { path: 'cde', outputPath: 'cde', docType: 'bad' },
@@ -58,7 +58,7 @@ describe('createSitemap processor', () => {
         expect(docs.pop().urls).toEqual(['abc', 'fgh']);
       });
 
-      it('ignoring blacklisted paths', () => {
+      it('ignoring excluded paths', () => {
         const docs = [
           { path: 'abc', outputPath: 'abc' },
           { path: 'cde', outputPath: 'cde' },


### PR DESCRIPTION
Remove usage of blacklist in test naming of processor tranform tests.
