### PR TITLE
ci: update to latest version of sauce-connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "nock": "^13.0.3",
     "ora": "^5.0.0",
     "rewire": "2.5.2",
-    "sauce-connect": "https://saucelabs.com/downloads/sc-4.5.1-linux.tar.gz",
+    "sauce-connect": "https://saucelabs.com/downloads/sc-4.6.2-linux.tar.gz",
     "semver": "^6.3.0",
     "ts-node": "^8.6.2",
     "tslint-eslint-rules": "5.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13553,9 +13553,9 @@ sauce-connect-launcher@^1.2.4:
     lodash "^4.16.6"
     rimraf "^2.5.4"
 
-"sauce-connect@https://saucelabs.com/downloads/sc-4.5.1-linux.tar.gz":
+"sauce-connect@https://saucelabs.com/downloads/sc-4.6.2-linux.tar.gz":
   version "0.0.0"
-  resolved "https://saucelabs.com/downloads/sc-4.5.1-linux.tar.gz#5ca9328724c5ff16b12ea49e7a748d44f7305be5"
+  resolved "https://saucelabs.com/downloads/sc-4.6.2-linux.tar.gz#7b7f35433af9c3380758e048894d7b9aecf3754e"
 
 saucelabs@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
Update to the latest version of sauce-connect, 4.6.2.
