### PR TITLE
Add quick info at location

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/symbols.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/symbols.ts
@@ -204,6 +204,8 @@ export interface ElementSymbol {
 
   /** The location in the shim file for the variable that holds the type of the element. */
   shimLocation: ShimLocation;
+
+  templateNode: TmplAstElement;
 }
 
 export interface TemplateSymbol {
@@ -211,6 +213,8 @@ export interface TemplateSymbol {
 
   /** A list of directives applied to the element. */
   directives: DirectiveSymbol[];
+
+  templateNode: TmplAstTemplate;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
@@ -193,18 +193,21 @@ export class SymbolBuilder {
       return host !== null ? {kind: SymbolKind.DomBinding, host} : null;
     }
 
+    if (binding.keySpan === null) {
+      return null;
+    }
     const node = findFirstMatchingNode(
-        this.typeCheckBlock, {withSpan: binding.sourceSpan, filter: isAssignment});
-    if (node === null || !isAccessExpression(node.left)) {
+        this.typeCheckBlock, {withSpan: binding.keySpan, filter: isAccessExpression});
+    if (node === null) {
       return null;
     }
 
-    const symbolInfo = this.getSymbolOfTsNode(node.left);
+    const symbolInfo = this.getSymbolOfTsNode(node);
     if (symbolInfo === null || symbolInfo.tsSymbol === null) {
       return null;
     }
 
-    const target = this.getDirectiveSymbolForAccessExpression(node.left, consumer);
+    const target = this.getDirectiveSymbolForAccessExpression(node, consumer);
     if (target === null) {
       return null;
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -618,6 +618,12 @@ class TcbDirectiveInputsOp extends TcbOp {
               ts.createPropertyAccess(dirId, ts.createIdentifier(fieldName));
         }
 
+
+        if (input.attribute.keySpan !== null) {
+          // If we have a keySpan for the attribute, add it to the target node so it can be uniquely
+          // identified.
+          addParseSpanInfo(target, input.attribute.keySpan);
+        }
         // Finally the assignment is extended by assigning it into the target expression.
         assignment = ts.createBinary(target, ts.SyntaxKind.EqualsToken, assignment);
       }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -36,7 +36,7 @@ runInEachFileSystem(() => {
           }]);
 
       expect(messages).toEqual(
-          [`TestComponent.html(1, 10): Type 'string' is not assignable to type 'number'.`]);
+          [`TestComponent.html(1, 11): Type 'string' is not assignable to type 'number'.`]);
     });
 
     it('infers type of template variables', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -178,7 +178,7 @@ describe('type check blocks diagnostics', () => {
         }];
         const TEMPLATE = `<my-cmp [inputA]="''"></my-cmp>`;
         expect(tcbWithSpans(TEMPLATE, DIRECTIVES))
-            .toContain('_t1.inputA = ("" /*18,20*/) /*8,21*/;');
+            .toContain('_t1.inputA /*9,15*/ = ("" /*18,20*/) /*8,21*/;');
       });
     });
   });

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
@@ -186,7 +186,7 @@ runInEachFileSystem(() => {
         beforeEach(() => {
           const fileName = absoluteFrom('/main.ts');
           const templateString = `
-              <div *ngFor="let user of users; let i = index;">
+              <div *ngFor="let user of users; trackBy: trackByFn; let i = index;">
                 {{user.name}} {{user.streetNumber}}
                 <div [tabIndex]="i"></div>
               </div>`;
@@ -219,6 +219,17 @@ runInEachFileSystem(() => {
           assertExpressionSymbol(symbol);
           expect(program.getTypeChecker().symbolToString(symbol.tsSymbol!)).toEqual('users');
           expect(program.getTypeChecker().typeToString(symbol.tsType)).toEqual('Array<User>');
+        });
+
+        it('should retrieve a symbol for second binding inside microsyntax', () => {
+          const ngForTrackByBinding = templateNode.templateAttrs.find(
+                                          a => a.name === 'ngForTrackBy')! as TmplAstBoundAttribute;
+          const symbol = templateTypeChecker.getSymbolOfNode(ngForTrackByBinding, cmp)!;
+          assertInputBindingSymbol(symbol);
+          expect(program.getTypeChecker().symbolToString(symbol.bindings[0].tsSymbol))
+              .toEqual('ngForTrackBy');
+          expect(program.getTypeChecker().typeToString(symbol.bindings[0].tsType))
+              .toEqual('TrackByFunction<User>');
         });
 
         it('should retrieve a symbol for property reads of implicit variable inside structural binding',

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
@@ -133,6 +133,7 @@ runInEachFileSystem(() => {
         it('should get a symbol for local ref which refers to a directive', () => {
           const symbol = templateTypeChecker.getSymbolOfNode(templateNode.references[1], cmp)!;
           assertReferenceSymbol(symbol);
+          expect(program.getTypeChecker().symbolToString(symbol.tsSymbol)).toEqual('TestDir');
           assertDirectiveReference(symbol);
         });
 
@@ -140,6 +141,7 @@ runInEachFileSystem(() => {
           const symbol = templateTypeChecker.getSymbolOfNode(
               (templateNode.children[0] as TmplAstTemplate).inputs[2].value, cmp)!;
           assertReferenceSymbol(symbol);
+          expect(program.getTypeChecker().symbolToString(symbol.tsSymbol)).toEqual('TestDir');
           assertDirectiveReference(symbol);
         });
 
@@ -748,6 +750,40 @@ runInEachFileSystem(() => {
     });
 
     describe('input bindings', () => {
+      it('can get a symbol for empty binding', () => {
+        const fileName = absoluteFrom('/main.ts');
+        const dirFile = absoluteFrom('/dir.ts');
+        const {program, templateTypeChecker} = setup([
+          {
+            fileName,
+            templates: {'Cmp': `<div dir [inputA]=""></div>`},
+            declarations: [{
+              name: 'TestDir',
+              selector: '[dir]',
+              file: dirFile,
+              type: 'directive',
+              inputs: {inputA: 'inputA'},
+            }]
+          },
+          {
+            fileName: dirFile,
+            source: `export class TestDir {inputA?: string; }`,
+            templates: {},
+          }
+        ]);
+        const sf = getSourceFileOrError(program, fileName);
+        const cmp = getClass(sf, 'Cmp');
+
+        const nodes = templateTypeChecker.getTemplate(cmp)!;
+
+        const inputAbinding = (nodes[0] as TmplAstElement).inputs[0];
+        const aSymbol = templateTypeChecker.getSymbolOfNode(inputAbinding, cmp)!;
+        assertInputBindingSymbol(aSymbol);
+        expect((aSymbol.bindings[0].tsSymbol!.declarations[0] as ts.PropertyDeclaration)
+                   .name.getText())
+            .toEqual('inputA');
+      });
+
       it('can retrieve a symbol for an input binding', () => {
         const fileName = absoluteFrom('/main.ts');
         const dirFile = absoluteFrom('/dir.ts');

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -1242,11 +1242,11 @@ export declare class AnimationEvent {
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(3);
       expect(diags[0].messageText).toBe(`Type 'boolean' is not assignable to type 'number'.`);
-      expect(getSourceCodeForDiagnostic(diags[0])).toEqual('[fromAbstract]="true"');
+      expect(getSourceCodeForDiagnostic(diags[0])).toEqual('fromAbstract');
       expect(diags[1].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
-      expect(getSourceCodeForDiagnostic(diags[1])).toEqual('[fromBase]="3"');
+      expect(getSourceCodeForDiagnostic(diags[1])).toEqual('fromBase');
       expect(diags[2].messageText).toBe(`Type 'number' is not assignable to type 'boolean'.`);
-      expect(getSourceCodeForDiagnostic(diags[2])).toEqual('[fromChild]="4"');
+      expect(getSourceCodeForDiagnostic(diags[2])).toEqual('fromChild');
     });
 
     it('should properly type-check inherited directives from external libraries', () => {
@@ -1299,11 +1299,11 @@ export declare class AnimationEvent {
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(3);
       expect(diags[0].messageText).toBe(`Type 'boolean' is not assignable to type 'number'.`);
-      expect(getSourceCodeForDiagnostic(diags[0])).toEqual('[fromAbstract]="true"');
+      expect(getSourceCodeForDiagnostic(diags[0])).toEqual('fromAbstract');
       expect(diags[1].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
-      expect(getSourceCodeForDiagnostic(diags[1])).toEqual('[fromBase]="3"');
+      expect(getSourceCodeForDiagnostic(diags[1])).toEqual('fromBase');
       expect(diags[2].messageText).toBe(`Type 'number' is not assignable to type 'boolean'.`);
-      expect(getSourceCodeForDiagnostic(diags[2])).toEqual('[fromChild]="4"');
+      expect(getSourceCodeForDiagnostic(diags[2])).toEqual('fromChild');
     });
 
     it('should detect an illegal write to a template variable', () => {

--- a/packages/compiler/src/i18n/extractor_merger.ts
+++ b/packages/compiler/src/i18n/extractor_merger.ts
@@ -394,10 +394,12 @@ class _Visitor implements html.Visitor {
         const nodes = this._translations.get(message);
         if (nodes) {
           if (nodes.length == 0) {
-            translatedAttributes.push(new html.Attribute(attr.name, '', attr.sourceSpan));
+            translatedAttributes.push(
+                new html.Attribute(attr.name, '', attr.sourceSpan, null, undefined, undefined));
           } else if (nodes[0] instanceof html.Text) {
             const value = (nodes[0] as html.Text).value;
-            translatedAttributes.push(new html.Attribute(attr.name, value, attr.sourceSpan));
+            translatedAttributes.push(
+                new html.Attribute(attr.name, value, attr.sourceSpan, null, undefined, undefined));
           } else {
             this._reportError(
                 el,

--- a/packages/compiler/src/ml_parser/ast.ts
+++ b/packages/compiler/src/ml_parser/ast.ts
@@ -53,7 +53,8 @@ export class ExpansionCase implements Node {
 export class Attribute extends NodeWithI18n {
   constructor(
       public name: string, public value: string, sourceSpan: ParseSourceSpan,
-      public valueSpan?: ParseSourceSpan, i18n?: I18nMeta) {
+      readonly keySpan: ParseSourceSpan|null, public valueSpan: ParseSourceSpan|undefined,
+      i18n: I18nMeta|undefined) {
     super(sourceSpan, i18n);
   }
   visit(visitor: Visitor, context: any): any {

--- a/packages/compiler/src/ml_parser/icu_ast_expander.ts
+++ b/packages/compiler/src/ml_parser/icu_ast_expander.ts
@@ -102,10 +102,13 @@ function _expandPluralForm(ast: html.Expansion, errors: ParseError[]): html.Elem
     errors.push(...expansionResult.errors);
 
     return new html.Element(
-        `ng-template`, [new html.Attribute('ngPluralCase', `${c.value}`, c.valueSourceSpan)],
+        `ng-template`,
+        [new html.Attribute(
+            'ngPluralCase', `${c.value}`, c.valueSourceSpan, null, undefined, undefined)],
         expansionResult.nodes, c.sourceSpan, c.sourceSpan, c.sourceSpan);
   });
-  const switchAttr = new html.Attribute('[ngPlural]', ast.switchValue, ast.switchValueSourceSpan);
+  const switchAttr = new html.Attribute(
+      '[ngPlural]', ast.switchValue, ast.switchValueSourceSpan, null, undefined, undefined);
   return new html.Element(
       'ng-container', [switchAttr], children, ast.sourceSpan, ast.sourceSpan, ast.sourceSpan);
 }
@@ -119,15 +122,19 @@ function _expandDefaultForm(ast: html.Expansion, errors: ParseError[]): html.Ele
     if (c.value === 'other') {
       // other is the default case when no values match
       return new html.Element(
-          `ng-template`, [new html.Attribute('ngSwitchDefault', '', c.valueSourceSpan)],
+          `ng-template`, [new html.Attribute(
+                             'ngSwitchDefault', '', c.valueSourceSpan, null, undefined, undefined)],
           expansionResult.nodes, c.sourceSpan, c.sourceSpan, c.sourceSpan);
     }
 
     return new html.Element(
-        `ng-template`, [new html.Attribute('ngSwitchCase', `${c.value}`, c.valueSourceSpan)],
+        `ng-template`,
+        [new html.Attribute(
+            'ngSwitchCase', `${c.value}`, c.valueSourceSpan, null, undefined, undefined)],
         expansionResult.nodes, c.sourceSpan, c.sourceSpan, c.sourceSpan);
   });
-  const switchAttr = new html.Attribute('[ngSwitch]', ast.switchValue, ast.switchValueSourceSpan);
+  const switchAttr = new html.Attribute(
+      '[ngSwitch]', ast.switchValue, ast.switchValueSourceSpan, null, undefined, undefined);
   return new html.Element(
       'ng-container', [switchAttr], children, ast.sourceSpan, ast.sourceSpan, ast.sourceSpan);
 }

--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -346,8 +346,10 @@ class _TreeBuilder {
       const quoteToken = this._advance();
       end = quoteToken.sourceSpan.end;
     }
+    const keySpan = new ParseSourceSpan(attrName.sourceSpan.start, attrName.sourceSpan.end);
     return new html.Attribute(
-        fullName, value, new ParseSourceSpan(attrName.sourceSpan.start, end), valueSpan);
+        fullName, value, new ParseSourceSpan(attrName.sourceSpan.start, end), keySpan, valueSpan,
+        undefined);
   }
 
   private _getParentElement(): html.Element|null {

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -33,7 +33,8 @@ export class BoundText implements Node {
 export class TextAttribute implements Node {
   constructor(
       public name: string, public value: string, public sourceSpan: ParseSourceSpan,
-      public valueSpan?: ParseSourceSpan, public i18n?: I18nMeta) {}
+      readonly keySpan: ParseSourceSpan|null, public valueSpan?: ParseSourceSpan,
+      public i18n?: I18nMeta) {}
   visit<Result>(visitor: Visitor<Result>): Result {
     return visitor.visitTextAttribute(this);
   }

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -168,7 +168,7 @@ class HtmlAstToIvyAst implements html.Visitor {
 
       if (!hasBinding && !isTemplateBinding) {
         // don't include the bindings as attributes as well in the AST
-        attributes.push(this.visitAttribute(attribute) as t.TextAttribute);
+        attributes.push(this.visitAttribute(attribute));
       }
     }
 
@@ -240,7 +240,8 @@ class HtmlAstToIvyAst implements html.Visitor {
 
   visitAttribute(attribute: html.Attribute): t.TextAttribute {
     return new t.TextAttribute(
-        attribute.name, attribute.value, attribute.sourceSpan, attribute.valueSpan, attribute.i18n);
+        attribute.name, attribute.value, attribute.sourceSpan, attribute.keySpan,
+        attribute.valueSpan, attribute.i18n);
   }
 
   visitText(text: html.Text): t.Node {
@@ -308,7 +309,8 @@ class HtmlAstToIvyAst implements html.Visitor {
       const i18n = i18nPropsMeta[prop.name];
       if (prop.isLiteral) {
         literal.push(new t.TextAttribute(
-            prop.name, prop.expression.source || '', prop.sourceSpan, undefined, i18n));
+            prop.name, prop.expression.source || '', prop.sourceSpan, prop.keySpan ?? null,
+            undefined, i18n));
       } else {
         // Note that validation is skipped and property mapping is disabled
         // due to the fact that we need to make sure a given prop is not an
@@ -492,7 +494,7 @@ class NonBindableVisitor implements html.Visitor {
 
   visitAttribute(attribute: html.Attribute): t.TextAttribute {
     return new t.TextAttribute(
-        attribute.name, attribute.value, attribute.sourceSpan, undefined, attribute.i18n);
+        attribute.name, attribute.value, attribute.sourceSpan, null, undefined, attribute.i18n);
   }
 
   visitText(text: html.Text): t.Text {

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -64,8 +64,10 @@ class R3AstSourceSpans implements t.Visitor<void> {
   }
 
   visitTextAttribute(attribute: t.TextAttribute) {
-    this.result.push(
-        ['TextAttribute', humanizeSpan(attribute.sourceSpan), humanizeSpan(attribute.valueSpan)]);
+    this.result.push([
+      'TextAttribute', humanizeSpan(attribute.sourceSpan), humanizeSpan(attribute.keySpan),
+      humanizeSpan(attribute.valueSpan)
+    ]);
   }
 
   visitBoundAttribute(attribute: t.BoundAttribute) {
@@ -126,14 +128,14 @@ describe('R3 AST source spans', () => {
     it('is correct for elements with attributes', () => {
       expectFromHtml('<div a="b"></div>').toEqual([
         ['Element', '<div a="b"></div>', '<div a="b">', '</div>'],
-        ['TextAttribute', 'a="b"', 'b'],
+        ['TextAttribute', 'a="b"', 'a', 'b'],
       ]);
     });
 
     it('is correct for elements with attributes without value', () => {
       expectFromHtml('<div a></div>').toEqual([
         ['Element', '<div a></div>', '<div a>', '</div>'],
-        ['TextAttribute', 'a', '<empty>'],
+        ['TextAttribute', 'a', 'a', '<empty>'],
       ]);
     });
   });
@@ -187,7 +189,7 @@ describe('R3 AST source spans', () => {
     it('is correct for * directives', () => {
       expectFromHtml('<div *ngIf></div>').toEqual([
         ['Template', '<div *ngIf></div>', '<div *ngIf>', '</div>'],
-        ['TextAttribute', 'ngIf', '<empty>'],
+        ['TextAttribute', 'ngIf', 'ngIf', '<empty>'],
         ['Element', '<div *ngIf></div>', '<div *ngIf>', '</div>'],
       ]);
     });
@@ -257,7 +259,7 @@ describe('R3 AST source spans', () => {
           'Template', '<ng-template k1="v1"></ng-template>', '<ng-template k1="v1">',
           '</ng-template>'
         ],
-        ['TextAttribute', 'k1="v1"', 'v1'],
+        ['TextAttribute', 'k1="v1"', 'k1', 'v1'],
       ]);
     });
 
@@ -284,7 +286,7 @@ describe('R3 AST source spans', () => {
           'Template', '<div *ngFor="let item of items"></div>', '<div *ngFor="let item of items">',
           '</div>'
         ],
-        ['TextAttribute', 'ngFor', '<empty>'],
+        ['TextAttribute', 'ngFor', 'ngFor', '<empty>'],
         ['BoundAttribute', '*ngFor="let item of items"', 'of', 'items'],
         ['Variable', 'let item ', 'item', '<empty>'],
         [
@@ -313,7 +315,7 @@ describe('R3 AST source spans', () => {
           'Template', '<div *ngFor="let item of items; trackBy: trackByFn"></div>',
           '<div *ngFor="let item of items; trackBy: trackByFn">', '</div>'
         ],
-        ['TextAttribute', 'ngFor', '<empty>'],
+        ['TextAttribute', 'ngFor', 'ngFor', '<empty>'],
         ['BoundAttribute', '*ngFor="let item of items; trackBy: trackByFn"', 'of', 'items'],
         [
           'BoundAttribute', '*ngFor="let item of items; trackBy: trackByFn"', 'trackBy', 'trackByFn'
@@ -330,7 +332,7 @@ describe('R3 AST source spans', () => {
     it('is correct for variables via let ...', () => {
       expectFromHtml('<div *ngIf="let a=b"></div>').toEqual([
         ['Template', '<div *ngIf="let a=b"></div>', '<div *ngIf="let a=b">', '</div>'],
-        ['TextAttribute', 'ngIf', '<empty>'],
+        ['TextAttribute', 'ngIf', 'ngIf', '<empty>'],
         ['Variable', 'let a=b', 'a', 'b'],
         ['Element', '<div *ngIf="let a=b"></div>', '<div *ngIf="let a=b">', '</div>'],
       ]);

--- a/packages/language-service/ivy/BUILD.bazel
+++ b/packages/language-service/ivy/BUILD.bazel
@@ -15,6 +15,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/shims",
         "//packages/compiler-cli/src/ngtsc/typecheck",
         "//packages/compiler-cli/src/ngtsc/typecheck/api",
+        "//packages/language-service",
         "@npm//typescript",
     ],
 )

--- a/packages/language-service/ivy/hybrid_visitor.ts
+++ b/packages/language-service/ivy/hybrid_visitor.ts
@@ -10,6 +10,8 @@ import {AbsoluteSourceSpan, ParseSourceSpan} from '@angular/compiler';
 import * as e from '@angular/compiler/src/expression_parser/ast';  // e for expression AST
 import * as t from '@angular/compiler/src/render3/r3_ast';         // t for template AST
 
+import {isTemplateNode, isTemplateNodeWithKeyAndValue} from './utils';
+
 /**
  * Return the template AST node or expression AST node that most accurately
  * represents the node at the specified cursor `position`.
@@ -161,24 +163,6 @@ class ExpressionVisitor extends e.RecursiveAstVisitor {
       node.visit(this, path);
     }
   }
-}
-
-export function isTemplateNode(node: t.Node|e.AST): node is t.Node {
-  // Template node implements the Node interface so we cannot use instanceof.
-  return node.sourceSpan instanceof ParseSourceSpan;
-}
-
-interface NodeWithKeyAndValue extends t.Node {
-  keySpan: ParseSourceSpan;
-  valueSpan?: ParseSourceSpan;
-}
-
-export function isTemplateNodeWithKeyAndValue(node: t.Node|e.AST): node is NodeWithKeyAndValue {
-  return isTemplateNode(node) && node.hasOwnProperty('keySpan');
-}
-
-export function isExpressionNode(node: t.Node|e.AST): node is e.AST {
-  return node instanceof e.AST;
 }
 
 function getSpanIncludingEndTag(ast: t.Node) {

--- a/packages/language-service/ivy/quick_info.ts
+++ b/packages/language-service/ivy/quick_info.ts
@@ -1,0 +1,197 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {AST, BindingPipe, ImplicitReceiver, MethodCall, TmplAstBoundAttribute, TmplAstNode, TmplAstTextAttribute} from '@angular/compiler';
+import {DirectiveSymbol, DomBindingSymbol, ElementSymbol, ExpressionSymbol, InputBindingSymbol, OutputBindingSymbol, ReferenceSymbol, ShimLocation, Symbol, SymbolKind, TemplateTypeChecker, VariableSymbol} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
+import * as ts from 'typescript';
+
+import {createQuickInfo, SYMBOL_PUNC, SYMBOL_SPACE, SYMBOL_TEXT} from '../src/hover';
+
+import {findNodeAtPosition} from './hybrid_visitor';
+import {filterAliasImports, getDirectiveMatches, getDirectiveMatchesForAttribute, getTemplateInfoAtPosition, getTextSpanOfNode} from './utils';
+
+
+export class QuickInfoBuilder {
+  readonly typeChecker = this.program.getTypeChecker();
+  constructor(
+      private readonly program: ts.Program,
+      private readonly templateTypeChecker: TemplateTypeChecker,
+      private readonly tsLS: ts.LanguageService) {}
+
+  getQuickInfoAtPosition(fileName: string, position: number): ts.QuickInfo|undefined {
+    const templateInfo =
+        getTemplateInfoAtPosition(fileName, position, this.program, this.templateTypeChecker);
+    if (templateInfo === undefined) {
+      return undefined;
+    }
+    const {template, component} = templateInfo;
+
+    const node = findNodeAtPosition(template, position);
+    if (node === undefined) {
+      return undefined;
+    }
+
+    const symbol = this.templateTypeChecker.getSymbolOfNode(node, component) ?? undefined;
+    if (symbol === undefined) {
+      return isDollarAny(node) ? createDollarAnyQuickInfo(node) : undefined;
+    }
+
+    return this.getQuickInfoForSymbol(symbol, node);
+  }
+
+  private getQuickInfoForSymbol(symbol: Symbol, node: TmplAstNode|AST): ts.QuickInfo|undefined {
+    if (symbol.kind === SymbolKind.Input || symbol.kind === SymbolKind.Output) {
+      return this.getQuickInfoForBindingSymbol(symbol, node);
+    } else if (symbol.kind === SymbolKind.Template) {
+      return undefined;
+    } else if (symbol.kind === SymbolKind.Element) {
+      return this.getQuickInfoForElementSymbol(symbol);
+    } else if (symbol.kind === SymbolKind.Variable) {
+      return this.getQuickInfoForVariableSymbol(symbol, node);
+    } else if (symbol.kind === SymbolKind.Reference) {
+      return this.getQuickInfoForReferenceSymbol(symbol, node);
+    } else if (symbol.kind === SymbolKind.Expression && node instanceof BindingPipe) {
+      return this.getQuickInfoForPipeSymbol(symbol, node);
+    } else if (symbol.kind === SymbolKind.DomBinding) {
+      return this.getQuickInfoForDomBinding(node, symbol);
+    } else {
+      return this.getQuickInfoAtShimLocation(symbol.shimLocation, node);
+    }
+  }
+
+  private getQuickInfoForBindingSymbol(
+      symbol: InputBindingSymbol|OutputBindingSymbol, node: TmplAstNode|AST) {
+    if (symbol.bindings.length === 0) {
+      return undefined;
+    }
+
+    const kind = symbol.kind === SymbolKind.Input ? 'property' : 'event';
+
+    const quickInfo = this.getQuickInfoAtShimLocation(symbol.bindings[0].shimLocation, node);
+    return quickInfo === undefined ? undefined : updateQuickInfoKind(quickInfo, kind);
+  }
+
+  private getQuickInfoForElementSymbol(symbol: ElementSymbol) {
+    const {templateNode} = symbol;
+    const matches = getDirectiveMatches(symbol.directives, templateNode.name);
+    if (matches.length > 0) {
+      return this.getQuickInfoForDirectiveSymbol(matches[0], templateNode);
+    }
+
+    return createQuickInfo(
+        templateNode.name, 'element', getTextSpanOfNode(templateNode), undefined,
+        this.typeChecker.typeToString(symbol.tsType));
+  }
+
+  private getQuickInfoForVariableSymbol(symbol: VariableSymbol, node: TmplAstNode|AST) {
+    const documentation = this.getDocumentationFromTypeDefAtLocation(symbol.shimLocation);
+    return createQuickInfo(
+        symbol.declaration.name, 'variable', getTextSpanOfNode(node), undefined,
+        this.typeChecker.typeToString(symbol.tsType), documentation);
+  }
+
+  private getQuickInfoForReferenceSymbol(symbol: ReferenceSymbol, node: TmplAstNode|AST) {
+    const documentation = this.getDocumentationFromTypeDefAtLocation(symbol.shimLocation);
+    return createQuickInfo(
+        symbol.declaration.name, 'local var', getTextSpanOfNode(node), undefined,
+        this.typeChecker.typeToString(symbol.tsType), documentation);
+  }
+
+  private getQuickInfoForPipeSymbol(symbol: ExpressionSymbol, node: TmplAstNode|AST) {
+    const quickInfo = this.getQuickInfoAtShimLocation(symbol.shimLocation, node);
+    return quickInfo === undefined ? undefined : updateQuickInfoKind(quickInfo, 'pipe');
+  }
+
+  private getQuickInfoForDomBinding(node: TmplAstNode|AST, symbol: DomBindingSymbol) {
+    if (!(node instanceof TmplAstTextAttribute) && !(node instanceof TmplAstBoundAttribute)) {
+      return undefined;
+    }
+    const directives = getDirectiveMatchesForAttribute(
+        node.name, symbol.host.templateNode, symbol.host.directives);
+    if (directives.length === 0) {
+      return undefined;
+    }
+
+    return this.getQuickInfoForDirectiveSymbol(directives[0], node);
+  }
+
+  private getQuickInfoForDirectiveSymbol(dir: DirectiveSymbol, node: TmplAstNode|AST) {
+    const kind = dir.isComponent ? 'component' : 'directive';
+    const documentation = this.getDocumentationFromTypeDefAtLocation(dir.shimLocation);
+    return createQuickInfo(
+        this.typeChecker.typeToString(dir.tsType), kind, getTextSpanOfNode(node), undefined,
+        undefined, documentation);
+  }
+
+  private getDocumentationFromTypeDefAtLocation(shimLocation: ShimLocation):
+      ts.SymbolDisplayPart[]|undefined {
+    const typeDefs = this.tsLS.getTypeDefinitionAtPosition(
+        shimLocation.shimPath, shimLocation.positionInShimFile);
+    if (typeDefs === undefined || typeDefs.length === 0) {
+      return undefined;
+    }
+    return this.tsLS.getQuickInfoAtPosition(typeDefs[0].fileName, typeDefs[0].textSpan.start)
+        ?.documentation;
+  }
+
+  private getQuickInfoAtShimLocation(location: ShimLocation, node: TmplAstNode|AST): ts.QuickInfo
+      |undefined {
+    const quickInfo =
+        this.tsLS.getQuickInfoAtPosition(location.shimPath, location.positionInShimFile);
+    if (quickInfo === undefined || quickInfo.displayParts === undefined) {
+      return quickInfo;
+    }
+
+    quickInfo.displayParts = filterAliasImports(quickInfo.displayParts);
+
+    const textSpan = getTextSpanOfNode(node);
+    return {...quickInfo, textSpan};
+  }
+}
+
+function updateQuickInfoKind(quickInfo: ts.QuickInfo, kind: string) {
+  if (quickInfo.displayParts === undefined) {
+    return quickInfo;
+  }
+
+  const startsWithKind = quickInfo.displayParts.length >= 3 &&
+      displayPartsEqual(quickInfo.displayParts[0], {text: '(', kind: SYMBOL_PUNC}) &&
+      quickInfo.displayParts[1].kind === SYMBOL_TEXT &&
+      displayPartsEqual(quickInfo.displayParts[2], {text: ')', kind: SYMBOL_PUNC});
+  if (startsWithKind) {
+    quickInfo.displayParts[1].text = kind;
+  } else {
+    quickInfo.displayParts = [
+      {text: '(', kind: SYMBOL_PUNC}, {text: kind, kind: SYMBOL_TEXT},
+      {text: ')', kind: SYMBOL_PUNC}, {text: ' ', kind: SYMBOL_SPACE}, ...quickInfo.displayParts
+    ];
+  }
+  return quickInfo;
+}
+
+function displayPartsEqual(a: {text: string, kind: string}, b: {text: string, kind: string}) {
+  return a.text === b.text && a.kind === b.kind;
+}
+
+function isDollarAny(node: TmplAstNode|AST): node is MethodCall {
+  return node instanceof MethodCall && node.receiver instanceof ImplicitReceiver &&
+      node.name === '$any' && node.args.length === 1;
+}
+
+function createDollarAnyQuickInfo(node: MethodCall) {
+  return createQuickInfo(
+      '$any',
+      'method',
+      getTextSpanOfNode(node),
+      undefined,
+      'any',
+      [{
+        kind: 'text',
+        text: 'function to cast an expression to the `any` type',
+      }],
+  );
+}

--- a/packages/language-service/ivy/test/BUILD.bazel
+++ b/packages/language-service/ivy/test/BUILD.bazel
@@ -7,6 +7,7 @@ ts_library(
     deps = [
         "//packages/compiler",
         "//packages/language-service/ivy",
+        "//packages/language-service/test:test_utils_lib",
         "@npm//typescript",
     ],
 )

--- a/packages/language-service/ivy/test/hybrid_visitor_spec.ts
+++ b/packages/language-service/ivy/test/hybrid_visitor_spec.ts
@@ -10,7 +10,8 @@ import {ParseError, parseTemplate} from '@angular/compiler';
 import * as e from '@angular/compiler/src/expression_parser/ast';  // e for expression AST
 import * as t from '@angular/compiler/src/render3/r3_ast';         // t for template AST
 
-import {findNodeAtPosition, isExpressionNode, isTemplateNode} from '../hybrid_visitor';
+import {findNodeAtPosition} from '../hybrid_visitor';
+import {isExpressionNode, isTemplateNode} from '../utils';
 
 interface ParseResult {
   nodes: t.Node[];

--- a/packages/language-service/ivy/test/quick_info_spec.ts
+++ b/packages/language-service/ivy/test/quick_info_spec.ts
@@ -1,0 +1,313 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript/lib/tsserverlibrary';
+
+import {toText} from '../../test/test_utils';
+import {LanguageService} from '../language_service';
+
+import {APP_COMPONENT, setup} from './mock_host';
+
+describe('quick info', () => {
+  const {project, service, tsLS} = setup();
+  const ngLS = new LanguageService(project, tsLS);
+
+  beforeEach(() => {
+    service.reset();
+  });
+
+  describe('elements', () => {
+    it('should work for native elements', () => {
+      expectQuickInfo({
+        templateOverride: `<butt¦on></button>`,
+        expectedSpanText: '<button></button>',
+        expectedDisplayParts: '(element) button: HTMLButtonElement'
+      });
+    });
+  });
+
+  describe('templates', () => {
+    it('should return undefined for ng-templates', () => {
+      const {position} =
+          service.overwriteInlineTemplate(APP_COMPONENT, `<ng-templ¦ate></ng-template>`);
+      const quickInfo = ngLS.getQuickInfoAtPosition(APP_COMPONENT, position);
+      expect(quickInfo).toBeUndefined();
+    });
+  });
+
+  describe('directives', () => {
+    it('should work for directives', () => {
+      expectQuickInfo({
+        templateOverride: `<div string-model¦></div>`,
+        expectedSpanText: 'string-model',
+        // TODO(atscott): Find a way to include the module
+        // expectedDisplayParts: '(directive) AppModule.StringModel: typeof StringModel'
+        expectedDisplayParts: '(directive) StringModel'
+      });
+    });
+
+    it('should work for components', () => {
+      const {documentation} = expectQuickInfo({
+        templateOverride: `<t¦est-comp></test-comp>`,
+        expectedSpanText: '<test-comp></test-comp>',
+        // TODO(atscott): Find a way to include the module
+        // expectedDisplayParts: '(component) AppModule.TestComponent'
+        expectedDisplayParts: '(component) TestComponent'
+      });
+      expect(toText(documentation)).toBe('This Component provides the `test-comp` selector.');
+    });
+
+    it('should work for structural directives', () => {
+      const {documentation} = expectQuickInfo({
+        templateOverride: `<div *¦ngFor="let item of heroes"></div>`,
+        expectedSpanText: 'ngFor',
+        expectedDisplayParts: '(directive) NgForOf<Hero, Array<Hero>>'
+      });
+      expect(toText(documentation))
+          .toContain('A [structural directive](guide/structural-directives) that renders');
+    });
+
+    it('should work for directives with compound selectors, some of which are bindings', () => {
+      expectQuickInfo({
+        templateOverride: `<ng-template ngF¦or let-item [ngForOf]="items">{{item}}</ng-template>`,
+        expectedSpanText: 'ngFor',
+        expectedDisplayParts: '(directive) NgForOf<any, any>'
+      });
+    });
+  });
+
+  describe('bindings', () => {
+    describe('inputs', () => {
+      it('should work for input providers', () => {
+        expectQuickInfo({
+          templateOverride: `<test-comp [tcN¦ame]="name"></test-comp>`,
+          expectedSpanText: 'tcName',
+          expectedDisplayParts: '(property) TestComponent.name: string'
+        });
+      });
+
+      it('should work for structural directive inputs ngForTrackBy', () => {
+        expectQuickInfo({
+          templateOverride: `<div *ngFor="let item of heroes; tr¦ackBy: test;"></div>`,
+          expectedSpanText: 'trackBy',
+          expectedDisplayParts:
+              '(property) NgForOf<Hero, Hero[]>.ngForTrackBy: TrackByFunction<Hero>'
+        });
+      });
+
+      // TODO(atscott): This does not work because of a bug in the hybrid visitor, which returns the
+      // BoundAttribute for the TrackBy
+      xit('should work for structural directive inputs ngForOf', () => {
+        expectQuickInfo({
+          templateOverride: `<div *ngFor="let item o¦f heroes; trackBy: test;"></div>`,
+          expectedSpanText: 'of',
+          expectedDisplayParts:
+              '(property) NgForOf<Hero, Hero[]>.ngForOf: Hero[] | (Hero[] & Iterable<Hero>) | null | undefined'
+        });
+      });
+
+      it('should work for two-way binding providers', () => {
+        expectQuickInfo({
+          templateOverride: `<test-comp string-model [(mo¦del)]="title"></test-comp>`,
+          expectedSpanText: 'model',
+          expectedDisplayParts: '(property) StringModel.model: string'
+        });
+      });
+    });
+
+    describe('outputs', () => {
+      it('should work for event providers', () => {
+        expectQuickInfo({
+          templateOverride: `<test-comp (te¦st)="myClick($event)"></test-comp>`,
+          expectedSpanText: '(test)="myClick($event)"',
+          expectedDisplayParts: '(event) TestComponent.testEvent: EventEmitter<any>'
+        });
+      });
+    });
+  });
+
+  describe('references', () => {
+    it('should work for element reference declarations', () => {
+      const {documentation} = expectQuickInfo({
+        templateOverride: `<div #¦chart></div>`,
+        expectedSpanText: '#chart',
+        expectedDisplayParts: '(local var) chart: HTMLDivElement'
+      });
+      expect(toText(documentation))
+          .toEqual(
+              'Provides special properties (beyond the regular HTMLElement ' +
+              'interface it also has available to it by inheritance) for manipulating <div> elements.');
+    });
+  });
+
+  describe('variables', () => {
+    it('should work for array members', () => {
+      const {documentation} = expectQuickInfo({
+        templateOverride: `<div *ngFor="let hero of heroes">{{her¦o}}</div>`,
+        expectedSpanText: 'hero',
+        expectedDisplayParts: '(variable) hero: Hero'
+      });
+      expect(toText(documentation)).toEqual('The most heroic being.');
+    });
+
+    it('should work for ReadonlyArray members (#36191)', () => {
+      expectQuickInfo({
+        templateOverride: `<div *ngFor="let hero of readonlyHeroes">{{her¦o}}</div>`,
+        expectedSpanText: 'hero',
+        expectedDisplayParts: '(variable) hero: Readonly<Hero>'
+      });
+    });
+
+    it('should work for const array members (#36191)', () => {
+      expectQuickInfo({
+        templateOverride: `<div *ngFor="let name of constNames">{{na¦me}}</div>`,
+        expectedSpanText: 'name',
+        expectedDisplayParts: '(variable) name: { readonly name: "name"; }'
+      });
+    });
+  });
+
+  describe('pipes', () => {
+    it('should work for pipes', () => {
+      const templateOverride = `<p>The hero's birthday is {{birthday | da¦te: "MM/dd/yy"}}</p>`;
+      expectQuickInfo({
+        templateOverride,
+        expectedSpanText: 'date',
+        expectedDisplayParts:
+            '(pipe) DatePipe.transform(value: any, format?: string | undefined, timezone?:' +
+            ' string | undefined, locale?: string | undefined): string | null'
+      });
+    });
+  });
+
+  describe('expressions', () => {
+    it('should find members in a text interpolation', () => {
+      expectQuickInfo({
+        templateOverride: `<div>{{ tit¦le }}</div>`,
+        expectedSpanText: 'title',
+        expectedDisplayParts: '(property) AppComponent.title: string'
+      });
+    });
+
+    it('should work for accessed property reads', () => {
+      expectQuickInfo({
+        templateOverride: `<div>{{title.len¦gth}}</div>`,
+        expectedSpanText: 'length',
+        expectedDisplayParts: '(property) String.length: number'
+      });
+    });
+
+    it('should find members in an attribute interpolation', () => {
+      expectQuickInfo({
+        templateOverride: `<div string-model model="{{tit¦le}}"></div>`,
+        expectedSpanText: 'title',
+        expectedDisplayParts: '(property) AppComponent.title: string'
+      });
+    });
+
+    it('should find members of input binding', () => {
+      expectQuickInfo({
+        templateOverride: `<test-comp [tcName]="ti¦tle"></test-comp>`,
+        expectedSpanText: 'title',
+        expectedDisplayParts: '(property) AppComponent.title: string'
+      });
+    });
+
+    it('should find input binding on text attribute', () => {
+      expectQuickInfo({
+        templateOverride: `<test-comp tcN¦ame="title"></test-comp>`,
+        expectedSpanText: 'tcName="title"',
+        expectedDisplayParts: '(property) TestComponent.name: string'
+      });
+    });
+
+    it('should find members of event binding', () => {
+      expectQuickInfo({
+        templateOverride: `<test-comp (test)="ti¦tle=$event"></test-comp>`,
+        expectedSpanText: 'title',
+        expectedDisplayParts: '(property) AppComponent.title: string'
+      });
+    });
+
+    it('should work for method calls', () => {
+      expectQuickInfo({
+        templateOverride: `<div (click)="setT¦itle('title')"></div>`,
+        expectedSpanText: 'setTitle',
+        expectedDisplayParts: '(method) AppComponent.setTitle(newTitle: string): void'
+      });
+    });
+
+    it('should work for accessed properties in writes', () => {
+      expectQuickInfo({
+        templateOverride: `<div (click)="hero.i¦d = 2"></div>`,
+        expectedSpanText: 'id',
+        expectedDisplayParts: '(property) Hero.id: number'
+      });
+    });
+
+    it('should work for method call arguments', () => {
+      expectQuickInfo({
+        templateOverride: `<div (click)="setTitle(hero.nam¦e)"></div>`,
+        expectedSpanText: 'name',
+        expectedDisplayParts: '(property) Hero.name: string'
+      });
+    });
+
+    it('should find members of two-way binding', () => {
+      expectQuickInfo({
+        templateOverride: `<input [(ngModel)]="ti¦tle" />`,
+        expectedSpanText: 'title',
+        expectedDisplayParts: '(property) AppComponent.title: string'
+      });
+    });
+
+    it('should find members in a structural directive', () => {
+      expectQuickInfo({
+        templateOverride: `<div *ngIf="anyV¦alue"></div>`,
+        expectedSpanText: 'anyValue',
+        expectedDisplayParts: '(property) AppComponent.anyValue: any'
+      });
+    });
+
+    it('should work for members in structural directives', () => {
+      expectQuickInfo({
+        templateOverride: `<div *ngFor="let item of her¦oes; trackBy: test;"></div>`,
+        expectedSpanText: 'heroes',
+        expectedDisplayParts: '(property) AppComponent.heroes: Hero[]'
+      });
+    });
+
+    it('should work for the $any() cast function', () => {
+      expectQuickInfo({
+        templateOverride: `<div>{{$an¦y(title)}}</div>`,
+        expectedSpanText: '$any',
+        expectedDisplayParts: '(method) $any: any'
+      });
+    });
+
+    it('should provide documentation', () => {
+      const {position} = service.overwriteInlineTemplate(APP_COMPONENT, `<div>{{¦title}}</div>`);
+      const quickInfo = ngLS.getQuickInfoAtPosition(APP_COMPONENT, position);
+      const documentation = toText(quickInfo!.documentation);
+      expect(documentation).toBe('This is the title of the `AppComponent` Component.');
+    });
+  });
+
+  function expectQuickInfo(
+      {templateOverride, expectedSpanText, expectedDisplayParts}:
+          {templateOverride: string, expectedSpanText: string, expectedDisplayParts: string}):
+      ts.QuickInfo {
+    const {position, text} = service.overwriteInlineTemplate(APP_COMPONENT, templateOverride);
+    const quickInfo = ngLS.getQuickInfoAtPosition(APP_COMPONENT, position);
+    expect(quickInfo).toBeTruthy();
+    const {textSpan, displayParts} = quickInfo!;
+    expect(text.substr(textSpan.start, textSpan.length)).toEqual(expectedSpanText);
+    expect(toText(displayParts)).toEqual(expectedDisplayParts);
+    return quickInfo!;
+  }
+});

--- a/packages/language-service/ivy/ts_plugin.ts
+++ b/packages/language-service/ivy/ts_plugin.ts
@@ -24,8 +24,13 @@ export function create(info: ts.server.PluginCreateInfo): ts.LanguageService {
     return diagnostics;
   }
 
+  function getQuickInfoAtPosition(fileName: string, position: number): ts.QuickInfo|undefined {
+    return ngLS.getQuickInfoAtPosition(fileName, position);
+  }
+
   return {
     ...tsLS,
     getSemanticDiagnostics,
+    getQuickInfoAtPosition,
   };
 }

--- a/packages/language-service/ivy/utils.ts
+++ b/packages/language-service/ivy/utils.ts
@@ -1,0 +1,178 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {AbsoluteSourceSpan, AST, BindingPipe, CssSelector, MethodCall, ParseSourceSpan, PropertyRead, PropertyWrite, SelectorMatcher, TmplAstBoundAttribute, TmplAstElement, TmplAstNode, TmplAstTemplate, TmplAstTextAttribute, TmplAstVariable,} from '@angular/compiler';
+import {DirectiveSymbol, TemplateTypeChecker} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
+import * as e from '@angular/compiler/src/expression_parser/ast';
+import * as t from '@angular/compiler/src/render3/r3_ast';
+import {ALIAS_NAME, SYMBOL_PUNC} from '@angular/language-service/src/hover';
+import * as ts from 'typescript';
+
+/**
+ * Given a list of directives and a text to use as a selector, returns the directives which match
+ * for the selector.
+ */
+export function getDirectiveMatches(
+    directives: DirectiveSymbol[], selector: string): DirectiveSymbol[] {
+  const selectorToMatch = CssSelector.parse(selector);
+  if (selectorToMatch.length === 0) {
+    return [];
+  }
+  return directives.filter((dir: DirectiveSymbol) => {
+    if (dir.selector === null) {
+      return false;
+    }
+
+    const matcher = new SelectorMatcher();
+    matcher.addSelectables(CssSelector.parse(dir.selector));
+
+    return matcher.match(selectorToMatch[0], null);
+  });
+}
+
+export function getTextSpanOfNode(node: TmplAstNode|AST) {
+  if (isTemplateNode(node)) {
+    const spanToUse = (node instanceof TmplAstBoundAttribute || node instanceof TmplAstVariable) ?
+        node.keySpan :
+        node.sourceSpan;
+    return toTextSpan(spanToUse);
+  } else if (
+      node instanceof PropertyWrite || node instanceof MethodCall || node instanceof BindingPipe ||
+      node instanceof PropertyRead) {
+    // The `name` part of a `PropertyWrite`, `MethodCall`, and `BindingPipe` does not
+    // have its own AST so there is no way to retrieve a `Symbol` for just the `name` via a specific
+    // node.
+    return toTextSpan(node.nameSpan);
+  } else {
+    return toTextSpan(node.sourceSpan);
+  }
+}
+
+export function toTextSpan(span: AbsoluteSourceSpan|ParseSourceSpan) {
+  let start: number, end: number;
+  if (span instanceof AbsoluteSourceSpan) {
+    start = span.start;
+    end = span.end;
+  } else {
+    start = span.start.offset;
+    end = span.end.offset;
+  }
+  return {start, length: end - start};
+}
+
+interface NodeWithKeyAndValue extends t.Node {
+  keySpan: ParseSourceSpan;
+  valueSpan?: ParseSourceSpan;
+}
+
+export function isTemplateNodeWithKeyAndValue(node: t.Node|e.AST): node is NodeWithKeyAndValue {
+  return isTemplateNode(node) && node.hasOwnProperty('keySpan');
+}
+
+export function isTemplateNode(node: TmplAstNode|AST): node is TmplAstNode {
+  // Template node implements the Node interface so we cannot use instanceof.
+  return node.sourceSpan instanceof ParseSourceSpan;
+}
+
+export function isExpressionNode(node: t.Node|e.AST): node is e.AST {
+  return node instanceof e.AST;
+}
+
+/**
+ * Retrieves the `ts.ClassDeclaration` at a location along with its template nodes.
+ */
+export function getTemplateInfoAtPosition(
+    fileName: string, position: number, program: ts.Program,
+    templateTypeChecker: TemplateTypeChecker):
+    {template: TmplAstNode[], component: ts.ClassDeclaration}|undefined {
+  if (fileName.endsWith('.ts')) {
+    return getInlineTemplateInfoAtPosition(fileName, position, program, templateTypeChecker);
+  } else {
+    throw new Error('Ivy LS currently does not support external templates.');
+  }
+}
+
+/**
+ * Retrieves the `ts.ClassDeclaration` at a location along with its template nodes.
+ */
+function getInlineTemplateInfoAtPosition(
+    fileName: string, position: number, program: ts.Program,
+    templateTypeChecker: TemplateTypeChecker):
+    {template: TmplAstNode[], component: ts.ClassDeclaration}|undefined {
+  const sourceFile = program.getSourceFile(fileName);
+  if (!sourceFile) {
+    return undefined;
+  }
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isClassDeclaration(statement) || position < statement.pos || position > statement.end) {
+      continue;
+    }
+
+    const template = templateTypeChecker.getTemplate(statement);
+    if (template === null) {
+      return undefined;
+    }
+
+    return {template, component: statement};
+  }
+
+  return undefined;
+}
+
+/**
+ * Given an attribute name and the element or template the attribute appears on, determines which
+ * directives match because the attribute is present. That is, we find which directives are applied
+ * because of this attribute by elimination: compare the directive matches with the attribute
+ * present against the directive matches without it. The difference would be the directives which
+ * match because the attribute is present.
+ *
+ * @param attribute The attribute name to use for directive matching
+ * @param hostNode The element or template node that the attribute is on
+ * @param directives The list of directives to match against
+ */
+export function getDirectiveMatchesForAttribute(
+    attribute: string, hostNode: TmplAstTemplate|TmplAstElement, directives: DirectiveSymbol[]) {
+  let attributes: Array<TmplAstTextAttribute|TmplAstBoundAttribute> =
+      [...hostNode.attributes, ...hostNode.inputs];
+  if (hostNode instanceof TmplAstTemplate) {
+    attributes = [...attributes, ...hostNode.templateAttrs];
+  }
+  const toAttributeString = (a: TmplAstTextAttribute|TmplAstBoundAttribute) =>
+      `[${a.name}=${a.valueSpan?.toString() ?? ''}]`;
+  const attrs = attributes.map(a => toAttributeString(a));
+  const attrsOmit = attributes.map(a => a.name === attribute ? '' : toAttributeString(a));
+
+  const hostNodeName = hostNode instanceof TmplAstTemplate ? hostNode.tagName : hostNode.name;
+  const directivesWithAttribute = getDirectiveMatches(directives, hostNodeName + attrs.join(''));
+  const directivesWithoutAttribute =
+      getDirectiveMatches(directives, hostNodeName + attrsOmit.join(''));
+  return directivesWithAttribute.filter(d => !directivesWithoutAttribute.some(s => s === d));
+}
+
+/**
+ * Returns a new `ts.SymbolDisplayPart` array which has the alias imports from the tcb filtered
+ * out, i.e. `i0.NgForOf`.
+ */
+export function filterAliasImports(displayParts: ts.SymbolDisplayPart[]) {
+  return displayParts.filter((part, i) => {
+    const tcbAliasImportRegex = /i\d+/;
+    const previousPart = displayParts![i - 1];
+    const nextPart = displayParts![i + 1];
+    const isImportAlias = (p: {kind: string, text: string}) =>
+        p.kind === ALIAS_NAME && p.text.match(tcbAliasImportRegex) !== null;
+    const isDotPunctuation = (p: {kind: string, text: string}) =>
+        p.kind === SYMBOL_PUNC && p.text === '.';
+
+    const aliasNameFollowedByDot =
+        isImportAlias(part) && nextPart !== undefined && isDotPunctuation(nextPart);
+    const dotPrecededByAlias =
+        isDotPunctuation(part) && previousPart !== undefined && isImportAlias(previousPart);
+
+    return !aliasNameFollowedByDot && !dotPrecededByAlias;
+  });
+}

--- a/packages/language-service/src/hover.ts
+++ b/packages/language-service/src/hover.ts
@@ -13,10 +13,11 @@ import * as ng from './types';
 import {inSpan} from './utils';
 
 // Reverse mappings of enum would generate strings
-const SYMBOL_SPACE = ts.SymbolDisplayPartKind[ts.SymbolDisplayPartKind.space];
-const SYMBOL_PUNC = ts.SymbolDisplayPartKind[ts.SymbolDisplayPartKind.punctuation];
-const SYMBOL_TEXT = ts.SymbolDisplayPartKind[ts.SymbolDisplayPartKind.text];
-const SYMBOL_INTERFACE = ts.SymbolDisplayPartKind[ts.SymbolDisplayPartKind.interfaceName];
+export const SYMBOL_SPACE = ts.SymbolDisplayPartKind[ts.SymbolDisplayPartKind.space];
+export const SYMBOL_PUNC = ts.SymbolDisplayPartKind[ts.SymbolDisplayPartKind.punctuation];
+export const SYMBOL_TEXT = ts.SymbolDisplayPartKind[ts.SymbolDisplayPartKind.text];
+export const SYMBOL_INTERFACE = ts.SymbolDisplayPartKind[ts.SymbolDisplayPartKind.interfaceName];
+export const ALIAS_NAME = ts.SymbolDisplayPartKind[ts.SymbolDisplayPartKind.aliasName];
 
 /**
  * Traverse the template AST and look for the symbol located at `position`, then
@@ -80,7 +81,7 @@ export function getTsHover(
  * @param type user-friendly name of the type
  * @param documentation docstring or comment
  */
-function createQuickInfo(
+export function createQuickInfo(
     name: string, kind: string, textSpan: ts.TextSpan, containerName?: string, type?: string,
     documentation?: ts.SymbolDisplayPart[]): ts.QuickInfo {
   const containerDisplayParts = containerName ?

--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
     srcs = [
         "test_utils.ts",
     ],
+    visibility = ["//packages/language-service:__subpackages__"],
     deps = [
         "//packages/compiler",
         "//packages/compiler-cli/test:test_utils",

--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 import {createLanguageService} from '../src/language_service';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 
-import {MockTypescriptHost} from './test_utils';
+import {MockTypescriptHost, toText} from './test_utils';
 
 const TEST_TEMPLATE = '/app/test.ng';
 const PARSING_CASES = '/app/parsing-cases.ts';
@@ -351,7 +351,3 @@ describe('hover', () => {
     });
   });
 });
-
-function toText(displayParts?: ts.SymbolDisplayPart[]): string {
-  return (displayParts || []).map(p => p.text).join('');
-}

--- a/packages/language-service/test/project/app/app.component.ts
+++ b/packages/language-service/test/project/app/app.component.ts
@@ -8,6 +8,7 @@
 
 import {Component} from '@angular/core';
 
+/** The most heroic being. */
 export interface Hero {
   id: number;
   name: string;
@@ -21,9 +22,27 @@ export interface Hero {
   `
 })
 export class AppComponent {
+  /** This is the title of the `AppComponent` Component. */
   title = 'Tour of Heroes';
   hero: Hero = {id: 1, name: 'Windstorm'};
   private internal: string = 'internal';
+  heroP = Promise.resolve(this.hero);
+  heroes: Hero[] = [this.hero];
+  heroesP = Promise.resolve(this.heroes);
+  tupleArray: [string, Hero] = ['test', this.hero];
+  league: Hero[][] = [this.heroes];
+  heroesByName: {[name: string]: Hero} = {};
+  primitiveIndexType: {[name: string]: string} = {};
+  anyValue: any;
+  optional?: string;
+  // Use to test the `index` variable conflict between the `ngFor` and component context.
+  index = null;
+  myClick(event: any) {}
+  birthday = new Date();
+  readonlyHeroes: ReadonlyArray<Readonly<Hero>> = this.heroes;
+  constNames = [{name: 'name'}] as const;
+  private myField = 'My Field';
+  strOrNumber: string|number = '';
   setTitle(newTitle: string) {
     this.title = newTitle;
   }

--- a/packages/language-service/test/project/tsconfig.json
+++ b/packages/language-service/test/project/tsconfig.json
@@ -13,6 +13,7 @@
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true
+    "strictInjectionParameters": true,
+    "strictTemplates": true
   }
 }

--- a/packages/language-service/test/test_utils.ts
+++ b/packages/language-service/test/test_utils.ts
@@ -474,3 +474,7 @@ export function findDirectiveMetadataByName(
     }
   }
 }
+
+export function toText(displayParts?: ts.SymbolDisplayPart[]): string {
+  return (displayParts || []).map(p => p.text).join('');
+}


### PR DESCRIPTION
Support for template that aren't inline depends on #39002. Several microsyntax tests are currently failing and depend on #39036 and follow-up fix to the hybrid visitor to return the correct attribute binding.