### PR TITLE
refactor(zone.js): rename BlacklistedStackFrames to InternalZoneJsStackFrames

### DIFF
--- a/packages/zone.js/MODULE.md
+++ b/packages/zone.js/MODULE.md
@@ -102,7 +102,7 @@ This package will provide following functionality.
 
      without `zone-error` patch, the example above will output `false`, with the patch, the reuslt will be `true`.
 
-  2. BlacklistZoneStackFrames: remove zone.js stack from `stackTrace`, and add `zone`  information. Without this patch, a lot of `zone.js` invocation stack will be shown
+  2. ZoneJsInternalStackFrames: remove zone.js stack from `stackTrace`, and add `zone`  information. Without this patch, a lot of `zone.js` invocation stack will be shown
      in stack frames.
 
     ```
@@ -123,18 +123,18 @@ This package will provide following functionality.
      ```
 
   The second feature will slow down the `Error` performance, so `zone.js` provide a flag to let you be able to control the behavior.
-  The flag is `__Zone_Error_BlacklistedStackFrames_policy`. And the available options is:
+  The flag is `__Zone_Error_ZoneJsInternalStackFrames_policy`. And the available options is:
 
     1. default: this is the default one, if you load `zone.js/dist/zone-error` without
-     setting the flag, `default` will be used, and `BlackListStackFrames` will be available
+     setting the flag, `default` will be used, and `ZoneJsInternalStackFrames` will be available
      when `new Error()`, you can get a `error.stack`  which is `zone stack free`. But this
      will slow down `new Error()` a little bit.
 
-    2. disable: this will disable `BlackListZoneStackFrame` feature, and if you load
+    2. disable: this will disable `ZoneJsInternalStackFrames` feature, and if you load
      `zone.js/dist/zone-error`, you will only get a `wrapped Error` which can handle
       `Error inherit` issue.
 
-    3. lazy: this is a feature to let you be able to get `BlackListZoneStackFrame` feature,
+    3. lazy: this is a feature to let you be able to get `ZoneJsInternalStackFrames` feature,
      but not impact performance. But as a trade off, you can't get the `zone free stack
      frames` by access `error.stack`. You can only get it by access `error.zoneAwareStack`.
 

--- a/packages/zone.js/test/main.ts
+++ b/packages/zone.js/test/main.ts
@@ -19,13 +19,13 @@ __karma__.loaded = function() {};
 let entryPoint = 'browser_entry_point';
 
 if (typeof __karma__ !== 'undefined') {
-  (window as any)['__Zone_Error_BlacklistedStackFrames_policy'] =
+  (window as any)['__Zone_Error_ZoneJsInternalStackFrames_policy'] =
       (__karma__ as any).config.errorpolicy;
   if ((__karma__ as any).config.entrypoint) {
     entryPoint = (__karma__ as any).config.entrypoint;
   }
 } else if (typeof process !== 'undefined') {
-  (window as any)['__Zone_Error_BlacklistedStackFrames_policy'] = process.env.errorpolicy;
+  (window as any)['__Zone_Error_ZoneJsInternalStackFrames_policy'] = process.env.errorpolicy;
   if (process.env.entrypoint) {
     entryPoint = process.env.entrypoint;
   }

--- a/packages/zone.js/test/node_error_disable_policy_entry_point.ts
+++ b/packages/zone.js/test/node_error_disable_policy_entry_point.ts
@@ -6,6 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-process.env['errorpolicy'] = (global as any)['__Zone_Error_BlacklistedStackFrames_policy'] =
+process.env['errorpolicy'] = (global as any)['__Zone_Error_ZoneJsInternalStackFrames_policy'] =
     'disable';
 import './node_error_entry_point';

--- a/packages/zone.js/test/node_error_entry_point.ts
+++ b/packages/zone.js/test/node_error_entry_point.ts
@@ -14,7 +14,7 @@ import '../lib/zone';
 import '../lib/common/promise';
 import '../lib/common/to-string';
 
-process.env['errorpolicy'] = (global as any)['__Zone_Error_BlacklistedStackFrames_policy'] =
+process.env['errorpolicy'] = (global as any)['__Zone_Error_ZoneJsInternalStackFrames_policy'] =
     'disable';
 // Setup test environment
 require('@bazel/jasmine').boot();

--- a/packages/zone.js/test/node_error_lazy_policy_entry_point.ts
+++ b/packages/zone.js/test/node_error_lazy_policy_entry_point.ts
@@ -6,5 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-process.env['errorpolicy'] = (global as any)['__Zone_Error_BlacklistedStackFrames_policy'] = 'lazy';
+process.env['errorpolicy'] = (global as any)['__Zone_Error_ZoneJsInternalStackFrames_policy'] =
+    'lazy';
 import './node_error_entry_point';


### PR DESCRIPTION
BlacklistedStackFrames to InternalZoneJsStackFrames along with other related
symbols renamed with the same changes (with appropriate casing style).
