### PR TITLE
build(zone.js): zone.js should output esm format for fesm2015 bundles

### DIFF
--- a/packages/zone.js/tools.bzl
+++ b/packages/zone.js/tools.bzl
@@ -31,7 +31,7 @@ def copy_dist(module_name, module_format, output_module_name, suffix, umd):
     native.genrule(
         name = module_name + "." + suffix_output + "dist",
         srcs = [
-            "//packages/zone.js:" + module_name + "-rollup." + suffix_output + module_format + "umd.js",
+            "//packages/zone.js:" + module_name + "-rollup." + suffix_output + module_format,
         ],
         outs = [
             output_module_name + "." + umd_output + suffix_output + "js",
@@ -69,9 +69,9 @@ def generate_rollup_bundle(bundles):
             )
 
 def generate_dist(bundles, output_format, umd):
-    module_format = ""
+    module_format = "esm.js"
     if output_format == "es5":
-        module_format = "es5"
+        module_format = "es5umd.js"
     for b in bundles:
         module_name = b[0]
         copy_dist(

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -400,6 +400,8 @@ def rollup_bundle(name, testonly = False, sourcemap = "true", **kwargs):
     es2015 iife                  : "%{name}.es2015.js"
     es2015 iife minified         : "%{name}.min.es2015.js"
     es2015 iife minified (debug) : "%{name}.min_debug.es2015.js"
+    esm                          : "%{name}.esm.js"
+    esm                          : "%{name}.min.esm.js"
     es5 iife                     : "%{name}.js"
     es5 iife minified            : "%{name}.min.js"
     es5 iife minified (debug)    : "%{name}.min_debug.js"
@@ -421,6 +423,11 @@ def rollup_bundle(name, testonly = False, sourcemap = "true", **kwargs):
         "args": ["--comments"],
         "sourcemap": False,
     }
+
+    # esm
+    _rollup_bundle(name = name + ".esm", testonly = testonly, format = "esm", sourcemap = sourcemap, **kwargs)
+    terser_minified(name = name + ".min.esm", testonly = testonly, src = name + ".esm", **common_terser_args)
+    native.filegroup(name = name + ".min.esm.js", testonly = testonly, srcs = [name + ".min.esm"])
 
     # es2015
     _rollup_bundle(name = name + ".es2015", testonly = testonly, format = "iife", sourcemap = sourcemap, **kwargs)


### PR DESCRIPTION
Zone.js support `Angular package format` since `0.11`, but the `fesm2015` bundles
are not `esm` format, it still use `umd` bundle which is not correct, in this PR,
a new `esm` bundle output is added in `rollup_bundle` rule under `tools`, so
zone.js can use the new rule to generate `esm` bundles.

Before this PR, `fesm2015/zone.js` is a `umd` bundle.

```

(function (factory) {
    typeof define === 'function' && define.amd ? define(factory) :
    factory();
}((function () { 'use strict';

    /**
     * @license
     * Copyright Google LLC All Rights Reserved.
     *
     * Use of this source code is governed by an MIT-style license that can be
     * found in the LICENSE file at https://angular.io/license
     */
    const Zone$1 = (function (global) {
        const performance = global['performance'];
        ...
```

now it is a `esm` bundle.

```
const Zone$1 = (function (global) {
    const performance = global['performance'];
    ...
```

