### PR TITLE
refactor: remove code specific to IE 9 and IE 10 support

### DIFF
--- a/aio/src/polyfills.ts
+++ b/aio/src/polyfills.ts
@@ -18,7 +18,7 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+/** IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**

--- a/aio/src/testing/dom-utils.ts
+++ b/aio/src/testing/dom-utils.ts
@@ -5,7 +5,7 @@ export function createCustomEvent(doc: Document, name: string, detail: any): Cus
   const bubbles = false;
   const cancelable = false;
 
-  // On IE9-11, `CustomEvent` is not a constructor.
+  // On IE11, `CustomEvent` is not a constructor.
   if (typeof CustomEvent !== 'function') {
     const event = doc.createEvent('CustomEvent');
     event.initCustomEvent(name, bubbles, cancelable, detail);

--- a/aio/tools/examples/shared/boilerplate/cli/.browserslistrc
+++ b/aio/tools/examples/shared/boilerplate/cli/.browserslistrc
@@ -14,5 +14,4 @@ last 2 Edge major versions
 last 2 Safari major versions
 last 2 iOS major versions
 Firefox ESR
-not IE 9-10 # Angular support for IE 9-10 has been deprecated and will be removed as of Angular v11. To opt-in, remove the 'not' prefix on this line.
 not IE 11 # Angular supports IE 11 only as an opt-in. To opt-in, remove the 'not' prefix on this line.

--- a/aio/tools/examples/shared/boilerplate/cli/src/polyfills.ts
+++ b/aio/tools/examples/shared/boilerplate/cli/src/polyfills.ts
@@ -18,7 +18,7 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+/** IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**

--- a/aio/tools/examples/shared/boilerplate/elements/src/polyfills.ts
+++ b/aio/tools/examples/shared/boilerplate/elements/src/polyfills.ts
@@ -18,7 +18,7 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+/** IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**

--- a/aio/tools/examples/shared/boilerplate/i18n/src/polyfills.ts
+++ b/aio/tools/examples/shared/boilerplate/i18n/src/polyfills.ts
@@ -22,7 +22,7 @@ import '@angular/localize/init';
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+/** IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 140709,
+        "main-es2015": 140199,
         "polyfills-es2015": 36571
       }
     }

--- a/integration/cli-hello-world-ivy-compat/browserslist
+++ b/integration/cli-hello-world-ivy-compat/browserslist
@@ -9,4 +9,4 @@
 last 2 versions
 Firefox ESR
 not dead
-not IE 9-11 # For IE 9-11 support, remove 'not'.
+not IE 11 # For IE 11 support, remove 'not'.

--- a/integration/cli-hello-world-ivy-compat/src/polyfills.ts
+++ b/integration/cli-hello-world-ivy-compat/src/polyfills.ts
@@ -18,7 +18,7 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+/** IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**

--- a/integration/cli-hello-world-ivy-i18n/browserslist
+++ b/integration/cli-hello-world-ivy-i18n/browserslist
@@ -9,4 +9,4 @@
 last 2 versions
 Firefox ESR
 not dead
-not IE 9-11 # For IE 9-11 support, remove 'not'.
+not IE 11 # For IE 11 support, remove 'not'.

--- a/integration/cli-hello-world-ivy-i18n/src/polyfills.ts
+++ b/integration/cli-hello-world-ivy-i18n/src/polyfills.ts
@@ -18,7 +18,7 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+/** IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**

--- a/integration/cli-hello-world-ivy-minimal/browserslist
+++ b/integration/cli-hello-world-ivy-minimal/browserslist
@@ -9,4 +9,4 @@
 last 2 versions
 Firefox ESR
 not dead
-not IE 9-11 # For IE 9-11 support, remove 'not'.
+not IE 11 # For IE 11 support, remove 'not'.

--- a/integration/cli-hello-world-ivy-minimal/src/polyfills.ts
+++ b/integration/cli-hello-world-ivy-minimal/src/polyfills.ts
@@ -18,7 +18,7 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+/** IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**

--- a/integration/cli-hello-world-lazy-rollup/browserslist
+++ b/integration/cli-hello-world-lazy-rollup/browserslist
@@ -9,4 +9,4 @@
 last 2 versions
 Firefox ESR
 not dead
-not IE 9-11 # For IE 9-11 support, remove 'not'.
+not IE 11 # For IE 11 support, remove 'not'.

--- a/integration/cli-hello-world-lazy-rollup/src/polyfills.ts
+++ b/integration/cli-hello-world-lazy-rollup/src/polyfills.ts
@@ -18,7 +18,7 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+/** IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**

--- a/integration/cli-hello-world-lazy/browserslist
+++ b/integration/cli-hello-world-lazy/browserslist
@@ -9,4 +9,4 @@
 last 2 versions
 Firefox ESR
 not dead
-not IE 9-11 # For IE 9-11 support, remove 'not'.
+not IE 11 # For IE 11 support, remove 'not'.

--- a/integration/cli-hello-world-lazy/src/polyfills.ts
+++ b/integration/cli-hello-world-lazy/src/polyfills.ts
@@ -18,7 +18,7 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+/** IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**

--- a/integration/cli-hello-world/browserslist
+++ b/integration/cli-hello-world/browserslist
@@ -9,4 +9,4 @@
 last 2 versions
 Firefox ESR
 not dead
-not IE 9-11 # For IE 9-11 support, remove 'not'.
+not IE 11 # For IE 11 support, remove 'not'.

--- a/integration/cli-hello-world/src/polyfills.ts
+++ b/integration/cli-hello-world/src/polyfills.ts
@@ -18,7 +18,7 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+/** IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**

--- a/integration/ivy-i18n/browserslist
+++ b/integration/ivy-i18n/browserslist
@@ -9,4 +9,4 @@
 last 2 versions
 Firefox ESR
 not dead
-not IE 9-11 # For IE 9-11 support, remove 'not'.
+not IE 11 # For IE 11 support, remove 'not'.

--- a/integration/ivy-i18n/src/polyfills-runtime.ts
+++ b/integration/ivy-i18n/src/polyfills-runtime.ts
@@ -18,7 +18,7 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+/** IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**

--- a/integration/ivy-i18n/src/polyfills.ts
+++ b/integration/ivy-i18n/src/polyfills.ts
@@ -18,7 +18,7 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+/** IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**

--- a/integration/ng_update_migrations/browserslist
+++ b/integration/ng_update_migrations/browserslist
@@ -9,5 +9,5 @@
 last 2 versions
 Firefox ESR
 not dead
-not IE 9-11 # For IE 9-11 support, remove 'not'.
+not IE 11 # For IE 11 support, remove 'not'.
 not Chrome 41 # For Googlebot support, remove 'not'.

--- a/integration/ng_update_migrations/src/polyfills.ts
+++ b/integration/ng_update_migrations/src/polyfills.ts
@@ -18,7 +18,7 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+/** IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**

--- a/packages/animations/browser/test/render/css_keyframes/css_keyframes_driver_spec.ts
+++ b/packages/animations/browser/test/render/css_keyframes/css_keyframes_driver_spec.ts
@@ -106,7 +106,7 @@ describe('CssKeyframesDriver tests', () => {
 
     it('should animate until the `animationend` method is emitted, but stil retain the <style> method and the element animation details',
        fakeAsync(() => {
-         // IE10 and IE11 cannot create an instanceof AnimationEvent
+         // IE11 cannot create an instanceof AnimationEvent
          if (!supportsAnimationEventCreation()) return;
 
          const elm = createElement();

--- a/packages/animations/browser/test/render/css_keyframes/element_animation_style_handler_spec.ts
+++ b/packages/animations/browser/test/render/css_keyframes/element_animation_style_handler_spec.ts
@@ -195,7 +195,7 @@ const EMPTY_FN = () => {};
     });
 
     it('should fire the onDone method when the matching animationend event is emitted', () => {
-      // IE10 and IE11 cannot create an instanceof AnimationEvent
+      // IE11 cannot create an instanceof AnimationEvent
       if (!supportsAnimationEventCreation()) return;
 
       const element = createElement();

--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -667,7 +667,7 @@ function getDateFormatter(format: string): DateFormatter|null {
 }
 
 function timezoneToOffset(timezone: string, fallback: number): number {
-  // Support: IE 9-11 only, Edge 13-15+
+  // Support: IE 11 only, Edge 13-15+
   // IE/Edge do not "understand" colon (`:`) in timezone
   timezone = timezone.replace(/:/g, '');
   const requestedTimezoneOffset = Date.parse('Jan 01, 1970 00:00:00 ' + timezone) / 60000;

--- a/packages/common/upgrade/src/location_shim.ts
+++ b/packages/common/upgrade/src/location_shim.ts
@@ -689,7 +689,7 @@ export class $locationShim {
    *
    * This method is supported only in HTML5 mode and only in browsers supporting
    * the HTML5 History API methods such as `pushState` and `replaceState`. If you need to support
-   * older browsers (like IE9 or Android < 4.0), don't use this method.
+   * older browsers (like Android < 4.0), don't use this method.
    *
    */
   state(): unknown;

