### PR TITLE
ci: do not require g3 checks for the changes in `ngtsc/sourcemaps` folder

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -48,6 +48,7 @@ merge:
       - "packages/bazel/src/protractor/**"
       - "packages/bazel/src/schematics/**"
       - "packages/compiler-cli/ngcc/**"
+      - "packages/compiler-cli/src/ngtsc/sourcemaps/**",
       - "packages/docs/**"
       - "packages/elements/schematics/**"
       - "packages/examples/**"


### PR DESCRIPTION
This commit updates ngbot config to avoid requesting google3 presubmit for the changes in
the `packages/compiler-cli/src/ngtsc/sourcemaps` folder (which is not synced into google3).

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No