### PR TITLE
fix(router): Allow undefined inputs on routerLink

### DIFF
--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -376,13 +376,11 @@ export declare class RouterEvent {
 }
 
 export declare class RouterLink implements OnChanges {
-    fragment: string;
+    fragment?: string;
     preserveFragment: boolean;
     /** @deprecated */ set preserveQueryParams(value: boolean);
-    queryParams: {
-        [k: string]: any;
-    };
-    queryParamsHandling: QueryParamsHandling;
+    queryParams?: Params | null;
+    queryParamsHandling?: QueryParamsHandling | null;
     replaceUrl: boolean;
     set routerLink(commands: any[] | string | null | undefined);
     skipLocationChange: boolean;
@@ -410,14 +408,12 @@ export declare class RouterLinkActive implements OnChanges, OnDestroy, AfterCont
 }
 
 export declare class RouterLinkWithHref implements OnChanges, OnDestroy {
-    fragment: string;
+    fragment?: string;
     href: string;
     preserveFragment: boolean;
     /** @deprecated */ set preserveQueryParams(value: boolean);
-    queryParams: {
-        [k: string]: any;
-    };
-    queryParamsHandling: QueryParamsHandling;
+    queryParams?: Params | null;
+    queryParamsHandling?: QueryParamsHandling | null;
     replaceUrl: boolean;
     set routerLink(commands: any[] | string | null | undefined);
     skipLocationChange: boolean;

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -14,6 +14,7 @@ import {QueryParamsHandling} from '../config';
 import {Event, NavigationEnd} from '../events';
 import {Router} from '../router';
 import {ActivatedRoute} from '../router_state';
+import {Params} from '../shared';
 import {UrlTree} from '../url_tree';
 
 
@@ -122,24 +123,21 @@ export class RouterLink implements OnChanges {
    * @see {@link UrlCreationOptions#queryParams UrlCreationOptions#queryParams}
    * @see {@link Router#createUrlTree Router#createUrlTree}
    */
-  // TODO(issue/24571): remove '!'.
-  @Input() queryParams!: {[k: string]: any};
+  @Input() queryParams?: Params|null;
   /**
    * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the
    * `UrlCreationOptions`.
    * @see {@link UrlCreationOptions#fragment UrlCreationOptions#fragment}
    * @see {@link Router#createUrlTree Router#createUrlTree}
    */
-  // TODO(issue/24571): remove '!'.
-  @Input() fragment!: string;
+  @Input() fragment?: string;
   /**
    * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the
    * `UrlCreationOptions`.
    * @see {@link UrlCreationOptions#queryParamsHandling UrlCreationOptions#queryParamsHandling}
    * @see {@link Router#createUrlTree Router#createUrlTree}
    */
-  // TODO(issue/24571): remove '!'.
-  @Input() queryParamsHandling!: QueryParamsHandling;
+  @Input() queryParamsHandling?: QueryParamsHandling|null;
   /**
    * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the
    * `UrlCreationOptions`.
@@ -264,24 +262,21 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
    * @see {@link UrlCreationOptions#queryParams UrlCreationOptions#queryParams}
    * @see {@link Router#createUrlTree Router#createUrlTree}
    */
-  // TODO(issue/24571): remove '!'.
-  @Input() queryParams!: {[k: string]: any};
+  @Input() queryParams?: Params|null;
   /**
    * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the
    * `UrlCreationOptions`.
    * @see {@link UrlCreationOptions#fragment UrlCreationOptions#fragment}
    * @see {@link Router#createUrlTree Router#createUrlTree}
    */
-  // TODO(issue/24571): remove '!'.
-  @Input() fragment!: string;
+  @Input() fragment?: string;
   /**
    * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the
    * `UrlCreationOptions`.
    * @see {@link UrlCreationOptions#queryParamsHandling UrlCreationOptions#queryParamsHandling}
    * @see {@link Router#createUrlTree Router#createUrlTree}
    */
-  // TODO(issue/24571): remove '!'.
-  @Input() queryParamsHandling!: QueryParamsHandling;
+  @Input() queryParamsHandling?: QueryParamsHandling|null;
   /**
    * Passed to {@link Router#createUrlTree Router#createUrlTree} as part of the
    * `UrlCreationOptions`.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

When compiling in the most strict mode, the following will throw error, but it is should be valid:

```html
    <a [routerLink]="['foo']" [fragment]="null">some link</a>
```

The error would be similar to:

```
    ERROR in foo.component.html:2:52 - error TS2322: Type 'null' is not assignable to type 'string'.
    
    2         <a [routerLink]="['foo']" [fragment]="null">some link</a>
```

## What is the new behavior?

This make it coherent with typing of Router.createUrlTree to which those inputs are directly forwarded to. And hence it allow to pass `undefined`, `null` or a value to the routerLink directive.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
