### PR TITLE
fix(core): use single quotes for relative link resolution migration to align with style guide

### DIFF
--- a/packages/core/schematics/migrations/relative-link-resolution/transform.ts
+++ b/packages/core/schematics/migrations/relative-link-resolution/transform.ts
@@ -44,8 +44,8 @@ export class RelativeLinkResolutionTransform {
       // literal already defines a value for relativeLinkResolution. Skip it
       return literal;
     }
-    const legacyExpression =
-        ts.createPropertyAssignment(RELATIVE_LINK_RESOLUTION, ts.createStringLiteral('legacy'));
+    const legacyExpression = ts.createPropertyAssignment(
+        RELATIVE_LINK_RESOLUTION, ts.createStringLiteral('legacy', true /* singleQuotes */));
     return ts.updateObjectLiteral(literal, [...literal.properties, legacyExpression]);
   }
 

--- a/packages/core/schematics/test/google3/relative_link_resolution_default_spec.ts
+++ b/packages/core/schematics/test/google3/relative_link_resolution_default_spec.ts
@@ -85,7 +85,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
 
     runTSLint(true);
     expect(getFile('/index.ts'))
-        .toContain(`RouterModule.forRoot([], { relativeLinkResolution: "legacy" })`);
+        .toContain(`RouterModule.forRoot([], { relativeLinkResolution: 'legacy' })`);
   });
 
   it('should migrate options without relativeLinkResolution', () => {
@@ -103,7 +103,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
 
     runTSLint(true);
     expect(getFile('/index.ts'))
-        .toContain(`RouterModule.forRoot([], { useHash: true, relativeLinkResolution: "legacy" })`);
+        .toContain(`RouterModule.forRoot([], { useHash: true, relativeLinkResolution: 'legacy' })`);
   });
 
   it('should not migrate options containing relativeLinkResolution', () => {
@@ -133,7 +133,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
     runTSLint(true);
     expect(getFile('/index.ts'))
         .toContain(
-            `const options = { useHash: true, relativeLinkResolution: "legacy" } as ExtraOptions;`);
+            `const options = { useHash: true, relativeLinkResolution: 'legacy' } as ExtraOptions;`);
   });
 
   it('should migrate when options is a variable', () => {
@@ -145,7 +145,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
     runTSLint(true);
     expect(getFile('/index.ts'))
         .toContain(
-            `const options: ExtraOptions = { useHash: true, relativeLinkResolution: "legacy" };`);
+            `const options: ExtraOptions = { useHash: true, relativeLinkResolution: 'legacy' };`);
   });
 
   it('should migrate when options is a variable with no type', () => {
@@ -166,7 +166,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
 
     runTSLint(true);
     expect(getFile('/index.ts'))
-        .toContain(`const options = { useHash: true, relativeLinkResolution: "legacy" };`);
+        .toContain(`const options = { useHash: true, relativeLinkResolution: 'legacy' };`);
     expect(getFile('/index.ts')).toContain(`RouterModule.forRoot([], options)`);
   });
 
@@ -179,7 +179,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
     runTSLint(true);
     expect(getFile('/index.ts'))
         .toContain(
-            `const options: RouterExtraOptions = { useHash: true, relativeLinkResolution: "legacy" };`);
+            `const options: RouterExtraOptions = { useHash: true, relativeLinkResolution: 'legacy' };`);
   });
 
   it('should migrate aliased RouterModule.forRoot', () => {
@@ -197,6 +197,6 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
 
     runTSLint(true);
     expect(getFile('/index.ts'))
-        .toContain(`AngularRouterModule.forRoot([], { relativeLinkResolution: "legacy" }),`);
+        .toContain(`AngularRouterModule.forRoot([], { relativeLinkResolution: 'legacy' }),`);
   });
 });

--- a/packages/core/schematics/test/relative_link_resolution_spec.ts
+++ b/packages/core/schematics/test/relative_link_resolution_spec.ts
@@ -61,7 +61,7 @@ describe('initial navigation migration', () => {
 
     await runMigration();
     expect(tree.readContent('/index.ts'))
-        .toContain(`RouterModule.forRoot([], { relativeLinkResolution: "legacy" })`);
+        .toContain(`RouterModule.forRoot([], { relativeLinkResolution: 'legacy' })`);
   });
 
   it('should migrate options without relativeLinkResolution', async () => {
@@ -79,7 +79,7 @@ describe('initial navigation migration', () => {
 
     await runMigration();
     expect(tree.readContent('/index.ts'))
-        .toContain(`RouterModule.forRoot([], { useHash: true, relativeLinkResolution: "legacy" })`);
+        .toContain(`RouterModule.forRoot([], { useHash: true, relativeLinkResolution: 'legacy' })`);
   });
 
   it('should not migrate options containing relativeLinkResolution', async () => {
@@ -109,7 +109,7 @@ describe('initial navigation migration', () => {
     await runMigration();
     expect(tree.readContent('/index.ts'))
         .toContain(
-            `const options = { useHash: true, relativeLinkResolution: "legacy" } as ExtraOptions;`);
+            `const options = { useHash: true, relativeLinkResolution: 'legacy' } as ExtraOptions;`);
   });
 
   it('should migrate when options is a variable', async () => {
@@ -121,7 +121,7 @@ describe('initial navigation migration', () => {
     await runMigration();
     expect(tree.readContent('/index.ts'))
         .toContain(
-            `const options: ExtraOptions = { useHash: true, relativeLinkResolution: "legacy" };`);
+            `const options: ExtraOptions = { useHash: true, relativeLinkResolution: 'legacy' };`);
   });
 
   it('should migrate when options is a variable with no type', async () => {
@@ -142,7 +142,7 @@ describe('initial navigation migration', () => {
 
     await runMigration();
     expect(tree.readContent('/index.ts'))
-        .toContain(`const options = { useHash: true, relativeLinkResolution: "legacy" };`);
+        .toContain(`const options = { useHash: true, relativeLinkResolution: 'legacy' };`);
     expect(tree.readContent('/index.ts')).toContain(`RouterModule.forRoot([], options)`);
   });
 
@@ -155,7 +155,7 @@ describe('initial navigation migration', () => {
     await runMigration();
     expect(tree.readContent('/index.ts'))
         .toContain(
-            `const options: RouterExtraOptions = { useHash: true, relativeLinkResolution: "legacy" };`);
+            `const options: RouterExtraOptions = { useHash: true, relativeLinkResolution: 'legacy' };`);
   });
 
   it('should migrate aliased RouterModule.forRoot', async () => {
@@ -173,7 +173,7 @@ describe('initial navigation migration', () => {
 
     await runMigration();
     expect(tree.readContent('/index.ts'))
-        .toContain(`AngularRouterModule.forRoot([], { relativeLinkResolution: "legacy" }),`);
+        .toContain(`AngularRouterModule.forRoot([], { relativeLinkResolution: 'legacy' }),`);
   });
 
   function writeFile(filePath: string, contents: string) {


### PR DESCRIPTION
This updates the migration to align with the style guide and work with default lint rules. It avoids a lint error on
newly migrated projects and fixes a test in the CLI repo.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix


## What is the current behavior?
Projects using the link resolution migration generate code using double quotes, when the default style guide is to use single quotes. This causes unnecessary lint errors in projects.

Issue Number: N/A


## What is the new behavior?
The migration now generates single quotes instead of double quotes.

## Does this PR introduce a breaking change?

- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
