### PR TITLE
refactor(core): rename checkNoChangesMode to be clearer

### DIFF
--- a/packages/core/src/render3/bindings.ts
+++ b/packages/core/src/render3/bindings.ts
@@ -11,7 +11,7 @@ import {assertIndexInRange, assertLessThan, assertNotSame} from '../util/assert'
 
 import {getExpressionChangedErrorDetails, throwErrorIfNoChangesMode} from './errors';
 import {LView} from './interfaces/view';
-import {getCheckNoChangesMode} from './state';
+import {isInCheckNoChangesMode} from './state';
 import {NO_CHANGE} from './tokens';
 
 
@@ -52,7 +52,7 @@ export function bindingUpdated(lView: LView, bindingIndex: number, value: any): 
   if (Object.is(oldValue, value)) {
     return false;
   } else {
-    if (ngDevMode && getCheckNoChangesMode()) {
+    if (ngDevMode && isInCheckNoChangesMode()) {
       // View engine didn't report undefined values as changed on the first checkNoChanges pass
       // (before the change detection was run).
       const oldValueToCompare = oldValue !== NO_CHANGE ? oldValue : undefined;

--- a/packages/core/src/render3/hooks.ts
+++ b/packages/core/src/render3/hooks.ts
@@ -13,7 +13,7 @@ import {NgOnChangesFeatureImpl} from './features/ng_onchanges_feature';
 import {DirectiveDef} from './interfaces/definition';
 import {TNode} from './interfaces/node';
 import {FLAGS, HookData, InitPhaseState, LView, LViewFlags, PREORDER_HOOK_FLAGS, PreOrderHookFlags, TView} from './interfaces/view';
-import {getCheckNoChangesMode} from './state';
+import {isInCheckNoChangesMode} from './state';
 
 
 
@@ -205,8 +205,8 @@ function callHooks(
     currentNodeIndex: number|null|undefined): void {
   ngDevMode &&
       assertEqual(
-          getCheckNoChangesMode(), false,
-          'Hooks should never be run in the check no changes mode.');
+          isInCheckNoChangesMode(), false,
+          'Hooks should never be run when in check no changes mode.');
   const startIndex = currentNodeIndex !== undefined ?
       (currentView[PREORDER_HOOK_FLAGS] & PreOrderHookFlags.IndexOfTheNextPreOrderHookMaskMask) :
       0;

--- a/packages/core/src/render3/instructions/advance.ts
+++ b/packages/core/src/render3/instructions/advance.ts
@@ -8,7 +8,7 @@
 import {assertGreaterThan, assertIndexInRange} from '../../util/assert';
 import {executeCheckHooks, executeInitAndCheckHooks} from '../hooks';
 import {FLAGS, HEADER_OFFSET, InitPhaseState, LView, LViewFlags, TView} from '../interfaces/view';
-import {getCheckNoChangesMode, getLView, getSelectedIndex, getTView, setSelectedIndex} from '../state';
+import {getLView, getSelectedIndex, getTView, isInCheckNoChangesMode, setSelectedIndex} from '../state';
 
 
 /**
@@ -36,7 +36,7 @@ import {getCheckNoChangesMode, getLView, getSelectedIndex, getTView, setSelected
  */
 export function ɵɵadvance(delta: number): void {
   ngDevMode && assertGreaterThan(delta, 0, 'Can only advance forward');
-  selectIndexInternal(getTView(), getLView(), getSelectedIndex() + delta, getCheckNoChangesMode());
+  selectIndexInternal(getTView(), getLView(), getSelectedIndex() + delta, isInCheckNoChangesMode());
 }
 
 export function selectIndexInternal(

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -159,14 +159,17 @@ interface InstructionState {
    * In this mode, any changes in bindings will throw an ExpressionChangedAfterChecked error.
    *
    * Necessary to support ChangeDetectorRef.checkNoChanges().
+   *
+   * checkNoChanges Runs only in devmode=true and verifies that no unintended changes exist in
+   * the change detector or its children.
    */
-  checkNoChangesMode: boolean;
+  isInCheckNoChangesMode: boolean;
 }
 
 export const instructionState: InstructionState = {
   lFrame: createLFrame(null),
   bindingsEnabled: true,
-  checkNoChangesMode: false,
+  isInCheckNoChangesMode: false,
 };
 
 
@@ -287,13 +290,13 @@ export function getContextLView(): LView {
   return instructionState.lFrame.contextLView;
 }
 
-export function getCheckNoChangesMode(): boolean {
+export function isInCheckNoChangesMode(): boolean {
   // TODO(misko): remove this from the LView since it is ngDevMode=true mode only.
-  return instructionState.checkNoChangesMode;
+  return instructionState.isInCheckNoChangesMode;
 }
 
-export function setCheckNoChangesMode(mode: boolean): void {
-  instructionState.checkNoChangesMode = mode;
+export function setIsInCheckNoChangesMode(mode: boolean): void {
+  instructionState.isInCheckNoChangesMode = mode;
 }
 
 // top level variables should not be exported for performance reasons (PERF_NOTES.md)

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -156,7 +156,7 @@
     "name": "generatePropertyAliases"
   },
   {
-    "name": "getCheckNoChangesMode"
+    "name": "isInCheckNoChangesMode"
   },
   {
     "name": "getClosureSafeProperty"

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -948,7 +948,7 @@
     "name": "generatePropertyAliases"
   },
   {
-    "name": "getCheckNoChangesMode"
+    "name": "isInCheckNoChangesMode"
   },
   {
     "name": "getClosureSafeProperty"
@@ -1485,7 +1485,7 @@
     "name": "setBindingRootForHostBindings"
   },
   {
-    "name": "setCheckNoChangesMode"
+    "name": "setIsInCheckNoChangesMode"
   },
   {
     "name": "setCurrentDirectiveIndex"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -108,7 +108,7 @@
     "name": "extractPipeDef"
   },
   {
-    "name": "getCheckNoChangesMode"
+    "name": "isInCheckNoChangesMode"
   },
   {
     "name": "getClosureSafeProperty"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1260,7 +1260,7 @@
     "name": "getBootstrapListener"
   },
   {
-    "name": "getCheckNoChangesMode"
+    "name": "isInCheckNoChangesMode"
   },
   {
     "name": "getClosureSafeProperty"
@@ -1818,7 +1818,7 @@
     "name": "setBindingRootForHostBindings"
   },
   {
-    "name": "setCheckNoChangesMode"
+    "name": "setIsInCheckNoChangesMode"
   },
   {
     "name": "setCurrentDirectiveIndex"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -330,7 +330,7 @@
     "name": "generatePropertyAliases"
   },
   {
-    "name": "getCheckNoChangesMode"
+    "name": "isInCheckNoChangesMode"
   },
   {
     "name": "getClosureSafeProperty"
@@ -642,7 +642,7 @@
     "name": "setBindingRootForHostBindings"
   },
   {
-    "name": "setCheckNoChangesMode"
+    "name": "setIsInCheckNoChangesMode"
   },
   {
     "name": "setCurrentDirectiveIndex"


### PR DESCRIPTION
`getCheckNoChangesMode` was discovered to be unclear as to the purpose of
it. This refactor is a simple renaming to make it much clearer what that
method and property does.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
