### PR TITLE
docs: add "modules" topic to "main concepts"

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -210,6 +210,32 @@
           ]
         },
         {
+          "title": "Modules",
+          "tooltip": "Encapsulate, organize and speed up your app with modules.",
+          "children": [
+            {
+              "url": "guide/ngmodules",
+              "title": "NgModules",
+              "tooltip": "An introduction to the basic concept of modules."
+            },
+            {
+              "url": "guide/feature-modules",
+              "title": "Feature modules",
+              "tooltip": "More on the re-/use of modules."
+            },
+            {
+              "url": "guide/sharing-ngmodules",
+              "title": "Sharing modules",
+              "tooltip": "Reusing functionality with shared modules."
+            },
+            {
+              "url": "guide/lazy-loading-ngmodules",
+              "title": "Lazy-loading feature modules",
+              "tooltip": "Instructions on module loading strategies (lazy vs. eager)."
+            }
+          ]
+        },
+        {
           "title": "Directives",
           "tooltip": "Control the behavior of elements and the layout of your pages with directives.",
           "children": [


### PR DESCRIPTION
Expand the section with links to the core concepts of modules.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior & What is the new behavior?
The current side-nav doesn't feature modules as a main concept.
I've expand the section with links to the four basic module techniques.

Issue Number: #39015 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Some might consider modules to be a best practice rather than a "core concept", but I'd strongly argue that modules are an inevitable part of every profound Angular application and should thus be taught at very early stage.

Edit: Can someone add the "hacktoberfest-accepted" label if we decide to go for these changes?