### PR TITLE
ci: run windows CI jobs on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -876,20 +876,12 @@ workflows:
       - test_zonejs:
           requires:
             - setup
-      # Windows Jobs
-      # These are very slow so we run them on non-PRs only for now.
-      # TODO: remove the filter when CircleCI makes Windows FS faster.
-      # The Windows jobs are only run after their non-windows counterparts finish successfully.
-      # This isn't strictly necessary as there is no artifact dependency, but helps economize
-      # CI resources by not attempting to build when we know should fail.
       - test_win:
-          <<: *skip_on_pull_requests
           requires:
-            - test
+            - setup
       - test_ivy_aot_win:
-          <<: *skip_on_pull_requests
           requires:
-            - test_ivy_aot
+            - setup
 
   monitoring:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,6 @@ var_3: &cache_key v7-angular-node-12-{{ checksum ".bazelversion" }}-{{ checksum 
 # folder will contain all previously used versions and ultimately cause the cache restoring to
 # be slower due to its growing size.
 var_4: &cache_key_fallback v7-angular-node-12-{{ checksum ".bazelversion" }}
-var_3_win: &cache_key_win v7-angular-win-node-12-{{ checksum ".bazelversion" }}-{{ checksum "yarn.lock" }}-{{ checksum "WORKSPACE" }}-{{ checksum "packages/bazel/package.bzl" }}-{{ checksum "aio/yarn.lock" }}
-var_4_win: &cache_key_win_fallback v7-angular-win-node-12-{{ checksum ".bazelversion" }}
 
 # Cache key for the `components-repo-unit-tests` job. **Note** when updating the SHA in the
 # cache keys also update the SHA for the "COMPONENTS_REPO_COMMIT" environment variable.
@@ -184,22 +182,12 @@ commands:
     description: Setup windows node environment
     steps:
       # Use the Linux workspace directly, as it already has checkout, rebased and node modules.
-      - custom_attach_workspace
+      - checkout
       # Install Bazel pre-requisites that aren't in the preconfigured CircleCI Windows VM.
       - run: ./.circleci/windows-env.ps1
       - run: node --version
       - run: yarn --version
-      - restore_cache:
-          keys:
-            - *cache_key_win
-            - *cache_key_win_fallback
-      # Reinstall to get windows binaries.
       - run: yarn install --frozen-lockfile --non-interactive
-      # Install @bazel/bazelisk globally and use that for the first run.
-      # Workaround for https://github.com/bazelbuild/rules_nodejs/issues/894
-      # NB: the issue was for @bazel/bazel but the same problem applies to @bazel/bazelisk
-      - run: yarn global add @bazel/bazelisk@$env:BAZELISK_VERSION
-      - run: bazelisk info
 
   notify_webhook_on_fail:
     description: Notify a webhook about failure
@@ -766,12 +754,6 @@ jobs:
           # Probably a powershell command parsing thing. There's no problem using a yarn script though.
           command: yarn circleci-win-ve
           no_output_timeout: 45m
-      # Save bazel repository cache to use on subsequent runs.
-      # We don't save node_modules because it's faster to use the linux workspace and reinstall.
-      - save_cache:
-          key: *cache_key_win
-          paths:
-            - "C:/Users/circleci/bazel_repository_cache"
 
   test_ivy_aot_win:
     executor: windows-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,6 @@ commands:
   setup_win:
     description: Setup windows node environment
     steps:
-      # Use the Linux workspace directly, as it already has checkout, rebased and node modules.
       - checkout
       # Install Bazel pre-requisites that aren't in the preconfigured CircleCI Windows VM.
       - run: ./.circleci/windows-env.ps1

--- a/.circleci/windows-env.ps1
+++ b/.circleci/windows-env.ps1
@@ -2,8 +2,8 @@
 # https://docs.bazel.build/versions/master/install-windows.html
 # https://docs.bazel.build/versions/master/windows.html
 # Install MSYS2 and packages
-choco install msys2 --version 20180531.0.0 --no-progress --package-parameters "/NoUpdate"
-C:\tools\msys64\usr\bin\bash.exe -l -c "pacman --needed --noconfirm -S zip unzip patch diffutils git"
+choco install msys2 --version 20200903.0.0 --no-progress --package-parameters "/NoUpdate"
+C:\tools\msys64\usr\bin\bash.exe -l -c "pacman --needed --noconfirm -S zip unzip patch diffutils"
 
 # Add PATH modifications to the Powershell profile. This is the win equivalent of .bash_profile.
 # https://docs.microsoft.com/en-us/previous-versions//bb613488(v=vs.85)


### PR DESCRIPTION
Previously windows CI jobs were only run on upstream branches, with the addition
of larger Windows executors as well as the improvement of setup speed in the
windows environment setup script allows for the windows tests to pass in a
reasonable timeframe.
