### PR TITLE
refactor(compiler-cli): Remove program from NgCompiler constructor

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -90,6 +90,7 @@ export class NgCompiler {
   private diagnostics: ts.Diagnostic[]|null = null;
 
   private closureCompilerEnabled: boolean;
+  private tsProgram: ts.Program;
   private nextProgram: ts.Program;
   private entryPoint: ts.SourceFile|null;
   private moduleResolver: ModuleResolver;
@@ -102,7 +103,6 @@ export class NgCompiler {
   constructor(
       private adapter: NgCompilerAdapter,
       private options: NgCompilerOptions,
-      private tsProgram: ts.Program,
       private typeCheckingProgramStrategy: TypeCheckingProgramStrategy,
       private incrementalStrategy: IncrementalBuildStrategy,
       private enableTemplateTypeChecker: boolean,
@@ -114,7 +114,8 @@ export class NgCompiler {
     if (incompatibleTypeCheckOptionsDiagnostic !== null) {
       this.constructionDiagnostics.push(incompatibleTypeCheckOptionsDiagnostic);
     }
-
+    const tsProgram = this.typeCheckingProgramStrategy.getProgram();
+    this.tsProgram = tsProgram;
     this.nextProgram = tsProgram;
     this.closureCompilerEnabled = !!this.options.annotateForClosureCompiler;
 

--- a/packages/compiler-cli/src/ngtsc/core/test/compiler_test.ts
+++ b/packages/compiler-cli/src/ngtsc/core/test/compiler_test.ts
@@ -50,7 +50,7 @@ runInEachFileSystem(() => {
       const host = NgCompilerHost.wrap(baseHost, [COMPONENT], options, /* oldProgram */ null);
       const program = ts.createProgram({host, options, rootNames: host.inputFiles});
       const compiler = new NgCompiler(
-          host, options, program, new ReusedProgramStrategy(program, host, options, []),
+          host, options, new ReusedProgramStrategy(program, host, options, []),
           new NoopIncrementalBuildStrategy(), /** enableTemplateTypeChecker */ false);
 
       const diags = compiler.getDiagnostics(getSourceFileOrError(program, COMPONENT));
@@ -99,7 +99,7 @@ runInEachFileSystem(() => {
         const CmpA = getClass(getSourceFileOrError(program, cmpAFile), 'CmpA');
         const CmpC = getClass(getSourceFileOrError(program, cmpCFile), 'CmpC');
         const compiler = new NgCompiler(
-            host, options, program, new ReusedProgramStrategy(program, host, options, []),
+            host, options, new ReusedProgramStrategy(program, host, options, []),
             new NoopIncrementalBuildStrategy(), /** enableTemplateTypeChecker */ false);
         const components = compiler.getComponentsWithTemplateFile(templateFile);
         expect(components).toEqual(new Set([CmpA, CmpC]));
@@ -128,7 +128,7 @@ runInEachFileSystem(() => {
         const host = NgCompilerHost.wrap(baseHost, [COMPONENT], options, /* oldProgram */ null);
         const program = ts.createProgram({host, options, rootNames: host.inputFiles});
         const compiler = new NgCompiler(
-            host, options, program, new ReusedProgramStrategy(program, host, options, []),
+            host, options, new ReusedProgramStrategy(program, host, options, []),
             new NoopIncrementalBuildStrategy(), /** enableTemplateTypeChecker */ false);
 
         const deps = compiler.getResourceDependencies(getSourceFileOrError(program, COMPONENT));

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -99,7 +99,7 @@ export class NgtscProgram implements api.Program {
 
     // Create the NgCompiler which will drive the rest of the compilation.
     this.compiler = new NgCompiler(
-        this.host, options, this.tsProgram, reusedProgramStrategy, this.incrementalStrategy,
+        this.host, options, reusedProgramStrategy, this.incrementalStrategy,
         /** enableTemplateTypeChecker */ false, reuseProgram, this.perfRecorder);
   }
 

--- a/packages/compiler-cli/src/ngtsc/tsc_plugin.ts
+++ b/packages/compiler-cli/src/ngtsc/tsc_plugin.ts
@@ -101,9 +101,8 @@ export class NgTscPlugin implements TscPlugin {
     const typeCheckStrategy = new ReusedProgramStrategy(
         program, this.host, this.options, this.host.shimExtensionPrefixes);
     this._compiler = new NgCompiler(
-        this.host, this.options, program, typeCheckStrategy,
-        new PatchedProgramIncrementalBuildStrategy(), /** enableTemplateTypeChecker */ false,
-        oldProgram, NOOP_PERF_RECORDER);
+        this.host, this.options, typeCheckStrategy, new PatchedProgramIncrementalBuildStrategy(),
+        /** enableTemplateTypeChecker */ false, oldProgram, NOOP_PERF_RECORDER);
     return {
       ignoreForDiagnostics: this._compiler.ignoreForDiagnostics,
       ignoreForEmit: this._compiler.ignoreForEmit,

--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -87,7 +87,6 @@ export class LanguageService {
     return new NgCompiler(
         this.adapter,
         this.options,
-        program,
         this.strategy,
         new PatchedProgramIncrementalBuildStrategy(),
         /** enableTemplateTypeChecker */ true,


### PR DESCRIPTION
This commit removes the `program` parameter fron `NgCompiler` constructor
because the program can now be obtained from the
`typeCheckingProgramStrategy`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
