### PR TITLE
Revert "refactor(compiler-cli): wrap RHS of property write in parens …

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -243,14 +243,7 @@ class AstTranslator implements AstVisitor {
     //     ^     nameSpan
     const leftWithPath = wrapForDiagnostics(left);
     addParseSpanInfo(leftWithPath, ast.sourceSpan);
-    let right = this.translate(ast.value);
-    // The right needs to be wrapped in parens as well or we cannot accurately match its
-    // span to just the RHS. For example, the span in `e = $event /*0,10*/` is ambiguous.
-    // It could refer to either the whole binary expression or just the RHS.
-    // We should instead generate `e = ($event /*0,10*/)` so we know the span 0,10 matches RHS.
-    if (!ts.isParenthesizedExpression(right)) {
-      right = wrapForTypeChecker(right);
-    }
+    const right = this.translate(ast.value);
     const node =
         wrapForDiagnostics(ts.createBinary(leftWithPath, ts.SyntaxKind.EqualsToken, right));
     addParseSpanInfo(node, ast.sourceSpan);

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -94,12 +94,6 @@ describe('type check blocks diagnostics', () => {
               '(((((((ctx).a /*14,15*/) /*14,15*/).b /*16,17*/) /*14,17*/).c /*18,19*/) /*14,23*/ = ((ctx).d /*22,23*/) /*22,23*/) /*14,23*/');
     });
 
-    it('should $event property writes', () => {
-      const TEMPLATE = `<div (click)='a = $event'></div>`;
-      expect(tcbWithSpans(TEMPLATE))
-          .toContain('(((ctx).a /*14,15*/) /*14,24*/ = ($event /*18,24*/)) /*14,24*/;');
-    });
-
     it('should annotate keyed property access', () => {
       const TEMPLATE = `{{ a[b] }}`;
       expect(tcbWithSpans(TEMPLATE))


### PR DESCRIPTION
…(#39143)"

This reverts commit ba0df5250f667c337b61ef7415d178ef27024207 for patch branch.
Causes CI failures
https://app.circleci.com/pipelines/github/angular/angular/22588/workflows/c6a4a32f-f6b5-4b91-ac52-ff47b280cfeb