### PR TITLE
feat(language-service): merge compiler options, watch extended configs

### DIFF
--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -169,7 +169,8 @@ export function readCommandLineAndConfiguration(
       rootNames: [],
       options: cmdConfig.options,
       errors: cmdErrors,
-      emitFlags: api.EmitFlags.Default
+      emitFlags: api.EmitFlags.Default,
+      allExtendedConfigs: [],
     };
   }
   const config = readConfiguration(project, cmdConfig.options);
@@ -182,7 +183,8 @@ export function readCommandLineAndConfiguration(
     rootNames: config.rootNames,
     options,
     errors: config.errors,
-    emitFlags: config.emitFlags
+    emitFlags: config.emitFlags,
+    allExtendedConfigs: config.allExtendedConfigs,
   };
 }
 

--- a/packages/compiler-cli/test/perform_watch_spec.ts
+++ b/packages/compiler-cli/test/perform_watch_spec.ts
@@ -32,7 +32,8 @@ describe('perform watch', () => {
       rootNames: [path.resolve(testSupport.basePath, 'src/index.ts')],
       project: path.resolve(testSupport.basePath, 'src/tsconfig.json'),
       emitFlags: ng.EmitFlags.Default,
-      errors: []
+      errors: [],
+      allExtendedConfigs: [],
     };
   }
 

--- a/packages/language-service/ivy/test/BUILD.bazel
+++ b/packages/language-service/ivy/test/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
     srcs = glob(["*.ts"]),
     deps = [
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/language-service/ivy",
         "@npm//typescript",
     ],

