### PR TITLE
WIP(core): support Trusted Types in ViewEngine

### DIFF
--- a/goldens/public-api/core/core.d.ts
+++ b/goldens/public-api/core/core.d.ts
@@ -808,7 +808,7 @@ export declare abstract class Renderer2 {
     abstract removeClass(el: any, name: string): void;
     abstract removeStyle(el: any, style: string, flags?: RendererStyleFlags2): void;
     abstract selectRootElement(selectorOrNode: string | any, preserveContent?: boolean): any;
-    abstract setAttribute(el: any, name: string, value: string, namespace?: string | null): void;
+    abstract setAttribute(el: any, name: string, value: string | TrustedHTML | TrustedScript | TrustedScriptURL, namespace?: string | null): void;
     abstract setProperty(el: any, name: string, value: any): void;
     abstract setStyle(el: any, style: string, value: any, flags?: RendererStyleFlags2): void;
     abstract setValue(node: any, value: string): void;

--- a/packages/core/src/render/api.ts
+++ b/packages/core/src/render/api.ts
@@ -10,6 +10,7 @@ import {InjectionToken} from '../di/injection_token';
 import {ViewEncapsulation} from '../metadata/view';
 import {injectRenderer2 as render3InjectRenderer2} from '../render3/view_engine_compatibility';
 import {noop} from '../util/noop';
+import {TrustedHTML, TrustedScript, TrustedScriptURL} from '../util/security/trusted_type_defs';
 
 
 export const Renderer2Interceptor = new InjectionToken<Renderer2[]>('Renderer2Interceptor');
@@ -205,7 +206,9 @@ export abstract class Renderer2 {
    * @param value The new value.
    * @param namespace The namespace.
    */
-  abstract setAttribute(el: any, name: string, value: string, namespace?: string|null): void;
+  abstract setAttribute(
+      el: any, name: string, value: string|TrustedHTML|TrustedScript|TrustedScriptURL,
+      namespace?: string|null): void;
 
   /**
    * Implement this callback to remove an attribute from an element in the DOM.

--- a/packages/platform-browser-dynamic/src/compiler_reflector.ts
+++ b/packages/platform-browser-dynamic/src/compiler_reflector.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CompileReflector, ExternalReference, getUrlScheme, Identifiers, syntaxError} from '@angular/compiler';
-import {ANALYZE_FOR_ENTRY_COMPONENTS, ChangeDetectionStrategy, ChangeDetectorRef, Component, ComponentFactory, ComponentFactoryResolver, ComponentRef, ElementRef, Injector, LOCALE_ID, NgModuleFactory, NgModuleRef, QueryList, Renderer2, SecurityContext, TemplateRef, TRANSLATIONS_FORMAT, ViewContainerRef, ViewEncapsulation, ɵand, ɵccf, ɵcmf, ɵCodegenComponentFactoryResolver, ɵcrt, ɵdid, ɵeld, ɵEMPTY_ARRAY, ɵEMPTY_MAP, ɵinlineInterpolate, ɵinterpolate, ɵmod, ɵmpd, ɵncd, ɵnov, ɵpad, ɵpid, ɵpod, ɵppd, ɵprd, ɵqud, ɵReflectionCapabilities as ReflectionCapabilities, ɵregisterModuleFactory, ɵstringify as stringify, ɵted, ɵunv, ɵvid} from '@angular/core';
+import {CompileReflector, ExternalReference, getUrlScheme, Identifiers, R3Identifiers, syntaxError} from '@angular/compiler';
+import {ANALYZE_FOR_ENTRY_COMPONENTS, ChangeDetectionStrategy, ChangeDetectorRef, Component, ComponentFactory, ComponentFactoryResolver, ComponentRef, ElementRef, Injector, LOCALE_ID, NgModuleFactory, NgModuleRef, QueryList, Renderer2, SecurityContext, TemplateRef, TRANSLATIONS_FORMAT, ViewContainerRef, ViewEncapsulation, ɵand, ɵccf, ɵcmf, ɵCodegenComponentFactoryResolver, ɵcrt, ɵdid, ɵeld, ɵEMPTY_ARRAY, ɵEMPTY_MAP, ɵinlineInterpolate, ɵinterpolate, ɵmod, ɵmpd, ɵncd, ɵnov, ɵpad, ɵpid, ɵpod, ɵppd, ɵprd, ɵqud, ɵReflectionCapabilities as ReflectionCapabilities, ɵregisterModuleFactory, ɵstringify as stringify, ɵted, ɵunv, ɵvid, ɵɵtrustConstantHtml, ɵɵtrustConstantResourceUrl, ɵɵtrustConstantScript} from '@angular/core';
 
 export const MODULE_SUFFIX = '';
 const builtinExternalReferences = createBuiltinExternalReferencesMap();
@@ -80,6 +80,9 @@ function createBuiltinExternalReferencesMap() {
   map.set(Identifiers.ViewEncapsulation, ViewEncapsulation);
   map.set(Identifiers.ChangeDetectionStrategy, ChangeDetectionStrategy);
   map.set(Identifiers.SecurityContext, SecurityContext);
+  map.set(R3Identifiers.trustConstantHtml, ɵɵtrustConstantHtml);
+  map.set(R3Identifiers.trustConstantScript, ɵɵtrustConstantScript);
+  map.set(R3Identifiers.trustConstantResourceUrl, ɵɵtrustConstantResourceUrl);
   map.set(Identifiers.LOCALE_ID, LOCALE_ID);
   map.set(Identifiers.TRANSLATIONS_FORMAT, TRANSLATIONS_FORMAT);
   map.set(Identifiers.inlineInterpolate, ɵinlineInterpolate);


### PR DESCRIPTION
Fix Trusted Types violations that occur in Angular applications that
use ViewEngine.

Promote constant values of properties and attributes to
an appropriate Trusted Type directly in the compiled source code, before
they are passed to an instruction that assigns this value to the given
property or attribute. This re-uses the conversion functions introduced
in the corresponding fix for Ivy.

Promote output from the sanitizer to an appropriate
Trusted Type before it is assigned to an attribute or property, using
Angular's unsafe-bypass policy.

This differs slightly from the corresponding fix for Ivy, in that
Angular's main policy is not used to promote output from Angular's
native sanitizer. This is for technical reasons; ViewEngine (defined in
the core package) does not have access to the native sanitizer (defined
in the platform-browser package) and thus has no way to detect it. This
is considered good enough to unblock Trusted Types adoption in
applications using ViewEngine, considering that ViewEngine is being
turned down in favor of Ivy.

This is based on #39211. See the individual commits for more details.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
This is part of an ongoing effort to add support for Trusted Types to Angular.