### PR TITLE
build(docs-infra): render optional decorator options with a ?

### DIFF
--- a/aio/tools/transforms/templates/api/decorator.template.html
+++ b/aio/tools/transforms/templates/api/decorator.template.html
@@ -12,12 +12,16 @@
   {% for option in doc.members %}
   <a id="{$ option.anchor $}"></a>
   <table class="is-full-width option-table">
-    <thead><tr><th>
-      <div class="with-github-links">
-        <h3>{$ option.name $}</h3>
-        {$ github.githubLinks(option, versionInfo) $}
-      </div>
-    </th></tr></thead>
+    <thead>
+      <tr>
+        <th>
+          <div class="with-github-links">
+            <h3>{$ option.name $}</h3>
+            {$ github.githubLinks(option, versionInfo) $}
+          </div>
+        </th>
+      </tr>
+    </thead>
     <tbody>
       <tr>
         <td>
@@ -26,8 +30,9 @@
       </tr>
       <tr>
         <td>
-          <code-example language="ts" hideCopy="true" class="no-box api-heading{% if option.deprecated %} deprecated-api-item{% endif %}">
-          {$ option.name $}: {$ option.type | escape $}
+          <code-example language="ts" hideCopy="true"
+            class="no-box api-heading{% if option.deprecated %} deprecated-api-item{% endif %}">
+            {$ option.name $}{%- if option.isOptional  %}?{% endif -%}: {$ option.type | escape $}
           </code-example>
         </td>
       </tr>

--- a/aio/tools/transforms/templates/api/includes/decorator-overview.html
+++ b/aio/tools/transforms/templates/api/includes/decorator-overview.html
@@ -10,7 +10,7 @@
     <tr class="option">
       <td>
         <a class="code-anchor" href="{$ doc.path $}#{$ option.anchor | urlencode $}">
-          <code>{$ option.name $}</code>
+          <code>{$ option.name $}{%- if option.isOptional  %}?{% endif -%}</code>
         </a>
       </td>
       <td>{$ option.shortDescription | marked $}</td>


### PR DESCRIPTION
Decorator API pages list all their available options in an overview
table and also in a detailed view. Now the rendered syntax of each
option will show a `?` after the name if the option is not required.
This is inline with how class and interface members are rendered.

Here is an example: https://pr39167-9fec9f5.ngbuilds.io/api/core/Pipe

**Overview**
<img width="267" alt="Screenshot 2020-10-07 at 21 13 13" src="https://user-images.githubusercontent.com/15655/95382695-f4a43c80-08e1-11eb-8aef-d61df3e7f365.png">

**Details**
<img width="322" alt="Screenshot 2020-10-07 at 21 13 21" src="https://user-images.githubusercontent.com/15655/95382690-f40ba600-08e1-11eb-9503-c7272cc90d49.png">
