### PR TITLE
fix(core): make development mode Trusted Types compatible

### DIFF
--- a/packages/core/src/util/named_array_type.ts
+++ b/packages/core/src/util/named_array_type.ts
@@ -8,6 +8,7 @@
  */
 
 import './ng_dev_mode';
+import {newTrustedFunctionForDev} from './security/trusted_types';
 
 /**
  * THIS FILE CONTAINS CODE WHICH SHOULD BE TREE SHAKEN AND NEVER CALLED FROM PRODUCTION CODE!!!
@@ -27,9 +28,10 @@ export function createNamedArrayType(name: string): typeof Array {
   // This should never be called in prod mode, so let's verify that is the case.
   if (ngDevMode) {
     try {
-      // We need to do it this way so that TypeScript does not down-level the below code.
-      const FunctionConstructor: any = createNamedArrayType.constructor;
-      return (new FunctionConstructor('Array', `return class ${name} extends Array{}`))(Array);
+      // If this function were compromised the following could lead to arbitrary
+      // script execution. We bless it with Trusted Types anyway since this
+      // function is stripped out of production binaries.
+      return (newTrustedFunctionForDev('Array', `return class ${name} extends Array{}`))(Array);
     } catch (e) {
       // If it does not work just give up and fall back to regular Array.
       return Array;


### PR DESCRIPTION
Introduce a Trusted Types policy that is only available in development
mode. It allows arbitrary unsafe conversions to Trusted Types to support
development features.

Address a Trusted Types violation that occurs in createNamedArrayType
during development mode. Instead of passing strings directly to "new
Function", use the Trusted Types compatible function constructor exposed
by the Trusted Types development policy.

Implement a workaround to make "new Function" work with Trusted Types,
as described here:
https://github.com/w3c/webappsec-trusted-types/wiki/Trusted-Types-for-function-constructor

This is based on #39207. See the individual commits for more details.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
This is part of an ongoing effort to add support for Trusted Types to Angular.