### PR TITLE
feat(language-service): implement go to definition for style and template urls

### DIFF
--- a/packages/language-service/common/BUILD.bazel
+++ b/packages/language-service/common/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
     name = "common",
     srcs = glob(["*.ts"]),
     deps = [
+        "@npm//@types/node",
         "@npm//typescript",
     ],
 )

--- a/packages/language-service/common/BUILD.bazel
+++ b/packages/language-service/common/BUILD.bazel
@@ -6,7 +6,6 @@ ts_library(
     name = "common",
     srcs = glob(["*.ts"]),
     deps = [
-        "@npm//@types/node",
         "@npm//typescript",
     ],
 )

--- a/packages/language-service/common/definitions.ts
+++ b/packages/language-service/common/definitions.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as path from 'path';
+import * as ts from 'typescript';
+
+import {findTightestNode, getClassDeclFromDecoratorProp, getPropertyAssignmentFromValue} from './ts_utils';
+
+/**
+ * Gets an Angular-specific definition in a TypeScript source file.
+ */
+export function getTsDefinitionAndBoundSpan(
+    sf: ts.SourceFile, position: number,
+    tsLsHost: Pick<ts.LanguageServiceHost, 'fileExists'>): ts.DefinitionInfoAndBoundSpan|undefined {
+  const node = findTightestNode(sf, position);
+  if (!node) return;
+  switch (node.kind) {
+    case ts.SyntaxKind.StringLiteral:
+    case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
+      // Attempt to extract definition of a URL in a property assignment.
+      return getUrlFromProperty(node as ts.StringLiteralLike, tsLsHost);
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Attempts to get the definition of a file whose URL is specified in a property assignment in a
+ * directive decorator.
+ * Currently applies to `templateUrl` and `styleUrls` properties.
+ */
+function getUrlFromProperty(
+    urlNode: ts.StringLiteralLike,
+    tsLsHost: Pick<ts.LanguageServiceHost, 'fileExists'>): ts.DefinitionInfoAndBoundSpan|undefined {
+  // Get the property assignment node corresponding to the `templateUrl` or `styleUrls` assignment.
+  // These assignments are specified differently; `templateUrl` is a string, and `styleUrls` is
+  // an array of strings:
+  //   {
+  //        templateUrl: './template.ng.html',
+  //        styleUrls: ['./style.css', './other-style.css']
+  //   }
+  // `templateUrl`'s property assignment can be found from the string literal node;
+  // `styleUrls`'s property assignment can be found from the array (parent) node.
+  //
+  // First search for `templateUrl`.
+  let asgn = getPropertyAssignmentFromValue(urlNode, 'templateUrl');
+  if (!asgn) {
+    // `templateUrl` assignment not found; search for `styleUrls` array assignment.
+    asgn = getPropertyAssignmentFromValue(urlNode.parent, 'styleUrls');
+    if (!asgn) {
+      // Nothing found, bail.
+      return;
+    }
+  }
+
+  // If the property assignment is not a property of a class decorator, don't generate definitions
+  // for it.
+  if (!getClassDeclFromDecoratorProp(asgn)) {
+    return;
+  }
+
+  const sf = urlNode.getSourceFile();
+  // Extract url path specified by the url node, which is relative to the TypeScript source file
+  // the url node is defined in.
+  const url = path.join(path.dirname(sf.fileName), urlNode.text);
+
+  // If the file does not exist, bail. It is possible that the TypeScript language service host
+  // does not have a `fileExists` method, in which case optimistically assume the file exists.
+  if (tsLsHost.fileExists && !tsLsHost.fileExists(url)) return;
+
+  const templateDefinitions: ts.DefinitionInfo[] = [{
+    kind: ts.ScriptElementKind.externalModuleName,
+    name: url,
+    containerKind: ts.ScriptElementKind.unknown,
+    containerName: '',
+    // Reading the template is expensive, so don't provide a preview.
+    textSpan: {start: 0, length: 0},
+    fileName: url,
+  }];
+
+  return {
+    definitions: templateDefinitions,
+    textSpan: {
+      // Exclude opening and closing quotes in the url span.
+      start: urlNode.getStart() + 1,
+      length: urlNode.getWidth() - 2,
+    },
+  };
+}

--- a/packages/language-service/common/ts_utils.ts
+++ b/packages/language-service/common/ts_utils.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+/**
+ * Return the node that most tightly encompass the specified `position`.
+ * @param node
+ * @param position
+ */
+export function findTightestNode(node: ts.Node, position: number): ts.Node|undefined {
+  if (node.getStart() <= position && position < node.getEnd()) {
+    return node.forEachChild(c => findTightestNode(c, position)) || node;
+  }
+}
+
+/**
+ * Returns a property assignment from the assignment value if the property name
+ * matches the specified `key`, or `undefined` if there is no match.
+ */
+export function getPropertyAssignmentFromValue(value: ts.Node, key: string): ts.PropertyAssignment|
+    undefined {
+  const propAssignment = value.parent;
+  if (!propAssignment || !ts.isPropertyAssignment(propAssignment) ||
+      propAssignment.name.getText() !== key) {
+    return;
+  }
+  return propAssignment;
+}
+
+/**
+ * Given a decorator property assignment, return the ClassDeclaration node that corresponds to the
+ * directive class the property applies to.
+ * If the property assignment is not on a class decorator, no declaration is returned.
+ *
+ * For example,
+ *
+ * @Component({
+ *   template: '<div></div>'
+ *   ^^^^^^^^^^^^^^^^^^^^^^^---- property assignment
+ * })
+ * class AppComponent {}
+ *           ^---- class declaration node
+ *
+ * @param propAsgnNode property assignment
+ */
+export function getClassDeclFromDecoratorProp(propAsgnNode: ts.PropertyAssignment):
+    ts.ClassDeclaration|undefined {
+  if (!propAsgnNode.parent || !ts.isObjectLiteralExpression(propAsgnNode.parent)) {
+    return;
+  }
+  const objLitExprNode = propAsgnNode.parent;
+  if (!objLitExprNode.parent || !ts.isCallExpression(objLitExprNode.parent)) {
+    return;
+  }
+  const callExprNode = objLitExprNode.parent;
+  if (!callExprNode.parent || !ts.isDecorator(callExprNode.parent)) {
+    return;
+  }
+  const decorator = callExprNode.parent;
+  if (!decorator.parent || !ts.isClassDeclaration(decorator.parent)) {
+    return;
+  }
+  const classDeclNode = decorator.parent;
+  return classDeclNode;
+}
+
+/**
+ * Given the node which is the string of the inline template for a component, returns the
+ * `ts.ClassDeclaration` for the component.
+ */
+export function getClassDeclOfInlineTemplateNode(templateStringNode: ts.Node): ts.ClassDeclaration|
+    undefined {
+  if (!ts.isStringLiteralLike(templateStringNode)) {
+    return;
+  }
+  const tmplAsgn = getPropertyAssignmentFromValue(templateStringNode, 'template');
+  if (!tmplAsgn) {
+    return;
+  }
+  return getClassDeclFromDecoratorProp(tmplAsgn)
+}

--- a/packages/language-service/common/ts_utils.ts
+++ b/packages/language-service/common/ts_utils.ts
@@ -83,5 +83,5 @@ export function getClassDeclOfInlineTemplateNode(templateStringNode: ts.Node): t
   if (!tmplAsgn) {
     return;
   }
-  return getClassDeclFromDecoratorProp(tmplAsgn)
+  return getClassDeclFromDecoratorProp(tmplAsgn);
 }

--- a/packages/language-service/ivy/BUILD.bazel
+++ b/packages/language-service/ivy/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/incremental",
         "//packages/compiler-cli/src/ngtsc/reflection",
+        "//packages/compiler-cli/src/ngtsc/resource",
         "//packages/compiler-cli/src/ngtsc/shims",
         "//packages/compiler-cli/src/ngtsc/typecheck",
         "//packages/compiler-cli/src/ngtsc/typecheck/api",

--- a/packages/language-service/ivy/compiler_factory.ts
+++ b/packages/language-service/ivy/compiler_factory.ts
@@ -12,7 +12,8 @@ import {TrackedIncrementalBuildStrategy} from '@angular/compiler-cli/src/ngtsc/i
 import {TypeCheckingProgramStrategy} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import * as ts from 'typescript/lib/tsserverlibrary';
 
-import {isExternalTemplate, LanguageServiceAdapter} from './language_service_adapter';
+import {LanguageServiceAdapter} from './language_service_adapter';
+import {isExternalTemplate} from './utils';
 
 export class CompilerFactory {
   private readonly incrementalStrategy = new TrackedIncrementalBuildStrategy();

--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -7,7 +7,6 @@
  */
 
 import {CompilerOptions, createNgCompilerOptions} from '@angular/compiler-cli';
-import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 import {absoluteFromSourceFile, AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {TypeCheckShimGenerator} from '@angular/compiler-cli/src/ngtsc/typecheck';
 import {OptimizeFor, TypeCheckingProgramStrategy} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
@@ -15,8 +14,9 @@ import * as ts from 'typescript/lib/tsserverlibrary';
 
 import {CompilerFactory} from './compiler_factory';
 import {DefinitionBuilder} from './definitions';
-import {isExternalTemplate, isTypeScriptFile, LanguageServiceAdapter} from './language_service_adapter';
+import {LanguageServiceAdapter} from './language_service_adapter';
 import {QuickInfoBuilder} from './quick_info';
+import {isTypeScriptFile} from './utils';
 
 export class LanguageService {
   private options: CompilerOptions;
@@ -57,8 +57,8 @@ export class LanguageService {
   getDefinitionAndBoundSpan(fileName: string, position: number): ts.DefinitionInfoAndBoundSpan
       |undefined {
     const compiler = this.compilerFactory.getOrCreateWithChangedFile(fileName, this.options);
-    const results =
-        new DefinitionBuilder(this.tsLS, compiler).getDefinitionAndBoundSpan(fileName, position);
+    const results = new DefinitionBuilder(this.tsLS, compiler, this.adapter)
+                        .getDefinitionAndBoundSpan(fileName, position);
     this.compilerFactory.registerLastKnownProgram();
     return results;
   }
@@ -66,8 +66,8 @@ export class LanguageService {
   getTypeDefinitionAtPosition(fileName: string, position: number):
       readonly ts.DefinitionInfo[]|undefined {
     const compiler = this.compilerFactory.getOrCreateWithChangedFile(fileName, this.options);
-    const results =
-        new DefinitionBuilder(this.tsLS, compiler).getTypeDefinitionsAtPosition(fileName, position);
+    const results = new DefinitionBuilder(this.tsLS, compiler, this.adapter)
+                        .getTypeDefinitionsAtPosition(fileName, position);
     this.compilerFactory.registerLastKnownProgram();
     return results;
   }

--- a/packages/language-service/ivy/language_service_adapter.ts
+++ b/packages/language-service/ivy/language_service_adapter.ts
@@ -8,10 +8,15 @@
 
 import {NgCompilerAdapter} from '@angular/compiler-cli/src/ngtsc/core/api';
 import {absoluteFrom, AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AdapterResourceLoader} from '@angular/compiler-cli/src/ngtsc/resource';
 import {isShim} from '@angular/compiler-cli/src/ngtsc/shims';
 import * as ts from 'typescript/lib/tsserverlibrary';
 
-export class LanguageServiceAdapter implements NgCompilerAdapter {
+import {ResourceResolver} from '../common/definitions';
+
+import {isTypeScriptFile} from './utils';
+
+export class LanguageServiceAdapter implements NgCompilerAdapter, ResourceResolver {
   readonly entryPoint = null;
   readonly constructionDiagnostics: ts.Diagnostic[] = [];
   readonly ignoreForEmit: Set<ts.SourceFile> = new Set();
@@ -75,12 +80,9 @@ export class LanguageServiceAdapter implements NgCompilerAdapter {
     const latestVersion = this.project.getScriptVersion(fileName);
     return lastVersion !== latestVersion;
   }
-}
 
-export function isTypeScriptFile(fileName: string): boolean {
-  return fileName.endsWith('.ts');
-}
-
-export function isExternalTemplate(fileName: string): boolean {
-  return !isTypeScriptFile(fileName);
+  resolve(file: string, basePath: string): string {
+    const loader = new AdapterResourceLoader(this, this.project.getCompilationSettings());
+    return loader.resolve(file, basePath);
+  }
 }

--- a/packages/language-service/ivy/test/definitions_spec.ts
+++ b/packages/language-service/ivy/test/definitions_spec.ts
@@ -448,6 +448,53 @@ describe('definitions', () => {
     });
   });
 
+  describe('external resources', () => {
+    it('should be able to find a template from a url', () => {
+      const {position, text} = service.overwrite(APP_COMPONENT, `
+        import {Component} from '@angular/core';
+	      @Component({
+	        templateUrl: './tes¦t.ng',
+	      })
+	      export class MyComponent {}`);
+      const result = ngLS.getDefinitionAndBoundSpan(APP_COMPONENT, position);
+
+      expect(result).toBeDefined();
+      const {textSpan, definitions} = result!;
+
+      expect(text.substring(textSpan.start, textSpan.start + textSpan.length)).toEqual('./test.ng');
+
+      expect(definitions).toBeDefined();
+      expect(definitions!.length).toBe(1);
+      const [def] = definitions!;
+      expect(def.fileName).toContain('/app/test.ng');
+      expect(def.textSpan).toEqual({start: 0, length: 0});
+    });
+
+    it('should be able to find a stylesheet from a url', () => {
+      const {position, text} = service.overwrite(APP_COMPONENT, `
+        import {Component} from '@angular/core';
+	      @Component({
+	        template: 'empty',
+	        styleUrls: ['./te¦st.css']
+	      })
+	      export class MyComponent {}`);
+      const result = ngLS.getDefinitionAndBoundSpan(APP_COMPONENT, position);
+
+
+      expect(result).toBeDefined();
+      const {textSpan, definitions} = result!;
+
+      expect(text.substring(textSpan.start, textSpan.start + textSpan.length))
+          .toEqual('./test.css');
+
+      expect(definitions).toBeDefined();
+      expect(definitions!.length).toBe(1);
+      const [def] = definitions!;
+      expect(def.fileName).toContain('/app/test.css');
+      expect(def.textSpan).toEqual({start: 0, length: 0});
+    });
+  });
+
   function getDefinitionsAndAssertBoundSpan(
       {templateOverride, expectedSpanText}: {templateOverride: string, expectedSpanText: string}):
       Array<{textSpan: string, contextSpan: string | undefined, fileName: string}> {

--- a/packages/language-service/ivy/test/mock_host.ts
+++ b/packages/language-service/ivy/test/mock_host.ts
@@ -8,7 +8,8 @@
 
 import {join} from 'path';
 import * as ts from 'typescript/lib/tsserverlibrary';
-import {isTypeScriptFile} from '../language_service_adapter';
+
+import {isTypeScriptFile} from '../utils';
 
 const logger: ts.server.Logger = {
   close(): void{},

--- a/packages/language-service/ivy/utils.ts
+++ b/packages/language-service/ivy/utils.ts
@@ -14,6 +14,7 @@ import * as t from '@angular/compiler/src/render3/r3_ast';         // t for temp
 import * as ts from 'typescript';
 
 import {ALIAS_NAME, SYMBOL_PUNC} from '../common/quick_info';
+import {findTightestNode, getClassDeclOfInlineTemplateNode} from '../common/ts_utils';
 
 export function getTextSpanOfNode(node: t.Node|e.AST): ts.TextSpan {
   if (isTemplateNodeWithKeyAndValue(node)) {
@@ -70,8 +71,8 @@ export interface TemplateInfo {
  */
 export function getTemplateInfoAtPosition(
     fileName: string, position: number, compiler: NgCompiler): TemplateInfo|undefined {
-  if (fileName.endsWith('.ts')) {
-    return getInlineTemplateInfoAtPosition(fileName, position, compiler);
+  if (isTypeScriptFile(fileName)) {
+    return getTemplateInfoFromClassMeta(fileName, position, compiler);
   } else {
     return getFirstComponentForTemplateFile(fileName, compiler);
   }
@@ -116,28 +117,29 @@ function getFirstComponentForTemplateFile(fileName: string, compiler: NgCompiler
 /**
  * Retrieves the `ts.ClassDeclaration` at a location along with its template nodes.
  */
-function getInlineTemplateInfoAtPosition(
+function getTemplateInfoFromClassMeta(
     fileName: string, position: number, compiler: NgCompiler): TemplateInfo|undefined {
+  const classDecl = getClassDeclForInlineTemplateAtPosition(fileName, position, compiler);
+  if (!classDecl || !classDecl.name) {  // Does not handle anonymous class
+    return;
+  }
+  const template = compiler.getTemplateTypeChecker().getTemplate(classDecl);
+  if (template === null) {
+    return;
+  }
+
+  return {template, component: classDecl};
+}
+
+function getClassDeclForInlineTemplateAtPosition(
+    fileName: string, position: number, compiler: NgCompiler): ts.ClassDeclaration|undefined {
   const sourceFile = compiler.getNextProgram().getSourceFile(fileName);
   if (!sourceFile) {
     return undefined;
   }
-
-  // We only support top level statements / class declarations
-  for (const statement of sourceFile.statements) {
-    if (!ts.isClassDeclaration(statement) || position < statement.pos || position > statement.end) {
-      continue;
-    }
-
-    const template = compiler.getTemplateTypeChecker().getTemplate(statement);
-    if (template === null) {
-      return undefined;
-    }
-
-    return {template, component: statement};
-  }
-
-  return undefined;
+  const node = findTightestNode(sourceFile, position);
+  if (!node) return;
+  return getClassDeclOfInlineTemplateNode(node);
 }
 
 /**
@@ -290,4 +292,12 @@ export function flatMap<T, R>(items: T[]|readonly T[], f: (item: T) => R[] | rea
     results.push(...f(x));
   }
   return results;
+}
+
+export function isTypeScriptFile(fileName: string): boolean {
+  return fileName.endsWith('.ts');
+}
+
+export function isExternalTemplate(fileName: string): boolean {
+  return !isTypeScriptFile(fileName);
 }

--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -6,11 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as path from 'path';
 import * as ts from 'typescript';  // used as value and is provided at runtime
 
 import {locateSymbols} from './locate_symbol';
-import {findTightestNode, getClassDeclFromDecoratorProp, getPropertyAssignmentFromValue} from './ts_utils';
 import {AstResult, Span} from './types';
 
 /**
@@ -80,87 +78,5 @@ export function getDefinitionAndBoundSpan(
   return {
     definitions,
     textSpan: symbols[0].span,
-  };
-}
-
-/**
- * Gets an Angular-specific definition in a TypeScript source file.
- */
-export function getTsDefinitionAndBoundSpan(
-    sf: ts.SourceFile, position: number,
-    tsLsHost: Readonly<ts.LanguageServiceHost>): ts.DefinitionInfoAndBoundSpan|undefined {
-  const node = findTightestNode(sf, position);
-  if (!node) return;
-  switch (node.kind) {
-    case ts.SyntaxKind.StringLiteral:
-    case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
-      // Attempt to extract definition of a URL in a property assignment.
-      return getUrlFromProperty(node as ts.StringLiteralLike, tsLsHost);
-    default:
-      return undefined;
-  }
-}
-
-/**
- * Attempts to get the definition of a file whose URL is specified in a property assignment in a
- * directive decorator.
- * Currently applies to `templateUrl` and `styleUrls` properties.
- */
-function getUrlFromProperty(
-    urlNode: ts.StringLiteralLike,
-    tsLsHost: Readonly<ts.LanguageServiceHost>): ts.DefinitionInfoAndBoundSpan|undefined {
-  // Get the property assignment node corresponding to the `templateUrl` or `styleUrls` assignment.
-  // These assignments are specified differently; `templateUrl` is a string, and `styleUrls` is
-  // an array of strings:
-  //   {
-  //        templateUrl: './template.ng.html',
-  //        styleUrls: ['./style.css', './other-style.css']
-  //   }
-  // `templateUrl`'s property assignment can be found from the string literal node;
-  // `styleUrls`'s property assignment can be found from the array (parent) node.
-  //
-  // First search for `templateUrl`.
-  let asgn = getPropertyAssignmentFromValue(urlNode, 'templateUrl');
-  if (!asgn) {
-    // `templateUrl` assignment not found; search for `styleUrls` array assignment.
-    asgn = getPropertyAssignmentFromValue(urlNode.parent, 'styleUrls');
-    if (!asgn) {
-      // Nothing found, bail.
-      return;
-    }
-  }
-
-  // If the property assignment is not a property of a class decorator, don't generate definitions
-  // for it.
-  if (!getClassDeclFromDecoratorProp(asgn)) {
-    return;
-  }
-
-  const sf = urlNode.getSourceFile();
-  // Extract url path specified by the url node, which is relative to the TypeScript source file
-  // the url node is defined in.
-  const url = path.join(path.dirname(sf.fileName), urlNode.text);
-
-  // If the file does not exist, bail. It is possible that the TypeScript language service host
-  // does not have a `fileExists` method, in which case optimistically assume the file exists.
-  if (tsLsHost.fileExists && !tsLsHost.fileExists(url)) return;
-
-  const templateDefinitions: ts.DefinitionInfo[] = [{
-    kind: ts.ScriptElementKind.externalModuleName,
-    name: url,
-    containerKind: ts.ScriptElementKind.unknown,
-    containerName: '',
-    // Reading the template is expensive, so don't provide a preview.
-    textSpan: {start: 0, length: 0},
-    fileName: url,
-  }];
-
-  return {
-    definitions: templateDefinitions,
-    textSpan: {
-      // Exclude opening and closing quotes in the url span.
-      start: urlNode.getStart() + 1,
-      length: urlNode.getWidth() - 2,
-    },
   };
 }

--- a/packages/language-service/src/diagnostics.ts
+++ b/packages/language-service/src/diagnostics.ts
@@ -10,9 +10,11 @@ import {NgAnalyzedModules} from '@angular/compiler';
 import * as path from 'path';
 import * as ts from 'typescript';
 
+import {findTightestNode} from '../common/ts_utils';
+
 import {createDiagnostic, Diagnostic} from './diagnostic_messages';
 import {getTemplateExpressionDiagnostics} from './expression_diagnostics';
-import {findPropertyValueOfType, findTightestNode} from './ts_utils';
+import {findPropertyValueOfType} from './ts_utils';
 import * as ng from './types';
 import {TypeScriptServiceHost} from './typescript_host';
 import {offsetSpan, spanOf} from './utils';

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {getTsDefinitionAndBoundSpan} from '@angular/language-service/common/definitions';
 import * as tss from 'typescript/lib/tsserverlibrary';
 
 import {getTemplateCompletions} from './completions';
-import {getDefinitionAndBoundSpan, getTsDefinitionAndBoundSpan} from './definitions';
+import {getDefinitionAndBoundSpan} from './definitions';
 import {getDeclarationDiagnostics, getTemplateDiagnostics, ngDiagnosticToTsDiagnostic} from './diagnostics';
 import {getTemplateHover, getTsHover} from './hover';
 import * as ng from './types';

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {getTsDefinitionAndBoundSpan} from '@angular/language-service/common/definitions';
+import * as path from 'path';
 import * as tss from 'typescript/lib/tsserverlibrary';
+
+import {getTsDefinitionAndBoundSpan, ResourceResolver} from '../common/definitions';
 
 import {getTemplateCompletions} from './completions';
 import {getDefinitionAndBoundSpan} from './definitions';
@@ -76,13 +78,13 @@ class LanguageServiceImpl implements ng.LanguageService {
     if (templateInfo) {
       return getDefinitionAndBoundSpan(templateInfo, position);
     }
-
     // Attempt to get Angular-specific definitions in a TypeScript file, like templates defined
     // in a `templateUrl` property.
     if (fileName.endsWith('.ts')) {
       const sf = this.host.getSourceFile(fileName);
       if (sf) {
-        return getTsDefinitionAndBoundSpan(sf, position, this.host.tsLsHost);
+        return getTsDefinitionAndBoundSpan(
+            sf, position, new ViewEngineLSResourceResolver(this.host.tsLsHost));
       }
     }
   }
@@ -111,5 +113,22 @@ class LanguageServiceImpl implements ng.LanguageService {
       return;
     }
     return this.host.tsLS.getReferencesAtPosition(tsDef.fileName, tsDef.textSpan.start);
+  }
+}
+
+class ViewEngineLSResourceResolver implements ResourceResolver {
+  constructor(private host: ts.LanguageServiceHost) {}
+
+  resolve(file: string, basePath: string): string {
+    // Extract url path specified by the url node, which is relative to the TypeScript source file
+    // the url node is defined in.
+    const url = path.join(path.dirname(basePath), file);
+
+    // If the file does not exist, bail. It is possible that the TypeScript language service host
+    // does not have a `fileExists` method, in which case optimistically assume the file exists.
+    if (this.host.fileExists && !this.host.fileExists(url)) {
+      throw new Error(`ResourceResolver: could not resolve ${url} in context of ${basePath})`);
+    }
+    return url;
   }
 }

--- a/packages/language-service/src/ts_utils.ts
+++ b/packages/language-service/src/ts_utils.ts
@@ -8,68 +8,6 @@
 
 import * as ts from 'typescript/lib/tsserverlibrary';
 
-/**
- * Return the node that most tightly encompass the specified `position`.
- * @param node
- * @param position
- */
-export function findTightestNode(node: ts.Node, position: number): ts.Node|undefined {
-  if (node.getStart() <= position && position < node.getEnd()) {
-    return node.forEachChild(c => findTightestNode(c, position)) || node;
-  }
-}
-
-/**
- * Returns a property assignment from the assignment value if the property name
- * matches the specified `key`, or `undefined` if there is no match.
- */
-export function getPropertyAssignmentFromValue(value: ts.Node, key: string): ts.PropertyAssignment|
-    undefined {
-  const propAssignment = value.parent;
-  if (!propAssignment || !ts.isPropertyAssignment(propAssignment) ||
-      propAssignment.name.getText() !== key) {
-    return;
-  }
-  return propAssignment;
-}
-
-/**
- * Given a decorator property assignment, return the ClassDeclaration node that corresponds to the
- * directive class the property applies to.
- * If the property assignment is not on a class decorator, no declaration is returned.
- *
- * For example,
- *
- * @Component({
- *   template: '<div></div>'
- *   ^^^^^^^^^^^^^^^^^^^^^^^---- property assignment
- * })
- * class AppComponent {}
- *           ^---- class declaration node
- *
- * @param propAsgn property assignment
- */
-export function getClassDeclFromDecoratorProp(propAsgnNode: ts.PropertyAssignment):
-    ts.ClassDeclaration|undefined {
-  if (!propAsgnNode.parent || !ts.isObjectLiteralExpression(propAsgnNode.parent)) {
-    return;
-  }
-  const objLitExprNode = propAsgnNode.parent;
-  if (!objLitExprNode.parent || !ts.isCallExpression(objLitExprNode.parent)) {
-    return;
-  }
-  const callExprNode = objLitExprNode.parent;
-  if (!callExprNode.parent || !ts.isDecorator(callExprNode.parent)) {
-    return;
-  }
-  const decorator = callExprNode.parent;
-  if (!decorator.parent || !ts.isClassDeclaration(decorator.parent)) {
-    return;
-  }
-  const classDeclNode = decorator.parent;
-  return classDeclNode;
-}
-
 interface DirectiveClassLike {
   decoratorId: ts.Identifier;  // decorator identifier, like @Component
   classId: ts.Identifier;

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -10,10 +10,12 @@ import {analyzeNgModules, AotSummaryResolver, CompileDirectiveSummary, CompileMe
 import {SchemaMetadata, ViewEncapsulation, ɵConsole as Console} from '@angular/core';
 import * as tss from 'typescript/lib/tsserverlibrary';
 
+import {findTightestNode, getClassDeclOfInlineTemplateNode} from '../common/ts_utils';
+
 import {createLanguageService} from './language_service';
 import {ReflectorHost} from './reflector_host';
 import {ExternalTemplate, InlineTemplate} from './template';
-import {findTightestNode, getClassDeclFromDecoratorProp, getDirectiveClassLike, getPropertyAssignmentFromValue} from './ts_utils';
+import {getDirectiveClassLike} from './ts_utils';
 import {AstResult, Declaration, DeclarationError, DiagnosticMessageChain, LanguageService, LanguageServiceHost, Span, TemplateSource} from './types';
 
 /**
@@ -382,11 +384,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
     if (!tss.isStringLiteralLike(node)) {
       return;
     }
-    const tmplAsgn = getPropertyAssignmentFromValue(node, 'template');
-    if (!tmplAsgn) {
-      return;
-    }
-    const classDecl = getClassDeclFromDecoratorProp(tmplAsgn);
+    const classDecl = getClassDeclOfInlineTemplateNode(node);
     if (!classDecl || !classDecl.name) {  // Does not handle anonymous class
       return;
     }

--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -59,6 +59,7 @@ ts_library(
         "//packages/compiler",
         "//packages/language-service",
         "//packages/language-service:ts_utils",
+        "//packages/language-service/common",
         "@npm//typescript",
     ],
 )

--- a/packages/language-service/test/utils_spec.ts
+++ b/packages/language-service/test/utils_spec.ts
@@ -9,7 +9,8 @@
 import * as ng from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {getClassDeclFromDecoratorProp, getDirectiveClassLike} from '../src/ts_utils';
+import {getClassDeclFromDecoratorProp} from '../common/ts_utils';
+import {getDirectiveClassLike} from '../src/ts_utils';
 import {getPathToNodeAtPosition} from '../src/utils';
 import {MockTypescriptHost} from './test_utils';
 


### PR DESCRIPTION
…late urls

This commit enables the Ivy Language Service to "go to definition" of a
templateUrl or styleUrl, which would jump to the template/style file
itself.
