### PR TITLE
build(docs-infra): support passing args to `ng serve` via `serve-and-sync`

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -64,7 +64,7 @@
     "tools-lint": "tslint --config \"tools/tslint.json\" --project \"tools/firebase-test-utils\"",
     "tools-test": "./scripts/deploy-to-firebase.test.sh && yarn docs-test && yarn boilerplate:test && jasmine tools/ng-packages-installer/index.spec.js && yarn firebase-utils-test",
     "preserve-and-sync": "yarn docs",
-    "serve-and-sync": "run-p \"start\" \"docs-watch --watch-only\"",
+    "serve-and-sync": "run-p \"docs-watch --watch-only\" \"start {@}\" --",
     "boilerplate:add": "node ./tools/examples/example-boilerplate add",
     "boilerplate:add:viewengine": "yarn boilerplate:add --viewengine",
     "boilerplate:remove": "node ./tools/examples/example-boilerplate remove",


### PR DESCRIPTION
When working on the docs, it is helpful to run a local instance of the angular.io app and run scripts that watch both the docs contents and the app build artifacts to automatically update the running instance on changes. Typically, this is achieved via the `start` and `docs-watch` npm scripts. As a convenience, one can run the `serve-and-sync` script, which runs both in one terminal.

Previously, it was not possible to pass arguments to `ng serve` (which is what the `start` script runs under the hood) when running it via `serve-and-sync`.

This commit adds support for passing any arguments passed to `serve-and-sync` through to the `start` script. This can be useful for things like specifying a custom host or port.
