### PR TITLE
ci: remove errant comma from angular robot config

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -48,7 +48,7 @@ merge:
       - "packages/bazel/src/protractor/**"
       - "packages/bazel/src/schematics/**"
       - "packages/compiler-cli/ngcc/**"
-      - "packages/compiler-cli/src/ngtsc/sourcemaps/**",
+      - "packages/compiler-cli/src/ngtsc/sourcemaps/**"
       - "packages/docs/**"
       - "packages/elements/schematics/**"
       - "packages/examples/**"


### PR DESCRIPTION
Remove superfluous comma from exclude list for g3 status in the angular
robot config.
