### PR TITLE
fix(dev-infra): addressing review feedback from #39135

### DIFF
--- a/dev-infra/release/publish/external-commands.ts
+++ b/dev-infra/release/publish/external-commands.ts
@@ -44,7 +44,7 @@ export async function invokeSetNpmDistCommand(npmDistTag: string, version: semve
     info(green(`  ✓   Set "${npmDistTag}" NPM dist tag for all packages to v${version}.`));
   } catch (e) {
     error(e);
-    error(red('  ✘   An error occurred while setting the NPM dist tag for "${npmDistTag}".'));
+    error(red(`  ✘   An error occurred while setting the NPM dist tag for "${npmDistTag}".`));
     throw new FatalReleaseActionError();
   }
 }

--- a/dev-infra/release/publish/pull-request-state.ts
+++ b/dev-infra/release/publish/pull-request-state.ts
@@ -68,5 +68,6 @@ async function isCommitClosingPullRequest(api: GitClient, sha: string, id: numbe
   const {data} = await api.github.repos.getCommit({...api.remoteParams, ref: sha});
   // Matches the closing keyword supported in commit messages. See:
   // https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords.
-  return data.commit.message.match(new RegExp(`close[sd]? #${id}(?!\\d)`, 'i'));
+  return data.commit.message.match(
+      new RegExp(`(?:close[sd]?|fix(?:e[sd]?)|resolve[sd]?):? #${id}(?!\\d)`, 'i'));
 }


### PR DESCRIPTION
#39135 was accidentally merged before the review feedback had been addressed (because it didn't have the `cleanup` label).
This PR addresses the review feedback left on #39135. (See the individual commits for more details.)