### PR TITLE
fix(core): pass a Trusted Types policy to inert DOM builder

### DIFF
--- a/packages/core/src/sanitization/inert_body.ts
+++ b/packages/core/src/sanitization/inert_body.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {trustedHTMLFromString} from '../util/security/trusted_types';
+
 /**
  * This helper is used to get hold of an inert tree of DOM elements containing dirty HTML
  * that needs sanitizing.
@@ -36,8 +38,9 @@ class DOMParserHelper implements InertBodyHelper {
     // in `html` from consuming the otherwise explicit `</body>` tag.
     html = '<body><remove></remove>' + html;
     try {
-      const body = new (window as any).DOMParser().parseFromString(html, 'text/html').body as
-          HTMLBodyElement;
+      const body = new window.DOMParser()
+                       .parseFromString(trustedHTMLFromString(html) as string, 'text/html')
+                       .body as HTMLBodyElement;
       body.removeChild(body.firstChild!);
       return body;
     } catch {
@@ -71,7 +74,7 @@ class InertDocumentHelper implements InertBodyHelper {
     // Prefer using <template> element if supported.
     const templateEl = this.inertDocument.createElement('template');
     if ('content' in templateEl) {
-      templateEl.innerHTML = html;
+      templateEl.innerHTML = trustedHTMLFromString(html) as string;
       return templateEl;
     }
 
@@ -83,7 +86,7 @@ class InertDocumentHelper implements InertBodyHelper {
     // down the line. This has been worked around by creating a new inert `body` and using it as
     // the root node in which we insert the HTML.
     const inertBody = this.inertDocument.createElement('body');
-    inertBody.innerHTML = html;
+    inertBody.innerHTML = trustedHTMLFromString(html) as string;
 
     // Support: IE 9-11 only
     // strip custom-namespaced attributes on IE<=11
@@ -129,7 +132,8 @@ class InertDocumentHelper implements InertBodyHelper {
  */
 export function isDOMParserAvailable() {
   try {
-    return !!new (window as any).DOMParser().parseFromString('', 'text/html');
+    return !!new window.DOMParser().parseFromString(
+        trustedHTMLFromString('') as string, 'text/html');
   } catch {
     return false;
   }


### PR DESCRIPTION
When Angular is used in an environment that enforces Trusted Types, the
inert DOM builder raises a Trusted Types violation due to its use of
DOMParser and element.innerHTML with plain strings. Indeed, depending on
what is passed into the inert DOM builder and how its output is used,
this could be the cause of a XSS vulnerability.

There are legitimately safe uses of the inert DOM builder, such as with
Angular's HTML sanitizer and its I18n/ICU message parser, neither of
which uses the resulting DOM tree in a security sensitive manner.

To support such use cases in a manner that is compatible with Trusted
Types, the inert DOM builder is made to accept and use an optional
Trusted Types policy for converting (potentially arbitrary) strings to
TrustedHTML, before using the dangerous DOM APIs. The caller must thus
prove that a particular use is safe by providing an appropriate policy.

As their use is safe, both the HTML sanitizer and the ICU message parser
are updated to pass Angular's main Trusted Types policy to the inert DOM
builder.

This is based on https://github.com/angular/angular/pull/39207. See the individual commits for more details.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
This is part of an ongoing effort to add support for Trusted Types to Angular.