### PR TITLE
fix(ngcc): support inline `exports.<name> = <decl>` style exports in UMD files

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/module_with_providers_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/module_with_providers_analyzer.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 import {ReferencesRegistry} from '../../../src/ngtsc/annotations';
 import {Reference} from '../../../src/ngtsc/imports';
 import {PartialEvaluator} from '../../../src/ngtsc/partial_evaluator';
-import {ClassDeclaration, isNamedClassDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, DeclarationNode, isNamedClassDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
 import {NgccReflectionHost} from '../host/ngcc_host';
 import {hasNameIdentifier, isDefined} from '../utils';
 
@@ -30,7 +30,7 @@ export interface ModuleWithProvidersInfo {
   /**
    * Declaration of the containing class (if this is a method)
    */
-  container: ts.Declaration|null;
+  container: DeclarationNode|null;
   /**
    * The declaration of the class that the `ngModule` property on the `ModuleWithProviders` object
    * refers to.
@@ -125,7 +125,7 @@ export class ModuleWithProvidersAnalyzer {
    */
   private parseForModuleWithProviders(
       name: string, node: ts.Node|null, implementation: ts.Node|null = node,
-      container: ts.Declaration|null = null): ModuleWithProvidersInfo|null {
+      container: DeclarationNode|null = null): ModuleWithProvidersInfo|null {
     if (implementation === null ||
         (!ts.isFunctionDeclaration(implementation) && !ts.isMethodDeclaration(implementation) &&
          !ts.isFunctionExpression(implementation))) {

--- a/packages/compiler-cli/ngcc/src/analysis/ngcc_references_registry.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/ngcc_references_registry.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 import {ReferencesRegistry} from '../../../src/ngtsc/annotations';
 import {Reference} from '../../../src/ngtsc/imports';
-import {ConcreteDeclaration, ReflectionHost} from '../../../src/ngtsc/reflection';
+import {Declaration, DeclarationNode, ReflectionHost} from '../../../src/ngtsc/reflection';
 import {hasNameIdentifier} from '../utils';
 
 /**
@@ -20,7 +20,7 @@ import {hasNameIdentifier} from '../utils';
  * from libraries that are compiled by ngcc.
  */
 export class NgccReferencesRegistry implements ReferencesRegistry {
-  private map = new Map<ts.Identifier, ConcreteDeclaration>();
+  private map = new Map<ts.Identifier, Declaration>();
 
   constructor(private host: ReflectionHost) {}
 
@@ -29,12 +29,12 @@ export class NgccReferencesRegistry implements ReferencesRegistry {
    * Only `ResolveReference` references are stored. Other types are ignored.
    * @param references A collection of references to register.
    */
-  add(source: ts.Declaration, ...references: Reference<ts.Declaration>[]): void {
+  add(source: DeclarationNode, ...references: Reference<DeclarationNode>[]): void {
     references.forEach(ref => {
       // Only store relative references. We are not interested in literals.
       if (ref.bestGuessOwningModule === null && hasNameIdentifier(ref.node)) {
         const declaration = this.host.getDeclarationOfIdentifier(ref.node.name);
-        if (declaration && declaration.node !== null && hasNameIdentifier(declaration.node)) {
+        if (declaration && hasNameIdentifier(declaration.node)) {
           this.map.set(declaration.node.name, declaration);
         }
       }
@@ -45,7 +45,7 @@ export class NgccReferencesRegistry implements ReferencesRegistry {
    * Create and return a mapping for the registered resolved references.
    * @returns A map of reference identifiers to reference declarations.
    */
-  getDeclarationMap(): Map<ts.Identifier, ConcreteDeclaration> {
+  getDeclarationMap(): Map<ts.Identifier, Declaration> {
     return this.map;
   }
 }

--- a/packages/compiler-cli/ngcc/src/analysis/private_declarations_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/private_declarations_analyzer.ts
@@ -8,7 +8,7 @@
 import * as ts from 'typescript';
 
 import {absoluteFromSourceFile, AbsoluteFsPath} from '../../../src/ngtsc/file_system';
-import {ConcreteDeclaration} from '../../../src/ngtsc/reflection';
+import {Declaration} from '../../../src/ngtsc/reflection';
 import {NgccReflectionHost} from '../host/ngcc_host';
 import {hasNameIdentifier, isDefined} from '../utils';
 
@@ -40,8 +40,8 @@ export class PrivateDeclarationsAnalyzer {
 
   private getPrivateDeclarations(
       rootFiles: ts.SourceFile[],
-      declarations: Map<ts.Identifier, ConcreteDeclaration>): PrivateDeclarationsAnalyses {
-    const privateDeclarations: Map<ts.Identifier, ConcreteDeclaration> = new Map(declarations);
+      declarations: Map<ts.Identifier, Declaration>): PrivateDeclarationsAnalyses {
+    const privateDeclarations: Map<ts.Identifier, Declaration> = new Map(declarations);
 
     rootFiles.forEach(f => {
       const exports = this.host.getExportsOfModule(f);

--- a/packages/compiler-cli/ngcc/src/dependencies/commonjs_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/commonjs_dependency_host.ts
@@ -9,7 +9,6 @@ import * as ts from 'typescript';
 
 import {AbsoluteFsPath} from '../../../src/ngtsc/file_system';
 import {isRequireCall, isWildcardReexportStatement, RequireCall} from '../host/commonjs_umd_utils';
-import {isAssignment, isAssignmentStatement} from '../host/esm2015_host';
 
 import {DependencyHostBase} from './dependency_host';
 

--- a/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 
 import {absoluteFrom} from '../../../src/ngtsc/file_system';
 import {Logger} from '../../../src/ngtsc/logging';
-import {Declaration, Import} from '../../../src/ngtsc/reflection';
+import {Declaration, DeclarationKind, Import} from '../../../src/ngtsc/reflection';
 import {BundleProgram} from '../packages/bundle_program';
 import {FactoryMap, isDefined} from '../utils';
 
@@ -181,7 +181,7 @@ export class CommonJsReflectionHost extends Esm5ReflectionHost {
     } else {
       return {
         name,
-        declaration: {node: null, known: null, expression, viaModule: null},
+        declaration: {node: expression, known: null, kind: DeclarationKind.Inline, viaModule: null},
       };
     }
   }
@@ -204,7 +204,7 @@ export class CommonJsReflectionHost extends Esm5ReflectionHost {
       return null;
     }
     const viaModule = isExternalImport(importPath) ? importPath : null;
-    return {node: module, known: null, viaModule, identity: null};
+    return {node: module, known: null, viaModule, identity: null, kind: DeclarationKind.Concrete};
   }
 
   private resolveModuleName(moduleName: string, containingFile: ts.SourceFile): ts.SourceFile

--- a/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_host.ts
@@ -14,7 +14,7 @@ import {Declaration, Import} from '../../../src/ngtsc/reflection';
 import {BundleProgram} from '../packages/bundle_program';
 import {FactoryMap, isDefined} from '../utils';
 
-import {DefinePropertyReexportStatement, ExportDeclaration, ExportStatement, extractGetterFnExpression, findNamespaceOfIdentifier, findRequireCallReference, isDefinePropertyReexportStatement, isExportStatement, isExternalImport, isRequireCall, isWildcardReexportStatement, RequireCall, WildcardReexportStatement} from './commonjs_umd_utils';
+import {DefinePropertyReexportStatement, ExportDeclaration, ExportsStatement, extractGetterFnExpression, findNamespaceOfIdentifier, findRequireCallReference, isDefinePropertyReexportStatement, isExportsStatement, isExternalImport, isRequireCall, isWildcardReexportStatement, RequireCall, WildcardReexportStatement} from './commonjs_umd_utils';
 import {Esm5ReflectionHost} from './esm5_host';
 import {NgccClassSymbol} from './ngcc_host';
 
@@ -98,7 +98,7 @@ export class CommonJsReflectionHost extends Esm5ReflectionHost {
   private computeExportsOfCommonJsModule(sourceFile: ts.SourceFile): Map<string, Declaration> {
     const moduleMap = new Map<string, Declaration>();
     for (const statement of this.getModuleStatements(sourceFile)) {
-      if (isExportStatement(statement)) {
+      if (isExportsStatement(statement)) {
         const exportDeclaration = this.extractBasicCommonJsExportDeclaration(statement);
         moduleMap.set(exportDeclaration.name, exportDeclaration.declaration);
       } else if (isWildcardReexportStatement(statement)) {
@@ -116,7 +116,7 @@ export class CommonJsReflectionHost extends Esm5ReflectionHost {
     return moduleMap;
   }
 
-  private extractBasicCommonJsExportDeclaration(statement: ExportStatement): ExportDeclaration {
+  private extractBasicCommonJsExportDeclaration(statement: ExportsStatement): ExportDeclaration {
     const exportExpression = statement.expression.right;
     const name = statement.expression.left.name.text;
     return this.extractCommonJsExportDeclaration(name, exportExpression);

--- a/packages/compiler-cli/ngcc/src/host/commonjs_umd_utils.ts
+++ b/packages/compiler-cli/ngcc/src/host/commonjs_umd_utils.ts
@@ -8,20 +8,11 @@
 
 import * as ts from 'typescript';
 import {Declaration} from '../../../src/ngtsc/reflection';
-
+import {isAssignment} from '../../../src/ngtsc/util/src/typescript';
 
 export interface ExportDeclaration {
   name: string;
   declaration: Declaration;
-}
-
-export interface ExportStatement extends ts.ExpressionStatement {
-  expression: ts.BinaryExpression&{
-    left: ts.PropertyAccessExpression &
-        {
-          expression: ts.Identifier
-        }
-  };
 }
 
 /**
@@ -59,6 +50,9 @@ export interface DefinePropertyReexportStatement extends ts.ExpressionStatement 
       {arguments: [ts.Identifier, ts.StringLiteral, ts.ObjectLiteralExpression]};
 }
 
+/**
+ * A call expression that has a string literal for its first argument.
+ */
 export interface RequireCall extends ts.CallExpression {
   arguments: ts.CallExpression['arguments']&[ts.StringLiteral];
 }
@@ -88,18 +82,6 @@ export function findRequireCallReference(id: ts.Identifier, checker: ts.TypeChec
   const initializer =
       declaration && ts.isVariableDeclaration(declaration) && declaration.initializer || null;
   return initializer && isRequireCall(initializer) ? initializer : null;
-}
-
-/**
- * Check whether the specified `ts.Statement` is an export statement, i.e. an expression statement
- * of the form: `exports.<foo> = <bar>`
- */
-export function isExportStatement(stmt: ts.Statement): stmt is ExportStatement {
-  return ts.isExpressionStatement(stmt) && ts.isBinaryExpression(stmt.expression) &&
-      (stmt.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken) &&
-      ts.isPropertyAccessExpression(stmt.expression.left) &&
-      ts.isIdentifier(stmt.expression.left.expression) &&
-      stmt.expression.left.expression.text === 'exports';
 }
 
 /**
@@ -194,6 +176,12 @@ export function isDefinePropertyReexportStatement(stmt: ts.Statement):
       prop => prop.name !== undefined && ts.isIdentifier(prop.name) && prop.name.text === 'get'));
 }
 
+/**
+ * Extract the "value" of the getter in a `defineProperty` statement.
+ *
+ * This will return the `ts.Expression` value of a single `return` statement in the `get` method
+ * of the property definition object, or `null` if that is not possible.
+ */
 export function extractGetterFnExpression(statement: DefinePropertyReexportStatement):
     ts.Expression|null {
   const args = statement.expression.arguments;
@@ -220,6 +208,59 @@ export function isRequireCall(node: ts.Node): node is RequireCall {
       ts.isStringLiteral(node.arguments[0]);
 }
 
+/**
+ * Check whether the specified `path` is an "external" import.
+ * In other words, that it comes from a entry-point outside the current one.
+ */
 export function isExternalImport(path: string): boolean {
   return !/^\.\.?(\/|$)/.test(path);
+}
+
+/**
+ * A UMD/CommonJS style export declaration of the form `exports.<name>`.
+ */
+export interface ExportsDeclaration extends ts.PropertyAccessExpression {
+  name: ts.Identifier;
+  expression: ts.Identifier;
+  parent: ExportsAssignment;
+}
+
+/**
+ * Check whether the specified `node` is a property access expression of the form
+ * `exports.<foo>`.
+ */
+export function isExportsDeclaration(expr: ts.Node): expr is ExportsDeclaration {
+  return expr.parent && isExportsAssignment(expr.parent);
+}
+
+/**
+ * A UMD/CommonJS style export assignment of the form `exports.<foo> = <bar>`.
+ */
+export interface ExportsAssignment extends ts.BinaryExpression {
+  left: ExportsDeclaration;
+}
+
+/**
+ * Check whether the specified `node` is an assignment expression of the form
+ * `exports.<foo> = <bar>`.
+ */
+export function isExportsAssignment(expr: ts.Node): expr is ExportsAssignment {
+  return isAssignment(expr) && ts.isPropertyAccessExpression(expr.left) &&
+      ts.isIdentifier(expr.left.expression) && expr.left.expression.text === 'exports' &&
+      ts.isIdentifier(expr.left.name);
+}
+
+/**
+ * An expression statement of the form `exports.<foo> = <bar>;`.
+ */
+export interface ExportsStatement extends ts.ExpressionStatement {
+  expression: ExportsAssignment;
+}
+
+/**
+ * Check whether the specified `stmt` is an expression statement of the form
+ * `exports.<foo> = <bar>;`.
+ */
+export function isExportsStatement(stmt: ts.Node): stmt is ExportsStatement {
+  return ts.isExpressionStatement(stmt) && isExportsAssignment(stmt.expression);
 }

--- a/packages/compiler-cli/ngcc/src/host/delegating_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/delegating_host.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ClassMember, CtorParameter, Declaration, Decorator, FunctionDefinition, Import, ReflectionHost} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, ClassMember, CtorParameter, Declaration, DeclarationNode, Decorator, FunctionDefinition, Import, ReflectionHost} from '../../../src/ngtsc/reflection';
 import {isFromDtsFile} from '../../../src/ngtsc/util/src/typescript';
 
 import {NgccClassSymbol, NgccReflectionHost, SwitchableVariableDeclaration} from './ngcc_host';
@@ -38,7 +38,7 @@ export class DelegatingReflectionHost implements NgccReflectionHost {
     return this.ngccHost.getDeclarationOfIdentifier(id);
   }
 
-  getDecoratorsOfDeclaration(declaration: ts.Declaration): Decorator[]|null {
+  getDecoratorsOfDeclaration(declaration: DeclarationNode): Decorator[]|null {
     if (isFromDtsFile(declaration)) {
       return this.tsHost.getDecoratorsOfDeclaration(declaration);
     }
@@ -52,7 +52,7 @@ export class DelegatingReflectionHost implements NgccReflectionHost {
     return this.ngccHost.getDefinitionOfFunction(fn);
   }
 
-  getDtsDeclaration(declaration: ts.Declaration): ts.Declaration|null {
+  getDtsDeclaration(declaration: DeclarationNode): ts.Declaration|null {
     if (isFromDtsFile(declaration)) {
       return this.tsHost.getDtsDeclaration(declaration);
     }

--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -2311,7 +2311,7 @@ function isInitializedVariableClassDeclaration(node: ts.Node):
  * var MyClass = alias1 = alias2 = <<declaration>>
  * ```
  *
- * @node the LHS of a variable declaration.
+ * @param node the LHS of a variable declaration.
  * @returns the original AST node or the RHS of a series of assignments in a variable
  *     declaration.
  */

--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -8,10 +8,10 @@
 
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ClassMember, ClassMemberKind, Declaration, Decorator, FunctionDefinition, KnownDeclaration, Parameter, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, ClassMember, ClassMemberKind, Declaration, Decorator, FunctionDefinition, isNamedFunctionDeclaration, KnownDeclaration, Parameter, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
 import {getTsHelperFnFromDeclaration, getTsHelperFnFromIdentifier, hasNameIdentifier} from '../utils';
 
-import {Esm2015ReflectionHost, getClassDeclarationFromInnerDeclaration, getPropertyValueFromSymbol, isAssignmentStatement, ParamInfo} from './esm2015_host';
+import {Esm2015ReflectionHost, getOuterNodeFromInnerDeclaration, getPropertyValueFromSymbol, isAssignmentStatement, ParamInfo} from './esm2015_host';
 import {NgccClassSymbol} from './ngcc_host';
 
 
@@ -186,16 +186,16 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
       return classSymbol;
     }
 
-    if (!ts.isFunctionDeclaration(declaration) || !hasNameIdentifier(declaration)) {
+    if (!isNamedFunctionDeclaration(declaration)) {
       return undefined;
     }
 
-    const outerDeclaration = getClassDeclarationFromInnerDeclaration(declaration);
-    if (outerDeclaration === null || !hasNameIdentifier(outerDeclaration)) {
+    const outerNode = getOuterNodeFromInnerDeclaration(declaration);
+    if (outerNode === null || !hasNameIdentifier(outerNode)) {
       return undefined;
     }
 
-    return this.createClassSymbol(outerDeclaration, declaration);
+    return this.createClassSymbol(outerNode.name, declaration);
   }
 
   /**

--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ClassMember, ClassMemberKind, Declaration, Decorator, FunctionDefinition, isNamedFunctionDeclaration, KnownDeclaration, Parameter, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, ClassMember, ClassMemberKind, Declaration, DeclarationKind, Decorator, FunctionDefinition, isNamedFunctionDeclaration, KnownDeclaration, Parameter, reflectObjectLiteral} from '../../../src/ngtsc/reflection';
 import {getTsHelperFnFromDeclaration, getTsHelperFnFromIdentifier, hasNameIdentifier} from '../utils';
 
 import {Esm2015ReflectionHost, getOuterNodeFromInnerDeclaration, getPropertyValueFromSymbol, isAssignmentStatement, ParamInfo} from './esm2015_host';
@@ -82,9 +82,9 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
         // `importHelpers: false` (the default). This is, for example, the case with
         // `@nativescript/angular@9.0.0-next-2019-11-12-155500-01`.
         return {
-          expression: id,
+          kind: DeclarationKind.Inline,
+          node: id,
           known: nonEmittedNorImportedTsHelperDeclaration,
-          node: null,
           viaModule: null,
         };
       }

--- a/packages/compiler-cli/ngcc/src/host/umd_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/umd_host.ts
@@ -14,7 +14,7 @@ import {Declaration, Import} from '../../../src/ngtsc/reflection';
 import {BundleProgram} from '../packages/bundle_program';
 import {FactoryMap, getTsHelperFnFromIdentifier, stripExtension} from '../utils';
 
-import {DefinePropertyReexportStatement, ExportDeclaration, ExportStatement, extractGetterFnExpression, findNamespaceOfIdentifier, findRequireCallReference, isDefinePropertyReexportStatement, isExportStatement, isExternalImport, isRequireCall, isWildcardReexportStatement, WildcardReexportStatement} from './commonjs_umd_utils';
+import {DefinePropertyReexportStatement, ExportDeclaration, ExportsStatement, extractGetterFnExpression, findNamespaceOfIdentifier, findRequireCallReference, isDefinePropertyReexportStatement, isExportsStatement, isExternalImport, isRequireCall, isWildcardReexportStatement, WildcardReexportStatement} from './commonjs_umd_utils';
 import {Esm5ReflectionHost} from './esm5_host';
 import {stripParentheses} from './utils';
 
@@ -90,7 +90,7 @@ export class UmdReflectionHost extends Esm5ReflectionHost {
   private computeExportsOfUmdModule(sourceFile: ts.SourceFile): Map<string, Declaration>|null {
     const moduleMap = new Map<string, Declaration>();
     for (const statement of this.getModuleStatements(sourceFile)) {
-      if (isExportStatement(statement)) {
+      if (isExportsStatement(statement)) {
         const exportDeclaration = this.extractBasicUmdExportDeclaration(statement);
         moduleMap.set(exportDeclaration.name, exportDeclaration.declaration);
       } else if (isWildcardReexportStatement(statement)) {
@@ -132,7 +132,7 @@ export class UmdReflectionHost extends Esm5ReflectionHost {
     return importPath;
   }
 
-  private extractBasicUmdExportDeclaration(statement: ExportStatement): ExportDeclaration {
+  private extractBasicUmdExportDeclaration(statement: ExportsStatement): ExportDeclaration {
     const name = statement.expression.left.name.text;
     const exportExpression = statement.expression.right;
     return this.extractUmdExportDeclaration(name, exportExpression);

--- a/packages/compiler-cli/ngcc/src/migrations/missing_injectable_migration.ts
+++ b/packages/compiler-cli/ngcc/src/migrations/missing_injectable_migration.ts
@@ -151,7 +151,7 @@ function migrateProviderClass(provider: ResolvedValue, host: MigrationHost): voi
     return;
   }
 
-  const clazz = provider.node as ts.Declaration;
+  const clazz = provider.node;
   if (isClassDeclaration(clazz) && host.isInScope(clazz) && needsInjectableDecorator(clazz, host)) {
     host.injectSyntheticDecorator(clazz, createInjectableDecorator(clazz));
   }

--- a/packages/compiler-cli/ngcc/src/migrations/undecorated_parent_migration.ts
+++ b/packages/compiler-cli/ngcc/src/migrations/undecorated_parent_migration.ts
@@ -101,7 +101,7 @@ function determineBaseClass(
   }
 
   const baseClass = host.evaluator.evaluate(baseClassExpr);
-  if (!(baseClass instanceof Reference) || !isClassDeclaration(baseClass.node as ts.Declaration)) {
+  if (!(baseClass instanceof Reference) || !isClassDeclaration(baseClass.node)) {
     return null;
   }
 

--- a/packages/compiler-cli/ngcc/src/migrations/utils.ts
+++ b/packages/compiler-cli/ngcc/src/migrations/utils.ts
@@ -10,7 +10,7 @@ import {Reference} from '../../../src/ngtsc/imports';
 import {ClassDeclaration, Decorator, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
 import {MigrationHost} from './migration';
 
-export function isClassDeclaration(clazz: ts.Declaration): clazz is ClassDeclaration {
+export function isClassDeclaration(clazz: ts.Node): clazz is ClassDeclaration<ts.Declaration> {
   return isNamedClassDeclaration(clazz) || isNamedFunctionDeclaration(clazz) ||
       isNamedVariableDeclaration(clazz);
 }

--- a/packages/compiler-cli/ngcc/src/utils.ts
+++ b/packages/compiler-cli/ngcc/src/utils.ts
@@ -71,9 +71,9 @@ export function findAll<T>(node: ts.Node, test: (node: ts.Node) => node is ts.No
  * @param declaration The declaration to test.
  * @returns true if the declaration has an identifier for a name.
  */
-export function hasNameIdentifier(declaration: ts.Declaration): declaration is ts.Declaration&
+export function hasNameIdentifier(declaration: ts.Node): declaration is ts.Declaration&
     {name: ts.Identifier} {
-  const namedDeclaration: ts.Declaration&{name?: ts.Node} = declaration;
+  const namedDeclaration: ts.Node&{name?: ts.Node} = declaration;
   return namedDeclaration.name !== undefined && ts.isIdentifier(namedDeclaration.name);
 }
 

--- a/packages/compiler-cli/ngcc/src/utils.ts
+++ b/packages/compiler-cli/ngcc/src/utils.ts
@@ -8,7 +8,7 @@
 import * as ts from 'typescript';
 
 import {absoluteFrom, AbsoluteFsPath, FileSystem, isRooted} from '../../src/ngtsc/file_system';
-import {KnownDeclaration} from '../../src/ngtsc/reflection';
+import {DeclarationNode, KnownDeclaration} from '../../src/ngtsc/reflection';
 
 /**
  * A list (`Array`) of partially ordered `T` items.
@@ -71,7 +71,7 @@ export function findAll<T>(node: ts.Node, test: (node: ts.Node) => node is ts.No
  * @param declaration The declaration to test.
  * @returns true if the declaration has an identifier for a name.
  */
-export function hasNameIdentifier(declaration: ts.Node): declaration is ts.Declaration&
+export function hasNameIdentifier(declaration: ts.Node): declaration is DeclarationNode&
     {name: ts.Identifier} {
   const namedDeclaration: ts.Node&{name?: ts.Node} = declaration;
   return namedDeclaration.name !== undefined && ts.isIdentifier(namedDeclaration.name);
@@ -136,7 +136,7 @@ export function resolveFileWithPostfixes(
  * Determine whether a function declaration corresponds with a TypeScript helper function, returning
  * its kind if so or null if the declaration does not seem to correspond with such a helper.
  */
-export function getTsHelperFnFromDeclaration(decl: ts.Declaration): KnownDeclaration|null {
+export function getTsHelperFnFromDeclaration(decl: DeclarationNode): KnownDeclaration|null {
   if (!ts.isFunctionDeclaration(decl) && !ts.isVariableDeclaration(decl)) {
     return null;
   }

--- a/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/decoration_analyzer_spec.ts
@@ -11,7 +11,7 @@ import {FatalDiagnosticError, makeDiagnostic} from '../../../src/ngtsc/diagnosti
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
-import {ClassDeclaration, Decorator} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, DeclarationNode, Decorator} from '../../../src/ngtsc/reflection';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence} from '../../../src/ngtsc/transform';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {DecorationAnalyzer} from '../../src/analysis/decoration_analyzer';
@@ -52,7 +52,7 @@ runInEachFileSystem(() => {
         ]);
         // Only detect the Component and Directive decorators
         handler.detect.and.callFake(
-            (node: ts.Declaration, decorators: Decorator[]|null): DetectResult<unknown>|
+            (node: DeclarationNode, decorators: Decorator[]|null): DetectResult<unknown>|
             undefined => {
               const className = (node as any).name.text;
               if (decorators === null) {
@@ -76,7 +76,7 @@ runInEachFileSystem(() => {
               }
             });
         // The "test" analysis is an object with the name of the decorator being analyzed
-        handler.analyze.and.callFake((decl: ts.Declaration, dec: Decorator) => {
+        handler.analyze.and.callFake((decl: DeclarationNode, dec: Decorator) => {
           logs.push(`analyze: ${(decl as any).name.text}@${dec.name}`);
           return {
             analysis: {decoratorName: dec.name},
@@ -85,7 +85,7 @@ runInEachFileSystem(() => {
           };
         });
         // The "test" resolution is just setting `resolved: true` on the analysis
-        handler.resolve.and.callFake((decl: ts.Declaration, analysis: any) => {
+        handler.resolve.and.callFake((decl: DeclarationNode, analysis: any) => {
           logs.push(`resolve: ${(decl as any).name.text}@${analysis.decoratorName}`);
           analysis.resolved = true;
           return {
@@ -95,10 +95,10 @@ runInEachFileSystem(() => {
         });
         // The "test" compilation result is just the name of the decorator being compiled
         // (suffixed with `(compiled)`)
-        (handler.compileFull as any).and.callFake((decl: ts.Declaration, analysis: any) => {
+        handler.compileFull.and.callFake((decl: DeclarationNode, analysis: any) => {
           logs.push(`compile: ${(decl as any).name.text}@${analysis.decoratorName} (resolved: ${
               analysis.resolved})`);
-          return `@${analysis.decoratorName} (compiled)`;
+          return `@${analysis.decoratorName} (compiled)` as any;
         });
         return handler;
       };

--- a/packages/compiler-cli/ngcc/test/analysis/module_with_providers_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/module_with_providers_analyzer_spec.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 import {absoluteFrom, AbsoluteFsPath, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
-import {isNamedClassDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
+import {DeclarationNode, isNamedClassDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadTestFiles} from '../../../test/helpers';
 import {ModuleWithProvidersAnalyses, ModuleWithProvidersAnalyzer} from '../../src/analysis/module_with_providers_analyzer';
@@ -660,7 +660,7 @@ runInEachFileSystem(() => {
                           [];
       }
 
-      function getName(node: ts.Declaration|null): string {
+      function getName(node: DeclarationNode|null): string {
         return node && (isNamedVariableDeclaration(node) || isNamedClassDeclaration(node)) ?
             `${node.name.text}.` :
             '';

--- a/packages/compiler-cli/ngcc/test/analysis/module_with_providers_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/module_with_providers_analyzer_spec.ts
@@ -10,8 +10,8 @@ import * as ts from 'typescript';
 import {absoluteFrom, AbsoluteFsPath, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
-import {DeclarationNode, isNamedClassDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
-import {getDeclaration} from '../../../src/ngtsc/testing';
+import {DeclarationNode} from '../../../src/ngtsc/reflection';
+import {getDeclaration, isNamedDeclaration} from '../../../src/ngtsc/testing';
 import {loadTestFiles} from '../../../test/helpers';
 import {ModuleWithProvidersAnalyses, ModuleWithProvidersAnalyzer} from '../../src/analysis/module_with_providers_analyzer';
 import {NgccReferencesRegistry} from '../../src/analysis/ngcc_references_registry';
@@ -661,9 +661,7 @@ runInEachFileSystem(() => {
       }
 
       function getName(node: DeclarationNode|null): string {
-        return node && (isNamedVariableDeclaration(node) || isNamedClassDeclaration(node)) ?
-            `${node.name.text}.` :
-            '';
+        return node && isNamedDeclaration(node) ? `${node.name.text}.` : '';
       }
     });
   });

--- a/packages/compiler-cli/ngcc/test/analysis/references_registry_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/references_registry_spec.ts
@@ -11,7 +11,7 @@ import {absoluteFrom} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {Reference} from '../../../src/ngtsc/imports';
 import {PartialEvaluator} from '../../../src/ngtsc/partial_evaluator';
-import {TypeScriptReflectionHost} from '../../../src/ngtsc/reflection';
+import {DeclarationNode, TypeScriptReflectionHost} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadTestFiles} from '../../../test/helpers';
 import {NgccReferencesRegistry} from '../../src/analysis/ngcc_references_registry';
@@ -61,7 +61,7 @@ runInEachFileSystem(() => {
     });
   });
 
-  function isReference(ref: any): ref is Reference<ts.Declaration> {
+  function isReference(ref: any): ref is Reference<DeclarationNode> {
     return ref instanceof Reference;
   }
 });

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
-import {ClassMemberKind, ConcreteDeclaration, CtorParameter, DownleveledEnum, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost, TypeValueReferenceKind} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, ConcreteDeclaration, CtorParameter, DeclarationKind, DownleveledEnum, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost, TypeValueReferenceKind} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {CommonJsReflectionHost} from '../../src/host/commonjs_host';
@@ -1840,6 +1840,7 @@ exports.MissingClass2 = MissingClass2;
                   const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
 
                   expect(helperDeclaration).toEqual({
+                    kind: DeclarationKind.Concrete,
                     known: knownAs,
                     node: getHelperDeclaration(helperName),
                     viaModule,
@@ -2163,9 +2164,9 @@ exports.MissingClass2 = MissingClass2;
                 const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
 
                 expect(helperDeclaration).toEqual({
+                  kind: DeclarationKind.Inline,
                   known: knownAs,
-                  expression: helperIdentifier,
-                  node: null,
+                  node: helperIdentifier,
                   viaModule: null,
                 });
               };
@@ -2197,9 +2198,9 @@ exports.MissingClass2 = MissingClass2;
                 const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
 
                 expect(helperDeclaration).toEqual({
+                  kind: DeclarationKind.Inline,
                   known: knownAs,
-                  expression: helperIdentifier,
-                  node: null,
+                  node: helperIdentifier,
                   viaModule: null,
                 });
               };
@@ -2421,10 +2422,10 @@ exports.MissingClass2 = MissingClass2;
           const file = getSourceFileOrError(bundle.program, _('/inline_export.js'));
           const exportDeclarations = host.getExportsOfModule(file);
           expect(exportDeclarations).not.toBeNull();
-          const decl = exportDeclarations!.get('directives') as InlineDeclaration;
-          expect(decl).not.toBeUndefined();
-          expect(decl.node).toBeNull();
-          expect(decl.expression).toBeDefined();
+          const decl = exportDeclarations!.get('directives')!;
+          expect(decl).toBeDefined();
+          expect(decl.node).toBeDefined();
+          expect(decl.kind).toEqual(DeclarationKind.Inline);
         });
 
         it('should recognize declarations of known TypeScript helpers', () => {

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -178,7 +178,7 @@ var OuterClass2 = (function() {
 }());
 var SuperClass = (function() { function SuperClass() {} return SuperClass; }());
 var ChildClass = /** @class */ (function (_super) {
-  __extends(ChildClass, _super);
+  __extends(InnerChildClass, _super);
   function InnerChildClass() {}
   return InnerChildClass;
 }(SuperClass);

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
@@ -13,7 +13,7 @@ import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/test
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
 import {ClassMemberKind, ConcreteDeclaration, CtorParameter, DownleveledEnum, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, TypeScriptReflectionHost} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
-import {walkForDeclaration} from '../../../src/ngtsc/testing/src/utils';
+import {walkForDeclarations} from '../../../src/ngtsc/testing/src/utils';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {DelegatingReflectionHost} from '../../src/host/delegating_host';
 import {Esm2015ReflectionHost} from '../../src/host/esm2015_host';
@@ -1732,13 +1732,13 @@ runInEachFileSystem(() => {
            const classDeclaration = getDeclaration(
                bundle.program, WRAPPED_CLASS_EXPRESSION_FILE.name, 'DecoratedWrappedClass',
                ts.isVariableDeclaration);
-           const innerClassDeclaration =
-               walkForDeclaration('InnerDecoratedWrappedClass', classDeclaration);
-           if (innerClassDeclaration === null) {
+           const innerClassDeclarations =
+               walkForDeclarations('InnerDecoratedWrappedClass', classDeclaration);
+           if (innerClassDeclarations.length === 0) {
              throw new Error('Expected InnerDecoratedWrappedClass to exist');
            }
            const aliasedClassIdentifier =
-               (innerClassDeclaration.parent as ts.BinaryExpression).left as ts.Identifier;
+               (innerClassDeclarations[0].parent as ts.BinaryExpression).left as ts.Identifier;
            expect(aliasedClassIdentifier.text).toBe('DecoratedWrappedClass_1');
            const d = host.getDeclarationOfIdentifier(aliasedClassIdentifier);
            expect(d!.node).toBe(classDeclaration);
@@ -2065,18 +2065,18 @@ runInEachFileSystem(() => {
            const outerNode = getDeclaration(
                bundle.program, WRAPPED_CLASS_EXPRESSION_FILE.name, 'DecoratedWrappedClass',
                isNamedVariableDeclaration);
-           const innerNode = walkForDeclaration('InnerDecoratedWrappedClass', outerNode);
-           if (innerNode === null) {
+           const innerNodes = walkForDeclarations('InnerDecoratedWrappedClass', outerNode);
+           if (innerNodes.length === 0) {
              throw new Error('Expected to find InnerDecoratedWrappedClass');
            }
-           const classSymbol = host.getClassSymbol(innerNode);
+           const classSymbol = host.getClassSymbol(innerNodes[0]);
 
            if (classSymbol === undefined) {
              return fail('Expected classSymbol to be defined');
            }
            expect(classSymbol.name).toEqual('DecoratedWrappedClass');
            expect(classSymbol.declaration.valueDeclaration).toBe(outerNode);
-           expect(classSymbol.implementation.valueDeclaration).toBe(innerNode);
+           expect(classSymbol.implementation.valueDeclaration).toBe(innerNodes[0]);
 
            if (classSymbol.adjacent === undefined ||
                !isNamedVariableDeclaration(classSymbol.adjacent.valueDeclaration)) {
@@ -2096,8 +2096,8 @@ runInEachFileSystem(() => {
            const outerNode = getDeclaration(
                bundle.program, WRAPPED_CLASS_EXPRESSION_FILE.name, 'DecoratedWrappedClass',
                isNamedVariableDeclaration);
-           const innerNode = walkForDeclaration('InnerDecoratedWrappedClass', outerNode);
-           if (innerNode === null) {
+           const innerNodes = walkForDeclarations('InnerDecoratedWrappedClass', outerNode);
+           if (innerNodes.length === 0) {
              throw new Error('Expected to find InnerDecoratedWrappedClass');
            }
            const adjacentNode: ts.ClassExpression =
@@ -2112,7 +2112,7 @@ runInEachFileSystem(() => {
            }
            expect(classSymbol.name).toEqual('DecoratedWrappedClass');
            expect(classSymbol.declaration.valueDeclaration).toBe(outerNode);
-           expect(classSymbol.implementation.valueDeclaration).toBe(innerNode);
+           expect(classSymbol.implementation.valueDeclaration).toBe(innerNodes[0]);
 
            if (classSymbol.adjacent === undefined ||
                !isNamedVariableDeclaration(classSymbol.adjacent.valueDeclaration)) {
@@ -2131,12 +2131,12 @@ runInEachFileSystem(() => {
            const outerNode = getDeclaration(
                bundle.program, WRAPPED_CLASS_EXPRESSION_FILE.name, 'DecoratedWrappedClass',
                isNamedVariableDeclaration);
-           const innerNode = walkForDeclaration('InnerDecoratedWrappedClass', outerNode);
-           if (innerNode === null) {
+           const innerNodes = walkForDeclarations('InnerDecoratedWrappedClass', outerNode);
+           if (innerNodes.length === 0) {
              throw new Error('Expected to find InnerDecoratedWrappedClass');
            }
 
-           const innerSymbol = host.getClassSymbol(innerNode)!;
+           const innerSymbol = host.getClassSymbol(innerNodes[0])!;
            const outerSymbol = host.getClassSymbol(outerNode)!;
            expect(innerSymbol.declaration).toBe(outerSymbol.declaration);
            expect(innerSymbol.implementation).toBe(outerSymbol.implementation);

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
@@ -2076,7 +2076,8 @@ runInEachFileSystem(() => {
            }
            expect(classSymbol.name).toEqual('DecoratedWrappedClass');
            expect(classSymbol.declaration.valueDeclaration).toBe(outerNode);
-           expect(classSymbol.implementation.valueDeclaration).toBe(innerNodes[0]);
+           expect(classSymbol.implementation.valueDeclaration)
+               .toBe(innerNodes[0] as ts.Declaration);
 
            if (classSymbol.adjacent === undefined ||
                !isNamedVariableDeclaration(classSymbol.adjacent.valueDeclaration)) {
@@ -2112,7 +2113,8 @@ runInEachFileSystem(() => {
            }
            expect(classSymbol.name).toEqual('DecoratedWrappedClass');
            expect(classSymbol.declaration.valueDeclaration).toBe(outerNode);
-           expect(classSymbol.implementation.valueDeclaration).toBe(innerNodes[0]);
+           expect(classSymbol.implementation.valueDeclaration)
+               .toBe(innerNodes[0] as ts.Declaration);
 
            if (classSymbol.adjacent === undefined ||
                !isNamedVariableDeclaration(classSymbol.adjacent.valueDeclaration)) {

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -223,7 +223,7 @@ runInEachFileSystem(() => {
     }());
     var SuperClass = (function() { function SuperClass() {} return SuperClass; }());
     var ChildClass = /** @class */ (function (_super) {
-      __extends(ChildClass, _super);
+      __extends(InnerChildClass, _super);
       function InnerChildClass() {}
       return InnerChildClass;
     }(SuperClass);

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
-import {ClassMemberKind, ConcreteDeclaration, CtorParameter, Decorator, DownleveledEnum, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost, TypeValueReferenceKind} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, ConcreteDeclaration, CtorParameter, DeclarationKind, Decorator, DownleveledEnum, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost, TypeValueReferenceKind} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {DelegatingReflectionHost} from '../../src/host/delegating_host';
@@ -1858,6 +1858,7 @@ runInEachFileSystem(() => {
                 const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
 
                 expect(helperDeclaration).toEqual({
+                  kind: DeclarationKind.Concrete,
                   known: knownAs,
                   node: getHelperDeclaration(helperName),
                   viaModule,
@@ -2253,9 +2254,9 @@ runInEachFileSystem(() => {
           const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
 
           expect(helperDeclaration).toEqual({
+            kind: DeclarationKind.Inline,
             known: knownAs,
-            expression: helperIdentifier,
-            node: null,
+            node: helperIdentifier,
             viaModule: null,
           });
         };
@@ -2284,9 +2285,9 @@ runInEachFileSystem(() => {
           const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
 
           expect(helperDeclaration).toEqual({
+            kind: DeclarationKind.Inline,
             known: knownAs,
-            expression: helperIdentifier,
-            node: null,
+            node: helperIdentifier,
             viaModule: null,
           });
         };

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -971,7 +971,7 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
         const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators).toBeDefined();
@@ -1081,7 +1081,7 @@ runInEachFileSystem(() => {
         const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
 
         const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators.length).toEqual(1);
@@ -1159,7 +1159,7 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
         const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const input1 = members.find(member => member.name === 'input1')!;
@@ -1178,7 +1178,7 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
         const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const instanceProperty = members.find(member => member.name === 'instanceProperty')!;
@@ -1193,7 +1193,7 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
         const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const staticMethod = members.find(member => member.name === 'staticMethod')!;
@@ -1207,7 +1207,7 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
         const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
         const members = host.getMembersOfClass(classNode);
 
         const staticProperty = members.find(member => member.name === 'staticProperty')!;
@@ -1304,7 +1304,7 @@ runInEachFileSystem(() => {
       const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
 
       const classNode = getDeclaration(
-          bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+          bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
       const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
       expect(decorators.length).toEqual(1);
@@ -1425,7 +1425,7 @@ runInEachFileSystem(() => {
            const bundle = makeTestBundleProgram(_('/main.js'));
            const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
            const classNode = getDeclaration(
-               bundle.program, _('/main.js'), 'SomeClass', isNamedVariableDeclaration);
+               bundle.program, _('/main.js'), 'SomeClass', isNamedFunctionDeclaration);
 
            const parameters = host.getConstructorParameters(classNode)!;
 
@@ -1439,7 +1439,7 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
         const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
         const parameters = host.getConstructorParameters(classNode);
 
         expect(parameters).toBeDefined();
@@ -1604,7 +1604,7 @@ runInEachFileSystem(() => {
           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
               bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
-              isNamedVariableDeclaration);
+              isNamedFunctionDeclaration);
           const mockImportInfo: Import = {from: '@angular/core', name: 'Directive'};
           const spy = spyOn(UmdReflectionHost.prototype, 'getImportOfIdentifier')
                           .and.returnValue(mockImportInfo);
@@ -2033,7 +2033,7 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
         const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
         const ctrDecorators = host.getConstructorParameters(classNode)!;
         const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference! as {
                                                kind: TypeValueReferenceKind.LOCAL,
@@ -2092,7 +2092,7 @@ runInEachFileSystem(() => {
         const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
         const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedVariableDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
         const classDecorators = host.getDecoratorsOfDeclaration(classNode)!;
         const identifierOfDirective =
             (((classDecorators[0].node as ts.ObjectLiteralExpression).properties[0] as

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -638,7 +638,8 @@ runInEachFileSystem(() => {
               `  exports.d = b;\n` +
               `  exports.e = e;\n` +
               `  exports.DirectiveX = core.Directive;\n` +
-              `  exports.SomeClass = SomeClass;\n` +
+              `  var SomeClass_1;\n` +
+              `  exports.SomeClass = SomeClass_1 = SomeClass;\n` +
               `})));\n`,
         },
         {

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
-import {ClassMemberKind, ConcreteDeclaration, CtorParameter, DownleveledEnum, Import, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost, TypeValueReferenceKind} from '../../../src/ngtsc/reflection';
+import {ClassMemberKind, ConcreteDeclaration, CtorParameter, DeclarationKind, DownleveledEnum, Import, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost, TypeValueReferenceKind} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
 import {isExportsStatement} from '../../src/host/commonjs_umd_utils';
@@ -2003,6 +2003,7 @@ runInEachFileSystem(() => {
                 const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
 
                 expect(helperDeclaration).toEqual({
+                  kind: DeclarationKind.Concrete,
                   known: knownAs,
                   node: getHelperDeclaration(factoryFn, helperName),
                   viaModule,
@@ -2410,9 +2411,9 @@ runInEachFileSystem(() => {
           const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
 
           expect(helperDeclaration).toEqual({
+            kind: DeclarationKind.Inline,
             known: knownAs,
-            expression: helperIdentifier,
-            node: null,
+            node: helperIdentifier,
             viaModule: null,
           });
         };
@@ -2449,9 +2450,9 @@ runInEachFileSystem(() => {
           const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
 
           expect(helperDeclaration).toEqual({
+            kind: DeclarationKind.Inline,
             known: knownAs,
-            expression: helperIdentifier,
-            node: null,
+            node: helperIdentifier,
             viaModule: null,
           });
         };
@@ -2697,10 +2698,10 @@ runInEachFileSystem(() => {
         const file = getSourceFileOrError(bundle.program, INLINE_EXPORT_FILE.name);
         const exportDeclarations = host.getExportsOfModule(file);
         expect(exportDeclarations).not.toBe(null);
-        const decl = exportDeclarations!.get('directives') as InlineDeclaration;
-        expect(decl).not.toBeUndefined();
-        expect(decl.node).toBeNull();
-        expect(decl.expression).toBeDefined();
+        const decl = exportDeclarations!.get('directives')!;
+        expect(decl).toBeDefined();
+        expect(decl.node).toBeDefined();
+        expect(decl.kind).toEqual(DeclarationKind.Inline);
       });
 
       it('should recognize declarations of known TypeScript helpers', () => {
@@ -2901,7 +2902,7 @@ runInEachFileSystem(() => {
            const classSymbol = host.getClassSymbol(outerNode);
 
            expect(classSymbol).toBeDefined();
-           expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode);
+           expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode as any);
            expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
          });
 

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -14,53 +14,104 @@ import {MockLogger} from '../../../src/ngtsc/logging/testing';
 import {ClassMemberKind, ConcreteDeclaration, CtorParameter, DeclarationKind, DownleveledEnum, Import, InlineDeclaration, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, TypeScriptReflectionHost, TypeValueReferenceKind} from '../../../src/ngtsc/reflection';
 import {getDeclaration} from '../../../src/ngtsc/testing';
 import {loadFakeCore, loadTestFiles} from '../../../test/helpers';
-import {isExportsStatement} from '../../src/host/commonjs_umd_utils';
+import {isExportsDeclaration, isExportsStatement} from '../../src/host/commonjs_umd_utils';
 import {DelegatingReflectionHost} from '../../src/host/delegating_host';
-import {getIifeBody} from '../../src/host/esm2015_host';
 import {NgccReflectionHost} from '../../src/host/ngcc_host';
 import {parseStatementForUmdModule, UmdReflectionHost} from '../../src/host/umd_host';
 import {BundleProgram} from '../../src/packages/bundle_program';
+import {hasNameIdentifier} from '../../src/utils';
 import {getRootFiles, makeTestBundleProgram} from '../helpers/utils';
 
 import {expectTypeValueReferencesForParameters} from './util';
 
 runInEachFileSystem(() => {
-  describe('UmdReflectionHost', () => {
-    let _: typeof absoluteFrom;
+  for (const mode of ['inline exports', 'exported vars']) {
+    describe(`UmdReflectionHost [with ${mode}]`, () => {
+      let _: typeof absoluteFrom;
 
-    let SOME_DIRECTIVE_FILE: TestFile;
-    let TOPLEVEL_DECORATORS_FILE: TestFile;
-    let CTOR_DECORATORS_ARRAY_FILE: TestFile;
-    let SIMPLE_ES2015_CLASS_FILE: TestFile;
-    let SIMPLE_CLASS_FILE: TestFile;
-    let FOO_FUNCTION_FILE: TestFile;
-    let INLINE_EXPORT_FILE: TestFile;
-    let EXPORTS_IDENTIFIERS_FILE: TestFile;
-    let INVALID_DECORATORS_FILE: TestFile;
-    let INVALID_DECORATOR_ARGS_FILE: TestFile;
-    let INVALID_PROP_DECORATORS_FILE: TestFile;
-    let INVALID_PROP_DECORATOR_ARGS_FILE: TestFile;
-    let INVALID_CTOR_DECORATORS_FILE: TestFile;
-    let INVALID_CTOR_DECORATOR_ARGS_FILE: TestFile;
-    let IMPORTS_FILES: TestFile[];
-    let EXPORTS_FILES: TestFile[];
-    let FUNCTION_BODY_FILE: TestFile;
-    let DECORATED_FILES: TestFile[];
-    let TYPINGS_SRC_FILES: TestFile[];
-    let TYPINGS_DTS_FILES: TestFile[];
+      let SOME_DIRECTIVE_FILE: TestFile;
+      let TOPLEVEL_DECORATORS_FILE: TestFile;
+      let CTOR_DECORATORS_ARRAY_FILE: TestFile;
+      let SIMPLE_ES2015_CLASS_FILE: TestFile;
+      let SIMPLE_CLASS_FILE: TestFile;
+      let FOO_FUNCTION_FILE: TestFile;
+      let INLINE_EXPORT_FILE: TestFile;
+      let EXPORTS_IDENTIFIERS_FILE: TestFile;
+      let INVALID_DECORATORS_FILE: TestFile;
+      let INVALID_DECORATOR_ARGS_FILE: TestFile;
+      let INVALID_PROP_DECORATORS_FILE: TestFile;
+      let INVALID_PROP_DECORATOR_ARGS_FILE: TestFile;
+      let INVALID_CTOR_DECORATORS_FILE: TestFile;
+      let INVALID_CTOR_DECORATOR_ARGS_FILE: TestFile;
+      let IMPORTS_FILES: TestFile[];
+      let EXPORTS_FILES: TestFile[];
+      let FUNCTION_BODY_FILE: TestFile;
+      let DECORATED_FILES: TestFile[];
+      let TYPINGS_SRC_FILES: TestFile[];
+      let TYPINGS_DTS_FILES: TestFile[];
 
-    // Helpers
-    const createHost = (bundle: BundleProgram, ngccHost: UmdReflectionHost) => {
-      const tsHost = new TypeScriptReflectionHost(bundle.program.getTypeChecker());
-      return new DelegatingReflectionHost(tsHost, ngccHost);
-    };
+      // Helpers
+      const createHost = (bundle: BundleProgram, ngccHost: UmdReflectionHost) => {
+        const tsHost = new TypeScriptReflectionHost(bundle.program.getTypeChecker());
+        return new DelegatingReflectionHost(tsHost, ngccHost);
+      };
 
-    beforeEach(() => {
-      _ = absoluteFrom;
+      // There are two different forms of UMD export declaration.
+      //
+      // - "exported vars" where there is a variable declaration that is then assigned to the
+      //   `exports` object. For example:
+      //   ```
+      //   var MyClass = <...>;
+      //   exports.MyClass = MyClass;
+      //   ```
+      //
+      // - "inline exports" where there is no intemediate variable declaration. For example:
+      //   ```
+      //   exports.MyClass = <...>;
+      //   ```
 
-      SOME_DIRECTIVE_FILE = {
-        name: _('/some_directive.umd.js'),
-        contents: `
+      // The following helpers allow us to setup code examples to use these two different
+      // approaches.
+
+      /**
+       * Create an export declaration: e.g.
+       *
+       * ```
+       * exports.<name> = <implementation>;
+       * ```
+       *
+       * or
+       *
+       * ```
+       * var <name> = <implementation>;
+       * ```
+       */
+      const expDecl = (name: string, noVar = false) =>
+          mode === 'exported vars' ? `${noVar ? '' : 'var '}${name}` : `exports.${name}`;
+
+      /**
+       * Export a variable that references a declaration (only for when the export was defined as a
+       * variable). For example:
+       *
+       * ```
+       * exports.<name> = <name>;
+       * ```
+       */
+      const varExp = (name: string) => mode === 'exported vars' ? `exports.${name} = ${name};` : '';
+
+      /**
+       * Select a predicate for matching an exported declaration based on whether the code contains
+       * "exported vars" or "inline exports".
+       */
+      const isDesiredDeclaration: typeof hasNameIdentifier =
+          mode === 'exported vars' ? isNamedVariableDeclaration : isExportsDeclaration;
+
+      beforeEach(() => {
+        _ = absoluteFrom;
+
+        SOME_DIRECTIVE_FILE = {
+          name: _('/some_directive.umd.js'),
+          contents: `
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
   typeof define === 'function' && define.amd ? define('some_directive', ['exports', '@angular/core'], factory) :
@@ -71,7 +122,7 @@ runInEachFileSystem(() => {
   var ViewContainerRef = {};
   var TemplateRef = {};
 
-  var SomeDirective = (function() {
+  ${expDecl('SomeDirective')} = (function() {
     function SomeDirective(_viewContainer, _template, injected) {
       this.instanceProperty = 'instance';
     }
@@ -94,13 +145,13 @@ runInEachFileSystem(() => {
     };
     return SomeDirective;
   }());
-  exports.SomeDirective = SomeDirective;
+  ${varExp('SomeDirective')}
 })));`,
-      };
+        };
 
-      TOPLEVEL_DECORATORS_FILE = {
-        name: _('/toplevel_decorators.umd.js'),
-        contents: `
+        TOPLEVEL_DECORATORS_FILE = {
+          name: _('/toplevel_decorators.umd.js'),
+          contents: `
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
   typeof define === 'function' && define.amd ? define('some_directive', ['exports', '@angular/core'], factory) :
@@ -111,105 +162,105 @@ runInEachFileSystem(() => {
   var ViewContainerRef = {};
   var TemplateRef = {};
 
-  var SomeDirective = (function() {
+  ${expDecl('SomeDirective')} = (function() {
     function SomeDirective(_viewContainer, _template, injected) {}
     return SomeDirective;
   }());
-  SomeDirective.decorators = [
+  ${expDecl('SomeDirective', true)}.decorators = [
     { type: core.Directive, args: [{ selector: '[someDirective]' },] }
   ];
-  SomeDirective.ctorParameters = function() { return [
+  ${expDecl('SomeDirective', true)}.ctorParameters = function() { return [
     { type: ViewContainerRef, },
     { type: TemplateRef, },
     { type: undefined, decorators: [{ type: core.Inject, args: [INJECTED_TOKEN,] },] },
   ]; };
-  SomeDirective.propDecorators = {
+  ${expDecl('SomeDirective', true)}.propDecorators = {
     "input1": [{ type: core.Input },],
     "input2": [{ type: core.Input },],
   };
-  exports.SomeDirective = SomeDirective;
+  ${varExp('SomeDirective')}
 })));`,
-      };
+        };
 
-      CTOR_DECORATORS_ARRAY_FILE = {
-        name: _('/ctor_decorated_as_array.js'),
-        contents: `
+        CTOR_DECORATORS_ARRAY_FILE = {
+          name: _('/ctor_decorated_as_array.js'),
+          contents: `
         (function (global, factory) {
           typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
           typeof define === 'function' && define.amd ? define('ctor_decorated_as_array', ['exports', '@angular/core'], factory) :
           (factory(global.ctor_decorated_as_array,global.ng.core));
         }(this, (function (exports,core) { 'use strict';
-            var CtorDecoratedAsArray = (function() {
+          ${expDecl('CtorDecoratedAsArray')} = (function() {
             function CtorDecoratedAsArray(arg1) {
             }
             CtorDecoratedAsArray.ctorParameters = [{ type: ParamType, decorators: [{ type: Inject },] }];
             return CtorDecoratedAsArray;
           }());
-          exports.CtorDecoratedAsArray = CtorDecoratedAsArray;
+          ${varExp('CtorDecoratedAsArray')}
         })));`,
-      };
+        };
 
-      SIMPLE_ES2015_CLASS_FILE = {
-        name: _('/simple_es2015_class.d.ts'),
-        contents: `
+        SIMPLE_ES2015_CLASS_FILE = {
+          name: _('/simple_es2015_class.d.ts'),
+          contents: `
     export class EmptyClass {}
   `,
-      };
+        };
 
-      SIMPLE_CLASS_FILE = {
-        name: _('/simple_class.js'),
-        contents: `
+        SIMPLE_CLASS_FILE = {
+          name: _('/simple_class.js'),
+          contents: `
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
   typeof define === 'function' && define.amd ? define('simple_class', ['exports'], factory) :
   (factory(global.simple_class));
 }(this, (function (exports) { 'use strict';
-  var EmptyClass = (function() {
+  ${expDecl('EmptyClass')} = (function() {
     function EmptyClass() {
     }
     return EmptyClass;
   }());
-  var NoParensClass = function() {
-    function EmptyClass() {
+  ${expDecl('NoParensClass')} = function() {
+    function NoParensClass() {
     }
-    return EmptyClass;
+    return NoParensClass;
   }();
-  var InnerParensClass = (function() {
-    function EmptyClass() {
+  ${expDecl('InnerParensClass')} = (function() {
+    function InnerParensClass() {
     }
-    return EmptyClass;
+    return InnerParensClass;
   })();
-  var NoDecoratorConstructorClass = (function() {
+  ${expDecl('NoDecoratorConstructorClass')} = (function() {
     function NoDecoratorConstructorClass(foo) {
     }
     return NoDecoratorConstructorClass;
   }());
-  var OuterClass1 = (function() {
+  ${expDecl('OuterClass1')} = (function() {
     function InnerClass1() {
     }
     return InnerClass1;
   }());
-  var OuterClass2 = (function() {
+  ${expDecl('OuterClass2')} = (function() {
     function InnerClass2() {
     }
     InnerClass2_1 = InnerClass12
     var InnerClass2_1;
     return InnerClass2;
   }());
-  var SuperClass = (function() { function SuperClass() {} return SuperClass; }());
-  var ChildClass = /** @class */ (function (_super) {
-    __extends(ChildClass, _super);
+  ${expDecl('SuperClass')} = (function() { function SuperClass() {} return SuperClass; }());
+  ${expDecl('ChildClass')} = /** @class */ (function (_super) {
+  __extends(InnerChildClass, _super);
     function InnerChildClass() {}
     return InnerChildClass;
   }(SuperClass);
-  exports.EmptyClass = EmptyClass;
-  exports.NoDecoratorConstructorClass = NoDecoratorConstructorClass;
+  ${varExp('EmptyClass')}
+  ${varExp('NoDecoratorConstructorClass')}
 })));`,
-      };
+        };
 
-      FOO_FUNCTION_FILE = {
-        name: _('/foo_function.js'),
-        contents: `
+        FOO_FUNCTION_FILE = {
+          name: _('/foo_function.js'),
+          contents: `
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
   typeof define === 'function' && define.amd ? define('foo_function', ['exports', '@angular/core'], factory) :
@@ -219,13 +270,13 @@ runInEachFileSystem(() => {
   foo.decorators = [
     { type: core.Directive, args: [{ selector: '[ignored]' },] }
   ];
-  exports.foo = foo;
+  ${varExp('foo')}
 })));`,
-      };
+        };
 
-      INLINE_EXPORT_FILE = {
-        name: _('/inline_export.js'),
-        contents: `
+        INLINE_EXPORT_FILE = {
+          name: _('/inline_export.js'),
+          contents: `
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
   typeof define === 'function' && define.amd ? define('foo_function', ['exports', '@angular/core'], factory) :
@@ -238,11 +289,11 @@ runInEachFileSystem(() => {
   exports.directives = [foo];
 })));
 `,
-      };
+        };
 
-      EXPORTS_IDENTIFIERS_FILE = {
-        name: _('/exports_identifiers.js'),
-        contents: `
+        EXPORTS_IDENTIFIERS_FILE = {
+          name: _('/exports_identifiers.js'),
+          contents: `
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
   typeof define === 'function' && define.amd ? define('foo_function', ['exports', '@angular/core'], factory) :
@@ -265,17 +316,17 @@ runInEachFileSystem(() => {
   }
 })));
 `,
-      };
+        };
 
-      INVALID_DECORATORS_FILE = {
-        name: _('/invalid_decorators.js'),
-        contents: `
+        INVALID_DECORATORS_FILE = {
+          name: _('/invalid_decorators.js'),
+          contents: `
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
   typeof define === 'function' && define.amd ? define('invalid_decorators', ['exports', '@angular/core'], factory) :
   (factory(global.invalid_decorators, global.ng.core));
 }(this, (function (exports,core) { 'use strict';
-  var NotArrayLiteral = (function() {
+  ${expDecl('NotArrayLiteral')} = (function() {
     function NotArrayLiteral() {
     }
     NotArrayLiteral.decorators = () => [
@@ -284,7 +335,7 @@ runInEachFileSystem(() => {
     return NotArrayLiteral;
   }());
 
-  var NotObjectLiteral = (function() {
+  ${expDecl('NotObjectLiteral')} = (function() {
     function NotObjectLiteral() {
     }
     NotObjectLiteral.decorators = [
@@ -294,7 +345,7 @@ runInEachFileSystem(() => {
     return NotObjectLiteral;
   }());
 
-  var NoTypeProperty = (function() {
+  ${expDecl('NoTypeProperty')} = (function() {
     function NoTypeProperty() {
     }
     NoTypeProperty.decorators = [
@@ -304,7 +355,7 @@ runInEachFileSystem(() => {
     return NoTypeProperty;
   }());
 
-  var NotIdentifier = (function() {
+  ${expDecl('NotIdentifier')} = (function() {
     function NotIdentifier() {
     }
     NotIdentifier.decorators = [
@@ -314,17 +365,17 @@ runInEachFileSystem(() => {
     return NotIdentifier;
   }());
 })));`,
-      };
+        };
 
-      INVALID_DECORATOR_ARGS_FILE = {
-        name: _('/invalid_decorator_args.js'),
-        contents: `
+        INVALID_DECORATOR_ARGS_FILE = {
+          name: _('/invalid_decorator_args.js'),
+          contents: `
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
   typeof define === 'function' && define.amd ? define('invalid_decorator_args', ['exports', '@angular/core'], factory) :
   (factory(global.invalid_decorator_args, global.ng.core));
 }(this, (function (exports,core) { 'use strict';
-  var NoArgsProperty = (function() {
+  ${expDecl('NoArgsProperty')} = (function() {
     function NoArgsProperty() {
     }
     NoArgsProperty.decorators = [
@@ -334,7 +385,7 @@ runInEachFileSystem(() => {
   }());
 
   var args = [{ selector: '[ignored]' },];
-  var NoPropertyAssignment = (function() {
+  ${expDecl('NoPropertyAssignment')} = (function() {
     function NoPropertyAssignment() {
     }
     NoPropertyAssignment.decorators = [
@@ -343,7 +394,7 @@ runInEachFileSystem(() => {
     return NoPropertyAssignment;
   }());
 
-  var NotArrayLiteral = (function() {
+  ${expDecl('NotArrayLiteral')} = (function() {
     function NotArrayLiteral() {
     }
     NotArrayLiteral.decorators = [
@@ -352,17 +403,17 @@ runInEachFileSystem(() => {
     return NotArrayLiteral;
   }());
 })));`,
-      };
+        };
 
-      INVALID_PROP_DECORATORS_FILE = {
-        name: _('/invalid_prop_decorators.js'),
-        contents: `
+        INVALID_PROP_DECORATORS_FILE = {
+          name: _('/invalid_prop_decorators.js'),
+          contents: `
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
   typeof define === 'function' && define.amd ? define('invalid_prop_decorators', ['exports', '@angular/core'], factory) :
   (factory(global.invalid_prop_decorators, global.ng.core));
 }(this, (function (exports,core) { 'use strict';
-  var NotObjectLiteral = (function() {
+  ${expDecl('NotObjectLiteral')} = (function() {
     function NotObjectLiteral() {
     }
     NotObjectLiteral.propDecorators = () => ({
@@ -371,7 +422,7 @@ runInEachFileSystem(() => {
     return NotObjectLiteral;
   }());
 
-  var NotObjectLiteralProp = (function() {
+  ${expDecl('NotObjectLiteralProp')} = (function() {
     function NotObjectLiteralProp() {
     }
     NotObjectLiteralProp.propDecorators = {
@@ -383,7 +434,7 @@ runInEachFileSystem(() => {
     return NotObjectLiteralProp;
   }());
 
-  var NoTypeProperty = (function() {
+  ${expDecl('NoTypeProperty')} = (function() {
     function NoTypeProperty() {
     }
     NoTypeProperty.propDecorators = {
@@ -395,7 +446,7 @@ runInEachFileSystem(() => {
     return NoTypeProperty;
   }());
 
-  var NotIdentifier = (function() {
+  ${expDecl('NotIdentifier')} = (function() {
     function NotIdentifier() {
     }
     NotIdentifier.propDecorators = {
@@ -407,17 +458,17 @@ runInEachFileSystem(() => {
     return NotIdentifier;
   }());
 })));`,
-      };
+        };
 
-      INVALID_PROP_DECORATOR_ARGS_FILE = {
-        name: _('/invalid_prop_decorator_args.js'),
-        contents: `
+        INVALID_PROP_DECORATOR_ARGS_FILE = {
+          name: _('/invalid_prop_decorator_args.js'),
+          contents: `
   (function (global, factory) {
     typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
     typeof define === 'function' && define.amd ? define('invalid_prop_decorator_args', ['exports', '@angular/core'], factory) :
     (factory(global.invalid_prop_decorator_args, global.ng.core));
   }(this, (function (exports,core) { 'use strict';
-  var NoArgsProperty = (function() {
+  ${expDecl('NoArgsProperty')} = (function() {
     function NoArgsProperty() {
     }
     NoArgsProperty.propDecorators = {
@@ -427,7 +478,7 @@ runInEachFileSystem(() => {
   }());
 
   var args = [{ selector: '[ignored]' },];
-  var NoPropertyAssignment = (function() {
+  ${expDecl('NoPropertyAssignment')} = (function() {
     function NoPropertyAssignment() {
     }
     NoPropertyAssignment.propDecorators = {
@@ -436,7 +487,7 @@ runInEachFileSystem(() => {
     return NoPropertyAssignment;
   }());
 
-  var NotArrayLiteral = (function() {
+  ${expDecl('NotArrayLiteral')} = (function() {
     function NotArrayLiteral() {
     }
     NotArrayLiteral.propDecorators = {
@@ -445,29 +496,29 @@ runInEachFileSystem(() => {
     return NotArrayLiteral;
   }());
 })));`,
-      };
+        };
 
-      INVALID_CTOR_DECORATORS_FILE = {
-        name: _('/invalid_ctor_decorators.js'),
-        contents: `
+        INVALID_CTOR_DECORATORS_FILE = {
+          name: _('/invalid_ctor_decorators.js'),
+          contents: `
   (function (global, factory) {
     typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
     typeof define === 'function' && define.amd ? define('invalid_ctor_decorators', ['exports', '@angular/core'], factory) :
     (factory(global.invalid_ctor_decorators,global.ng.core));
   }(this, (function (exports,core) { 'use strict';
-    var NoParameters = (function() {
+    ${expDecl('NoParameters')} = (function() {
     function NoParameters() {}
     return NoParameters;
   }());
 
-  var NotArrayLiteral = (function() {
+  ${expDecl('NotArrayLiteral')} = (function() {
     function NotArrayLiteral(arg1) {
     }
     NotArrayLiteral.ctorParameters = function() { return 'StringsAreNotArrayLiterals'; };
     return NotArrayLiteral;
   }());
 
-  var NotObjectLiteral = (function() {
+  ${expDecl('NotObjectLiteral')} = (function() {
     function NotObjectLiteral(arg1, arg2) {
     }
     NotObjectLiteral.ctorParameters = function() { return [
@@ -477,7 +528,7 @@ runInEachFileSystem(() => {
     return NotObjectLiteral;
   }());
 
-  var NoTypeProperty = (function() {
+  ${expDecl('NoTypeProperty')} = (function() {
     function NoTypeProperty(arg1, arg2) {
     }
     NoTypeProperty.ctorParameters = function() { return [
@@ -492,7 +543,7 @@ runInEachFileSystem(() => {
     return NoTypeProperty;
   }());
 
-  var NotIdentifier = (function() {
+  ${expDecl('NotIdentifier')} = (function() {
     function NotIdentifier(arg1, arg2) {
     }
     NotIdentifier.ctorParameters = function() { return [
@@ -507,17 +558,17 @@ runInEachFileSystem(() => {
     return NotIdentifier;
   }());
 })));`,
-      };
+        };
 
-      INVALID_CTOR_DECORATOR_ARGS_FILE = {
-        name: _('/invalid_ctor_decorator_args.js'),
-        contents: `
+        INVALID_CTOR_DECORATOR_ARGS_FILE = {
+          name: _('/invalid_ctor_decorator_args.js'),
+          contents: `
   (function (global, factory) {
     typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
     typeof define === 'function' && define.amd ? define('invalid_ctor_decorator_args', ['exports', '@angular/core'], factory) :
     (factory(global.invalid_ctor_decorator_args,global.ng.core));
   }(this, (function (exports,core) { 'use strict';
-    var NoArgsProperty = (function() {
+    ${expDecl('NoArgsProperty')} = (function() {
     function NoArgsProperty(arg1) {
     }
     NoArgsProperty.ctorParameters = function() { return [
@@ -527,7 +578,7 @@ runInEachFileSystem(() => {
   }());
 
   var args = [{ selector: '[ignored]' },];
-  var NoPropertyAssignment = (function() {
+  ${expDecl('NoPropertyAssignment')} = (function() {
     function NoPropertyAssignment(arg1) {
     }
     NoPropertyAssignment.ctorParameters = function() { return [
@@ -536,7 +587,7 @@ runInEachFileSystem(() => {
     return NoPropertyAssignment;
   }());
 
-  var NotArrayLiteral = (function() {
+  ${expDecl('NotArrayLiteral')} = (function() {
     function NotArrayLiteral(arg1) {
     }
     NotArrayLiteral.ctorParameters = function() { return [
@@ -545,34 +596,34 @@ runInEachFileSystem(() => {
     return NotArrayLiteral;
   }());
 })));`,
-      };
+        };
 
-      IMPORTS_FILES = [
-        {
-          name: _('/index.js'),
-          contents: `
+        IMPORTS_FILES = [
+          {
+            name: _('/index.js'),
+            contents: `
           (function (global, factory) {
             typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('./file_a'), require('./file_b'), require('./file_c')) :
             typeof define === 'function' && define.amd ? define('index', ['exports', './file_a', './file_b', './file_c'], factory) :
             (factory(global.index, global.file_a, global.file_b, global.file_c));
           }(this, (function (exports, file_a, file_b, file_c) { 'use strict';
           })));`,
-        },
-        {
-          name: _('/file_a.js'),
-          contents: `
+          },
+          {
+            name: _('/file_a.js'),
+            contents: `
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
   typeof define === 'function' && define.amd ? define('file_a', ['exports'], factory) :
   (factory(global.file_a));
 }(this, (function (exports) { 'use strict';
   var a = 'a';
-  exports.a = a;
+  ${varExp('a')}
 })));`,
-        },
-        {
-          name: _('/file_b.js'),
-          contents: `
+          },
+          {
+            name: _('/file_b.js'),
+            contents: `
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('./file_a')) :
   typeof define === 'function' && define.amd ? define('file_b', ['exports', './file_a'], factory) :
@@ -582,10 +633,10 @@ runInEachFileSystem(() => {
   var c = 'c';
   var d = c;
 })));`,
-        },
-        {
-          name: _('/file_c.js'),
-          contents: `
+          },
+          {
+            name: _('/file_c.js'),
+            contents: `
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('./file_a')) :
   typeof define === 'function' && define.amd ? define('file_c', ['exports', 'file_a'], factory) :
@@ -593,122 +644,146 @@ runInEachFileSystem(() => {
 }(this, function (exports, file_a) { 'use strict';
   var c = file_a.a;
 }));`,
-        },
-      ];
+          },
+        ];
 
-      EXPORTS_FILES = [
-        {
-          name: _('/index.js'),
-          contents: `(function (global, factory) {\n` +
-              `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('./a_module'), require('./b_module'), require('./wildcard_reexports'), require('./wildcard_reexports_imported_helpers'), require('./wildcard_reexports_with_require'), require('./define_property_reexports')) :\n` +
-              `  typeof define === 'function' && define.amd ? define('index', ['exports', './a_module', './b_module', './wildcard_reexports', './wildcard_reexports_imported_helpers', './wildcard_reexports_with_require', './define_property_reexports'], factory) :\n` +
-              `  (factory(global.index, global.a_module, global.b_module, global.wildcard_reexports, global.wildcard_reexports_imported_helpers, global.wildcard_reexports_with_require, global.define_property_reexports));\n` +
-              `}(this, (function (exports, a_module, b_module, wildcard_reexports, wildcard_reexports_imported_helpers, wildcard_reexports_with_require, define_property_reexports) { 'use strict';\n` +
-              `})));\n`
-        },
-        {
-          name: _('/a_module.js'),
-          contents: `(function (global, factory) {\n` +
-              `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :\n` +
-              `  typeof define === 'function' && define.amd ? define('a_module', ['exports'], factory) :\n` +
-              `  (factory(global.a_module));\n` +
-              `}(this, (function (exports) { 'use strict';\n` +
-              `  var a = 'a';\n` +
-              `  exports.a = a;\n` +
-              `})));\n`,
-        },
-        {
-          name: _('/b_module.js'),
-          contents: `(function (global, factory) {\n` +
-              `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core'), require('./a_module')) :\n` +
-              `  typeof define === 'function' && define.amd ? define('b_module', ['exports', '@angular/core', './a_module'], factory) :\n` +
-              `  (factory(global.b_module));\n` +
-              `}(this, (function (exports, core, a_module) { 'use strict';\n` +
-              `  var b = a_module.a;\n` +
-              `  var e = 'e';\n` +
-              `  var SomeClass = (function() {\n` +
-              `    function SomeClass() {}\n` +
-              `    return SomeClass;\n` +
-              `  }());\n` +
-              `\n` +
-              `  exports.Directive = core.Directive;\n` +
-              `  exports.a = a_module.a;\n` +
-              `  exports.b = b;\n` +
-              `  exports.c = a_module.a;\n` +
-              `  exports.d = b;\n` +
-              `  exports.e = e;\n` +
-              `  exports.DirectiveX = core.Directive;\n` +
-              `  var SomeClass_1;\n` +
-              `  exports.SomeClass = SomeClass_1 = SomeClass;\n` +
-              `})));\n`,
-        },
-        {
-          name: _('/xtra_module.js'),
-          contents: `(function (global, factory) {\n` +
-              `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :\n` +
-              `  typeof define === 'function' && define.amd ? define('xtra_module', ['exports'], factory) :\n` +
-              `  (factory(global.xtra_module));\n` +
-              `}(this, (function (exports) { 'use strict';\n` +
-              `  var xtra1 = 'xtra1';\n` +
-              `  var xtra2 = 'xtra2';\n` +
-              `  exports.xtra1 = xtra1;\n` +
-              `  exports.xtra2 = xtra2;\n` +
-              `})));\n`,
-        },
-        {
-          name: _('/wildcard_reexports.js'),
-          contents: `(function (global, factory) {\n` +
-              `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('./b_module'), require('./xtra_module')) :\n` +
-              `  typeof define === 'function' && define.amd ? define('wildcard_reexports', ['exports', './b_module', './xtra_module'], factory) :\n` +
-              `  (factory(global.wildcard_reexports, b_module, xtra_module));\n` +
-              `}(this, (function (exports, b_module, xtra_module) { 'use strict';\n` +
-              `  function __export(m) {\n` +
-              `    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];\n` +
-              `  }\n` +
-              `  __export(b_module);\n` +
-              `  __export(xtra_module);\n` +
-              `})));\n`,
-        },
-        {
-          name: _('/wildcard_reexports_imported_helpers.js'),
-          contents: `(function (global, factory) {\n` +
-              `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('tslib'), require('./b_module'), require('./xtra_module')) :\n` +
-              `  typeof define === 'function' && define.amd ? define('wildcard_reexports', ['exports', 'tslib', './b_module', './xtra_module'], factory) :\n` +
-              `  (factory(global.wildcard_reexports_imported_helpers, tslib, b_module, xtra_module));\n` +
-              `}(this, (function (exports, tslib, b_module, xtra_module) { 'use strict';\n` +
-              `  tslib.__exportStar(b_module, exports);\n` +
-              `  tslib.__exportStar(xtra_module, exports);\n` +
-              `})));\n`,
-        },
-        {
-          name: _('/wildcard_reexports_with_require.js'),
-          contents: `(function (global, factory) {\n` +
-              `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(require, exports) :\n` +
-              `  typeof define === 'function' && define.amd ? define('wildcard_reexports_with_require', ['require', 'exports'], factory);\n` +
-              `}(this, (function (require, exports) { 'use strict';\n` +
-              `  function __export(m) {\n` +
-              `    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];\n` +
-              `  }\n` +
-              `  var b_module = require('./b_module');\n` +
-              `  __export(b_module);\n` +
-              `  __export(require('./xtra_module'));\n` +
-              `})));\n`,
-        },
-        {
-          name: _('/define_property_reexports.js'),
-          contents: `(function (global, factory) {\n` +
-              `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(require, exports) :\n` +
-              `  typeof define === 'function' && define.amd ? define('define_property_reexports', ['require', 'exports'], factory);\n` +
-              `}(this, (function (require, exports) { 'use strict';\n` +
-              `var moduleA = require("./a_module");\n` +
-              `Object.defineProperty(exports, "newA", { enumerable: true, get: function () { return moduleA.a; } });\n` +
-              `})));`,
-        },
-      ];
+        EXPORTS_FILES = [
+          {
+            name: _('/index.js'),
+            contents: `(function (global, factory) {\n` +
+                `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('./a_module'), require('./b_module'), require('./wildcard_reexports'), require('./wildcard_reexports_imported_helpers'), require('./wildcard_reexports_with_require'), require('./define_property_reexports')) :\n` +
+                `  typeof define === 'function' && define.amd ? define('index', ['exports', './a_module', './b_module', './wildcard_reexports', './wildcard_reexports_imported_helpers', './wildcard_reexports_with_require', './define_property_reexports'], factory) :\n` +
+                `  (factory(global.index, global.a_module, global.b_module, global.wildcard_reexports, global.wildcard_reexports_imported_helpers, global.wildcard_reexports_with_require, global.define_property_reexports));\n` +
+                `}(this, (function (exports, a_module, b_module, wildcard_reexports, wildcard_reexports_imported_helpers, wildcard_reexports_with_require, define_property_reexports) { 'use strict';\n` +
+                `})));\n`
+          },
+          {
+            name: _('/a_module.js'),
+            contents: `(function (global, factory) {\n` +
+                `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :\n` +
+                `  typeof define === 'function' && define.amd ? define('a_module', ['exports'], factory) :\n` +
+                `  (factory(global.a_module));\n` +
+                `}(this, (function (exports) { 'use strict';\n` +
+                `  var a = 'a';\n` +
+                `  exports.a = a;\n` +
+                `})));\n`,
+          },
+          {
+            name: _('/b_module.js'),
+            contents: `(function (global, factory) {\n` +
+                `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core'), require('./a_module')) :\n` +
+                `  typeof define === 'function' && define.amd ? define('b_module', ['exports', '@angular/core', './a_module'], factory) :\n` +
+                `  (factory(global.b_module));\n` +
+                `}(this, (function (exports, core, a_module) { 'use strict';\n` +
+                `  var b = a_module.a;\n` +
+                `  var e = 'e';\n` +
+                `  var SomeClass = (function() {\n` +
+                `    function SomeClass() {}\n` +
+                `    return SomeClass;\n` +
+                `  }());\n` +
+                `\n` +
+                `  exports.Directive = core.Directive;\n` +
+                `  exports.a = a_module.a;\n` +
+                `  exports.b = b;\n` +
+                `  exports.c = a_module.a;\n` +
+                `  exports.d = b;\n` +
+                `  exports.e = e;\n` +
+                `  exports.DirectiveX = core.Directive;\n` +
+                `  var SomeClass_1;\n` +
+                `  exports.SomeClass = SomeClass_1 = SomeClass;\n` +
+                `})));\n`,
+          },
+          {
+            name: _('/xtra_module.js'),
+            contents: `(function (global, factory) {\n` +
+                `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :\n` +
+                `  typeof define === 'function' && define.amd ? define('xtra_module', ['exports'], factory) :\n` +
+                `  (factory(global.xtra_module));\n` +
+                `}(this, (function (exports) { 'use strict';\n` +
+                `  var xtra1 = 'xtra1';\n` +
+                `  var xtra2 = 'xtra2';\n` +
+                `  exports.xtra1 = xtra1;\n` +
+                `  exports.xtra2 = xtra2;\n` +
+                `})));\n`,
+          },
+          {
+            name: _('/wildcard_reexports.js'),
+            contents: `(function (global, factory) {\n` +
+                `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('./b_module'), require('./xtra_module')) :\n` +
+                `  typeof define === 'function' && define.amd ? define('wildcard_reexports', ['exports', './b_module', './xtra_module'], factory) :\n` +
+                `  (factory(global.wildcard_reexports, b_module, xtra_module));\n` +
+                `}(this, (function (exports, b_module, xtra_module) { 'use strict';\n` +
+                `  function __export(m) {\n` +
+                `    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];\n` +
+                `  }\n` +
+                `  __export(b_module);\n` +
+                `  __export(xtra_module);\n` +
+                `})));\n`,
+          },
+          {
+            name: _('/wildcard_reexports_imported_helpers.js'),
+            contents: `(function (global, factory) {\n` +
+                `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('tslib'), require('./b_module'), require('./xtra_module')) :\n` +
+                `  typeof define === 'function' && define.amd ? define('wildcard_reexports', ['exports', 'tslib', './b_module', './xtra_module'], factory) :\n` +
+                `  (factory(global.wildcard_reexports_imported_helpers, tslib, b_module, xtra_module));\n` +
+                `}(this, (function (exports, tslib, b_module, xtra_module) { 'use strict';\n` +
+                `  tslib.__exportStar(b_module, exports);\n` +
+                `  tslib.__exportStar(xtra_module, exports);\n` +
+                `})));\n`,
+          },
+          {
+            name: _('/wildcard_reexports_with_require.js'),
+            contents: `(function (global, factory) {\n` +
+                `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(require, exports) :\n` +
+                `  typeof define === 'function' && define.amd ? define('wildcard_reexports_with_require', ['require', 'exports'], factory);\n` +
+                `}(this, (function (require, exports) { 'use strict';\n` +
+                `  function __export(m) {\n` +
+                `    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];\n` +
+                `  }\n` +
+                `  var b_module = require('./b_module');\n` +
+                `  __export(b_module);\n` +
+                `  __export(require('./xtra_module'));\n` +
+                `})));\n`,
+          },
+          {
+            name: _('/define_property_reexports.js'),
+            contents: `(function (global, factory) {\n` +
+                `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(require, exports) :\n` +
+                `  typeof define === 'function' && define.amd ? define('define_property_reexports', ['require', 'exports'], factory);\n` +
+                `}(this, (function (require, exports) { 'use strict';\n` +
+                `var moduleA = require("./a_module");\n` +
+                `Object.defineProperty(exports, "newA", { enumerable: true, get: function () { return moduleA.a; } });\n` +
+                `})));`,
+          },
+          {
+            name: _('/decorated_class.js'),
+            contents: `(function (global, factory) {\n` +
+                `  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :\n` +
+                `  typeof define === 'function' && define.amd ? define('decorated_class', ['exports'], factory) :\n` +
+                `  (factory(global.decorated_class));\n` +
+                `}(this, (function (exports) { 'use strict';\n` +
+                `var DecoratedClass_1;\n` +
+                `\n` +
+                `exports.DecoratedClass = DecoratedClass_1 = (function() {\n` +
+                `  function DecoratedClass() {\n` +
+                `  }\n` +
+                `  return DecoratedClass;\n` +
+                `}());\n` +
+                `\n` +
+                `exports.DecoratedClass = DecoratedClass_1 = __decorate([\n` +
+                `  SomeDecorator([ej2AngularBase.ComponentBase, ej2AngularBase.FormBase]),\n` +
+                `  __metadata("design:paramtypes", [core.ElementRef,\n` +
+                `      core.Renderer2,\n` +
+                `      core.ViewContainerRef,\n` +
+                `      core.Injector])\n` +
+                `], exports.DecoratedClass);\n` +
+                `})));\n`,
+          }
+        ];
 
-      FUNCTION_BODY_FILE = {
-        name: _('/function_body.js'),
-        contents: `
+        FUNCTION_BODY_FILE = {
+          name: _('/function_body.js'),
+          contents: `
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
   typeof define === 'function' && define.amd ? define('function_body', ['exports'], factory) :
@@ -746,67 +821,67 @@ runInEachFileSystem(() => {
     return x;
   }
 })));`
-      };
+        };
 
-      DECORATED_FILES = [
-        {
-          name: _('/primary.js'),
-          contents: `
+        DECORATED_FILES = [
+          {
+            name: _('/primary.js'),
+            contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core'), require('./secondary')) :
       typeof define === 'function' && define.amd ? define('primary', ['exports', '@angular/core', './secondary'], factory) :
       (factory(global.primary,global.ng.core, global.secondary));
     }(this, (function (exports,core,secondary) { 'use strict';
-    var A = (function() {
+    ${expDecl('A')} = (function() {
       function A() {}
       A.decorators = [
         { type: core.Directive, args: [{ selector: '[a]' }] }
       ];
       return A;
     }());
-     var B = (function() {
+    var B = (function() {
       function B() {}
       B.decorators = [
         { type: core.Directive, args: [{ selector: '[b]' }] }
       ];
       return B;
     }());
-     function x() {}
-     function y() {}
-     var C = (function() {
+    function x() {}
+    function y() {}
+    ${expDecl('C')} = (function() {
       function C() {}
       return C;
     });
-    exports.A = A;
+    ${varExp('A')}
     exports.x = x;
-    exports.C = C;
+    ${varExp('C')}
     })));`
-        },
-        {
-          name: _('/secondary.js'),
-          contents: `
+          },
+          {
+            name: _('/secondary.js'),
+            contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
       typeof define === 'function' && define.amd ? define('primary', ['exports', '@angular/core'], factory) :
       (factory(global.primary,global.ng.core));
     }(this, (function (exports,core) { 'use strict';
-    var D = (function() {
+    ${expDecl('D')} = (function() {
       function D() {}
       D.decorators = [
         { type: core.Directive, args: [{ selector: '[d]' }] }
       ];
       return D;
     }());
-    exports.D = D;
+    ${varExp('D')}
   })));
     `
-        }
-      ];
+          }
+        ];
 
-      TYPINGS_SRC_FILES = [
-        {
-          name: _('/ep/src/index.js'),
-          contents: `
+        TYPINGS_SRC_FILES = [
+          {
+            name: _('/ep/src/index.js'),
+            contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('./internal'), require('./class1'), require('./class2'), require('./missing-class'), require('./flat-file'), require('./func1')) :
       typeof define === 'function' && define.amd ? define('index', ['exports', './internal', './class1', './class2', './missing-class', './flat-file', './func1'], factory) :
@@ -820,98 +895,111 @@ runInEachFileSystem(() => {
       __export(class2);
     })));
     `
-        },
-        {
-          name: _('/ep/src/class1.js'),
-          contents: `
+          },
+          {
+            name: _('/ep/src/class1.js'),
+            contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
       typeof define === 'function' && define.amd ? define('class1', ['exports'], factory) :
       (factory(global.class1));
     }(this, (function (exports) { 'use strict';
-      var Class1 = (function() {
+      ${expDecl('Class1')} = (function() {
         function Class1() {}
         return Class1;
       }());
-      var MissingClass1 = (function() {
+      ${expDecl('MissingClass1')} = (function() {
         function MissingClass1() {}
         return MissingClass1;
       }());
-      exports.Class1 = Class1;
-      exports.MissingClass1 = MissingClass1;
+      ${varExp('Class1')}
+      ${varExp('MissingClass1')}
     })));
     `
-        },
-        {
-          name: _('/ep/src/class2.js'),
-          contents: `
+          },
+          {
+            name: _('/ep/src/class2.js'),
+            contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
       typeof define === 'function' && define.amd ? define('class2', ['exports'], factory) :
       (factory(global.class2));
     }(this, (function (exports) { 'use strict';
-      var Class2 = (function() {
+      ${expDecl('Class2')} = (function() {
         function Class2() {}
         return Class2;
       }());
-      exports.Class2 = Class2;
+      ${varExp('Class2')}
     })));
     `
-        },
-        {name: _('/ep/src/func1.js'), contents: 'function mooFn() {} export {mooFn}'}, {
-          name: _('/ep/src/internal.js'),
-          contents: `
+          },
+          {
+            name: _('/ep/src/func1.js'),
+            contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
       typeof define === 'function' && define.amd ? define('internal', ['exports'], factory) :
       (factory(global.internal));
     }(this, (function (exports) { 'use strict';
-      var InternalClass = (function() {
+      function mooFn() {}
+      exports.mooFn = mooFn;
+    })));
+    `
+          },
+          {
+            name: _('/ep/src/internal.js'),
+            contents: `
+    (function (global, factory) {
+      typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+      typeof define === 'function' && define.amd ? define('internal', ['exports'], factory) :
+      (factory(global.internal));
+    }(this, (function (exports) { 'use strict';
+      ${expDecl('InternalClass')} = (function() {
         function InternalClass() {}
         return InternalClass;
       }());
-      var Class2 = (function() {
+      ${expDecl('Class2')} = (function() {
         function Class2() {}
         return Class2;
       }());
-      exports.InternalClass =InternalClass;
-      exports.Class2 = Class2;
+      ${varExp('InternalClass')}
+      ${varExp('Class2')}
     })));
     `
-        },
-        {
-          name: _('/ep/src/missing-class.js'),
-          contents: `
+          },
+          {
+            name: _('/ep/src/missing-class.js'),
+            contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
       typeof define === 'function' && define.amd ? define('missingClass', ['exports'], factory) :
       (factory(global.missingClass));
     }(this, (function (exports) { 'use strict';
-      var MissingClass2 = (function() {
+      ${expDecl('MissingClass2')} = (function() {
         function MissingClass2() {}
         return MissingClass2;
       }());
       exports. MissingClass2 = MissingClass2;
     })));
     `
-        },
-        {
-          name: _('/ep/src/flat-file.js'),
-          contents: `
+          },
+          {
+            name: _('/ep/src/flat-file.js'),
+            contents: `
     (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
       typeof define === 'function' && define.amd ? define('missingClass', ['exports'], factory) :
       (factory(global.missingClass));
     }(this, (function (exports) { 'use strict';
-      var Class1 = (function() {
+      ${expDecl('Class1')} = (function() {
         function Class1() {}
         return Class1;
       }());
-      var MissingClass1 = (function() {
+      ${expDecl('MissingClass1')} = (function() {
         function MissingClass1() {}
         return MissingClass1;
       }());
-      var MissingClass2 = (function() {
+      ${expDecl('MissingClass2')} = (function() {
         function MissingClass2() {}
         return MissingClass2;
       }());
@@ -919,157 +1007,380 @@ runInEachFileSystem(() => {
         function SourceClass() {}
         return SourceClass;
       }());
-    exports.Class1 = Class1;
+      ${varExp('Class1')}
       exports.AliasedClass = SourceClass;
-      exports.MissingClass1 = MissingClass1;
-      exports.MissingClass2 = MissingClass2;
+      ${varExp('MissingClass1')}
+      ${varExp('MissingClass2')}
     })));
     `
-        }
-      ];
+          }
+        ];
 
-      TYPINGS_DTS_FILES = [
-        {
-          name: _('/ep/typings/index.d.ts'),
-          contents: `
+        TYPINGS_DTS_FILES = [
+          {
+            name: _('/ep/typings/index.d.ts'),
+            contents: `
             import '../../an_external_lib/index';
             import {InternalClass} from './internal';
             import {mooFn} from './func1';
             export * from './class1';
             export * from './class2';
             `
-        },
-        {
-          name: _('/ep/typings/class1.d.ts'),
-          contents: `export declare class Class1 {}\nexport declare class OtherClass {}`
-        },
-        {
-          name: _('/ep/typings/class2.d.ts'),
-          contents: `
+          },
+          {
+            name: _('/ep/typings/class1.d.ts'),
+            contents: `export declare class Class1 {}\nexport declare class OtherClass {}`
+          },
+          {
+            name: _('/ep/typings/class2.d.ts'),
+            contents: `
             export declare class Class2 {}
             export declare interface SomeInterface {}
             export {TypingsClass as AliasedClass} from './typings-class';
           `
-        },
-        {name: _('/ep/typings/func1.d.ts'), contents: 'export declare function mooFn(): void;'},
-        {
-          name: _('/ep/typings/internal.d.ts'),
-          contents: `export declare class InternalClass {}\nexport declare class Class2 {}`
-        },
-        {
-          name: _('/ep/typings/typings-class.d.ts'),
-          contents: `export declare class TypingsClass {}`
-        },
-        {name: _('/ep/typings/shadow-class.d.ts'), contents: `export declare class ShadowClass {}`},
-        {name: _('/an_external_lib/index.d.ts'), contents: 'export declare class ShadowClass {}'},
-      ];
-    });
-
-    describe('getDecoratorsOfDeclaration()', () => {
-      it('should find the decorators on a class', () => {
-        loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
-
-        expect(decorators).toBeDefined();
-        expect(decorators.length).toEqual(1);
-
-        const decorator = decorators[0];
-        expect(decorator.name).toEqual('Directive');
-        expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
-        expect(decorator.args!.map(arg => arg.getText())).toEqual([
-          '{ selector: \'[someDirective]\' }',
-        ]);
+          },
+          {name: _('/ep/typings/func1.d.ts'), contents: 'export declare function mooFn(): void;'},
+          {
+            name: _('/ep/typings/internal.d.ts'),
+            contents: `export declare class InternalClass {}\nexport declare class Class2 {}`
+          },
+          {
+            name: _('/ep/typings/typings-class.d.ts'),
+            contents: `export declare class TypingsClass {}`
+          },
+          {
+            name: _('/ep/typings/shadow-class.d.ts'),
+            contents: `export declare class ShadowClass {}`
+          },
+          {name: _('/an_external_lib/index.d.ts'), contents: 'export declare class ShadowClass {}'},
+        ];
       });
 
-      it('should find the decorators on a class at the top level', () => {
-        loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
-        const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
-            isNamedVariableDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
+      describe('getDecoratorsOfDeclaration()', () => {
+        it('should find the decorators on a class', () => {
+          loadTestFiles([SOME_DIRECTIVE_FILE]);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isDesiredDeclaration);
+          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
-        expect(decorators).toBeDefined();
-        expect(decorators.length).toEqual(1);
+          expect(decorators).toBeDefined();
+          expect(decorators.length).toEqual(1);
 
-        const decorator = decorators[0];
-        expect(decorator.name).toEqual('Directive');
-        expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
-        expect(decorator.args!.map(arg => arg.getText())).toEqual([
-          '{ selector: \'[someDirective]\' }',
-        ]);
+          const decorator = decorators[0];
+          expect(decorator.name).toEqual('Directive');
+          expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+          expect(decorator.args!.map(arg => arg.getText())).toEqual([
+            '{ selector: \'[someDirective]\' }',
+          ]);
+        });
+
+        it('should find the decorators on a class at the top level', () => {
+          loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
+          const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isDesiredDeclaration);
+          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
+
+          expect(decorators).toBeDefined();
+          expect(decorators.length).toEqual(1);
+
+          const decorator = decorators[0];
+          expect(decorator.name).toEqual('Directive');
+          expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+          expect(decorator.args!.map(arg => arg.getText())).toEqual([
+            '{ selector: \'[someDirective]\' }',
+          ]);
+        });
+
+        it('should return null if the symbol is not a class', () => {
+          loadTestFiles([FOO_FUNCTION_FILE]);
+          const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const functionNode = getDeclaration(
+              bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+          const decorators = host.getDecoratorsOfDeclaration(functionNode);
+          expect(decorators).toBe(null);
+        });
+
+        it('should return null if there are no decorators', () => {
+          loadTestFiles([SIMPLE_CLASS_FILE]);
+          const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isDesiredDeclaration);
+          const decorators = host.getDecoratorsOfDeclaration(classNode);
+          expect(decorators).toBe(null);
+        });
+
+        it('should ignore `decorators` if it is not an array literal', () => {
+          loadTestFiles([INVALID_DECORATORS_FILE]);
+          const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, INVALID_DECORATORS_FILE.name, 'NotArrayLiteral',
+              isDesiredDeclaration);
+          const decorators = host.getDecoratorsOfDeclaration(classNode);
+          expect(decorators).toEqual([]);
+        });
+
+        it('should ignore decorator elements that are not object literals', () => {
+          loadTestFiles([INVALID_DECORATORS_FILE]);
+          const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, INVALID_DECORATORS_FILE.name, 'NotObjectLiteral',
+              isDesiredDeclaration);
+          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
+
+          expect(decorators.length).toBe(1);
+          expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
+        });
+
+        it('should ignore decorator elements that have no `type` property', () => {
+          loadTestFiles([INVALID_DECORATORS_FILE]);
+          const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, INVALID_DECORATORS_FILE.name, 'NoTypeProperty', isDesiredDeclaration);
+          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
+
+          expect(decorators.length).toBe(1);
+          expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
+        });
+
+        it('should ignore decorator elements whose `type` value is not an identifier', () => {
+          loadTestFiles([INVALID_DECORATORS_FILE]);
+          const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, INVALID_DECORATORS_FILE.name, 'NotIdentifier', isDesiredDeclaration);
+          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
+
+          expect(decorators.length).toBe(1);
+          expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
+        });
+
+        it('should have import information on decorators', () => {
+          loadTestFiles([SOME_DIRECTIVE_FILE]);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+
+          const classNode = getDeclaration(
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isDesiredDeclaration);
+          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
+
+          expect(decorators.length).toEqual(1);
+          expect(decorators[0].import).toEqual({name: 'Directive', from: '@angular/core'});
+        });
+
+        it('should find decorated members on a class at the top level', () => {
+          loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
+          const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isDesiredDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          const input1 = members.find(member => member.name === 'input1')!;
+          expect(input1.kind).toEqual(ClassMemberKind.Property);
+          expect(input1.isStatic).toEqual(false);
+          expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
+
+          const input2 = members.find(member => member.name === 'input2')!;
+          expect(input2.kind).toEqual(ClassMemberKind.Property);
+          expect(input2.isStatic).toEqual(false);
+          expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
+        });
+
+        describe('(returned decorators `args`)', () => {
+          it('should be an empty array if decorator has no `args` property', () => {
+            loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
+            const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+            const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+            const classNode = getDeclaration(
+                bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+                isDesiredDeclaration);
+            const decorators = host.getDecoratorsOfDeclaration(classNode)!;
+
+            expect(decorators.length).toBe(1);
+            expect(decorators[0].name).toBe('Directive');
+            expect(decorators[0].args).toEqual([]);
+          });
+
+          it('should be an empty array if decorator\'s `args` has no property assignment', () => {
+            loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
+            const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+            const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+            const classNode = getDeclaration(
+                bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+                isDesiredDeclaration);
+            const decorators = host.getDecoratorsOfDeclaration(classNode)!;
+
+            expect(decorators.length).toBe(1);
+            expect(decorators[0].name).toBe('Directive');
+            expect(decorators[0].args).toEqual([]);
+          });
+
+          it('should be an empty array if `args` property value is not an array literal', () => {
+            loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
+            const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+            const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+            const classNode = getDeclaration(
+                bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+                isDesiredDeclaration);
+            const decorators = host.getDecoratorsOfDeclaration(classNode)!;
+
+            expect(decorators.length).toBe(1);
+            expect(decorators[0].name).toBe('Directive');
+            expect(decorators[0].args).toEqual([]);
+          });
+        });
       });
 
-      it('should return null if the symbol is not a class', () => {
-        loadTestFiles([FOO_FUNCTION_FILE]);
-        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const functionNode = getDeclaration(
-            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(functionNode);
-        expect(decorators).toBe(null);
+      describe('getMembersOfClass()', () => {
+        it('should find decorated members on a class', () => {
+          loadTestFiles([SOME_DIRECTIVE_FILE]);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isDesiredDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          const input1 = members.find(member => member.name === 'input1')!;
+          expect(input1.kind).toEqual(ClassMemberKind.Property);
+          expect(input1.isStatic).toEqual(false);
+          expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
+
+          const input2 = members.find(member => member.name === 'input2')!;
+          expect(input2.kind).toEqual(ClassMemberKind.Property);
+          expect(input2.isStatic).toEqual(false);
+          expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
+        });
+
+        it('should find non decorated properties on a class', () => {
+          loadTestFiles([SOME_DIRECTIVE_FILE]);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isDesiredDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          const instanceProperty = members.find(member => member.name === 'instanceProperty')!;
+          expect(instanceProperty.kind).toEqual(ClassMemberKind.Property);
+          expect(instanceProperty.isStatic).toEqual(false);
+          expect(ts.isBinaryExpression(instanceProperty.implementation!)).toEqual(true);
+          expect(instanceProperty.value!.getText()).toEqual(`'instance'`);
+        });
+
+        it('should find static methods on a class', () => {
+          loadTestFiles([SOME_DIRECTIVE_FILE]);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isDesiredDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          const staticMethod = members.find(member => member.name === 'staticMethod')!;
+          expect(staticMethod.kind).toEqual(ClassMemberKind.Method);
+          expect(staticMethod.isStatic).toEqual(true);
+          expect(ts.isFunctionExpression(staticMethod.implementation!)).toEqual(true);
+        });
+
+        it('should find static properties on a class', () => {
+          loadTestFiles([SOME_DIRECTIVE_FILE]);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isDesiredDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          const staticProperty = members.find(member => member.name === 'staticProperty')!;
+          expect(staticProperty.kind).toEqual(ClassMemberKind.Property);
+          expect(staticProperty.isStatic).toEqual(true);
+          expect(ts.isPropertyAccessExpression(staticProperty.implementation!)).toEqual(true);
+          expect(staticProperty.value!.getText()).toEqual(`'static'`);
+        });
+
+        it('should throw if the symbol is not a class', () => {
+          loadTestFiles([FOO_FUNCTION_FILE]);
+          const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const functionNode = getDeclaration(
+              bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+          expect(() => {
+            host.getMembersOfClass(functionNode);
+          }).toThrowError(`Attempted to get members of a non-class: "function foo() {}"`);
+        });
+
+        it('should return an empty array if there are no prop decorators', () => {
+          loadTestFiles([SIMPLE_CLASS_FILE]);
+          const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isDesiredDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          expect(members).toEqual([]);
+        });
+
+        it('should not process decorated properties in `propDecorators` if it is not an object literal',
+           () => {
+             loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
+             const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const classNode = getDeclaration(
+                 bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteral',
+                 isDesiredDeclaration);
+             const members = host.getMembersOfClass(classNode);
+
+             expect(members.map(member => member.name)).not.toContain('prop');
+           });
+
+        it('should ignore prop decorator elements that are not object literals', () => {
+          loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
+          const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteralProp',
+              isDesiredDeclaration);
+          const members = host.getMembersOfClass(classNode);
+          const prop = members.find(m => m.name === 'prop')!;
+          const decorators = prop.decorators!;
+
+          expect(decorators.length).toBe(1);
+          expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
+        });
+
+        it('should ignore prop decorator elements that have no `type` property', () => {
+          loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
+          const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NoTypeProperty',
+              isDesiredDeclaration);
+          const members = host.getMembersOfClass(classNode);
+          const prop = members.find(m => m.name === 'prop')!;
+          const decorators = prop.decorators!;
+
+          expect(decorators.length).toBe(1);
+          expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
+        });
       });
 
-      it('should return null if there are no decorators', () => {
-        loadTestFiles([SIMPLE_CLASS_FILE]);
-        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+      it('should ignore prop decorator elements whose `type` value is not an identifier', () => {
+        loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
+        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
         const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
         const classNode = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode);
-        expect(decorators).toBe(null);
-      });
-
-      it('should ignore `decorators` if it is not an array literal', () => {
-        loadTestFiles([INVALID_DECORATORS_FILE]);
-        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, INVALID_DECORATORS_FILE.name, 'NotArrayLiteral',
-            isNamedVariableDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode);
-        expect(decorators).toEqual([]);
-      });
-
-      it('should ignore decorator elements that are not object literals', () => {
-        loadTestFiles([INVALID_DECORATORS_FILE]);
-        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, INVALID_DECORATORS_FILE.name, 'NotObjectLiteral',
-            isNamedVariableDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
-
-        expect(decorators.length).toBe(1);
-        expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
-      });
-
-      it('should ignore decorator elements that have no `type` property', () => {
-        loadTestFiles([INVALID_DECORATORS_FILE]);
-        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, INVALID_DECORATORS_FILE.name, 'NoTypeProperty',
-            isNamedVariableDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
-
-        expect(decorators.length).toBe(1);
-        expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
-      });
-
-      it('should ignore decorator elements whose `type` value is not an identifier', () => {
-        loadTestFiles([INVALID_DECORATORS_FILE]);
-        const bundle = makeTestBundleProgram(INVALID_DECORATORS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, INVALID_DECORATORS_FILE.name, 'NotIdentifier',
-            isNamedVariableDeclaration);
-        const decorators = host.getDecoratorsOfDeclaration(classNode)!;
+            bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotIdentifier',
+            isDesiredDeclaration);
+        const members = host.getMembersOfClass(classNode);
+        const prop = members.find(m => m.name === 'prop')!;
+        const decorators = prop.decorators!;
 
         expect(decorators.length).toBe(1);
         expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
@@ -1081,306 +1392,85 @@ runInEachFileSystem(() => {
         const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
 
         const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
+            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isDesiredDeclaration);
         const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators.length).toEqual(1);
         expect(decorators[0].import).toEqual({name: 'Directive', from: '@angular/core'});
       });
 
-      it('should find decorated members on a class at the top level', () => {
-        loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
-        const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
-            isNamedVariableDeclaration);
-        const members = host.getMembersOfClass(classNode);
-
-        const input1 = members.find(member => member.name === 'input1')!;
-        expect(input1.kind).toEqual(ClassMemberKind.Property);
-        expect(input1.isStatic).toEqual(false);
-        expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
-
-        const input2 = members.find(member => member.name === 'input2')!;
-        expect(input2.kind).toEqual(ClassMemberKind.Property);
-        expect(input2.isStatic).toEqual(false);
-        expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
-      });
-
-      describe('(returned decorators `args`)', () => {
-        it('should be an empty array if decorator has no `args` property', () => {
-          loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-          const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+      describe('(returned prop decorators `args`)', () => {
+        it('should be an empty array if prop decorator has no `args` property', () => {
+          loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
+          const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
-              bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
-              isNamedVariableDeclaration);
-          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
+              bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+              isDesiredDeclaration);
+          const members = host.getMembersOfClass(classNode);
+          const prop = members.find(m => m.name === 'prop')!;
+          const decorators = prop.decorators!;
 
           expect(decorators.length).toBe(1);
-          expect(decorators[0].name).toBe('Directive');
+          expect(decorators[0].name).toBe('Input');
           expect(decorators[0].args).toEqual([]);
         });
 
-        it('should be an empty array if decorator\'s `args` has no property assignment', () => {
-          loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-          const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
-          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-          const classNode = getDeclaration(
-              bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
-              isNamedVariableDeclaration);
-          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
+        it('should be an empty array if prop decorator\'s `args` has no property assignment',
+           () => {
+             loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
+             const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const classNode = getDeclaration(
+                 bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+                 isDesiredDeclaration);
+             const members = host.getMembersOfClass(classNode);
+             const prop = members.find(m => m.name === 'prop')!;
+             const decorators = prop.decorators!;
 
-          expect(decorators.length).toBe(1);
-          expect(decorators[0].name).toBe('Directive');
-          expect(decorators[0].args).toEqual([]);
-        });
+             expect(decorators.length).toBe(1);
+             expect(decorators[0].name).toBe('Input');
+             expect(decorators[0].args).toEqual([]);
+           });
 
         it('should be an empty array if `args` property value is not an array literal', () => {
-          loadTestFiles([INVALID_DECORATOR_ARGS_FILE]);
-          const bundle = makeTestBundleProgram(INVALID_DECORATOR_ARGS_FILE.name);
+          loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
+          const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
-              bundle.program, INVALID_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
-              isNamedVariableDeclaration);
-          const decorators = host.getDecoratorsOfDeclaration(classNode)!;
+              bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+              isDesiredDeclaration);
+          const members = host.getMembersOfClass(classNode);
+          const prop = members.find(m => m.name === 'prop')!;
+          const decorators = prop.decorators!;
 
           expect(decorators.length).toBe(1);
-          expect(decorators[0].name).toBe('Directive');
+          expect(decorators[0].name).toBe('Input');
           expect(decorators[0].args).toEqual([]);
         });
       });
-    });
 
-    describe('getMembersOfClass()', () => {
-      it('should find decorated members on a class', () => {
-        loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
-        const members = host.getMembersOfClass(classNode);
-
-        const input1 = members.find(member => member.name === 'input1')!;
-        expect(input1.kind).toEqual(ClassMemberKind.Property);
-        expect(input1.isStatic).toEqual(false);
-        expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
-
-        const input2 = members.find(member => member.name === 'input2')!;
-        expect(input2.kind).toEqual(ClassMemberKind.Property);
-        expect(input2.isStatic).toEqual(false);
-        expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
-      });
-
-      it('should find non decorated properties on a class', () => {
-        loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
-        const members = host.getMembersOfClass(classNode);
-
-        const instanceProperty = members.find(member => member.name === 'instanceProperty')!;
-        expect(instanceProperty.kind).toEqual(ClassMemberKind.Property);
-        expect(instanceProperty.isStatic).toEqual(false);
-        expect(ts.isBinaryExpression(instanceProperty.implementation!)).toEqual(true);
-        expect(instanceProperty.value!.getText()).toEqual(`'instance'`);
-      });
-
-      it('should find static methods on a class', () => {
-        loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
-        const members = host.getMembersOfClass(classNode);
-
-        const staticMethod = members.find(member => member.name === 'staticMethod')!;
-        expect(staticMethod.kind).toEqual(ClassMemberKind.Method);
-        expect(staticMethod.isStatic).toEqual(true);
-        expect(ts.isFunctionExpression(staticMethod.implementation!)).toEqual(true);
-      });
-
-      it('should find static properties on a class', () => {
-        loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
-        const members = host.getMembersOfClass(classNode);
-
-        const staticProperty = members.find(member => member.name === 'staticProperty')!;
-        expect(staticProperty.kind).toEqual(ClassMemberKind.Property);
-        expect(staticProperty.isStatic).toEqual(true);
-        expect(ts.isPropertyAccessExpression(staticProperty.implementation!)).toEqual(true);
-        expect(staticProperty.value!.getText()).toEqual(`'static'`);
-      });
-
-      it('should throw if the symbol is not a class', () => {
-        loadTestFiles([FOO_FUNCTION_FILE]);
-        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const functionNode = getDeclaration(
-            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
-        expect(() => {
-          host.getMembersOfClass(functionNode);
-        }).toThrowError(`Attempted to get members of a non-class: "function foo() {}"`);
-      });
-
-      it('should return an empty array if there are no prop decorators', () => {
-        loadTestFiles([SIMPLE_CLASS_FILE]);
-        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
-        const members = host.getMembersOfClass(classNode);
-
-        expect(members).toEqual([]);
-      });
-
-      it('should not process decorated properties in `propDecorators` if it is not an object literal',
-         () => {
-           loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-           const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-           const classNode = getDeclaration(
-               bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteral',
-               isNamedVariableDeclaration);
-           const members = host.getMembersOfClass(classNode);
-
-           expect(members.map(member => member.name)).not.toContain('prop');
-         });
-
-      it('should ignore prop decorator elements that are not object literals', () => {
-        loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotObjectLiteralProp',
-            isNamedVariableDeclaration);
-        const members = host.getMembersOfClass(classNode);
-        const prop = members.find(m => m.name === 'prop')!;
-        const decorators = prop.decorators!;
-
-        expect(decorators.length).toBe(1);
-        expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
-      });
-
-      it('should ignore prop decorator elements that have no `type` property', () => {
-        loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NoTypeProperty',
-            isNamedVariableDeclaration);
-        const members = host.getMembersOfClass(classNode);
-        const prop = members.find(m => m.name === 'prop')!;
-        const decorators = prop.decorators!;
-
-        expect(decorators.length).toBe(1);
-        expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
-      });
-    });
-
-    it('should ignore prop decorator elements whose `type` value is not an identifier', () => {
-      loadTestFiles([INVALID_PROP_DECORATORS_FILE]);
-      const bundle = makeTestBundleProgram(INVALID_PROP_DECORATORS_FILE.name);
-      const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-      const classNode = getDeclaration(
-          bundle.program, INVALID_PROP_DECORATORS_FILE.name, 'NotIdentifier',
-          isNamedVariableDeclaration);
-      const members = host.getMembersOfClass(classNode);
-      const prop = members.find(m => m.name === 'prop')!;
-      const decorators = prop.decorators!;
-
-      expect(decorators.length).toBe(1);
-      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
-    });
-
-    it('should have import information on decorators', () => {
-      loadTestFiles([SOME_DIRECTIVE_FILE]);
-      const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-      const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-
-      const classNode = getDeclaration(
-          bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
-      const decorators = host.getDecoratorsOfDeclaration(classNode)!;
-
-      expect(decorators.length).toEqual(1);
-      expect(decorators[0].import).toEqual({name: 'Directive', from: '@angular/core'});
-    });
-
-    describe('(returned prop decorators `args`)', () => {
-      it('should be an empty array if prop decorator has no `args` property', () => {
-        loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
-            isNamedVariableDeclaration);
-        const members = host.getMembersOfClass(classNode);
-        const prop = members.find(m => m.name === 'prop')!;
-        const decorators = prop.decorators!;
-
-        expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('Input');
-        expect(decorators[0].args).toEqual([]);
-      });
-
-      it('should be an empty array if prop decorator\'s `args` has no property assignment', () => {
-        loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
-            isNamedVariableDeclaration);
-        const members = host.getMembersOfClass(classNode);
-        const prop = members.find(m => m.name === 'prop')!;
-        const decorators = prop.decorators!;
-
-        expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('Input');
-        expect(decorators[0].args).toEqual([]);
-      });
-
-      it('should be an empty array if `args` property value is not an array literal', () => {
-        loadTestFiles([INVALID_PROP_DECORATOR_ARGS_FILE]);
-        const bundle = makeTestBundleProgram(INVALID_PROP_DECORATOR_ARGS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, INVALID_PROP_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
-            isNamedVariableDeclaration);
-        const members = host.getMembersOfClass(classNode);
-        const prop = members.find(m => m.name === 'prop')!;
-        const decorators = prop.decorators!;
-
-        expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('Input');
-        expect(decorators[0].args).toEqual([]);
-      });
-    });
-
-    describe('getConstructorParameters', () => {
-      it('should retain imported name for type value references for decorated constructor parameter types',
-         () => {
-           const files = [
-             {
-               name: _('/node_modules/shared-lib/foo.d.ts'),
-               contents: `
+      describe('getConstructorParameters', () => {
+        it('should retain imported name for type value references for decorated constructor parameter types',
+           () => {
+             const files = [
+               {
+                 name: _('/node_modules/shared-lib/foo.d.ts'),
+                 contents: `
     declare class Foo {}
     export {Foo as Bar};
   `,
-             },
-             {
-               name: _('/node_modules/shared-lib/index.d.ts'),
-               contents: `
+               },
+               {
+                 name: _('/node_modules/shared-lib/index.d.ts'),
+                 contents: `
     export {Bar as Baz} from './foo';
   `,
-             },
-             {
-               name: _('/local.js'),
-               contents: `
+               },
+               {
+                 name: _('/local.js'),
+                 contents: `
   (function (global, factory) {
     typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
     typeof define === 'function' && define.amd ? define('local', ['exports'], factory) :
@@ -1394,295 +1484,299 @@ runInEachFileSystem(() => {
     exports.External = Internal;
   })));
      `
-             },
-             {
-               name: _('/main.js'),
-               contents: `
+               },
+               {
+                 name: _('/main.js'),
+                 contents: `
   (function (global, factory) {
     typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('shared-lib'), require('./local')) :
     typeof define === 'function' && define.amd ? define('main', ['exports', 'shared-lib', './local'], factory) :
     (factory(global.main, global.shared, global.local));
   }(this, (function (exports, shared, local) { 'use strict';
-    var SameFile = (function() {
+    ${expDecl('SameFile')} = (function() {
       function SameFile() {
       }
       return SameFile;
     }());
-    exports.SameFile = SameFile;
+    ${varExp('SameFile')}
 
-    var SomeClass = (function() {
+    ${expDecl('SomeClass')} = (function() {
       function SomeClass(arg1, arg2, arg3) {}
       return SomeClass;
     }());
-    SomeClass.ctorParameters = function() { return [{ type: shared.Baz }, { type: local.External }, { type: SameFile }]; };
-    exports.SomeClass = SomeClass;
+    ${
+                     expDecl(
+                         'SomeClass',
+                         true)}.ctorParameters = function() { return [{ type: shared.Baz }, { type: local.External }, { type: SameFile }]; };
+    ${varExp('SomeClass')}
   })));
   `,
-             },
-           ];
+               },
+             ];
 
-           loadTestFiles(files);
-           const bundle = makeTestBundleProgram(_('/main.js'));
-           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-           const classNode = getDeclaration(
-               bundle.program, _('/main.js'), 'SomeClass', isNamedFunctionDeclaration);
+             loadTestFiles(files);
+             const bundle = makeTestBundleProgram(_('/main.js'));
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const classNode = getDeclaration(
+                 bundle.program, _('/main.js'), 'SomeClass', isNamedFunctionDeclaration);
 
-           const parameters = host.getConstructorParameters(classNode)!;
+             const parameters = host.getConstructorParameters(classNode)!;
 
-           expect(parameters.map(p => p.name)).toEqual(['arg1', 'arg2', 'arg3']);
-           expectTypeValueReferencesForParameters(
-               parameters, ['Baz', 'External', 'SameFile'], ['shared-lib', './local', null]);
-         });
+             expect(parameters.map(p => p.name)).toEqual(['arg1', 'arg2', 'arg3']);
+             expectTypeValueReferencesForParameters(
+                 parameters, ['Baz', 'External', 'SameFile'], ['shared-lib', './local', null]);
+           });
 
-      it('should find the decorated constructor parameters', () => {
-        loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
-        const parameters = host.getConstructorParameters(classNode);
-
-        expect(parameters).toBeDefined();
-        expect(parameters!.map(parameter => parameter.name)).toEqual([
-          '_viewContainer', '_template', 'injected'
-        ]);
-        expectTypeValueReferencesForParameters(parameters!, [
-          'ViewContainerRef',
-          'TemplateRef',
-          null,
-        ]);
-      });
-
-      it('should find the decorated constructor parameters at the top level', () => {
-        loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
-        const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective',
-            isNamedVariableDeclaration);
-        const parameters = host.getConstructorParameters(classNode);
-
-        expect(parameters).toBeDefined();
-        expect(parameters!.map(parameter => parameter.name)).toEqual([
-          '_viewContainer', '_template', 'injected'
-        ]);
-        expectTypeValueReferencesForParameters(parameters!, [
-          'ViewContainerRef',
-          'TemplateRef',
-          null,
-        ]);
-      });
-
-      it('should accept `ctorParameters` as an array', () => {
-        loadTestFiles([CTOR_DECORATORS_ARRAY_FILE]);
-        const bundle = makeTestBundleProgram(CTOR_DECORATORS_ARRAY_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, CTOR_DECORATORS_ARRAY_FILE.name, 'CtorDecoratedAsArray',
-            isNamedVariableDeclaration);
-        const parameters = host.getConstructorParameters(classNode)!;
-
-        expect(parameters).toBeDefined();
-        expect(parameters.map(parameter => parameter.name)).toEqual(['arg1']);
-        expectTypeValueReferencesForParameters(parameters, ['ParamType']);
-      });
-
-      it('should throw if the symbol is not a class', () => {
-        loadTestFiles([FOO_FUNCTION_FILE]);
-        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const functionNode = getDeclaration(
-            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
-        expect(() => {
-          host.getConstructorParameters(functionNode);
-        })
-            .toThrowError(
-                'Attempted to get constructor parameters of a non-class: "function foo() {}"');
-      });
-
-      // In ES5 there is no such thing as a constructor-less class
-      // it('should return `null` if there is no constructor', () => { });
-
-      it('should return an array even if there are no decorators', () => {
-        loadTestFiles([SIMPLE_CLASS_FILE]);
-        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'NoDecoratorConstructorClass',
-            isNamedVariableDeclaration);
-        const parameters = host.getConstructorParameters(classNode);
-
-        expect(parameters).toEqual(jasmine.any(Array));
-        expect(parameters!.length).toEqual(1);
-        expect(parameters![0].name).toEqual('foo');
-        expect(parameters![0].decorators).toBe(null);
-      });
-
-      it('should return an empty array if there are no constructor parameters', () => {
-        loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-        const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoParameters',
-            isNamedVariableDeclaration);
-        const parameters = host.getConstructorParameters(classNode);
-
-        expect(parameters).toEqual([]);
-      });
-
-      // In ES5 there are no arrow functions
-      // it('should ignore `ctorParameters` if it is an arrow function', () => { });
-
-      it('should ignore `ctorParameters` if it does not return an array literal', () => {
-        loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-        const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrayLiteral',
-            isNamedVariableDeclaration);
-        const parameters = host.getConstructorParameters(classNode);
-
-        expect(parameters!.length).toBe(1);
-        expect(parameters![0]).toEqual(jasmine.objectContaining<CtorParameter>({
-          name: 'arg1',
-          decorators: null,
-        }));
-      });
-
-      describe('(returned parameters `decorators`)', () => {
-        it('should ignore param decorator elements that are not object literals', () => {
-          loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-          const classNode = getDeclaration(
-              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotObjectLiteral',
-              isNamedVariableDeclaration);
-          const parameters = host.getConstructorParameters(classNode);
-
-          expect(parameters!.length).toBe(2);
-          expect(parameters![0]).toEqual(jasmine.objectContaining<CtorParameter>({
-            name: 'arg1',
-            decorators: null,
-          }));
-          expect(parameters![1]).toEqual(jasmine.objectContaining<CtorParameter>({
-            name: 'arg2',
-            decorators: jasmine.any(Array) as any
-          }));
-        });
-
-        it('should ignore param decorator elements that have no `type` property', () => {
-          loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-          const classNode = getDeclaration(
-              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoTypeProperty',
-              isNamedVariableDeclaration);
-          const parameters = host.getConstructorParameters(classNode);
-          const decorators = parameters![0].decorators!;
-
-          expect(decorators.length).toBe(1);
-          expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Inject'}));
-        });
-
-        it('should ignore param decorator elements whose `type` value is not an identifier', () => {
-          loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
-          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
-          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-          const classNode = getDeclaration(
-              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotIdentifier',
-              isNamedVariableDeclaration);
-          const parameters = host.getConstructorParameters(classNode);
-          const decorators = parameters![0].decorators!;
-
-          expect(decorators.length).toBe(1);
-          expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Inject'}));
-        });
-
-        it('should use `getImportOfIdentifier()` to retrieve import info', () => {
+        it('should find the decorated constructor parameters', () => {
           loadTestFiles([SOME_DIRECTIVE_FILE]);
           const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
-              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective',
-              isNamedFunctionDeclaration);
-          const mockImportInfo: Import = {from: '@angular/core', name: 'Directive'};
-          const spy = spyOn(UmdReflectionHost.prototype, 'getImportOfIdentifier')
-                          .and.returnValue(mockImportInfo);
-
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isDesiredDeclaration);
           const parameters = host.getConstructorParameters(classNode);
-          const decorators = parameters![2].decorators!;
 
-          expect(decorators.length).toEqual(1);
-          expect(decorators[0].import).toBe(mockImportInfo);
+          expect(parameters).toBeDefined();
+          expect(parameters!.map(parameter => parameter.name)).toEqual([
+            '_viewContainer', '_template', 'injected'
+          ]);
+          expectTypeValueReferencesForParameters(parameters!, [
+            'ViewContainerRef',
+            'TemplateRef',
+            null,
+          ]);
         });
-      });
 
-      describe('(returned parameters `decorators.args`)', () => {
-        it('should be an empty array if param decorator has no `args` property', () => {
-          loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+        it('should find the decorated constructor parameters at the top level', () => {
+          loadTestFiles([TOPLEVEL_DECORATORS_FILE]);
+          const bundle = makeTestBundleProgram(TOPLEVEL_DECORATORS_FILE.name);
           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
           const classNode = getDeclaration(
-              bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
-              isNamedVariableDeclaration);
+              bundle.program, TOPLEVEL_DECORATORS_FILE.name, 'SomeDirective', isDesiredDeclaration);
           const parameters = host.getConstructorParameters(classNode);
+
+          expect(parameters).toBeDefined();
+          expect(parameters!.map(parameter => parameter.name)).toEqual([
+            '_viewContainer', '_template', 'injected'
+          ]);
+          expectTypeValueReferencesForParameters(parameters!, [
+            'ViewContainerRef',
+            'TemplateRef',
+            null,
+          ]);
+        });
+
+        it('should accept `ctorParameters` as an array', () => {
+          loadTestFiles([CTOR_DECORATORS_ARRAY_FILE]);
+          const bundle = makeTestBundleProgram(CTOR_DECORATORS_ARRAY_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, CTOR_DECORATORS_ARRAY_FILE.name, 'CtorDecoratedAsArray',
+              isDesiredDeclaration);
+          const parameters = host.getConstructorParameters(classNode)!;
+
+          expect(parameters).toBeDefined();
+          expect(parameters.map(parameter => parameter.name)).toEqual(['arg1']);
+          expectTypeValueReferencesForParameters(parameters, ['ParamType']);
+        });
+
+        it('should throw if the symbol is not a class', () => {
+          loadTestFiles([FOO_FUNCTION_FILE]);
+          const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const functionNode = getDeclaration(
+              bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+          expect(() => {
+            host.getConstructorParameters(functionNode);
+          })
+              .toThrowError(
+                  'Attempted to get constructor parameters of a non-class: "function foo() {}"');
+        });
+
+        // In ES5 there is no such thing as a constructor-less class
+        // it('should return `null` if there is no constructor', () => { });
+
+        it('should return an array even if there are no decorators', () => {
+          loadTestFiles([SIMPLE_CLASS_FILE]);
+          const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'NoDecoratorConstructorClass',
+              isDesiredDeclaration);
+          const parameters = host.getConstructorParameters(classNode);
+
+          expect(parameters).toEqual(jasmine.any(Array));
+          expect(parameters!.length).toEqual(1);
+          expect(parameters![0].name).toEqual('foo');
+          expect(parameters![0].decorators).toBe(null);
+        });
+
+        it('should return an empty array if there are no constructor parameters', () => {
+          loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoParameters',
+              isDesiredDeclaration);
+          const parameters = host.getConstructorParameters(classNode);
+
+          expect(parameters).toEqual([]);
+        });
+
+        // In ES5 there are no arrow functions
+        // it('should ignore `ctorParameters` if it is an arrow function', () => { });
+
+        it('should ignore `ctorParameters` if it does not return an array literal', () => {
+          loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
+          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrayLiteral',
+              isDesiredDeclaration);
+          const parameters = host.getConstructorParameters(classNode);
+
           expect(parameters!.length).toBe(1);
-          const decorators = parameters![0].decorators!;
-
-          expect(decorators.length).toBe(1);
-          expect(decorators[0].name).toBe('Inject');
-          expect(decorators[0].args).toEqual([]);
+          expect(parameters![0]).toEqual(jasmine.objectContaining<CtorParameter>({
+            name: 'arg1',
+            decorators: null,
+          }));
         });
 
-        it('should be an empty array if param decorator\'s `args` has no property assignment',
-           () => {
-             loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-             const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-             const host =
-                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-             const classNode = getDeclaration(
-                 bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
-                 isNamedVariableDeclaration);
-             const parameters = host.getConstructorParameters(classNode);
-             const decorators = parameters![0].decorators!;
+        describe('(returned parameters `decorators`)', () => {
+          it('should ignore param decorator elements that are not object literals', () => {
+            loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
+            const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+            const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+            const classNode = getDeclaration(
+                bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotObjectLiteral',
+                isDesiredDeclaration);
+            const parameters = host.getConstructorParameters(classNode);
 
-             expect(decorators.length).toBe(1);
-             expect(decorators[0].name).toBe('Inject');
-             expect(decorators[0].args).toEqual([]);
-           });
+            expect(parameters!.length).toBe(2);
+            expect(parameters![0]).toEqual(jasmine.objectContaining<CtorParameter>({
+              name: 'arg1',
+              decorators: null,
+            }));
+            expect(parameters![1]).toEqual(jasmine.objectContaining<CtorParameter>({
+              name: 'arg2',
+              decorators: jasmine.any(Array) as any
+            }));
+          });
 
-        it('should be an empty array if `args` property value is not an array literal', () => {
-          loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
-          const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
-          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-          const classNode = getDeclaration(
-              bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
-              isNamedVariableDeclaration);
-          const parameters = host.getConstructorParameters(classNode);
-          const decorators = parameters![0].decorators!;
+          it('should ignore param decorator elements that have no `type` property', () => {
+            loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
+            const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+            const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+            const classNode = getDeclaration(
+                bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NoTypeProperty',
+                isDesiredDeclaration);
+            const parameters = host.getConstructorParameters(classNode);
+            const decorators = parameters![0].decorators!;
 
-          expect(decorators.length).toBe(1);
-          expect(decorators[0].name).toBe('Inject');
-          expect(decorators[0].args).toEqual([]);
+            expect(decorators.length).toBe(1);
+            expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Inject'}));
+          });
+
+          it('should ignore param decorator elements whose `type` value is not an identifier',
+             () => {
+               loadTestFiles([INVALID_CTOR_DECORATORS_FILE]);
+               const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATORS_FILE.name);
+               const host =
+                   createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+               const classNode = getDeclaration(
+                   bundle.program, INVALID_CTOR_DECORATORS_FILE.name, 'NotIdentifier',
+                   isDesiredDeclaration);
+               const parameters = host.getConstructorParameters(classNode);
+               const decorators = parameters![0].decorators!;
+
+               expect(decorators.length).toBe(1);
+               expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Inject'}));
+             });
+
+          it('should use `getImportOfIdentifier()` to retrieve import info', () => {
+            loadTestFiles([SOME_DIRECTIVE_FILE]);
+            const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+            const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+            const classNode = getDeclaration(
+                bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isDesiredDeclaration);
+            const mockImportInfo: Import = {from: '@angular/core', name: 'Directive'};
+            const spy = spyOn(UmdReflectionHost.prototype, 'getImportOfIdentifier')
+                            .and.returnValue(mockImportInfo);
+
+            const parameters = host.getConstructorParameters(classNode);
+            const decorators = parameters![2].decorators!;
+
+            expect(decorators.length).toEqual(1);
+            expect(decorators[0].import).toBe(mockImportInfo);
+          });
         });
-      });
 
-      function getConstructorParameters(
-          constructor: string, mode: 'inlined'|'inlined_with_suffix'|'imported' = 'imported') {
-        let fileHeaderWithUmd = '';
+        describe('(returned parameters `decorators.args`)', () => {
+          it('should be an empty array if param decorator has no `args` property', () => {
+            loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
+            const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+            const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+            const classNode = getDeclaration(
+                bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoArgsProperty',
+                isDesiredDeclaration);
+            const parameters = host.getConstructorParameters(classNode);
+            expect(parameters!.length).toBe(1);
+            const decorators = parameters![0].decorators!;
 
-        switch (mode) {
-          case 'imported':
-            fileHeaderWithUmd = `
+            expect(decorators.length).toBe(1);
+            expect(decorators[0].name).toBe('Inject');
+            expect(decorators[0].args).toEqual([]);
+          });
+
+          it('should be an empty array if param decorator\'s `args` has no property assignment',
+             () => {
+               loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
+               const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+               const host =
+                   createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+               const classNode = getDeclaration(
+                   bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NoPropertyAssignment',
+                   isDesiredDeclaration);
+               const parameters = host.getConstructorParameters(classNode);
+               const decorators = parameters![0].decorators!;
+
+               expect(decorators.length).toBe(1);
+               expect(decorators[0].name).toBe('Inject');
+               expect(decorators[0].args).toEqual([]);
+             });
+
+          it('should be an empty array if `args` property value is not an array literal', () => {
+            loadTestFiles([INVALID_CTOR_DECORATOR_ARGS_FILE]);
+            const bundle = makeTestBundleProgram(INVALID_CTOR_DECORATOR_ARGS_FILE.name);
+            const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+            const classNode = getDeclaration(
+                bundle.program, INVALID_CTOR_DECORATOR_ARGS_FILE.name, 'NotArrayLiteral',
+                isDesiredDeclaration);
+            const parameters = host.getConstructorParameters(classNode);
+            const decorators = parameters![0].decorators!;
+
+            expect(decorators.length).toBe(1);
+            expect(decorators[0].name).toBe('Inject');
+            expect(decorators[0].args).toEqual([]);
+          });
+        });
+
+        function getConstructorParameters(
+            constructor: string, mode: 'inlined'|'inlined_with_suffix'|'imported' = 'imported') {
+          let fileHeaderWithUmd = '';
+
+          switch (mode) {
+            case 'imported':
+              fileHeaderWithUmd = `
               (function (global, factory) {
                 typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('tslib'))) :
                 typeof define === 'function' && define.amd ? define('test', ['exports', 'tslib'], factory) :
                     (factory(global.test, global.tslib));
                 }(this, (function (exports, tslib) { 'use strict';
             `;
-            break;
-          case 'inlined':
-            fileHeaderWithUmd = `
+              break;
+            case 'inlined':
+              fileHeaderWithUmd = `
               (function (global, factory) {
                 typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports)) :
                 typeof define === 'function' && define.amd ? define('test', ['exports'], factory) :
@@ -1691,9 +1785,9 @@ runInEachFileSystem(() => {
 
                   var __spread = (this && this.__spread) || function (...args) { /* ... */ }
             `;
-            break;
-          case 'inlined_with_suffix':
-            fileHeaderWithUmd = `
+              break;
+            case 'inlined_with_suffix':
+              fileHeaderWithUmd = `
               (function (global, factory) {
                 typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports)) :
                 typeof define === 'function' && define.amd ? define('test', ['exports'], factory) :
@@ -1702,12 +1796,12 @@ runInEachFileSystem(() => {
 
                   var __spread$1 = (this && this.__spread$1) || function (...args) { /* ... */ }
               `;
-            break;
-        }
+              break;
+          }
 
-        const file = {
-          name: _('/synthesized_constructors.js'),
-          contents: `
+          const file = {
+            name: _('/synthesized_constructors.js'),
+            contents: `
             ${fileHeaderWithUmd}
                 var TestClass = /** @class */ (function (_super) {
                   __extends(TestClass, _super);
@@ -1718,19 +1812,19 @@ runInEachFileSystem(() => {
                 exports.TestClass = TestClass;
               })));
           `,
-        };
+          };
 
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode =
-            getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
-        return host.getConstructorParameters(classNode);
-      }
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode =
+              getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
+          return host.getConstructorParameters(classNode);
+        }
 
-      describe('TS -> ES5: synthesized constructors', () => {
-        it('recognizes _this assignment from super call', () => {
-          const parameters = getConstructorParameters(`
+        describe('TS -> ES5: synthesized constructors', () => {
+          it('recognizes _this assignment from super call', () => {
+            const parameters = getConstructorParameters(`
             function TestClass() {
               var _this = _super !== null && _super.apply(this, arguments) || this;
               _this.synthesizedProperty = null;
@@ -1738,21 +1832,21 @@ runInEachFileSystem(() => {
             }
           `);
 
-          expect(parameters).toBeNull();
-        });
+            expect(parameters).toBeNull();
+          });
 
-        it('recognizes super call as return statement', () => {
-          const parameters = getConstructorParameters(`
+          it('recognizes super call as return statement', () => {
+            const parameters = getConstructorParameters(`
             function TestClass() {
               return _super !== null && _super.apply(this, arguments) || this;
             }
           `);
 
-          expect(parameters).toBeNull();
-        });
+            expect(parameters).toBeNull();
+          });
 
-        it('handles the case where a unique name was generated for _super or _this', () => {
-          const parameters = getConstructorParameters(`
+          it('handles the case where a unique name was generated for _super or _this', () => {
+            const parameters = getConstructorParameters(`
             function TestClass() {
               var _this_1 = _super_1 !== null && _super_1.apply(this, arguments) || this;
               _this_1._this = null;
@@ -1761,79 +1855,43 @@ runInEachFileSystem(() => {
             }
           `);
 
-          expect(parameters).toBeNull();
-        });
+            expect(parameters).toBeNull();
+          });
 
-        it('does not consider constructors with parameters as synthesized', () => {
-          const parameters = getConstructorParameters(`
+          it('does not consider constructors with parameters as synthesized', () => {
+            const parameters = getConstructorParameters(`
             function TestClass(arg) {
               return _super !== null && _super.apply(this, arguments) || this;
             }
           `);
 
-          expect(parameters!.length).toBe(1);
-        });
+            expect(parameters!.length).toBe(1);
+          });
 
-        it('does not consider manual super calls as synthesized', () => {
-          const parameters = getConstructorParameters(`
+          it('does not consider manual super calls as synthesized', () => {
+            const parameters = getConstructorParameters(`
             function TestClass() {
               return _super.call(this) || this;
             }
           `);
 
-          expect(parameters!.length).toBe(0);
+            expect(parameters!.length).toBe(0);
+          });
+
+          it('does not consider empty constructors as synthesized', () => {
+            const parameters = getConstructorParameters(`function TestClass() {}`);
+            expect(parameters!.length).toBe(0);
+          });
         });
 
-        it('does not consider empty constructors as synthesized', () => {
-          const parameters = getConstructorParameters(`function TestClass() {}`);
-          expect(parameters!.length).toBe(0);
-        });
-      });
-
-      // See: https://github.com/angular/angular/issues/38453.
-      describe('ES2015 -> ES5: synthesized constructors through TSC downleveling', () => {
-        it('recognizes delegate super call using inline spread helper', () => {
-          const parameters = getConstructorParameters(
-              `
-            function TestClass() {
-              return _super.apply(this, __spread(arguments)) || this;
-            }`,
-              'inlined');
-
-          expect(parameters).toBeNull();
-        });
-
-        it('recognizes delegate super call using inline spread helper with suffix', () => {
-          const parameters = getConstructorParameters(
-              `
-            function TestClass() {
-              return _super.apply(this, __spread$1(arguments)) || this;
-            }`,
-              'inlined_with_suffix');
-
-          expect(parameters).toBeNull();
-        });
-
-        it('recognizes delegate super call using imported spread helper', () => {
-          const parameters = getConstructorParameters(
-              `
-            function TestClass() {
-              return _super.apply(this, tslib_1.__spread(arguments)) || this;
-            }`,
-              'imported');
-
-          expect(parameters).toBeNull();
-        });
-
-        describe('with class member assignment', () => {
+        // See: https://github.com/angular/angular/issues/38453.
+        describe('ES2015 -> ES5: synthesized constructors through TSC downleveling', () => {
           it('recognizes delegate super call using inline spread helper', () => {
             const parameters = getConstructorParameters(
                 `
-              function TestClass() {
-                var _this = _super.apply(this, __spread(arguments)) || this;
-                _this.synthesizedProperty = null;
-                return _this;
-              }`,
+            function TestClass() {
+              return _super.apply(this, __spread(arguments)) || this;
+            }`,
                 'inlined');
 
             expect(parameters).toBeNull();
@@ -1842,11 +1900,9 @@ runInEachFileSystem(() => {
           it('recognizes delegate super call using inline spread helper with suffix', () => {
             const parameters = getConstructorParameters(
                 `
-              function TestClass() {
-                var _this = _super.apply(this, __spread$1(arguments)) || this;
-                _this.synthesizedProperty = null;
-                return _this;
-              }`,
+            function TestClass() {
+              return _super.apply(this, __spread$1(arguments)) || this;
+            }`,
                 'inlined_with_suffix');
 
             expect(parameters).toBeNull();
@@ -1855,213 +1911,253 @@ runInEachFileSystem(() => {
           it('recognizes delegate super call using imported spread helper', () => {
             const parameters = getConstructorParameters(
                 `
+            function TestClass() {
+              return _super.apply(this, tslib_1.__spread(arguments)) || this;
+            }`,
+                'imported');
+
+            expect(parameters).toBeNull();
+          });
+
+          describe('with class member assignment', () => {
+            it('recognizes delegate super call using inline spread helper', () => {
+              const parameters = getConstructorParameters(
+                  `
+              function TestClass() {
+                var _this = _super.apply(this, __spread(arguments)) || this;
+                _this.synthesizedProperty = null;
+                return _this;
+              }`,
+                  'inlined');
+
+              expect(parameters).toBeNull();
+            });
+
+            it('recognizes delegate super call using inline spread helper with suffix', () => {
+              const parameters = getConstructorParameters(
+                  `
+              function TestClass() {
+                var _this = _super.apply(this, __spread$1(arguments)) || this;
+                _this.synthesizedProperty = null;
+                return _this;
+              }`,
+                  'inlined_with_suffix');
+
+              expect(parameters).toBeNull();
+            });
+
+            it('recognizes delegate super call using imported spread helper', () => {
+              const parameters = getConstructorParameters(
+                  `
               function TestClass() {
                 var _this = _super.apply(this, tslib_1.__spread(arguments)) || this;
                 _this.synthesizedProperty = null;
                 return _this;
               }`,
-                'imported');
+                  'imported');
 
-            expect(parameters).toBeNull();
+              expect(parameters).toBeNull();
+            });
           });
-        });
 
-        it('handles the case where a unique name was generated for _super or _this', () => {
-          const parameters = getConstructorParameters(
-              `
+          it('handles the case where a unique name was generated for _super or _this', () => {
+            const parameters = getConstructorParameters(
+                `
             function TestClass() {
               var _this_1 = _super_1.apply(this, __spread(arguments)) || this;
               _this_1._this = null;
               _this_1._super = null;
               return _this_1;
             }`,
-              'inlined');
+                'inlined');
 
-          expect(parameters).toBeNull();
-        });
+            expect(parameters).toBeNull();
+          });
 
-        it('does not consider constructors with parameters as synthesized', () => {
-          const parameters = getConstructorParameters(
-              `
+          it('does not consider constructors with parameters as synthesized', () => {
+            const parameters = getConstructorParameters(
+                `
             function TestClass(arg) {
               return _super.apply(this, __spread(arguments)) || this;
             }`,
-              'inlined');
+                'inlined');
 
-          expect(parameters!.length).toBe(1);
+            expect(parameters!.length).toBe(1);
+          });
         });
       });
-    });
 
-    describe('getDefinitionOfFunction()', () => {
-      it('should return an object describing the function declaration passed as an argument',
-         () => {
-           loadTestFiles([FUNCTION_BODY_FILE]);
-           const bundle = makeTestBundleProgram(FUNCTION_BODY_FILE.name);
-           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+      describe('getDefinitionOfFunction()', () => {
+        it('should return an object describing the function declaration passed as an argument',
+           () => {
+             loadTestFiles([FUNCTION_BODY_FILE]);
+             const bundle = makeTestBundleProgram(FUNCTION_BODY_FILE.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
 
-           const fooNode = getDeclaration(
-               bundle.program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration)!;
-           const fooDef = host.getDefinitionOfFunction(fooNode)!;
-           expect(fooDef.node).toBe(fooNode);
-           expect(fooDef.body!.length).toEqual(1);
-           expect(fooDef.body![0].getText()).toEqual(`return x;`);
-           expect(fooDef.parameters.length).toEqual(1);
-           expect(fooDef.parameters[0].name).toEqual('x');
-           expect(fooDef.parameters[0].initializer).toBe(null);
+             const fooNode = getDeclaration(
+                 bundle.program, FUNCTION_BODY_FILE.name, 'foo', isNamedFunctionDeclaration)!;
+             const fooDef = host.getDefinitionOfFunction(fooNode)!;
+             expect(fooDef.node).toBe(fooNode);
+             expect(fooDef.body!.length).toEqual(1);
+             expect(fooDef.body![0].getText()).toEqual(`return x;`);
+             expect(fooDef.parameters.length).toEqual(1);
+             expect(fooDef.parameters[0].name).toEqual('x');
+             expect(fooDef.parameters[0].initializer).toBe(null);
 
-           const barNode = getDeclaration(
-               bundle.program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration)!;
-           const barDef = host.getDefinitionOfFunction(barNode)!;
-           expect(barDef.node).toBe(barNode);
-           expect(barDef.body!.length).toEqual(1);
-           expect(ts.isReturnStatement(barDef.body![0])).toBeTruthy();
-           expect(barDef.body![0].getText()).toEqual(`return x + y;`);
-           expect(barDef.parameters.length).toEqual(2);
-           expect(barDef.parameters[0].name).toEqual('x');
-           expect(fooDef.parameters[0].initializer).toBe(null);
-           expect(barDef.parameters[1].name).toEqual('y');
-           expect(barDef.parameters[1].initializer!.getText()).toEqual('42');
+             const barNode = getDeclaration(
+                 bundle.program, FUNCTION_BODY_FILE.name, 'bar', isNamedFunctionDeclaration)!;
+             const barDef = host.getDefinitionOfFunction(barNode)!;
+             expect(barDef.node).toBe(barNode);
+             expect(barDef.body!.length).toEqual(1);
+             expect(ts.isReturnStatement(barDef.body![0])).toBeTruthy();
+             expect(barDef.body![0].getText()).toEqual(`return x + y;`);
+             expect(barDef.parameters.length).toEqual(2);
+             expect(barDef.parameters[0].name).toEqual('x');
+             expect(fooDef.parameters[0].initializer).toBe(null);
+             expect(barDef.parameters[1].name).toEqual('y');
+             expect(barDef.parameters[1].initializer!.getText()).toEqual('42');
 
-           const bazNode = getDeclaration(
-               bundle.program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration)!;
-           const bazDef = host.getDefinitionOfFunction(bazNode)!;
-           expect(bazDef.node).toBe(bazNode);
-           expect(bazDef.body!.length).toEqual(3);
-           expect(bazDef.parameters.length).toEqual(1);
-           expect(bazDef.parameters[0].name).toEqual('x');
-           expect(bazDef.parameters[0].initializer).toBe(null);
+             const bazNode = getDeclaration(
+                 bundle.program, FUNCTION_BODY_FILE.name, 'baz', isNamedFunctionDeclaration)!;
+             const bazDef = host.getDefinitionOfFunction(bazNode)!;
+             expect(bazDef.node).toBe(bazNode);
+             expect(bazDef.body!.length).toEqual(3);
+             expect(bazDef.parameters.length).toEqual(1);
+             expect(bazDef.parameters[0].name).toEqual('x');
+             expect(bazDef.parameters[0].initializer).toBe(null);
 
-           const quxNode = getDeclaration(
-               bundle.program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration)!;
-           const quxDef = host.getDefinitionOfFunction(quxNode)!;
-           expect(quxDef.node).toBe(quxNode);
-           expect(quxDef.body!.length).toEqual(2);
-           expect(quxDef.parameters.length).toEqual(1);
-           expect(quxDef.parameters[0].name).toEqual('x');
-           expect(quxDef.parameters[0].initializer).toBe(null);
-         });
-    });
-
-    describe('getImportOfIdentifier', () => {
-      it('should find the import of an identifier', () => {
-        loadTestFiles(IMPORTS_FILES);
-        const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const variableNode =
-            getDeclaration(bundle.program, _('/file_b.js'), 'b', isNamedVariableDeclaration);
-        const identifier =
-            (variableNode.initializer && ts.isPropertyAccessExpression(variableNode.initializer) &&
-             ts.isIdentifier(variableNode.initializer.name)) ?
-            variableNode.initializer.name :
-            null;
-
-        expect(identifier).not.toBe(null);
-        const importOfIdent = host.getImportOfIdentifier(identifier!);
-        expect(importOfIdent).toEqual({name: 'a', from: './file_a'});
+             const quxNode = getDeclaration(
+                 bundle.program, FUNCTION_BODY_FILE.name, 'qux', isNamedFunctionDeclaration)!;
+             const quxDef = host.getDefinitionOfFunction(quxNode)!;
+             expect(quxDef.node).toBe(quxNode);
+             expect(quxDef.body!.length).toEqual(2);
+             expect(quxDef.parameters.length).toEqual(1);
+             expect(quxDef.parameters[0].name).toEqual('x');
+             expect(quxDef.parameters[0].initializer).toBe(null);
+           });
       });
 
-      it('should return null if the identifier was not imported', () => {
-        loadTestFiles(IMPORTS_FILES);
-        const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const variableNode =
-            getDeclaration(bundle.program, _('/file_b.js'), 'd', isNamedVariableDeclaration);
-        const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
+      describe('getImportOfIdentifier', () => {
+        it('should find the import of an identifier', () => {
+          loadTestFiles(IMPORTS_FILES);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const variableNode =
+              getDeclaration(bundle.program, _('/file_b.js'), 'b', isNamedVariableDeclaration);
+          const identifier = (variableNode.initializer &&
+                              ts.isPropertyAccessExpression(variableNode.initializer) &&
+                              ts.isIdentifier(variableNode.initializer.name)) ?
+              variableNode.initializer.name :
+              null;
 
-        expect(importOfIdent).toBeNull();
+          expect(identifier).not.toBe(null);
+          const importOfIdent = host.getImportOfIdentifier(identifier!);
+          expect(importOfIdent).toEqual({name: 'a', from: './file_a'});
+        });
+
+        it('should return null if the identifier was not imported', () => {
+          loadTestFiles(IMPORTS_FILES);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const variableNode =
+              getDeclaration(bundle.program, _('/file_b.js'), 'd', isNamedVariableDeclaration);
+          const importOfIdent =
+              host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
+
+          expect(importOfIdent).toBeNull();
+        });
+
+        it('should handle factory functions not wrapped in parentheses', () => {
+          loadTestFiles(IMPORTS_FILES);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const variableNode =
+              getDeclaration(bundle.program, _('/file_c.js'), 'c', isNamedVariableDeclaration);
+          const identifier = (variableNode.initializer &&
+                              ts.isPropertyAccessExpression(variableNode.initializer) &&
+                              ts.isIdentifier(variableNode.initializer.name)) ?
+              variableNode.initializer.name :
+              null;
+
+          expect(identifier).not.toBe(null);
+          const importOfIdent = host.getImportOfIdentifier(identifier!);
+          expect(importOfIdent).toEqual({name: 'a', from: './file_a'});
+        });
       });
 
-      it('should handle factory functions not wrapped in parentheses', () => {
-        loadTestFiles(IMPORTS_FILES);
-        const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const variableNode =
-            getDeclaration(bundle.program, _('/file_c.js'), 'c', isNamedVariableDeclaration);
-        const identifier =
-            (variableNode.initializer && ts.isPropertyAccessExpression(variableNode.initializer) &&
-             ts.isIdentifier(variableNode.initializer.name)) ?
-            variableNode.initializer.name :
-            null;
+      describe('getDeclarationOfIdentifier', () => {
+        // Helpers
+        const createTestForTsHelper =
+            (host: NgccReflectionHost, factoryFn: ts.FunctionExpression,
+             getHelperDeclaration: (factoryFn: ts.FunctionExpression, name: string) =>
+                 ts.Declaration) =>
+                (varName: string, helperName: string, knownAs: KnownDeclaration,
+                 viaModule: string|null = null) => {
+                  const node = getVariableDeclaration(factoryFn, varName);
+                  const helperIdentifier = getIdentifierFromCallExpression(node);
+                  const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
 
-        expect(identifier).not.toBe(null);
-        const importOfIdent = host.getImportOfIdentifier(identifier!);
-        expect(importOfIdent).toEqual({name: 'a', from: './file_a'});
-      });
-    });
+                  expect(helperDeclaration).toEqual({
+                    kind: DeclarationKind.Concrete,
+                    known: knownAs,
+                    node: getHelperDeclaration(factoryFn, helperName),
+                    viaModule,
+                    identity: null,
+                  });
+                };
 
-    describe('getDeclarationOfIdentifier', () => {
-      // Helpers
-      const createTestForTsHelper =
-          (host: NgccReflectionHost, factoryFn: ts.FunctionExpression,
-           getHelperDeclaration: (factoryFn: ts.FunctionExpression, name: string) =>
-               ts.Declaration) =>
-              (varName: string, helperName: string, knownAs: KnownDeclaration,
-               viaModule: string|null = null) => {
-                const node = getVariableDeclaration(factoryFn, varName);
-                const helperIdentifier = getIdentifierFromCallExpression(node);
-                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+        const getFunctionDeclaration = (factoryFn: ts.FunctionExpression, name: string) =>
+            factoryFn.body.statements.filter(ts.isFunctionDeclaration)
+                .find(decl => (decl.name !== undefined) && (decl.name.text === name))!;
 
-                expect(helperDeclaration).toEqual({
-                  kind: DeclarationKind.Concrete,
-                  known: knownAs,
-                  node: getHelperDeclaration(factoryFn, helperName),
-                  viaModule,
-                  identity: null,
-                });
-              };
+        const getIdentifierFromCallExpression = (decl: ts.VariableDeclaration) => {
+          if (decl.initializer !== undefined && ts.isCallExpression(decl.initializer)) {
+            const expr = decl.initializer.expression;
+            if (ts.isIdentifier(expr)) return expr;
+            if (ts.isPropertyAccessExpression(expr) && ts.isIdentifier(expr.name)) return expr.name;
+          }
+          throw new Error(`Unable to extract identifier from declaration '${decl.getText()}'.`);
+        };
 
-      const getFunctionDeclaration = (factoryFn: ts.FunctionExpression, name: string) =>
-          factoryFn.body.statements.filter(ts.isFunctionDeclaration)
-              .find(decl => (decl.name !== undefined) && (decl.name.text === name))!;
+        const getVariableDeclaration = (factoryFn: ts.FunctionExpression, name: string) =>
+            factoryFn.body.statements.filter(ts.isVariableStatement)
+                .map(stmt => stmt.declarationList.declarations[0])
+                .find(decl => ts.isIdentifier(decl.name) && (decl.name.text === name))!;
 
-      const getIdentifierFromCallExpression = (decl: ts.VariableDeclaration) => {
-        if (decl.initializer !== undefined && ts.isCallExpression(decl.initializer)) {
-          const expr = decl.initializer.expression;
-          if (ts.isIdentifier(expr)) return expr;
-          if (ts.isPropertyAccessExpression(expr) && ts.isIdentifier(expr.name)) return expr.name;
-        }
-        throw new Error(`Unable to extract identifier from declaration '${decl.getText()}'.`);
-      };
+        it('should return the declaration of a locally defined identifier', () => {
+          loadTestFiles([SOME_DIRECTIVE_FILE]);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isDesiredDeclaration);
+          const ctrDecorators = host.getConstructorParameters(classNode)!;
+          const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference! as {
+                                                 kind: TypeValueReferenceKind.LOCAL,
+                                                 expression: ts.Identifier,
+                                                 defaultImportStatement: null,
+                                               }).expression;
 
-      const getVariableDeclaration = (factoryFn: ts.FunctionExpression, name: string) =>
-          factoryFn.body.statements.filter(ts.isVariableStatement)
-              .map(stmt => stmt.declarationList.declarations[0])
-              .find(decl => ts.isIdentifier(decl.name) && (decl.name.text === name))!;
+          const expectedDeclarationNode = getDeclaration(
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'ViewContainerRef',
+              isNamedVariableDeclaration);
+          const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfViewContainerRef);
+          expect(actualDeclaration).not.toBe(null);
+          expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
+          expect(actualDeclaration!.viaModule).toBe(null);
+          expect((actualDeclaration as ConcreteDeclaration).identity).toBe(null);
+        });
 
-      it('should return the declaration of a locally defined identifier', () => {
-        loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
-        const ctrDecorators = host.getConstructorParameters(classNode)!;
-        const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference! as {
-                                               kind: TypeValueReferenceKind.LOCAL,
-                                               expression: ts.Identifier,
-                                               defaultImportStatement: null,
-                                             }).expression;
-
-        const expectedDeclarationNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'ViewContainerRef',
-            isNamedVariableDeclaration);
-        const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfViewContainerRef);
-        expect(actualDeclaration).not.toBe(null);
-        expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
-        expect(actualDeclaration!.viaModule).toBe(null);
-        expect((actualDeclaration as ConcreteDeclaration).identity).toBe(null);
-      });
-
-      it('should return the correct declaration for an outer alias identifier', () => {
-        const PROGRAM_FILE: TestFile = {
-          name: _('/test.js'),
-          contents: `
+        it('should return the correct declaration for an outer alias identifier', () => {
+          const PROGRAM_FILE: TestFile = {
+            name: _('/test.js'),
+            contents: `
             (function (global, factory) {
               typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
               typeof define === 'function' && define.amd ? define('test', ['exports'], factory) :
               (factory(global.test));
             }(this, (function (exports,module) { 'use strict';
-              var AliasedClass = AliasedClass_1 = (function () {
+              ${expDecl('AliasedClass')} = AliasedClass_1 = (function () {
                 function InnerClass() {
                 }
                 return InnerClass;
@@ -2069,155 +2165,164 @@ runInEachFileSystem(() => {
               var AliasedClass_1;
             })));
           `,
-        };
+          };
 
-        loadTestFiles([PROGRAM_FILE]);
-        const bundle = makeTestBundleProgram(PROGRAM_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          loadTestFiles([PROGRAM_FILE]);
+          const bundle = makeTestBundleProgram(PROGRAM_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
 
-        const expectedDeclaration = getDeclaration(
-            bundle.program, PROGRAM_FILE.name, 'AliasedClass', isNamedVariableDeclaration);
-        // Grab the `AliasedClass_1` identifier (which is an alias for `AliasedClass`).
-        const aliasIdentifier =
-            (expectedDeclaration.initializer as ts.BinaryExpression).left as ts.Identifier;
-        const actualDeclaration = host.getDeclarationOfIdentifier(aliasIdentifier);
+          const expectedDeclaration = getDeclaration(
+              bundle.program, PROGRAM_FILE.name, 'AliasedClass', isDesiredDeclaration);
+          // Grab the `AliasedClass_1` identifier (which is an alias for `AliasedClass`).
+          const aliasIdentifier = getDeclaration(
+              bundle.program, PROGRAM_FILE.name, 'AliasedClass_1', isNamedVariableDeclaration);
+          const actualDeclaration = host.getDeclarationOfIdentifier(aliasIdentifier.name);
 
-        expect(aliasIdentifier.getText()).toBe('AliasedClass_1');
-        expect(actualDeclaration).not.toBe(null);
-        expect(actualDeclaration!.node).toBe(expectedDeclaration);
-      });
+          expect(aliasIdentifier.getText()).toBe('AliasedClass_1');
+          expect(actualDeclaration).not.toBe(null);
+          expect(actualDeclaration!.node).toBe(expectedDeclaration);
+        });
 
-      it('should return the source-file of an import namespace', () => {
-        loadFakeCore(getFileSystem());
-        loadTestFiles([SOME_DIRECTIVE_FILE]);
-        const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode = getDeclaration(
-            bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isNamedFunctionDeclaration);
-        const classDecorators = host.getDecoratorsOfDeclaration(classNode)!;
-        const identifierOfDirective =
-            (((classDecorators[0].node as ts.ObjectLiteralExpression).properties[0] as
-              ts.PropertyAssignment)
-                 .initializer as ts.PropertyAccessExpression)
-                .expression as ts.Identifier;
+        it('should return the source-file of an import namespace', () => {
+          loadFakeCore(getFileSystem());
+          loadTestFiles([SOME_DIRECTIVE_FILE]);
+          const bundle = makeTestBundleProgram(SOME_DIRECTIVE_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode = getDeclaration(
+              bundle.program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', isDesiredDeclaration);
+          const classDecorators = host.getDecoratorsOfDeclaration(classNode)!;
+          const identifierOfDirective =
+              (((classDecorators[0].node as ts.ObjectLiteralExpression).properties[0] as
+                ts.PropertyAssignment)
+                   .initializer as ts.PropertyAccessExpression)
+                  .expression as ts.Identifier;
 
-        const expectedDeclarationNode =
-            getSourceFileOrError(bundle.program, _('/node_modules/@angular/core/index.d.ts'));
-        const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective);
-        expect(actualDeclaration).not.toBe(null);
-        expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
-        expect(actualDeclaration!.viaModule).toBe('@angular/core');
-      });
+          const expectedDeclarationNode =
+              getSourceFileOrError(bundle.program, _('/node_modules/@angular/core/index.d.ts'));
+          const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective);
+          expect(actualDeclaration).not.toBe(null);
+          expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
+          expect(actualDeclaration!.viaModule).toBe('@angular/core');
+        });
 
-      it('should return the source file as the declaration of a standalone "exports" identifier',
-         () => {
-           loadTestFiles([EXPORTS_IDENTIFIERS_FILE]);
-           const bundle = makeTestBundleProgram(EXPORTS_IDENTIFIERS_FILE.name);
-           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-           const xVar = getDeclaration(
-               bundle.program, EXPORTS_IDENTIFIERS_FILE.name, 'x', ts.isVariableDeclaration);
-           const exportsIdentifier = xVar.initializer;
-           if (exportsIdentifier === undefined || !ts.isIdentifier(exportsIdentifier)) {
-             throw new Error('Bad test - unable to find `var x = exports;` statement');
-           }
-           const exportsDeclaration = host.getDeclarationOfIdentifier(exportsIdentifier);
-           expect(exportsDeclaration).not.toBeNull();
-           expect(exportsDeclaration!.node).toBe(bundle.file);
-         });
+        it('should return the source file as the declaration of a standalone "exports" identifier',
+           () => {
+             loadTestFiles([EXPORTS_IDENTIFIERS_FILE]);
+             const bundle = makeTestBundleProgram(EXPORTS_IDENTIFIERS_FILE.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const xVar = getDeclaration(
+                 bundle.program, EXPORTS_IDENTIFIERS_FILE.name, 'x', isNamedVariableDeclaration);
+             const exportsIdentifier = xVar.initializer;
+             if (exportsIdentifier === undefined || !ts.isIdentifier(exportsIdentifier)) {
+               throw new Error('Bad test - unable to find `var x = exports;` statement');
+             }
+             const exportsDeclaration = host.getDeclarationOfIdentifier(exportsIdentifier);
+             expect(exportsDeclaration).not.toBeNull();
+             expect(exportsDeclaration!.node).toBe(bundle.file);
+           });
 
-      it('should return the source file as the declaration of "exports" in the LHS of a property access',
-         () => {
-           loadTestFiles([EXPORTS_IDENTIFIERS_FILE]);
-           const bundle = makeTestBundleProgram(EXPORTS_IDENTIFIERS_FILE.name);
-           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-           const exportsStatement = walkForNode(bundle.file, isExportsStatement);
-           if (exportsStatement === undefined) {
-             throw new Error('Bad test - unable to find `exports.foo = 42;` statement');
-           }
-           const exportsIdentifier = exportsStatement.expression.left.expression;
-           const exportDeclaration = host.getDeclarationOfIdentifier(exportsIdentifier);
-           expect(exportDeclaration).not.toBeNull();
-           expect(exportDeclaration!.node).toBe(bundle.file);
-         });
+        it('should return the source file as the declaration of "exports" in the LHS of a property access',
+           () => {
+             loadTestFiles([EXPORTS_IDENTIFIERS_FILE]);
+             const bundle = makeTestBundleProgram(EXPORTS_IDENTIFIERS_FILE.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const exportsStatement = walkForNode(bundle.file, isExportsStatement);
+             if (exportsStatement === undefined) {
+               throw new Error('Bad test - unable to find `exports.foo = 42;` statement');
+             }
+             const exportsIdentifier = exportsStatement.expression.left.expression;
+             const exportsDeclaration = host.getDeclarationOfIdentifier(exportsIdentifier);
+             expect(exportsDeclaration).not.toBeNull();
+             expect(exportsDeclaration!.node).toBe(bundle.file);
+           });
 
-      it('should return the source file as the declaration of "exports" in the LHS of a property access inside a local function',
-         () => {
-           loadTestFiles([EXPORTS_IDENTIFIERS_FILE]);
-           const bundle = makeTestBundleProgram(EXPORTS_IDENTIFIERS_FILE.name);
-           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-           const simpleFn = getDeclaration(
-               bundle.program, EXPORTS_IDENTIFIERS_FILE.name, 'simpleFn', ts.isFunctionDeclaration);
-           const exportsStatement = walkForNode(simpleFn, isExportsStatement);
-           if (exportsStatement === undefined) {
-             throw new Error('Bad test - unable to find `exports.foo = 42;` statement');
-           }
-           const exportsIdentifier = exportsStatement.expression.left.expression;
-           const exportDeclaration = host.getDeclarationOfIdentifier(exportsIdentifier);
-           expect(exportDeclaration).not.toBeNull();
-           expect(exportDeclaration!.node).toBe(bundle.file);
-         });
+        it('should return the source file as the declaration of "exports" in the LHS of a property access inside a local function',
+           () => {
+             loadTestFiles([EXPORTS_IDENTIFIERS_FILE]);
+             const bundle = makeTestBundleProgram(EXPORTS_IDENTIFIERS_FILE.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const simpleFn = getDeclaration(
+                 bundle.program, EXPORTS_IDENTIFIERS_FILE.name, 'simpleFn',
+                 ts.isFunctionDeclaration);
+             const exportsStatement = walkForNode(simpleFn, isExportsStatement);
+             if (exportsStatement === undefined) {
+               throw new Error('Bad test - unable to find `exports.foo = 42;` statement');
+             }
+             const exportsIdentifier = exportsStatement.expression.left.expression;
+             const exportDeclaration = host.getDeclarationOfIdentifier(exportsIdentifier);
+             expect(exportDeclaration).not.toBeNull();
+             expect(exportDeclaration!.node).toBe(bundle.file);
+           });
 
-      it('should return the variable declaration if a standalone "exports" is declared locally',
-         () => {
-           loadTestFiles([EXPORTS_IDENTIFIERS_FILE]);
-           const bundle = makeTestBundleProgram(EXPORTS_IDENTIFIERS_FILE.name);
-           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-           const localVarFn = getDeclaration(
-               bundle.program, EXPORTS_IDENTIFIERS_FILE.name, 'localVar', ts.isFunctionDeclaration);
-           const exportsVar = walkForNode(localVarFn, ts.isVariableDeclaration);
-           if (exportsVar === undefined) {
-             throw new Error('Bad test - unable to find `var exports = {}` statement');
-           }
-           const exportsIdentifier = exportsVar.name;
-           if (exportsIdentifier === undefined || !ts.isIdentifier(exportsIdentifier)) {
-             throw new Error('Bad test - unable to find `var exports = {};` statement');
-           }
-           const exportsDeclaration = host.getDeclarationOfIdentifier(exportsIdentifier);
-           expect(exportsDeclaration).not.toBeNull();
-           expect(exportsDeclaration!.node).toBe(exportsVar);
-         });
+        it('should return the variable declaration if a standalone "exports" is declared locally',
+           () => {
+             loadTestFiles([EXPORTS_IDENTIFIERS_FILE]);
+             const bundle = makeTestBundleProgram(EXPORTS_IDENTIFIERS_FILE.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const localVarFn = getDeclaration(
+                 bundle.program, EXPORTS_IDENTIFIERS_FILE.name, 'localVar',
+                 ts.isFunctionDeclaration);
+             const exportsVar = walkForNode(localVarFn, isNamedVariableDeclaration);
+             if (exportsVar === undefined) {
+               throw new Error('Bad test - unable to find `var exports = {}` statement');
+             }
+             const exportsIdentifier = exportsVar.name;
+             if (exportsIdentifier === undefined || !ts.isIdentifier(exportsIdentifier)) {
+               throw new Error('Bad test - unable to find `var exports = {};` statement');
+             }
+             const exportsDeclaration = host.getDeclarationOfIdentifier(exportsIdentifier);
+             expect(exportsDeclaration).not.toBeNull();
+             expect(exportsDeclaration!.node).toBe(exportsVar);
+           });
 
-      it('should return the variable declaration of "exports" in the LHS of a property access, if it is declared locally',
-         () => {
-           loadTestFiles([EXPORTS_IDENTIFIERS_FILE]);
-           const bundle = makeTestBundleProgram(EXPORTS_IDENTIFIERS_FILE.name);
-           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-           const localVarFn = getDeclaration(
-               bundle.program, EXPORTS_IDENTIFIERS_FILE.name, 'localVar', ts.isFunctionDeclaration);
-           const exportsVar = walkForNode(localVarFn, ts.isVariableDeclaration);
-           const exportsStatement = walkForNode(localVarFn, isExportsStatement);
-           if (exportsStatement === undefined) {
-             throw new Error('Bad test - unable to find `exports.foo = 42;` statement');
-           }
-           const exportsIdentifier = exportsStatement.expression.left.expression;
-           const exportDeclaration = host.getDeclarationOfIdentifier(exportsIdentifier);
-           expect(exportDeclaration).not.toBeNull();
-           expect(exportDeclaration?.node).toBe(exportsVar);
-         });
+        it('should return the variable declaration of "exports" in the LHS of a property access, if it is declared locally',
+           () => {
+             loadTestFiles([EXPORTS_IDENTIFIERS_FILE]);
+             const bundle = makeTestBundleProgram(EXPORTS_IDENTIFIERS_FILE.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const localVarFn = getDeclaration(
+                 bundle.program, EXPORTS_IDENTIFIERS_FILE.name, 'localVar',
+                 ts.isFunctionDeclaration);
+             const exportsVar = walkForNode(localVarFn, isNamedVariableDeclaration);
+             const exportsStatement = walkForNode(localVarFn, isExportsStatement);
+             if (exportsStatement === undefined) {
+               throw new Error('Bad test - unable to find `exports.foo = 42;` statement');
+             }
+             const exportsIdentifier = exportsStatement.expression.left.expression;
+             const exportDeclaration = host.getDeclarationOfIdentifier(exportsIdentifier);
+             expect(exportDeclaration).not.toBeNull();
+             expect(exportDeclaration?.node).toBe(exportsVar);
+           });
 
-      it('should return the variable declaration of "exports" in the LHS of a property access, if it is a local function parameter',
-         () => {
-           loadTestFiles([EXPORTS_IDENTIFIERS_FILE]);
-           const bundle = makeTestBundleProgram(EXPORTS_IDENTIFIERS_FILE.name);
-           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-           const exportsArgFn = getDeclaration(
-               bundle.program, EXPORTS_IDENTIFIERS_FILE.name, 'exportsArg',
-               ts.isFunctionDeclaration);
-           const exportsVar = exportsArgFn.parameters[0];
-           const exportsStatement = walkForNode(exportsArgFn, isExportsStatement);
-           if (exportsStatement === undefined) {
-             throw new Error('Bad test - unable to find `exports.foo = 42;` statement');
-           }
-           const exportsIdentifier = exportsStatement.expression.left.expression;
-           const exportDeclaration = host.getDeclarationOfIdentifier(exportsIdentifier);
-           expect(exportDeclaration).not.toBeNull();
-           expect(exportDeclaration?.node).toBe(exportsVar);
-         });
+        it('should return the variable declaration of "exports" in the LHS of a property access, if it is a local function parameter',
+           () => {
+             loadTestFiles([EXPORTS_IDENTIFIERS_FILE]);
+             const bundle = makeTestBundleProgram(EXPORTS_IDENTIFIERS_FILE.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const exportsArgFn = getDeclaration(
+                 bundle.program, EXPORTS_IDENTIFIERS_FILE.name, 'exportsArg',
+                 ts.isFunctionDeclaration);
+             const exportsVar = exportsArgFn.parameters[0];
+             const exportsStatement = walkForNode(exportsArgFn, isExportsStatement);
+             if (exportsStatement === undefined) {
+               throw new Error('Bad test - unable to find `exports.foo = 42;` statement');
+             }
+             const exportsIdentifier = exportsStatement.expression.left.expression;
+             const exportDeclaration = host.getDeclarationOfIdentifier(exportsIdentifier);
+             expect(exportDeclaration).not.toBeNull();
+             expect(exportDeclaration?.node).toBe(exportsVar);
+           });
 
-      it('should recognize TypeScript helpers (as function declarations)', () => {
-        const file: TestFile = {
-          name: _('/test.js'),
-          contents: `
+        it('should recognize TypeScript helpers (as function declarations)', () => {
+          const file: TestFile = {
+            name: _('/test.js'),
+            contents: `
             (function (global, factory) {
               typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
               typeof define === 'function' && define.amd ? define('test', ['exports'], factory) :
@@ -2232,24 +2337,24 @@ runInEachFileSystem(() => {
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
             })));
           `,
-        };
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const {factoryFn} = parseStatementForUmdModule(
-            getSourceFileOrError(bundle.program, file.name).statements[0])!;
+          };
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const {factoryFn} = parseStatementForUmdModule(
+              getSourceFileOrError(bundle.program, file.name).statements[0])!;
 
-        const testForHelper = createTestForTsHelper(host, factoryFn, getFunctionDeclaration);
+          const testForHelper = createTestForTsHelper(host, factoryFn, getFunctionDeclaration);
 
-        testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
-        testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
-        testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
-      });
+          testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
+          testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
+          testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+        });
 
-      it('should recognize suffixed TypeScript helpers (as function declarations)', () => {
-        const file: TestFile = {
-          name: _('/test.js'),
-          contents: `
+        it('should recognize suffixed TypeScript helpers (as function declarations)', () => {
+          const file: TestFile = {
+            name: _('/test.js'),
+            contents: `
             (function (global, factory) {
               typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
               typeof define === 'function' && define.amd ? define('test', ['exports'], factory) :
@@ -2264,24 +2369,24 @@ runInEachFileSystem(() => {
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
             })));
           `,
-        };
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const {factoryFn} = parseStatementForUmdModule(
-            getSourceFileOrError(bundle.program, file.name).statements[0])!;
+          };
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const {factoryFn} = parseStatementForUmdModule(
+              getSourceFileOrError(bundle.program, file.name).statements[0])!;
 
-        const testForHelper = createTestForTsHelper(host, factoryFn, getFunctionDeclaration);
+          const testForHelper = createTestForTsHelper(host, factoryFn, getFunctionDeclaration);
 
-        testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
-        testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
-        testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
-      });
+          testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
+          testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
+          testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+        });
 
-      it('should recognize TypeScript helpers (as variable declarations)', () => {
-        const file: TestFile = {
-          name: _('/test.js'),
-          contents: `
+        it('should recognize TypeScript helpers (as variable declarations)', () => {
+          const file: TestFile = {
+            name: _('/test.js'),
+            contents: `
             (function (global, factory) {
               typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
               typeof define === 'function' && define.amd ? define('test', ['exports'], factory) :
@@ -2296,24 +2401,24 @@ runInEachFileSystem(() => {
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
             })));
           `,
-        };
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const {factoryFn} = parseStatementForUmdModule(
-            getSourceFileOrError(bundle.program, file.name).statements[0])!;
+          };
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const {factoryFn} = parseStatementForUmdModule(
+              getSourceFileOrError(bundle.program, file.name).statements[0])!;
 
-        const testForHelper = createTestForTsHelper(host, factoryFn, getVariableDeclaration);
+          const testForHelper = createTestForTsHelper(host, factoryFn, getVariableDeclaration);
 
-        testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
-        testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
-        testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
-      });
+          testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
+          testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
+          testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+        });
 
-      it('should recognize suffixed TypeScript helpers (as variable declarations)', () => {
-        const file: TestFile = {
-          name: _('/test.js'),
-          contents: `
+        it('should recognize suffixed TypeScript helpers (as variable declarations)', () => {
+          const file: TestFile = {
+            name: _('/test.js'),
+            contents: `
             (function (global, factory) {
               typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
               typeof define === 'function' && define.amd ? define('test', ['exports'], factory) :
@@ -2328,25 +2433,25 @@ runInEachFileSystem(() => {
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
             })));
           `,
-        };
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const {factoryFn} = parseStatementForUmdModule(
-            getSourceFileOrError(bundle.program, file.name).statements[0])!;
+          };
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const {factoryFn} = parseStatementForUmdModule(
+              getSourceFileOrError(bundle.program, file.name).statements[0])!;
 
-        const testForHelper = createTestForTsHelper(host, factoryFn, getVariableDeclaration);
+          const testForHelper = createTestForTsHelper(host, factoryFn, getVariableDeclaration);
 
-        testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
-        testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
-        testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
-      });
+          testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
+          testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
+          testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+        });
 
-      it('should recognize imported TypeScript helpers', () => {
-        const files: TestFile[] = [
-          {
-            name: _('/test.js'),
-            contents: `
+        it('should recognize imported TypeScript helpers', () => {
+          const files: TestFile[] = [
+            {
+              name: _('/test.js'),
+              contents: `
               (function (global, factory) {
                 typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('tslib')) :
                 typeof define === 'function' && define.amd ? define('test', ['exports', 'tslib'], factory) :
@@ -2357,37 +2462,37 @@ runInEachFileSystem(() => {
                 var c = tslib_1.__spreadArrays(['foo', 'bar'], ['baz', 'qux']);
               })));
             `,
-          },
-          {
-            name: _('/node_modules/tslib/index.d.ts'),
-            contents: `
+            },
+            {
+              name: _('/node_modules/tslib/index.d.ts'),
+              contents: `
               export declare function __assign(t: any, ...sources: any[]): any;
               export declare function __spread(...args: any[][]): any[];
               export declare function __spreadArrays(...args: any[][]): any[];
             `,
-          },
-        ];
-        loadTestFiles(files);
+            },
+          ];
+          loadTestFiles(files);
 
-        const [testFile, tslibFile] = files;
-        const bundle = makeTestBundleProgram(testFile.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const {factoryFn} = parseStatementForUmdModule(
-            getSourceFileOrError(bundle.program, testFile.name).statements[0])!;
-        const testForHelper = createTestForTsHelper(
-            host, factoryFn,
-            (_fn, helperName) => getDeclaration(
-                bundle.program, tslibFile.name, helperName, ts.isFunctionDeclaration));
+          const [testFile, tslibFile] = files;
+          const bundle = makeTestBundleProgram(testFile.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const {factoryFn} = parseStatementForUmdModule(
+              getSourceFileOrError(bundle.program, testFile.name).statements[0])!;
+          const testForHelper = createTestForTsHelper(
+              host, factoryFn,
+              (_fn, helperName) => getDeclaration(
+                  bundle.program, tslibFile.name, helperName, ts.isFunctionDeclaration));
 
-        testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign, 'tslib');
-        testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
-        testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
-      });
+          testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign, 'tslib');
+          testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
+          testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
+        });
 
-      it('should recognize undeclared, unimported TypeScript helpers (by name)', () => {
-        const file: TestFile = {
-          name: _('/test.js'),
-          contents: `
+        it('should recognize undeclared, unimported TypeScript helpers (by name)', () => {
+          const file: TestFile = {
+            name: _('/test.js'),
+            contents: `
             (function (global, factory) {
               typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
               typeof define === 'function' && define.amd ? define('test', ['exports'], factory) :
@@ -2398,35 +2503,36 @@ runInEachFileSystem(() => {
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
             })));
           `,
-        };
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const {factoryFn} = parseStatementForUmdModule(
-            getSourceFileOrError(bundle.program, file.name).statements[0])!;
+          };
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const {factoryFn} = parseStatementForUmdModule(
+              getSourceFileOrError(bundle.program, file.name).statements[0])!;
 
-        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
-          const node = getVariableDeclaration(factoryFn, varName);
-          const helperIdentifier = getIdentifierFromCallExpression(node);
-          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+          const testForHelper =
+              (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+                const node = getVariableDeclaration(factoryFn, varName);
+                const helperIdentifier = getIdentifierFromCallExpression(node);
+                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
 
-          expect(helperDeclaration).toEqual({
-            kind: DeclarationKind.Inline,
-            known: knownAs,
-            node: helperIdentifier,
-            viaModule: null,
-          });
-        };
+                expect(helperDeclaration).toEqual({
+                  kind: DeclarationKind.Inline,
+                  known: knownAs,
+                  node: helperIdentifier,
+                  viaModule: null,
+                });
+              };
 
-        testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
-        testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
-        testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
-      });
+          testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
+          testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
+          testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+        });
 
-      it('should recognize suffixed, undeclared, unimported TypeScript helpers (by name)', () => {
-        const file: TestFile = {
-          name: _('/test.js'),
-          contents: `
+        it('should recognize suffixed, undeclared, unimported TypeScript helpers (by name)', () => {
+          const file: TestFile = {
+            name: _('/test.js'),
+            contents: `
             (function (global, factory) {
               typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
               typeof define === 'function' && define.amd ? define('test', ['exports'], factory) :
@@ -2437,35 +2543,36 @@ runInEachFileSystem(() => {
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
             })));
           `,
-        };
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const {factoryFn} = parseStatementForUmdModule(
-            getSourceFileOrError(bundle.program, file.name).statements[0])!;
+          };
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const {factoryFn} = parseStatementForUmdModule(
+              getSourceFileOrError(bundle.program, file.name).statements[0])!;
 
-        const testForHelper = (varName: string, helperName: string, knownAs: KnownDeclaration) => {
-          const node = getVariableDeclaration(factoryFn, varName);
-          const helperIdentifier = getIdentifierFromCallExpression(node);
-          const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
+          const testForHelper =
+              (varName: string, helperName: string, knownAs: KnownDeclaration) => {
+                const node = getVariableDeclaration(factoryFn, varName);
+                const helperIdentifier = getIdentifierFromCallExpression(node);
+                const helperDeclaration = host.getDeclarationOfIdentifier(helperIdentifier);
 
-          expect(helperDeclaration).toEqual({
-            kind: DeclarationKind.Inline,
-            known: knownAs,
-            node: helperIdentifier,
-            viaModule: null,
-          });
-        };
+                expect(helperDeclaration).toEqual({
+                  kind: DeclarationKind.Inline,
+                  known: knownAs,
+                  node: helperIdentifier,
+                  viaModule: null,
+                });
+              };
 
-        testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
-        testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
-        testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
-      });
+          testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
+          testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
+          testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+        });
 
-      it('should recognize enum declarations with string values', () => {
-        const testFile: TestFile = {
-          name: _('/node_modules/test-package/some/file.js'),
-          contents: `
+        it('should recognize enum declarations with string values', () => {
+          const testFile: TestFile = {
+            name: _('/node_modules/test-package/some/file.js'),
+            contents: `
           (function (global, factory) {
             typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
             typeof define === 'function' && define.amd ? define('some_directive', ['exports', '@angular/core'], factory) :
@@ -2480,30 +2587,30 @@ runInEachFileSystem(() => {
             var value = Enum;
           })));
           `
-        };
-        loadTestFiles([testFile]);
-        const bundle = makeTestBundleProgram(testFile.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const {factoryFn} = parseStatementForUmdModule(
-            getSourceFileOrError(bundle.program, _('/node_modules/test-package/some/file.js'))
-                .statements[0])!;
-        const valueDecl = getVariableDeclaration(factoryFn, 'value');
-        const declaration = host.getDeclarationOfIdentifier(
-                                valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
+          };
+          loadTestFiles([testFile]);
+          const bundle = makeTestBundleProgram(testFile.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const {factoryFn} = parseStatementForUmdModule(
+              getSourceFileOrError(bundle.program, _('/node_modules/test-package/some/file.js'))
+                  .statements[0])!;
+          const valueDecl = getVariableDeclaration(factoryFn, 'value');
+          const declaration = host.getDeclarationOfIdentifier(
+                                  valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
 
-        const enumMembers = (declaration.identity as DownleveledEnum).enumMembers;
-        expect(declaration.node.parent.parent.getText()).toBe('var Enum;');
-        expect(enumMembers!.length).toBe(2);
-        expect(enumMembers![0].name.getText()).toBe('"ValueA"');
-        expect(enumMembers![0].initializer!.getText()).toBe('"1"');
-        expect(enumMembers![1].name.getText()).toBe('"ValueB"');
-        expect(enumMembers![1].initializer!.getText()).toBe('"2"');
-      });
+          const enumMembers = (declaration.identity as DownleveledEnum).enumMembers;
+          expect(declaration.node.parent.parent.getText()).toBe('var Enum;');
+          expect(enumMembers!.length).toBe(2);
+          expect(enumMembers![0].name.getText()).toBe('"ValueA"');
+          expect(enumMembers![0].initializer!.getText()).toBe('"1"');
+          expect(enumMembers![1].name.getText()).toBe('"ValueB"');
+          expect(enumMembers![1].initializer!.getText()).toBe('"2"');
+        });
 
-      it('should recognize enum declarations with numeric values', () => {
-        const testFile: TestFile = {
-          name: _('/node_modules/test-package/some/file.js'),
-          contents: `
+        it('should recognize enum declarations with numeric values', () => {
+          const testFile: TestFile = {
+            name: _('/node_modules/test-package/some/file.js'),
+            contents: `
           (function (global, factory) {
             typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
             typeof define === 'function' && define.amd ? define('some_directive', ['exports', '@angular/core'], factory) :
@@ -2518,31 +2625,31 @@ runInEachFileSystem(() => {
             var value = Enum;
           })));
           `
-        };
-        loadTestFiles([testFile]);
-        const bundle = makeTestBundleProgram(testFile.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const {factoryFn} = parseStatementForUmdModule(
-            getSourceFileOrError(bundle.program, _('/node_modules/test-package/some/file.js'))
-                .statements[0])!;
-        const valueDecl = getVariableDeclaration(factoryFn, 'value');
-        const declaration = host.getDeclarationOfIdentifier(
-                                valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
+          };
+          loadTestFiles([testFile]);
+          const bundle = makeTestBundleProgram(testFile.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const {factoryFn} = parseStatementForUmdModule(
+              getSourceFileOrError(bundle.program, _('/node_modules/test-package/some/file.js'))
+                  .statements[0])!;
+          const valueDecl = getVariableDeclaration(factoryFn, 'value');
+          const declaration = host.getDeclarationOfIdentifier(
+                                  valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
 
-        const enumMembers = (declaration.identity as DownleveledEnum).enumMembers;
-        expect(declaration.node.parent.parent.getText()).toBe('var Enum;');
-        expect(enumMembers!.length).toBe(2);
-        expect(enumMembers![0].name.getText()).toBe('"ValueA"');
-        expect(enumMembers![0].initializer!.getText()).toBe('"1"');
-        expect(enumMembers![1].name.getText()).toBe('"ValueB"');
-        expect(enumMembers![1].initializer!.getText()).toBe('"2"');
-      });
+          const enumMembers = (declaration.identity as DownleveledEnum).enumMembers;
+          expect(declaration.node.parent.parent.getText()).toBe('var Enum;');
+          expect(enumMembers!.length).toBe(2);
+          expect(enumMembers![0].name.getText()).toBe('"ValueA"');
+          expect(enumMembers![0].initializer!.getText()).toBe('"1"');
+          expect(enumMembers![1].name.getText()).toBe('"ValueB"');
+          expect(enumMembers![1].initializer!.getText()).toBe('"2"');
+        });
 
-      it('should not consider IIFEs that do no assign members to the parameter as an enum declaration',
-         () => {
-           const testFile: TestFile = {
-             name: _('/node_modules/test-package/some/file.js'),
-             contents: `
+        it('should not consider IIFEs that do no assign members to the parameter as an enum declaration',
+           () => {
+             const testFile: TestFile = {
+               name: _('/node_modules/test-package/some/file.js'),
+               contents: `
           (function (global, factory) {
             typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
             typeof define === 'function' && define.amd ? define('some_directive', ['exports', '@angular/core'], factory) :
@@ -2557,24 +2664,25 @@ runInEachFileSystem(() => {
             var value = Enum;
           })));
           `
-           };
-           loadTestFiles([testFile]);
-           const bundle = makeTestBundleProgram(testFile.name);
-           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-           const valueDecl = getDeclaration(
-               bundle.program, _('/node_modules/test-package/some/file.js'), 'value',
-               ts.isVariableDeclaration);
-           const declaration = host.getDeclarationOfIdentifier(
-                                   valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
+             };
+             loadTestFiles([testFile]);
+             const bundle = makeTestBundleProgram(testFile.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const valueDecl = getDeclaration(
+                 bundle.program, _('/node_modules/test-package/some/file.js'), 'value',
+                 isNamedVariableDeclaration);
+             const declaration = host.getDeclarationOfIdentifier(
+                                     valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
 
-           expect(declaration.node.parent.parent.getText()).toBe('var Enum;');
-           expect(declaration.identity).toBe(null);
-         });
+             expect(declaration.node.parent.parent.getText()).toBe('var Enum;');
+             expect(declaration.identity).toBe(null);
+           });
 
-      it('should not consider IIFEs without call argument as an enum declaration', () => {
-        const testFile: TestFile = {
-          name: _('/node_modules/test-package/some/file.js'),
-          contents: `
+        it('should not consider IIFEs without call argument as an enum declaration', () => {
+          const testFile: TestFile = {
+            name: _('/node_modules/test-package/some/file.js'),
+            contents: `
           (function (global, factory) {
             typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('@angular/core')) :
             typeof define === 'function' && define.amd ? define('some_directive', ['exports', '@angular/core'], factory) :
@@ -2589,784 +2697,798 @@ runInEachFileSystem(() => {
             var value = Enum;
           })));
           `
-        };
-        loadTestFiles([testFile]);
-        const bundle = makeTestBundleProgram(testFile.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const valueDecl = getDeclaration(
-            bundle.program, _('/node_modules/test-package/some/file.js'), 'value',
-            ts.isVariableDeclaration);
-        const declaration = host.getDeclarationOfIdentifier(
-                                valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
+          };
+          loadTestFiles([testFile]);
+          const bundle = makeTestBundleProgram(testFile.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const valueDecl = getDeclaration(
+              bundle.program, _('/node_modules/test-package/some/file.js'), 'value',
+              isNamedVariableDeclaration);
+          const declaration = host.getDeclarationOfIdentifier(
+                                  valueDecl.initializer as ts.Identifier) as ConcreteDeclaration;
 
-        expect(declaration.node.parent.parent.getText()).toBe('var Enum;');
-        expect(declaration.identity).toBe(null);
+          expect(declaration.node.parent.parent.getText()).toBe('var Enum;');
+          expect(declaration.identity).toBe(null);
+        });
       });
-    });
 
-    describe('getExportsOfModule()', () => {
-      it('should return a map of all the exports from a given module', () => {
-        loadFakeCore(getFileSystem());
-        loadTestFiles(EXPORTS_FILES);
-        const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const file = getSourceFileOrError(bundle.program, _('/b_module.js'));
-        const exportDeclarations = host.getExportsOfModule(file);
-        expect(exportDeclarations).not.toBe(null);
-        expect(Array.from(exportDeclarations!.entries())
-                   .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
-            .toEqual([
-              ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, '@angular/core'],
-              ['a', `a = 'a'`, null],
-              ['b', `b = a_module.a`, null],
-              ['c', `a = 'a'`, null],
-              ['d', `b = a_module.a`, null],
-              ['e', `e = 'e'`, null],
-              ['DirectiveX', `Directive: FnWithArg<(clazz: any) => any>`, '@angular/core'],
-              [
-                'SomeClass', `SomeClass = (function() {
+      describe('getExportsOfModule()', () => {
+        it('should return a map of all the exports from a given module', () => {
+          loadFakeCore(getFileSystem());
+          loadTestFiles(EXPORTS_FILES);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const file = getSourceFileOrError(bundle.program, _('/b_module.js'));
+          const exportDeclarations = host.getExportsOfModule(file);
+          expect(exportDeclarations).not.toBe(null);
+          expect(Array.from(exportDeclarations!.entries())
+                     .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
+              .toEqual([
+                ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, '@angular/core'],
+                ['a', `a = 'a'`, null],
+                ['b', `b = a_module.a`, null],
+                ['c', `a = 'a'`, null],
+                ['d', `b = a_module.a`, null],
+                ['e', `e = 'e'`, null],
+                ['DirectiveX', `Directive: FnWithArg<(clazz: any) => any>`, '@angular/core'],
+                [
+                  'SomeClass', `SomeClass = (function() {
     function SomeClass() {}
     return SomeClass;
   }())`,
-                null
-              ],
-            ]);
-      });
+                  null
+                ],
+              ]);
+        });
 
-      it('should handle wildcard re-exports of other modules (with emitted helpers)', () => {
-        loadFakeCore(getFileSystem());
-        loadTestFiles(EXPORTS_FILES);
-        const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const file = getSourceFileOrError(bundle.program, _('/wildcard_reexports.js'));
-        const exportDeclarations = host.getExportsOfModule(file);
-        expect(exportDeclarations).not.toBe(null);
-        expect(Array.from(exportDeclarations!.entries())
-                   .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
-            .toEqual([
-              ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
-              ['a', `a = 'a'`, _('/b_module')],
-              ['b', `b = a_module.a`, _('/b_module')],
-              ['c', `a = 'a'`, _('/b_module')],
-              ['d', `b = a_module.a`, _('/b_module')],
-              ['e', `e = 'e'`, _('/b_module')],
-              ['DirectiveX', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
-              [
-                'SomeClass',
-                `SomeClass = (function() {\n    function SomeClass() {}\n    return SomeClass;\n  }())`,
-                _('/b_module')
-              ],
-              ['xtra1', `xtra1 = 'xtra1'`, _('/xtra_module')],
-              ['xtra2', `xtra2 = 'xtra2'`, _('/xtra_module')],
-            ]);
-      });
+        it('should return the correct declaration for a decorated class', () => {
+          loadFakeCore(getFileSystem());
+          loadTestFiles(EXPORTS_FILES);
+          const bundle = makeTestBundleProgram(_('/decorated_class.js'));
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const file = getSourceFileOrError(bundle.program, _('/decorated_class.js'));
+          const exportDeclarations = host.getExportsOfModule(file);
+          expect(exportDeclarations).not.toBe(null);
+          expect(exportDeclarations!.size).toEqual(1);
+          const classDecl = exportDeclarations!.get('DecoratedClass')!;
+          expect(classDecl).toBeDefined();
+          expect(classDecl.kind).toEqual(DeclarationKind.Inline);
+          expect(classDecl.known).toBe(null);
+          expect(classDecl.viaModule).toBe(null);
+          expect(classDecl.node.getText()).toEqual('exports.DecoratedClass');
+          expect(classDecl.node.parent.parent.getText()).toContain('function DecoratedClass() {');
+        });
 
-      it('should handle wildcard re-exports of other modules (with imported helpers)', () => {
-        loadFakeCore(getFileSystem());
-        loadTestFiles(EXPORTS_FILES);
-        const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const file =
-            getSourceFileOrError(bundle.program, _('/wildcard_reexports_imported_helpers.js'));
-        const exportDeclarations = host.getExportsOfModule(file);
-        expect(exportDeclarations).not.toBe(null);
-        expect(Array.from(exportDeclarations!.entries())
-                   .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
-            .toEqual([
-              ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
-              ['a', `a = 'a'`, _('/b_module')],
-              ['b', `b = a_module.a`, _('/b_module')],
-              ['c', `a = 'a'`, _('/b_module')],
-              ['d', `b = a_module.a`, _('/b_module')],
-              ['e', `e = 'e'`, _('/b_module')],
-              ['DirectiveX', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
-              [
-                'SomeClass',
-                `SomeClass = (function() {\n    function SomeClass() {}\n    return SomeClass;\n  }())`,
-                _('/b_module')
-              ],
-              ['xtra1', `xtra1 = 'xtra1'`, _('/xtra_module')],
-              ['xtra2', `xtra2 = 'xtra2'`, _('/xtra_module')],
-            ]);
-      });
+        it('should handle wildcard re-exports of other modules (with emitted helpers)', () => {
+          loadFakeCore(getFileSystem());
+          loadTestFiles(EXPORTS_FILES);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const file = getSourceFileOrError(bundle.program, _('/wildcard_reexports.js'));
+          const exportDeclarations = host.getExportsOfModule(file);
+          expect(exportDeclarations).not.toBe(null);
+          expect(Array.from(exportDeclarations!.entries())
+                     .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
+              .toEqual([
+                ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
+                ['a', `a = 'a'`, _('/b_module')],
+                ['b', `b = a_module.a`, _('/b_module')],
+                ['c', `a = 'a'`, _('/b_module')],
+                ['d', `b = a_module.a`, _('/b_module')],
+                ['e', `e = 'e'`, _('/b_module')],
+                ['DirectiveX', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
+                [
+                  'SomeClass',
+                  `SomeClass = (function() {\n    function SomeClass() {}\n    return SomeClass;\n  }())`,
+                  _('/b_module')
+                ],
+                ['xtra1', `xtra1 = 'xtra1'`, _('/xtra_module')],
+                ['xtra2', `xtra2 = 'xtra2'`, _('/xtra_module')],
+              ]);
+        });
 
-      it('should handle inline exports', () => {
-        loadFakeCore(getFileSystem());
-        loadTestFiles([INLINE_EXPORT_FILE]);
-        const bundle = makeTestBundleProgram(INLINE_EXPORT_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const file = getSourceFileOrError(bundle.program, INLINE_EXPORT_FILE.name);
-        const exportDeclarations = host.getExportsOfModule(file);
-        expect(exportDeclarations).not.toBe(null);
-        const decl = exportDeclarations!.get('directives')!;
-        expect(decl).toBeDefined();
-        expect(decl.node).toBeDefined();
-        expect(decl.kind).toEqual(DeclarationKind.Inline);
-      });
+        it('should handle wildcard re-exports of other modules (with imported helpers)', () => {
+          loadFakeCore(getFileSystem());
+          loadTestFiles(EXPORTS_FILES);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const file =
+              getSourceFileOrError(bundle.program, _('/wildcard_reexports_imported_helpers.js'));
+          const exportDeclarations = host.getExportsOfModule(file);
+          expect(exportDeclarations).not.toBe(null);
+          expect(Array.from(exportDeclarations!.entries())
+                     .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
+              .toEqual([
+                ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
+                ['a', `a = 'a'`, _('/b_module')],
+                ['b', `b = a_module.a`, _('/b_module')],
+                ['c', `a = 'a'`, _('/b_module')],
+                ['d', `b = a_module.a`, _('/b_module')],
+                ['e', `e = 'e'`, _('/b_module')],
+                ['DirectiveX', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
+                [
+                  'SomeClass',
+                  `SomeClass = (function() {\n    function SomeClass() {}\n    return SomeClass;\n  }())`,
+                  _('/b_module')
+                ],
+                ['xtra1', `xtra1 = 'xtra1'`, _('/xtra_module')],
+                ['xtra2', `xtra2 = 'xtra2'`, _('/xtra_module')],
+              ]);
+        });
 
-      it('should recognize declarations of known TypeScript helpers', () => {
-        const tslib = {
-          name: _('/tslib.d.ts'),
-          contents: `
+        it('should handle inline exports', () => {
+          loadFakeCore(getFileSystem());
+          loadTestFiles([INLINE_EXPORT_FILE]);
+          const bundle = makeTestBundleProgram(INLINE_EXPORT_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const file = getSourceFileOrError(bundle.program, INLINE_EXPORT_FILE.name);
+          const exportDeclarations = host.getExportsOfModule(file);
+          expect(exportDeclarations).not.toBe(null);
+          const decl = exportDeclarations!.get('directives')!;
+          expect(decl).toBeDefined();
+          expect(decl.node).toBeDefined();
+          expect(decl.kind).toEqual(DeclarationKind.Inline);
+        });
+
+        it('should recognize declarations of known TypeScript helpers', () => {
+          const tslib = {
+            name: _('/tslib.d.ts'),
+            contents: `
             export declare function __assign(t: any, ...sources: any[]): any;
             export declare function __spread(...args: any[][]): any[];
             export declare function __spreadArrays(...args: any[][]): any[];
             export declare function __unknownHelper(...args: any[]): any;
           `,
-        };
-        loadTestFiles([tslib]);
-        const bundle = makeTestBundleProgram(tslib.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const sf = getSourceFileOrError(bundle.program, tslib.name);
-        const exportDeclarations = host.getExportsOfModule(sf)!;
+          };
+          loadTestFiles([tslib]);
+          const bundle = makeTestBundleProgram(tslib.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const sf = getSourceFileOrError(bundle.program, tslib.name);
+          const exportDeclarations = host.getExportsOfModule(sf)!;
 
-        expect([...exportDeclarations].map(([exportName, {known}]) => [exportName, known]))
-            .toEqual([
-              ['__assign', KnownDeclaration.TsHelperAssign],
-              ['__spread', KnownDeclaration.TsHelperSpread],
-              ['__spreadArrays', KnownDeclaration.TsHelperSpreadArrays],
-              ['__unknownHelper', null],
-            ]);
+          expect([...exportDeclarations].map(([exportName, {known}]) => [exportName, known]))
+              .toEqual([
+                ['__assign', KnownDeclaration.TsHelperAssign],
+                ['__spread', KnownDeclaration.TsHelperSpread],
+                ['__spreadArrays', KnownDeclaration.TsHelperSpreadArrays],
+                ['__unknownHelper', null],
+              ]);
+        });
+
+        it('should define property exports from a module', () => {
+          loadFakeCore(getFileSystem());
+          loadTestFiles(EXPORTS_FILES);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const file = getSourceFileOrError(bundle.program, _('/define_property_reexports.js'));
+          const exportDeclarations = host.getExportsOfModule(file);
+          expect(exportDeclarations).not.toBe(null);
+          expect(Array.from(exportDeclarations!.entries())
+                     .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
+              .toEqual([
+                ['newA', `a = 'a'`, null],
+              ]);
+        });
       });
 
-      it('should define property exports from a module', () => {
-        loadFakeCore(getFileSystem());
-        loadTestFiles(EXPORTS_FILES);
-        const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const file = getSourceFileOrError(bundle.program, _('/define_property_reexports.js'));
-        const exportDeclarations = host.getExportsOfModule(file);
-        expect(exportDeclarations).not.toBe(null);
-        expect(Array.from(exportDeclarations!.entries())
-                   .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
-            .toEqual([
-              ['newA', `a = 'a'`, null],
-            ]);
-      });
-    });
+      describe('getClassSymbol()', () => {
+        it('should return the class symbol for an ES2015 class', () => {
+          loadTestFiles([SIMPLE_ES2015_CLASS_FILE]);
+          const bundle = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const node = getDeclaration(
+              bundle.program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+          const classSymbol = host.getClassSymbol(node);
 
-    describe('getClassSymbol()', () => {
-      it('should return the class symbol for an ES2015 class', () => {
-        loadTestFiles([SIMPLE_ES2015_CLASS_FILE]);
-        const bundle = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const node = getDeclaration(
-            bundle.program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
-        const classSymbol = host.getClassSymbol(node);
+          expect(classSymbol).toBeDefined();
+          expect(classSymbol!.declaration.valueDeclaration).toBe(node);
+          expect(classSymbol!.implementation.valueDeclaration).toBe(node);
+        });
 
-        expect(classSymbol).toBeDefined();
-        expect(classSymbol!.declaration.valueDeclaration).toBe(node);
-        expect(classSymbol!.implementation.valueDeclaration).toBe(node);
-      });
+        it('should handle wildcard re-exports of other modules (with emitted helpers)', () => {
+          loadFakeCore(getFileSystem());
+          loadTestFiles(EXPORTS_FILES);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const file = getSourceFileOrError(bundle.program, _('/wildcard_reexports.js'));
+          const exportDeclarations = host.getExportsOfModule(file);
+          expect(exportDeclarations).not.toBe(null);
+          expect(Array.from(exportDeclarations!.entries())
+                     .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
+              .toEqual([
+                ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
+                ['a', `a = 'a'`, _('/b_module')],
+                ['b', `b = a_module.a`, _('/b_module')],
+                ['c', `a = 'a'`, _('/b_module')],
+                ['d', `b = a_module.a`, _('/b_module')],
+                ['e', `e = 'e'`, _('/b_module')],
+                ['DirectiveX', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
+                [
+                  'SomeClass',
+                  `SomeClass = (function() {\n    function SomeClass() {}\n    return SomeClass;\n  }())`,
+                  _('/b_module')
+                ],
+                ['xtra1', `xtra1 = 'xtra1'`, _('/xtra_module')],
+                ['xtra2', `xtra2 = 'xtra2'`, _('/xtra_module')],
+              ]);
+        });
 
-      it('should handle wildcard re-exports of other modules (with emitted helpers)', () => {
-        loadFakeCore(getFileSystem());
-        loadTestFiles(EXPORTS_FILES);
-        const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const file = getSourceFileOrError(bundle.program, _('/wildcard_reexports.js'));
-        const exportDeclarations = host.getExportsOfModule(file);
-        expect(exportDeclarations).not.toBe(null);
-        expect(Array.from(exportDeclarations!.entries())
-                   .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
-            .toEqual([
-              ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
-              ['a', `a = 'a'`, _('/b_module')],
-              ['b', `b = a_module.a`, _('/b_module')],
-              ['c', `a = 'a'`, _('/b_module')],
-              ['d', `b = a_module.a`, _('/b_module')],
-              ['e', `e = 'e'`, _('/b_module')],
-              ['DirectiveX', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
-              [
-                'SomeClass',
-                `SomeClass = (function() {\n    function SomeClass() {}\n    return SomeClass;\n  }())`,
-                _('/b_module')
-              ],
-              ['xtra1', `xtra1 = 'xtra1'`, _('/xtra_module')],
-              ['xtra2', `xtra2 = 'xtra2'`, _('/xtra_module')],
-            ]);
-      });
+        it('should handle wildcard re-exports of other modules (with imported helpers)', () => {
+          loadFakeCore(getFileSystem());
+          loadTestFiles(EXPORTS_FILES);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const file =
+              getSourceFileOrError(bundle.program, _('/wildcard_reexports_imported_helpers.js'));
+          const exportDeclarations = host.getExportsOfModule(file);
+          expect(exportDeclarations).not.toBe(null);
+          expect(Array.from(exportDeclarations!.entries())
+                     .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
+              .toEqual([
+                ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
+                ['a', `a = 'a'`, _('/b_module')],
+                ['b', `b = a_module.a`, _('/b_module')],
+                ['c', `a = 'a'`, _('/b_module')],
+                ['d', `b = a_module.a`, _('/b_module')],
+                ['e', `e = 'e'`, _('/b_module')],
+                ['DirectiveX', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
+                [
+                  'SomeClass',
+                  `SomeClass = (function() {\n    function SomeClass() {}\n    return SomeClass;\n  }())`,
+                  _('/b_module')
+                ],
+                ['xtra1', `xtra1 = 'xtra1'`, _('/xtra_module')],
+                ['xtra2', `xtra2 = 'xtra2'`, _('/xtra_module')],
+              ]);
+        });
 
-      it('should handle wildcard re-exports of other modules (with imported helpers)', () => {
-        loadFakeCore(getFileSystem());
-        loadTestFiles(EXPORTS_FILES);
-        const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const file =
-            getSourceFileOrError(bundle.program, _('/wildcard_reexports_imported_helpers.js'));
-        const exportDeclarations = host.getExportsOfModule(file);
-        expect(exportDeclarations).not.toBe(null);
-        expect(Array.from(exportDeclarations!.entries())
-                   .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
-            .toEqual([
-              ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
-              ['a', `a = 'a'`, _('/b_module')],
-              ['b', `b = a_module.a`, _('/b_module')],
-              ['c', `a = 'a'`, _('/b_module')],
-              ['d', `b = a_module.a`, _('/b_module')],
-              ['e', `e = 'e'`, _('/b_module')],
-              ['DirectiveX', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
-              [
-                'SomeClass',
-                `SomeClass = (function() {\n    function SomeClass() {}\n    return SomeClass;\n  }())`,
-                _('/b_module')
-              ],
-              ['xtra1', `xtra1 = 'xtra1'`, _('/xtra_module')],
-              ['xtra2', `xtra2 = 'xtra2'`, _('/xtra_module')],
-            ]);
-      });
+        it('should handle wildcard re-exports of other modules using `require()` calls', () => {
+          loadFakeCore(getFileSystem());
+          loadTestFiles(EXPORTS_FILES);
+          const bundle = makeTestBundleProgram(_('/index.js'));
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const file =
+              getSourceFileOrError(bundle.program, _('/wildcard_reexports_with_require.js'));
+          const exportDeclarations = host.getExportsOfModule(file);
+          expect(exportDeclarations).not.toBe(null);
+          expect(Array.from(exportDeclarations!.entries())
+                     .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
+              .toEqual([
+                ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
+                ['a', `a = 'a'`, _('/b_module')],
+                ['b', `b = a_module.a`, _('/b_module')],
+                ['c', `a = 'a'`, _('/b_module')],
+                ['d', `b = a_module.a`, _('/b_module')],
+                ['e', `e = 'e'`, _('/b_module')],
+                ['DirectiveX', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
+                [
+                  'SomeClass',
+                  `SomeClass = (function() {\n    function SomeClass() {}\n    return SomeClass;\n  }())`,
+                  _('/b_module')
+                ],
+                ['xtra1', `xtra1 = 'xtra1'`, _('/xtra_module')],
+                ['xtra2', `xtra2 = 'xtra2'`, _('/xtra_module')],
+              ]);
+        });
 
-      it('should handle wildcard re-exports of other modules using `require()` calls', () => {
-        loadFakeCore(getFileSystem());
-        loadTestFiles(EXPORTS_FILES);
-        const bundle = makeTestBundleProgram(_('/index.js'));
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const file = getSourceFileOrError(bundle.program, _('/wildcard_reexports_with_require.js'));
-        const exportDeclarations = host.getExportsOfModule(file);
-        expect(exportDeclarations).not.toBe(null);
-        expect(Array.from(exportDeclarations!.entries())
-                   .map(entry => [entry[0], entry[1].node!.getText(), entry[1].viaModule]))
-            .toEqual([
-              ['Directive', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
-              ['a', `a = 'a'`, _('/b_module')],
-              ['b', `b = a_module.a`, _('/b_module')],
-              ['c', `a = 'a'`, _('/b_module')],
-              ['d', `b = a_module.a`, _('/b_module')],
-              ['e', `e = 'e'`, _('/b_module')],
-              ['DirectiveX', `Directive: FnWithArg<(clazz: any) => any>`, _('/b_module')],
-              [
-                'SomeClass',
-                `SomeClass = (function() {\n    function SomeClass() {}\n    return SomeClass;\n  }())`,
-                _('/b_module')
-              ],
-              ['xtra1', `xtra1 = 'xtra1'`, _('/xtra_module')],
-              ['xtra2', `xtra2 = 'xtra2'`, _('/xtra_module')],
-            ]);
-      });
+        it('should return the class symbol for an ES5 class (outer variable declaration)', () => {
+          loadTestFiles([SIMPLE_CLASS_FILE]);
+          const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const outerNode = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isDesiredDeclaration);
+          const innerNode = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedFunctionDeclaration);
+          const classSymbol = host.getClassSymbol(outerNode);
 
-      it('should return the class symbol for an ES5 class (outer variable declaration)', () => {
-        loadTestFiles([SIMPLE_CLASS_FILE]);
-        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const outerNode = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
-        const innerNode = (getIifeBody(outerNode.initializer!) as ts.Block)
-                              .statements.find(isNamedFunctionDeclaration)!;
-        const classSymbol = host.getClassSymbol(outerNode);
+          expect(classSymbol).toBeDefined();
+          expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode as any);
+          expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
+        });
 
-        expect(classSymbol).toBeDefined();
-        expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode);
-        expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
-      });
+        it('should return the class symbol for an ES5 class (inner function declaration)', () => {
+          loadTestFiles([SIMPLE_CLASS_FILE]);
+          const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const outerNode = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isDesiredDeclaration);
+          const innerNode = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedFunctionDeclaration);
+          const classSymbol = host.getClassSymbol(innerNode);
 
-      it('should return the class symbol for an ES5 class (inner function declaration)', () => {
-        loadTestFiles([SIMPLE_CLASS_FILE]);
-        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const outerNode = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
-        const innerNode = (getIifeBody(outerNode.initializer!) as ts.Block)
-                              .statements.find(isNamedFunctionDeclaration)!;
-        const classSymbol = host.getClassSymbol(innerNode);
+          expect(classSymbol).toBeDefined();
+          expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode as any);
+          expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
+        });
 
-        expect(classSymbol).toBeDefined();
-        expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode);
-        expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
-      });
+        it('should return the same class symbol (of the outer declaration) for outer and inner declarations',
+           () => {
+             loadTestFiles([SIMPLE_CLASS_FILE]);
+             const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const outerNode = getDeclaration(
+                 bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isDesiredDeclaration);
+             const innerNode = getDeclaration(
+                 bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedFunctionDeclaration);
 
-      it('should return the same class symbol (of the outer declaration) for outer and inner declarations',
-         () => {
-           loadTestFiles([SIMPLE_CLASS_FILE]);
-           const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-           const outerNode = getDeclaration(
-               bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
-           const innerNode = (getIifeBody(outerNode.initializer!) as ts.Block)
-                                 .statements.find(isNamedFunctionDeclaration)!;
+             const innerSymbol = host.getClassSymbol(innerNode)!;
+             const outerSymbol = host.getClassSymbol(outerNode)!;
+             expect(innerSymbol.declaration).toBe(outerSymbol.declaration);
+             expect(innerSymbol.implementation).toBe(outerSymbol.implementation);
+           });
 
-           const innerSymbol = host.getClassSymbol(innerNode)!;
-           const outerSymbol = host.getClassSymbol(outerNode)!;
-           expect(innerSymbol.declaration).toBe(outerSymbol.declaration);
-           expect(innerSymbol.implementation).toBe(outerSymbol.implementation);
-         });
+        it('should return the class symbol for an ES5 class whose IIFE is not wrapped in parens',
+           () => {
+             loadTestFiles([SIMPLE_CLASS_FILE]);
+             const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const outerNode = getDeclaration(
+                 bundle.program, SIMPLE_CLASS_FILE.name, 'NoParensClass', isDesiredDeclaration);
+             const innerNode = getDeclaration(
+                 bundle.program, SIMPLE_CLASS_FILE.name, 'NoParensClass',
+                 isNamedFunctionDeclaration);
+             const classSymbol = host.getClassSymbol(outerNode);
 
-      it('should return the class symbol for an ES5 class whose IIFE is not wrapped in parens',
-         () => {
-           loadTestFiles([SIMPLE_CLASS_FILE]);
-           const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-           const outerNode = getDeclaration(
-               bundle.program, SIMPLE_CLASS_FILE.name, 'NoParensClass', isNamedVariableDeclaration);
-           const innerNode = (getIifeBody(outerNode.initializer!) as ts.Block)
-                                 .statements.find(isNamedFunctionDeclaration)!;
-           const classSymbol = host.getClassSymbol(outerNode);
+             expect(classSymbol).toBeDefined();
+             expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode as any);
+             expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
+           });
 
-           expect(classSymbol).toBeDefined();
-           expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode as any);
-           expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
-         });
+        it('should return the class symbol for an ES5 class whose IIFE is not wrapped with inner parens',
+           () => {
+             loadTestFiles([SIMPLE_CLASS_FILE]);
+             const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const outerNode = getDeclaration(
+                 bundle.program, SIMPLE_CLASS_FILE.name, 'InnerParensClass', isDesiredDeclaration);
+             const innerNode = getDeclaration(
+                 bundle.program, SIMPLE_CLASS_FILE.name, 'InnerParensClass',
+                 isNamedFunctionDeclaration);
+             const classSymbol = host.getClassSymbol(outerNode);
 
-      it('should return the class symbol for an ES5 class whose IIFE is not wrapped with inner parens',
-         () => {
-           loadTestFiles([SIMPLE_CLASS_FILE]);
-           const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-           const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-           const outerNode = getDeclaration(
-               bundle.program, SIMPLE_CLASS_FILE.name, 'InnerParensClass',
-               isNamedVariableDeclaration);
-           const innerNode = (getIifeBody(outerNode.initializer!) as ts.Block)
-                                 .statements.find(isNamedFunctionDeclaration)!;
-           const classSymbol = host.getClassSymbol(outerNode);
+             expect(classSymbol).toBeDefined();
+             expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode as any);
+             expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
+           });
 
-           expect(classSymbol).toBeDefined();
-           expect(classSymbol!.declaration.valueDeclaration).toBe(outerNode);
-           expect(classSymbol!.implementation.valueDeclaration).toBe(innerNode);
-         });
+        it('should return undefined if node is not an ES5 class', () => {
+          loadTestFiles([FOO_FUNCTION_FILE]);
+          const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const node = getDeclaration(
+              bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+          const classSymbol = host.getClassSymbol(node);
 
-      it('should return undefined if node is not an ES5 class', () => {
-        loadTestFiles([FOO_FUNCTION_FILE]);
-        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const node = getDeclaration(
-            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
-        const classSymbol = host.getClassSymbol(node);
+          expect(classSymbol).toBeUndefined();
+        });
 
-        expect(classSymbol).toBeUndefined();
-      });
+        it('should return undefined if variable declaration is not initialized using an IIFE',
+           () => {
+             const testFile = {
+               name: _('/test.js'),
+               contents: `var MyClass = null;`,
+             };
+             loadTestFiles([testFile]);
+             const bundle = makeTestBundleProgram(testFile.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const node = getDeclaration(
+                 bundle.program, testFile.name, 'MyClass', isNamedVariableDeclaration);
+             const classSymbol = host.getClassSymbol(node);
 
-      it('should return undefined if variable declaration is not initialized using an IIFE', () => {
-        const testFile = {
-          name: _('/test.js'),
-          contents: `var MyClass = null;`,
-        };
-        loadTestFiles([testFile]);
-        const bundle = makeTestBundleProgram(testFile.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const node =
-            getDeclaration(bundle.program, testFile.name, 'MyClass', isNamedVariableDeclaration);
-        const classSymbol = host.getClassSymbol(node);
-
-        expect(classSymbol).toBeUndefined();
-      });
-    });
-
-    describe('isClass()', () => {
-      it('should return true if a given node is a TS class declaration', () => {
-        loadTestFiles([SIMPLE_ES2015_CLASS_FILE]);
-        const bundle = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const node = getDeclaration(
-            bundle.program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
-        expect(host.isClass(node)).toBe(true);
+             expect(classSymbol).toBeUndefined();
+           });
       });
 
-      it('should return true if a given node is the outer variable declaration of a class', () => {
-        loadTestFiles([SIMPLE_CLASS_FILE]);
-        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const node = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
-        expect(host.isClass(node)).toBe(true);
+      describe('isClass()', () => {
+        it('should return true if a given node is a TS class declaration', () => {
+          loadTestFiles([SIMPLE_ES2015_CLASS_FILE]);
+          const bundle = makeTestBundleProgram(SIMPLE_ES2015_CLASS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const node = getDeclaration(
+              bundle.program, SIMPLE_ES2015_CLASS_FILE.name, 'EmptyClass', isNamedClassDeclaration);
+          expect(host.isClass(node)).toBe(true);
+        });
+
+        it('should return true if a given node is the outer variable declaration of a class',
+           () => {
+             loadTestFiles([SIMPLE_CLASS_FILE]);
+             const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const node = getDeclaration(
+                 bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isDesiredDeclaration);
+             expect(host.isClass(node)).toBe(true);
+           });
+
+        it('should return true if a given node is the inner variable declaration of a class',
+           () => {
+             loadTestFiles([SIMPLE_CLASS_FILE]);
+             const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+             const node = getDeclaration(
+                 bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedFunctionDeclaration);
+             expect(host.isClass(node)).toBe(true);
+           });
+
+        it('should return false if a given node is a function declaration', () => {
+          loadTestFiles([FOO_FUNCTION_FILE]);
+          const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const node = getDeclaration(
+              bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
+          expect(host.isClass(node)).toBe(false);
+        });
       });
 
-      it('should return true if a given node is the inner variable declaration of a class', () => {
-        loadTestFiles([SIMPLE_CLASS_FILE]);
-        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const outerNode = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
-        const innerNode = (getIifeBody(outerNode.initializer!) as ts.Block)
-                              .statements.find(isNamedFunctionDeclaration)!;
-        expect(host.isClass(innerNode)).toBe(true);
-      });
+      describe('hasBaseClass()', () => {
+        function hasBaseClass(source: string) {
+          const file = {
+            name: _('/synthesized_constructors.js'),
+            contents: source,
+          };
 
-      it('should return false if a given node is a function declaration', () => {
-        loadTestFiles([FOO_FUNCTION_FILE]);
-        const bundle = makeTestBundleProgram(FOO_FUNCTION_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const node = getDeclaration(
-            bundle.program, FOO_FUNCTION_FILE.name, 'foo', isNamedFunctionDeclaration);
-        expect(host.isClass(node)).toBe(false);
-      });
-    });
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode =
+              getDeclaration(bundle.program, file.name, 'TestClass', isDesiredDeclaration);
+          return host.hasBaseClass(classNode);
+        }
 
-    describe('hasBaseClass()', () => {
-      function hasBaseClass(source: string) {
-        const file = {
-          name: _('/synthesized_constructors.js'),
-          contents: source,
-        };
-
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode =
-            getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
-        return host.hasBaseClass(classNode);
-      }
-
-      it('should consider an IIFE with _super parameter as having a base class', () => {
-        const result = hasBaseClass(`
-      var TestClass = /** @class */ (function (_super) {
+        it('should consider an IIFE with _super parameter as having a base class', () => {
+          const result = hasBaseClass(`
+      ${expDecl('TestClass')} = /** @class */ (function (_super) {
         __extends(TestClass, _super);
         function TestClass() {}
         return TestClass;
       }(null));`);
-        expect(result).toBe(true);
-      });
+          expect(result).toBe(true);
+        });
 
-      it('should consider an IIFE with a unique name generated for the _super parameter as having a base class',
-         () => {
-           const result = hasBaseClass(`
-      var TestClass = /** @class */ (function (_super_1) {
+        it('should consider an IIFE with a unique name generated for the _super parameter as having a base class',
+           () => {
+             const result = hasBaseClass(`
+      ${expDecl('TestClass')} = /** @class */ (function (_super_1) {
         __extends(TestClass, _super_1);
         function TestClass() {}
         return TestClass;
       }(null));`);
-           expect(result).toBe(true);
-         });
+             expect(result).toBe(true);
+           });
 
-      it('should not consider an IIFE without parameter as having a base class', () => {
-        const result = hasBaseClass(`
-      var TestClass = /** @class */ (function () {
+        it('should not consider an IIFE without parameter as having a base class', () => {
+          const result = hasBaseClass(`
+      ${expDecl('TestClass')} = /** @class */ (function () {
         __extends(TestClass, _super);
         function TestClass() {}
         return TestClass;
       }(null));`);
-        expect(result).toBe(false);
+          expect(result).toBe(false);
+        });
       });
-    });
 
-    describe('getBaseClassExpression()', () => {
-      function getBaseClassIdentifier(source: string): ts.Identifier|null {
-        const file = {
-          name: _('/synthesized_constructors.js'),
-          contents: source,
-        };
+      describe('getBaseClassExpression()', () => {
+        function getBaseClassIdentifier(source: string): ts.Identifier|null {
+          const file = {
+            name: _('/synthesized_constructors.js'),
+            contents: source,
+          };
 
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode =
-            getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
-        const expression = host.getBaseClassExpression(classNode);
-        if (expression !== null && !ts.isIdentifier(expression)) {
-          throw new Error(
-              'Expected class to inherit via an identifier but got: ' + expression.getText());
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode =
+              getDeclaration(bundle.program, file.name, 'TestClass', isDesiredDeclaration);
+          const expression = host.getBaseClassExpression(classNode);
+          if (expression !== null && !ts.isIdentifier(expression)) {
+            throw new Error(
+                'Expected class to inherit via an identifier but got: ' + expression.getText());
+          }
+          return expression;
         }
-        return expression;
-      }
 
-      it('should find the base class of an IIFE with _super parameter', () => {
-        const identifier = getBaseClassIdentifier(`
-        var BaseClass = /** @class */ (function () {
+        it('should find the base class of an IIFE with _super parameter', () => {
+          const identifier = getBaseClassIdentifier(`
+        ${expDecl('BaseClass')} = /** @class */ (function () {
           function BaseClass() {}
           return BaseClass;
         }());
-        var TestClass = /** @class */ (function (_super) {
+        ${expDecl('TestClass')} = /** @class */ (function (_super) {
           __extends(TestClass, _super);
           function TestClass() {}
           return TestClass;
         }(BaseClass));`);
-        expect(identifier!.text).toBe('BaseClass');
-      });
+          expect(identifier!.text).toBe('BaseClass');
+        });
 
-      it('should find the base class of an IIFE with a unique name generated for the _super parameter',
-         () => {
-           const identifier = getBaseClassIdentifier(`
-        var BaseClass = /** @class */ (function () {
+        it('should find the base class of an IIFE with a unique name generated for the _super parameter',
+           () => {
+             const identifier = getBaseClassIdentifier(`
+        ${expDecl('BaseClass')} = /** @class */ (function () {
           function BaseClass() {}
           return BaseClass;
         }());
-        var TestClass = /** @class */ (function (_super_1) {
+        ${expDecl('TestClass')} = /** @class */ (function (_super_1) {
           __extends(TestClass, _super_1);
           function TestClass() {}
           return TestClass;
         }(BaseClass));`);
-           expect(identifier!.text).toBe('BaseClass');
-         });
+             expect(identifier!.text).toBe('BaseClass');
+           });
 
-      it('should not find a base class for an IIFE without parameter', () => {
-        const identifier = getBaseClassIdentifier(`
-        var BaseClass = /** @class */ (function () {
+        it('should not find a base class for an IIFE without parameter', () => {
+          const identifier = getBaseClassIdentifier(`
+        ${expDecl('BaseClass')} = /** @class */ (function () {
           function BaseClass() {}
           return BaseClass;
         }());
-        var TestClass = /** @class */ (function () {
+        ${expDecl('TestClass')} = /** @class */ (function () {
           __extends(TestClass, _super);
           function TestClass() {}
           return TestClass;
         }(BaseClass));`);
-        expect(identifier).toBe(null);
-      });
+          expect(identifier).toBe(null);
+        });
 
-      it('should find a dynamic base class expression of an IIFE', () => {
-        const file = {
-          name: _('/synthesized_constructors.js'),
-          contents: `
-          var BaseClass = /** @class */ (function () {
+        it('should find a dynamic base class expression of an IIFE', () => {
+          const file = {
+            name: _('/synthesized_constructors.js'),
+            contents: `
+          ${expDecl('BaseClass')} = /** @class */ (function () {
             function BaseClass() {}
             return BaseClass;
           }());
           function foo() { return BaseClass; }
-          var TestClass = /** @class */ (function (_super) {
+          ${expDecl('TestClass')} = /** @class */ (function (_super) {
             __extends(TestClass, _super);
             function TestClass() {}
             return TestClass;
           }(foo()));`,
-        };
+          };
 
-        loadTestFiles([file]);
-        const bundle = makeTestBundleProgram(file.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const classNode =
-            getDeclaration(bundle.program, file.name, 'TestClass', isNamedVariableDeclaration);
-        const expression = host.getBaseClassExpression(classNode)!;
-        expect(expression.getText()).toBe('foo()');
+          loadTestFiles([file]);
+          const bundle = makeTestBundleProgram(file.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const classNode =
+              getDeclaration(bundle.program, file.name, 'TestClass', isDesiredDeclaration);
+          const expression = host.getBaseClassExpression(classNode)!;
+          expect(expression.getText()).toBe('foo()');
+        });
+      });
+
+      describe('findClassSymbols()', () => {
+        it('should return an array of all classes in the given source file', () => {
+          loadTestFiles(DECORATED_FILES);
+          const bundle = makeTestBundleProgram(DECORATED_FILES[0].name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
+          const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
+
+          const classSymbolsPrimary = host.findClassSymbols(primaryFile);
+          expect(classSymbolsPrimary.length).toEqual(2);
+          expect(classSymbolsPrimary.map(c => c.name)).toEqual(['A', 'B']);
+
+          const classSymbolsSecondary = host.findClassSymbols(secondaryFile);
+          expect(classSymbolsSecondary.length).toEqual(1);
+          expect(classSymbolsSecondary.map(c => c.name)).toEqual(['D']);
+        });
+      });
+
+      describe('getDecoratorsOfSymbol()', () => {
+        it('should return decorators of class symbol', () => {
+          loadTestFiles(DECORATED_FILES);
+          const bundle = makeTestBundleProgram(DECORATED_FILES[0].name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+          const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
+          const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
+
+          const classSymbolsPrimary = host.findClassSymbols(primaryFile);
+          const classDecoratorsPrimary =
+              classSymbolsPrimary.map(s => host.getDecoratorsOfSymbol(s));
+          expect(classDecoratorsPrimary.length).toEqual(2);
+          expect(classDecoratorsPrimary[0]!.map(d => d.name)).toEqual(['Directive']);
+          expect(classDecoratorsPrimary[1]!.map(d => d.name)).toEqual(['Directive']);
+
+          const classSymbolsSecondary = host.findClassSymbols(secondaryFile);
+          const classDecoratorsSecondary =
+              classSymbolsSecondary.map(s => host.getDecoratorsOfSymbol(s));
+          expect(classDecoratorsSecondary.length).toEqual(1);
+          expect(classDecoratorsSecondary[0]!.map(d => d.name)).toEqual(['Directive']);
+        });
+      });
+
+      describe('getDtsDeclaration()', () => {
+        it('should find the dts declaration that has the same relative path to the source file',
+           () => {
+             loadTestFiles(TYPINGS_SRC_FILES);
+             loadTestFiles(TYPINGS_DTS_FILES);
+             const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+             const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
+             const class1 = getDeclaration(
+                 bundle.program, _('/ep/src/class1.js'), 'Class1', isDesiredDeclaration);
+
+             const dtsDeclaration = host.getDtsDeclaration(class1);
+             expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
+           });
+
+        it('should find the dts declaration for exported functions', () => {
+          loadTestFiles(TYPINGS_SRC_FILES);
+          loadTestFiles(TYPINGS_DTS_FILES);
+          const bundle = makeTestBundleProgram(_('/ep/src/func1.js'));
+          const dts = makeTestBundleProgram(_('/ep/typings/func1.d.ts'));
+          const mooFn =
+              getDeclaration(bundle.program, _('/ep/src/func1.js'), 'mooFn', isExportsDeclaration);
+          const host =
+              createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
+
+          const dtsDeclaration = host.getDtsDeclaration(mooFn);
+          expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/func1.d.ts'));
+        });
+
+        it('should return null if there is no matching class in the matching dts file', () => {
+          loadTestFiles(TYPINGS_SRC_FILES);
+          loadTestFiles(TYPINGS_DTS_FILES);
+          const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+          const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
+          const missingClass = getDeclaration(
+              bundle.program, _('/ep/src/class1.js'), 'MissingClass1', isDesiredDeclaration);
+          const host =
+              createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
+          expect(host.getDtsDeclaration(missingClass)).toBe(null);
+        });
+
+        it('should return null if there is no matching dts file', () => {
+          loadTestFiles(TYPINGS_SRC_FILES);
+          loadTestFiles(TYPINGS_DTS_FILES);
+          const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+          const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
+          const missingClass = getDeclaration(
+              bundle.program, _('/ep/src/missing-class.js'), 'MissingClass2', isDesiredDeclaration);
+          const host =
+              createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
+
+          expect(host.getDtsDeclaration(missingClass)).toBe(null);
+        });
+
+
+
+        it('should find the dts file that contains a matching class declaration, even if the source files do not match',
+           () => {
+             loadTestFiles(TYPINGS_SRC_FILES);
+             loadTestFiles(TYPINGS_DTS_FILES);
+             const bundle = makeTestBundleProgram(_('/ep/src/flat-file.js'));
+             const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
+             const class1 = getDeclaration(
+                 bundle.program, _('/ep/src/flat-file.js'), 'Class1', isDesiredDeclaration);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
+
+             const dtsDeclaration = host.getDtsDeclaration(class1);
+             expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
+           });
+
+        it('should find aliased exports', () => {
+          loadTestFiles(TYPINGS_SRC_FILES);
+          loadTestFiles(TYPINGS_DTS_FILES);
+          const bundle = makeTestBundleProgram(_('/ep/src/flat-file.js'));
+          const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
+          const sourceClass = getDeclaration(
+              bundle.program, _('/ep/src/flat-file.js'), 'AliasedClass', isExportsDeclaration);
+          const host =
+              createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
+
+          const dtsDeclaration = host.getDtsDeclaration(sourceClass);
+          if (dtsDeclaration === null) {
+            return fail('Expected dts class to be found');
+          }
+          if (!isNamedClassDeclaration(dtsDeclaration)) {
+            return fail('Expected a named class to be found.');
+          }
+          expect(dtsDeclaration.name.text).toEqual('TypingsClass');
+          expect(_(dtsDeclaration.getSourceFile().fileName))
+              .toEqual(_('/ep/typings/typings-class.d.ts'));
+        });
+
+        it('should match publicly and internal exported classes correctly, even if they have the same name',
+           () => {
+             loadTestFiles(TYPINGS_SRC_FILES);
+             loadTestFiles(TYPINGS_DTS_FILES);
+             const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
+             const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
+             const class2 = getDeclaration(
+                 bundle.program, _('/ep/src/class2.js'), 'Class2', isDesiredDeclaration);
+             const class2DtsDeclaration = host.getDtsDeclaration(class2);
+             expect(class2DtsDeclaration!.getSourceFile().fileName)
+                 .toEqual(_('/ep/typings/class2.d.ts'));
+
+             const internalClass2 = getDeclaration(
+                 bundle.program, _('/ep/src/internal.js'), 'Class2', isDesiredDeclaration);
+             const internalClass2DtsDeclaration = host.getDtsDeclaration(internalClass2);
+             expect(internalClass2DtsDeclaration!.getSourceFile().fileName)
+                 .toEqual(_('/ep/typings/internal.d.ts'));
+           });
+
+        it('should prefer the publicly exported class if there are multiple classes with the same name',
+           () => {
+             loadTestFiles(TYPINGS_SRC_FILES);
+             loadTestFiles(TYPINGS_DTS_FILES);
+             const bundle = makeTestBundleProgram(_('/ep/src/index.js'));
+             const dts = makeTestBundleProgram(_('/ep/typings/index.d.ts'));
+             const class2 = getDeclaration(
+                 bundle.program, _('/ep/src/class2.js'), 'Class2', isDesiredDeclaration);
+             const internalClass2 = getDeclaration(
+                 bundle.program, _('/ep/src/internal.js'), 'Class2', isDesiredDeclaration);
+             const host =
+                 createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
+
+             const class2DtsDeclaration = host.getDtsDeclaration(class2);
+             expect(class2DtsDeclaration!.getSourceFile().fileName)
+                 .toEqual(_('/ep/typings/class2.d.ts'));
+
+             const internalClass2DtsDeclaration = host.getDtsDeclaration(internalClass2);
+             expect(internalClass2DtsDeclaration!.getSourceFile().fileName)
+                 .toEqual(_('/ep/typings/internal.d.ts'));
+           });
+      });
+
+      describe('getInternalNameOfClass()', () => {
+        it('should return the name of the inner class declaration', () => {
+          loadTestFiles([SIMPLE_CLASS_FILE]);
+          const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+
+          const emptyClass = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isDesiredDeclaration);
+          expect(host.getInternalNameOfClass(emptyClass).text).toEqual('EmptyClass');
+
+          const class1 = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isDesiredDeclaration);
+          expect(host.getInternalNameOfClass(class1).text).toEqual('InnerClass1');
+
+          const class2 = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isDesiredDeclaration);
+          expect(host.getInternalNameOfClass(class2).text).toEqual('InnerClass2');
+
+          const childClass = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'ChildClass', isDesiredDeclaration);
+          expect(host.getInternalNameOfClass(childClass).text).toEqual('InnerChildClass');
+        });
+      });
+
+      describe('getAdjacentNameOfClass()', () => {
+        it('should return the name of the inner class declaration', () => {
+          loadTestFiles([SIMPLE_CLASS_FILE]);
+          const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
+          const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
+
+          const emptyClass = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isDesiredDeclaration);
+          expect(host.getAdjacentNameOfClass(emptyClass).text).toEqual('EmptyClass');
+
+          const class1 = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isDesiredDeclaration);
+          expect(host.getAdjacentNameOfClass(class1).text).toEqual('InnerClass1');
+
+          const class2 = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isDesiredDeclaration);
+          expect(host.getAdjacentNameOfClass(class2).text).toEqual('InnerClass2');
+
+          const childClass = getDeclaration(
+              bundle.program, SIMPLE_CLASS_FILE.name, 'ChildClass', isDesiredDeclaration);
+          expect(host.getAdjacentNameOfClass(childClass).text).toEqual('InnerChildClass');
+        });
       });
     });
-
-    describe('findClassSymbols()', () => {
-      it('should return an array of all classes in the given source file', () => {
-        loadTestFiles(DECORATED_FILES);
-        const bundle = makeTestBundleProgram(DECORATED_FILES[0].name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
-        const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
-
-        const classSymbolsPrimary = host.findClassSymbols(primaryFile);
-        expect(classSymbolsPrimary.length).toEqual(2);
-        expect(classSymbolsPrimary.map(c => c.name)).toEqual(['A', 'B']);
-
-        const classSymbolsSecondary = host.findClassSymbols(secondaryFile);
-        expect(classSymbolsSecondary.length).toEqual(1);
-        expect(classSymbolsSecondary.map(c => c.name)).toEqual(['D']);
-      });
-    });
-
-    describe('getDecoratorsOfSymbol()', () => {
-      it('should return decorators of class symbol', () => {
-        loadTestFiles(DECORATED_FILES);
-        const bundle = makeTestBundleProgram(DECORATED_FILES[0].name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-        const primaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[0].name);
-        const secondaryFile = getSourceFileOrError(bundle.program, DECORATED_FILES[1].name);
-
-        const classSymbolsPrimary = host.findClassSymbols(primaryFile);
-        const classDecoratorsPrimary = classSymbolsPrimary.map(s => host.getDecoratorsOfSymbol(s));
-        expect(classDecoratorsPrimary.length).toEqual(2);
-        expect(classDecoratorsPrimary[0]!.map(d => d.name)).toEqual(['Directive']);
-        expect(classDecoratorsPrimary[1]!.map(d => d.name)).toEqual(['Directive']);
-
-        const classSymbolsSecondary = host.findClassSymbols(secondaryFile);
-        const classDecoratorsSecondary =
-            classSymbolsSecondary.map(s => host.getDecoratorsOfSymbol(s));
-        expect(classDecoratorsSecondary.length).toEqual(1);
-        expect(classDecoratorsSecondary[0]!.map(d => d.name)).toEqual(['Directive']);
-      });
-    });
-
-    describe('getDtsDeclaration()', () => {
-      it('should find the dts declaration that has the same relative path to the source file',
-         () => {
-           loadTestFiles(TYPINGS_SRC_FILES);
-           loadTestFiles(TYPINGS_DTS_FILES);
-           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
-           const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-           const class1 = getDeclaration(
-               bundle.program, _('/ep/src/class1.js'), 'Class1', ts.isVariableDeclaration);
-           const host =
-               createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
-
-           const dtsDeclaration = host.getDtsDeclaration(class1);
-           expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
-         });
-
-      it('should find the dts declaration for exported functions', () => {
-        loadTestFiles(TYPINGS_SRC_FILES);
-        loadTestFiles(TYPINGS_DTS_FILES);
-        const bundle = makeTestBundleProgram(_('/ep/src/func1.js'));
-        const dts = makeTestBundleProgram(_('/ep/typings/func1.d.ts'));
-        const mooFn = getDeclaration(
-            bundle.program, _('/ep/src/func1.js'), 'mooFn', ts.isFunctionDeclaration);
-        const host =
-            createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
-
-        const dtsDeclaration = host.getDtsDeclaration(mooFn);
-        expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/func1.d.ts'));
-      });
-
-      it('should return null if there is no matching class in the matching dts file', () => {
-        loadTestFiles(TYPINGS_SRC_FILES);
-        loadTestFiles(TYPINGS_DTS_FILES);
-        const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
-        const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-        const missingClass = getDeclaration(
-            bundle.program, _('/ep/src/class1.js'), 'MissingClass1', ts.isVariableDeclaration);
-        const host =
-            createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
-        expect(host.getDtsDeclaration(missingClass)).toBe(null);
-      });
-
-      it('should return null if there is no matching dts file', () => {
-        loadTestFiles(TYPINGS_SRC_FILES);
-        loadTestFiles(TYPINGS_DTS_FILES);
-        const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
-        const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-        const missingClass = getDeclaration(
-            bundle.program, _('/ep/src/missing-class.js'), 'MissingClass2',
-            ts.isVariableDeclaration);
-        const host =
-            createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
-
-        expect(host.getDtsDeclaration(missingClass)).toBe(null);
-      });
-
-      it('should find the dts file that contains a matching class declaration, even if the source files do not match',
-         () => {
-           loadTestFiles(TYPINGS_SRC_FILES);
-           loadTestFiles(TYPINGS_DTS_FILES);
-           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
-           const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-           const class1 = getDeclaration(
-               bundle.program, _('/ep/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
-           const host =
-               createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
-
-           const dtsDeclaration = host.getDtsDeclaration(class1);
-           expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
-         });
-
-      it('should find the dts file that contains a matching class declaration, even if the source files do not match',
-         () => {
-           loadTestFiles(TYPINGS_SRC_FILES);
-           loadTestFiles(TYPINGS_DTS_FILES);
-           const bundle = makeTestBundleProgram(_('/ep/src/flat-file.js'));
-           const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-           const class1 = getDeclaration(
-               bundle.program, _('/ep/src/flat-file.js'), 'Class1', ts.isVariableDeclaration);
-           const host =
-               createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
-
-           const dtsDeclaration = host.getDtsDeclaration(class1);
-           expect(dtsDeclaration!.getSourceFile().fileName).toEqual(_('/ep/typings/class1.d.ts'));
-         });
-
-      it('should find aliased exports', () => {
-        loadTestFiles(TYPINGS_SRC_FILES);
-        loadTestFiles(TYPINGS_DTS_FILES);
-        const bundle = makeTestBundleProgram(_('/ep/src/flat-file.js'));
-        const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-        const sourceClass = getDeclaration(
-            bundle.program, _('/ep/src/flat-file.js'), 'SourceClass', ts.isVariableDeclaration);
-        const host =
-            createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
-
-        const dtsDeclaration = host.getDtsDeclaration(sourceClass);
-        if (dtsDeclaration === null) {
-          return fail('Expected dts class to be found');
-        }
-        if (!isNamedClassDeclaration(dtsDeclaration)) {
-          return fail('Expected a named class to be found.');
-        }
-        expect(dtsDeclaration.name.text).toEqual('TypingsClass');
-        expect(_(dtsDeclaration.getSourceFile().fileName))
-            .toEqual(_('/ep/typings/typings-class.d.ts'));
-      });
-
-      it('should match publicly and internal exported classes correctly, even if they have the same name',
-         () => {
-           loadTestFiles(TYPINGS_SRC_FILES);
-           loadTestFiles(TYPINGS_DTS_FILES);
-           const bundle = makeTestBundleProgram(getRootFiles(TYPINGS_SRC_FILES)[0]);
-           const dts = makeTestBundleProgram(getRootFiles(TYPINGS_DTS_FILES)[0]);
-           const host =
-               createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
-
-           const class2 = getDeclaration(
-               bundle.program, _('/ep/src/class2.js'), 'Class2', isNamedVariableDeclaration);
-           const class2DtsDeclaration = host.getDtsDeclaration(class2);
-           expect(class2DtsDeclaration!.getSourceFile().fileName)
-               .toEqual(_('/ep/typings/class2.d.ts'));
-
-           const internalClass2 = getDeclaration(
-               bundle.program, _('/ep/src/internal.js'), 'Class2', isNamedVariableDeclaration);
-           const internalClass2DtsDeclaration = host.getDtsDeclaration(internalClass2);
-           expect(internalClass2DtsDeclaration!.getSourceFile().fileName)
-               .toEqual(_('/ep/typings/internal.d.ts'));
-         });
-
-      it('should prefer the publicly exported class if there are multiple classes with the same name',
-         () => {
-           loadTestFiles(TYPINGS_SRC_FILES);
-           loadTestFiles(TYPINGS_DTS_FILES);
-           const bundle = makeTestBundleProgram(_('/ep/src/index.js'));
-           const dts = makeTestBundleProgram(_('/ep/typings/index.d.ts'));
-           const class2 = getDeclaration(
-               bundle.program, _('/ep/src/class2.js'), 'Class2', ts.isVariableDeclaration);
-           const internalClass2 = getDeclaration(
-               bundle.program, _('/ep/src/internal.js'), 'Class2', ts.isVariableDeclaration);
-           const host =
-               createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle, dts));
-
-           const class2DtsDeclaration = host.getDtsDeclaration(class2);
-           expect(class2DtsDeclaration!.getSourceFile().fileName)
-               .toEqual(_('/ep/typings/class2.d.ts'));
-
-           const internalClass2DtsDeclaration = host.getDtsDeclaration(internalClass2);
-           expect(internalClass2DtsDeclaration!.getSourceFile().fileName)
-               .toEqual(_('/ep/typings/internal.d.ts'));
-         });
-    });
-
-    describe('getInternalNameOfClass()', () => {
-      it('should return the name of the inner class declaration', () => {
-        loadTestFiles([SIMPLE_CLASS_FILE]);
-        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-
-        const emptyClass = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
-        expect(host.getInternalNameOfClass(emptyClass).text).toEqual('EmptyClass');
-
-        const class1 = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
-        expect(host.getInternalNameOfClass(class1).text).toEqual('InnerClass1');
-
-        const class2 = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
-        expect(host.getInternalNameOfClass(class2).text).toEqual('InnerClass2');
-
-        const childClass = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
-        expect(host.getInternalNameOfClass(childClass).text).toEqual('InnerChildClass');
-      });
-    });
-
-    describe('getAdjacentNameOfClass()', () => {
-      it('should return the name of the inner class declaration', () => {
-        loadTestFiles([SIMPLE_CLASS_FILE]);
-        const bundle = makeTestBundleProgram(SIMPLE_CLASS_FILE.name);
-        const host = createHost(bundle, new UmdReflectionHost(new MockLogger(), false, bundle));
-
-        const emptyClass = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'EmptyClass', isNamedVariableDeclaration);
-        expect(host.getAdjacentNameOfClass(emptyClass).text).toEqual('EmptyClass');
-
-        const class1 = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass1', isNamedVariableDeclaration);
-        expect(host.getAdjacentNameOfClass(class1).text).toEqual('InnerClass1');
-
-        const class2 = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'OuterClass2', isNamedVariableDeclaration);
-        expect(host.getAdjacentNameOfClass(class2).text).toEqual('InnerClass2');
-
-        const childClass = getDeclaration(
-            bundle.program, SIMPLE_CLASS_FILE.name, 'ChildClass', isNamedVariableDeclaration);
-        expect(host.getAdjacentNameOfClass(childClass).text).toEqual('InnerChildClass');
-      });
-    });
-  });
+  }
 });
 
 type WalkerPredicate<T extends ts.Node> = (node: ts.Node) => node is T;

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -17,7 +17,7 @@ import {DependencyTracker} from '../../incremental/api';
 import {IndexingContext} from '../../indexer';
 import {ClassPropertyMapping, DirectiveMeta, DirectiveTypeCheckMeta, extractDirectiveTypeCheckMeta, InjectableClassRegistry, MetadataReader, MetadataRegistry, TemplateMapping} from '../../metadata';
 import {EnumValue, PartialEvaluator} from '../../partial_evaluator';
-import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
+import {ClassDeclaration, DeclarationNode, Decorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
 import {ComponentScopeReader, LocalModuleScopeRegistry} from '../../scope';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerFlags, HandlerPrecedence, ResolveResult} from '../../transform';
 import {TemplateSourceMapping, TypeCheckContext} from '../../typecheck/api';
@@ -103,7 +103,7 @@ export class ComponentDecoratorHandler implements
    * any potential <link> tags which might need to be loaded. This cache ensures that work is not
    * thrown away, and the parsed template is reused during the analyze phase.
    */
-  private preanalyzeTemplateCache = new Map<ts.Declaration, ParsedTemplateWithSource>();
+  private preanalyzeTemplateCache = new Map<DeclarationNode, ParsedTemplateWithSource>();
 
   readonly precedence = HandlerPrecedence.PRIMARY;
   readonly name = ComponentDecoratorHandler.name;

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -463,12 +463,20 @@ export function extractQueriesFromDecorator(
   }
   reflectObjectLiteral(queryData).forEach((queryExpr, propertyName) => {
     queryExpr = unwrapExpression(queryExpr);
-    if (!ts.isNewExpression(queryExpr) || !ts.isIdentifier(queryExpr.expression)) {
+    if (!ts.isNewExpression(queryExpr)) {
       throw new FatalDiagnosticError(
           ErrorCode.VALUE_HAS_WRONG_TYPE, queryData,
           'Decorator query metadata must be an instance of a query type');
     }
-    const type = reflector.getImportOfIdentifier(queryExpr.expression);
+    const queryType = ts.isPropertyAccessExpression(queryExpr.expression) ?
+        queryExpr.expression.name :
+        queryExpr.expression;
+    if (!ts.isIdentifier(queryType)) {
+      throw new FatalDiagnosticError(
+          ErrorCode.VALUE_HAS_WRONG_TYPE, queryData,
+          'Decorator query metadata must be an instance of a query type');
+    }
+    const type = reflector.getImportOfIdentifier(queryType);
     if (type === null || (!isCore && type.from !== '@angular/core') ||
         !QUERY_TYPES.has(type.name)) {
       throw new FatalDiagnosticError(

--- a/packages/compiler-cli/src/ngtsc/annotations/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/metadata.ts
@@ -10,7 +10,7 @@ import {Expression, ExternalExpr, FunctionExpr, Identifiers, InvokeFunctionExpr,
 import * as ts from 'typescript';
 
 import {DefaultImportRecorder} from '../../imports';
-import {CtorParameter, Decorator, ReflectionHost, TypeValueReferenceKind} from '../../reflection';
+import {CtorParameter, DeclarationNode, Decorator, ReflectionHost, TypeValueReferenceKind} from '../../reflection';
 
 import {valueReferenceToExpression, wrapFunctionExpressionsInParens} from './util';
 
@@ -23,8 +23,9 @@ import {valueReferenceToExpression, wrapFunctionExpressionsInParens} from './uti
  * as a `Statement` for inclusion along with the class.
  */
 export function generateSetClassMetadataCall(
-    clazz: ts.Declaration, reflection: ReflectionHost, defaultImportRecorder: DefaultImportRecorder,
-    isCore: boolean, annotateForClosureCompiler?: boolean): Statement|null {
+    clazz: DeclarationNode, reflection: ReflectionHost,
+    defaultImportRecorder: DefaultImportRecorder, isCore: boolean,
+    annotateForClosureCompiler?: boolean): Statement|null {
   if (!reflection.isClass(clazz)) {
     return null;
   }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -13,7 +13,7 @@ import {ErrorCode, FatalDiagnosticError, makeDiagnostic, makeRelatedInformation}
 import {DefaultImportRecorder, Reference, ReferenceEmitter} from '../../imports';
 import {InjectableClassRegistry, MetadataReader, MetadataRegistry} from '../../metadata';
 import {PartialEvaluator, ResolvedValue} from '../../partial_evaluator';
-import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral, typeNodeToValueExpr} from '../../reflection';
+import {ClassDeclaration, DeclarationNode, Decorator, isNamedClassDeclaration, ReflectionHost, reflectObjectLiteral, typeNodeToValueExpr} from '../../reflection';
 import {NgModuleRouteAnalyzer} from '../../routing';
 import {LocalModuleScopeRegistry, ScopeData} from '../../scope';
 import {FactoryTracker} from '../../shims/api';
@@ -434,14 +434,14 @@ export class NgModuleDecoratorHandler implements
   }
 
   private _toR3Reference(
-      valueRef: Reference<ts.Declaration>, valueContext: ts.SourceFile,
+      valueRef: Reference<ClassDeclaration>, valueContext: ts.SourceFile,
       typeContext: ts.SourceFile): R3Reference {
     if (valueRef.hasOwningModuleGuess) {
       return toR3Reference(valueRef, valueRef, valueContext, valueContext, this.refEmitter);
     } else {
       let typeRef = valueRef;
       let typeNode = this.reflector.getDtsDeclaration(typeRef.node);
-      if (typeNode !== null && ts.isClassDeclaration(typeNode)) {
+      if (typeNode !== null && isNamedClassDeclaration(typeNode)) {
         typeRef = new Reference(typeNode);
       }
       return toR3Reference(valueRef, typeRef, valueContext, typeContext, this.refEmitter);
@@ -539,7 +539,7 @@ export class NgModuleDecoratorHandler implements
     return null;
   }
 
-  // Verify that a `ts.Declaration` reference is a `ClassDeclaration` reference.
+  // Verify that a "Declaration" reference is a `ClassDeclaration` reference.
   private isClassDeclarationReference(ref: Reference): ref is Reference<ClassDeclaration> {
     return this.reflector.isClass(ref.node);
   }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -540,8 +540,7 @@ export class NgModuleDecoratorHandler implements
   }
 
   // Verify that a `ts.Declaration` reference is a `ClassDeclaration` reference.
-  private isClassDeclarationReference(ref: Reference<ts.Declaration>):
-      ref is Reference<ClassDeclaration> {
+  private isClassDeclarationReference(ref: Reference): ref is Reference<ClassDeclaration> {
     return this.reflector.isClass(ref.node);
   }
 
@@ -568,7 +567,7 @@ export class NgModuleDecoratorHandler implements
       if (Array.isArray(entry)) {
         // Recurse into nested arrays.
         refList.push(...this.resolveTypeList(expr, entry, className, arrayName));
-      } else if (isDeclarationReference(entry)) {
+      } else if (entry instanceof Reference) {
         if (!this.isClassDeclarationReference(entry)) {
           throw createValueHasWrongTypeError(
               entry.node, entry,
@@ -592,10 +591,4 @@ export class NgModuleDecoratorHandler implements
 function isNgModule(node: ClassDeclaration, compilation: ScopeData): boolean {
   return !compilation.directives.some(directive => directive.ref.node === node) &&
       !compilation.pipes.some(pipe => pipe.ref.node === node);
-}
-
-function isDeclarationReference(ref: any): ref is Reference<ts.Declaration> {
-  return ref instanceof Reference &&
-      (ts.isClassDeclaration(ref.node) || ts.isFunctionDeclaration(ref.node) ||
-       ts.isVariableDeclaration(ref.node));
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/references_registry.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/references_registry.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as ts from 'typescript';
 import {Reference} from '../../imports';
+import {DeclarationNode} from '../../reflection';
 
 /**
  * Implement this interface if you want DecoratorHandlers to register
@@ -18,7 +18,7 @@ export interface ReferencesRegistry {
    * Register one or more references in the registry.
    * @param references A collection of references to register.
    */
-  add(source: ts.Declaration, ...references: Reference<ts.Declaration>[]): void;
+  add(source: DeclarationNode, ...references: Reference<DeclarationNode>[]): void;
 }
 
 /**
@@ -27,5 +27,5 @@ export interface ReferencesRegistry {
  * The ngcc tool implements a working version for its purposes.
  */
 export class NoopReferencesRegistry implements ReferencesRegistry {
-  add(source: ts.Declaration, ...references: Reference<ts.Declaration>[]): void {}
+  add(source: DeclarationNode, ...references: Reference<DeclarationNode>[]): void {}
 }

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -21,7 +21,7 @@ import {CompoundMetadataReader, CompoundMetadataRegistry, DtsMetadataReader, Inj
 import {ModuleWithProvidersScanner} from '../../modulewithproviders';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {NOOP_PERF_RECORDER, PerfRecorder} from '../../perf';
-import {ClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
+import {DeclarationNode, TypeScriptReflectionHost} from '../../reflection';
 import {AdapterResourceLoader} from '../../resource';
 import {entryPointKeyFor, NgModuleRouteAnalyzer} from '../../routing';
 import {ComponentScopeReader, LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../scope';
@@ -238,7 +238,7 @@ export class NgCompiler {
   /**
    * Retrieves the `ts.Declaration`s for any component(s) which use the given template file.
    */
-  getComponentsWithTemplateFile(templateFilePath: string): ReadonlySet<ts.Declaration> {
+  getComponentsWithTemplateFile(templateFilePath: string): ReadonlySet<DeclarationNode> {
     const {templateMapping} = this.ensureAnalyzed();
     return templateMapping.getComponentsWithTemplate(resolve(templateFilePath));
   }
@@ -378,7 +378,7 @@ export class NgCompiler {
    *
    * See the `indexing` package for more details.
    */
-  getIndexedComponents(): Map<ts.Declaration, IndexedComponent> {
+  getIndexedComponents(): Map<DeclarationNode, IndexedComponent> {
     const compilation = this.ensureAnalyzed();
     const context = new IndexingContext();
     compilation.traitCompiler.index(context);
@@ -880,7 +880,7 @@ https://v9.angular.io/guide/template-typecheck#template-type-checking`,
 class ReferenceGraphAdapter implements ReferencesRegistry {
   constructor(private graph: ReferenceGraph) {}
 
-  add(source: ts.Declaration, ...references: Reference<ts.Declaration>[]): void {
+  add(source: DeclarationNode, ...references: Reference<DeclarationNode>[]): void {
     for (const {node} of references) {
       let sourceFile = node.getSourceFile();
       if (sourceFile === undefined) {

--- a/packages/compiler-cli/src/ngtsc/entry_point/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/entry_point/BUILD.bazel
@@ -11,6 +11,7 @@ ts_library(
     deps = [
         "//packages/compiler-cli/src/ngtsc/diagnostics",
         "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/compiler-cli/src/ngtsc/shims:api",
         "//packages/compiler-cli/src/ngtsc/util",
         "@npm//@types/node",

--- a/packages/compiler-cli/src/ngtsc/entry_point/src/reference_graph.ts
+++ b/packages/compiler-cli/src/ngtsc/entry_point/src/reference_graph.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as ts from 'typescript';
+import {DeclarationNode} from '../../reflection';
 
-export class ReferenceGraph<T = ts.Declaration> {
+export class ReferenceGraph<T = DeclarationNode> {
   private references = new Map<T, Set<T>>();
 
   add(from: T, to: T): void {

--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -7,8 +7,7 @@
  */
 
 import {ParseSourceFile} from '@angular/compiler';
-import * as ts from 'typescript';
-import {ClassDeclaration} from '../../reflection';
+import {ClassDeclaration, DeclarationNode} from '../../reflection';
 
 /**
  * Describes the kind of identifier found in a template.
@@ -129,7 +128,7 @@ export interface IndexedComponent {
   file: ParseSourceFile;
   template: {
     identifiers: Set<TopLevelIdentifier>,
-    usedComponents: Set<ts.Declaration>,
+    usedComponents: Set<DeclarationNode>,
     isInline: boolean,
     file: ParseSourceFile;
   };

--- a/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
@@ -7,7 +7,7 @@
  */
 
 import {ParseSourceFile} from '@angular/compiler';
-import * as ts from 'typescript';
+import {DeclarationNode} from '../../reflection';
 import {IndexedComponent} from './api';
 import {IndexingContext} from './context';
 import {getTemplateIdentifiers} from './template';
@@ -18,13 +18,13 @@ import {getTemplateIdentifiers} from './template';
  *
  * The context must be populated before `generateAnalysis` is called.
  */
-export function generateAnalysis(context: IndexingContext): Map<ts.Declaration, IndexedComponent> {
-  const analysis = new Map<ts.Declaration, IndexedComponent>();
+export function generateAnalysis(context: IndexingContext): Map<DeclarationNode, IndexedComponent> {
+  const analysis = new Map<DeclarationNode, IndexedComponent>();
 
   context.components.forEach(({declaration, selector, boundTemplate, templateMeta}) => {
     const name = declaration.name.getText();
 
-    const usedComponents = new Set<ts.Declaration>();
+    const usedComponents = new Set<DeclarationNode>();
     const usedDirs = boundTemplate.getUsedDirectives();
     usedDirs.forEach(dir => {
       if (dir.isComponent) {

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -29,7 +29,7 @@ export function getComponentDeclaration(componentStr: string, className: string)
 
   return getDeclaration(
       program.program, getTestFilePath(), className,
-      (value: ts.Declaration): value is ClassDeclaration => ts.isClassDeclaration(value));
+      (value: ts.Node): value is ClassDeclaration => ts.isClassDeclaration(value));
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 import {Reference} from '../../imports';
 import {OwningModule} from '../../imports/src/references';
 import {DependencyTracker} from '../../incremental/api';
-import {ConcreteDeclaration, Declaration, EnumMember, FunctionDefinition, InlineDeclaration, ReflectionHost, SpecialDeclarationKind} from '../../reflection';
+import {Declaration, DeclarationNode, EnumMember, FunctionDefinition, isConcreteDeclaration, ReflectionHost, SpecialDeclarationKind} from '../../reflection';
 import {isDeclaration} from '../../util/src/typescript';
 
 import {ArrayConcatBuiltinFn, ArraySliceBuiltinFn} from './builtin';
@@ -231,12 +231,7 @@ export class StaticInterpreter {
       return this.getResolvedEnum(decl.node, decl.identity.enumMembers, context);
     }
     const declContext = {...context, ...joinModuleContext(context, node, decl)};
-    // The identifier's declaration is either concrete (a ts.Declaration exists for it) or inline
-    // (a direct reference to a ts.Expression).
-    // TODO(alxhub): remove cast once TS is upgraded in g3.
-    const result = decl.node !== null ?
-        this.visitDeclaration(decl.node, declContext) :
-        this.visitExpression((decl as InlineDeclaration).expression, declContext);
+    const result = this.visitDeclaration(decl.node, declContext);
     if (result instanceof Reference) {
       // Only record identifiers to non-synthetic references. Synthetic references may not have the
       // same value at runtime as they do at compile time, so it's not legal to refer to them by the
@@ -250,7 +245,7 @@ export class StaticInterpreter {
     return result;
   }
 
-  private visitDeclaration(node: ts.Declaration, context: Context): ResolvedValue {
+  private visitDeclaration(node: DeclarationNode, context: Context): ResolvedValue {
     if (this.dependencyTracker !== null) {
       this.dependencyTracker.addDependency(context.originatingFile, node.getSourceFile());
     }
@@ -342,10 +337,7 @@ export class StaticInterpreter {
       };
 
       // Visit both concrete and inline declarations.
-      // TODO(alxhub): remove cast once TS is upgraded in g3.
-      return decl.node !== null ?
-          this.visitDeclaration(decl.node, declContext) :
-          this.visitExpression((decl as InlineDeclaration).expression, declContext);
+      return this.visitDeclaration(decl.node, declContext);
     });
   }
 
@@ -667,7 +659,7 @@ export class StaticInterpreter {
     return map;
   }
 
-  private getReference<T extends ts.Declaration>(node: T, context: Context): Reference<T> {
+  private getReference<T extends DeclarationNode>(node: T, context: Context): Reference<T> {
     return new Reference(node, owningModule(context));
   }
 }
@@ -732,12 +724,4 @@ function owningModule(context: Context, override: OwningModule|null = null): Own
   } else {
     return null;
   }
-}
-
-/**
- * Helper type guard to workaround a narrowing limitation in g3, where testing for
- * `decl.node !== null` would not narrow `decl` to be of type `ConcreteDeclaration`.
- */
-function isConcreteDeclaration(decl: Declaration): decl is ConcreteDeclaration {
-  return decl.node !== null;
 }

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
@@ -11,7 +11,7 @@ import {absoluteFrom, getSourceFileOrError} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {Reference} from '../../imports';
 import {DependencyTracker} from '../../incremental/api';
-import {Declaration, KnownDeclaration, SpecialDeclarationKind, TypeScriptReflectionHost} from '../../reflection';
+import {Declaration, DeclarationKind, isConcreteDeclaration, KnownDeclaration, SpecialDeclarationKind, TypeScriptReflectionHost} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';
 import {DynamicValue} from '../src/dynamic';
 import {PartialEvaluator} from '../src/interface';
@@ -920,7 +920,7 @@ runInEachFileSystem(() => {
   class DownleveledEnumReflectionHost extends TypeScriptReflectionHost {
     getDeclarationOfIdentifier(id: ts.Identifier): Declaration|null {
       const declaration = super.getDeclarationOfIdentifier(id);
-      if (declaration !== null && declaration.node !== null) {
+      if (declaration !== null && isConcreteDeclaration(declaration)) {
         const enumMembers = [
           {name: ts.createStringLiteral('ValueA'), initializer: ts.createStringLiteral('a')},
           {name: ts.createStringLiteral('ValueB'), initializer: ts.createStringLiteral('b')},
@@ -961,6 +961,7 @@ runInEachFileSystem(() => {
           node: id,
           viaModule: null,
           identity: null,
+          kind: DeclarationKind.Concrete,
         };
       }
 
@@ -968,8 +969,8 @@ runInEachFileSystem(() => {
     }
   }
 
-  function getTsHelperFn(node: ts.Declaration): KnownDeclaration|null {
-    const id = (node as ts.Declaration & {name?: ts.Identifier}).name || null;
+  function getTsHelperFn(node: ts.Node): KnownDeclaration|null {
+    const id = (node as ts.Node & {name?: ts.Identifier}).name || null;
     const name = id && id.text;
 
     switch (name) {

--- a/packages/compiler-cli/src/ngtsc/perf/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/perf/BUILD.bazel
@@ -10,6 +10,7 @@ ts_library(
     deps = [
         "//packages:types",
         "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//@types/node",
         "@npm//typescript",
     ],

--- a/packages/compiler-cli/src/ngtsc/perf/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/perf/src/api.ts
@@ -6,13 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as ts from 'typescript';
+import {DeclarationNode} from '../../reflection';
 
 export interface PerfRecorder {
   readonly enabled: boolean;
 
-  mark(name: string, node?: ts.SourceFile|ts.Declaration, category?: string, detail?: string): void;
-  start(name: string, node?: ts.SourceFile|ts.Declaration, category?: string, detail?: string):
-      number;
+  mark(name: string, node?: DeclarationNode, category?: string, detail?: string): void;
+  start(name: string, node?: DeclarationNode, category?: string, detail?: string): number;
   stop(span: number): void;
 }

--- a/packages/compiler-cli/src/ngtsc/perf/src/noop.ts
+++ b/packages/compiler-cli/src/ngtsc/perf/src/noop.ts
@@ -5,18 +5,15 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
-import * as ts from 'typescript';
+import {DeclarationNode} from '../../reflection';
 
 import {PerfRecorder} from './api';
 
 export const NOOP_PERF_RECORDER: PerfRecorder = {
   enabled: false,
-  mark: (name: string, node: ts.SourceFile|ts.Declaration, category?: string, detail?: string):
-      void => {},
-  start: (name: string, node: ts.SourceFile|ts.Declaration, category?: string, detail?: string):
-      number => {
-        return 0;
-      },
+  mark: (name: string, node: DeclarationNode, category?: string, detail?: string): void => {},
+  start: (name: string, node: DeclarationNode, category?: string, detail?: string): number => {
+    return 0;
+  },
   stop: (span: number|false): void => {},
 };

--- a/packages/compiler-cli/src/ngtsc/perf/src/tracking.ts
+++ b/packages/compiler-cli/src/ngtsc/perf/src/tracking.ts
@@ -9,6 +9,7 @@
 import * as fs from 'fs';
 import * as ts from 'typescript';
 import {resolve} from '../../file_system';
+import {DeclarationNode} from '../../reflection';
 import {PerfRecorder} from './api';
 import {HrTime, mark, timeSinceInMicros} from './clock';
 
@@ -24,14 +25,12 @@ export class PerfTracker implements PerfRecorder {
     return new PerfTracker(mark());
   }
 
-  mark(name: string, node?: ts.SourceFile|ts.Declaration, category?: string, detail?: string):
-      void {
+  mark(name: string, node?: DeclarationNode, category?: string, detail?: string): void {
     const msg = this.makeLogMessage(PerfLogEventType.MARK, name, node, category, detail, undefined);
     this.log.push(msg);
   }
 
-  start(name: string, node?: ts.SourceFile|ts.Declaration, category?: string, detail?: string):
-      number {
+  start(name: string, node?: DeclarationNode, category?: string, detail?: string): number {
     const span = this.nextSpanId++;
     const msg = this.makeLogMessage(PerfLogEventType.SPAN_OPEN, name, node, category, detail, span);
     this.log.push(msg);
@@ -47,7 +46,7 @@ export class PerfTracker implements PerfRecorder {
   }
 
   private makeLogMessage(
-      type: PerfLogEventType, name: string, node: ts.SourceFile|ts.Declaration|undefined,
+      type: PerfLogEventType, name: string, node: DeclarationNode|undefined,
       category: string|undefined, detail: string|undefined, span: number|undefined): PerfLogEvent {
     const msg: PerfLogEvent = {
       type,

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -17,6 +17,7 @@ import {NgCompilerOptions} from './core/api';
 import {TrackedIncrementalBuildStrategy} from './incremental';
 import {IndexedComponent} from './indexer';
 import {NOOP_PERF_RECORDER, PerfRecorder, PerfTracker} from './perf';
+import {DeclarationNode} from './reflection';
 import {retagAllTsFiles, untagAllTsFiles} from './shims';
 import {ReusedProgramStrategy} from './typecheck';
 
@@ -276,7 +277,7 @@ export class NgtscProgram implements api.Program {
     return ((opts && opts.mergeEmitResultsCallback) || mergeEmitResults)(emitResults);
   }
 
-  getIndexedComponents(): Map<ts.Declaration, IndexedComponent> {
+  getIndexedComponents(): Map<DeclarationNode, IndexedComponent> {
     return this.compiler.getIndexedComponents();
   }
 

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -105,7 +105,6 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     if (!ts.isSourceFile(node)) {
       throw new Error(`getExportsOfModule() called on non-SourceFile in TS code`);
     }
-    const map = new Map<string, Declaration>();
 
     // Reflect the module to a Symbol, and use getExportsOfModule() to get a list of exported
     // Symbols.
@@ -113,6 +112,8 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     if (symbol === undefined) {
       return null;
     }
+
+    const map = new Map<string, Declaration>();
     this.checker.getExportsOfModule(symbol).forEach(exportSymbol => {
       // Map each exported Symbol to a Declaration and add it to the map.
       const decl = this.getDeclarationOfSymbol(exportSymbol, null);

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {ClassDeclaration, ClassMember, ClassMemberKind, CtorParameter, Declaration, Decorator, FunctionDefinition, Import, isDecoratorIdentifier, ReflectionHost} from './host';
+import {ClassDeclaration, ClassMember, ClassMemberKind, CtorParameter, Declaration, DeclarationKind, DeclarationNode, Decorator, FunctionDefinition, Import, isDecoratorIdentifier, ReflectionHost} from './host';
 import {typeToValue} from './type_to_value';
 import {isNamedClassDeclaration} from './util';
 
@@ -19,7 +19,7 @@ import {isNamedClassDeclaration} from './util';
 export class TypeScriptReflectionHost implements ReflectionHost {
   constructor(protected checker: ts.TypeChecker) {}
 
-  getDecoratorsOfDeclaration(declaration: ts.Declaration): Decorator[]|null {
+  getDecoratorsOfDeclaration(declaration: DeclarationNode): Decorator[]|null {
     if (declaration.decorators === undefined || declaration.decorators.length === 0) {
       return null;
     }
@@ -187,7 +187,7 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     return declaration.initializer || null;
   }
 
-  getDtsDeclaration(_: ts.Declaration): ts.Declaration|null {
+  getDtsDeclaration(_: ClassDeclaration): ts.Declaration|null {
     return null;
   }
 
@@ -207,7 +207,7 @@ export class TypeScriptReflectionHost implements ReflectionHost {
       return null;
     }
 
-    const decl: ts.Declaration = symbol.declarations[0];
+    const decl = symbol.declarations[0];
     const importDecl = getContainingImportDeclaration(decl);
 
     // Ignore declarations that are defined locally (not imported).
@@ -318,6 +318,7 @@ export class TypeScriptReflectionHost implements ReflectionHost {
         known: null,
         viaModule,
         identity: null,
+        kind: DeclarationKind.Concrete,
       };
     } else if (symbol.declarations !== undefined && symbol.declarations.length > 0) {
       return {
@@ -325,6 +326,7 @@ export class TypeScriptReflectionHost implements ReflectionHost {
         known: null,
         viaModule,
         identity: null,
+        kind: DeclarationKind.Concrete,
       };
     } else {
       return null;

--- a/packages/compiler-cli/src/ngtsc/reflection/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/util.ts
@@ -11,15 +11,19 @@ import {ClassDeclaration} from './host';
 
 export function isNamedClassDeclaration(node: ts.Node):
     node is ClassDeclaration<ts.ClassDeclaration> {
-  return ts.isClassDeclaration(node) && (node.name !== undefined);
+  return ts.isClassDeclaration(node) && isIdentifier(node.name);
 }
 
 export function isNamedFunctionDeclaration(node: ts.Node):
     node is ClassDeclaration<ts.FunctionDeclaration> {
-  return ts.isFunctionDeclaration(node) && (node.name !== undefined);
+  return ts.isFunctionDeclaration(node) && isIdentifier(node.name);
 }
 
 export function isNamedVariableDeclaration(node: ts.Node):
     node is ClassDeclaration<ts.VariableDeclaration> {
-  return ts.isVariableDeclaration(node) && (node.name !== undefined);
+  return ts.isVariableDeclaration(node) && isIdentifier(node.name);
+}
+
+function isIdentifier(node: ts.Node|undefined): node is ts.Identifier {
+  return node !== undefined && ts.isIdentifier(node);
 }

--- a/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
@@ -9,7 +9,7 @@ import * as ts from 'typescript';
 import {absoluteFrom, getSourceFileOrError} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {getDeclaration, makeProgram} from '../../testing';
-import {ClassMember, ClassMemberKind, CtorParameter, TypeValueReferenceKind} from '../src/host';
+import {ClassMember, ClassMemberKind, CtorParameter, DeclarationKind, TypeValueReferenceKind} from '../src/host';
 import {TypeScriptReflectionHost} from '../src/typescript';
 import {isNamedClassDeclaration} from '../src/util';
 
@@ -360,6 +360,7 @@ runInEachFileSystem(() => {
         const Target = foo.type.typeName;
         const decl = host.getDeclarationOfIdentifier(Target);
         expect(decl).toEqual({
+          kind: DeclarationKind.Concrete,
           node: targetDecl,
           known: null,
           viaModule: 'absolute',
@@ -395,6 +396,7 @@ runInEachFileSystem(() => {
           known: null,
           viaModule: 'absolute',
           identity: null,
+          kind: DeclarationKind.Concrete
         });
       });
     });

--- a/packages/compiler-cli/src/ngtsc/testing/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/testing/BUILD.bazel
@@ -11,6 +11,7 @@ ts_library(
     deps = [
         "//packages:types",
         "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/index.ts
@@ -5,4 +5,4 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-export {expectCompleteReuse, getDeclaration, makeProgram} from './src/utils';
+export {expectCompleteReuse, getDeclaration, isNamedDeclaration, makeProgram} from './src/utils';

--- a/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
@@ -60,7 +60,8 @@ export function getDeclaration<T extends ts.Declaration>(
     throw new Error(`No such symbol: ${name} in ${fileName}`);
   }
   if (!assert(chosenDecl)) {
-    throw new Error(`Symbol ${name} from ${fileName} is a ${ts.SyntaxKind[chosenDecl.kind]}`);
+    throw new Error(`Symbol ${name} from ${fileName} is a ${
+        ts.SyntaxKind[chosenDecl.kind]}. Expected it to pass predicate "${assert.name}()".`);
   }
   return chosenDecl;
 }

--- a/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
@@ -11,6 +11,7 @@
 import * as ts from 'typescript';
 
 import {AbsoluteFsPath, dirname, getFileSystem, getSourceFileOrError, NgtscCompilerHost} from '../../file_system';
+import {DeclarationNode} from '../../reflection';
 
 export function makeProgram(
     files: {name: AbsoluteFsPath, contents: string, isRoot?: boolean}[],
@@ -57,7 +58,7 @@ export function makeProgram(
  * An error will be thrown if there is not at least one AST node with the given `name` and passes
  * the `predicate` test.
  */
-export function getDeclaration<T extends ts.Declaration>(
+export function getDeclaration<T extends DeclarationNode>(
     program: ts.Program, fileName: AbsoluteFsPath, name: string,
     assert: (value: any) => value is T): T {
   const sf = getSourceFileOrError(program, fileName);
@@ -78,8 +79,8 @@ export function getDeclaration<T extends ts.Declaration>(
 /**
  * Walk the AST tree from the `rootNode` looking for a declaration that has the given `name`.
  */
-export function walkForDeclarations(name: string, rootNode: ts.Node): ts.Declaration[] {
-  const chosenDecls: ts.Declaration[] = [];
+export function walkForDeclarations(name: string, rootNode: ts.Node): DeclarationNode[] {
+  const chosenDecls: DeclarationNode[] = [];
   rootNode.forEachChild(node => {
     if (ts.isVariableStatement(node)) {
       node.declarationList.declarations.forEach(decl => {

--- a/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
@@ -93,9 +93,7 @@ export function walkForDeclarations(name: string, rootNode: ts.Node): Declaratio
           chosenDecls.push(...walkForDeclarations(name, node));
         }
       });
-    } else if (
-        ts.isClassDeclaration(node) || ts.isFunctionDeclaration(node) ||
-        ts.isInterfaceDeclaration(node) || ts.isClassExpression(node)) {
+    } else if (isNamedDeclaration(node)) {
       if (node.name !== undefined && node.name.text === name) {
         chosenDecls.push(node);
       }
@@ -109,6 +107,11 @@ export function walkForDeclarations(name: string, rootNode: ts.Node): Declaratio
     }
   });
   return chosenDecls;
+}
+
+export function isNamedDeclaration(node: ts.Node): node is ts.Declaration&{name: ts.Identifier} {
+  const namedNode = node as {name?: ts.Identifier};
+  return namedNode.name !== undefined && ts.isIdentifier(namedNode.name);
 }
 
 const COMPLETE_REUSE_FAILURE_MESSAGE =

--- a/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
@@ -50,52 +50,64 @@ export function makeProgram(
   return {program, host: compilerHost, options: compilerOptions};
 }
 
+/**
+ * Search the file specified by `fileName` in the given `program` for a declaration that has the
+ * name `name` and passes the `predicate` function.
+ *
+ * An error will be thrown if there is not at least one AST node with the given `name` and passes
+ * the `predicate` test.
+ */
 export function getDeclaration<T extends ts.Declaration>(
     program: ts.Program, fileName: AbsoluteFsPath, name: string,
     assert: (value: any) => value is T): T {
   const sf = getSourceFileOrError(program, fileName);
-  const chosenDecl = walkForDeclaration(name, sf);
+  const chosenDecls = walkForDeclarations(name, sf);
 
-  if (chosenDecl === null) {
+  if (chosenDecls.length === 0) {
     throw new Error(`No such symbol: ${name} in ${fileName}`);
   }
-  if (!assert(chosenDecl)) {
-    throw new Error(`Symbol ${name} from ${fileName} is a ${
-        ts.SyntaxKind[chosenDecl.kind]}. Expected it to pass predicate "${assert.name}()".`);
+  const chosenDecl = chosenDecls.find(assert);
+  if (chosenDecl === undefined) {
+    throw new Error(`Symbols with name ${name} in ${fileName} have types: ${
+        chosenDecls.map(decl => ts.SyntaxKind[decl.kind])}. Expected one to pass predicate "${
+        assert.name}()".`);
   }
   return chosenDecl;
 }
 
-// We walk the AST tree looking for a declaration that matches
-export function walkForDeclaration(name: string, rootNode: ts.Node): ts.Declaration|null {
-  let chosenDecl: ts.Declaration|null = null;
+/**
+ * Walk the AST tree from the `rootNode` looking for a declaration that has the given `name`.
+ */
+export function walkForDeclarations(name: string, rootNode: ts.Node): ts.Declaration[] {
+  const chosenDecls: ts.Declaration[] = [];
   rootNode.forEachChild(node => {
-    if (chosenDecl !== null) {
-      return;
-    }
     if (ts.isVariableStatement(node)) {
       node.declarationList.declarations.forEach(decl => {
         if (bindingNameEquals(decl.name, name)) {
-          chosenDecl = decl;
+          chosenDecls.push(decl);
+          if (decl.initializer) {
+            chosenDecls.push(...walkForDeclarations(name, decl.initializer));
+          }
         } else {
-          chosenDecl = walkForDeclaration(name, node);
+          chosenDecls.push(...walkForDeclarations(name, node));
         }
       });
     } else if (
         ts.isClassDeclaration(node) || ts.isFunctionDeclaration(node) ||
         ts.isInterfaceDeclaration(node) || ts.isClassExpression(node)) {
       if (node.name !== undefined && node.name.text === name) {
-        chosenDecl = node;
+        chosenDecls.push(node);
       }
+      chosenDecls.push(...walkForDeclarations(name, node));
     } else if (
         ts.isImportDeclaration(node) && node.importClause !== undefined &&
         node.importClause.name !== undefined && node.importClause.name.text === name) {
-      chosenDecl = node.importClause;
+      chosenDecls.push(node.importClause);
     } else {
-      chosenDecl = walkForDeclaration(name, node);
+      chosenDecls.push(...walkForDeclarations(name, node));
     }
   });
-  return chosenDecl;
+  return chosenDecls;
 }
 
 const COMPLETE_REUSE_FAILURE_MESSAGE =

--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -13,7 +13,7 @@ import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
 import {IncrementalBuild} from '../../incremental/api';
 import {IndexingContext} from '../../indexer';
 import {PerfRecorder} from '../../perf';
-import {ClassDeclaration, Decorator, ReflectionHost} from '../../reflection';
+import {ClassDeclaration, DeclarationNode, Decorator, ReflectionHost} from '../../reflection';
 import {ProgramTypeCheckAdapter, TypeCheckContext} from '../../typecheck/api';
 import {getSourceFile, isExported} from '../../util/src/typescript';
 
@@ -463,7 +463,7 @@ export class TraitCompiler implements ProgramTypeCheckAdapter {
     }
   }
 
-  compile(clazz: ts.Declaration, constantPool: ConstantPool): CompileResult[]|null {
+  compile(clazz: DeclarationNode, constantPool: ConstantPool): CompileResult[]|null {
     const original = ts.getOriginalNode(clazz) as typeof clazz;
     if (!this.reflector.isClass(clazz) || !this.reflector.isClass(original) ||
         !this.classes.has(original)) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/BUILD.bazel
@@ -9,6 +9,7 @@ ts_library(
     deps = [
         "//packages:types",
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/compiler-cli/src/ngtsc/typecheck/api",
         "@npm//typescript",
     ],

--- a/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/id.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/id.ts
@@ -7,6 +7,7 @@
  */
 
 import * as ts from 'typescript';
+import {DeclarationNode} from '../../../reflection';
 
 import {TemplateId} from '../../api';
 
@@ -22,7 +23,7 @@ interface HasNextTemplateId {
   [NEXT_TEMPLATE_ID]: number;
 }
 
-export function getTemplateId(clazz: ts.Declaration): TemplateId {
+export function getTemplateId(clazz: DeclarationNode): TemplateId {
   const node = clazz as ts.Declaration & Partial<HasTemplateId>;
   if (node[TEMPLATE_ID] === undefined) {
     node[TEMPLATE_ID] = allocateTemplateId(node.getSourceFile());

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_parameter_emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_parameter_emitter.ts
@@ -8,7 +8,7 @@
 import * as ts from 'typescript';
 
 import {OwningModule, Reference} from '../../imports';
-import {ReflectionHost} from '../../reflection';
+import {DeclarationNode, ReflectionHost} from '../../reflection';
 
 import {canEmitType, ResolvedTypeReference, TypeEmitter} from './type_emitter';
 
@@ -89,7 +89,7 @@ export class TypeParameterEmitter {
     return new Reference(declaration.node, owningModule);
   }
 
-  private isLocalTypeParameter(decl: ts.Declaration): boolean {
+  private isLocalTypeParameter(decl: DeclarationNode): boolean {
     // Checking for local type parameters only occurs during resolution of type parameters, so it is
     // guaranteed that type parameters are present.
     return this.typeParameters!.some(param => param === decl);

--- a/packages/compiler-cli/src/ngtsc/util/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/util/BUILD.bazel
@@ -11,6 +11,7 @@ ts_library(
         "//packages:types",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/incremental:api",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//@types/node",
         "@npm//typescript",
     ],

--- a/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
@@ -11,6 +11,7 @@ const D_TS = /\.d\.ts$/i;
 
 import * as ts from 'typescript';
 import {AbsoluteFsPath, absoluteFrom} from '../../file_system';
+import {DeclarationNode} from '../../reflection';
 
 export function isDtsPath(filePath: string): boolean {
   return D_TS.test(filePath);
@@ -82,7 +83,7 @@ export function isTypeDeclaration(node: ts.Node): node is ts.EnumDeclaration|
       ts.isInterfaceDeclaration(node);
 }
 
-export function isExported(node: ts.Declaration): boolean {
+export function isExported(node: DeclarationNode): boolean {
   let topLevel: ts.Node = node;
   if (ts.isVariableDeclaration(node) && ts.isVariableDeclarationList(node.parent)) {
     topLevel = node.parent.parent;

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -11,6 +11,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/file_system/testing",
         "//packages/compiler-cli/src/ngtsc/indexer",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/compiler-cli/src/ngtsc/routing",
         "//packages/compiler-cli/src/ngtsc/testing",
         "//packages/compiler-cli/src/ngtsc/util",

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -16,6 +16,7 @@ import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, NgtscCompilerHo
 import {Folder, MockFileSystem} from '../../src/ngtsc/file_system/testing';
 import {IndexedComponent} from '../../src/ngtsc/indexer';
 import {NgtscProgram} from '../../src/ngtsc/program';
+import {DeclarationNode} from '../../src/ngtsc/reflection';
 import {LazyRoute} from '../../src/ngtsc/routing';
 import {setWrapHostForTest} from '../../src/transformers/compiler_host';
 import {getCachedSourceFile} from '../helpers';
@@ -259,7 +260,7 @@ export class NgtscTestEnvironment {
     return program.listLazyRoutes(entryPoint);
   }
 
-  driveIndexer(): Map<ts.Declaration, IndexedComponent> {
+  driveIndexer(): Map<DeclarationNode, IndexedComponent> {
     const {rootNames, options} = readNgcCommandLineAndConfiguration(['-p', this.basePath]);
     const host = createCompilerHost({options});
     const program = createProgram({rootNames, host, options});

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -3064,12 +3064,13 @@ runInEachFileSystem(os => {
     it('should generate queries for directives', () => {
       env.write(`test.ts`, `
         import {Directive, ContentChild, ContentChildren, TemplateRef, ViewChild} from '@angular/core';
+        import * as core from '@angular/core';
 
         @Directive({
           selector: '[test]',
           queries: {
             'mview': new ViewChild('test1'),
-            'mcontent': new ContentChild('test2'),
+            'mcontent': new core.ContentChild('test2'),
           }
         })
         class FooCmp {

--- a/packages/language-service/ivy/BUILD.bazel
+++ b/packages/language-service/ivy/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/core:api",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/incremental",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/compiler-cli/src/ngtsc/shims",
         "//packages/compiler-cli/src/ngtsc/typecheck",
         "//packages/compiler-cli/src/ngtsc/typecheck/api",

--- a/packages/language-service/ivy/utils.ts
+++ b/packages/language-service/ivy/utils.ts
@@ -7,6 +7,7 @@
  */
 import {AbsoluteSourceSpan, CssSelector, ParseSourceSpan, SelectorMatcher} from '@angular/compiler';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
+import {DeclarationNode} from '@angular/compiler-cli/src/ngtsc/reflection';
 import {DirectiveSymbol} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import * as e from '@angular/compiler/src/expression_parser/ast';  // e for expression AST
 import * as t from '@angular/compiler/src/render3/r3_ast';         // t for template AST
@@ -103,7 +104,7 @@ export function getTemplateInfoAtPosition(
  * First, attempt to sort component declarations by file name.
  * If the files are the same, sort by start location of the declaration.
  */
-function tsDeclarationSortComparator(a: ts.Declaration, b: ts.Declaration): number {
+function tsDeclarationSortComparator(a: DeclarationNode, b: DeclarationNode): number {
   const aFile = a.getSourceFile().fileName;
   const bFile = b.getSourceFile().fileName;
   if (aFile < bFile) {


### PR DESCRIPTION
UMD files export values by assigning them to the `exports` variable.
When evaluating expressions ngcc was failing to cope with inline declarations
like `exports.MyComponent = <decl>`.

Fixes #38947
