### PR TITLE
test(compiler-cli): error when running tests on non-posix systems

### DIFF
--- a/packages/compiler-cli/test/helpers/src/mock_file_loading.ts
+++ b/packages/compiler-cli/test/helpers/src/mock_file_loading.ts
@@ -77,7 +77,9 @@ export function loadFakeCore(fs: FileSystem, basePath: string = '/') {
 
 function loadFolder(path: string): Folder {
   const tmpFs = new MockFileSystemPosix(true);
-  loadTestDirectory(tmpFs, tmpFs.resolve(path), tmpFs.resolve('/'));
+  // Note that we intentionally pass the native `path`, without resolving it through the file
+  // system, because the mock posix file system may break paths coming from a non-posix system.
+  loadTestDirectory(tmpFs, path, tmpFs.resolve('/'));
   return tmpFs.dump();
 }
 


### PR DESCRIPTION
We weren't resolving a path correctly which resulted in an error on Windows. For reference, here's the error. Note the extra slash before `C:`:

```
Error: ENOENT: no such file or directory, scandir '/C:/bazel_output_root/yxvwd24o/external/npm/node_modules/typescript'
    at Object.readdirSync (fs.js:854:3)
```