--- a/packages/language-service/ivy/test/language_service_spec.ts
+++ b/packages/language-service/ivy/test/language_service_spec.ts
@@ -6,19 +6,165 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {parseNgCompilerOptions} from '../language_service';
+import {getFileSystem, setFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import * as path from 'path';
+import * as ts from 'typescript/lib/tsserverlibrary';
+
+import {LanguageService} from '../language_service';
 
 import {setup} from './mock_host';
 
-const {project} = setup();
-
 describe('parseNgCompilerOptions', () => {
+  const {project, service, tsLS, host: fs} = setup();
+  const ORIG_FS = getFileSystem();
+  let ngLS: LanguageService;
+
+  beforeAll(() => {
+    setFileSystem(fs);
+  });
+
+  afterAll(() => {
+    setFileSystem(ORIG_FS);
+  });
+
+  beforeEach(() => {
+    service.reset();
+    fs.clear();
+    ngLS = new LanguageService(project, tsLS);
+  });
+
   it('should read angularCompilerOptions in tsconfig.json', () => {
-    const options = parseNgCompilerOptions(project);
-    expect(options).toEqual(jasmine.objectContaining({
+    expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
       enableIvy: true,  // default for ivy is true
       strictTemplates: true,
       strictInjectionParameters: true,
     }));
   });
+
+  it('should refresh angularCompilerOptions when tsconfig is changed', () => {
+    const proj = assertConfiguredProject(project);
+    const config = proj.getConfigFilePath();
+    fs.writeConfigFile(config, `{
+      "angularCompilerOptions": {
+        "strictTemplates": true
+      }
+    }`);
+    expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
+      strictTemplates: true,
+    }));
+    fs.writeConfigFile(config, `{
+      "angularCompilerOptions": {
+        "strictTemplates": false
+      }
+    }`);
+    expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
+      strictTemplates: false,
+    }));
+  });
+
+  it('should parse extended angularCompilerOptions', () => {
+    const proj = assertConfiguredProject(project);
+    const extended = proj.getConfigFilePath();
+    const base = path.join(path.dirname(extended), 'tsconfig-base.json');
+    fs.writeConfigFile(base, `{
+      "angularCompilerOptions": {
+        "strictTemplates": false,
+        "strictInjectionParameters": false
+      }
+    }`);
+    fs.writeConfigFile(extended, `{
+      "extends": "./tsconfig-base.json",
+      "angularCompilerOptions": {
+        "strictTemplates": true
+      }
+    }`);
+    expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
+      strictTemplates: true,
+      strictInjectionParameters: false,
+    }));
+  });
+
+  it('should refresh angularCompilerOptions when extended tsconfig is changed', () => {
+    const proj = assertConfiguredProject(project);
+    const extended = proj.getConfigFilePath();
+    const base = path.join(path.dirname(extended), 'tsconfig-base.json');
+    fs.writeConfigFile(base, `{
+      "angularCompilerOptions": {
+        "strictTemplates": false,
+        "strictInjectionParameters": false
+      }
+    }`);
+    fs.writeConfigFile(extended, `{
+      "extends": "./tsconfig-base.json",
+      "angularCompilerOptions": {
+        "strictTemplates": true
+      }
+    }`);
+    expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
+      strictTemplates: true,
+      strictInjectionParameters: false,
+    }));
+
+    fs.writeConfigFile(base, `{
+      "angularCompilerOptions": {
+        "strictInjectionParameters": true,
+        "fullTemplateTypeCheck": true
+      }
+    }`);
+    expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
+      strictTemplates: true,
+      strictInjectionParameters: true,
+      fullTemplateTypeCheck: true,
+    }));
+  });
+
+  it('should refresh angularCompilerOptions when extended tsconfig is deleted', () => {
+    const proj = assertConfiguredProject(project);
+    const extended = proj.getConfigFilePath();
+    const base = path.join(path.dirname(extended), 'tsconfig-base.json');
+    fs.writeConfigFile(base, `{
+      "angularCompilerOptions": {
+        "strictTemplates": false,
+        "strictInjectionParameters": false
+      }
+    }`);
+    fs.writeConfigFile(extended, `{
+      "extends": "./tsconfig-base.json",
+      "angularCompilerOptions": {
+        "strictTemplates": true
+      }
+    }`);
+    expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
+      strictTemplates: true,
+      strictInjectionParameters: false,
+    }));
+
+    fs.deleteFile(base);
+    expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
+      strictTemplates: true,
+    }));
+    expect(ngLS.getCompilerOptions()).not.toEqual(jasmine.objectContaining({
+      strictInjectionParameters: false,
+    }));
+  });
+
+  it('should unset angularCompilerOptions when tsconfig is deleted', () => {
+    const proj = assertConfiguredProject(project);
+    const origOptions = {
+      strictTemplates: true,
+      strictInjectionParameters: true,
+    };
+    // First verify options are present.
+    expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining(origOptions));
+    // Delete the config file and verify options are missing.
+    fs.deleteFile(proj.getConfigFilePath());
+    expect(ngLS.getCompilerOptions()).not.toEqual(jasmine.objectContaining(origOptions));
+  });
 });
+
+function assertConfiguredProject(project: ts.server.Project): ts.server.ConfiguredProject {
+  if (!(project instanceof ts.server.ConfiguredProject)) {
+    throw new Error('Project is not a configured project.');
+  }
+  return project;
+}


### PR DESCRIPTION
Currently the language service watches only the root config file of a
configured project for changes. However, since the Angular CLI merges
compiler options across all referenced config files, the Angular LS
should do the same, and watch for changes in any relevant config file.

This commit does the following:
   - Defer compiler option parsing to
     `perform_compile.readConfiguration`, which already merges compiler
     options across extended config files. Furthermore, return all
     extended config files from `readConfiguration`.
   - Attach file watchers to the project root config file, and all known
     extended config files as determined by `readConfiguration`. On a
     change to any config file, refresh the compiler options known by
     the Angular LS, and attach file watchers for any newly-extended
     config files.
     - Also: properly clean up file watchers, closing them when a file
       is deleted.

To test these changes, the mock server host is extended to support a
mock filesystem. This is needed because ngtsc reads files from a file
system interface, which the mock service does not provide. Furthermore,
methods on the mock filesystem defer to the mock host, so the host was
chosen to implement a filesystem rather than the service doing so.