### PR TITLE
feat(compiler): Recover on malformed keyed reads and keyed writes

### DIFF
--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -642,7 +642,7 @@ export class _ParseAST {
         this.writeContext = true;
         const key = this.parsePipe();
         if (key instanceof EmptyExpr) {
-          this.error(`Key access cannot be empty`)
+          this.error(`Key access cannot be empty`);
         }
         this.rbracketsExpected--;
         this.expectCharacter(chars.$RBRACKET);

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -1057,8 +1057,8 @@ export class _ParseAST {
    * parseChain() is always the root production and it expects a ';'.
    *
    * Furthermore, the presence of a stateful context can add more recovery points.
-   *   - in a `writeContext`, we are able to recover after seeing the `=` operator, which signals
-   *     the presence of an independent rvalue expression following the `=` operator.
+   *   - in a `Writable` context, we are able to recover after seeing the `=` operator, which
+   *     signals the presence of an independent rvalue expression following the `=` operator.
    *
    * If a production expects one of these token it increments the corresponding nesting count,
    * and then decrements it just prior to checking if the token is in the input.


### PR DESCRIPTION
This patch adds support for recovering well-formed (and near-complete)
ASTs for semantically malformed keyed reads and keyed writes. See the
added tests for details on the types of semantics we can now recover;
in particular, notice that some assumptions are made about the form of
a keyed read/write intended by a user. For example, in the malformed
expression `a[1 + = 2`, we assume that the user meant to write a binary
expression for the key of `a`, and assign that key the value `2`. In
particular, we now parse this as `a[1 + <empty expression>] = 2`. There
are some different interpretations that can be made here, but I think
this is reasonable.

The actual changes in the parser code are fairly minimal (a nice
surprise!); the biggest addition is a `writeContext` that marks whether
the `=` operator can serve as a recovery point after error detection.

Part of #38596

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Feature