### PR TITLE
docs: Move pipes documentation from Components to Templates

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -107,11 +107,6 @@
               "tooltip": "User input triggers DOM events. Angular listens to those events with event bindings that funnel updated values back into your app's components and models."
             },
             {
-              "url": "guide/pipes",
-              "title": "Pipes",
-              "tooltip": "Pipes transform displayed values within a template."
-            },
-            {
               "url": "guide/lifecycle-hooks",
               "title": "Component Lifecycle",
               "tooltip": "Angular calls lifecycle hook methods on directives and components as it creates, changes, and destroys them."
@@ -166,6 +161,11 @@
               "url": "guide/template-statements",
               "title": "Template statements",
               "tooltip": "Introductory guide to statements in templates that respond to events that components, directives, or elements raise."
+            },
+            {
+              "url": "guide/pipes",
+              "title": "Pipes",
+              "tooltip": "Pipes transform displayed values within a template."
             },
             {
               "url": "guide/binding-syntax",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Right now, the pipes documentation resides under the Components section of the left navigation. 

Issue Number: N/A


## What is the new behavior?
The pipes documentation is under the Templates section, which is more appropriate.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
