### PR TITLE
docs: fix broken link

### DIFF
--- a/aio/content/guide/entry-components.md
+++ b/aio/content/guide/entry-components.md
@@ -4,7 +4,7 @@ An entry component is any component that Angular loads imperatively, (which mean
 
 <div class="alert is-helpful">
 
-To contrast the two types of components, there are components which are included in the template, which are declarative. Additionally, there are components which you load imperatively; that is, entry components.
+    To contrast the two types of components, there are components which are included in the template, which are declarative. Additionally, there are components which you load imperatively; that is, entry components.
 
 </div>
 
@@ -75,11 +75,10 @@ All router components must be entry components. Because this would require you t
 
 
 ## The `entryComponents` array
-
 <div class="alert is-helpful">
-   
-Since 9.0.0 with Ivy, the `entryComponents` property is no longer necessary. See [deprecations guide](guide/deprecations#entryComponents).
-   
+
+   Since 9.0.0 with Ivy, the `entryComponents` property is no longer necessary. See [deprecations guide](guide/deprecations#entryComponents).
+
 </div>
 
 Though the `@NgModule` decorator has an `entryComponents` array, most of the time

--- a/aio/content/guide/glossary.md
+++ b/aio/content/guide/glossary.md
@@ -627,10 +627,11 @@ The [npm package manager](https://docs.npmjs.com/getting-started/what-is-npm) is
 
 Learn more about how Angular uses [Npm Packages](guide/npm-packages).
 
-{@ ngc}
+{@a ngc}
+
 ## ngc
 `ngc` is a Typescript-to-Javascript transpiler that processes Angular decorators, metadata, and templates, and emits JavaScript code.
-The most recent implementation is internally refered to as `ngtsc` because it's a minimalistic wrapper around the TypeScript compiler `tsc` that adds a transform for processing Angular code.
+The most recent implementation is internally referred to as `ngtsc` because it's a minimalistic wrapper around the TypeScript compiler `tsc` that adds a transform for processing Angular code.
 
 {@a O}
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- There is a broken link in the [entry components guide page](https://angular.io/guide/entry-components#the-entrycomponents-array), the link to deprecations guide appears as the raw text (`[deprecations guide](guide/deprecations#entryComponents)`).
- `{@ ngc}` appears above the [ngc section](https://angular.io/guide/entry-components#the-entrycomponents-array) in the glossary.

Issue Number: N/A


## What is the new behavior?
Fixed the above issues.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
