### PR TITLE
feat(dev-infra): Add github links to caretaker checks

### DIFF
--- a/dev-infra/caretaker/check/github.ts
+++ b/dev-infra/caretaker/check/github.ts
@@ -6,12 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {alias, params, types} from 'typed-graphqlify';
+import {alias, onUnion, params, types} from 'typed-graphqlify';
 
 import {bold, debug, info} from '../../utils/console';
 import {GitClient} from '../../utils/git';
 import {CaretakerConfig} from '../config';
 
+/**
+ * Cap the returned issues in the queries to an arbitrary 100. At that point, caretaker has a lot
+ * of work to do and showing more than that isn't really useful.
+ */
+const MAX_RETURNED_ISSUES = 20;
 
 /** Retrieve the number of matching issues for each github query. */
 export async function printGithubTasks(git: GitClient, config?: CaretakerConfig) {
@@ -19,7 +24,7 @@ export async function printGithubTasks(git: GitClient, config?: CaretakerConfig)
     debug('No github queries defined in the configuration, skipping.');
     return;
   }
-  info.group(bold('Github Tasks'));
+  info.group(bold(`Github Tasks`));
   await getGithubInfo(git, config);
   info.groupEnd();
   info();
@@ -28,7 +33,12 @@ export async function printGithubTasks(git: GitClient, config?: CaretakerConfig)
 /** Retrieve query match counts and log discovered counts to the console. */
 async function getGithubInfo(git: GitClient, {githubQueries: queries = []}: CaretakerConfig) {
   /** The query object for graphql. */
-  const graphQlQuery: {[key: string]: {issueCount: number}} = {};
+  const graphQlQuery: {
+    [key: string]: {
+      issueCount: number,
+      nodes: Array<{url: string}>,
+    }
+  } = {};
   /** The Github search filter for the configured repository. */
   const repoFilter = `repo:${git.remoteConfig.owner}/${git.remoteConfig.name}`;
   queries.forEach(({name, query}) => {
@@ -37,14 +47,37 @@ async function getGithubInfo(git: GitClient, {githubQueries: queries = []}: Care
     graphQlQuery[queryKey] = params(
         {
           type: 'ISSUE',
+          first: MAX_RETURNED_ISSUES,
           query: `"${repoFilter} ${query.replace(/"/g, '\\"')}"`,
         },
-        {issueCount: types.number},
+        {
+          issueCount: types.number,
+          nodes: [{...onUnion({
+            PullRequest: {
+              url: types.string,
+            },
+            Issue: {
+              url: types.string,
+            },
+          })}],
+        },
     );
   });
   /** The results of the generated github query. */
   const results = await git.github.graphql.query(graphQlQuery);
   Object.values(results).forEach((result, i) => {
     info(`${queries[i]?.name.padEnd(25)} ${result.issueCount}`);
+    if (result.issueCount > 0) {
+      const {owner, name: repo} = git.remoteConfig;
+      const url = encodeURI(`https://github.com/${owner}/${repo}/issues?q=${queries[i]?.query}`);
+      info.group(`${url}`);
+      if (result.nodes.length === MAX_RETURNED_ISSUES && result.nodes.length < result.issueCount) {
+        info(`(first ${MAX_RETURNED_ISSUES})`);
+      }
+      for (const node of result.nodes) {
+        info(`- ${node.url}`);
+      }
+      info.groupEnd();
+    }
   });
 }


### PR DESCRIPTION
This commit adds links to the PR/Issue for queries in the caretaker check.

Example output:
```

Github Tasks
  Merge Queue               0
  Merge Assistance Queue    0
  Initial Triage Queue      1
    • https://github.com/angular/angular/issues/39184
```