### PR TITLE
test(zone.js): add basic test for zone.js bundle size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -749,6 +749,7 @@ jobs:
              cp dist/bin/packages/zone.js/npm_package/bundles/zone-mix.umd.js ./packages/zone.js/test/extra/ &&
              cp dist/bin/packages/zone.js/npm_package/bundles/zone-patch-electron.umd.js ./packages/zone.js/test/extra/ &&
              yarn --cwd packages/zone.js electrontest
+      - run: yarn --cwd packages/zone.js filesizetest
       - run: yarn --cwd packages/zone.js jesttest
       - run: yarn --cwd packages/zone.js/test/typings install --frozen-lockfile --non-interactive
       - run: yarn --cwd packages/zone.js/test/typings test

--- a/packages/zone.js/check-file-size.js
+++ b/packages/zone.js/check-file-size.js
@@ -6,23 +6,47 @@
  * found in the LICENSE file at https://angular.io/license
  */
 const fs = require('fs');
+const {createGzip} = require('zlib');
+const {pipeline} = require('stream');
+const {promisify} = require('util');
+const pipe = promisify(pipeline);
+const remove = promisify(fs.unlink);
 
-module.exports = function(config) {
+async function do_gzip(input, output) {
+  const gzip = createGzip();
+  const source = fs.createReadStream(input);
+  const destination = fs.createWriteStream(output);
+  await pipe(source, gzip, destination);
+}
+
+function checkSize(file, limit) {
+  try {
+    const stats = fs.statSync(file);
+    if (stats.size > limit) {
+      console.error(`file ${file} size over limit, limit is ${limit}, actual is ${stats.size}`);
+      return false;
+    }
+  } catch (err) {
+    console.error(`failed to get filesize: ${file}`);
+    return false;
+  }
+  return true;
+}
+
+const checker = function(config) {
   let chkResult = true;
-  config.targets.forEach(target => {
+  config.targets.forEach(async target => {
     if (target.checkTarget) {
-      try {
-        const stats = fs.statSync(target.path);
-        if (stats.size > target.limit) {
-          console.error(`file ${target.path} size over limit, limit is ${target.limit}, actual is ${
-              stats.size}`);
-          chkResult = false;
-        }
-      } catch (err) {
-        console.error(`failed to get filesize: ${target.path}`);
-        chkResult = false;
+      if (target.gzipLimit) {
+        // gzip target
+        await do_gzip(target.path, `${target.path}.gz`);
       }
+      chkResult =
+          checkSize(target.path, target.limit) && checkSize(`${target.path}.gz`, target.gzipLimit);
+      await remove(`${target.path}.gz`);
     }
   });
   return chkResult;
 };
+
+process.exitCode = checker(require('./file-size-limit.json')) ? 0 : 1;

--- a/packages/zone.js/file-size-limit.json
+++ b/packages/zone.js/file-size-limit.json
@@ -1,14 +1,16 @@
 {
   "targets": [
     {
-      "path": "dist/zone-evergreen.min.js",
+      "path": "../../dist/zone.js-dist/zone.js/fesm2015/zone.js",
       "checkTarget": true,
-      "limit": 43000
+      "limit": 139000,
+      "gzipLimit": 26300
     },
     {
-      "path": "dist/zone.min.js",
+      "path": "../../dist/zone.js-dist/zone.js/bundles/zone.umd.js",
       "checkTarget": true,
-      "limit": 45000
+      "limit": 165000,
+      "gzipLimit": 31200
     }
   ]
 }

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "electrontest": "cd test/extra && node electron.js",
+    "filesizetest": "node ./check-file-size.js",
     "jesttest": "jest --config ./test/jest/jest.config.js ./test/jest/jest.spec.js",
     "promisetest": "tsc -p . && node ./test/promise/promise-test.js",
     "promisefinallytest": "tsc -p . && mocha ./test/promise/promise.finally.spec.js"


### PR DESCRIPTION
Zone.js bundle size impacts the `polyfills` size very much, so in this PR,
the basic test for legacy bundle `zone.umd.js` and evergreen bundle `zone.js`.

The script checks the unzipped and gzipped version of the bundles.

