### PR TITLE
WIP(core): add test util methods to fakeAsync()

### DIFF
--- a/packages/zone.js/lib/jest/jest.ts
+++ b/packages/zone.js/lib/jest/jest.ts
@@ -188,7 +188,7 @@ Zone.__load_patch('jest', (context: any, Zone: ZoneType, api: _ZonePrivate) => {
       return function(self: any, args: any[]) {
         const fakeAsyncZoneSpec = Zone.current.get('FakeAsyncTestZoneSpec');
         if (fakeAsyncZoneSpec && isPatchingFakeTimer()) {
-          fakeAsyncZoneSpec.setFakeBaseSystemTime(args[0]);
+          fakeAsyncZoneSpec.setFakeSystemTime(args[0]);
         } else {
           return delegate.apply(self, args);
         }

--- a/packages/zone.js/lib/zone-spec/fake-async-test.ts
+++ b/packages/zone.js/lib/zone-spec/fake-async-test.ts
@@ -87,8 +87,13 @@ class Scheduler {
     return this._currentFakeBaseSystemTime + this._currentTickTime;
   }
 
-  setFakeBaseSystemTime(fakeBaseSystemTime: number) {
-    this._currentFakeBaseSystemTime = fakeBaseSystemTime;
+  setFakeSystemTime(fakeSystemTime: number) {
+    this._currentFakeBaseSystemTime = fakeSystemTime;
+    // Since we need to reset _currentTickTime, we need to
+    // apply the diff to all endTime of the current remaining tasks.
+    this._schedulerQueue.forEach(
+        queueItem => queueItem.endTime = queueItem.endTime - this._currentTickTime);
+    this._currentTickTime = 0;
   }
 
   getRealSystemTime() {
@@ -433,8 +438,8 @@ class FakeAsyncTestZoneSpec implements ZoneSpec {
     return this._scheduler.getFakeSystemTime();
   }
 
-  setFakeBaseSystemTime(realTime: number) {
-    this._scheduler.setFakeBaseSystemTime(realTime);
+  setFakeSystemTime(realTime: number) {
+    this._scheduler.setFakeSystemTime(realTime);
   }
 
   getRealSystemTime() {

--- a/packages/zone.js/test/jest/jest.spec.js
+++ b/packages/zone.js/test/jest/jest.spec.js
@@ -130,17 +130,26 @@ describe('jest modern fakeTimers with zone.js fakeAsync', () => {
     let d = fakeAsyncZoneSpec.getRealSystemTime();
     jest.setSystemTime(d);
     expect(Date.now()).toEqual(d);
+    let j = 0;
     for (let i = 0; i < 100000; i++) {
+      j++;
     }
+    expect(j).toEqual(100000);
     expect(fakeAsyncZoneSpec.getRealSystemTime()).not.toEqual(d);
     d = fakeAsyncZoneSpec.getRealSystemTime();
-    let timeoutTriggered = false;
+    let timeoutTriggered1 = false;
+    let timeoutTriggered2 = false;
     setTimeout(() => {
-      timeoutTriggered = true;
+      timeoutTriggered1 = true;
     }, 100);
+    setTimeout(() => {
+      timeoutTriggered2 = true;
+    }, 200);
+    tick(100);
+    expect(timeoutTriggered1).toBe(true);
     jest.setSystemTime(d);
     tick(100);
-    expect(timeoutTriggered).toBe(true);
+    expect(timeoutTriggered2).toBe(true);
     expect(Date.now()).toEqual(d + 100);
   });
 


### PR DESCRIPTION
Add some util methods for `fakeAsync()` inspired by `jest`.  https://jestjs.io/docs/en/jest-object#mock-timers

Since `zone.js` now support integration with `jest fakeTimers`, internally zone.s `FakeAsyncZoneSpec` already supports all these functionalities of `jest fakeTimers`, so this PR expose those abilities as public APIs.

1. `getFakeBaseSystemTime()`.

 In `fakeAsync()`, the `Date.now()` is patched, so it
 always return a fixed number unless calling `tick()` to advance
 the virtual timer. This API returns the current fake system time.
 It will be the same with calling `Date.now()` in the `fakeAsync()`

2. `setFakeBaseSystemTime(time)`

 In `fakeAsync()`, the `Date.now()` is patched, so it
 always return a fixed number unless calling `tick()` to advance
 the virtual timer. This API set the current fake system time.

3. `getRealSystemTime()`

 In `fakeAsync()`, the `Date.now()` is patched, so it
 always return a fixed number unless calling `tick()` to advance
 the virtual timer. This API get the underlying real system time(unpatched)

4. `flushOnlyPendingTimers()`.

Flush all the pending timers, if any new timers are spawn,
 those new timers will not be consumed.

For example:
```
it('test nested timeout`, fakeAsync(() => {
  const logs = [];
  setTimeout(() => {
    logs.push(1);
    setTimeout(() => {
      logs.push(2);
    });
  });
  // flush(); will invoke the nested timeout as well, logs will be [1,2]
 // flushOnlyPendingTimeout will only flush the current pending timeout, the logs will be [1]
}));
```

5. `tickToNext(steps)`

tick to the `steps` amount of timers, steps by default is 1.

```
it('test nested timeout`, fakeAsync(() => {
  const logs = [];
  setTimeout(() => {
    logs.push(1);
  }, 100);
  setTimeout(() => {
    logs.push(11);
  }, 100);
  setTimeout(() => {
    logs.push(2);
  }, 200);
  setTimeout(() => {
    logs.push(3);
  }, 300);

  tickToNext();
  expect(logs).toEqual([1,11]); 
  tickToNext(2);
  expect(logs).toEqual([1, 11, 2, 3]);
}));
```

6. `removeAllTimers()`

Remove all the pending timers, intervals, microTasks.

7. `getTimerCount()`

 Get the count of the pending timers, intervals and microTasks.

