### PR TITLE
test(zone.js): do not run tests on IE 9 and IE 10

### DIFF
--- a/packages/zone.js/karma-build-sauce-selenium3-mocha.conf.js
+++ b/packages/zone.js/karma-build-sauce-selenium3-mocha.conf.js
@@ -8,5 +8,5 @@
 
 module.exports = function(config) {
   require('./karma-dist-mocha.conf.js')(config);
-  require('./sauce-selenium3.conf')(config, ['SL_IE9']);
+  require('./sauce-selenium3.conf')(config);
 };

--- a/packages/zone.js/karma-dist-sauce-jasmine3.conf.js
+++ b/packages/zone.js/karma-dist-sauce-jasmine3.conf.js
@@ -10,7 +10,6 @@ module.exports = function(config) {
   require('./karma-dist-jasmine.conf.js')(config);
   require('./sauce.conf')(config, [
     'SL_IOS9', 'SL_CHROME', 'SL_FIREFOX_54', 'SL_SAFARI8', 'SL_SAFARI9', 'SL_SAFARI10', 'SL_IOS8',
-    'SL_IOS9', 'SL_IOS10', 'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_MSEDGE15', 'SL_ANDROID4.4',
-    'SL_ANDROID5.1'
+    'SL_IOS9', 'SL_IOS10', 'SL_IE11', 'SL_MSEDGE15', 'SL_ANDROID4.4', 'SL_ANDROID5.1'
   ])
 };

--- a/packages/zone.js/sauce.conf.js
+++ b/packages/zone.js/sauce.conf.js
@@ -38,18 +38,6 @@ module.exports = function(config, ignoredLaunchers) {
     // 'SL_IOS9': {base: 'SauceLabs', browserName: 'iphone', platform: 'OS X 10.10', version:
     // '9.3'},
     'SL_IOS10': {base: 'SauceLabs', browserName: 'iphone', platform: 'OS X 10.10', version: '10.3'},
-    'SL_IE9': {
-      base: 'SauceLabs',
-      browserName: 'internet explorer',
-      platform: 'Windows 2008',
-      version: '9'
-    },
-    'SL_IE10': {
-      base: 'SauceLabs',
-      browserName: 'internet explorer',
-      platform: 'Windows 2012',
-      version: '10'
-    },
     'SL_IE11': {
       base: 'SauceLabs',
       browserName: 'internet explorer',

--- a/packages/zone.js/test/browser/browser.spec.ts
+++ b/packages/zone.js/test/browser/browser.spec.ts
@@ -315,11 +315,6 @@ describe('Zone', function() {
           // TODO: JiaLiPassion, need to find out why the test bundle is not `use strict`.
           xit('event handler with null context should use event.target',
               ifEnvSupports(canPatchOnProperty(Document.prototype, 'onmousedown'), function() {
-                const ieVer = getIEVersion();
-                if (ieVer && ieVer === 9) {
-                  // in ie9, this is window object even we call func.apply(undefined)
-                  return;
-                }
                 const logs: string[] = [];
                 const EventTarget = (window as any)['EventTarget'];
                 let oriAddEventListener = EventTarget && EventTarget.prototype ?

--- a/packages/zone.js/test/webdriver/test.sauce.js
+++ b/packages/zone.js/test/webdriver/test.sauce.js
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-const webdriverio = require('webdriverio');
 const desiredCapabilities = {
   firefox52Win7: {browserName: 'firefox', platform: 'Windows 7', version: '52'},
   firefox53Win7: {browserName: 'firefox', platform: 'Windows 7', version: '53'},
@@ -20,18 +19,6 @@ const desiredCapabilities = {
   /*ios84: {browserName: 'iphone', platform: 'OS X 10.10', version: '8.4'},*/
   ios10: {browserName: 'iphone', platform: 'OS X 10.10', version: '10.3'},
   ios11: {browserName: 'iphone', platform: 'OS X 10.12', version: '11.2'},
-  /*
-  ie9: {
-    browserName: 'internet explorer',
-    platform: 'Windows 2008',
-    version: '9'
-  },*/
-  /*
-  ie10: {
-    browserName: 'internet explorer',
-    platform: 'Windows 2012',
-    version: '10'
-  },*/
   ie11: {browserName: 'internet explorer', platform: 'Windows 10', version: '11'},
   // andriod44: {browserName: 'android', platform: 'Linux', version: '4.4'},
   android51: {browserName: 'android', platform: 'Linux', version: '5.1'},


### PR DESCRIPTION
Since IE 9 and IE 10 were deprecated and support is removed in v11, this commit updates ZoneJs configs to avoid running tests in these browsers.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No