### PR TITLE
WIP(core): introduce TrustedSanitizer interface

### DIFF
--- a/goldens/public-api/core/core.d.ts
+++ b/goldens/public-api/core/core.d.ts
@@ -961,6 +961,15 @@ export declare const TRANSLATIONS: InjectionToken<string>;
 
 export declare const TRANSLATIONS_FORMAT: InjectionToken<string>;
 
+export declare abstract class TrustedSanitizer {
+    abstract sanitize(context: SecurityContext.HTML, value: {} | string | null): string | TrustedHTML | null;
+    abstract sanitize(context: SecurityContext.SCRIPT, value: {} | string | null): string | TrustedScript | null;
+    abstract sanitize(context: SecurityContext.RESOURCE_URL, value: {} | string | null): string | TrustedScriptURL | null;
+    abstract sanitize(context: SecurityContext, value: {} | string | null): string | null;
+    abstract sanitize(context: SecurityContext, value: {} | string | null): string | TrustedHTML | TrustedScript | TrustedScriptURL | null;
+    static ɵprov: never;
+}
+
 export declare const Type: FunctionConstructor;
 
 export declare interface TypeDecorator {

--- a/goldens/public-api/platform-browser/platform-browser.d.ts
+++ b/goldens/public-api/platform-browser/platform-browser.d.ts
@@ -17,9 +17,9 @@ export declare class By {
 export declare function disableDebugTools(): void;
 
 export declare abstract class DomSanitizer implements Sanitizer {
-    abstract bypassSecurityTrustHtml(value: string): SafeHtml;
-    abstract bypassSecurityTrustResourceUrl(value: string): SafeResourceUrl;
-    abstract bypassSecurityTrustScript(value: string): SafeScript;
+    abstract bypassSecurityTrustHtml(value: string | TrustedHTML): SafeHtml;
+    abstract bypassSecurityTrustResourceUrl(value: string | TrustedScriptURL): SafeResourceUrl;
+    abstract bypassSecurityTrustScript(value: string | TrustedScript): SafeScript;
     abstract bypassSecurityTrustStyle(value: string): SafeStyle;
     abstract bypassSecurityTrustUrl(value: string): SafeUrl;
     abstract sanitize(context: SecurityContext, value: SafeValue | string | null): string | null;

--- a/goldens/public-api/platform-browser/platform-browser.d.ts
+++ b/goldens/public-api/platform-browser/platform-browser.d.ts
@@ -129,4 +129,12 @@ export declare class TransferState {
     toJson(): string;
 }
 
+export declare abstract class TrustedDomSanitizer implements TrustedSanitizer {
+    abstract sanitize(context: SecurityContext.HTML, value: {} | string | null): string | TrustedHTML | null;
+    abstract sanitize(context: SecurityContext.SCRIPT, value: {} | string | null): string | TrustedScript | null;
+    abstract sanitize(context: SecurityContext.RESOURCE_URL, value: {} | string | null): string | TrustedScriptURL | null;
+    abstract sanitize(context: SecurityContext, value: {} | string | null): string | null;
+    abstract sanitize(context: SecurityContext, value: {} | string | null): string | TrustedHTML | TrustedScript | TrustedScriptURL | null;
+}
+
 export declare const VERSION: Version;

--- a/integration/bazel/yarn.lock
+++ b/integration/bazel/yarn.lock
@@ -55,6 +55,7 @@
 "@angular/core@file:../../dist/packages-dist/core":
   version "11.0.0-next.4"
   dependencies:
+    "@types/trusted-types" "^1.0.6"
     tslib "^2.0.0"
 
 "@angular/forms@file:../../dist/packages-dist/forms":
@@ -453,6 +454,11 @@
   version "3.0.16"
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.16.tgz#50a4755f8e33edacd9c406729e9b930d2451902a"
   integrity sha512-lMC2G0ItF2xv4UCiwbJGbnJlIuUixHrioOhNGHSCsYCJ8l4t9hMCUimCytvFv7qy6AfSzRxhRHoGa+UqaqwyeA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 accepts@~1.3.4:
   version "1.3.7"

--- a/integration/cli-hello-world-ivy-compat/yarn.lock
+++ b/integration/cli-hello-world-ivy-compat/yarn.lock
@@ -165,6 +165,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-rc.1"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/forms@file:../../dist/packages-dist/forms":
   version "9.0.0-rc.1"
@@ -1092,6 +1094,11 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 "@types/webpack-sources@^0.1.5":
   version "0.1.5"

--- a/integration/cli-hello-world-ivy-i18n/yarn.lock
+++ b/integration/cli-hello-world-ivy-i18n/yarn.lock
@@ -165,6 +165,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-rc.1"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/forms@file:../../dist/packages-dist/forms":
   version "9.0.0-rc.1"
@@ -1163,6 +1165,11 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 "@types/webpack-sources@^0.1.5":
   version "0.1.5"

--- a/integration/cli-hello-world-ivy-minimal/yarn.lock
+++ b/integration/cli-hello-world-ivy-minimal/yarn.lock
@@ -165,6 +165,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-rc.1"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/forms@file:../../dist/packages-dist/forms":
   version "9.0.0-rc.1"
@@ -1092,6 +1094,11 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 "@types/webpack-sources@^0.1.5":
   version "0.1.5"

--- a/integration/cli-hello-world-lazy-rollup/yarn.lock
+++ b/integration/cli-hello-world-lazy-rollup/yarn.lock
@@ -165,6 +165,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-rc.1"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/forms@file:../../dist/packages-dist/forms":
   version "9.0.0-rc.1"
@@ -1153,6 +1155,11 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 "@types/webpack-sources@^0.1.5":
   version "0.1.5"

--- a/integration/cli-hello-world-lazy/yarn.lock
+++ b/integration/cli-hello-world-lazy/yarn.lock
@@ -165,6 +165,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-rc.1"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/forms@file:../../dist/packages-dist/forms":
   version "9.0.0-rc.1"
@@ -1153,6 +1155,11 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 "@types/webpack-sources@^0.1.5":
   version "0.1.5"

--- a/integration/cli-hello-world/yarn.lock
+++ b/integration/cli-hello-world/yarn.lock
@@ -165,6 +165,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-rc.1"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/forms@file:../../dist/packages-dist/forms":
   version "9.0.0-rc.1"
@@ -1085,6 +1087,11 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 "@types/webpack-sources@^0.1.5":
   version "0.1.5"

--- a/integration/dynamic-compiler/yarn.lock
+++ b/integration/dynamic-compiler/yarn.lock
@@ -28,6 +28,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-rc.1"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
   version "9.0.0-rc.1"
@@ -90,6 +92,11 @@
   version "3.0.16"
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.16.tgz#50a4755f8e33edacd9c406729e9b930d2451902a"
   integrity sha512-lMC2G0ItF2xv4UCiwbJGbnJlIuUixHrioOhNGHSCsYCJ8l4t9hMCUimCytvFv7qy6AfSzRxhRHoGa+UqaqwyeA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 abbrev@1:
   version "1.1.1"

--- a/integration/hello_world__closure/yarn.lock
+++ b/integration/hello_world__closure/yarn.lock
@@ -29,6 +29,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "10.0.0-next.5"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/platform-browser@file:../../dist/packages-dist/platform-browser":
   version "10.0.0-next.5"
@@ -71,6 +73,11 @@
   version "3.0.16"
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.16.tgz#50a4755f8e33edacd9c406729e9b930d2451902a"
   integrity sha512-lMC2G0ItF2xv4UCiwbJGbnJlIuUixHrioOhNGHSCsYCJ8l4t9hMCUimCytvFv7qy6AfSzRxhRHoGa+UqaqwyeA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 accepts@~1.3.4:
   version "1.3.7"

--- a/integration/hello_world__systemjs_umd/yarn.lock
+++ b/integration/hello_world__systemjs_umd/yarn.lock
@@ -10,6 +10,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-rc.1"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
   version "9.0.0-rc.1"
@@ -34,6 +36,11 @@
   version "3.0.16"
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.16.tgz#50a4755f8e33edacd9c406729e9b930d2451902a"
   integrity sha512-lMC2G0ItF2xv4UCiwbJGbnJlIuUixHrioOhNGHSCsYCJ8l4t9hMCUimCytvFv7qy6AfSzRxhRHoGa+UqaqwyeA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 abbrev@1:
   version "1.1.1"

--- a/integration/i18n/yarn.lock
+++ b/integration/i18n/yarn.lock
@@ -32,6 +32,7 @@
 "@angular/core@file:../../dist/packages-dist/core":
   version "10.0.0-next.9"
   dependencies:
+    "@types/trusted-types" "^1.0.6"
     tslib "^2.0.0"
 
 "@angular/platform-browser@file:../../dist/packages-dist/platform-browser":
@@ -71,6 +72,11 @@
   version "3.0.16"
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.16.tgz#50a4755f8e33edacd9c406729e9b930d2451902a"
   integrity sha512-lMC2G0ItF2xv4UCiwbJGbnJlIuUixHrioOhNGHSCsYCJ8l4t9hMCUimCytvFv7qy6AfSzRxhRHoGa+UqaqwyeA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 accepts@~1.3.4:
   version "1.3.7"

--- a/integration/injectable-def/yarn.lock
+++ b/integration/injectable-def/yarn.lock
@@ -28,6 +28,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-rc.1"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
   version "9.0.0-rc.1"
@@ -56,6 +58,11 @@
   version "3.0.16"
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.16.tgz#50a4755f8e33edacd9c406729e9b930d2451902a"
   integrity sha512-lMC2G0ItF2xv4UCiwbJGbnJlIuUixHrioOhNGHSCsYCJ8l4t9hMCUimCytvFv7qy6AfSzRxhRHoGa+UqaqwyeA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 abbrev@1:
   version "1.1.1"

--- a/integration/ivy-i18n/yarn.lock
+++ b/integration/ivy-i18n/yarn.lock
@@ -203,6 +203,7 @@
   version "0.0.0"
   resolved "file:../../../../../../../../private/var/tmp/_bazel_pete/f9acfb7f019473a10a34c8c30adc55ea/execroot/angular/bazel-out/darwin-fastbuild/bin/integration/ivy-i18n_test.debug.sh.runfiles/angular/packages/core/npm_package_archive.tar.gz#8a876eccb8039b838f3baaf47e57ebb6d6401b3d"
   dependencies:
+    "@types/trusted-types" "^1.0.6"
     tslib "^2.0.0"
 
 "@angular/forms@file:../../../../../../../../private/var/tmp/_bazel_pete/f9acfb7f019473a10a34c8c30adc55ea/execroot/angular/bazel-out/darwin-fastbuild/bin/integration/ivy-i18n_test.debug.sh.runfiles/angular/packages/forms/npm_package_archive.tar.gz":
@@ -1424,6 +1425,11 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 "@types/webpack-sources@^0.1.5":
   version "0.1.5"

--- a/integration/language_service_plugin/yarn.lock
+++ b/integration/language_service_plugin/yarn.lock
@@ -4,12 +4,19 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-rc.1"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/language-service@file:../../dist/packages-dist/language-service":
   version "9.0.0-rc.1"
 
 "@types/node@file:../../node_modules/@types/node":
   version "12.11.1"
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 balanced-match@^1.0.0:
   version "1.0.0"

--- a/integration/ng_elements/yarn.lock
+++ b/integration/ng_elements/yarn.lock
@@ -32,6 +32,7 @@
 "@angular/core@file:../../dist/packages-dist/core":
   version "10.0.0-next.9"
   dependencies:
+    "@types/trusted-types" "^1.0.6"
     tslib "^2.0.0"
 
 "@angular/elements@file:../../dist/packages-dist/elements":
@@ -76,6 +77,11 @@
   version "3.0.16"
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.16.tgz#50a4755f8e33edacd9c406729e9b930d2451902a"
   integrity sha512-lMC2G0ItF2xv4UCiwbJGbnJlIuUixHrioOhNGHSCsYCJ8l4t9hMCUimCytvFv7qy6AfSzRxhRHoGa+UqaqwyeA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 accepts@~1.3.4:
   version "1.3.7"

--- a/integration/ng_update/yarn.lock
+++ b/integration/ng_update/yarn.lock
@@ -28,6 +28,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-rc.1"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/forms@file:../../dist/packages-dist/forms":
   version "9.0.0-rc.1"
@@ -61,6 +63,11 @@
 
 "@angular/upgrade@file:../../dist/packages-dist/upgrade":
   version "9.0.0-rc.1"
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 ansi-regex@^2.0.0:
   version "2.1.1"

--- a/integration/ng_update_migrations/yarn.lock
+++ b/integration/ng_update_migrations/yarn.lock
@@ -165,6 +165,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-rc.1"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/forms@file:../../dist/packages-dist/forms":
   version "9.0.0-rc.1"
@@ -1080,6 +1082,11 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 "@types/webpack-sources@^0.1.5":
   version "0.1.5"

--- a/integration/ngcc/yarn.lock
+++ b/integration/ngcc/yarn.lock
@@ -36,6 +36,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.1.0-next.2"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/forms@file:../../dist/packages-dist/forms":
   version "9.1.0-next.2"
@@ -75,6 +77,11 @@
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.17.tgz#50bea0c3c2acc31c959c5b1e747798b3b3d06d4b"
   integrity sha512-tGomyEuzSC1H28y2zlW6XPCaDaXFaD6soTdb4GNdmte2qfHtrKqhy0ZFs4r/1hpazCfEZqeTSRLvSasmEx89uw==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 accepts@~1.3.4:
   version "1.3.7"

--- a/integration/platform-server/yarn.lock
+++ b/integration/platform-server/yarn.lock
@@ -29,6 +29,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "10.0.0-next.5"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
   version "10.0.0-next.5"
@@ -77,6 +79,11 @@
   version "3.0.14"
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.14.tgz#0b20a2370e6b1b8322c9c3dfcaa409e6c7c0c0a9"
   integrity sha512-4GbNCDs98uHCT/OMv40qQC/OpoPbYn9XdXeTiFwHBBFO6eJhYEPUu2zDKirXSbHlvDV8oZ9l8EQ+HrEx/YS9DQ==
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 abbrev@1:
   version "1.1.1"

--- a/integration/service-worker-schema/yarn.lock
+++ b/integration/service-worker-schema/yarn.lock
@@ -7,9 +7,16 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-rc.1"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/service-worker@file:../../dist/packages-dist/service-worker":
   version "9.0.0-rc.1"
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 "rxjs@file:../../node_modules/rxjs":
   version "6.5.3"

--- a/integration/side-effects/yarn.lock
+++ b/integration/side-effects/yarn.lock
@@ -20,6 +20,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-next.10"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/elements@file:../../dist/packages-dist/elements":
   version "9.0.0-next.10"
@@ -70,6 +72,11 @@
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 acorn@^6.1.1:
   version "6.1.1"

--- a/integration/terser/yarn.lock
+++ b/integration/terser/yarn.lock
@@ -22,6 +22,13 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.0.0-rc.1"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 ansi-regex@^2.0.0:
   version "2.1.1"

--- a/integration/typings_test_ts39/yarn.lock
+++ b/integration/typings_test_ts39/yarn.lock
@@ -29,6 +29,8 @@
 
 "@angular/core@file:../../dist/packages-dist/core":
   version "9.1.0-next.2"
+  dependencies:
+    "@types/trusted-types" "^1.0.6"
 
 "@angular/elements@file:../../dist/packages-dist/elements":
   version "9.1.0-next.2"
@@ -65,6 +67,11 @@
 
 "@types/jasmine@file:../../node_modules/@types/jasmine":
   version "2.8.8"
+
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
 
 ansi-regex@^2.0.0:
   version "2.1.1"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@types/semver": "^6.0.2",
     "@types/shelljs": "^0.8.6",
     "@types/systemjs": "0.19.32",
+    "@types/trusted-types": "^1.0.6",
     "@types/yaml": "^1.9.7",
     "@types/yargs": "^15.0.5",
     "@webcomponents/custom-elements": "^1.1.0",

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
     deps = [
         "//packages/zone.js/lib:zone_d_ts",
         "@npm//@types/hammerjs",
+        "@npm//@types/trusted-types",
     ],
 )
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "dependencies": {
+    "@types/trusted-types": "^1.0.6",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -34,7 +34,7 @@ export {ErrorHandler} from './error_handler';
 export * from './core_private_export';
 export * from './core_render3_private_export';
 export {SecurityContext} from './sanitization/security';
-export {Sanitizer} from './sanitization/sanitizer';
+export {Sanitizer, TrustedSanitizer} from './sanitization/sanitizer';
 export * from './codegen_private_exports';
 
 import {global} from './util/global';

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -16,7 +16,7 @@ import {ComponentFactoryResolver as viewEngine_ComponentFactoryResolver} from '.
 import {ElementRef as viewEngine_ElementRef} from '../linker/element_ref';
 import {NgModuleRef as viewEngine_NgModuleRef} from '../linker/ng_module_factory';
 import {RendererFactory2} from '../render/api';
-import {Sanitizer} from '../sanitization/sanitizer';
+import {Sanitizer, TrustedSanitizer} from '../sanitization/sanitizer';
 import {VERSION} from '../version';
 import {NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from '../view/provider';
 import {assertComponentType} from './assert';
@@ -139,7 +139,13 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
 
     const rendererFactory =
         rootViewInjector.get(RendererFactory2, domRendererFactory3) as RendererFactory3;
-    const sanitizer = rootViewInjector.get(Sanitizer, null);
+    let sanitizer = rootViewInjector.get(TrustedSanitizer, null);
+    if (!sanitizer) {
+      // DO NOT REFACTOR. Using `get(TrustedSanitizer) || get(Sanitizer)` seems
+      // to cause internal google apps to fail. This is documented in the
+      // following internal bug issue: b/142967802
+      sanitizer = rootViewInjector.get(Sanitizer, null);
+    }
 
     const hostRenderer = rendererFactory.createRenderer(null, this.componentDef);
     // Determine a tag name used for creating host elements when this component is created

--- a/packages/core/src/render3/instructions/lview_debug.ts
+++ b/packages/core/src/render3/instructions/lview_debug.ts
@@ -7,7 +7,7 @@
  */
 
 import {Injector, SchemaMetadata, Type} from '../../core';
-import {Sanitizer} from '../../sanitization/sanitizer';
+import {Sanitizer, TrustedSanitizer} from '../../sanitization/sanitizer';
 import {KeyValueArray} from '../../util/array_utils';
 import {assertDefined} from '../../util/assert';
 import {createNamedArrayType} from '../../util/named_array_type';
@@ -474,7 +474,7 @@ export class LViewDebug implements ILViewDebug {
   get renderer(): Renderer3 {
     return this._raw_lView[RENDERER];
   }
-  get sanitizer(): Sanitizer|null {
+  get sanitizer(): Sanitizer|TrustedSanitizer|null {
     return this._raw_lView[SANITIZER];
   }
   get childHead(): ILViewDebug|ILContainerDebug|null {

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -11,7 +11,7 @@ import {DoCheck, OnChanges, OnInit} from '../../interface/lifecycle_hooks';
 import {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA, SchemaMetadata} from '../../metadata/schema';
 import {ViewEncapsulation} from '../../metadata/view';
 import {validateAgainstEventAttributes, validateAgainstEventProperties} from '../../sanitization/sanitization';
-import {Sanitizer} from '../../sanitization/sanitizer';
+import {Sanitizer, TrustedSanitizer} from '../../sanitization/sanitizer';
 import {assertDefined, assertDomNode, assertEqual, assertGreaterThan, assertIndexInRange, assertLessThan, assertNotEqual, assertNotSame, assertSame} from '../../util/assert';
 import {createNamedArrayType} from '../../util/named_array_type';
 import {initNgDevMode} from '../../util/ng_dev_mode';
@@ -173,7 +173,7 @@ export function elementCreate(name: string, renderer: Renderer3, namespace: stri
 export function createLView<T>(
     parentLView: LView|null, tView: TView, context: T|null, flags: LViewFlags, host: RElement|null,
     tHostNode: TNode|null, rendererFactory: RendererFactory3|null, renderer: Renderer3|null,
-    sanitizer: Sanitizer|null, injector: Injector|null): LView {
+    sanitizer: Sanitizer|TrustedSanitizer|null, injector: Injector|null): LView {
   const lView =
       ngDevMode ? cloneToLViewFromTViewBlueprint(tView) : tView.blueprint.slice() as LView;
   lView[HOST] = host;

--- a/packages/core/src/render3/interfaces/renderer.ts
+++ b/packages/core/src/render3/interfaces/renderer.ts
@@ -80,7 +80,9 @@ export interface ProceduralRenderer3 {
   parentNode(node: RNode): RElement|null;
   nextSibling(node: RNode): RNode|null;
 
-  setAttribute(el: RElement, name: string, value: string, namespace?: string|null): void;
+  setAttribute(
+      el: RElement, name: string, value: string|TrustedHTML|TrustedScript|TrustedScriptURL,
+      namespace?: string|null): void;
   removeAttribute(el: RElement, name: string, namespace?: string|null): void;
   addClass(el: RElement, name: string): void;
   removeClass(el: RElement, name: string): void;
@@ -157,9 +159,11 @@ export interface RElement extends RNode {
   classList: RDomTokenList;
   className: string;
   textContent: string|null;
-  setAttribute(name: string, value: string): void;
+  setAttribute(name: string, value: string|TrustedHTML|TrustedScript|TrustedScriptURL): void;
   removeAttribute(name: string): void;
-  setAttributeNS(namespaceURI: string, qualifiedName: string, value: string): void;
+  setAttributeNS(
+      namespaceURI: string, qualifiedName: string,
+      value: string|TrustedHTML|TrustedScript|TrustedScriptURL): void;
   addEventListener(type: string, listener: EventListener, useCapture?: boolean): void;
   removeEventListener(type: string, listener?: EventListener, options?: boolean): void;
 

--- a/packages/core/src/render3/interfaces/sanitization.ts
+++ b/packages/core/src/render3/interfaces/sanitization.ts
@@ -9,4 +9,5 @@
 /**
  * Function used to sanitize the value before writing it into the renderer.
  */
-export type SanitizerFn = (value: any, tagName?: string, propName?: string) => string;
+export type SanitizerFn = (value: any, tagName?: string, propName?: string) =>
+    string|TrustedHTML|TrustedScript|TrustedScriptURL;

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -10,7 +10,7 @@ import {InjectionToken} from '../../di/injection_token';
 import {Injector} from '../../di/injector';
 import {Type} from '../../interface/type';
 import {SchemaMetadata} from '../../metadata';
-import {Sanitizer} from '../../sanitization/sanitizer';
+import {Sanitizer, TrustedSanitizer} from '../../sanitization/sanitizer';
 
 import {LContainer} from './container';
 import {ComponentDef, ComponentTemplate, DirectiveDef, DirectiveDefList, HostBindingsFunction, PipeDef, PipeDefList, ViewQueriesFunction} from './definition';
@@ -180,7 +180,7 @@ export interface LView extends Array<any> {
   [RENDERER]: Renderer3;
 
   /** An optional custom sanitizer. */
-  [SANITIZER]: Sanitizer|null;
+  [SANITIZER]: Sanitizer|TrustedSanitizer|null;
 
   /**
    * Reference to the first LView or LContainer beneath this LView in

--- a/packages/core/src/sanitization/bypass.ts
+++ b/packages/core/src/sanitization/bypass.ts
@@ -58,8 +58,8 @@ export interface SafeUrl extends SafeValue {}
 export interface SafeResourceUrl extends SafeValue {}
 
 
-abstract class SafeValueImpl implements SafeValue {
-  constructor(public changingThisBreaksApplicationSecurity: string) {}
+abstract class SafeValueImpl<T> implements SafeValue {
+  constructor(public changingThisBreaksApplicationSecurity: string|T) {}
 
   abstract getTypeName(): string;
 
@@ -69,35 +69,35 @@ abstract class SafeValueImpl implements SafeValue {
   }
 }
 
-class SafeHtmlImpl extends SafeValueImpl implements SafeHtml {
+class SafeHtmlImpl extends SafeValueImpl<TrustedHTML> implements SafeHtml {
   getTypeName() {
     return BypassType.Html;
   }
 }
-class SafeStyleImpl extends SafeValueImpl implements SafeStyle {
+class SafeStyleImpl extends SafeValueImpl<string> implements SafeStyle {
   getTypeName() {
     return BypassType.Style;
   }
 }
-class SafeScriptImpl extends SafeValueImpl implements SafeScript {
+class SafeScriptImpl extends SafeValueImpl<TrustedScript> implements SafeScript {
   getTypeName() {
     return BypassType.Script;
   }
 }
-class SafeUrlImpl extends SafeValueImpl implements SafeUrl {
+class SafeUrlImpl extends SafeValueImpl<string> implements SafeUrl {
   getTypeName() {
     return BypassType.Url;
   }
 }
-class SafeResourceUrlImpl extends SafeValueImpl implements SafeResourceUrl {
+class SafeResourceUrlImpl extends SafeValueImpl<TrustedScriptURL> implements SafeResourceUrl {
   getTypeName() {
     return BypassType.ResourceUrl;
   }
 }
 
-export function unwrapSafeValue(value: SafeValue): string;
+export function unwrapSafeValue<T>(value: SafeValue): string|T;
 export function unwrapSafeValue<T>(value: T): T;
-export function unwrapSafeValue<T>(value: T|SafeValue): T {
+export function unwrapSafeValue<T>(value: any): string|T {
   return value instanceof SafeValueImpl ? value.changingThisBreaksApplicationSecurity as any as T :
                                           value as any as T;
 }
@@ -137,7 +137,7 @@ export function getSanitizationBypassType(value: any): BypassType|null {
  * @param trustedHtml `html` string which needs to be implicitly trusted.
  * @returns a `html` which has been branded to be implicitly trusted.
  */
-export function bypassSanitizationTrustHtml(trustedHtml: string): SafeHtml {
+export function bypassSanitizationTrustHtml(trustedHtml: string|TrustedHTML): SafeHtml {
   return new SafeHtmlImpl(trustedHtml);
 }
 /**
@@ -161,7 +161,7 @@ export function bypassSanitizationTrustStyle(trustedStyle: string): SafeStyle {
  * @param trustedScript `script` string which needs to be implicitly trusted.
  * @returns a `script` which has been branded to be implicitly trusted.
  */
-export function bypassSanitizationTrustScript(trustedScript: string): SafeScript {
+export function bypassSanitizationTrustScript(trustedScript: string|TrustedScript): SafeScript {
   return new SafeScriptImpl(trustedScript);
 }
 /**
@@ -185,6 +185,7 @@ export function bypassSanitizationTrustUrl(trustedUrl: string): SafeUrl {
  * @param trustedResourceUrl `url` string which needs to be implicitly trusted.
  * @returns a `url` which has been branded to be implicitly trusted.
  */
-export function bypassSanitizationTrustResourceUrl(trustedResourceUrl: string): SafeResourceUrl {
+export function bypassSanitizationTrustResourceUrl(trustedResourceUrl: string|
+                                                   TrustedScriptURL): SafeResourceUrl {
   return new SafeResourceUrlImpl(trustedResourceUrl);
 }

--- a/packages/core/src/sanitization/html_sanitizer.ts
+++ b/packages/core/src/sanitization/html_sanitizer.ts
@@ -7,6 +7,7 @@
  */
 
 import {isDevMode} from '../util/is_dev_mode';
+import {trustedTypesPolicy} from '../util/security/trusted_types';
 import {getInertBodyHelper, InertBodyHelper} from './inert_body';
 import {_sanitizeUrl, sanitizeSrcset} from './url_sanitizer';
 
@@ -242,7 +243,7 @@ let inertBodyHelper: InertBodyHelper;
  * Sanitizes the given unsafe, untrusted HTML fragment, and returns HTML text that is safe to add to
  * the DOM in a browser environment.
  */
-export function _sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): string {
+export function _sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): TrustedHTML|string {
   let inertBodyElement: HTMLElement|null = null;
   try {
     inertBodyHelper = inertBodyHelper || getInertBodyHelper(defaultDoc);
@@ -274,7 +275,7 @@ export function _sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): string 
           'WARNING: sanitizing HTML stripped some content, see http://g.co/ng/security#xss');
     }
 
-    return safeHtml;
+    return trustedTypesPolicy.trustedHTMLFromStringRequiresSecurityReview(safeHtml);
   } finally {
     // In case anything goes wrong, clear out inertElement to reset the entire DOM structure.
     if (inertBodyElement) {

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -10,7 +10,8 @@ import {getDocument} from '../render3/interfaces/document';
 import {SANITIZER} from '../render3/interfaces/view';
 import {getLView} from '../render3/state';
 import {renderStringify} from '../render3/util/misc_utils';
-
+import {global} from '../util/global';
+import {trustedTypesPolicyForLegacyBypass} from '../util/security/trusted_types';
 import {allowSanitizationBypassAndThrow, BypassType, unwrapSafeValue} from './bypass';
 import {_sanitizeHtml as _sanitizeHtml} from './html_sanitizer';
 import {Sanitizer} from './sanitizer';
@@ -37,10 +38,15 @@ import {_sanitizeUrl as _sanitizeUrl} from './url_sanitizer';
 export function ɵɵsanitizeHtml(unsafeHtml: any): TrustedHTML|string {
   const sanitizer = getSanitizer();
   if (sanitizer) {
-    return sanitizer.sanitize(SecurityContext.HTML, unsafeHtml) || '';
+    return trustedTypesPolicyForLegacyBypass.trustedHTMLFromStringRequiresSecurityReview(
+        sanitizer.sanitize(SecurityContext.HTML, unsafeHtml) || '');
   }
   if (allowSanitizationBypassAndThrow(unsafeHtml, BypassType.Html)) {
-    return unwrapSafeValue<TrustedHTML>(unsafeHtml);
+    const value = unwrapSafeValue<TrustedHTML>(unsafeHtml);
+    if (global.trustedTypes && !(global.trustedTypes as TrustedTypePolicyFactory).isHTML(value)) {
+      return trustedTypesPolicyForLegacyBypass.trustedHTMLFromStringRequiresSecurityReview(value);
+    }
+    return value;
   }
   return _sanitizeHtml(getDocument(), renderStringify(unsafeHtml));
 }
@@ -108,10 +114,17 @@ export function ɵɵsanitizeUrl(unsafeUrl: any): string {
 export function ɵɵsanitizeResourceUrl(unsafeResourceUrl: any): TrustedScriptURL|string {
   const sanitizer = getSanitizer();
   if (sanitizer) {
-    return sanitizer.sanitize(SecurityContext.RESOURCE_URL, unsafeResourceUrl) || '';
+    return trustedTypesPolicyForLegacyBypass.trustedScriptURLFromStringRequiresSecurityReview(
+        sanitizer.sanitize(SecurityContext.RESOURCE_URL, unsafeResourceUrl) || '');
   }
   if (allowSanitizationBypassAndThrow(unsafeResourceUrl, BypassType.ResourceUrl)) {
-    return unwrapSafeValue<TrustedScriptURL>(unsafeResourceUrl);
+    const value = unwrapSafeValue<TrustedScriptURL>(unsafeResourceUrl);
+    if (global.trustedTypes &&
+        !(global.trustedTypes as TrustedTypePolicyFactory).isScriptURL(value)) {
+      return trustedTypesPolicyForLegacyBypass.trustedScriptURLFromStringRequiresSecurityReview(
+          value);
+    }
+    return value;
   }
   throw new Error('unsafe value used in a resource URL context (see http://g.co/ng/security#xss)');
 }
@@ -131,10 +144,15 @@ export function ɵɵsanitizeResourceUrl(unsafeResourceUrl: any): TrustedScriptUR
 export function ɵɵsanitizeScript(unsafeScript: any): TrustedScript|string {
   const sanitizer = getSanitizer();
   if (sanitizer) {
-    return sanitizer.sanitize(SecurityContext.SCRIPT, unsafeScript) || '';
+    return trustedTypesPolicyForLegacyBypass.trustedScriptFromStringRequiresSecurityReview(
+        sanitizer.sanitize(SecurityContext.SCRIPT, unsafeScript) || '');
   }
   if (allowSanitizationBypassAndThrow(unsafeScript, BypassType.Script)) {
-    return unwrapSafeValue<TrustedScript>(unsafeScript);
+    const value = unwrapSafeValue<TrustedScript>(unsafeScript);
+    if (global.trustedTypes && !(global.trustedTypes as TrustedTypePolicyFactory).isScript(value)) {
+      return trustedTypesPolicyForLegacyBypass.trustedScriptFromStringRequiresSecurityReview(value);
+    }
+    return value;
   }
   throw new Error('unsafe value used in a script context');
 }

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -11,10 +11,10 @@ import {SANITIZER} from '../render3/interfaces/view';
 import {getLView} from '../render3/state';
 import {renderStringify} from '../render3/util/misc_utils';
 import {global} from '../util/global';
-import {trustedTypesPolicyForLegacyBypass} from '../util/security/trusted_types';
+import {trustedTypesPolicy, trustedTypesPolicyForLegacyBypass} from '../util/security/trusted_types';
 import {allowSanitizationBypassAndThrow, BypassType, unwrapSafeValue} from './bypass';
 import {_sanitizeHtml as _sanitizeHtml} from './html_sanitizer';
-import {Sanitizer} from './sanitizer';
+import {Sanitizer, TrustedSanitizer} from './sanitizer';
 import {SecurityContext} from './security';
 import {_sanitizeUrl as _sanitizeUrl} from './url_sanitizer';
 
@@ -38,8 +38,13 @@ import {_sanitizeUrl as _sanitizeUrl} from './url_sanitizer';
 export function ɵɵsanitizeHtml(unsafeHtml: any): TrustedHTML|string {
   const sanitizer = getSanitizer();
   if (sanitizer) {
-    return trustedTypesPolicyForLegacyBypass.trustedHTMLFromStringRequiresSecurityReview(
-        sanitizer.sanitize(SecurityContext.HTML, unsafeHtml) || '');
+    if (sanitizer instanceof TrustedSanitizer) {
+      return sanitizer.sanitize(SecurityContext.HTML, unsafeHtml) ||
+          trustedTypesPolicy.trustedHTMLFromStringRequiresSecurityReview('');
+    } else {
+      return trustedTypesPolicyForLegacyBypass.trustedHTMLFromStringRequiresSecurityReview(
+          sanitizer.sanitize(SecurityContext.HTML, unsafeHtml) || '');
+    }
   }
   if (allowSanitizationBypassAndThrow(unsafeHtml, BypassType.Html)) {
     const value = unwrapSafeValue<TrustedHTML>(unsafeHtml);
@@ -114,8 +119,13 @@ export function ɵɵsanitizeUrl(unsafeUrl: any): string {
 export function ɵɵsanitizeResourceUrl(unsafeResourceUrl: any): TrustedScriptURL|string {
   const sanitizer = getSanitizer();
   if (sanitizer) {
-    return trustedTypesPolicyForLegacyBypass.trustedScriptURLFromStringRequiresSecurityReview(
-        sanitizer.sanitize(SecurityContext.RESOURCE_URL, unsafeResourceUrl) || '');
+    if (sanitizer instanceof TrustedSanitizer) {
+      return sanitizer.sanitize(SecurityContext.RESOURCE_URL, unsafeResourceUrl) ||
+          trustedTypesPolicy.trustedScriptURLFromStringRequiresSecurityReview('');
+    } else {
+      return trustedTypesPolicyForLegacyBypass.trustedScriptURLFromStringRequiresSecurityReview(
+          sanitizer.sanitize(SecurityContext.RESOURCE_URL, unsafeResourceUrl) || '');
+    }
   }
   if (allowSanitizationBypassAndThrow(unsafeResourceUrl, BypassType.ResourceUrl)) {
     const value = unwrapSafeValue<TrustedScriptURL>(unsafeResourceUrl);
@@ -144,8 +154,13 @@ export function ɵɵsanitizeResourceUrl(unsafeResourceUrl: any): TrustedScriptUR
 export function ɵɵsanitizeScript(unsafeScript: any): TrustedScript|string {
   const sanitizer = getSanitizer();
   if (sanitizer) {
-    return trustedTypesPolicyForLegacyBypass.trustedScriptFromStringRequiresSecurityReview(
-        sanitizer.sanitize(SecurityContext.SCRIPT, unsafeScript) || '');
+    if (sanitizer instanceof TrustedSanitizer) {
+      return sanitizer.sanitize(SecurityContext.SCRIPT, unsafeScript) ||
+          trustedTypesPolicy.trustedScriptFromStringRequiresSecurityReview('');
+    } else {
+      return trustedTypesPolicyForLegacyBypass.trustedScriptFromStringRequiresSecurityReview(
+          sanitizer.sanitize(SecurityContext.SCRIPT, unsafeScript) || '');
+    }
   }
   if (allowSanitizationBypassAndThrow(unsafeScript, BypassType.Script)) {
     const value = unwrapSafeValue<TrustedScript>(unsafeScript);

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -226,7 +226,7 @@ export function validateAgainstEventAttributes(name: string) {
   }
 }
 
-function getSanitizer(): Sanitizer|null {
+function getSanitizer(): Sanitizer|TrustedSanitizer|null {
   const lView = getLView();
   return lView && lView[SANITIZER];
 }

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -34,7 +34,7 @@ import {_sanitizeUrl as _sanitizeUrl} from './url_sanitizer';
  *
  * @codeGenApi
  */
-export function ɵɵsanitizeHtml(unsafeHtml: any): string {
+export function ɵɵsanitizeHtml(unsafeHtml: any): TrustedHTML|string {
   const sanitizer = getSanitizer();
   if (sanitizer) {
     return sanitizer.sanitize(SecurityContext.HTML, unsafeHtml) || '';
@@ -105,7 +105,7 @@ export function ɵɵsanitizeUrl(unsafeUrl: any): string {
  *
  * @codeGenApi
  */
-export function ɵɵsanitizeResourceUrl(unsafeResourceUrl: any): string {
+export function ɵɵsanitizeResourceUrl(unsafeResourceUrl: any): TrustedScriptURL|string {
   const sanitizer = getSanitizer();
   if (sanitizer) {
     return sanitizer.sanitize(SecurityContext.RESOURCE_URL, unsafeResourceUrl) || '';
@@ -128,7 +128,7 @@ export function ɵɵsanitizeResourceUrl(unsafeResourceUrl: any): string {
  *
  * @codeGenApi
  */
-export function ɵɵsanitizeScript(unsafeScript: any): string {
+export function ɵɵsanitizeScript(unsafeScript: any): TrustedScript|string {
   const sanitizer = getSanitizer();
   if (sanitizer) {
     return sanitizer.sanitize(SecurityContext.SCRIPT, unsafeScript) || '';

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -40,7 +40,7 @@ export function ɵɵsanitizeHtml(unsafeHtml: any): TrustedHTML|string {
     return sanitizer.sanitize(SecurityContext.HTML, unsafeHtml) || '';
   }
   if (allowSanitizationBypassAndThrow(unsafeHtml, BypassType.Html)) {
-    return unwrapSafeValue(unsafeHtml);
+    return unwrapSafeValue<TrustedHTML>(unsafeHtml);
   }
   return _sanitizeHtml(getDocument(), renderStringify(unsafeHtml));
 }
@@ -62,7 +62,7 @@ export function ɵɵsanitizeStyle(unsafeStyle: any): string {
     return sanitizer.sanitize(SecurityContext.STYLE, unsafeStyle) || '';
   }
   if (allowSanitizationBypassAndThrow(unsafeStyle, BypassType.Style)) {
-    return unwrapSafeValue(unsafeStyle);
+    return unwrapSafeValue<string>(unsafeStyle);
   }
   return renderStringify(unsafeStyle);
 }
@@ -89,7 +89,7 @@ export function ɵɵsanitizeUrl(unsafeUrl: any): string {
     return sanitizer.sanitize(SecurityContext.URL, unsafeUrl) || '';
   }
   if (allowSanitizationBypassAndThrow(unsafeUrl, BypassType.Url)) {
-    return unwrapSafeValue(unsafeUrl);
+    return unwrapSafeValue<string>(unsafeUrl);
   }
   return _sanitizeUrl(renderStringify(unsafeUrl));
 }
@@ -111,7 +111,7 @@ export function ɵɵsanitizeResourceUrl(unsafeResourceUrl: any): TrustedScriptUR
     return sanitizer.sanitize(SecurityContext.RESOURCE_URL, unsafeResourceUrl) || '';
   }
   if (allowSanitizationBypassAndThrow(unsafeResourceUrl, BypassType.ResourceUrl)) {
-    return unwrapSafeValue(unsafeResourceUrl);
+    return unwrapSafeValue<TrustedScriptURL>(unsafeResourceUrl);
   }
   throw new Error('unsafe value used in a resource URL context (see http://g.co/ng/security#xss)');
 }
@@ -134,7 +134,7 @@ export function ɵɵsanitizeScript(unsafeScript: any): TrustedScript|string {
     return sanitizer.sanitize(SecurityContext.SCRIPT, unsafeScript) || '';
   }
   if (allowSanitizationBypassAndThrow(unsafeScript, BypassType.Script)) {
-    return unwrapSafeValue(unsafeScript);
+    return unwrapSafeValue<TrustedScript>(unsafeScript);
   }
   throw new Error('unsafe value used in a script context');
 }

--- a/packages/core/src/sanitization/sanitizer.ts
+++ b/packages/core/src/sanitization/sanitizer.ts
@@ -23,3 +23,26 @@ export abstract class Sanitizer {
     factory: () => null,
   });
 }
+
+/**
+ * TrustedSanitizer is used by the views to sanitize potentially dangerous
+ * values, using Trusted Types to prove their safety after sanitization.
+ *
+ * @publicApi
+ */
+export abstract class TrustedSanitizer {
+  abstract sanitize(context: SecurityContext.HTML, value: {}|string|null): string|TrustedHTML|null;
+  abstract sanitize(context: SecurityContext.SCRIPT, value: {}|string|null): string|TrustedScript
+      |null;
+  abstract sanitize(context: SecurityContext.RESOURCE_URL, value: {}|string|null): string
+      |TrustedScriptURL|null;
+  abstract sanitize(context: SecurityContext, value: {}|string|null): string|null;
+  abstract sanitize(context: SecurityContext, value: {}|string|null): string|TrustedHTML
+      |TrustedScript|TrustedScriptURL|null;
+  /** @nocollapse */
+  static ɵprov = ɵɵdefineInjectable({
+    token: TrustedSanitizer,
+    providedIn: 'root',
+    factory: () => null,
+  });
+}

--- a/packages/core/src/util/security/trusted_types.ts
+++ b/packages/core/src/util/security/trusted_types.ts
@@ -93,3 +93,11 @@ export class AngularTrustedTypesPolicy {
  * The Trusted Types policy used by Angular for all trusted conversions.
  */
 export const trustedTypesPolicy = new AngularTrustedTypesPolicy('angular');
+
+/**
+ * The Trusted Types policy used by Angular for untrusted legacy conversions in
+ * the sanitization pipeline, in particular for the bypassSecurityTrust
+ * functions and custom sanitizers.
+ */
+export const trustedTypesPolicyForLegacyBypass =
+    new AngularTrustedTypesPolicy('angular#unsafe-legacy-bypass');

--- a/packages/core/src/util/security/trusted_types.ts
+++ b/packages/core/src/util/security/trusted_types.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {global} from '../global';
+
+/**
+ * A class to facilitate use of Trusted Types policies within Angular. Lazily
+ * constructs a Trusted Types policy with the specified name, providing helper
+ * utilities for promoting strings to Trusted Types. When Trusted Types are not
+ * available, strings are used as a fallback.
+ */
+export class AngularTrustedTypesPolicy {
+  /**
+   * The wrapped Trusted Types policy, or null if Trusted Types are
+   * not enabled/supported, or undefined if the policy has not been created yet.
+   */
+  private policy: TrustedTypePolicy|null|undefined;
+
+  constructor(private policyName: string) {}
+
+  /**
+   * Returns the wrapped Trusted Types policy, or null if Trusted Types are not
+   * enabled/supported. The first call to this function will create the policy.
+   */
+  private getPolicy(): TrustedTypePolicy|null {
+    if (this.policy === undefined) {
+      this.policy = null;
+      if (global.trustedTypes) {
+        try {
+          this.policy =
+              (global.trustedTypes as TrustedTypePolicyFactory).createPolicy(this.policyName, {
+                createHTML: (s: string) => s,
+                createScript: (s: string) => s,
+                createScriptURL: (s: string) => s,
+              });
+        } catch {
+          // trustedTypes.createPolicy throws if called with a name that is
+          // already registered, even in report-only mode. Until the API changes,
+          // catch the error not to break the applications functionally. In such
+          // cases, the code will fall back to using strings.
+          ngDevMode &&
+              console.error(`Could not create Trusted Types policy ${
+                  this.policyName}. Are two instances of Angular running on the same page?`);
+        }
+      }
+    }
+    return this.policy;
+  }
+
+  /**
+   * Unsafely promote a string to a TrustedHTML, falling back to strings when
+   * Trusted Types are not available. This is a security-sensitive function; any
+   * use of this function must go through security review. In particular, it must
+   * be assured that the provided string will never cause an XSS vulnerability if
+   * used in a context that will be interpreted as HTML by a browser, e.g. when
+   * assigning to element.innerHTML.
+   */
+  trustedHTMLFromStringRequiresSecurityReview(html: string): TrustedHTML|string {
+    return this.getPolicy()?.createHTML(html) || html;
+  }
+
+  /**
+   * Unsafely promote a string to a TrustedScript, falling back to strings when
+   * Trusted Types are not available. This is a security-sensitive function; any
+   * use of this function must go through security review. In particular, it must
+   * be assured that the provided string will never cause an XSS vulnerability if
+   * used in a context that will be interpreted and executed as a script by a
+   * browser, e.g. when calling eval.
+   */
+  trustedScriptFromStringRequiresSecurityReview(script: string): TrustedScript|string {
+    return this.getPolicy()?.createScript(script) || script;
+  }
+
+  /**
+   * Unsafely promote a string to a TrustedScriptURL, falling back to strings
+   * when Trusted Types are not available. This is a security-sensitive function;
+   * any use of this function must go through security review. In particular, it
+   * must be assured that the provided string will never cause an XSS
+   * vulnerability if used in a context that will cause a browser to load and
+   * execute a resource, e.g. when assigning to script.src.
+   */
+  trustedScriptURLFromStringRequiresSecurityReview(url: string): TrustedScriptURL|string {
+    return this.getPolicy()?.createScriptURL(url) || url;
+  }
+}
+
+/**
+ * The Trusted Types policy used by Angular for all trusted conversions.
+ */
+export const trustedTypesPolicy = new AngularTrustedTypesPolicy('angular');

--- a/packages/core/src/view/services.ts
+++ b/packages/core/src/view/services.ts
@@ -14,7 +14,7 @@ import {Type} from '../interface/type';
 import {ComponentFactory} from '../linker/component_factory';
 import {NgModuleRef} from '../linker/ng_module_factory';
 import {Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2} from '../render/api';
-import {Sanitizer} from '../sanitization/sanitizer';
+import {Sanitizer, TrustedSanitizer} from '../sanitization/sanitizer';
 import {isDevMode} from '../util/is_dev_mode';
 import {normalizeDebugBindingName, normalizeDebugBindingValue} from '../util/ng_reflect';
 
@@ -123,7 +123,8 @@ function debugCreateRootView(
 function createRootData(
     elInjector: Injector, ngModule: NgModuleRef<any>, rendererFactory: RendererFactory2,
     projectableNodes: any[][], rootSelectorOrNode: any): RootData {
-  const sanitizer = ngModule.injector.get(Sanitizer);
+  const sanitizer =
+      ngModule.injector.get(TrustedSanitizer, null) || ngModule.injector.get(Sanitizer);
   const errorHandler = ngModule.injector.get(ErrorHandler);
   const renderer = rendererFactory.createRenderer(null, null);
   return {

--- a/packages/core/src/view/types.ts
+++ b/packages/core/src/view/types.ts
@@ -15,7 +15,7 @@ import {QueryList} from '../linker/query_list';
 import {TemplateRef} from '../linker/template_ref';
 import {ViewContainerRef} from '../linker/view_container_ref';
 import {Renderer2, RendererFactory2, RendererType2} from '../render/api';
-import {Sanitizer} from '../sanitization/sanitizer';
+import {Sanitizer, TrustedSanitizer} from '../sanitization/sanitizer';
 import {SecurityContext} from '../sanitization/security';
 
 
@@ -563,7 +563,7 @@ export interface RootData {
   renderer: Renderer2;
   rendererFactory: RendererFactory2;
   errorHandler: ErrorHandler;
-  sanitizer: Sanitizer;
+  sanitizer: Sanitizer|TrustedSanitizer;
 }
 
 export abstract class DebugContext {

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -612,6 +612,9 @@
     "name": "TestabilityRegistry"
   },
   {
+    "name": "TrustedSanitizer"
+  },
+  {
     "name": "USE_VALUE"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -816,6 +816,9 @@
     "name": "TreeNode"
   },
   {
+    "name": "TrustedSanitizer"
+  },
+  {
     "name": "USE_VALUE"
   },
   {

--- a/packages/core/test/sanitization/html_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/html_sanitizer_spec.ts
@@ -11,6 +11,10 @@ import {browserDetection} from '@angular/platform-browser/testing/src/browser_ut
 import {_sanitizeHtml} from '../../src/sanitization/html_sanitizer';
 import {isDOMParserAvailable} from '../../src/sanitization/inert_body';
 
+function sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): string {
+  return _sanitizeHtml(defaultDoc, unsafeHtmlInput).toString();
+}
+
 {
   describe('HTML sanitizer', () => {
     let defaultDoc: any;
@@ -29,73 +33,73 @@ import {isDOMParserAvailable} from '../../src/sanitization/inert_body';
     });
 
     it('serializes nested structures', () => {
-      expect(_sanitizeHtml(defaultDoc, '<div alt="x"><p>a</p>b<b>c<a alt="more">d</a></b>e</div>'))
+      expect(sanitizeHtml(defaultDoc, '<div alt="x"><p>a</p>b<b>c<a alt="more">d</a></b>e</div>'))
           .toEqual('<div alt="x"><p>a</p>b<b>c<a alt="more">d</a></b>e</div>');
       expect(logMsgs).toEqual([]);
     });
 
     it('serializes self closing elements', () => {
-      expect(_sanitizeHtml(defaultDoc, '<p>Hello <br> World</p>'))
+      expect(sanitizeHtml(defaultDoc, '<p>Hello <br> World</p>'))
           .toEqual('<p>Hello <br> World</p>');
     });
 
     it('supports namespaced elements', () => {
-      expect(_sanitizeHtml(defaultDoc, 'a<my:hr/><my:div>b</my:div>c')).toEqual('abc');
+      expect(sanitizeHtml(defaultDoc, 'a<my:hr/><my:div>b</my:div>c')).toEqual('abc');
     });
 
     it('supports namespaced attributes', () => {
-      expect(_sanitizeHtml(defaultDoc, '<a xlink:href="something">t</a>'))
+      expect(sanitizeHtml(defaultDoc, '<a xlink:href="something">t</a>'))
           .toEqual('<a xlink:href="something">t</a>');
-      expect(_sanitizeHtml(defaultDoc, '<a xlink:evil="something">t</a>')).toEqual('<a>t</a>');
-      expect(_sanitizeHtml(defaultDoc, '<a xlink:href="javascript:foo()">t</a>'))
+      expect(sanitizeHtml(defaultDoc, '<a xlink:evil="something">t</a>')).toEqual('<a>t</a>');
+      expect(sanitizeHtml(defaultDoc, '<a xlink:href="javascript:foo()">t</a>'))
           .toEqual('<a xlink:href="unsafe:javascript:foo()">t</a>');
     });
 
     it('supports HTML5 elements', () => {
-      expect(_sanitizeHtml(defaultDoc, '<main><summary>Works</summary></main>'))
+      expect(sanitizeHtml(defaultDoc, '<main><summary>Works</summary></main>'))
           .toEqual('<main><summary>Works</summary></main>');
     });
 
     it('supports ARIA attributes', () => {
-      expect(_sanitizeHtml(defaultDoc, '<h1 role="presentation" aria-haspopup="true">Test</h1>'))
+      expect(sanitizeHtml(defaultDoc, '<h1 role="presentation" aria-haspopup="true">Test</h1>'))
           .toEqual('<h1 role="presentation" aria-haspopup="true">Test</h1>');
-      expect(_sanitizeHtml(defaultDoc, '<i aria-label="Info">Info</i>'))
+      expect(sanitizeHtml(defaultDoc, '<i aria-label="Info">Info</i>'))
           .toEqual('<i aria-label="Info">Info</i>');
-      expect(_sanitizeHtml(defaultDoc, '<img src="pteranodon.jpg" aria-details="details">'))
+      expect(sanitizeHtml(defaultDoc, '<img src="pteranodon.jpg" aria-details="details">'))
           .toEqual('<img src="pteranodon.jpg" aria-details="details">');
     });
 
     it('sanitizes srcset attributes', () => {
-      expect(_sanitizeHtml(defaultDoc, '<img srcset="/foo.png 400px, javascript:evil() 23px">'))
+      expect(sanitizeHtml(defaultDoc, '<img srcset="/foo.png 400px, javascript:evil() 23px">'))
           .toEqual('<img srcset="/foo.png 400px, unsafe:javascript:evil() 23px">');
     });
 
     it('supports sanitizing plain text', () => {
-      expect(_sanitizeHtml(defaultDoc, 'Hello, World')).toEqual('Hello, World');
+      expect(sanitizeHtml(defaultDoc, 'Hello, World')).toEqual('Hello, World');
     });
 
     it('ignores non-element, non-attribute nodes', () => {
-      expect(_sanitizeHtml(defaultDoc, '<!-- comments? -->no.')).toEqual('no.');
-      expect(_sanitizeHtml(defaultDoc, '<?pi nodes?>no.')).toEqual('no.');
+      expect(sanitizeHtml(defaultDoc, '<!-- comments? -->no.')).toEqual('no.');
+      expect(sanitizeHtml(defaultDoc, '<?pi nodes?>no.')).toEqual('no.');
       expect(logMsgs.join('\n')).toMatch(/sanitizing HTML stripped some content/);
     });
 
     it('supports sanitizing escaped entities', () => {
-      expect(_sanitizeHtml(defaultDoc, '&#128640;')).toEqual('&#128640;');
+      expect(sanitizeHtml(defaultDoc, '&#128640;')).toEqual('&#128640;');
       expect(logMsgs).toEqual([]);
     });
 
     it('does not warn when just re-encoding text', () => {
-      expect(_sanitizeHtml(defaultDoc, '<p>Hellö Wörld</p>'))
+      expect(sanitizeHtml(defaultDoc, '<p>Hellö Wörld</p>'))
           .toEqual('<p>Hell&#246; W&#246;rld</p>');
       expect(logMsgs).toEqual([]);
     });
 
     it('escapes entities', () => {
-      expect(_sanitizeHtml(defaultDoc, '<p>Hello &lt; World</p>'))
+      expect(sanitizeHtml(defaultDoc, '<p>Hello &lt; World</p>'))
           .toEqual('<p>Hello &lt; World</p>');
-      expect(_sanitizeHtml(defaultDoc, '<p>Hello < World</p>')).toEqual('<p>Hello &lt; World</p>');
-      expect(_sanitizeHtml(defaultDoc, '<p alt="% &amp; &quot; !">Hello</p>'))
+      expect(sanitizeHtml(defaultDoc, '<p>Hello < World</p>')).toEqual('<p>Hello &lt; World</p>');
+      expect(sanitizeHtml(defaultDoc, '<p alt="% &amp; &quot; !">Hello</p>'))
           .toEqual('<p alt="% &amp; &#34; !">Hello</p>');  // NB: quote encoded as ASCII &#34;.
     });
 
@@ -110,7 +114,7 @@ import {isDOMParserAvailable} from '../../src/sanitization/inert_body';
       ];
       for (const tag of dangerousTags) {
         it(tag, () => {
-          expect(_sanitizeHtml(defaultDoc, `<${tag}>evil!</${tag}>`)).toEqual('evil!');
+          expect(sanitizeHtml(defaultDoc, `<${tag}>evil!</${tag}>`)).toEqual('evil!');
         });
       }
 
@@ -125,7 +129,7 @@ import {isDOMParserAvailable} from '../../src/sanitization/inert_body';
       ];
       for (const tag of dangerousSelfClosingTags) {
         it(tag, () => {
-          expect(_sanitizeHtml(defaultDoc, `before<${tag}>After`)).toEqual('beforeAfter');
+          expect(sanitizeHtml(defaultDoc, `before<${tag}>After`)).toEqual('beforeAfter');
         });
       }
 
@@ -136,7 +140,7 @@ import {isDOMParserAvailable} from '../../src/sanitization/inert_body';
       ];
       for (const tag of dangerousSkipContentTags) {
         it(tag, () => {
-          expect(_sanitizeHtml(defaultDoc, `<${tag}>evil!</${tag}>`)).toEqual('');
+          expect(sanitizeHtml(defaultDoc, `<${tag}>evil!</${tag}>`)).toEqual('');
         });
       }
 
@@ -144,7 +148,7 @@ import {isDOMParserAvailable} from '../../src/sanitization/inert_body';
         // `<frame>` is special, because different browsers treat it differently (e.g. remove it
         // altogether). // We just verify that (one way or another), there is no `<frame>` element
         // after sanitization.
-        expect(_sanitizeHtml(defaultDoc, `<frame>evil!</frame>`)).not.toContain('<frame>');
+        expect(sanitizeHtml(defaultDoc, `<frame>evil!</frame>`)).not.toContain('<frame>');
       });
     });
 
@@ -153,45 +157,45 @@ import {isDOMParserAvailable} from '../../src/sanitization/inert_body';
 
       for (const attr of dangerousAttrs) {
         it(`${attr}`, () => {
-          expect(_sanitizeHtml(defaultDoc, `<a ${attr}="x">evil!</a>`)).toEqual('<a>evil!</a>');
+          expect(sanitizeHtml(defaultDoc, `<a ${attr}="x">evil!</a>`)).toEqual('<a>evil!</a>');
         });
       }
     });
 
     it('ignores content of script elements', () => {
-      expect(_sanitizeHtml(defaultDoc, '<script>var foo="<p>bar</p>"</script>')).toEqual('');
-      expect(_sanitizeHtml(defaultDoc, '<script>var foo="<p>bar</p>"</script><div>hi</div>'))
+      expect(sanitizeHtml(defaultDoc, '<script>var foo="<p>bar</p>"</script>')).toEqual('');
+      expect(sanitizeHtml(defaultDoc, '<script>var foo="<p>bar</p>"</script><div>hi</div>'))
           .toEqual('<div>hi</div>');
-      expect(_sanitizeHtml(defaultDoc, '<style>\<\!-- something--\>hi</style>')).toEqual('');
+      expect(sanitizeHtml(defaultDoc, '<style>\<\!-- something--\>hi</style>')).toEqual('');
     });
 
     it('ignores content of style elements', () => {
-      expect(_sanitizeHtml(defaultDoc, '<style><!-- foobar --></style><div>hi</div>'))
+      expect(sanitizeHtml(defaultDoc, '<style><!-- foobar --></style><div>hi</div>'))
           .toEqual('<div>hi</div>');
-      expect(_sanitizeHtml(defaultDoc, '<style><!-- foobar --></style>')).toEqual('');
-      expect(_sanitizeHtml(defaultDoc, '<style>\<\!-- something--\>hi</style>')).toEqual('');
+      expect(sanitizeHtml(defaultDoc, '<style><!-- foobar --></style>')).toEqual('');
+      expect(sanitizeHtml(defaultDoc, '<style>\<\!-- something--\>hi</style>')).toEqual('');
       expect(logMsgs.join('\n')).toMatch(/sanitizing HTML stripped some content/);
     });
 
     it('should strip unclosed iframe tag', () => {
-      expect(_sanitizeHtml(defaultDoc, '<iframe>')).toEqual('');
+      expect(sanitizeHtml(defaultDoc, '<iframe>')).toEqual('');
       expect([
         '&lt;iframe&gt;',
         // Double-escaped on IE
         '&amp;lt;iframe&amp;gt;'
-      ]).toContain(_sanitizeHtml(defaultDoc, '<iframe><iframe>'));
+      ]).toContain(sanitizeHtml(defaultDoc, '<iframe><iframe>'));
       expect([
         '&lt;script&gt;evil();&lt;/script&gt;',
         // Double-escaped on IE
         '&amp;lt;script&amp;gt;evil();&amp;lt;/script&amp;gt;'
-      ]).toContain(_sanitizeHtml(defaultDoc, '<iframe><script>evil();</script>'));
+      ]).toContain(sanitizeHtml(defaultDoc, '<iframe><script>evil();</script>'));
     });
 
     it('should ignore extraneous body tags', () => {
-      expect(_sanitizeHtml(defaultDoc, '</body>')).toEqual('');
-      expect(_sanitizeHtml(defaultDoc, 'foo</body>bar')).toEqual('foobar');
-      expect(_sanitizeHtml(defaultDoc, 'foo<body>bar')).toEqual('foobar');
-      expect(_sanitizeHtml(defaultDoc, 'fo<body>ob</body>ar')).toEqual('foobar');
+      expect(sanitizeHtml(defaultDoc, '</body>')).toEqual('');
+      expect(sanitizeHtml(defaultDoc, 'foo</body>bar')).toEqual('foobar');
+      expect(sanitizeHtml(defaultDoc, 'foo<body>bar')).toEqual('foobar');
+      expect(sanitizeHtml(defaultDoc, 'fo<body>ob</body>ar')).toEqual('foobar');
     });
 
     it('should not enter an infinite loop on clobbered elements', () => {
@@ -200,18 +204,17 @@ import {isDOMParserAvailable} from '../../src/sanitization/inert_body';
       // Anyway what we want to test is that browsers do not enter an infinite loop which would
       // result in a timeout error for the test.
       try {
-        _sanitizeHtml(defaultDoc, '<form><input name="parentNode" /></form>');
+        sanitizeHtml(defaultDoc, '<form><input name="parentNode" /></form>');
       } catch (e) {
         // depending on the browser, we might ge an exception
       }
       try {
-        _sanitizeHtml(defaultDoc, '<form><input name="nextSibling" /></form>');
+        sanitizeHtml(defaultDoc, '<form><input name="nextSibling" /></form>');
       } catch (e) {
         // depending on the browser, we might ge an exception
       }
       try {
-        _sanitizeHtml(
-            defaultDoc, '<form><div><div><input name="nextSibling" /></div></div></form>');
+        sanitizeHtml(defaultDoc, '<form><div><div><input name="nextSibling" /></div></div></form>');
       } catch (e) {
         // depending on the browser, we might ge an exception
       }
@@ -220,7 +223,7 @@ import {isDOMParserAvailable} from '../../src/sanitization/inert_body';
     // See
     // https://github.com/cure53/DOMPurify/blob/a992d3a75031cb8bb032e5ea8399ba972bdf9a65/src/purify.js#L439-L449
     it('should not allow JavaScript execution when creating inert document', () => {
-      const output = _sanitizeHtml(defaultDoc, '<svg><g onload="window.xxx = 100"></g></svg>');
+      const output = sanitizeHtml(defaultDoc, '<svg><g onload="window.xxx = 100"></g></svg>');
       const window = defaultDoc.defaultView;
       if (window) {
         expect(window.xxx).toBe(undefined);
@@ -232,7 +235,7 @@ import {isDOMParserAvailable} from '../../src/sanitization/inert_body';
     // See https://github.com/cure53/DOMPurify/releases/tag/0.6.7
     it('should not allow JavaScript hidden in badly formed HTML to get through sanitization (Firefox bug)',
        () => {
-         expect(_sanitizeHtml(
+         expect(sanitizeHtml(
                     defaultDoc, '<svg><p><style><img src="</style><img src=x onerror=alert(1)//">'))
              .toEqual(
                  isDOMParserAvailable() ?
@@ -245,7 +248,7 @@ import {isDOMParserAvailable} from '../../src/sanitization/inert_body';
     if (browserDetection.isWebkit) {
       it('should prevent mXSS attacks', function() {
         // In Chrome Canary 62, the ideographic space character is kept as a stringified HTML entity
-        expect(_sanitizeHtml(defaultDoc, '<a href="&#x3000;javascript:alert(1)">CLICKME</a>'))
+        expect(sanitizeHtml(defaultDoc, '<a href="&#x3000;javascript:alert(1)">CLICKME</a>'))
             .toMatch(/<a href="unsafe:(&#12288;)?javascript:alert\(1\)">CLICKME<\/a>/);
       });
     }

--- a/packages/core/test/sanitization/sanitization_spec.ts
+++ b/packages/core/test/sanitization/sanitization_spec.ts
@@ -29,11 +29,11 @@ describe('sanitization', () => {
     }
   }
   it('should sanitize html', () => {
-    expect(ɵɵsanitizeHtml('<div></div>')).toEqual('<div></div>');
-    expect(ɵɵsanitizeHtml(new Wrap('<div></div>'))).toEqual('<div></div>');
-    expect(ɵɵsanitizeHtml('<img src="javascript:true">'))
+    expect(ɵɵsanitizeHtml('<div></div>').toString()).toEqual('<div></div>');
+    expect(ɵɵsanitizeHtml(new Wrap('<div></div>')).toString()).toEqual('<div></div>');
+    expect(ɵɵsanitizeHtml('<img src="javascript:true">').toString())
         .toEqual('<img src="unsafe:javascript:true">');
-    expect(ɵɵsanitizeHtml(new Wrap('<img src="javascript:true">')))
+    expect(ɵɵsanitizeHtml(new Wrap('<img src="javascript:true">')).toString())
         .toEqual('<img src="unsafe:javascript:true">');
     expect(() => ɵɵsanitizeHtml(bypassSanitizationTrustUrl('<img src="javascript:true">')))
         .toThrowError(/Required a safe HTML, got a URL/);

--- a/packages/core/test/sanitization/sanitization_spec.ts
+++ b/packages/core/test/sanitization/sanitization_spec.ts
@@ -37,7 +37,7 @@ describe('sanitization', () => {
         .toEqual('<img src="unsafe:javascript:true">');
     expect(() => ɵɵsanitizeHtml(bypassSanitizationTrustUrl('<img src="javascript:true">')))
         .toThrowError(/Required a safe HTML, got a URL/);
-    expect(ɵɵsanitizeHtml(bypassSanitizationTrustHtml('<img src="javascript:true">')))
+    expect(ɵɵsanitizeHtml(bypassSanitizationTrustHtml('<img src="javascript:true">')).toString())
         .toEqual('<img src="javascript:true">');
   });
 
@@ -57,7 +57,7 @@ describe('sanitization', () => {
     expect(() => ɵɵsanitizeResourceUrl('javascript:true')).toThrowError(ERROR);
     expect(() => ɵɵsanitizeResourceUrl(bypassSanitizationTrustHtml('javascript:true')))
         .toThrowError(/Required a safe ResourceURL, got a HTML/);
-    expect(ɵɵsanitizeResourceUrl(bypassSanitizationTrustResourceUrl('javascript:true')))
+    expect(ɵɵsanitizeResourceUrl(bypassSanitizationTrustResourceUrl('javascript:true')).toString())
         .toEqual('javascript:true');
   });
 
@@ -78,7 +78,7 @@ describe('sanitization', () => {
     expect(() => ɵɵsanitizeScript('true')).toThrowError(ERROR);
     expect(() => ɵɵsanitizeScript(bypassSanitizationTrustHtml('true')))
         .toThrowError(/Required a safe Script, got a HTML/);
-    expect(ɵɵsanitizeScript(bypassSanitizationTrustScript('true'))).toEqual('true');
+    expect(ɵɵsanitizeScript(bypassSanitizationTrustScript('true')).toString()).toEqual('true');
   });
 
   it('should select correct sanitizer for URL props', () => {
@@ -114,7 +114,8 @@ describe('sanitization', () => {
             bypassSanitizationTrustHtml('javascript:true'), 'iframe', 'src'))
         .toThrowError(/Required a safe ResourceURL, got a HTML/);
     expect(ɵɵsanitizeUrlOrResourceUrl(
-               bypassSanitizationTrustResourceUrl('javascript:true'), 'iframe', 'src'))
+               bypassSanitizationTrustResourceUrl('javascript:true'), 'iframe', 'src')
+               .toString())
         .toEqual('javascript:true');
   });
 

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -20,6 +20,7 @@ import {HAMMER_PROVIDERS} from './dom/events/hammer_gestures';
 import {KeyEventsPlugin} from './dom/events/key_events';
 import {DomSharedStylesHost, SharedStylesHost} from './dom/shared_styles_host';
 import {DomSanitizer, DomSanitizerImpl} from './security/dom_sanitization_service';
+import {TrustedDomSanitizer, TrustedDomSanitizerImpl} from './security/trusted_dom_sanitization_service';
 
 export function initDomAdapter() {
   BrowserDomAdapter.makeCurrent();
@@ -44,7 +45,8 @@ export const INTERNAL_BROWSER_PLATFORM_PROVIDERS: StaticProvider[] = [
 
 const BROWSER_SANITIZATION_PROVIDERS__PRE_R3__: StaticProvider[] = [
   {provide: Sanitizer, useExisting: DomSanitizer},
-  {provide: DomSanitizer, useClass: DomSanitizerImpl, deps: [DOCUMENT]},
+  {provide: DomSanitizer, useClass: DomSanitizerImpl, deps: [TrustedDomSanitizer]},
+  {provide: TrustedDomSanitizer, useClass: TrustedDomSanitizerImpl, deps: [DOCUMENT]},
 ];
 
 export const BROWSER_SANITIZATION_PROVIDERS__POST_R3__ = [];

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -15,6 +15,7 @@ export {By} from './dom/debug/by';
 export {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 export {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HAMMER_PROVIDERS__POST_R3__ as ɵHAMMER_PROVIDERS__POST_R3__, HammerGestureConfig, HammerLoader, HammerModule} from './dom/events/hammer_gestures';
 export {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl, SafeValue} from './security/dom_sanitization_service';
+export {TrustedDomSanitizer} from './security/trusted_dom_sanitization_service';
 
 export * from './private_export';
 export {VERSION} from './version';

--- a/packages/platform-browser/src/security/dom_sanitization_service.ts
+++ b/packages/platform-browser/src/security/dom_sanitization_service.ts
@@ -106,7 +106,7 @@ export abstract class DomSanitizer implements Sanitizer {
    * **WARNING:** calling this method with untrusted user data exposes your application to XSS
    * security risks!
    */
-  abstract bypassSecurityTrustHtml(value: string): SafeHtml;
+  abstract bypassSecurityTrustHtml(value: string|TrustedHTML): SafeHtml;
 
   /**
    * Bypass security and trust the given value to be safe style value (CSS).
@@ -122,7 +122,7 @@ export abstract class DomSanitizer implements Sanitizer {
    * **WARNING:** calling this method with untrusted user data exposes your application to XSS
    * security risks!
    */
-  abstract bypassSecurityTrustScript(value: string): SafeScript;
+  abstract bypassSecurityTrustScript(value: string|TrustedScript): SafeScript;
 
   /**
    * Bypass security and trust the given value to be a safe style URL, i.e. a value that can be used
@@ -140,7 +140,7 @@ export abstract class DomSanitizer implements Sanitizer {
    * **WARNING:** calling this method with untrusted user data exposes your application to XSS
    * security risks!
    */
-  abstract bypassSecurityTrustResourceUrl(value: string): SafeResourceUrl;
+  abstract bypassSecurityTrustResourceUrl(value: string|TrustedScriptURL): SafeResourceUrl;
 }
 
 export function domSanitizerImplFactory(injector: Injector) {
@@ -160,28 +160,28 @@ export class DomSanitizerImpl extends DomSanitizer {
         return value as string;
       case SecurityContext.HTML:
         if (allowSanitizationBypassOrThrow(value, BypassType.Html)) {
-          return unwrapSafeValue(value);
+          return unwrapSafeValue<TrustedHTML>(value).toString();
         }
         return _sanitizeHtml(this._doc, String(value));
       case SecurityContext.STYLE:
         if (allowSanitizationBypassOrThrow(value, BypassType.Style)) {
-          return unwrapSafeValue(value);
+          return unwrapSafeValue<string>(value);
         }
         return value as string;
       case SecurityContext.SCRIPT:
         if (allowSanitizationBypassOrThrow(value, BypassType.Script)) {
-          return unwrapSafeValue(value);
+          return unwrapSafeValue<TrustedScript>(value).toString();
         }
         throw new Error('unsafe value used in a script context');
       case SecurityContext.URL:
         const type = getSanitizationBypassType(value);
         if (allowSanitizationBypassOrThrow(value, BypassType.Url)) {
-          return unwrapSafeValue(value);
+          return unwrapSafeValue<string>(value);
         }
         return _sanitizeUrl(String(value));
       case SecurityContext.RESOURCE_URL:
         if (allowSanitizationBypassOrThrow(value, BypassType.ResourceUrl)) {
-          return unwrapSafeValue(value);
+          return unwrapSafeValue<TrustedScriptURL>(value).toString();
         }
         throw new Error(
             'unsafe value used in a resource URL context (see http://g.co/ng/security#xss)');
@@ -190,19 +190,19 @@ export class DomSanitizerImpl extends DomSanitizer {
     }
   }
 
-  bypassSecurityTrustHtml(value: string): SafeHtml {
+  bypassSecurityTrustHtml(value: string|TrustedHTML): SafeHtml {
     return bypassSanitizationTrustHtml(value);
   }
   bypassSecurityTrustStyle(value: string): SafeStyle {
     return bypassSanitizationTrustStyle(value);
   }
-  bypassSecurityTrustScript(value: string): SafeScript {
+  bypassSecurityTrustScript(value: string|TrustedScript): SafeScript {
     return bypassSanitizationTrustScript(value);
   }
   bypassSecurityTrustUrl(value: string): SafeUrl {
     return bypassSanitizationTrustUrl(value);
   }
-  bypassSecurityTrustResourceUrl(value: string): SafeResourceUrl {
+  bypassSecurityTrustResourceUrl(value: string|TrustedScriptURL): SafeResourceUrl {
     return bypassSanitizationTrustResourceUrl(value);
   }
 }

--- a/packages/platform-browser/src/security/dom_sanitization_service.ts
+++ b/packages/platform-browser/src/security/dom_sanitization_service.ts
@@ -162,7 +162,7 @@ export class DomSanitizerImpl extends DomSanitizer {
         if (allowSanitizationBypassOrThrow(value, BypassType.Html)) {
           return unwrapSafeValue<TrustedHTML>(value).toString();
         }
-        return _sanitizeHtml(this._doc, String(value));
+        return _sanitizeHtml(this._doc, String(value)).toString();
       case SecurityContext.STYLE:
         if (allowSanitizationBypassOrThrow(value, BypassType.Style)) {
           return unwrapSafeValue<string>(value);

--- a/packages/platform-browser/src/security/trusted_dom_sanitization_service.ts
+++ b/packages/platform-browser/src/security/trusted_dom_sanitization_service.ts
@@ -7,36 +7,15 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {forwardRef, Inject, Injectable, Injector, Sanitizer, SecurityContext, TrustedSanitizer, ɵ_sanitizeHtml as _sanitizeHtml, ɵ_sanitizeUrl as _sanitizeUrl, ɵallowSanitizationBypassAndThrow as allowSanitizationBypassOrThrow, ɵbypassSanitizationTrustHtml as bypassSanitizationTrustHtml, ɵbypassSanitizationTrustResourceUrl as bypassSanitizationTrustResourceUrl, ɵbypassSanitizationTrustScript as bypassSanitizationTrustScript, ɵbypassSanitizationTrustStyle as bypassSanitizationTrustStyle, ɵbypassSanitizationTrustUrl as bypassSanitizationTrustUrl, ɵBypassType as BypassType, ɵgetSanitizationBypassType as getSanitizationBypassType, ɵglobal as global, ɵunwrapSafeValue as unwrapSafeValue} from '@angular/core';
+import {forwardRef, Inject, Injectable, Injector, SecurityContext, TrustedSanitizer, ɵ_sanitizeHtml as _sanitizeHtml, ɵ_sanitizeUrl as _sanitizeUrl, ɵallowSanitizationBypassAndThrow as allowSanitizationBypassOrThrow, ɵBypassType as BypassType, ɵgetSanitizationBypassType as getSanitizationBypassType, ɵunwrapSafeValue as unwrapSafeValue} from '@angular/core';
 
 /**
  * TrustedDomSanitizer helps preventing Cross Site Scripting Security bugs (XSS) by sanitizing
- * values to be safe to use in the different DOM contexts.
+ * values to be safe to use in the different DOM contexts, producing Trusted Types as a proof.
  *
  * For example, when binding a URL in an `<a [href]="someValue">` hyperlink, `someValue` will be
  * sanitized so that an attacker cannot inject e.g. a `javascript:` URL that would execute code on
  * the website.
- *
- * In specific situations, it might be necessary to disable sanitization, for example if the
- * application genuinely needs to produce a `javascript:` style link with a dynamic value in it.
- * Users can bypass security by constructing a value with one of the `bypassSecurityTrust...`
- * methods, and then binding to that value from the template.
- *
- * These situations should be very rare, and extraordinary care must be taken to avoid creating a
- * Cross Site Scripting (XSS) security bug!
- *
- * When using `bypassSecurityTrust...`, make sure to call the method as early as possible and as
- * close as possible to the source of the value, to make it easy to verify no security bug is
- * created by its use.
- *
- * It is not required (and not recommended) to bypass security if the value is safe, e.g. a URL that
- * does not start with a suspicious protocol, or an HTML snippet that does not contain dangerous
- * code. The sanitizer leaves safe values intact.
- *
- * @security Calling any of the `bypassSecurityTrust...` APIs disables Angular's built-in
- * sanitization for the value passed in. Carefully check and audit all values and code paths going
- * into this call. Make sure any user data is appropriately escaped for this security context.
- * For more detail, see the [Security Guide](http://g.co/ng/security).
  *
  * @publicApi
  */

--- a/packages/platform-browser/src/security/trusted_dom_sanitization_service.ts
+++ b/packages/platform-browser/src/security/trusted_dom_sanitization_service.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DOCUMENT} from '@angular/common';
+import {forwardRef, Inject, Injectable, Injector, Sanitizer, SecurityContext, TrustedSanitizer, ɵ_sanitizeHtml as _sanitizeHtml, ɵ_sanitizeUrl as _sanitizeUrl, ɵallowSanitizationBypassAndThrow as allowSanitizationBypassOrThrow, ɵbypassSanitizationTrustHtml as bypassSanitizationTrustHtml, ɵbypassSanitizationTrustResourceUrl as bypassSanitizationTrustResourceUrl, ɵbypassSanitizationTrustScript as bypassSanitizationTrustScript, ɵbypassSanitizationTrustStyle as bypassSanitizationTrustStyle, ɵbypassSanitizationTrustUrl as bypassSanitizationTrustUrl, ɵBypassType as BypassType, ɵgetSanitizationBypassType as getSanitizationBypassType, ɵglobal as global, ɵunwrapSafeValue as unwrapSafeValue} from '@angular/core';
+
+/**
+ * TrustedDomSanitizer helps preventing Cross Site Scripting Security bugs (XSS) by sanitizing
+ * values to be safe to use in the different DOM contexts.
+ *
+ * For example, when binding a URL in an `<a [href]="someValue">` hyperlink, `someValue` will be
+ * sanitized so that an attacker cannot inject e.g. a `javascript:` URL that would execute code on
+ * the website.
+ *
+ * In specific situations, it might be necessary to disable sanitization, for example if the
+ * application genuinely needs to produce a `javascript:` style link with a dynamic value in it.
+ * Users can bypass security by constructing a value with one of the `bypassSecurityTrust...`
+ * methods, and then binding to that value from the template.
+ *
+ * These situations should be very rare, and extraordinary care must be taken to avoid creating a
+ * Cross Site Scripting (XSS) security bug!
+ *
+ * When using `bypassSecurityTrust...`, make sure to call the method as early as possible and as
+ * close as possible to the source of the value, to make it easy to verify no security bug is
+ * created by its use.
+ *
+ * It is not required (and not recommended) to bypass security if the value is safe, e.g. a URL that
+ * does not start with a suspicious protocol, or an HTML snippet that does not contain dangerous
+ * code. The sanitizer leaves safe values intact.
+ *
+ * @security Calling any of the `bypassSecurityTrust...` APIs disables Angular's built-in
+ * sanitization for the value passed in. Carefully check and audit all values and code paths going
+ * into this call. Make sure any user data is appropriately escaped for this security context.
+ * For more detail, see the [Security Guide](http://g.co/ng/security).
+ *
+ * @publicApi
+ */
+@Injectable({providedIn: 'root', useExisting: forwardRef(() => TrustedDomSanitizerImpl)})
+export abstract class TrustedDomSanitizer implements TrustedSanitizer {
+  /**
+   * Sanitizes a value for use in the given SecurityContext.
+   *
+   * If value is trusted for the context, this method will unwrap the contained safe value and use
+   * it directly. Otherwise, value will be sanitized to be safe in the given context, for example
+   * by replacing URLs that have an unsafe protocol part (such as `javascript:`). The implementation
+   * is responsible to make sure that the value can definitely be safely used in the given context.
+   */
+  abstract sanitize(context: SecurityContext.HTML, value: {}|string|null): string|TrustedHTML|null;
+  abstract sanitize(context: SecurityContext.SCRIPT, value: {}|string|null): string|TrustedScript
+      |null;
+  abstract sanitize(context: SecurityContext.RESOURCE_URL, value: {}|string|null): string
+      |TrustedScriptURL|null;
+  abstract sanitize(context: SecurityContext, value: {}|string|null): string|null;
+  abstract sanitize(context: SecurityContext, value: {}|string|null): string|TrustedHTML
+      |TrustedScript|TrustedScriptURL|null;
+}
+
+export function trustedDomSanitizerImplFactory(injector: Injector) {
+  return new TrustedDomSanitizerImpl(injector.get(DOCUMENT));
+}
+
+@Injectable({providedIn: 'root', useFactory: trustedDomSanitizerImplFactory, deps: [Injector]})
+export class TrustedDomSanitizerImpl extends TrustedDomSanitizer {
+  constructor(@Inject(DOCUMENT) private _doc: any) {
+    super();
+  }
+
+  sanitize(ctx: SecurityContext.HTML, value: {}|string|null): string|TrustedHTML|null;
+  sanitize(ctx: SecurityContext.SCRIPT, value: {}|string|null): string|TrustedScript|null;
+  sanitize(ctx: SecurityContext.RESOURCE_URL, value: {}|string|null): string|TrustedScriptURL|null;
+  sanitize(ctx: SecurityContext, value: {}|string|null): string|null;
+  sanitize(ctx: SecurityContext, value: {}|string|null): string|TrustedHTML|TrustedScript
+      |TrustedScriptURL|null {
+    if (value == null) return null;
+    switch (ctx) {
+      case SecurityContext.NONE:
+        return value as string;
+      case SecurityContext.HTML:
+        if (allowSanitizationBypassOrThrow(value, BypassType.Html)) {
+          return unwrapSafeValue<TrustedHTML>(value);
+        }
+        return _sanitizeHtml(this._doc, String(value));
+      case SecurityContext.STYLE:
+        if (allowSanitizationBypassOrThrow(value, BypassType.Style)) {
+          return unwrapSafeValue<string>(value);
+        }
+        return value as string;
+      case SecurityContext.SCRIPT:
+        if (allowSanitizationBypassOrThrow(value, BypassType.Script)) {
+          return unwrapSafeValue<TrustedScript>(value);
+        }
+        throw new Error('unsafe value used in a script context');
+      case SecurityContext.URL:
+        const type = getSanitizationBypassType(value);
+        if (allowSanitizationBypassOrThrow(value, BypassType.Url)) {
+          return unwrapSafeValue<string>(value);
+        }
+        return _sanitizeUrl(String(value));
+      case SecurityContext.RESOURCE_URL:
+        if (allowSanitizationBypassOrThrow(value, BypassType.ResourceUrl)) {
+          return unwrapSafeValue<TrustedScriptURL>(value);
+        }
+        throw new Error(
+            'unsafe value used in a resource URL context (see http://g.co/ng/security#xss)');
+      default:
+        throw new Error(`Unexpected SecurityContext ${ctx} (see http://g.co/ng/security#xss)`);
+    }
+  }
+}

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT, isPlatformBrowser, ɵgetDOM as getDOM} from '@angular/common';
-import {APP_INITIALIZER, Compiler, Component, createPlatformFactory, CUSTOM_ELEMENTS_SCHEMA, Directive, ErrorHandler, Inject, Injector, Input, LOCALE_ID, NgModule, OnDestroy, Pipe, PLATFORM_ID, PLATFORM_INITIALIZER, Provider, Sanitizer, StaticProvider, Type, VERSION} from '@angular/core';
+import {APP_INITIALIZER, Compiler, Component, createPlatformFactory, CUSTOM_ELEMENTS_SCHEMA, Directive, ErrorHandler, Inject, Injector, Input, LOCALE_ID, NgModule, OnDestroy, Pipe, PLATFORM_ID, PLATFORM_INITIALIZER, Provider, Sanitizer, StaticProvider, TrustedSanitizer, Type, VERSION} from '@angular/core';
 import {ApplicationRef, destroyPlatform} from '@angular/core/src/application_ref';
 import {Console} from '@angular/core/src/console';
 import {ComponentRef} from '@angular/core/src/linker/component_factory';
@@ -206,7 +206,8 @@ function bootstrap(
            }));
 
     it('should retrieve sanitizer', inject([Injector], (injector: Injector) => {
-         const sanitizer: Sanitizer|null = injector.get(Sanitizer, null);
+         const sanitizer: Sanitizer|TrustedSanitizer|null =
+             injector.get(TrustedSanitizer, null) || injector.get(Sanitizer, null);
          if (ivyEnabled) {
            // In Ivy we don't want to have sanitizer in DI. We use DI only to overwrite the
            // sanitizer, but not for default one. The default one is pulled in by the Ivy

--- a/packages/platform-browser/test/security/dom_sanitization_service_spec.ts
+++ b/packages/platform-browser/test/security/dom_sanitization_service_spec.ts
@@ -9,11 +9,13 @@
 import {SecurityContext} from '@angular/core';
 import * as t from '@angular/core/testing/src/testing_internal';
 import {DomSanitizerImpl} from '@angular/platform-browser/src/security/dom_sanitization_service';
+import {TrustedDomSanitizerImpl} from '@angular/platform-browser/src/security/trusted_dom_sanitization_service';
 
 {
   t.describe('DOM Sanitization Service', () => {
     t.it('accepts resource URL values for resource contexts', () => {
-      const svc = new DomSanitizerImpl(null);
+      const trustedSvc = new TrustedDomSanitizerImpl(null);
+      const svc = new DomSanitizerImpl(trustedSvc);
       const resourceUrl = svc.bypassSecurityTrustResourceUrl('http://hello/world');
       t.expect(svc.sanitize(SecurityContext.URL, resourceUrl)).toBe('http://hello/world');
     });

--- a/packages/types.d.ts
+++ b/packages/types.d.ts
@@ -9,6 +9,7 @@
 // This file contains all ambient imports needed to compile the packages/ source code
 
 /// <reference types="hammerjs" />
+/// <reference types="trusted-types" />
 /// <reference lib="es2015" />
 /// <reference path="./goog.d.ts" />
 /// <reference path="./system.d.ts" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2358,6 +2358,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/trusted-types@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
+  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
+
 "@types/webpack-sources@^0.1.5":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-0.1.7.tgz#0a330a9456113410c74a5d64180af0cbca007141"


### PR DESCRIPTION
Create a new interface for sanitizers that support Trusted Types, called
TrustedSanitizer. It is almost the same as the existing Sanitizer
interface, but lets the sanitize function return a Trusted Type in
addition to string and null.

Also update Ivy's sanitization functions to pass sanitized values
from TrustedSanitizers directly through.

When an application provides a TrustedSanitizer, make Ivy and ViewEngine
prefer it over any Sanitizer that has been provided. Update associated
types to accommodate the new TrustedSanitizer interface.

This is based on #39218. See the individual commits for more details.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
This is part of an ongoing effort to add support for Trusted Types to Angular.