### PR TITLE
docs: remove explicit boolean type definitions in examples as typescript infers it automatically

### DIFF
--- a/packages/examples/common/ngIf/ts/module.ts
+++ b/packages/examples/common/ngIf/ts/module.ts
@@ -22,7 +22,7 @@ import {Subject} from 'rxjs';
 `
 })
 export class NgIfSimple {
-  show: boolean = true;
+  show = true;
 }
 // #enddocregion
 
@@ -38,7 +38,7 @@ export class NgIfSimple {
 `
 })
 export class NgIfElse {
-  show: boolean = true;
+  show = true;
 }
 // #enddocregion
 
@@ -58,7 +58,7 @@ export class NgIfElse {
 })
 export class NgIfThenElse implements OnInit {
   thenBlock: TemplateRef<any>|null = null;
-  show: boolean = true;
+  show = true;
 
   @ViewChild('primaryBlock', {static: true}) primaryBlock: TemplateRef<any>|null = null;
   @ViewChild('secondaryBlock', {static: true}) secondaryBlock: TemplateRef<any>|null = null;


### PR DESCRIPTION


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the `packages/examples/common/ngif/module.ts` file, the field `show` is given an explicit boolean 
type. Since typescript infers boolean type, it is redundant and this commit removes it.

Issue Number: N/A


## What is the new behavior?
Remove the type definition. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
