### PR TITLE
refactor(language-service): create getTypeDefinitionAtPosition stubs

### DIFF
--- a/packages/language-service/ivy/ts_plugin.ts
+++ b/packages/language-service/ivy/ts_plugin.ts
@@ -24,8 +24,13 @@ export function create(info: ts.server.PluginCreateInfo): ts.LanguageService {
     return diagnostics;
   }
 
+  function getTypeDefinitionAtPosition(fileName: string, position: number) {
+    return undefined;
+  }
+
   return {
     ...tsLS,
     getSemanticDiagnostics,
+    getTypeDefinitionAtPosition,
   };
 }

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -110,16 +110,20 @@ export function create(info: tss.server.PluginCreateInfo): tss.LanguageService {
     return ngLS.getDefinitionAndBoundSpan(fileName, position);
   }
 
-  const proxy: tss.LanguageService = Object.assign(
-      // First clone the original TS language service
-      {}, tsLS,
-      // Then override the methods supported by Angular language service
-      {
-        getCompletionsAtPosition,
-        getQuickInfoAtPosition,
-        getSemanticDiagnostics,
-        getDefinitionAtPosition,
-        getDefinitionAndBoundSpan,
-      });
-  return proxy;
+  function getTypeDefinitionAtPosition(fileName: string, position: number) {
+    // Not implemented in VE Language Service
+    return undefined;
+  }
+
+  return {
+    // First clone the original TS language service
+    ...tsLS,
+    // Then override the methods supported by Angular language service
+    getCompletionsAtPosition,
+    getQuickInfoAtPosition,
+    getSemanticDiagnostics,
+    getDefinitionAtPosition,
+    getDefinitionAndBoundSpan,
+    getTypeDefinitionAtPosition,
+  };
 }


### PR DESCRIPTION
Create stubs for getTypeDefinitionAtPosition for both VE and Ivy Language Service implementations.
This will prevent failed requests when it is implemented on the vscode plugin side
