### PR TITLE
docs(docs-infra): remove usage of whitelist in aio-builds-setup docs

### DIFF
--- a/aio/aio-builds-setup/docs/image-config--environment-variables.md
+++ b/aio/aio-builds-setup/docs/image-config--environment-variables.md
@@ -22,7 +22,7 @@ you don't need to specify values for those.
   The domain name of the server.
 
 - `AIO_GITHUB_ORGANIZATION`:
-  The GitHub organization whose teams are whitelisted for accepting build artifacts.
+  The GitHub organization whose teams are trusted for accepting build artifacts.
   See also `AIO_GITHUB_TEAM_SLUGS`.
 
 - `AIO_GITHUB_REPO`:

--- a/aio/aio-builds-setup/docs/overview--security-model.md
+++ b/aio/aio-builds-setup/docs/overview--security-model.md
@@ -98,7 +98,7 @@ This section describes how each of the aforementioned sub-tasks is accomplished:
       Such a label can only have been added by a maintainer (with the necessary rights) and
       designates that they have manually verified the PR contents.
    2. We can verify (again using the GitHub API) the author's membership in one of the
-      whitelisted/trusted GitHub teams. For this operation, we need a Personal Access Token with the
+      trusted GitHub teams. For this operation, we need a Personal Access Token with the
       `read:org` scope issued by a user that can "see" the specified GitHub organization.
       Here too, we use the token by @mary-poppins.
 


### PR DESCRIPTION
Removes the usage of the term whitelist in the aio-builds-setup docs.
