### PR TITLE
docs: move Inputs and Outputs topic to Components section

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -132,6 +132,11 @@
               "tooltip": "Add CSS styles that are specific to a component."
             },
             {
+              "url": "guide/inputs-outputs",
+              "title": "Inputs and Outputs",
+              "tooltip": "Introductory guide to sharing data between parent and child directives or components."
+            },
+            {
               "url": "guide/dynamic-component-loader",
               "title": "Dynamic Components",
               "tooltip": "Load components dynamically."
@@ -191,11 +196,6 @@
               "url": "guide/template-reference-variables",
               "title": "Template reference variables",
               "tooltip": "Introductory guide to referring to DOM elements within a template."
-            },
-            {
-              "url": "guide/inputs-outputs",
-              "title": "Inputs and Outputs",
-              "tooltip": "Introductory guide to sharing data between parent and child directives or components."
             },
             {
               "url": "guide/template-expression-operators",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Content about using @Input() and @Output() is currently under the Templates section of the left navigation. A more appropriate location is under the Components section.

Issue Number: N/A


## What is the new behavior?
Content about @Input() and @Output() is now under the Components section.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
