### PR TITLE
refactor(dev-infra): PRs need initial triage

### DIFF
--- a/.ng-dev/caretaker.ts
+++ b/.ng-dev/caretaker.ts
@@ -9,11 +9,11 @@ export const caretaker: CaretakerConfig = {
     },
     {
       name: 'Merge Assistance Queue',
-      query: `is:pr is:open status:success label:"action: merge-assistance"`,
+      query: `is:pr is:open label:"action: merge-assistance"`,
     },
     {
       name: 'Initial Triage Queue',
-      query: `is:open is:issue no:milestone`,
+      query: `is:open no:milestone`,
     }
   ]
 };


### PR DESCRIPTION
- The current initial triage does not include PRs. This includes them by removing the issue filter
- The merge assistance label is often applied to PRs that do not have
status=success. Caretaker should handle these as well