### PR TITLE
docs(zone.js): update changelog to add jest useFakeTimers feature

### DIFF
--- a/packages/zone.js/CHANGELOG.md
+++ b/packages/zone.js/CHANGELOG.md
@@ -12,6 +12,11 @@
 * **zone.js:** zone.js toString patch should check typeof Promise is function ([#38350](https://github.com/angular/angular/issues/38350)) ([18e474f](https://github.com/angular/angular/commit/18e474f)), closes [#38361](https://github.com/angular/angular/issues/38361)
 
 
+### Features
+
+* **zone.js:** add jest fakeTimers support ([#39016](https://github.com/angular/angular/issues/39016)) ([82d54fe](https://github.com/angular/angular/commit/82d54fe)), closes [#38851](https://github.com/angular/angular/issues/38851)
+
+
 ### BREAKING CHANGES
 
 * **zone.js:** ZoneJS no longer swallows errors produced by `Object.defineProperty` calls.


### PR DESCRIPTION
Since we are merged https://github.com/angular/angular/issues/38851 PR
about integration of jest.useFakeTimers with fakeAsync, so the
new release should also include this feature, this PR updated the zone.js
0.11.2 changelog.


