### PR TITLE
refactor(compiler-cli): support generation of completion contexts

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, ParseError, TmplAstNode,} from '@angular/compiler';
+import {AST, ParseError, TmplAstBoundEvent, TmplAstNode, TmplAstTemplate} from '@angular/compiler';
 import * as ts from 'typescript';
+
+import {AbsoluteFsPath} from '../../file_system';
 
 import {Symbol} from './symbols';
 
@@ -88,6 +90,38 @@ export interface TemplateTypeChecker {
    * @see Symbol
    */
   getSymbolOfNode(node: AST|TmplAstNode, component: ts.ClassDeclaration): Symbol|null;
+
+  /**
+   * Retrieve a `CompletionContext` for a given global context within the template, which will allow
+   * for use of TypeScript Language Service APIs to access relevant code completion results for that
+   * location.
+   *
+   * The `context` given can either be a particular embedded view, or `null` to represent the
+   * top level of the template.
+   */
+  getGlobalCompletionPosition(component: ts.ClassDeclaration, context: TmplAstTemplate|null):
+      CompletionPosition|null;
+}
+
+/**
+ * A pointer into the TCB where an expression has been generated that's suitable as an input to
+ * TypeScript's code completion APIs.
+ */
+export interface CompletionPosition {
+  /**
+   * Full path to the shim file which contains the TCB for the given template.
+   */
+  shimFile: AbsoluteFsPath;
+
+  /**
+   * Offset into the shim file of an expression which is suitable as an input to TypeScript code
+   * completion APIs.
+   *
+   * Often this expression is of the form `foo. ;`, an incomplete expression that emulates what a
+   * user might type to retrieve completions that are property values of `foo`. The given position
+   * immediately follows the `.`.
+   */
+  position: number;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/comments.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/comments.ts
@@ -42,6 +42,7 @@ export enum CommentTriviaType {
 /** Identifies what the TCB expression is for (for example, a directive declaration). */
 export enum ExpressionIdentifier {
   DIRECTIVE = 'DIR',
+  CONTEXT_COMPLETION = 'CCTX',
 }
 
 /** Tags the node with the given expression identifier. */
@@ -86,6 +87,7 @@ function makeRecursiveVisitor<T extends ts.Node>(visitor: (node: ts.Node) => T |
 export interface FindOptions<T extends ts.Node> {
   filter: (node: ts.Node) => node is T;
   withSpan?: AbsoluteSourceSpan|ParseSourceSpan;
+  withExpressionIdentifier?: ExpressionIdentifier;
 }
 
 function getSpanFromOptions(opts: FindOptions<ts.Node>) {
@@ -119,6 +121,11 @@ export function findFirstMatchingNode<T extends ts.Node>(tcb: ts.Node, opts: Fin
       if (comment === null || withSpan.start !== comment.start || withSpan.end !== comment.end) {
         return null;
       }
+    }
+
+    if (opts.withExpressionIdentifier !== undefined &&
+        !hasExpressionIdentifier(sf, node, opts.withExpressionIdentifier)) {
+      return null;
     }
     return node;
   });

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/diagnostics.ts
@@ -203,3 +203,8 @@ function getTemplateId(node: ts.Node, sourceFile: ts.SourceFile): TemplateId|nul
     return commentText;
   }) as TemplateId || null;
 }
