### PR TITLE
refactor:i flag(ignore case) is not needed

### DIFF
--- a/packages/common/upgrade/src/params.ts
+++ b/packages/common/upgrade/src/params.ts
@@ -310,7 +310,7 @@ function toKeyValue(obj: {[k: string]: unknown}) {
  */
 function encodeUriSegment(val: string) {
   return encodeUriQuery(val, true)
-      .replace(/%26/gi, '&')
+      .replace(/%26/g, '&')
       .replace(/%3D/gi, '=')
       .replace(/%2B/gi, '+');
 }
@@ -331,7 +331,7 @@ function encodeUriSegment(val: string) {
  */
 function encodeUriQuery(val: string, pctEncodeSpaces: boolean = false) {
   return encodeURIComponent(val)
-      .replace(/%40/gi, '@')
+      .replace(/%40/g, '@')
       .replace(/%3A/gi, ':')
       .replace(/%24/g, '$')
       .replace(/%2C/gi, ',')

--- a/packages/common/upgrade/src/params.ts
+++ b/packages/common/upgrade/src/params.ts
@@ -309,10 +309,7 @@ function toKeyValue(obj: {[k: string]: unknown}) {
  * Logic from https://github.com/angular/angular.js/blob/864c7f0/src/Angular.js#L1437
  */
 function encodeUriSegment(val: string) {
-  return encodeUriQuery(val, true)
-      .replace(/%26/g, '&')
-      .replace(/%3D/gi, '=')
-      .replace(/%2B/gi, '+');
+  return encodeUriQuery(val, true).replace(/%26/g, '&').replace(/%3D/gi, '=').replace(/%2B/gi, '+');
 }
 
 


### PR DESCRIPTION
This commit removes i flags from regular expressions without any alphabetical characters.

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No