--- a/packages/core/src/di/jit/injectable.ts
+++ b/packages/core/src/di/jit/injectable.ts
@@ -12,7 +12,7 @@ import {NG_FACTORY_DEF} from '../../render3/fields';
 import {getClosureSafeProperty} from '../../util/property';
 import {resolveForwardRef} from '../forward_ref';
 import {Injectable} from '../injectable';
-import {NG_PROV_DEF, NG_PROV_DEF_FALLBACK} from '../interface/defs';
+import {NG_PROV_DEF} from '../interface/defs';
 import {ClassSansProvider, ExistingSansProvider, FactorySansProvider, ValueProvider, ValueSansProvider} from '../interface/provider';
 
 import {angularCoreDiEnv} from './environment';
@@ -40,16 +40,6 @@ export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
         return ngInjectableDef;
       },
     });
-
-    // On IE10 properties defined via `defineProperty` won't be inherited by child classes,
-    // which will break inheriting the injectable definition from a grandparent through an
-    // undecorated parent class. We work around it by defining a method which should be used
-    // as a fallback. This should only be a problem in JIT mode, because in AOT TypeScript
-    // seems to have a workaround for static properties. When inheriting from an undecorated
-    // parent is no longer supported (v11 or later), this can safely be removed.
-    if (!type.hasOwnProperty(NG_PROV_DEF_FALLBACK)) {
-      (type as any)[NG_PROV_DEF_FALLBACK] = () => (type as any)[NG_PROV_DEF];
-    }
   }
 
   // if NG_FACTORY_DEF is already defined on this class then don't overwrite it

