### PR TITLE
test(compiler): Demonstrate recoverable parsing of unterminated pipes

### DIFF
--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -491,14 +491,14 @@ export class _ParseAST {
     this.error(`Missing expected operator ${operator}`);
   }
 
-  ppToken(tok: Token): string {
+  prettyPrintToken(tok: Token): string {
     return tok === EOF ? 'end of input' : `token ${tok}`;
   }
 
   expectIdentifierOrKeyword(): string {
     const n = this.next;
     if (!n.isIdentifier() && !n.isKeyword()) {
-      this.error(`Unexpected ${this.ppToken(n)}, expected identifier or keyword`);
+      this.error(`Unexpected ${this.prettyPrintToken(n)}, expected identifier or keyword`);
       return '';
     }
     this.advance();
@@ -508,7 +508,7 @@ export class _ParseAST {
   expectIdentifierOrKeywordOrString(): string {
     const n = this.next;
     if (!n.isIdentifier() && !n.isKeyword() && !n.isString()) {
-      this.error(`Unexpected ${this.ppToken(n)}, expected identifier, keyword, or string`);
+      this.error(`Unexpected ${this.prettyPrintToken(n)}, expected identifier, keyword, or string`);
       return '';
     }
     this.advance();

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -491,10 +491,14 @@ export class _ParseAST {
     this.error(`Missing expected operator ${operator}`);
   }
 
+  ppToken(tok: Token): string {
+    return tok === EOF ? 'end of input' : `token ${tok}`;
+  }
+
   expectIdentifierOrKeyword(): string {
     const n = this.next;
     if (!n.isIdentifier() && !n.isKeyword()) {
-      this.error(`Unexpected token ${n}, expected identifier or keyword`);
+      this.error(`Unexpected ${this.ppToken(n)}, expected identifier or keyword`);
       return '';
     }
     this.advance();
@@ -504,7 +508,7 @@ export class _ParseAST {
   expectIdentifierOrKeywordOrString(): string {
     const n = this.next;
     if (!n.isIdentifier() && !n.isKeyword() && !n.isString()) {
-      this.error(`Unexpected token ${n}, expected identifier, keyword, or string`);
+      this.error(`Unexpected ${this.ppToken(n)}, expected identifier, keyword, or string`);
       return '';
     }
     this.advance();

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -361,6 +361,11 @@ describe('parser', () => {
         checkBinding('a | b:(c | d)', '(a | b:(c | d))');
       });
 
+      it('should parse incomplete pipes', () => {
+        checkBinding('a | b | ', '((a | b) | )');
+        expectBindingError('a | b | ', 'Unexpected end of input, expected identifier or keyword');
+      });
+
       it('should only allow identifier or keyword as formatter names', () => {
         expectBindingError('"Foo"|(', 'identifier or keyword');
         expectBindingError('"Foo"|1234', 'identifier or keyword');


### PR DESCRIPTION
There is no actionable change in this commit other than to pretty-print
EOF tokens. Actual parsing of unterminated pipes is already supported,
this just adds a test for it.

Part of #38596
