### PR TITLE
fix(core): promote i18n constants to Trusted Types

### DIFF
--- a/packages/core/src/render3/i18n/i18n_apply.ts
+++ b/packages/core/src/render3/i18n/i18n_apply.ts
@@ -8,6 +8,7 @@
 
 import {getPluralCase} from '../../i18n/localization';
 import {assertDefined, assertEqual, assertIndexInRange} from '../../util/assert';
+import {trustedConstantAttributeSanitizer} from '../../util/security/trusted_types';
 import {attachPatchData} from '../context_discovery';
 import {elementAttributeInternal, elementPropertyInternal, getOrCreateTNode, textBindingInternal} from '../instructions/shared';
 import {LContainer, NATIVE} from '../interfaces/container';
@@ -136,7 +137,12 @@ export function applyCreateOpCodes(
           // This code is used for ICU expressions only, since we don't support
           // directives/components in ICUs, we don't need to worry about inputs here
           elementAttributeInternal(
-              getTNode(tView, elementNodeIndex), lView, attrName, attrValue, null, null);
+              getTNode(tView, elementNodeIndex), lView, attrName, attrValue,
+              // A sanitizer that promotes values to Trusted Types without any
+              // sanitization. This is safe because this attribute has a
+              // constant value coming directly from an Angular template or its
+              // translation, and is thus trusted by the application.
+              trustedConstantAttributeSanitizer, null);
           break;
         default:
           throw new Error(`Unable to determine the type of mutate operation for "${opCode}"`);

--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -13,6 +13,7 @@ import {getInertBodyHelper} from '../../sanitization/inert_body';
 import {_sanitizeUrl, sanitizeSrcset} from '../../sanitization/url_sanitizer';
 import {addAllToArray} from '../../util/array_utils';
 import {assertEqual} from '../../util/assert';
+import {trustedConstantAttributeSanitizer} from '../../util/security/trusted_types';
 import {allocExpando, elementAttributeInternal, setInputsForProperty, setNgReflectProperties} from '../instructions/shared';
 import {getDocument} from '../interfaces/document';
 import {COMMENT_MARKER, ELEMENT_MARKER, I18nMutateOpCode, I18nMutateOpCodes, I18nUpdateOpCode, I18nUpdateOpCodes, IcuCase, IcuExpression, IcuType, TI18n, TIcu} from '../interfaces/i18n';
@@ -241,7 +242,13 @@ export function i18nAttributesFirstPass(
           // Set attributes for Elements only, for other types (like ElementContainer),
           // only set inputs below
           if (tNode.type === TNodeType.Element) {
-            elementAttributeInternal(tNode, lView, attrName, value, null, null);
+            elementAttributeInternal(
+                tNode, lView, attrName, value,
+                // A sanitizer that promotes values to Trusted Types without any
+                // sanitization. This is safe because this attribute has a
+                // constant value coming directly from an Angular template, and
+                // is thus trusted by the application.
+                trustedConstantAttributeSanitizer, null);
           }
           // Check if that attribute is a directive input
           const dataValue = tNode.inputs !== null && tNode.inputs[attrName];


### PR DESCRIPTION
When an attribute has a constant value that is marked for translation
(i18n-attrName), a special variable is created in the `consts` array of
the compiled template. Since this is not a constant, it is not promoted
to a Trusted Type by #39211, and can thus cause Trusted Types
violations. The same applies to constant attributes parsed out of
(potentially translated) i18n ICU messages.

Add an implementation of a `SanitizerFn` that promotes strings directly to
an appropriate Trusted Type without any sanitization.  Use this function to
promote these constants directly to appropriate Trusted Types. Tree
shakability is not a concern here since Trusted Types are already required
for i18n to work (#39208).

This is based on #39207. See the individual commits for more details.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
This is part of an ongoing effort to add support for Trusted Types to Angular.