### PR TITLE
feat(dev-infra): add a command to verify NgBot YAML config syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,6 +273,7 @@ jobs:
       - run: yarn -s ng-dev format changed $CI_GIT_BASE_REVISION --check
       - run: yarn -s ts-circular-deps:check
       - run: yarn -s ng-dev pullapprove verify
+      - run: yarn -s ng-dev ngbot verify
       - run: yarn -s ng-dev commit-message validate-range --range $CI_COMMIT_RANGE
 
   test:

--- a/dev-infra/BUILD.bazel
+++ b/dev-infra/BUILD.bazel
@@ -11,6 +11,7 @@ ts_library(
         "//dev-infra/caretaker",
         "//dev-infra/commit-message",
         "//dev-infra/format",
+        "//dev-infra/ngbot",
         "//dev-infra/pr",
         "//dev-infra/pullapprove",
         "//dev-infra/release",

--- a/dev-infra/cli.ts
+++ b/dev-infra/cli.ts
@@ -28,7 +28,7 @@ yargs.scriptName('ng-dev')
     .command('release <command>', '', buildReleaseParser)
     .command('ts-circular-deps <command>', '', tsCircularDependenciesBuilder)
     .command('caretaker <command>', '', buildCaretakerParser)
-    .command('ngbot <command>', '', buildNgbotParser)
+    .command('ngbot <command>', false, buildNgbotParser)
     .wrap(120)
     .strict()
     .parse();

--- a/dev-infra/cli.ts
+++ b/dev-infra/cli.ts
@@ -15,6 +15,7 @@ import {buildReleaseParser} from './release/cli';
 import {buildPrParser} from './pr/cli';
 import {captureLogOutputForCommand} from './utils/console';
 import {buildCaretakerParser} from './caretaker/cli';
+import {buildNgbotParser} from './ngbot/cli';
 
 yargs.scriptName('ng-dev')
     .middleware(captureLogOutputForCommand)
@@ -27,6 +28,7 @@ yargs.scriptName('ng-dev')
     .command('release <command>', '', buildReleaseParser)
     .command('ts-circular-deps <command>', '', tsCircularDependenciesBuilder)
     .command('caretaker <command>', '', buildCaretakerParser)
+    .command('ngbot <command>', '', buildNgbotParser)
     .wrap(120)
     .strict()
     .parse();

--- a/dev-infra/ngbot/BUILD.bazel
+++ b/dev-infra/ngbot/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
+
+ts_library(
+    name = "ngbot",
+    srcs = [
+        "cli.ts",
+        "verify.ts",
+    ],
+    module_name = "@angular/dev-infra-private/ngbot",
+    visibility = ["//dev-infra:__subpackages__"],
+    deps = [
+        "//dev-infra/utils",
+        "@npm//@types/node",
+        "@npm//@types/yaml",
+        "@npm//@types/yargs",
+        "@npm//yaml",
+        "@npm//yargs",
+    ],
+)

--- a/dev-infra/ngbot/cli.ts
+++ b/dev-infra/ngbot/cli.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as yargs from 'yargs';
+import {verify} from './verify';
+
+/** Build the parser for the NgBot commands. */
+export function buildNgbotParser(localYargs: yargs.Argv) {
+  return localYargs.help().strict().demandCommand().command(
+      'verify', 'Verify the NgBot config', {}, () => verify());
+}
+
+if (require.main === module) {
+  buildNgbotParser(yargs).parse();
+}

--- a/dev-infra/ngbot/verify.ts
+++ b/dev-infra/ngbot/verify.ts
@@ -10,7 +10,7 @@ import {resolve} from 'path';
 import {parse as parseYaml} from 'yaml';
 
 import {getRepoBaseDir} from '../utils/config';
-import {error, info} from '../utils/console';
+import {error, green, info, red} from '../utils/console';
 
 export function verify() {
   /** Full path to NgBot config file */
@@ -22,9 +22,10 @@ export function verify() {
   try {
     // Try parsing the config file to verify that the syntax is correct.
     parseYaml(ngBotYaml);
-    info('NgBot YAML config is valid');
+    info(`${green('√')}  Valid NgBot YAML config`);
   } catch (e) {
+    error(`${red('!')} Invalid NgBot YAML config`);
     error(e);
-    process.exit(1);
+    process.exitCode = 1;
   }
 }

--- a/dev-infra/ngbot/verify.ts
+++ b/dev-infra/ngbot/verify.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {readFileSync} from 'fs';
+import {resolve} from 'path';
+import {parse as parseYaml} from 'yaml';
+
+import {getRepoBaseDir} from '../utils/config';
+import {error, info} from '../utils/console';
+
+export function verify() {
+  /** Full path to NgBot config file */
+  const NGBOT_CONFIG_YAML_PATH = resolve(getRepoBaseDir(), '.github/angular-robot.yml');
+
+  /** The pull approve config file. */
+  const ngBotYaml = readFileSync(NGBOT_CONFIG_YAML_PATH, 'utf8');
+
+  try {
+    // Try parsing the config file to verify that the syntax is correct.
+    parseYaml(ngBotYaml);
+    info('NgBot YAML config is valid');
+  } catch (e) {
+    error(e);
+    process.exit(1);
+  }
+}

--- a/dev-infra/ngbot/verify.ts
+++ b/dev-infra/ngbot/verify.ts
@@ -16,7 +16,7 @@ export function verify() {
   /** Full path to NgBot config file */
   const NGBOT_CONFIG_YAML_PATH = resolve(getRepoBaseDir(), '.github/angular-robot.yml');
 
-  /** The pull approve config file. */
+  /** The NgBot config file */
   const ngBotYaml = readFileSync(NGBOT_CONFIG_YAML_PATH, 'utf8');
 
   try {


### PR DESCRIPTION
This commit adds a new command to the `ng-dev` suite, which verifies that the NgBot YAML config is
correct. It also adds this command to the `lint` CircleCI job so that we execute this check while
running CI.

This should help prevent syntax errors similar to the one introduced in:
https://github.com/angular/angular/commit/393ce5574b76ad1344554a6aa9e2e8a6c3591ac9

## PR Type
What kind of change does this PR introduce?

- [x] Feature


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No