### PR TITLE
refactor(language-service): Return directive defs when input name is part of selector

### DIFF
--- a/packages/language-service/ivy/hybrid_visitor.ts
+++ b/packages/language-service/ivy/hybrid_visitor.ts
@@ -13,12 +13,14 @@ import * as t from '@angular/compiler/src/render3/r3_ast';         // t for temp
 import {isTemplateNode, isTemplateNodeWithKeyAndValue} from './utils';
 
 /**
- * Return the template AST node or expression AST node that most accurately
+ * Return the path to the template AST node or expression AST node that most accurately
  * represents the node at the specified cursor `position`.
+ *
  * @param ast AST tree
  * @param position cursor position
  */
-export function findNodeAtPosition(ast: t.Node[], position: number): t.Node|e.AST|undefined {
+export function getPathToNodeAtPosition(ast: t.Node[], position: number): Array<t.Node|e.AST>|
+    undefined {
   const visitor = new R3Visitor(position);
   visitor.visitAll(ast);
   const candidate = visitor.path[visitor.path.length - 1];
@@ -35,7 +37,22 @@ export function findNodeAtPosition(ast: t.Node[], position: number): t.Node|e.AS
       return;
     }
   }
-  return candidate;
+  return visitor.path;
+}
+
+/**
+ * Return the template AST node or expression AST node that most accurately
+ * represents the node at the specified cursor `position`.
+ *
+ * @param ast AST tree
+ * @param position cursor position
+ */
+export function findNodeAtPosition(ast: t.Node[], position: number): t.Node|e.AST|undefined {
+  const path = getPathToNodeAtPosition(ast, position);
+  if (!path) {
+    return;
+  }
+  return path[path.length - 1];
 }
 
 class R3Visitor implements t.Visitor {

--- a/packages/language-service/ivy/utils.ts
+++ b/packages/language-service/ivy/utils.ts
@@ -143,8 +143,12 @@ function getInlineTemplateInfoAtPosition(
 /**
  * Given an attribute node, converts it to string form.
  */
-function toAttributeString(attribute: t.TextAttribute|t.BoundAttribute): string {
-  return `[${attribute.name}=${attribute.valueSpan?.toString() ?? ''}]`;
+function toAttributeString(attribute: t.TextAttribute|t.BoundAttribute|t.BoundEvent): string {
+  if (attribute instanceof t.BoundEvent) {
+    return `[${attribute.name}]`;
+  } else {
+    return `[${attribute.name}=${attribute.valueSpan?.toString() ?? ''}]`;
+  }
 }
 
 function getNodeName(node: t.Template|t.Element): string {
@@ -154,8 +158,10 @@ function getNodeName(node: t.Template|t.Element): string {
 /**
  * Given a template or element node, returns all attributes on the node.
  */
-function getAttributes(node: t.Template|t.Element): Array<t.TextAttribute|t.BoundAttribute> {
-  const attributes: Array<t.TextAttribute|t.BoundAttribute> = [...node.attributes, ...node.inputs];
+function getAttributes(node: t.Template|
+                       t.Element): Array<t.TextAttribute|t.BoundAttribute|t.BoundEvent> {
+  const attributes: Array<t.TextAttribute|t.BoundAttribute|t.BoundEvent> =
+      [...node.attributes, ...node.inputs, ...node.outputs];
   if (node instanceof t.Template) {
     attributes.push(...node.templateAttrs);
   }
@@ -216,8 +222,8 @@ export function getDirectiveMatchesForAttribute(
   const allDirectiveMatches =
       getDirectiveMatchesForSelector(directives, getNodeName(hostNode) + allAttrs.join(''));
   const attrsExcludingName = attributes.filter(a => a.name !== name).map(toAttributeString);
-  const matchesWithoutAttr =
-      getDirectiveMatchesForSelector(directives, attrsExcludingName.join(''));
+  const matchesWithoutAttr = getDirectiveMatchesForSelector(
+      directives, getNodeName(hostNode) + attrsExcludingName.join(''));
   return difference(allDirectiveMatches, matchesWithoutAttr);
 }
 

--- a/packages/language-service/test/project/app/main.ts
+++ b/packages/language-service/test/project/app/main.ts
@@ -25,6 +25,7 @@ import * as ParsingCases from './parsing-cases';
     ParsingCases.TestPipe,
     ParsingCases.WithContextDirective,
     ParsingCases.CompoundCustomButtonDirective,
+    ParsingCases.EventSelectorDirective,
   ]
 })
 export class AppModule {

--- a/packages/language-service/test/project/app/parsing-cases.ts
+++ b/packages/language-service/test/project/app/parsing-cases.ts
@@ -75,6 +75,11 @@ export class CompoundCustomButtonDirective {
   @Input() config?: {color?: string};
 }
 
+@Directive({selector: '[eventSelector]'})
+export class EventSelectorDirective {
+  @Output() eventSelector = new EventEmitter<void>();
+}
+
 @Pipe({
   name: 'prefixPipe',
 })


### PR DESCRIPTION
…part of selector

When an input name is part of the directive selector, it would be good to return the directive as well
when performing 'go to definition' or 'go to type definition'. As an example, this would allow
'go to type definition' for ngIf to take the user to the NgIf directive.
'Go to type definition' would otherwise return no results because the
input is a generic type. This would also be the case for all primitive
input types.