+
+export function isTemplateDiagnostic(diagnostic: ts.Diagnostic): diagnostic is TemplateDiagnostic {
+  return diagnostic.hasOwnProperty('componentFile') &&
+      ts.isSourceFile((diagnostic as any).componentFile);
+}

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__completion_context_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__completion_context_spec.ts
@@ -1,0 +1,203 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {TmplAstElement, TmplAstTemplate} from '@angular/compiler';
+import * as ts from 'typescript';
+
+import {absoluteFrom, getSourceFileOrError} from '../../file_system';
+import {runInEachFileSystem} from '../../file_system/testing';
+import {getTokenAtPosition} from '../../util/src/typescript';
+import {OptimizeFor, TemplateTypeChecker, TypeCheckingConfig} from '../api';
+import {ReusedProgramStrategy} from '../src/augmented_program';
+
+import {getClass, getLineAtPositionWithCursor, ngForDeclaration, ngForDts, setup as baseTestSetup, TypeCheckingTarget} from './test_utils';
+
+runInEachFileSystem(() => {
+  describe('global completion positions', () => {
+    describe('for the top-level of a template', () => {
+      it('should include available references', () => {
+        const fileName = absoluteFrom('/main.ts');
+        const {templateTypeChecker, program, programStrategy} = setup([{
+          fileName,
+          templates: {
+            'Cmp': `<div #refA></div><span #refB></span>`,
+          },
+          source: `export class Cmp { propA: string; propB: number; }`,
+        }]);
+
+        const sf = getSourceFileOrError(program, fileName);
+        const cmp = getClass(sf, 'Cmp');
+
+        const completionPos =
+            templateTypeChecker.getGlobalCompletionPosition(cmp, /* top-level context */ null);
+        if (completionPos === null) {
+          return fail('Null context!');
+        }
+
+        const file = programStrategy.getProgram().getSourceFile(completionPos.shimFile)!;
+        const node = getTokenAtPosition(file, completionPos.position - 2);
+        if (!ts.isIdentifier(node)) {
+          return fail(`Expected context to be a ts.Identifier, got ${ts.SyntaxKind[node.kind]}`);
+        }
+
+        const checker = programStrategy.getProgram().getTypeChecker();
+
+        expect(getDeclaredTypeString(node, checker))
+            .toEqual('Omit<typeof ctx, "refA" | "refB"> & { refA: typeof _t1; refB: typeof _t3; }');
+        expect(getProperties(node, checker)).toEqual(new Set(['propA', 'propB', 'refA', 'refB']));
+      });
+
+      it('should not result in additional diagnostics when generated', () => {
+        const fileName = absoluteFrom('/main.ts');
+        const templateString = `<div *ngFor="let item of items"></div>`;
+        const {templateTypeChecker, program, programStrategy} = setup(
+            [
+              {
+                fileName,
+                templates: {'Cmp': templateString},
+                source: `export class Cmp { items: string[]; other: number; }`,
+                declarations: [ngForDeclaration()]
+              },
+              ngForDts(),
+            ],
+        );
+        const sf = getSourceFileOrError(program, fileName);
+        const diags = templateTypeChecker.getDiagnosticsForFile(sf, OptimizeFor.WholeProgram);
+        expect(diags.length).toBe(0);
+      });
+    });
+
+    describe('for embedded views', () => {
+      it('should include declared variables', () => {
+        const fileName = absoluteFrom('/main.ts');
+        const templateString = `<div *ngFor="let item of items"></div>`;
+        const {templateTypeChecker, program, programStrategy} = setup(
+            [
+              {
+                fileName,
+                templates: {'Cmp': templateString},
+                source: `export class Cmp { items: string[]; other: number; }`,
+                declarations: [ngForDeclaration()]
+              },
+              ngForDts(),
+            ],
+        );
+        const sf = getSourceFileOrError(program, fileName);
+        const cmp = getClass(sf, 'Cmp');
+        const embeddedView = templateTypeChecker.getTemplate(cmp)![0] as TmplAstTemplate;
+
+        const completionPos = templateTypeChecker.getGlobalCompletionPosition(cmp, embeddedView);
+        if (completionPos === null) {
+          return fail('Null context!');
+        }
+
+        const file = programStrategy.getProgram().getSourceFile(completionPos.shimFile)!;
+        const node = getTokenAtPosition(file, completionPos.position - 2);
+        if (!ts.isIdentifier(node)) {
+          return fail(`Expected context to be a ts.Identifier, got ${ts.SyntaxKind[node.kind]}`);
+        }
+
+        const checker = programStrategy.getProgram().getTypeChecker();
+
+        expect(getDeclaredTypeString(node, checker))
+            .toEqual('Omit<typeof _t1, "item"> & { item: typeof _t4; }');
+        expect(getProperties(node, checker)).toEqual(new Set(['items', 'other', 'item']));
+      });
+
+      it('should support multiple levels of nesting', () => {
+        const fileName = absoluteFrom('/main.ts');
+        const templateString = `
+              <span #refA></span>
+              <div *ngFor="let varA of items">
+                <span #refB></span>
+                <div *ngFor="let varB of item.subitems"></div>
+              </div>
+            `;
+        const {templateTypeChecker, program, programStrategy} = setup(
+            [
+              {
+                fileName,
+                templates: {'Cmp': templateString},
+                source: `export class Cmp { propA: string; propB: number; }`,
+                declarations: [ngForDeclaration()]
+              },
+              ngForDts(),
+            ],
+        );
+        const sf = getSourceFileOrError(program, fileName);
+        const cmp = getClass(sf, 'Cmp');
+        const embeddedViewA = templateTypeChecker.getTemplate(cmp)![1] as TmplAstTemplate;
+        const embeddedViewB =
+            (embeddedViewA.children[0] as TmplAstElement).children[1] as TmplAstTemplate;
+
+        const completionPos = templateTypeChecker.getGlobalCompletionPosition(cmp, embeddedViewB);
+        if (completionPos === null) {
+          return fail('Null context!');
+        }
+
+        const file = programStrategy.getProgram().getSourceFile(completionPos.shimFile)!;
+        const node = getTokenAtPosition(file, completionPos.position - 2);
+        if (!ts.isIdentifier(node)) {
+          return fail(`Expected context to be a ts.Identifier, got ${ts.SyntaxKind[node.kind]}`);
+        }
+
+        const checker = programStrategy.getProgram().getTypeChecker();
+
+        expect(getProperties(node, checker)).toEqual(new Set([
+          'propA', 'propB', 'varA', 'varB', 'refA', 'refB'
+        ]));
+      });
+    });
+
+    it('should not result in additional diagnostics when generated', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const templateString = `<div *ngFor="let item of items"></div>`;
+      const {templateTypeChecker, program, programStrategy} = setup(
+          [
+            {
+              fileName,
+              templates: {'Cmp': templateString},
+              source: `export class Cmp { items: string[]; other: number; }`,
+              declarations: [ngForDeclaration()]
+            },
+            ngForDts(),
+          ],
+      );
+      const sf = getSourceFileOrError(program, fileName);
+      const diags = templateTypeChecker.getDiagnosticsForFile(sf, OptimizeFor.WholeProgram);
+      expect(diags.length).toBe(0);
+    });
+  });
+});
+
+export function setup(targets: TypeCheckingTarget[], config?: Partial<TypeCheckingConfig>): {
+  templateTypeChecker: TemplateTypeChecker,
+  program: ts.Program,
+  programStrategy: ReusedProgramStrategy,
+} {
+  return baseTestSetup(
+      targets, {inlining: false, config: {...config, enableTemplateTypeChecker: true}});
+}
+
+function getDeclaredTypeString(node: ts.Node, checker: ts.TypeChecker): string {
+  const symbol = checker.getSymbolAtLocation(node);
+  if (symbol === undefined) {
+    throw new Error(`Expected defined symbol`);
+  } else if (!ts.isVariableDeclaration(symbol.valueDeclaration)) {
+    throw new Error(`Expected ts.VariableDeclaration`);
+  } else if (symbol.valueDeclaration.type === undefined) {
+    throw new Error(`Expected explicit type node for ts.VariableDeclaration`);
+  }
+
+  return symbol.valueDeclaration.type.getText().replace(/[\r\n\t ]+/g, ' ');
+}
+
+function getProperties(node: ts.Node, checker: ts.TypeChecker): Set<string> {
+  const type = checker.getTypeAtLocation(node);
+  return new Set(checker.getPropertiesOfType(type).map(sym => sym.escapedName as string));
+}

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker_spec.ts
@@ -117,7 +117,6 @@ runInEachFileSystem(() => {
       // Next, ask for a TCB from file2. This operation should clear data on TCBs generated for
       // file1.
       expect(templateTypeChecker.getTypeCheckBlock(cmpB)).not.toBeNull();
-      console.error(templateTypeChecker.getTypeCheckBlock(cmpB)?.getSourceFile().text);
 
       // This can be detected by asking for a TCB again from file1. Since no data should be
       // available for file1, this should cause another type-checking program step.


### PR DESCRIPTION
This commit introduces an API in the `TemplateTypeChecker` for generating a
"completion context" - a point in the TCB where a tool such as the Language
Service can use TS APIs to retrieve valid completions for various template
contexts. A completion context is a partially complete expression in the TCB
with a synthetic object type, containing keys representing all possible
completions at that location.

Currently only completion contexts for top level expressions as well as
embedded views are supported. Future work will expand this to contexts for
variable and reference declarations.
