### PR TITLE
ci: use larger resource classes for bazel builds

### DIFF
--- a/.circleci/bazel.linux.rc
+++ b/.circleci/bazel.linux.rc
@@ -14,8 +14,8 @@ build --repository_cache=/home/circleci/bazel_repository_cache
 # Bazel doesn't calculate the memory ceiling correctly when running under Docker.
 # Limit Bazel to consuming resources that fit in CircleCI "xlarge" class
 # https://circleci.com/docs/2.0/configuration-reference/#resource_class
-build --local_cpu_resources=8
-build --local_ram_resources=14336
+build --local_cpu_resources=20
+build --local_ram_resources=32768
 
 # All build executed remotely should be done using our RBE configuration.
 build:remote --google_default_credentials

--- a/.circleci/bazel.windows.rc
+++ b/.circleci/bazel.windows.rc
@@ -11,8 +11,8 @@ try-import %workspace%/.circleci/bazel.common.rc
 build --repository_cache=C:/Users/circleci/bazel_repository_cache
 
 # Manually set the local resources used in windows CI runs
-build --local_ram_resources=13500
-build --local_cpu_resources=4
+build --local_ram_resources=120000
+build --local_cpu_resources=32
 
 # All windows jobs run on master and should use http caching
 build --remote_http_cache=https://storage.googleapis.com/angular-team-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ executors:
 
   windows-executor:
     working_directory: ~/ng
-    resource_class: windows.medium
+    resource_class: windows.2xlarge
     # CircleCI windows VMs do have the GitBash shell available:
     # https://github.com/CircleCI-Public/windows-preview-docs#shells
     # But in this specific case we really should not use it because Bazel must not be ran from

--- a/.circleci/windows-env.ps1
+++ b/.circleci/windows-env.ps1
@@ -41,7 +41,8 @@ copy .circleci\bazel.windows.rc ${Env:USERPROFILE}\.bazelrc
 ####################################################################################################
 # Install specific version of node.
 ####################################################################################################
-choco install nodejs --version 12.14.1 --no-progress
+nvm install 12.14.1
+nvm use 12.14.1
 
 # These Bazel prereqs aren't needed because the CircleCI image already includes them.
 # choco install yarn --version 1.16.0 --no-progress


### PR DESCRIPTION
Migrates to using larger resource classes for windows CI runs as well as updating
the bazel rcs for windows and linux to use all/more of the resources available in
the executors
