### PR TITLE
I18n extractor avoid standalone filesystem api

### DIFF
--- a/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file.ts
+++ b/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file.ts
@@ -8,7 +8,7 @@
 import {removeComments, removeMapFileComments} from 'convert-source-map';
 import {decode, encode, SourceMapMappings, SourceMapSegment} from 'sourcemap-codec';
 
-import {AbsoluteFsPath, dirname, relative} from '../../file_system';
+import {AbsoluteFsPath, FileSystem} from '../../file_system';
 
 import {RawSourceMap} from './raw_source_map';
 import {compareSegments, offsetSegment, SegmentMarker} from './segment_marker';
@@ -38,7 +38,9 @@ export class SourceFile {
       /** Whether this source file's source map was inline or external. */
       readonly inline: boolean,
       /** Any source files referenced by the raw source map associated with this source file. */
-      readonly sources: (SourceFile|null)[]) {
+      readonly sources: (SourceFile|null)[],
+      private fs: FileSystem,
+  ) {
     this.contents = removeSourceMapComments(contents);
     this.startOfLinePositions = computeStartOfLinePositions(this.contents);
     this.flattenedMappings = this.flattenMappings();
@@ -75,11 +77,11 @@ export class SourceFile {
       mappings[line].push(mappingArray);
     }
 
-    const sourcePathDir = dirname(this.sourcePath);
+    const sourcePathDir = this.fs.dirname(this.sourcePath);
     const sourceMap: RawSourceMap = {
       version: 3,
-      file: relative(sourcePathDir, this.sourcePath),
-      sources: sources.map(sf => relative(sourcePathDir, sf.sourcePath)),
+      file: this.fs.relative(sourcePathDir, this.sourcePath),
+      sources: sources.map(sf => this.fs.relative(sourcePathDir, sf.sourcePath)),
       names,
       mappings: encode(mappings),
       sourcesContent: sources.map(sf => sf.contents),

--- a/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file_loader.ts
+++ b/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file_loader.ts
@@ -7,7 +7,7 @@
  */
 import {commentRegex, fromComment, mapFileCommentRegex} from 'convert-source-map';
 
-import {absoluteFrom, AbsoluteFsPath, FileSystem} from '../../file_system';
+import {AbsoluteFsPath, FileSystem} from '../../file_system';
 import {Logger} from '../../logging';
 
 import {RawSourceMap} from './raw_source_map';
@@ -83,7 +83,7 @@ export class SourceFileLoader {
         inline = mapAndPath.mapPath === null;
       }
 
-      return new SourceFile(sourcePath, contents, map, inline, sources);
+      return new SourceFile(sourcePath, contents, map, inline, sources, this.fs);
     } catch (e) {
       this.logger.warn(
           `Unable to fully load ${sourcePath} for source-map flattening: ${e.message}`);
@@ -124,7 +124,7 @@ export class SourceFileLoader {
       }
     }
 
-    const impliedMapPath = absoluteFrom(sourcePath + '.map');
+    const impliedMapPath = this.fs.resolve(sourcePath + '.map');
     if (this.fs.exists(impliedMapPath)) {
       return {map: this.readRawSourceMap(impliedMapPath), mapPath: impliedMapPath};
     }

--- a/packages/localize/src/tools/src/diagnostics.ts
+++ b/packages/localize/src/tools/src/diagnostics.ts
@@ -14,6 +14,8 @@ export type DiagnosticHandlingStrategy = 'error'|'warning'|'ignore';
 /**
  * This class is used to collect and then report warnings and errors that occur during the execution
  * of the tools.
+ *
+ * @publicApi used by CLI
  */
 export class Diagnostics {
   readonly messages: {type: 'warning'|'error', message: string}[] = [];

--- a/packages/localize/src/tools/src/extract/extraction.ts
+++ b/packages/localize/src/tools/src/extract/extraction.ts
@@ -52,8 +52,8 @@ export class MessageExtractor {
         sourceRoot: this.basePath,
         filename,
         plugins: [
-          makeEs2015ExtractPlugin(messages, this.localizeName),
-          makeEs5ExtractPlugin(messages, this.localizeName),
+          makeEs2015ExtractPlugin(this.fs, messages, this.localizeName),
+          makeEs5ExtractPlugin(this.fs, messages, this.localizeName),
         ],
         code: false,
         ast: false

--- a/packages/localize/src/tools/src/extract/extraction.ts
+++ b/packages/localize/src/tools/src/extract/extraction.ts
@@ -23,6 +23,8 @@ export interface ExtractionOptions {
 /**
  * Extracts parsed messages from file contents, by parsing the contents as JavaScript
  * and looking for occurrences of `$localize` in the source code.
+ *
+ * @publicApi used by CLI
  */
 export class MessageExtractor {
   private basePath: AbsoluteFsPath;

--- a/packages/localize/src/tools/src/extract/source_files/es2015_extract_plugin.ts
+++ b/packages/localize/src/tools/src/extract/source_files/es2015_extract_plugin.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedMessage, ɵparseMessage} from '@angular/localize';
 import {NodePath, PluginObj} from '@babel/core';
 import {TaggedTemplateExpression} from '@babel/types';
@@ -12,7 +13,7 @@ import {TaggedTemplateExpression} from '@babel/types';
 import {getLocation, isGlobalIdentifier, isNamedIdentifier, unwrapExpressionsFromTemplateLiteral, unwrapMessagePartsFromTemplateLiteral} from '../../source_file_utils';
 
 export function makeEs2015ExtractPlugin(
-    messages: ɵParsedMessage[], localizeName = '$localize'): PluginObj {
+    fs: FileSystem, messages: ɵParsedMessage[], localizeName = '$localize'): PluginObj {
   return {
     visitor: {
       TaggedTemplateExpression(path: NodePath<TaggedTemplateExpression>) {
@@ -20,10 +21,10 @@ export function makeEs2015ExtractPlugin(
         if (isNamedIdentifier(tag, localizeName) && isGlobalIdentifier(tag)) {
           const quasiPath = path.get('quasi');
           const [messageParts, messagePartLocations] =
-              unwrapMessagePartsFromTemplateLiteral(quasiPath.get('quasis'));
+              unwrapMessagePartsFromTemplateLiteral(quasiPath.get('quasis'), fs);
           const [expressions, expressionLocations] =
-              unwrapExpressionsFromTemplateLiteral(quasiPath);
-          const location = getLocation(quasiPath);
+              unwrapExpressionsFromTemplateLiteral(quasiPath, fs);
+          const location = getLocation(fs, quasiPath);
           const message = ɵparseMessage(
               messageParts, expressions, location, messagePartLocations, expressionLocations);
           messages.push(message);

--- a/packages/localize/src/tools/src/extract/source_files/es5_extract_plugin.ts
+++ b/packages/localize/src/tools/src/extract/source_files/es5_extract_plugin.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedMessage, ɵparseMessage} from '@angular/localize';
 import {NodePath, PluginObj} from '@babel/core';
 import {CallExpression} from '@babel/types';
@@ -12,16 +13,18 @@ import {CallExpression} from '@babel/types';
 import {getLocation, isGlobalIdentifier, isNamedIdentifier, unwrapMessagePartsFromLocalizeCall, unwrapSubstitutionsFromLocalizeCall} from '../../source_file_utils';
 
 export function makeEs5ExtractPlugin(
-    messages: ɵParsedMessage[], localizeName = '$localize'): PluginObj {
+    fs: FileSystem, messages: ɵParsedMessage[], localizeName = '$localize'): PluginObj {
   return {
     visitor: {
       CallExpression(callPath: NodePath<CallExpression>) {
         const calleePath = callPath.get('callee');
         if (isNamedIdentifier(calleePath, localizeName) && isGlobalIdentifier(calleePath)) {
-          const [messageParts, messagePartLocations] = unwrapMessagePartsFromLocalizeCall(callPath);
-          const [expressions, expressionLocations] = unwrapSubstitutionsFromLocalizeCall(callPath);
+          const [messageParts, messagePartLocations] =
+              unwrapMessagePartsFromLocalizeCall(callPath, fs);
+          const [expressions, expressionLocations] =
+              unwrapSubstitutionsFromLocalizeCall(callPath, fs);
           const [messagePartsArg, expressionsArg] = callPath.get('arguments');
-          const location = getLocation(messagePartsArg, expressionsArg);
+          const location = getLocation(fs, messagePartsArg, expressionsArg);
           const message = ɵparseMessage(
               messageParts, expressions, location, messagePartLocations, expressionLocations);
           messages.push(message);

--- a/packages/localize/src/tools/src/extract/translation_files/xliff1_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/xliff1_translation_serializer.ts
@@ -23,6 +23,7 @@ const LEGACY_XLIFF_MESSAGE_LENGTH = 40;
  * http://docs.oasis-open.org/xliff/v1.2/xliff-profile-html/xliff-profile-html-1.2.html
  *
  * @see Xliff1TranslationParser
+ * @publicApi used by CLI
  */
 export class Xliff1TranslationSerializer implements TranslationSerializer {
   constructor(

--- a/packages/localize/src/tools/src/extract/translation_files/xliff1_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/xliff1_translation_serializer.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, relative} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedMessage, ɵSourceLocation} from '@angular/localize';
 
 import {FormatOptions, validateOptions} from './format_options';
@@ -28,7 +28,7 @@ const LEGACY_XLIFF_MESSAGE_LENGTH = 40;
 export class Xliff1TranslationSerializer implements TranslationSerializer {
   constructor(
       private sourceLocale: string, private basePath: AbsoluteFsPath, private useLegacyIds: boolean,
-      private formatOptions: FormatOptions = {}) {
+      private formatOptions: FormatOptions = {}, private fs: FileSystem = getFileSystem()) {
     validateOptions('Xliff1TranslationSerializer', [['xml:space', ['preserve']]], formatOptions);
   }
 
@@ -115,7 +115,7 @@ export class Xliff1TranslationSerializer implements TranslationSerializer {
 
   private serializeLocation(xml: XmlFile, location: ɵSourceLocation): void {
     xml.startTag('context-group', {purpose: 'location'});
-    this.renderContext(xml, 'sourcefile', relative(this.basePath, location.file));
+    this.renderContext(xml, 'sourcefile', this.fs.relative(this.basePath, location.file));
     const endLineString = location.end !== undefined && location.end.line !== location.start.line ?
         `,${location.end.line + 1}` :
         '';

--- a/packages/localize/src/tools/src/extract/translation_files/xliff2_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/xliff2_translation_serializer.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, relative} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedMessage, ɵSourceLocation} from '@angular/localize';
 
 import {FormatOptions, validateOptions} from './format_options';
@@ -28,7 +28,7 @@ export class Xliff2TranslationSerializer implements TranslationSerializer {
   private currentPlaceholderId = 0;
   constructor(
       private sourceLocale: string, private basePath: AbsoluteFsPath, private useLegacyIds: boolean,
-      private formatOptions: FormatOptions = {}) {
+      private formatOptions: FormatOptions = {}, private fs: FileSystem = getFileSystem()) {
     validateOptions('Xliff1TranslationSerializer', [['xml:space', ['preserve']]], formatOptions);
   }
 
@@ -64,7 +64,7 @@ export class Xliff2TranslationSerializer implements TranslationSerializer {
               end !== undefined && end.line !== start.line ? `,${end.line + 1}` : '';
           this.serializeNote(
               xml, 'location',
-              `${relative(this.basePath, file)}:${start.line + 1}${endLineString}`);
+              `${this.fs.relative(this.basePath, file)}:${start.line + 1}${endLineString}`);
         }
         if (message.description) {
           this.serializeNote(xml, 'description', message.description);

--- a/packages/localize/src/tools/src/extract/translation_files/xliff2_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/xliff2_translation_serializer.ts
@@ -22,6 +22,7 @@ const MAX_LEGACY_XLIFF_2_MESSAGE_LENGTH = 20;
  * http://docs.oasis-open.org/xliff/xliff-core/v2.0/os/xliff-core-v2.0-os.html
  *
  * @see Xliff2TranslationParser
+ * @publicApi used by CLI
  */
 export class Xliff2TranslationSerializer implements TranslationSerializer {
   private currentPlaceholderId = 0;

--- a/packages/localize/src/tools/src/extract/translation_files/xmb_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/xmb_translation_serializer.ts
@@ -18,6 +18,7 @@ import {XmlFile} from './xml_file';
  * http://cldr.unicode.org/development/development-process/design-proposals/xmb
  *
  * @see XmbTranslationParser
+ * @publicApi used by CLI
  */
 export class XmbTranslationSerializer implements TranslationSerializer {
   constructor(private basePath: AbsoluteFsPath, private useLegacyIds: boolean) {}

--- a/packages/localize/src/tools/src/extract/translation_files/xmb_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/xmb_translation_serializer.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, relative} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedMessage, ɵSourceLocation} from '@angular/localize';
 
 import {extractIcuPlaceholders} from './icu_parsing';
@@ -21,7 +21,9 @@ import {XmlFile} from './xml_file';
  * @publicApi used by CLI
  */
 export class XmbTranslationSerializer implements TranslationSerializer {
-  constructor(private basePath: AbsoluteFsPath, private useLegacyIds: boolean) {}
+  constructor(
+      private basePath: AbsoluteFsPath, private useLegacyIds: boolean,
+      private fs: FileSystem = getFileSystem()) {}
 
   serialize(messages: ɵParsedMessage[]): string {
     const ids = new Set<string>();
@@ -74,7 +76,8 @@ export class XmbTranslationSerializer implements TranslationSerializer {
     const endLineString = location.end !== undefined && location.end.line !== location.start.line ?
         `,${location.end.line + 1}` :
         '';
-    xml.text(`${relative(this.basePath, location.file)}:${location.start.line}${endLineString}`);
+    xml.text(
+        `${this.fs.relative(this.basePath, location.file)}:${location.start.line}${endLineString}`);
     xml.endTag('source');
   }
 

--- a/packages/localize/src/tools/src/source_file_utils.ts
+++ b/packages/localize/src/tools/src/source_file_utils.ts
@@ -36,7 +36,9 @@ export function isNamedIdentifier(
 
 /**
  * Is the given `identifier` declared globally.
+ *
  * @param identifier The identifier to check.
+ * @publicApi used by CLI
  */
 export function isGlobalIdentifier(identifier: NodePath<t.Identifier>) {
   return !identifier.scope || !identifier.scope.hasBinding(identifier.node.name);
@@ -46,6 +48,7 @@ export function isGlobalIdentifier(identifier: NodePath<t.Identifier>) {
  * Build a translated expression to replace the call to `$localize`.
  * @param messageParts The static parts of the message.
  * @param substitutions The expressions to substitute into the message.
+ * @publicApi used by CLI
  */
 export function buildLocalizeReplacement(
     messageParts: TemplateStringsArray, substitutions: readonly t.Expression[]): t.Expression {
@@ -65,6 +68,7 @@ export function buildLocalizeReplacement(
  * to a helper function like `__makeTemplateObject`.
  *
  * @param call The AST node of the call to process.
+ * @publicApi used by CLI
  */
 export function unwrapMessagePartsFromLocalizeCall(call: NodePath<t.CallExpression>):
     [TemplateStringsArray, (ɵSourceLocation | undefined)[]] {
@@ -142,9 +146,11 @@ export function unwrapMessagePartsFromLocalizeCall(call: NodePath<t.CallExpressi
   return [ɵmakeTemplateObject(cookedStrings, rawStrings), rawLocations];
 }
 
-
-export function unwrapSubstitutionsFromLocalizeCall(call: NodePath<t.CallExpression>):
-    [t.Expression[], (ɵSourceLocation | undefined)[]] {
+/**
+ * Parse the localize call expression to extract the arguments that hold the substition expressions.
+ *
+ * @publicApi used by CLI
+ */
   const expressions = call.get('arguments').splice(1);
   if (!isArrayOfExpressions(expressions)) {
     const badExpression = expressions.find(expression => !expression.isExpression())!;
@@ -157,8 +163,11 @@ export function unwrapSubstitutionsFromLocalizeCall(call: NodePath<t.CallExpress
   ];
 }
 
-export function unwrapMessagePartsFromTemplateLiteral(elements: NodePath<t.TemplateElement>[]):
-    [TemplateStringsArray, (ɵSourceLocation | undefined)[]] {
+/**
+ * Parse the tagged template literal to extract the message parts.
+ *
+ * @publicApi used by CLI
+ */
   const cooked = elements.map(q => {
     if (q.node.value.cooked === undefined) {
       throw new BabelParseError(
@@ -172,9 +181,11 @@ export function unwrapMessagePartsFromTemplateLiteral(elements: NodePath<t.Templ
   return [ɵmakeTemplateObject(cooked, raw), locations];
 }
 
-export function unwrapExpressionsFromTemplateLiteral(quasi: NodePath<t.TemplateLiteral>):
-    [t.Expression[], (ɵSourceLocation | undefined)[]] {
-  return [quasi.node.expressions, quasi.get('expressions').map(e => getLocation(e))];
+/**
+ * Parse the tagged template literal to extract the interpolation expressions.
+ *
+ * @publicApi used by CLI
+ */
 }
 
 /**
@@ -321,6 +332,7 @@ export interface TranslatePluginOptions {
  * Translate the text of the given message, using the given translations.
  *
  * Logs as warning if the translation is not available
+ * @publicApi used by CLI
  */
 export function translate(
     diagnostics: Diagnostics, translations: Record<string, ɵParsedTranslation>,

--- a/packages/localize/src/tools/src/translate/source_files/es2015_translate_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/es2015_translate_plugin.ts
@@ -13,6 +13,12 @@ import {Diagnostics} from '../../diagnostics';
 
 import {buildCodeFrameError, buildLocalizeReplacement, isBabelParseError, isLocalize, translate, TranslatePluginOptions, unwrapMessagePartsFromTemplateLiteral} from '../../source_file_utils';
 
+/**
+ * Create a Babel plugin that can be used to do compile-time translation of `$localize` tagged
+ * messages.
+ *
+ * @publicApi used by CLI
+ */
 export function makeEs2015TranslatePlugin(
     diagnostics: Diagnostics, translations: Record<string, ɵParsedTranslation>,
     {missingTranslation = 'error', localizeName = '$localize'}: TranslatePluginOptions = {}):

--- a/packages/localize/src/tools/src/translate/source_files/es2015_translate_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/es2015_translate_plugin.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedTranslation} from '@angular/localize';
 import {NodePath, PluginObj} from '@babel/core';
 import {TaggedTemplateExpression} from '@babel/types';
@@ -21,8 +22,8 @@ import {buildCodeFrameError, buildLocalizeReplacement, isBabelParseError, isLoca
  */
 export function makeEs2015TranslatePlugin(
     diagnostics: Diagnostics, translations: Record<string, ɵParsedTranslation>,
-    {missingTranslation = 'error', localizeName = '$localize'}: TranslatePluginOptions = {}):
-    PluginObj {
+    {missingTranslation = 'error', localizeName = '$localize'}: TranslatePluginOptions = {},
+    fs: FileSystem = getFileSystem()): PluginObj {
   return {
     visitor: {
       TaggedTemplateExpression(path: NodePath<TaggedTemplateExpression>) {
@@ -30,7 +31,7 @@ export function makeEs2015TranslatePlugin(
           const tag = path.get('tag');
           if (isLocalize(tag, localizeName)) {
             const [messageParts] =
-                unwrapMessagePartsFromTemplateLiteral(path.get('quasi').get('quasis'));
+                unwrapMessagePartsFromTemplateLiteral(path.get('quasi').get('quasis'), fs);
             const translated = translate(
                 diagnostics, translations, messageParts, path.node.quasi.expressions,
                 missingTranslation);

--- a/packages/localize/src/tools/src/translate/source_files/es5_translate_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/es5_translate_plugin.ts
@@ -13,6 +13,12 @@ import {Diagnostics} from '../../diagnostics';
 
 import {buildCodeFrameError, buildLocalizeReplacement, isBabelParseError, isLocalize, translate, TranslatePluginOptions, unwrapMessagePartsFromLocalizeCall, unwrapSubstitutionsFromLocalizeCall} from '../../source_file_utils';
 
+/**
+ * Create a Babel plugin that can be used to do compile-time translation of `$localize` tagged
+ * messages.
+ *
+ * @publicApi used by CLI
+ */
 export function makeEs5TranslatePlugin(
     diagnostics: Diagnostics, translations: Record<string, ɵParsedTranslation>,
     {missingTranslation = 'error', localizeName = '$localize'}: TranslatePluginOptions = {}):

--- a/packages/localize/src/tools/src/translate/source_files/es5_translate_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/es5_translate_plugin.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedTranslation} from '@angular/localize';
 import {NodePath, PluginObj} from '@babel/core';
 import {CallExpression} from '@babel/types';
@@ -21,16 +22,16 @@ import {buildCodeFrameError, buildLocalizeReplacement, isBabelParseError, isLoca
  */
 export function makeEs5TranslatePlugin(
     diagnostics: Diagnostics, translations: Record<string, ɵParsedTranslation>,
-    {missingTranslation = 'error', localizeName = '$localize'}: TranslatePluginOptions = {}):
-    PluginObj {
+    {missingTranslation = 'error', localizeName = '$localize'}: TranslatePluginOptions = {},
+    fs: FileSystem = getFileSystem()): PluginObj {
   return {
     visitor: {
       CallExpression(callPath: NodePath<CallExpression>) {
         try {
           const calleePath = callPath.get('callee');
           if (isLocalize(calleePath, localizeName)) {
-            const [messageParts] = unwrapMessagePartsFromLocalizeCall(callPath);
-            const [expressions] = unwrapSubstitutionsFromLocalizeCall(callPath);
+            const [messageParts] = unwrapMessagePartsFromLocalizeCall(callPath, fs);
+            const [expressions] = unwrapSubstitutionsFromLocalizeCall(callPath, fs);
             const translated =
                 translate(diagnostics, translations, messageParts, expressions, missingTranslation);
             callPath.replaceWith(buildLocalizeReplacement(translated[0], translated[1]));

--- a/packages/localize/src/tools/src/translate/source_files/locale_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/locale_plugin.ts
@@ -21,6 +21,7 @@ import {isLocalize, TranslatePluginOptions} from '../../source_file_utils';
  *
  * @param locale The name of the locale to inline into the code.
  * @param options Additional options including the name of the `$localize` function.
+ * @publicApi used by CLI
  */
 export function makeLocalePlugin(
     locale: string, {localizeName = '$localize'}: TranslatePluginOptions = {}): PluginObj {

--- a/packages/localize/src/tools/src/translate/source_files/source_file_translation_handler.ts
+++ b/packages/localize/src/tools/src/translate/source_files/source_file_translation_handler.ts
@@ -78,8 +78,8 @@ export class SourceFileTranslationHandler implements TranslationHandler {
       generatorOpts: {minified: true},
       plugins: [
         makeLocalePlugin(translationBundle.locale),
-        makeEs2015TranslatePlugin(diagnostics, translationBundle.translations, options),
-        makeEs5TranslatePlugin(diagnostics, translationBundle.translations, options),
+        makeEs2015TranslatePlugin(diagnostics, translationBundle.translations, options, this.fs),
+        makeEs5TranslatePlugin(diagnostics, translationBundle.translations, options, this.fs),
       ],
       filename,
     });

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/simple_json_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/simple_json_translation_parser.ts
@@ -25,6 +25,7 @@ import {ParseAnalysis, ParsedTranslationBundle, TranslationParser} from './trans
  * ```
  *
  * @see SimpleJsonTranslationSerializer
+ * @publicApi used by CLI
  */
 export class SimpleJsonTranslationParser implements TranslationParser<Object> {
   /**

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff1_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff1_translation_parser.ts
@@ -21,6 +21,7 @@ import {addErrorsToBundle, addParseDiagnostic, addParseError, canParseXml, getAt
  * http://docs.oasis-open.org/xliff/v1.2/xliff-profile-html/xliff-profile-html-1.2.html
  *
  * @see Xliff1TranslationSerializer
+ * @publicApi used by CLI
  */
 export class Xliff1TranslationParser implements TranslationParser<XmlTranslationParserHint> {
   /**

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff2_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xliff2_translation_parser.ts
@@ -20,6 +20,7 @@ import {addErrorsToBundle, addParseDiagnostic, addParseError, canParseXml, getAt
  * http://docs.oasis-open.org/xliff/xliff-core/v2.0/os/xliff-core-v2.0-os.html
  *
  * @see Xliff2TranslationSerializer
+ * @publicApi used by CLI
  */
 export class Xliff2TranslationParser implements TranslationParser<XmlTranslationParserHint> {
   /**

--- a/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser.ts
@@ -22,6 +22,7 @@ import {addErrorsToBundle, addParseDiagnostic, addParseError, canParseXml, getAt
  * http://cldr.unicode.org/development/development-process/design-proposals/xmb
  *
  * @see XmbTranslationSerializer
+ * @publicApi used by CLI
  */
 export class XtbTranslationParser implements TranslationParser<XmlTranslationParserHint> {
   /**

--- a/packages/localize/src/tools/test/extract/integration/main_spec.ts
+++ b/packages/localize/src/tools/test/extract/integration/main_spec.ts
@@ -5,7 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, setFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {InvalidFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/src/invalid_file_system';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {MockLogger} from '@angular/compiler-cli/src/ngtsc/logging/testing';
 import {loadTestDirectory} from '@angular/compiler-cli/test/helpers';
@@ -34,6 +35,7 @@ runInEachFileSystem(() => {
 
     fs.ensureDir(fs.dirname(sourceFilePath));
     loadTestDirectory(fs, __dirname + '/test_files', absoluteFrom('/project/test_files'));
+    setFileSystem(new InvalidFileSystem());
   });
 
   describe('extractTranslations()', () => {
@@ -48,6 +50,7 @@ runInEachFileSystem(() => {
         useSourceMaps: false,
         useLegacyIds: false,
         duplicateMessageHandling: 'ignore',
+        fileSystem: fs,
       });
       expect(fs.readFile(outputPath)).toEqual([
         `{`,
@@ -70,6 +73,7 @@ runInEachFileSystem(() => {
             useSourceMaps: false,
             useLegacyIds,
             duplicateMessageHandling: 'ignore',
+            fileSystem: fs,
           });
           expect(fs.readFile(outputPath)).toEqual([
             `{`,
@@ -97,6 +101,7 @@ runInEachFileSystem(() => {
             useSourceMaps: false,
             useLegacyIds,
             duplicateMessageHandling: 'ignore',
+            fileSystem: fs,
           });
           expect(fs.readFile(outputPath)).toEqual([
             `<?xml version="1.0" encoding="UTF-8" ?>`,
@@ -151,6 +156,7 @@ runInEachFileSystem(() => {
                  useLegacyIds,
                  duplicateMessageHandling: 'ignore',
                  formatOptions,
+                 fileSystem: fs,
                });
                expect(fs.readFile(outputPath)).toEqual([
                  `<?xml version="1.0" encoding="UTF-8" ?>`,
@@ -222,6 +228,7 @@ runInEachFileSystem(() => {
               useLegacyIds,
               duplicateMessageHandling: 'ignore',
               formatOptions,
+              fileSystem: fs,
             });
             expect(fs.readFile(outputPath)).toEqual([
               `<?xml version="1.0" encoding="UTF-8" ?>`,
@@ -299,6 +306,7 @@ runInEachFileSystem(() => {
              useSourceMaps: true,
              useLegacyIds: false,
              duplicateMessageHandling: 'ignore',
+             fileSystem: fs,
            });
            expect(fs.readFile(outputPath)).toEqual([
              `<?xml version="1.0" encoding="UTF-8" ?>`,
@@ -308,7 +316,8 @@ runInEachFileSystem(() => {
              `      <trans-unit id="157258427077572998" datatype="html">`,
              `        <source>Message in <x id="a-file" equiv-text="file"/>!</source>`,
              `        <context-group purpose="location">`,
-             // These source file paths are due to how Bazel TypeScript compilation source-maps work
+             // These source file paths are due to how Bazel TypeScript compilation source-maps
+             // work
              `          <context context-type="sourcefile">../packages/localize/src/tools/test/extract/integration/test_files/src/a.ts</context>`,
              `          <context context-type="linenumber">3</context>`,
              `        </context-group>`,
@@ -339,6 +348,7 @@ runInEachFileSystem(() => {
                  useSourceMaps: false,
                  useLegacyIds: false,
                  duplicateMessageHandling: 'error',
+                 fileSystem: fs,
                }))
             .toThrowError(
                 `Failed to extract messages\n` +
@@ -360,6 +370,7 @@ runInEachFileSystem(() => {
           useSourceMaps: false,
           useLegacyIds: false,
           duplicateMessageHandling: 'warning',
+          fileSystem: fs,
         });
         expect(logger.logs.warn).toEqual([
           ['Messages extracted with warnings\n' +
@@ -390,6 +401,7 @@ runInEachFileSystem(() => {
           useSourceMaps: false,
           useLegacyIds: false,
           duplicateMessageHandling: 'ignore',
+          fileSystem: fs,
         });
         expect(logger.logs.warn).toEqual([]);
         expect(fs.readFile(outputPath)).toEqual([

--- a/packages/localize/src/tools/test/extract/translation_files/xmb_translation_serializer_spec.ts
+++ b/packages/localize/src/tools/test/extract/translation_files/xmb_translation_serializer_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {absoluteFrom} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {absoluteFrom, FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {ɵParsedMessage, ɵSourceLocation} from '@angular/localize';
 
@@ -14,6 +14,8 @@ import {XmbTranslationSerializer} from '../../../src/extract/translation_files/x
 import {mockMessage} from './mock_message';
 
 runInEachFileSystem(() => {
+  let fs: FileSystem;
+  beforeEach(() => fs = getFileSystem());
   describe('XmbTranslationSerializer', () => {
     [false, true].forEach(useLegacyIds => {
       describe(`renderFile() [using ${useLegacyIds ? 'legacy' : 'canonical'} ids]`, () => {
@@ -61,7 +63,8 @@ runInEachFileSystem(() => {
                 ],
                 [], {}),
           ];
-          const serializer = new XmbTranslationSerializer(absoluteFrom('/project'), useLegacyIds);
+          const serializer =
+              new XmbTranslationSerializer(absoluteFrom('/project'), useLegacyIds, fs);
           const output = serializer.serialize(messages);
           expect(output).toContain([
             `<messagebundle>`,

--- a/packages/localize/src/tools/test/translate/source_files/es2015_translate_plugin_spec.ts
+++ b/packages/localize/src/tools/test/translate/source_files/es2015_translate_plugin_spec.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {ɵcomputeMsgId, ɵparseTranslation} from '@angular/localize';
 import {ɵParsedTranslation} from '@angular/localize/private';
@@ -15,6 +16,8 @@ import {TranslatePluginOptions} from '../../../src/source_file_utils';
 import {makeEs2015TranslatePlugin} from '../../../src/translate/source_files/es2015_translate_plugin';
 
 runInEachFileSystem(() => {
+  let fs: FileSystem;
+  beforeEach(() => fs = getFileSystem());
   describe('makeEs2015Plugin', () => {
     describe('(no translations)', () => {
       it('should transform `$localize` tags with binary expression', () => {
@@ -168,13 +171,13 @@ runInEachFileSystem(() => {
       });
     });
   });
-});
 
-function transformCode(
-    input: string, translations: Record<string, ɵParsedTranslation> = {},
-    pluginOptions?: TranslatePluginOptions, diagnostics = new Diagnostics()): string {
-  return transformSync(input, {
-           plugins: [makeEs2015TranslatePlugin(diagnostics, translations, pluginOptions)],
-           filename: '/app/dist/test.js'
-         })!.code!;
-}
+  function transformCode(
+      input: string, translations: Record<string, ɵParsedTranslation> = {},
+      pluginOptions?: TranslatePluginOptions, diagnostics = new Diagnostics()): string {
+    return transformSync(input, {
+             plugins: [makeEs2015TranslatePlugin(diagnostics, translations, pluginOptions)],
+             filename: '/app/dist/test.js'
+           })!.code!;
+  }
+});

--- a/packages/localize/src/tools/test/translate/source_files/es5_translate_plugin_spec.ts
+++ b/packages/localize/src/tools/test/translate/source_files/es5_translate_plugin_spec.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {ɵcomputeMsgId, ɵparseTranslation} from '@angular/localize';
 import {ɵParsedTranslation} from '@angular/localize/private';
@@ -15,6 +16,8 @@ import {TranslatePluginOptions} from '../../../src/source_file_utils';
 import {makeEs5TranslatePlugin} from '../../../src/translate/source_files/es5_translate_plugin';
 
 runInEachFileSystem(() => {
+  let fs: FileSystem;
+  beforeEach(() => fs = getFileSystem());
   describe('makeEs5Plugin', () => {
     describe('(no translations)', () => {
       it('should transform `$localize` calls with binary expression', () => {
@@ -357,13 +360,13 @@ runInEachFileSystem(() => {
       expect(output).toEqual('"abc" + (1 + 2 + 3) + " - Hello, " + getName() + "!";');
     });
   });
-});
 
-function transformCode(
-    input: string, translations: Record<string, ɵParsedTranslation> = {},
-    pluginOptions?: TranslatePluginOptions, diagnostics = new Diagnostics()): string {
-  return transformSync(input, {
-           plugins: [makeEs5TranslatePlugin(diagnostics, translations, pluginOptions)],
-           filename: '/app/dist/test.js'
-         })!.code!;
-}
+  function transformCode(
+      input: string, translations: Record<string, ɵParsedTranslation> = {},
+      pluginOptions?: TranslatePluginOptions, diagnostics = new Diagnostics()): string {
+    return transformSync(input, {
+             plugins: [makeEs5TranslatePlugin(diagnostics, translations, pluginOptions)],
+             filename: '/app/dist/test.js'
+           })!.code!;
+  }
+});


### PR DESCRIPTION
This should fix Windows source-mapping in the i18n extraction integration with CLI.

I have tried to ensure that the public API items are backward compatible with what the CLI currently uses.
Ideally the CLI will switch over to providing the file-system object where needed but I am not sure if this is entirely necessary to fix the reported problem.

FIxes #38711