### PR TITLE
fix(core): migrate relative link resolution with single quotes

### DIFF
--- a/packages/core/schematics/migrations/relative-link-resolution/transform.ts
+++ b/packages/core/schematics/migrations/relative-link-resolution/transform.ts
@@ -45,7 +45,7 @@ export class RelativeLinkResolutionTransform {
       return literal;
     }
     const legacyExpression =
-        ts.createPropertyAssignment(RELATIVE_LINK_RESOLUTION, ts.createStringLiteral('legacy'));
+        ts.createPropertyAssignment(RELATIVE_LINK_RESOLUTION, ts.createIdentifier(`'legacy'`));
     return ts.updateObjectLiteral(literal, [...literal.properties, legacyExpression]);
   }
 

--- a/packages/core/schematics/test/google3/relative_link_resolution_default_spec.ts
+++ b/packages/core/schematics/test/google3/relative_link_resolution_default_spec.ts
@@ -85,7 +85,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
 
     runTSLint(true);
     expect(getFile('/index.ts'))
-        .toContain(`RouterModule.forRoot([], { relativeLinkResolution: "legacy" })`);
+        .toContain(`RouterModule.forRoot([], { relativeLinkResolution: 'legacy' })`);
   });
 
   it('should migrate options without relativeLinkResolution', () => {
@@ -103,7 +103,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
 
     runTSLint(true);
     expect(getFile('/index.ts'))
-        .toContain(`RouterModule.forRoot([], { useHash: true, relativeLinkResolution: "legacy" })`);
+        .toContain(`RouterModule.forRoot([], { useHash: true, relativeLinkResolution: 'legacy' })`);
   });
 
   it('should not migrate options containing relativeLinkResolution', () => {
@@ -133,7 +133,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
     runTSLint(true);
     expect(getFile('/index.ts'))
         .toContain(
-            `const options = { useHash: true, relativeLinkResolution: "legacy" } as ExtraOptions;`);
+            `const options = { useHash: true, relativeLinkResolution: 'legacy' } as ExtraOptions;`);
   });
 
   it('should migrate when options is a variable', () => {
@@ -145,7 +145,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
     runTSLint(true);
     expect(getFile('/index.ts'))
         .toContain(
-            `const options: ExtraOptions = { useHash: true, relativeLinkResolution: "legacy" };`);
+            `const options: ExtraOptions = { useHash: true, relativeLinkResolution: 'legacy' };`);
   });
 
   it('should migrate when options is a variable with no type', () => {
@@ -166,7 +166,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
 
     runTSLint(true);
     expect(getFile('/index.ts'))
-        .toContain(`const options = { useHash: true, relativeLinkResolution: "legacy" };`);
+        .toContain(`const options = { useHash: true, relativeLinkResolution: 'legacy' };`);
     expect(getFile('/index.ts')).toContain(`RouterModule.forRoot([], options)`);
   });
 
@@ -179,7 +179,7 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
     runTSLint(true);
     expect(getFile('/index.ts'))
         .toContain(
-            `const options: RouterExtraOptions = { useHash: true, relativeLinkResolution: "legacy" };`);
+            `const options: RouterExtraOptions = { useHash: true, relativeLinkResolution: 'legacy' };`);
   });
 
   it('should migrate aliased RouterModule.forRoot', () => {
@@ -197,6 +197,6 @@ describe('Google3 relativeLinkResolution TSLint rule', () => {
 
     runTSLint(true);
     expect(getFile('/index.ts'))
-        .toContain(`AngularRouterModule.forRoot([], { relativeLinkResolution: "legacy" }),`);
+        .toContain(`AngularRouterModule.forRoot([], { relativeLinkResolution: 'legacy' }),`);
   });
 });

--- a/packages/core/schematics/test/relative_link_resolution_spec.ts
+++ b/packages/core/schematics/test/relative_link_resolution_spec.ts
@@ -61,7 +61,7 @@ describe('initial navigation migration', () => {
 
     await runMigration();
     expect(tree.readContent('/index.ts'))
-        .toContain(`RouterModule.forRoot([], { relativeLinkResolution: "legacy" })`);
+        .toContain(`RouterModule.forRoot([], { relativeLinkResolution: 'legacy' })`);
   });
 
   it('should migrate options without relativeLinkResolution', async () => {
@@ -79,7 +79,7 @@ describe('initial navigation migration', () => {
 
     await runMigration();
     expect(tree.readContent('/index.ts'))
-        .toContain(`RouterModule.forRoot([], { useHash: true, relativeLinkResolution: "legacy" })`);
+        .toContain(`RouterModule.forRoot([], { useHash: true, relativeLinkResolution: 'legacy' })`);
   });
 
   it('should not migrate options containing relativeLinkResolution', async () => {
@@ -109,7 +109,7 @@ describe('initial navigation migration', () => {
     await runMigration();
     expect(tree.readContent('/index.ts'))
         .toContain(
-            `const options = { useHash: true, relativeLinkResolution: "legacy" } as ExtraOptions;`);
+            `const options = { useHash: true, relativeLinkResolution: 'legacy' } as ExtraOptions;`);
   });
 
   it('should migrate when options is a variable', async () => {
@@ -121,7 +121,7 @@ describe('initial navigation migration', () => {
     await runMigration();
     expect(tree.readContent('/index.ts'))
         .toContain(
-            `const options: ExtraOptions = { useHash: true, relativeLinkResolution: "legacy" };`);
+            `const options: ExtraOptions = { useHash: true, relativeLinkResolution: 'legacy' };`);
   });
 
   it('should migrate when options is a variable with no type', async () => {
@@ -142,7 +142,7 @@ describe('initial navigation migration', () => {
 
     await runMigration();
     expect(tree.readContent('/index.ts'))
-        .toContain(`const options = { useHash: true, relativeLinkResolution: "legacy" };`);
+        .toContain(`const options = { useHash: true, relativeLinkResolution: 'legacy' };`);
     expect(tree.readContent('/index.ts')).toContain(`RouterModule.forRoot([], options)`);
   });
 
@@ -155,7 +155,7 @@ describe('initial navigation migration', () => {
     await runMigration();
     expect(tree.readContent('/index.ts'))
         .toContain(
-            `const options: RouterExtraOptions = { useHash: true, relativeLinkResolution: "legacy" };`);
+            `const options: RouterExtraOptions = { useHash: true, relativeLinkResolution: 'legacy' };`);
   });
 
   it('should migrate aliased RouterModule.forRoot', async () => {
@@ -173,7 +173,7 @@ describe('initial navigation migration', () => {
 
     await runMigration();
     expect(tree.readContent('/index.ts'))
-        .toContain(`AngularRouterModule.forRoot([], { relativeLinkResolution: "legacy" }),`);
+        .toContain(`AngularRouterModule.forRoot([], { relativeLinkResolution: 'legacy' }),`);
   });
 
   function writeFile(filePath: string, contents: string) {


### PR DESCRIPTION
This is a roll forward of #39082, using ```ts.createIdentifier(`'legacy'`)``` as a cross-version compatible way of making
a single quoted string literal.

Migrated code now uses single quotes, which is in line with the default linting options, so there is no lint error after
migration.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix

## What is the current behavior?
Migrating code for legacy relative link resolution generates double quotes, which is against the default style guide and leads to a lint warning in the CLI. This is also a CI failure in the CLI repo.

Issue Number: N/A

## What is the new behavior?
Migrating code for legacy relative link resolution now generates single quotes, which is in line with the style guide and no longer generates a lint warning.

## Does this PR introduce a breaking change?

- [X] No