### PR TITLE
refactor(compiler-cli): wrap RHS of property write in parens

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -94,6 +94,12 @@ describe('type check blocks diagnostics', () => {
               '(((((((ctx).a /*14,15*/) /*14,15*/).b /*16,17*/) /*14,17*/).c /*18,19*/) /*14,23*/ = ((ctx).d /*22,23*/) /*22,23*/) /*14,23*/');
     });
 
+    it('should $event property writes', () => {
+      const TEMPLATE = `<div (click)='a = $event'></div>`;
+      expect(tcbWithSpans(TEMPLATE))
+          .toContain('(((ctx).a /*14,15*/) /*14,24*/ = ($event /*18,24*/)) /*14,24*/;');
+    });
+
     it('should annotate keyed property access', () => {
       const TEMPLATE = `{{ a[b] }}`;
       expect(tcbWithSpans(TEMPLATE))


### PR DESCRIPTION
The right needs to be wrapped in parens or we cannot accurately match its
span to just the RHS. For example, the span in `e = $event /*0,10*/` is ambiguous.
It could refer to either the whole binary expression or just the RHS.
We should instead generate `e = ($event /*0,10*/)` so we know the span 0,10 matches RHS.
This is specifically needed for the TemplateTypeChecker/Language Service
when mapping template positions to items in the TCB.
