### PR TITLE
refactor(compiler): iteratively parse interpolations

### DIFF
--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -189,43 +189,63 @@ export class Parser {
       input: string, location: string,
       interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG): SplitInterpolation
       |null {
-    const regexp = _getInterpolateRegExp(interpolationConfig);
-    const parts = input.split(regexp);
-    if (parts.length <= 1) {
-      return null;
-    }
     const strings: string[] = [];
     const expressions: string[] = [];
     const offsets: number[] = [];
     const stringSpans: {start: number, end: number}[] = [];
     const expressionSpans: {start: number, end: number}[] = [];
-    let offset = 0;
-    for (let i = 0; i < parts.length; i++) {
-      const part: string = parts[i];
-      if (i % 2 === 0) {
-        // fixed string
+    let i = 0;
+    let inInterpolation = false;
+    let {start: interpStart, end: interpEnd} = interpolationConfig;
+    while (i < input.length) {
+      if (!inInterpolation) {
+        // parse until starting {{
+        const start = i;
+        while (i < input.length && input.substring(i, i + interpStart.length) !== interpStart) {
+          ++i;
+        }
+        const part = input.substring(start, i);
         strings.push(part);
-        const start = offset;
-        offset += part.length;
-        stringSpans.push({start, end: offset});
-      } else if (part.trim().length > 0) {
-        const start = offset;
-        offset += interpolationConfig.start.length;
-        expressions.push(part);
-        offsets.push(offset);
-        offset += part.length + interpolationConfig.end.length;
-        expressionSpans.push({start, end: offset});
+        stringSpans.push({start, end: i});
+
+        inInterpolation = true;
       } else {
-        this._reportError(
-            'Blank expressions are not allowed in interpolated strings', input,
-            `at column ${this._findInterpolationErrorColumn(parts, i, interpolationConfig)} in`,
-            location);
-        expressions.push('$implicit');
-        offsets.push(offset);
-        expressionSpans.push({start: offset, end: offset});
+        // parse from starting {{ to ending }}
+        const fullStart = i;
+        const exprStart = fullStart + interpStart.length;
+        let exprEnd = exprStart;
+        while (exprEnd < input.length &&
+               input.substring(exprEnd, exprEnd + interpEnd.length) !== interpEnd) {
+          ++exprEnd;
+        }
+        const fullEnd = exprEnd + interpEnd.length;
+
+        const part = input.substring(exprStart, exprEnd);
+        if (part.trim().length > 0) {
+          expressions.push(part);
+        } else {
+          this._reportError(
+              'Blank expressions are not allowed in interpolated strings', input,
+              `at column ${i} in`, location);
+          expressions.push('$implicit');
+        }
+        offsets.push(exprStart);
+        expressionSpans.push({start: fullStart, end: fullEnd});
+
+        i = fullEnd;
+        inInterpolation = false;
       }
     }
-    return new SplitInterpolation(strings, stringSpans, expressions, expressionSpans, offsets);
+    if (!inInterpolation) {
+      // If we ended with an interpolation, add an empty string, which is expected by
+      // SplitInterpolation consumers.
+      strings.push('');
+      const loc = input.length;
+      stringSpans.push({start: loc, end: loc});
+    }
+    return expressions.length === 0 ?
+        null :
+        new SplitInterpolation(strings, stringSpans, expressions, expressionSpans, offsets);
   }
 
   wrapLiteralPrimitive(input: string|null, location: any, absoluteOffset: number): ASTWithSource {

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -208,8 +208,9 @@ export class Parser {
       if (!atInterpolation) {
         // parse until starting {{
         const start = i;
-        while (i < input.length && !input.startsWith(interpStart, i)) {
-          ++i;
+        i = input.indexOf(interpStart, i);
+        if (i === -1) {
+          i = input.length;
         }
         const part = input.substring(start, i);
         strings.push(part);
@@ -220,16 +221,13 @@ export class Parser {
         // parse from starting {{ to ending }}
         const fullStart = i;
         const exprStart = fullStart + interpStart.length;
-        let exprEnd = exprStart;
-        while (exprEnd < input.length && !input.startsWith(interpEnd, exprEnd)) {
-          ++exprEnd;
-        }
-        const fullEnd = exprEnd + interpEnd.length;
-
-        if (exprEnd >= input.length) {
-          i = fullStart;
+        const exprEnd = input.indexOf(interpEnd, exprStart);
+        if (exprEnd === -1) {
+          // Could not find the end of the interpolation; do not parse an
+          // expression.
           break;
         }
+        const fullEnd = exprEnd + interpEnd.length;
 
         const part = input.substring(exprStart, exprEnd);
         if (part.trim().length > 0) {

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -650,8 +650,11 @@ describe('parser', () => {
       expect(parseInterpolation('nothing')).toBe(null);
     });
 
-    it('should return null if malformed interpolation', () => {
-      expect(parseInterpolation('{{example}<!---->}')).toBe(null);
+    it('should not parse malformed interpolations as strings', () => {
+      const ast = parseInterpolation('{{a}} {{example}<!--->}')!.ast as Interpolation;
+      expect(ast.strings).toEqual(['', ' {{example}<!--->}']);
+      expect(ast.expressions.length).toEqual(1);
+      expect(ast.expressions[0].name).toEqual('a');
     });
 
     it('should parse no prefix/suffix interpolation', () => {

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -650,6 +650,10 @@ describe('parser', () => {
       expect(parseInterpolation('nothing')).toBe(null);
     });
 
+    it('should return null if malformed interpolation', () => {
+      expect(parseInterpolation('{{example}<!---->}')).toBe(null);
+    });
+
     it('should parse no prefix/suffix interpolation', () => {
       const ast = parseInterpolation('{{a}}')!.ast as Interpolation;
       expect(ast.strings).toEqual(['', '']);


### PR DESCRIPTION
This patch refactors the interpolation parser to do so iteratively
rather than using a regex. Doing so prepares us for supporting granular
recovery on poorly-formed interpolations, for example when an
interpolation does not terminate (`{{ 1 + 2`) or is not terminated
properly (`{{ 1 + 2 {{ 2 + 3 }}`).

Part of #38596

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Refactoring (no functional changes, no api changes)
