### PR TITLE
fix(router): update getRouteGuards to check if the context outlet is activated

### DIFF
--- a/packages/router/src/utils/preactivation.ts
+++ b/packages/router/src/utils/preactivation.ts
@@ -121,9 +121,8 @@ function getRouteGuards(
       getChildRouteGuards(futureNode, currNode, parentContexts, futurePath, checks);
     }
 
-    if (shouldRun) {
-      const component = context && context.outlet && context.outlet.component || null;
-      checks.canDeactivateChecks.push(new CanDeactivate(component, curr));
+    if (shouldRun && context && context.outlet && context.outlet.isActivated) {
+      checks.canDeactivateChecks.push(new CanDeactivate(context.outlet.component, curr));
     }
   } else {
     if (curr) {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -3027,6 +3027,13 @@ describe('Integration', () => {
                   resolve: {data: 'resolver'},
                 },
               ]
+            },
+            {
+              path: 'throwing',
+              runGuardsAndResolvers,
+              component: ThrowingCmp,
+              canActivate: ['guard'],
+              resolve: {data: 'resolver'}
             }
           ]);
 
@@ -3125,6 +3132,15 @@ describe('Integration', () => {
              advance(fixture);
              expect(guardRunCount).toEqual(5);
              expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}, {data: 4}]);
+
+             // Issue #39030, always running guards and resolvers should not throw
+             // when navigating away from a component with a throwing constructor.
+             expect(() => {
+               router.navigateByUrl('/throwing').catch(() => {});
+               advance(fixture);
+               router.navigateByUrl('/a;p=1');
+               advance(fixture);
+             }).not.toThrow();
            })));
 
         it('should rerun rerun guards and resolvers when path params change',


### PR DESCRIPTION
In certain circumstances (errors during component constructor) the router outlet may not be activated before redirecting to a new route. If the new route requires running guards and resolvers the current logic will throw when accessing outlet.component due to an isActivated check within the property getter.  This update brings the logic inline with deactivateRouterAndItsChildren, namely checking outlet.isActivated before trying to access outlet.component.

Fixes #39030

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
  - No existing tests for this file
- [ ] Docs have been added / updated (for bug fixes / features)
  - No doc updates are required


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
When navigating to a future route, if the current router outlet is not activated (due to an error during the component constructor) there is a flaw in the runGuardsAndResolvers logic which does not handle an exception thrown in the outlet.component property getter

Issue Number: 39030


## What is the new behavior?
The runGuardsAndResolvers logic properly checks for outlet.isActivated before trying to access the outlet.component property

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
