### PR TITLE
Revert "fix(core): use single quotes for relative link resolution migration to align with style guide (#39070)"

### DIFF
--- a/packages/core/schematics/migrations/relative-link-resolution/transform.ts
+++ b/packages/core/schematics/migrations/relative-link-resolution/transform.ts
@@ -44,8 +44,8 @@ export class RelativeLinkResolutionTransform {
       // literal already defines a value for relativeLinkResolution. Skip it
       return literal;
     }
-    const legacyExpression = ts.createPropertyAssignment(
-        RELATIVE_LINK_RESOLUTION, ts.createStringLiteral('legacy', true /* singleQuotes */));
+    const legacyExpression =
+        ts.createPropertyAssignment(RELATIVE_LINK_RESOLUTION, ts.createStringLiteral('legacy'));
     return ts.updateObjectLiteral(literal, [...literal.properties, legacyExpression]);
   }
 

--- a/packages/core/schematics/test/google3/relative_link_resolution_default_spec.ts
+++ b/packages/core/schematics/test/google3/relative_link_resolution_default_spec.ts
@@ -85,7 +85,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
 
     runTSLint(true);
     expect(getFile('/index.ts'))
-        .toContain(`RouterModule.forRoot([], { relativeLinkResolution: 'legacy' })`);
+        .toContain(`RouterModule.forRoot([], { relativeLinkResolution: "legacy" })`);
   });
 
   it('should migrate options without relativeLinkResolution', () => {
@@ -103,7 +103,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
 
     runTSLint(true);
     expect(getFile('/index.ts'))
-        .toContain(`RouterModule.forRoot([], { useHash: true, relativeLinkResolution: 'legacy' })`);
+        .toContain(`RouterModule.forRoot([], { useHash: true, relativeLinkResolution: "legacy" })`);
   });
 
   it('should not migrate options containing relativeLinkResolution', () => {
@@ -133,7 +133,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
     runTSLint(true);
     expect(getFile('/index.ts'))
         .toContain(
-            `const options = { useHash: true, relativeLinkResolution: 'legacy' } as ExtraOptions;`);
+            `const options = { useHash: true, relativeLinkResolution: "legacy" } as ExtraOptions;`);
   });
 
   it('should migrate when options is a variable', () => {
@@ -145,7 +145,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
     runTSLint(true);
     expect(getFile('/index.ts'))
         .toContain(
-            `const options: ExtraOptions = { useHash: true, relativeLinkResolution: 'legacy' };`);
+            `const options: ExtraOptions = { useHash: true, relativeLinkResolution: "legacy" };`);
   });
 
   it('should migrate when options is a variable with no type', () => {
@@ -166,7 +166,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
 
     runTSLint(true);
     expect(getFile('/index.ts'))
-        .toContain(`const options = { useHash: true, relativeLinkResolution: 'legacy' };`);
+        .toContain(`const options = { useHash: true, relativeLinkResolution: "legacy" };`);
     expect(getFile('/index.ts')).toContain(`RouterModule.forRoot([], options)`);
   });
 
@@ -179,7 +179,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
     runTSLint(true);
     expect(getFile('/index.ts'))
         .toContain(
-            `const options: RouterExtraOptions = { useHash: true, relativeLinkResolution: 'legacy' };`);
+            `const options: RouterExtraOptions = { useHash: true, relativeLinkResolution: "legacy" };`);
   });
 
   it('should migrate aliased RouterModule.forRoot', () => {
@@ -197,6 +197,6 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
 
     runTSLint(true);
     expect(getFile('/index.ts'))
-        .toContain(`AngularRouterModule.forRoot([], { relativeLinkResolution: 'legacy' }),`);
+        .toContain(`AngularRouterModule.forRoot([], { relativeLinkResolution: "legacy" }),`);
   });
 });

--- a/packages/core/schematics/test/relative_link_resolution_spec.ts
+++ b/packages/core/schematics/test/relative_link_resolution_spec.ts
@@ -61,7 +61,7 @@ describe('initial navigation migration', () => {
 
     await runMigration();
     expect(tree.readContent('/index.ts'))
-        .toContain(`RouterModule.forRoot([], { relativeLinkResolution: 'legacy' })`);
+        .toContain(`RouterModule.forRoot([], { relativeLinkResolution: "legacy" })`);
   });
 
   it('should migrate options without relativeLinkResolution', async () => {
@@ -79,7 +79,7 @@ describe('initial navigation migration', () => {
 
     await runMigration();
     expect(tree.readContent('/index.ts'))
-        .toContain(`RouterModule.forRoot([], { useHash: true, relativeLinkResolution: 'legacy' })`);
+        .toContain(`RouterModule.forRoot([], { useHash: true, relativeLinkResolution: "legacy" })`);
   });
 
   it('should not migrate options containing relativeLinkResolution', async () => {
@@ -109,7 +109,7 @@ describe('initial navigation migration', () => {
     await runMigration();
     expect(tree.readContent('/index.ts'))
         .toContain(
-            `const options = { useHash: true, relativeLinkResolution: 'legacy' } as ExtraOptions;`);
+            `const options = { useHash: true, relativeLinkResolution: "legacy" } as ExtraOptions;`);
   });
 
   it('should migrate when options is a variable', async () => {
@@ -121,7 +121,7 @@ describe('initial navigation migration', () => {
     await runMigration();
     expect(tree.readContent('/index.ts'))
         .toContain(
-            `const options: ExtraOptions = { useHash: true, relativeLinkResolution: 'legacy' };`);
+            `const options: ExtraOptions = { useHash: true, relativeLinkResolution: "legacy" };`);
   });
 
   it('should migrate when options is a variable with no type', async () => {
@@ -142,7 +142,7 @@ describe('initial navigation migration', () => {
 
     await runMigration();
     expect(tree.readContent('/index.ts'))
-        .toContain(`const options = { useHash: true, relativeLinkResolution: 'legacy' };`);
+        .toContain(`const options = { useHash: true, relativeLinkResolution: "legacy" };`);
     expect(tree.readContent('/index.ts')).toContain(`RouterModule.forRoot([], options)`);
   });
 
@@ -155,7 +155,7 @@ describe('initial navigation migration', () => {
     await runMigration();
     expect(tree.readContent('/index.ts'))
         .toContain(
-            `const options: RouterExtraOptions = { useHash: true, relativeLinkResolution: 'legacy' };`);
+            `const options: RouterExtraOptions = { useHash: true, relativeLinkResolution: "legacy" };`);
   });
 
   it('should migrate aliased RouterModule.forRoot', async () => {
@@ -173,7 +173,7 @@ describe('initial navigation migration', () => {
 
     await runMigration();
     expect(tree.readContent('/index.ts'))
-        .toContain(`AngularRouterModule.forRoot([], { relativeLinkResolution: 'legacy' }),`);
+        .toContain(`AngularRouterModule.forRoot([], { relativeLinkResolution: "legacy" }),`);
   });
 
   function writeFile(filePath: string, contents: string) {


### PR DESCRIPTION


This reverts commit 889470663d2bcb82e8018996c7a751635491ebe7.

This is unable to cleanly land in google3 at this time.