--- a/packages/core/src/render3/metadata.ts
+++ b/packages/core/src/render3/metadata.ts
@@ -30,18 +30,8 @@ export function setClassMetadata(
   return noSideEffects(() => {
            const clazz = type as TypeWithMetadata;
 
-           // We determine whether a class has its own metadata by taking the metadata from the
-           // parent constructor and checking whether it's the same as the subclass metadata below.
-           // We can't use `hasOwnProperty` here because it doesn't work correctly in IE10 for
-           // static fields that are defined by TS. See
-           // https://github.com/angular/angular/pull/28439#issuecomment-459349218.
-           const parentPrototype = clazz.prototype ? Object.getPrototypeOf(clazz.prototype) : null;
-           const parentConstructor: TypeWithMetadata|null =
-               parentPrototype && parentPrototype.constructor;
-
            if (decorators !== null) {
-             if (clazz.decorators !== undefined &&
-                 (!parentConstructor || parentConstructor.decorators !== clazz.decorators)) {
+             if (clazz.hasOwnProperty('decorators') && clazz.decorators !== undefined) {
                clazz.decorators.push(...decorators);
              } else {
                clazz.decorators = decorators;
@@ -58,9 +48,7 @@ export function setClassMetadata(
              // different decorator types. Decorators on individual fields are not merged, as it's
              // also incredibly unlikely that a field will be decorated both with an Angular
              // decorator and a non-Angular decorator that's also been downleveled.
-             if (clazz.propDecorators !== undefined &&
-                 (!parentConstructor ||
-                  parentConstructor.propDecorators !== clazz.propDecorators)) {
+             if (clazz.hasOwnProperty('propDecorators') && clazz.propDecorators !== undefined) {
                clazz.propDecorators = {...clazz.propDecorators, ...propDecorators};
              } else {
                clazz.propDecorators = propDecorators;

--- a/packages/core/src/sanitization/inert_body.ts
+++ b/packages/core/src/sanitization/inert_body.ts
@@ -85,7 +85,7 @@ class InertDocumentHelper implements InertBodyHelper {
     const inertBody = this.inertDocument.createElement('body');
     inertBody.innerHTML = html;
 
-    // Support: IE 9-11 only
+    // Support: IE 11 only
     // strip custom-namespaced attributes on IE<=11
     if ((this.defaultDoc as any).documentMode) {
       this.stripCustomNsAttrs(inertBody);
@@ -95,7 +95,7 @@ class InertDocumentHelper implements InertBodyHelper {
   }
 
   /**
-   * When IE9-11 comes across an unknown namespaced attribute e.g. 'xlink:foo' it adds 'xmlns:ns1'
+   * When IE11 comes across an unknown namespaced attribute e.g. 'xlink:foo' it adds 'xmlns:ns1'
    * attribute to declare ns1 namespace and prefixes the attribute with 'ns1' (e.g.
    * 'ns1:xlink:foo').
    *

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -2304,18 +2304,6 @@ describe('di', () => {
   });
 
   it('should not be able to inject ViewRef', () => {
-    // If the current browser does not support `__proto__` natively, this test will never
-    // result in an error as the `__NG_ELEMENT_ID__` from `ChangeDetectorRef` is directly
-    // assigned to the `ViewRef` instance, due to TypeScript, and `setPrototypeOf` polyfills
-    // not being able to simulate the prototype chain. This means that Angular's DI system
-    // considers `ViewRef` as injectable due to it having a `__NG_ELEMENT_ID__` directly
-    // assigned. We skip this test in such cases. This is currently the case in IE9 and
-    // IE10 as those don't support `__proto__`. Related TypeScript issue:
-    // https://github.com/microsoft/TypeScript/issues/1601#issuecomment-94892833.
-    if (!('__proto__' in {})) {
-      return;
-    }
-
     @Component({template: ''})
     class App {
       constructor(_viewRef: ViewRef) {}

--- a/packages/core/test/acceptance/host_binding_spec.ts
+++ b/packages/core/test/acceptance/host_binding_spec.ts
@@ -1132,9 +1132,6 @@ describe('host bindings', () => {
     fixture.componentInstance.name = 'Ned';
     fixture.detectChanges();
 
-    // Note that we assert for each binding individually, rather than checking against
-    // innerHTML, because IE10 changes the attribute order and makes it inconsistent with
-    // all other browsers.
     expect(hostElement.id).toBe('red,blue');
     expect(hostElement.title).toBe('blue');
     expect(fixture.nativeElement.innerHTML.endsWith('Ned')).toBe(true);

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -3460,8 +3460,8 @@ describe('styling', () => {
       if (!ivyEnabled && !supportsWritingStringsToStyleProperty()) {
         // VE does not treat `[style]` as anything special, instead it simply writes to the
         // `style` property on the element like so `element.style=value`. This seems to work fine
-        // every where except ie10, where it throws an error and as a consequence this test fails in
-        // VE on ie10.
+        // every where except IE11, where it throws an error and as a consequence this test fails in
+        // VE on IE11.
         return;
       }
       @Component({template: `<div [style]="style"></div>`})
@@ -3479,7 +3479,7 @@ describe('styling', () => {
     /**
      * Tests to see if the current browser supports non standard way of writing into styles.
      *
-     * This is not the correct way to write to style and is not supported in ie10.
+     * This is not the correct way to write to style and is not supported in IE11.
      * ```
      * div.style = 'color: white';
      * ```
@@ -3490,7 +3490,7 @@ describe('styling', () => {
      * ```
      *
      * Even though writing to `div.style` is not officially supported, it works in all
-     * browsers except ie10.
+     * browsers except IE11.
      *
      * This function detects this condition and allows us to skip the test.
      */

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -357,9 +357,6 @@
     "name": "NG_PROV_DEF"
   },
   {
-    "name": "NG_PROV_DEF_FALLBACK"
-  },
-  {
     "name": "NG_VALIDATORS"
   },
   {

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -39,9 +39,6 @@
     "name": "NG_PROV_DEF"
   },
   {
-    "name": "NG_PROV_DEF_FALLBACK"
-  },
-  {
     "name": "NOT_YET"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -432,9 +432,6 @@
     "name": "NG_PROV_DEF"
   },
   {
-    "name": "NG_PROV_DEF_FALLBACK"
-  },
-  {
     "name": "NONE"
   },
   {

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -1290,13 +1290,6 @@ describe('providers', () => {
     function addFoo() {
       return (constructor: Type<any>): any => {
         const decoratedClass = class Extender extends constructor { foo = 'bar'; };
-
-        // On IE10 child classes don't inherit static properties by default. If we detect
-        // such a case, try to account for it so the tests are consistent between browsers.
-        if (Object.getPrototypeOf(decoratedClass) !== constructor) {
-          decoratedClass.prototype = constructor.prototype;
-        }
-
         return decoratedClass;
       };
     }

--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -157,18 +157,9 @@ export function createCustomElement<P>(
               string, any
             ] => [propName, (this as any)[propName]]);
 
-        // In some browsers (e.g. IE10), `Object.setPrototypeOf()` (which is required by some Custom
-        // Elements polyfills) is not defined and is thus polyfilled in a way that does not preserve
-        // the prototype chain. In such cases, `this` will not be an instance of `NgElementImpl` and
-        // thus not have the component input getters/setters defined on `NgElementImpl.prototype`.
-        if (!(this instanceof NgElementImpl)) {
-          // Add getters and setters to the instance itself for each property input.
-          defineInputGettersSetters(inputs, this);
-        } else {
-          // Delete the property from the instance, so that it can go through the getters/setters
-          // set on `NgElementImpl.prototype`.
-          preExistingValues.forEach(([propName]) => delete (this as any)[propName]);
-        }
+        // Delete the property from the instance, so that it can go through the getters/setters
+        // set on `NgElementImpl.prototype`.
+        preExistingValues.forEach(([propName]) => delete (this as any)[propName]);
 
         // Re-apply pre-existing values through the strategy.
         preExistingValues.forEach(([propName, value]) => strategy.setInputValue(propName, value));
@@ -236,16 +227,6 @@ export function createCustomElement<P>(
       });
     }
   }
-
-  // TypeScript 3.9+ defines getters/setters as configurable but non-enumerable properties (in
-  // compliance with the spec). This breaks emulated inheritance in ES5 on environments that do not
-  // natively support `Object.setPrototypeOf()` (such as IE 9-10).
-  // Update the property descriptor of `NgElementImpl#ngElementStrategy` to make it enumerable.
-  // The below 'const', shouldn't be needed but currently this breaks build-optimizer
-  // Build-optimizer currently uses TypeScript 3.6 which is unable to resolve an 'accessor'
-  // in 'getTypeOfVariableOrParameterOrPropertyWorker'.
-  const getterName = 'ngElementStrategy';
-  Object.defineProperty(NgElementImpl.prototype, getterName, {enumerable: true});
 
   // Add getters and setters to the prototype for each property input.
   defineInputGettersSetters(inputs, NgElementImpl.prototype);

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -59,7 +59,7 @@ export function createCustomEvent(doc: Document, name: string, detail: any): Cus
   const bubbles = false;
   const cancelable = false;
 
-  // On IE9-11, `CustomEvent` is not a constructor.
+  // On IE11, `CustomEvent` is not a constructor.
   if (typeof CustomEvent !== 'function') {
     const event = doc.createEvent('CustomEvent');
     event.initCustomEvent(name, bubbles, cancelable, detail);

--- a/packages/platform-browser/animations/test/BUILD.bazel
+++ b/packages/platform-browser/animations/test/BUILD.bazel
@@ -39,37 +39,6 @@ jasmine_node_test(
 
 karma_web_test_suite(
     name = "test_web",
-    tags = [
-        # FIXME: fix on saucelabs
-        # IE 10.0.0 (Windows 8.0.0) AnimationRenderer should support nested animation triggers FAILED
-        #     TypeError: Unable to get property 'length' of undefined or null reference
-        #     error properties: Object({ number: -2146823281 })
-        #         at <Jasmine>
-        # IE 10.0.0 (Windows 8.0.0) AnimationRenderer should hook into the engine's setProperty call if the property begins with `@` FAILED
-        #     TypeError: Unable to get property 'setProperty' of undefined or null reference
-        #     error properties: Object({ number: -2146823281 })
-        #         at <Jasmine>
-        # IE 10.0.0 (Windows 8.0.0) AnimationRenderer should hook into the engine's insert operations when removing children FAILED
-        #     TypeError: Unable to get property 'onRemove' of undefined or null reference
-        #     error properties: Object({ number: -2146823281 })
-        #         at <Jasmine>
-        # IE 10.0.0 (Windows 8.0.0) AnimationRenderer should hook into the engine's insert operations when inserting a child before another FAILED
-        #     TypeError: Unable to get property 'onInsert' of undefined or null reference
-        #     error properties: Object({ number: -2146823281 })
-        #         at <Jasmine>
-        # IE 10.0.0 (Windows 8.0.0) AnimationRenderer should hook into the engine's insert operations when appending children FAILED
-        #     TypeError: Unable to get property 'onInsert' of undefined or null reference
-        #     error properties: Object({ number: -2146823281 })
-        #         at <Jasmine>
-        # IE 10.0.0 (Windows 8.0.0) AnimationRenderer listen should hook into the engine's listen call if the property begins with `@` FAILED
-        #     TypeError: Unable to get property 'listen' of undefined or null reference
-        #     error properties: Object({ number: -2146823281 })
-        #         at <Jasmine>
-        # IE 10.0.0 (Windows 8.0.0) AnimationRenderer listen should resolve the body|document|window nodes given their values as strings as input FAILED
-        #     Error: Unable to listen on the animation trigger event "event" because the animation trigger "" doesn't exist!
-        #         at <Jasmine>
-        "fixme-saucelabs-ivy",
-    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/platform-browser/src/browser/tools/common_tools.ts
+++ b/packages/platform-browser/src/browser/tools/common_tools.ts
@@ -45,7 +45,7 @@ export class AngularProfiler {
   timeChangeDetection(config: any): ChangeDetectionPerfRecord {
     const record = config && config['record'];
     const profileName = 'Change Detection';
-    // Profiler is not available in Android browsers, nor in IE 9 without dev tools opened
+    // Profiler is not available in Android browsers without dev tools opened
     const isProfilerAvailable = window.console.profile != null;
     if (record && isProfilerAvailable) {
       window.console.profile(profileName);

--- a/packages/platform-browser/test/browser_util_spec.ts
+++ b/packages/platform-browser/test/browser_util_spec.ts
@@ -52,32 +52,6 @@ import {BrowserDetection} from '../testing/src/browser_util';
         isOldChrome: false
       },
       {
-        name: 'IE9',
-        ua: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; SLCC2; .NET CLR 2.0.50727)',
-        isFirefox: false,
-        isAndroid: false,
-        isEdge: false,
-        isIE: true,
-        isWebkit: false,
-        isIOS7: false,
-        isSlow: true,
-        isChromeDesktop: false,
-        isOldChrome: false
-      },
-      {
-        name: 'IE10',
-        ua: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0; .NET4.0E; .NET4.0C)',
-        isFirefox: false,
-        isAndroid: false,
-        isEdge: false,
-        isIE: true,
-        isWebkit: false,
-        isIOS7: false,
-        isSlow: true,
-        isChromeDesktop: false,
-        isOldChrome: false
-      },
-      {
         name: 'IE11',
         ua: 'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko',
         isFirefox: false,

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -301,7 +301,7 @@ describe('bootstrap', () => {
     await router.navigateByUrl('/aa');
     window.scrollTo(0, 5000);
 
-    // IE 9/10/11 use non-standard pageYOffset instead of scrollY
+    // IE 11 uses non-standard pageYOffset instead of scrollY
     const getScrollY = () => window.scrollY !== undefined ? window.scrollY : window.pageYOffset;
 
     await router.navigateByUrl('/fail');

--- a/packages/upgrade/src/dynamic/test/upgrade_spec.ts
+++ b/packages/upgrade/src/dynamic/test/upgrade_spec.ts
@@ -2120,7 +2120,7 @@ withEachNg1Version(() => {
                }
              }
 
-             // On browsers that don't support `requestAnimationFrame` (IE 9, Android <= 4.3),
+             // On browsers that don't support `requestAnimationFrame` (Android <= 4.3),
              // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
              // on
              // the queue at the end of the test, causing it to fail.
@@ -2217,7 +2217,7 @@ withEachNg1Version(() => {
                }
              }
 
-             // On browsers that don't support `requestAnimationFrame` (IE 9, Android <= 4.3),
+             // On browsers that don't support `requestAnimationFrame` (Android <= 4.3),
              // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
              // on
              // the queue at the end of the test, causing it to fail.
@@ -2294,7 +2294,7 @@ withEachNg1Version(() => {
                }
              }
 
-             // On browsers that don't support `requestAnimationFrame` (IE 9, Android <= 4.3),
+             // On browsers that don't support `requestAnimationFrame` (Android <= 4.3),
              // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
              // on
              // the queue at the end of the test, causing it to fail.
@@ -2342,10 +2342,9 @@ withEachNg1Version(() => {
                }
              }
 
-             // On browsers that don't support `requestAnimationFrame` (IE 9, Android <= 4.3),
+             // On browsers that don't support `requestAnimationFrame` (Android <= 4.3),
              // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
-             // on
-             // the queue at the end of the test, causing it to fail.
+             // on the queue at the end of the test, causing it to fail.
              // Mocking animations (via `ngAnimateMock`) avoids the issue.
              angular.module_('ng1', ['ngAnimateMock'])
                  .component('ng1', {


### PR DESCRIPTION
This PR contains several commits that remove code specific to IE 9 and IE 10 support.
The code is no longer needed since IE 9 and IE 10 support is removed.
