### PR TITLE
feat(core): create internal Trusted Types module

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@types/semver": "^6.0.2",
     "@types/shelljs": "^0.8.6",
     "@types/systemjs": "0.19.32",
+    "@types/trusted-types": "^1.0.6",
     "@types/yaml": "^1.9.7",
     "@types/yargs": "^15.0.5",
     "@webcomponents/custom-elements": "^1.1.0",

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
     deps = [
         "//packages/zone.js/lib:zone_d_ts",
         "@npm//@types/hammerjs",
+        "@npm//@types/trusted-types",
     ],
 )
 

--- a/packages/core/src/util/security/trusted_types.ts
+++ b/packages/core/src/util/security/trusted_types.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * @fileoverview
+ * A module to facilitate use of a Trusted Types policy internally within
+ * Angular. It lazily constructs the Trusted Types policy, providing helper
+ * utilities for promoting strings to Trusted Types. When Trusted Types are not
+ * available, strings are used as a fallback.
+ * @security All use of this module is security-sensitive and should go through
+ * security review.
+ */
+
+import {global} from '../global';
+
+/**
+ * The Trusted Types policy, or null if Trusted Types are not
+ * enabled/supported, or undefined if the policy has not been created yet.
+ */
+let policy: TrustedTypePolicy|null|undefined;
+
+/**
+ * Returns the Trusted Types policy, or null if Trusted Types are not
+ * enabled/supported. The first call to this function will create the policy.
+ */
+function getPolicy(): TrustedTypePolicy|null {
+  if (policy === undefined) {
+    policy = null;
+    if (global.trustedTypes) {
+      try {
+        policy = (global.trustedTypes as TrustedTypePolicyFactory).createPolicy('angular', {
+          createHTML: (s: string) => s,
+          createScript: (s: string) => s,
+          createScriptURL: (s: string) => s,
+        });
+      } catch {
+        // trustedTypes.createPolicy throws if called with a name that is
+        // already registered, even in report-only mode. Until the API changes,
+        // catch the error not to break the applications functionally. In such
+        // cases, the code will fall back to using strings.
+      }
+    }
+  }
+  return policy;
+}
+
+/**
+ * Unsafely promote a string to a TrustedHTML, falling back to strings when
+ * Trusted Types are not available.
+ * @security This is a security-sensitive function; any use of this function
+ * must go through security review. In particular, it must be assured that the
+ * provided string will never cause an XSS vulnerability if used in a context
+ * that will be interpreted as HTML by a browser, e.g. when assigning to
+ * element.innerHTML.
+ */
+export function trustedHTMLFromString(html: string): TrustedHTML|string {
+  return getPolicy()?.createHTML(html) || html;
+}
+
+/**
+ * Unsafely promote a string to a TrustedScript, falling back to strings when
+ * Trusted Types are not available.
+ * @security In particular, it must be assured that the provided string will
+ * never cause an XSS vulnerability if used in a context that will be
+ * interpreted and executed as a script by a browser, e.g. when calling eval.
+ */
+export function trustedScriptFromString(script: string): TrustedScript|string {
+  return getPolicy()?.createScript(script) || script;
+}
+
+/**
+ * Unsafely promote a string to a TrustedScriptURL, falling back to strings
+ * when Trusted Types are not available.
+ * @security This is a security-sensitive function; any use of this function
+ * must go through security review. In particular, it must be assured that the
+ * provided string will never cause an XSS vulnerability if used in a context
+ * that will cause a browser to load and execute a resource, e.g. when
+ * assigning to script.src.
+ */
+export function trustedScriptURLFromString(url: string): TrustedScriptURL|string {
+  return getPolicy()?.createScriptURL(url) || url;
+}

--- a/packages/types.d.ts
+++ b/packages/types.d.ts
@@ -9,6 +9,7 @@
 // This file contains all ambient imports needed to compile the packages/ source code
 
 /// <reference types="hammerjs" />
+/// <reference types="trusted-types" />
 /// <reference lib="es2015" />
 /// <reference path="./goog.d.ts" />
 /// <reference path="./system.d.ts" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2358,6 +2358,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
+
 "@types/webpack-sources@^0.1.5":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-0.1.7.tgz#0a330a9456113410c74a5d64180af0cbca007141"


### PR DESCRIPTION
Add a module that provides a [Trusted Types](https://web.dev/trusted-types/) policy for use internally by
Angular. The policy is created lazily and stored in a module-local
variable. For now the module does not allow configuring custom policies
or policy names, and instead creates its own policy with 'angular' as a
fixed policy name. This is to more easily support tree-shakability.

Helper functions for unsafely converting strings to each of the three
Trusted Types are also introduced, with names that make it clear that
their use requires a security review. When Trusted Types are not
available, these helper functions fall back to returning strings.

The TypeScript type definitions for Trusted Types is also added as
a dependency. See the individual commits for more details.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
This is part of an ongoing effort to add support for Trusted Types to Angular.