### PR TITLE
docs: remove IE9-10 from `.browserslistrc` in docs

### DIFF
--- a/aio/content/guide/deployment.md
+++ b/aio/content/guide/deployment.md
@@ -530,7 +530,7 @@ last 2 Edge major versions
 last 2 Safari major versions
 last 2 iOS major versions
 Firefox ESR
-not IE 9-11 # For IE 9-11 support, remove 'not'.
+not IE 11 # Angular supports IE 11 only as an opt-in. To opt-in, remove the 'not' prefix on this line.
 </code-example>
 
 <code-example language="json" header="tsconfig.json">


### PR DESCRIPTION
Remove IE9-10 from docs `.browserslistrc` since in v11 support for this was removed.
