### PR TITLE
fix(language-service): [Ivy] hybrid visitor should not locate let keyword

### DIFF
--- a/packages/language-service/ivy/hybrid_visitor.ts
+++ b/packages/language-service/ivy/hybrid_visitor.ts
@@ -27,9 +27,11 @@ export function findNodeAtPosition(ast: t.Node[], position: number): t.Node|e.AS
   }
   if (isTemplateNodeWithKeyAndValue(candidate)) {
     const {keySpan, valueSpan} = candidate;
-    // If cursor is within source span but not within key span or value span,
-    // do not return the node.
-    if (!isWithin(position, keySpan) && (valueSpan && !isWithin(position, valueSpan))) {
+    const isWithinKeyValue =
+        isWithin(position, keySpan) || (valueSpan && isWithin(position, valueSpan));
+    if (!isWithinKeyValue) {
+      // If cursor is within source span but not within key span or value span,
+      // do not return the node.
       return;
     }
   }

--- a/packages/language-service/ivy/test/hybrid_visitor_spec.ts
+++ b/packages/language-service/ivy/test/hybrid_visitor_spec.ts
@@ -504,8 +504,7 @@ describe('findNodeAtPosition for microsyntax expression', () => {
     const {errors, nodes, position} = parse(`<div *ngFor="l¦et item of items"></div>`);
     expect(errors).toBe(null);
     const node = findNodeAtPosition(nodes, position);
-    // TODO: this is currently wrong because node is currently pointing to
-    // "item". In this case, it should return undefined.
+    expect(node).toBeUndefined();
   });
 
   it('should locate let variable', () => {


### PR DESCRIPTION
Fixed a boolean logic error that prevented hybrid visitor from returning
undefined when a variable does not have value and cursor is not in the
key span.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
