### PR TITLE
fix(dev-infra): correctly check for commit that closes PR

### DIFF
--- a/.ng-dev/release.ts
+++ b/.ng-dev/release.ts
@@ -26,7 +26,7 @@ export const release: ReleaseConfig = {
   ],
   // TODO: Implement release package building here.
   buildPackages: async () => [],
-  // TODO: This can be removed once there is a org-wide tool for changelog generation.
+  // TODO: This can be removed once there is an org-wide tool for changelog generation.
   generateReleaseNotesForHead: async () => {
     exec('yarn -s gulp changelog', {cwd: join(__dirname, '../')});
   },

--- a/dev-infra/pr/merge/defaults/labels.ts
+++ b/dev-infra/pr/merge/defaults/labels.ts
@@ -41,8 +41,8 @@ export async function getDefaultTargetLabelConfiguration(
         // allow merging of PRs with `target: major`.
         if (!next.isMajor) {
           throw new InvalidTargetLabelError(
-              `Unable to merge pull request. The "${nextBranchName}" branch will be ` +
-              `released as a minor version.`);
+              `Unable to merge pull request. The "${nextBranchName}" branch will be released as ` +
+              'a minor version.');
         }
         return [nextBranchName];
       },

--- a/dev-infra/pr/merge/defaults/lts-branch.ts
+++ b/dev-infra/pr/merge/defaults/lts-branch.ts
@@ -30,8 +30,8 @@ export async function assertActiveLtsBranch(
   const ltsNpmTag = getLtsNpmDistTagOfMajor(version.major);
   const ltsVersion = semver.parse(distTags[ltsNpmTag]);
 
-  // Ensure that there is a LTS version tagged for the given version-branch major. e.g.
-  // if the version branch is `9.2.x` then we want to make sure that there is a LTS
+  // Ensure that there is an LTS version tagged for the given version-branch major. e.g.
+  // if the version branch is `9.2.x` then we want to make sure that there is an LTS
   // version tagged in NPM for `v9`, following the `v{major}-lts` tag convention.
   if (ltsVersion === null) {
     throw new InvalidTargetBranchError(`No LTS version tagged for v${version.major} in NPM.`);

--- a/dev-infra/pr/merge/index.ts
+++ b/dev-infra/pr/merge/index.ts
@@ -33,7 +33,7 @@ export async function mergePullRequest(
     prNumber: number, githubToken: string, projectRoot: string = getRepoBaseDir(),
     config?: MergeConfigWithRemote) {
   // Set the environment variable to skip all git commit hooks triggered by husky. We are unable to
-  // rely on `---no-verify` as some hooks still run, notably the `prepare-commit-msg` hook.
+  // rely on `--no-verify` as some hooks still run, notably the `prepare-commit-msg` hook.
   process.env['HUSKY_SKIP_HOOKS'] = '1';
 
   const api = await createPullRequestMergeTask(githubToken, projectRoot, config);

--- a/dev-infra/release/build/build.spec.ts
+++ b/dev-infra/release/build/build.spec.ts
@@ -60,7 +60,7 @@ describe('ng-dev release build', () => {
   });
 
   it('should error if package has not been built', async () => {
-    // Set up a NPM package that is not built.
+    // Set up an NPM package that is not built.
     npmPackages.push('@angular/non-existent');
 
     spyOn(console, 'error');

--- a/dev-infra/release/publish/actions.ts
+++ b/dev-infra/release/publish/actions.ts
@@ -7,7 +7,7 @@
  */
 
 import {promises as fs} from 'fs';
-import * as Ora from 'ora';
+import * as ora from 'ora';
 import {join} from 'path';
 import * as semver from 'semver';
 
@@ -44,7 +44,7 @@ export interface PullRequest {
   forkBranch: string;
 }
 
-/** Constructor type for a instantiating a release action */
+/** Constructor type for instantiating a release action */
 export interface ReleaseActionConstructor<T extends ReleaseAction = ReleaseAction> {
   /** Whether the release action is currently active. */
   isActive(active: ActiveReleaseTrains): Promise<boolean>;
@@ -107,25 +107,22 @@ export abstract class ReleaseAction {
     if (state === 'failure') {
       error(
           red(`  ✘   Cannot stage release. Commit "${commitSha}" does not pass all github ` +
-              `status checks. Please make sure this commit passes all checks before re-running.`));
+              'status checks. Please make sure this commit passes all checks before re-running.'));
       error(`      Please have a look at: ${branchCommitsUrl}`);
 
       if (await promptConfirm('Do you want to ignore the Github status and proceed?')) {
         info(yellow(
-            `  ⚠   Upstream commit is failing CI checks, but status has been ` +
-            `forcibly ignored.`));
+            '  ⚠   Upstream commit is failing CI checks, but status has been forcibly ignored.'));
         return;
       }
       throw new UserAbortedReleaseActionError();
     } else if (state === 'pending') {
       error(
           red(`  ✘   Commit "${commitSha}" still has pending github statuses that ` +
-              `need to succeed before staging a release.`));
+              'need to succeed before staging a release.'));
       error(red(`      Please have a look at: ${branchCommitsUrl}`));
       if (await promptConfirm('Do you want to ignore the Github status and proceed?')) {
-        info(yellow(
-            `  ⚠   Upstream commit is pending CI, but status has been ` +
-            `forcibly ignored.`));
+        info(yellow('  ⚠   Upstream commit is pending CI, but status has been forcibly ignored.'));
         return;
       }
       throw new UserAbortedReleaseActionError();
@@ -157,9 +154,9 @@ export abstract class ReleaseAction {
    */
   protected async waitForEditsAndCreateReleaseCommit(newVersion: semver.SemVer) {
     info(yellow(
-        `  ⚠   Please review the changelog and ensure that the log contains only changes ` +
-        `that apply to the public API surface. Manual changes can be made. When done, please ` +
-        `proceed with the prompt below.`));
+        '  ⚠   Please review the changelog and ensure that the log contains only changes ' +
+        'that apply to the public API surface. Manual changes can be made. When done, please ' +
+        'proceed with the prompt below.'));
 
     if (!await promptConfirm('Do you want to proceed and commit the changes?')) {
       throw new UserAbortedReleaseActionError();
@@ -188,7 +185,7 @@ export abstract class ReleaseAction {
     const forks = result.repository.forks.nodes;
 
     if (forks.length === 0) {
-      error(red(`  ✘   Unable to find fork for currently authenticated user.`));
+      error(red('  ✘   Unable to find fork for currently authenticated user.'));
       error(red(`      Please ensure you created a fork of: ${owner}/${name}.`));
       throw new FatalReleaseActionError();
     }
@@ -304,7 +301,7 @@ export abstract class ReleaseAction {
     return new Promise((resolve, reject) => {
       debug(`Waiting for pull request #${id} to be merged.`);
 
-      const spinner = Ora().start(`Waiting for pull request #${id} to be merged.`);
+      const spinner = ora().start(`Waiting for pull request #${id} to be merged.`);
       const intervalId = setInterval(async () => {
         const prState = await getPullRequestState(this.git, id);
         if (prState === 'merged') {
@@ -451,7 +448,7 @@ export abstract class ReleaseAction {
 
     info(green(
         `  ✓   Pull request for cherry-picking the changelog into "${nextBranch}" ` +
-        `has been created.`));
+        'has been created.'));
     info(yellow(`      Please ask team members to review: ${url}.`));
     return true;
   }
@@ -490,7 +487,7 @@ export abstract class ReleaseAction {
 
     if (!await this._isCommitForVersionStaging(newVersion, versionBumpCommitSha)) {
       error(red(`  ✘   Latest commit in "${publishBranch}" branch is not a staging commit.`));
-      error(red(`      Please make sure the staging pull request has been merged.`));
+      error(red('      Please make sure the staging pull request has been merged.'));
       throw new FatalReleaseActionError();
     }
 
@@ -514,13 +511,13 @@ export abstract class ReleaseAction {
       await this._publishBuiltPackageToNpm(builtPackage, npmDistTag);
     }
 
-    info(green(`  ✓   Published all packages successfully`));
+    info(green('  ✓   Published all packages successfully'));
   }
 
   /** Publishes the given built package to NPM with the specified NPM dist tag. */
   private async _publishBuiltPackageToNpm(pkg: BuiltPackage, npmDistTag: string) {
     debug(`Starting publish of "${pkg.name}".`);
-    const spinner = Ora().start(`Publishing "${pkg.name}"`);
+    const spinner = ora().start(`Publishing "${pkg.name}"`);
 
     try {
       await runNpmPublish(pkg.outputPath, npmDistTag, this.config.publishRegistry);

--- a/dev-infra/release/publish/actions/cut-lts-patch.ts
+++ b/dev-infra/release/publish/actions/cut-lts-patch.ts
@@ -65,14 +65,14 @@ export class CutLongTermSupportPatchAction extends ReleaseAction {
           {
             name: 'activeLtsBranch',
             type: 'list',
-            message: 'Please select a version for which you want to cut a LTS patch',
+            message: 'Please select a version for which you want to cut an LTS patch',
             choices: activeBranchChoices,
           },
           {
             name: 'inactiveLtsBranch',
             type: 'list',
             when: o => o.activeLtsBranch === null,
-            message: 'Please select an inactive LTS version for which you want to cut a LTS patch',
+            message: 'Please select an inactive LTS version for which you want to cut an LTS patch',
             choices: inactive.map(branch => this._getChoiceForLtsBranch(branch)),
           }
         ]);

--- a/dev-infra/release/publish/external-commands.ts
+++ b/dev-infra/release/publish/external-commands.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as Ora from 'ora';
+import * as ora from 'ora';
 import * as semver from 'semver';
 
 import {spawnWithDebugOutput} from '../../utils/child-process';
@@ -19,11 +19,11 @@ import {FatalReleaseActionError} from './actions-error';
  * ###############################################################
  *
  * This file contains helpers for invoking external `ng-dev` commands. A subset of actions,
- * like building release output or setting a NPM dist tag for release packages, cannot be
+ * like building release output or setting aν NPM dist tag for release packages, cannot be
  * performed directly as part of the release tool and need to be delegated to external `ng-dev`
  * commands that exist across arbitrary version branches.
  *
- * In an concrete example: Consider a new patch version is released and that a new release
+ * In a concrete example: Consider a new patch version is released and that a new release
  * package has been added to the `next` branch. The patch branch will not contain the new
  * release package, so we could not build the release output for it. To work around this, we
  * call the ng-dev build command for the patch version branch and expect it to return a list
@@ -44,7 +44,7 @@ export async function invokeSetNpmDistCommand(npmDistTag: string, version: semve
     info(green(`  ✓   Set "${npmDistTag}" NPM dist tag for all packages to v${version}.`));
   } catch (e) {
     error(e);
-    error(red(`  ✘   An error occurred while setting the NPM dist tag for ${npmDistTag}.`));
+    error(red('  ✘   An error occurred while setting the NPM dist tag for "${npmDistTag}".'));
     throw new FatalReleaseActionError();
   }
 }
@@ -54,21 +54,21 @@ export async function invokeSetNpmDistCommand(npmDistTag: string, version: semve
  * packages for the currently checked out branch.
  */
 export async function invokeReleaseBuildCommand(): Promise<BuiltPackage[]> {
-  const spinner = Ora().start('Building release output.');
+  const spinner = ora().start('Building release output.');
   try {
     // Since we expect JSON to be printed from the `ng-dev release build` command,
     // we spawn the process in silent mode. We have set up an Ora progress spinner.
     const {stdout} = await spawnWithDebugOutput(
         'yarn', ['--silent', 'ng-dev', 'release', 'build', '--json'], {mode: 'silent'});
     spinner.stop();
-    info(green(`  ✓   Built release output for all packages.`));
+    info(green('  ✓   Built release output for all packages.'));
     // The `ng-dev release build` command prints a JSON array to stdout
     // that represents the built release packages and their output paths.
     return JSON.parse(stdout.trim());
   } catch (e) {
     spinner.stop();
     error(e);
-    error(red(`  ✘   An error occurred while building the release packages.`));
+    error(red('  ✘   An error occurred while building the release packages.'));
     throw new FatalReleaseActionError();
   }
 }
@@ -83,10 +83,10 @@ export async function invokeYarnInstallCommand(projectDir: string): Promise<void
     // TODO: Consider using an Ora spinner instead to ensure minimal console output.
     await spawnWithDebugOutput(
         'yarn', ['install', '--frozen-lockfile', '--non-interactive'], {cwd: projectDir});
-    info(green(`  ✓   Installed project dependencies.`));
+    info(green('  ✓   Installed project dependencies.'));
   } catch (e) {
     error(e);
-    error(red(`  ✘   An error occurred while installing dependencies.`));
+    error(red('  ✘   An error occurred while installing dependencies.'));
     throw new FatalReleaseActionError();
   }
 }

--- a/dev-infra/release/publish/index.ts
+++ b/dev-infra/release/publish/index.ts
@@ -66,8 +66,7 @@ export class ReleaseTool {
       // Only print the error message and stack if the error is not a known fatal release
       // action error (for which we print the error gracefully to the console with colors).
       if (!(e instanceof FatalReleaseActionError) && e instanceof Error) {
-        console.error(e.message);
-        console.error(e.stack);
+        console.error(e);
       }
       return CompletionState.FATAL_ERROR;
     } finally {
@@ -90,7 +89,7 @@ export class ReleaseTool {
       }
     }
 
-    info(`Please select the type of release you want to perform.`);
+    info('Please select the type of release you want to perform.');
 
     const {releaseAction} = await prompt<{releaseAction: ReleaseAction}>({
       name: 'releaseAction',
@@ -108,9 +107,7 @@ export class ReleaseTool {
    */
   private async _verifyNoUncommittedChanges(): Promise<boolean> {
     if (this._git.hasUncommittedChanges()) {
-      error(
-          red(`  ✘   There are changes which are not committed and should be ` +
-              `discarded.`));
+      error(red('  ✘   There are changes which are not committed and should be discarded.'));
       return false;
     }
     return true;
@@ -126,7 +123,7 @@ export class ReleaseTool {
         await this._git.github.repos.getBranch({...this._git.remoteParams, branch: nextBranchName});
 
     if (headSha !== data.commit.sha) {
-      error(red(`  ✘   Running release tool from an outdated local branch.`));
+      error(red('  ✘   Running release tool from an outdated local branch.'));
       error(red(`      Please make sure you are running from the "${nextBranchName}" branch.`));
       return false;
     }

--- a/dev-infra/release/publish/pull-request-state.ts
+++ b/dev-infra/release/publish/pull-request-state.ts
@@ -68,5 +68,5 @@ async function isCommitClosingPullRequest(api: GitClient, sha: string, id: numbe
   const {data} = await api.github.repos.getCommit({...api.remoteParams, ref: sha});
   // Matches the closing keyword supported in commit messages. See:
   // https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords.
-  return data.commit.message.match(new RegExp(`close[sd]? #${id}[^0-9]?`, 'i'));
+  return data.commit.message.match(new RegExp(`close[sd]? #${id}(?!\\d)`, 'i'));
 }

--- a/dev-infra/release/publish/test/cut-lts-patch.spec.ts
+++ b/dev-infra/release/publish/test/cut-lts-patch.spec.ts
@@ -13,7 +13,7 @@ import {CutLongTermSupportPatchAction} from '../actions/cut-lts-patch';
 
 import {expectStagingAndPublishWithCherryPick, fakeNpmPackageQueryRequest, getTestingMocksForReleaseAction, parse, setupReleaseActionForTesting, testTmpDir} from './test-utils';
 
-describe('cut a LTS patch action', () => {
+describe('cut an LTS patch action', () => {
   it('should be active', async () => {
     expect(await CutLongTermSupportPatchAction.isActive({
       releaseCandidate: null,

--- a/dev-infra/release/set-dist-tag/cli.ts
+++ b/dev-infra/release/set-dist-tag/cli.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as Ora from 'ora';
+import * as ora from 'ora';
 import * as semver from 'semver';
 import {Arguments, Argv, CommandModule} from 'yargs';
 
@@ -15,7 +15,7 @@ import {getReleaseConfig} from '../config/index';
 import {setNpmTagForPackage} from '../versioning/npm-publish';
 
 
-/** Command line options for setting a NPM dist tag. */
+/** Command line options for setting an NPM dist tag. */
 export interface ReleaseSetDistTagOptions {
   tagName: string;
   targetVersion: string;
@@ -42,11 +42,11 @@ async function handler(args: Arguments<ReleaseSetDistTagOptions>) {
   const version = semver.parse(rawVersion);
 
   if (version === null) {
-    error(red(`Invalid version specified. Unable to set NPM dist tag.`));
+    error(red(`Invalid version specified (${rawVersion}). Unable to set NPM dist tag.`));
     process.exit(1);
   }
 
-  const spinner = Ora().start();
+  const spinner = ora().start();
   debug(`Setting "${tagName}" NPM dist tag for release packages to v${version}.`);
 
   for (const pkgName of npmPackages) {
@@ -69,7 +69,7 @@ async function handler(args: Arguments<ReleaseSetDistTagOptions>) {
   info(green(`      ${bold(tagName)} will now point to ${bold(`v${version}`)}.`));
 }
 
-/** CLI command module for setting a NPM dist tag. */
+/** CLI command module for setting an NPM dist tag. */
 export const ReleaseSetDistTagCommand: CommandModule<{}, ReleaseSetDistTagOptions> = {
   builder,
   handler,

--- a/dev-infra/release/set-dist-tag/set-dist-tag.spec.ts
+++ b/dev-infra/release/set-dist-tag/set-dist-tag.spec.ts
@@ -66,7 +66,7 @@ describe('ng-dev release set-dist-tag', () => {
     await invokeCommand('latest', '10.0');
 
     expect(console.error)
-        .toHaveBeenCalledWith('Invalid version specified. Unable to set NPM dist tag.');
+        .toHaveBeenCalledWith('Invalid version specified (10.0). Unable to set NPM dist tag.');
     expect(process.exit).toHaveBeenCalledWith(1);
     expect(process.exit).toHaveBeenCalledTimes(1);
   });

--- a/dev-infra/release/versioning/README.md
+++ b/dev-infra/release/versioning/README.md
@@ -1,5 +1,5 @@
 ## Versioning for the Angular organization
 
 The folder contains common tooling needed for implementing the versioning as proposed
-by [this design document](https://docs.google.com/document/d/197kVillDwx-RZtSVOBtPb4BBIAw0E9RT3q3v6DZkykU/edit#heading=h.s3qlps8f4zq7).
+by [this design document](https://docs.google.com/document/d/197kVillDwx-RZtSVOBtPb4BBIAw0E9RT3q3v6DZkykU).
 Primary tooling is the determination of _active_ release trains.

--- a/dev-infra/release/versioning/active-release-trains.ts
+++ b/dev-infra/release/versioning/active-release-trains.ts
@@ -17,7 +17,7 @@ export interface ActiveReleaseTrains {
   releaseCandidate: ReleaseTrain|null;
   /** Release-train currently in the "latest" phase. */
   latest: ReleaseTrain;
-  /** Release-train in the `next` phase */
+  /** Release-train in the `next` phase. */
   next: ReleaseTrain;
 }
 

--- a/dev-infra/release/versioning/long-term-support.ts
+++ b/dev-infra/release/versioning/long-term-support.ts
@@ -34,16 +34,16 @@ export interface LtsBranch {
  * Number of months a major version in Angular is actively supported. See:
  * https://angular.io/guide/releases#support-policy-and-schedule.
  */
-export const majorActiveSupportDuration = 6;
+const majorActiveSupportDuration = 6;
 
 /**
  * Number of months a major version has active long-term support. See:
  * https://angular.io/guide/releases#support-policy-and-schedule.
  */
-export const majorActiveTermSupportDuration = 12;
+const majorLongTermSupportDuration = 12;
 
 /** Regular expression that matches LTS NPM dist tags. */
-export const ltsNpmDistTagRegex = /^v(\d+)-lts$/;
+const ltsNpmDistTagRegex = /^v(\d+)-lts$/;
 
 /** Finds all long-term support release trains from the specified NPM package. */
 export async function fetchLongTermSupportBranchesFromNpm(config: ReleaseConfig):
@@ -54,7 +54,7 @@ export async function fetchLongTermSupportBranchesFromNpm(config: ReleaseConfig)
   const inactive: LtsBranch[] = [];
 
   // Iterate through the NPM package information and determine active/inactive LTS versions with
-  // their corresponding branches. We assume that a LTS tagged version in NPM belongs to the
+  // their corresponding branches. We assume that an LTS tagged version in NPM belongs to the
   // last-minor branch of a given major (i.e. we assume there are no outdated LTS NPM dist tags).
   for (const npmDistTag in distTags) {
     if (ltsNpmDistTagRegex.test(npmDistTag)) {
@@ -64,7 +64,7 @@ export async function fetchLongTermSupportBranchesFromNpm(config: ReleaseConfig)
       const ltsEndDate = computeLtsEndDateOfMajor(majorReleaseDate);
       const ltsBranch: LtsBranch = {name: branchName, version, npmDistTag};
       // Depending on whether the LTS phase is still active, add the branch
-      // the list of active or inactive LTS branches.
+      // to the list of active or inactive LTS branches.
       if (today <= ltsEndDate) {
         active.push(ltsBranch);
       } else {
@@ -87,7 +87,7 @@ export async function fetchLongTermSupportBranchesFromNpm(config: ReleaseConfig)
 export function computeLtsEndDateOfMajor(majorReleaseDate: Date): Date {
   return new Date(
       majorReleaseDate.getFullYear(),
-      majorReleaseDate.getMonth() + majorActiveSupportDuration + majorActiveTermSupportDuration,
+      majorReleaseDate.getMonth() + majorActiveSupportDuration + majorLongTermSupportDuration,
       majorReleaseDate.getDate(), majorReleaseDate.getHours(), majorReleaseDate.getMinutes(),
       majorReleaseDate.getSeconds(), majorReleaseDate.getMilliseconds());
 }

--- a/dev-infra/release/versioning/npm-registry.ts
+++ b/dev-infra/release/versioning/npm-registry.ts
@@ -57,10 +57,9 @@ function getRepresentativeNpmPackage(config: ReleaseConfig) {
 
 /** Fetches the specified NPM package from the NPM registry. */
 async function fetchPackageInfoFromNpmRegistry(pkgName: string): Promise<NpmPackageInfo> {
-  if (_npmPackageInfoCache[pkgName] !== undefined) {
-    return await _npmPackageInfoCache[pkgName];
+  if (_npmPackageInfoCache[pkgName] === undefined) {
+    _npmPackageInfoCache[pkgName] =
+        fetch(`https://registry.npmjs.org/${pkgName}`).then(r => r.json());
   }
-  const result = _npmPackageInfoCache[pkgName] =
-      fetch(`https://registry.npmjs.org/${pkgName}`).then(r => r.json());
-  return await result;
+  return await _npmPackageInfoCache[pkgName];
 }

--- a/dev-infra/release/versioning/print-active-trains.ts
+++ b/dev-infra/release/versioning/print-active-trains.ts
@@ -59,14 +59,14 @@ export async function printActiveReleaseTrains(
         `published yet.`);
   }
 
-  // If no release-train in release-candidate of feature-freeze phase is active,
+  // If no release-train in release-candidate or feature-freeze phase is active,
   // we print a message as last bullet point to make this clear.
   if (releaseCandidate === null) {
-    info(` • No release-candidate or feature-freeze branch currently active.`);
+    info(' • No release-candidate or feature-freeze branch currently active.');
   }
 
   info();
-  info(blue(`Current active LTS version branches:`));
+  info(blue('Current active LTS version branches:'));
 
   // Print all active LTS branches (each branch as own bullet point).
   if (ltsBranches.active.length !== 0) {

--- a/dev-infra/release/versioning/version-branches.ts
+++ b/dev-infra/release/versioning/version-branches.ts
@@ -28,7 +28,7 @@ export interface VersionBranch {
 }
 
 /** Regular expression that matches version-branches. */
-const versionBranchNameRegex = /(\d+)\.(\d+)\.x/;
+const versionBranchNameRegex = /^(\d+)\.(\d+)\.x$/;
 
 /** Gets the version of a given branch by reading the `package.json` upstream. */
 export async function getVersionOfBranch(
@@ -56,8 +56,6 @@ export function isVersionBranch(branchName: string): boolean {
  * relevant but needed for parsing. SemVer does not allow `x` as patch digit.
  */
 export function getVersionForVersionBranch(branchName: string): semver.SemVer|null {
-  // Convert a given version-branch into a SemVer version that can be used
-  // with the SemVer utilities. i.e. to determine semantic order.
   return semver.parse(branchName.replace(versionBranchNameRegex, '$1.$2.0'));
 }
 

--- a/dev-infra/utils/child-process.ts
+++ b/dev-infra/utils/child-process.ts
@@ -48,7 +48,7 @@ export function spawnWithDebugOutput(
     childProcess.stderr.on('data', message => {
       logOutput += message;
       // If console output is enabled, print the message directly to the stderr. Note that
-      // we intentionally print all output to stderr as stderr should not be polluted.
+      // we intentionally print all output to stderr as stdout should not be polluted.
       if (outputMode === undefined || outputMode === 'enabled') {
         process.stderr.write(message);
       }
@@ -57,7 +57,7 @@ export function spawnWithDebugOutput(
       stdout += message;
       logOutput += message;
       // If console output is enabled, print the message directly to the stderr. Note that
-      // we intentionally print all output to stderr as stderr should not be polluted.
+      // we intentionally print all output to stderr as stdout should not be polluted.
       if (outputMode === undefined || outputMode === 'enabled') {
         process.stderr.write(message);
       }
@@ -67,7 +67,7 @@ export function spawnWithDebugOutput(
       const exitDescription = status !== null ? `exit code "${status}"` : `signal "${signal}"`;
       const printFn = outputMode === 'on-error' ? error : debug;
 
-      printFn(`Command ${commandText} completed with ${exitDescription}.`);
+      printFn(`Command "${commandText}" completed with ${exitDescription}.`);
       printFn(`Process output: \n${logOutput}`);
 
       // On success, resolve the promise. Otherwise reject with the captured stderr

--- a/dev-infra/utils/git/github-urls.ts
+++ b/dev-infra/utils/git/github-urls.ts
@@ -12,16 +12,16 @@ import {GithubConfig} from '../config';
 import {GitClient} from './index';
 
 /** URL to the Github page where personal access tokens can be managed. */
-export const GITHUB_TOKEN_SETTINGS_URL = `https://github.com/settings/tokens`;
+export const GITHUB_TOKEN_SETTINGS_URL = 'https://github.com/settings/tokens';
 
 /** URL to the Github page where personal access tokens can be generated. */
-export const GITHUB_TOKEN_GENERATE_URL = `https://github.com/settings/tokens/new`;
+export const GITHUB_TOKEN_GENERATE_URL = 'https://github.com/settings/tokens/new';
 
 /** Adds the provided token to the given Github HTTPs remote url. */
 export function addTokenToGitHttpsUrl(githubHttpsUrl: string, token: string) {
   const url = new URL(githubHttpsUrl);
   url.username = token;
-  return url.toString();
+  return url.href;
 }
 
 /** Gets the repository Git URL for the given github config. */
@@ -36,7 +36,7 @@ export function getRepositoryGitUrl(config: GithubConfig, githubToken?: string):
   return baseHttpUrl;
 }
 
-/** Gets a Github URL that refers to a lists of recent commits within a specified branch. */
+/** Gets a Github URL that refers to a list of recent commits within a specified branch. */
 export function getListCommitsInBranchUrl({remoteParams}: GitClient, branchName: string) {
   return `https://github.com/${remoteParams.owner}/${remoteParams.repo}/commits/${branchName}`;
 }

--- a/dev-infra/utils/git/index.ts
+++ b/dev-infra/utils/git/index.ts
@@ -88,8 +88,8 @@ export class GitClient {
    */
   runGraceful(args: string[], options: SpawnSyncOptions = {}): SpawnSyncReturns<string> {
     // To improve the debugging experience in case something fails, we print all executed Git
-    // commands unless the `stdio` is explicitly to `ignore` (which is equivalent to silent).
-    // Note that we do not want to print the token if is contained in the command. It's common
+    // commands unless the `stdio` is explicitly set to `ignore` (which is equivalent to silent).
+    // Note that we do not want to print the token if it is contained in the command. It's common
     // to share errors with others if the tool failed, and we do not want to leak tokens.
     // TODO: Add support for configuring this on a per-client basis. Some tools do not want
     // to print the Git command messages to the console at all (e.g. to maintain clean output).
@@ -202,7 +202,7 @@ export class GitClient {
   /**
    * Retrieve the OAuth scopes for the loaded Github token.
    **/
-  private async getAuthScopesForToken() {
+  private getAuthScopesForToken() {
     // If the OAuth scopes have already been loaded, return the Promise containing them.
     if (this._cachedOauthScopes !== null) {
       return this._cachedOauthScopes;

--- a/dev-infra/utils/testing/index.ts
+++ b/dev-infra/utils/testing/index.ts
@@ -6,6 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+export * from './semver-matchers';
 export * from './virtual-git-client';
 export * from './virtual-git-matchers';
-export * from './semver-matchers';

--- a/dev-infra/utils/testing/virtual-git-client.ts
+++ b/dev-infra/utils/testing/virtual-git-client.ts
@@ -123,7 +123,7 @@ export class VirtualGitClient extends GitClient {
       this.branches[ref.destination] = {
         branch: ref.destination,
         ref: this.fetchHeadRef,
-        newCommits: []
+        newCommits: [],
       };
     }
   }
@@ -141,7 +141,7 @@ export class VirtualGitClient extends GitClient {
       }
       this.head = {ref: this.fetchHeadRef, newCommits: []};
     } else if (this.branches[target]) {
-      this.head = {...this._cloneHead(this.branches[target], detached)};
+      this.head = this._cloneHead(this.branches[target], detached);
     } else if (createBranch) {
       this.head = this.branches[target] = {branch: target, ...this._cloneHead(this.head, detached)};
     } else {


### PR DESCRIPTION
The `ng-dev release publish` command needs to check whether a commit closed a pull request. This is implemented via checking the commit message for specific closing keywords referencing the pull request number.

The regex used previously failed to correctly ensure that the specified pull request was referenced. For example, it would allow `#12345` to also match for `#1234`.

This PR fixes the regex.

##
This PR also includes a `refactor` commit that addresses my feedback from https://github.com/angular/angular/pull/38656#pullrequestreview-482129333.