### PR TITLE
fix(docs-infra): better distinguish wrapped headings from other entries in TOC

### DIFF
--- a/aio/src/styles/2-modules/_toc.scss
+++ b/aio/src/styles/2-modules/_toc.scss
@@ -105,9 +105,7 @@
 
     li {
       box-sizing: border-box;
-      @include font-size(12);
-      @include line-height(16);
-      padding: 3px 0 3px 12px;
+      padding: 7px 0 7px 12px;
       position: relative;
       transition: all 0.3s ease-in-out;
 
@@ -129,6 +127,7 @@
         color: lighten($darkgray, 10);
         overflow: visible;
         @include font-size(12);
+        @include line-height(16);
         display: table-cell;
       }
 
@@ -168,11 +167,11 @@
       }
 
       &:first-child:before {
-        top: 13px;
+        top: 15px;
       }
 
       &:last-child:before {
-        bottom: calc(100% - 14px);
+        bottom: calc(100% - 15px);
       }
 
       &:not(.active):hover a:before {


### PR DESCRIPTION
Previously, when a heading was longer than the Table of Content's  (TOC) width and it had to be wrapped into multiple lines, it was hard to distinguish the subsequent lines from other TOC entries (i.e. other headings).

This commit makes it easier to visually distinguish wrapped heading lines from other headings by reducing the spacing between wrapped lines of the same heading (making it more obvious that they belong together).

##
For example, look at the _"Accessing query parameters and fragments"_ heading below:

**BEFORE:**
![toc before](https://user-images.githubusercontent.com/8604205/94908187-fe750c80-04a9-11eb-9938-4f787214cb5b.png)

**AFTER:**
![toc after](https://user-images.githubusercontent.com/8604205/94908192-ffa63980-04a9-11eb-94fb-329df1c66293.png)
