### PR TITLE
refactor(core): Replace `ExpandoInstructions` with `HostBindingOpCodes`

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3037,
-        "main-es2015": 448676,
+        "main-es2015": 448085,
         "polyfills-es2015": 52415
       }
     }

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 17092,
+        "main-es2015": 17049,
         "polyfills-es2015": 36657
       }
     }
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 218527,
+        "main-es2015": 217879,
         "polyfills-es2015": 36723,
         "5-es2015": 781
       }

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -30,7 +30,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 136096,
+        "main-es2015": 135506,
         "polyfills-es2015": 37248
       }
     }
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 242460,
+        "main-es2015": 241945,
         "polyfills-es2015": 36938,
         "5-es2015": 751
       }

--- a/integration/README.md
+++ b/integration/README.md
@@ -139,3 +139,14 @@ On CircleCI, the puppeteer provisioned Chrome crashes with `CI we get Root cause
 
 See: https://github.com/puppeteer/puppeteer/blob/v1.0.0/docs/troubleshooting.md#tips
 See: https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t
+
+## Debugging Size Regressions
+
+If size regression occurs, one way to debug is to get a build which shows the code before and after. Here are the steps to do that.
+
+1. Check out both the `master` branch as well as the your change (let's refer to it as `change` branch) into two different working locations. (A suggested way to do this is using `git worktree`.)
+2. In both `master` and `change` locations update the failing tests `package.json` with `NG_BUILD_DEBUG_OPTIMIZE=minify` environment variable so that the resulting build would contain a human readable but optimized output. As an example:
+   - Open `integration/cli-hello-world/package.json` and prefix `NG_BUILD_DEBUG_OPTIMIZE=minify` into the `build` rule. Resulting in something like: `"build": "NG_BUILD_DEBUG_OPTIMIZE=minify ng build --prod",`
+   - Run `bazel run //integration:cli-hello-world_test.debug` to build the output. (optionally just run `yarn build` in the directory if you want to do a quick rebuild which will only pick up changes to the test application (not framework).)
+   - Diff the `master` vs `change` to see the differences. `myDiffTool change/integration/cli-hello-world/dist/main-es2015.*.js master/integration/cli-hello-world/dist/main-es2015.*.js`
+   - The above should give you a better understanding as to what has changed and what is causing the regression.

--- a/packages/core/src/render3/VIEW_DATA.md
+++ b/packages/core/src/render3/VIEW_DATA.md
@@ -198,57 +198,6 @@ The above will create the following layout:
 | ...   | ...                 | ...
 
 
-The `EXPANDO` section needs additional information for information stored in `TView.expandoInstructions`
-
-| Index | `TView.expandoInstructions` | Meaning
-| ----: | ---------------------------:| -------
-| 0     | -10                         | Negative numbers signify pointers to elements. In this case 10 (`<child>`)
-| 1     | 2                           | Injector size. Number of values to skip to get to Host Bindings.
-| 2     | Child.ɵcmp.hostBindings     | The function to call. (Only when `hostVars` is not `0`)
-| 3     | Child.ɵcmp.hostVars         | Number of host bindings to process. (Only when `hostVars` is not `0`)
-| 4     | Tooltip.ɵdir.hostBindings   | The function to call. (Only when `hostVars` is not `0`)
-| 5     | Tooltip.ɵdir.hostVars       | Number of host bindings to process. (Only when `hostVars` is not `0`)
-
-The reason for this layout is to make the host binding update efficient using this pseudo code:
-```typescript
-let currentDirectiveIndex = -1;
-let currentElementIndex = -1;
-// This is global state which is used internally by hostBindings to know where the offset is
-let bindingRootIndex = tView.expandoStartIndex;
-for(var i = 0; i < tView.expandoInstructions.length; i++) {
-  let instruction = tView.expandoInstructions[i];
-  if (typeof instruction === 'number') {
-    // Numbers are used to update the indices.
-    if (instruction < 0) {
-      // Negative numbers means that we are starting new EXPANDO block and need to update current element and directive index
-      bindingRootIndex += BLOOM_OFFSET;
-      currentDirectiveIndex = bindingRootIndex;
-      currentElementIndex = -instruction;
-    } else {
-      bindingRootIndex += instruction;
-    }
-  } else {
-    // We know that we are hostBinding function so execute it.
-    instruction(currentDirectiveIndex, currentElementIndex);
-    currentDirectiveIndex++;
-  }
-}
-```
-
-The above code should execute as:
-
-| Instruction                 | `bindingRootIndex` | `currentDirectiveIndex`   | `currentElementIndex`
-| ----------:                 | -----------------: | ----------------------:   | --------------------:
-| (initial)                   | `11`               | `-1`                      | `-1`
-| `-10`                       | `19`               | `\* new Child() *\ 19`    | `\* <child> *\ 10`
-| `2`                         | `21`               | `\* new Child() *\ 19`    | `\* <child> *\ 10`
-| `Child.ɵcmp.hostBindings`   | invoke with =>     | `\* new Child() *\ 19`    | `\* <child> *\ 10`
-|                             | `21`               | `\* new Tooltip() *\ 20`  | `\* <child> *\ 10`
-| `Child.ɵcmp.hostVars`       | `22`               | `\* new Tooltip() *\ 20`  | `\* <child> *\ 10`
-| `Tooltip.ɵdir.hostBindings` | invoke with =>     | `\* new Tooltip() *\ 20`  | `\* <child> *\ 10`
-|                             | `22`               | `21`                      | `\* <child> *\ 10`
-| `Tooltip.ɵdir.hostVars`     | `22`               | `21`                      | `\* <child> *\ 10`
-
 ## `EXPANDO` and Injection
 
 `EXPANDO` will also store the injection information for the element.

--- a/packages/core/src/render3/hooks.ts
+++ b/packages/core/src/render3/hooks.ts
@@ -7,7 +7,7 @@
  */
 
 import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, DoCheck, OnChanges, OnDestroy, OnInit} from '../interface/lifecycle_hooks';
-import {assertEqual, assertNotEqual} from '../util/assert';
+import {assertDefined, assertEqual, assertNotEqual} from '../util/assert';
 import {assertFirstCreatePass} from './assert';
 import {NgOnChangesFeatureImpl} from './features/ng_onchanges_feature';
 import {DirectiveDef} from './interfaces/definition';
@@ -77,6 +77,7 @@ export function registerPostOrderHooks(tView: TView, tNode: TNode): void {
   // hooks for projected components and directives must be called *before* their hosts.
   for (let i = tNode.directiveStart, end = tNode.directiveEnd; i < end; i++) {
     const directiveDef = tView.data[i] as DirectiveDef<any>;
+    ngDevMode && assertDefined(directiveDef, 'Expecting DirectiveDef');
     const lifecycleHooks: AfterContentInit&AfterContentChecked&AfterViewInit&AfterViewChecked&
         OnDestroy = directiveDef.type.prototype;
     const {

--- a/packages/core/src/render3/i18n/i18n_insert_before_index.ts
+++ b/packages/core/src/render3/i18n/i18n_insert_before_index.ts
@@ -8,6 +8,8 @@
 
 import {assertEqual} from '../../util/assert';
 import {TNode, TNodeType} from '../interfaces/node';
+import {setI18nHandling} from '../node_manipulation';
+import {getInsertInFrontOfRNodeWithI18n, processI18nInsertBefore} from '../node_manipulation_i18n';
 
 /**
  * Add `tNode` to `previousTNodes` list and update relevant `TNode`s in `previousTNodes` list
@@ -81,6 +83,7 @@ function setInsertBeforeIndex(tNode: TNode, value: number): void {
     // Array is stored if we have to insert child nodes. See `TNode.insertBeforeIndex`
     index[0] = value;
   } else {
+    setI18nHandling(getInsertInFrontOfRNodeWithI18n, processI18nInsertBefore);
     tNode.insertBeforeIndex = value;
   }
 }

--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -117,7 +117,7 @@ export function i18nStartFirstCreatePass(
       }
     } else {
       // Odd indexes are placeholders (elements and sub-templates)
-      // At this point value is something like: '/#1:2' (orginally coming from '�/#1:2�')
+      // At this point value is something like: '/#1:2' (originally coming from '�/#1:2�')
       const isClosing = value.charCodeAt(0) === CharCode.SLASH;
       const type = value.charCodeAt(isClosing ? 1 : 0);
       ngDevMode && assertOneOf(type, CharCode.STAR, CharCode.HASH, CharCode.EXCLAMATION);

--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -154,7 +154,7 @@ export function i18nStartFirstCreatePass(
 function createTNodeAndAddOpCode(
     tView: TView, rootTNode: TNode|null, existingTNodes: TNode[], lView: LView,
     createOpCodes: I18nCreateOpCodes, text: string|null, isICU: boolean): TNode {
-  const i18nNodeIdx = allocExpando(tView, lView, 1);
+  const i18nNodeIdx = allocExpando(tView, lView, 1, null);
   let opCode = i18nNodeIdx << I18nCreateOpCode.SHIFT;
   let parentTNode = getCurrentParentTNode();
 
@@ -423,7 +423,7 @@ export function icuStart(
   let bindingMask = 0;
   const tIcu: TIcu = {
     type: icuExpression.type,
-    currentCaseLViewIndex: allocExpando(tView, lView, 1),
+    currentCaseLViewIndex: allocExpando(tView, lView, 1, null),
     anchorIdx,
     cases: [],
     create: [],
@@ -596,7 +596,7 @@ function walkIcuTree(
   let bindingMask = 0;
   let currentNode = parentNode.firstChild;
   while (currentNode) {
-    const newIndex = allocExpando(tView, lView, 1);
+    const newIndex = allocExpando(tView, lView, 1, null);
     switch (currentNode.nodeType) {
       case Node.ELEMENT_NODE:
         const element = currentNode as Element;

--- a/packages/core/src/render3/i18n/i18n_util.ts
+++ b/packages/core/src/render3/i18n/i18n_util.ts
@@ -13,6 +13,8 @@ import {IcuCreateOpCode, TIcu} from '../interfaces/i18n';
 import {TIcuContainerNode, TNode, TNodeType} from '../interfaces/node';
 import {LView, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
+import {setI18nHandling} from '../node_manipulation';
+import {getInsertInFrontOfRNodeWithI18n, processI18nInsertBefore} from '../node_manipulation_i18n';
 import {addTNodeAndUpdateInsertBeforeIndex} from './i18n_insert_before_index';
 
 
@@ -83,6 +85,7 @@ export function setTNodeInsertBeforeIndex(tNode: TNode, index: number) {
   ngDevMode && assertTNode(tNode);
   let insertBeforeIndex = tNode.insertBeforeIndex;
   if (insertBeforeIndex === null) {
+    setI18nHandling(getInsertInFrontOfRNodeWithI18n, processI18nInsertBefore);
     insertBeforeIndex = tNode.insertBeforeIndex =
         [null!/* may be updated to number later */, index];
   } else {

--- a/packages/core/src/render3/instructions/lview_debug.ts
+++ b/packages/core/src/render3/instructions/lview_debug.ts
@@ -22,7 +22,7 @@ import {SelectorFlags} from '../interfaces/projection';
 import {LQueries, TQueries} from '../interfaces/query';
 import {RComment, RElement, Renderer3, RendererFactory3, RNode} from '../interfaces/renderer';
 import {getTStylingRangeNext, getTStylingRangeNextDuplicate, getTStylingRangePrev, getTStylingRangePrevDuplicate, TStylingKey, TStylingRange} from '../interfaces/styling';
-import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DebugNode, DECLARATION_VIEW, DestroyHookData, ExpandoInstructions, FLAGS, HEADER_OFFSET, HookData, HOST, INJECTOR, LContainerDebug as ILContainerDebug, LView, LViewDebug as ILViewDebug, LViewDebugRange, LViewDebugRangeContent, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, SANITIZER, T_HOST, TData, TView as ITView, TVIEW, TView, TViewType, TViewTypeAsString} from '../interfaces/view';
+import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DebugNode, DECLARATION_VIEW, DestroyHookData, FLAGS, HEADER_OFFSET, HookData, HOST, HostBindingOpCodes, INJECTOR, LContainerDebug as ILContainerDebug, LView, LViewDebug as ILViewDebug, LViewDebugRange, LViewDebugRangeContent, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, SANITIZER, T_HOST, TData, TView as ITView, TVIEW, TView, TViewType, TViewTypeAsString} from '../interfaces/view';
 import {attachDebugObject} from '../util/debug_utils';
 import {getParentInjectorIndex, getParentInjectorView} from '../util/injector_utils';
 import {unwrapRNode} from '../util/view_utils';
@@ -115,38 +115,38 @@ function nameSuffix(text: string|null|undefined): string {
  */
 export const TViewConstructor = class TView implements ITView {
   constructor(
-      public type: TViewType,                                //
-      public blueprint: LView,                               //
-      public template: ComponentTemplate<{}>|null,           //
-      public queries: TQueries|null,                         //
-      public viewQuery: ViewQueriesFunction<{}>|null,        //
-      public declTNode: ITNode|null,                         //
-      public data: TData,                                    //
-      public bindingStartIndex: number,                      //
-      public expandoStartIndex: number,                      //
-      public expandoInstructions: ExpandoInstructions|null,  //
-      public firstCreatePass: boolean,                       //
-      public firstUpdatePass: boolean,                       //
-      public staticViewQueries: boolean,                     //
-      public staticContentQueries: boolean,                  //
-      public preOrderHooks: HookData|null,                   //
-      public preOrderCheckHooks: HookData|null,              //
-      public contentHooks: HookData|null,                    //
-      public contentCheckHooks: HookData|null,               //
-      public viewHooks: HookData|null,                       //
-      public viewCheckHooks: HookData|null,                  //
-      public destroyHooks: DestroyHookData|null,             //
-      public cleanup: any[]|null,                            //
-      public contentQueries: number[]|null,                  //
-      public components: number[]|null,                      //
-      public directiveRegistry: DirectiveDefList|null,       //
-      public pipeRegistry: PipeDefList|null,                 //
-      public firstChild: ITNode|null,                        //
-      public schemas: SchemaMetadata[]|null,                 //
-      public consts: TConstants|null,                        //
-      public incompleteFirstPass: boolean,                   //
-      public _decls: number,                                 //
-      public _vars: number,                                  //
+      public type: TViewType,
+      public blueprint: LView,
+      public template: ComponentTemplate<{}>|null,
+      public queries: TQueries|null,
+      public viewQuery: ViewQueriesFunction<{}>|null,
+      public declTNode: ITNode|null,
+      public data: TData,
+      public bindingStartIndex: number,
+      public expandoStartIndex: number,
+      public hostBindingOpCodes: HostBindingOpCodes|null,
+      public firstCreatePass: boolean,
+      public firstUpdatePass: boolean,
+      public staticViewQueries: boolean,
+      public staticContentQueries: boolean,
+      public preOrderHooks: HookData|null,
+      public preOrderCheckHooks: HookData|null,
+      public contentHooks: HookData|null,
+      public contentCheckHooks: HookData|null,
+      public viewHooks: HookData|null,
+      public viewCheckHooks: HookData|null,
+      public destroyHooks: DestroyHookData|null,
+      public cleanup: any[]|null,
+      public contentQueries: number[]|null,
+      public components: number[]|null,
+      public directiveRegistry: DirectiveDefList|null,
+      public pipeRegistry: PipeDefList|null,
+      public firstChild: ITNode|null,
+      public schemas: SchemaMetadata[]|null,
+      public consts: TConstants|null,
+      public incompleteFirstPass: boolean,
+      public _decls: number,
+      public _vars: number,
 
   ) {}
 

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -12,7 +12,7 @@ import {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA, SchemaMetadata} from '../../me
 import {ViewEncapsulation} from '../../metadata/view';
 import {validateAgainstEventAttributes, validateAgainstEventProperties} from '../../sanitization/sanitization';
 import {Sanitizer} from '../../sanitization/sanitizer';
-import {assertDefined, assertDomNode, assertEqual, assertGreaterThan, assertGreaterThanOrEqual, assertIndexInRange, assertNotEqual, assertNotSame, assertSame, assertString} from '../../util/assert';
+import {assertDefined, assertDomNode, assertEqual, assertGreaterThanOrEqual, assertIndexInRange, assertNotEqual, assertNotSame, assertSame, assertString} from '../../util/assert';
 import {createNamedArrayType} from '../../util/named_array_type';
 import {initNgDevMode} from '../../util/ng_dev_mode';
 import {normalizeDebugBindingName, normalizeDebugBindingValue} from '../../util/ng_reflect';

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -409,11 +409,17 @@ export interface TNode {
 
   /**
    * Stores starting index of the directives.
+   *
+   * NOTE: The first directive is always component (if present).
    */
   directiveStart: number;
 
   /**
    * Stores final exclusive index of the directives.
+   *
+   * The area right behind the `directiveStart-directiveEnd` range is used to allocate the
+   * `HostBindingFunction` `vars` (or null if no bindings.) Therefore `directiveEnd` is used to set
+   * `LFrame.bindingRootIndex` before `HostBindingFunction` is executed.
    */
   directiveEnd: number;
 

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -427,11 +427,69 @@ export const enum PreOrderHookFlags {
 }
 
 /**
- * Set of instructions used to process host bindings efficiently.
+ * Stores a set of OpCodes to process `HostBindingsFunction` associated with a current view.
  *
- * See VIEW_DATA.md for more information.
+ * In order to invoke `HostBindingsFunction` we need:
+ * 1. 'elementIdx`: Index to the element associated with the `HostBindingsFunction`.
+ * 2. 'directiveIdx`: Index to the directive associated with the `HostBindingsFunction`. (This will
+ *    become the context for the `HostBindingsFunction` invocation.)
+ * 3. `bindingRootIdx`: Location where the bindings for the `HostBindingsFunction` start. Internally
+ *    `HostBindingsFunction` binding indexes start from `0` so we need to add `bindingRootIdx` to
+ *    it.
+ * 4. `HostBindingsFunction`: A host binding function to execute.
+ *
+ * The above information needs to be encoded into the `HostBindingOpCodes` in an efficient manner.
+ *
+ * 1. `elementIdx` is encoded into the `HostBindingOpCodes` as `~elementIdx` (so a negative number);
+ * 2. `directiveIdx`
+ * 3. `bindingRootIdx`
+ * 4. `HostBindingsFunction` is passed in as is.
+ *
+ * The `HostBindingOpCodes` array contains:
+ * - negative number to select the element index.
+ * - followed by 1 or more of:
+ *    - a number to select the directive index
+ *    - a number to select the bindingRoot index
+ *    - and a function to invoke.
+ *
+ * ## Example
+ *
+ * ```
+ * const hostBindingOpCodes = [
+ *   ~30,                               // Select element 30
+ *   40, 45, MyDir.ɵdir.hostBindings    // Invoke host bindings on MyDir on element 30;
+ *                                      // directiveIdx = 40; bindingRootIdx = 45;
+ *   50, 55, OtherDir.ɵdir.hostBindings // Invoke host bindings on OtherDire on element 30
+ *                                      // directiveIdx = 50; bindingRootIdx = 55;
+ * ]
+ * ```
+ *
+ * ## Pseudocode
+ * ```
+ * const hostBindingOpCodes = tView.hostBindingOpCodes;
+ * if (hostBindingOpCodes === null) return;
+ * for (let i = 0; i < hostBindingOpCodes.length; i++) {
+ *   const opCode = hostBindingOpCodes[i] as number;
+ *   if (opCode < 0) {
+ *     // Negative numbers are element indexes.
+ *     setSelectedIndex(~opCode);
+ *   } else {
+ *     // Positive numbers are NumberTuple which store bindingRootIndex and directiveIndex.
+ *     const directiveIdx = opCode;
+ *     const bindingRootIndx = hostBindingOpCodes[++i] as number;
+ *     const hostBindingFn = hostBindingOpCodes[++i] as HostBindingsFunction<any>;
+ *     setBindingRootForHostBindings(bindingRootIndx, directiveIdx);
+ *     const context = lView[directiveIdx];
+ *     hostBindingFn(RenderFlags.Update, context);
+ *   }
+ * }
+ * ```
+ *
  */
-export interface ExpandoInstructions extends Array<number|HostBindingsFunction<any>|null> {}
+export interface HostBindingOpCodes extends Array<number|HostBindingsFunction<any>> {
+  __brand__: 'HostBindingOpCodes';
+  debug?: string[];
+}
 
 /**
  * Explicitly marks `TView` as a specific type in `ngDevMode`
@@ -572,13 +630,11 @@ export interface TView {
   firstChild: TNode|null;
 
   /**
-   * Set of instructions used to process host bindings efficiently.
+   * Stores the OpCodes to be replayed during change-detection to process the `HostBindings`
    *
-   * See VIEW_DATA.md for more information.
+   * See `HostBindingOpCodes` for encoding details.
    */
-  // TODO(misko): `expandoInstructions` should be renamed to `hostBindingsInstructions` since they
-  // keep track of `hostBindings` which need to be executed.
-  expandoInstructions: ExpandoInstructions|null;
+  hostBindingOpCodes: HostBindingOpCodes|null;
 
   /**
    * Full registry of directives and components that may be found in this view.

--- a/packages/core/src/render3/node_manipulation_i18n.ts
+++ b/packages/core/src/render3/node_manipulation_i18n.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {assertDomNode, assertIndexInRange} from '../util/assert';
+import {TNode, TNodeFlags, TNodeType} from './interfaces/node';
+import {RElement, Renderer3, RNode} from './interfaces/renderer';
+import {LView} from './interfaces/view';
+import {getInsertInFrontOfRNodeWithNoI18n, nativeInsertBefore} from './node_manipulation';
+import {unwrapRNode} from './util/view_utils';
+
+
+/**
+ * Find a node in front of which `currentTNode` should be inserted (takes i18n into account).
+ *
+ * This method determines the `RNode` in front of which we should insert the `currentRNode`. This
+ * takes `TNode.insertBeforeIndex` into account.
+ *
+ * @param parentTNode parent `TNode`
+ * @param currentTNode current `TNode` (The node which we would like to insert into the DOM)
+ * @param lView current `LView`
+ */
+export function getInsertInFrontOfRNodeWithI18n(
+    parentTNode: TNode, currentTNode: TNode, lView: LView): RNode|null {
+  const tNodeInsertBeforeIndex = currentTNode.insertBeforeIndex;
+  const insertBeforeIndex =
+      Array.isArray(tNodeInsertBeforeIndex) ? tNodeInsertBeforeIndex[0] : tNodeInsertBeforeIndex;
+  if (insertBeforeIndex === null) {
+    return getInsertInFrontOfRNodeWithNoI18n(parentTNode, currentTNode, lView);
+  } else {
+    ngDevMode && assertIndexInRange(lView, insertBeforeIndex);
+    return unwrapRNode(lView[insertBeforeIndex]);
+  }
+}
+
+
+/**
+ * Process `TNode.insertBeforeIndex` by adding i18n text nodes.
+ *
+ * See `TNode.insertBeforeIndex`
+ */
+export function processI18nInsertBefore(
+    renderer: Renderer3, childTNode: TNode, lView: LView, childRNode: RNode|RNode[],
+    parentRElement: RElement|null): void {
+  const tNodeInsertBeforeIndex = childTNode.insertBeforeIndex;
+  if (Array.isArray(tNodeInsertBeforeIndex)) {
+    // An array indicates that there are i18n nodes that need to be added as children of this
+    // `childRNode`. These i18n nodes were created before this `childRNode` was available and so
+    // only now can be added. The first element of the array is the normal index where we should
+    // insert the `childRNode`. Additional elements are the extra nodes to be added as children of
+    // `childRNode`.
+    ngDevMode && assertDomNode(childRNode);
+    let i18nParent: RElement|null = childRNode as RElement;
+    let anchorRNode: RNode|null = null;
+    if (!(childTNode.type & TNodeType.AnyRNode)) {
+      anchorRNode = i18nParent;
+      i18nParent = parentRElement;
+    }
+    if (i18nParent !== null && (childTNode.flags & TNodeFlags.isComponentHost) === 0) {
+      for (let i = 1; i < tNodeInsertBeforeIndex.length; i++) {
+        // No need to `unwrapRNode` because all of the indexes point to i18n text nodes.
+        // see `assertDomNode` below.
+        const i18nChild = lView[tNodeInsertBeforeIndex[i]];
+        nativeInsertBefore(renderer, i18nParent, i18nChild, anchorRNode, false);
+      }
+    }
+  }
+}

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -570,7 +570,7 @@ function createTQuery(tView: TView, metadata: TQueryMetadata, nodeIndex: number)
 function saveContentQueryAndDirectiveIndex(tView: TView, directiveIndex: number) {
   const tViewContentQueries = tView.contentQueries || (tView.contentQueries = []);
   const lastSavedDirectiveIndex =
-      tView.contentQueries.length ? tViewContentQueries[tViewContentQueries.length - 1] : -1;
+      tViewContentQueries.length ? tViewContentQueries[tViewContentQueries.length - 1] : -1;
   if (directiveIndex !== lastSavedDirectiveIndex) {
     tViewContentQueries.push(tView.queries!.length - 1, directiveIndex);
   }

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -69,10 +69,10 @@
     "name": "addComponentLogic"
   },
   {
-    "name": "addHostBindingsToExpandoInstructions"
+    "name": "addToViewTree"
   },
   {
-    "name": "addToViewTree"
+    "name": "allocExpando"
   },
   {
     "name": "allocLFrame"
@@ -85,9 +85,6 @@
   },
   {
     "name": "autoRegisterModuleById"
-  },
-  {
-    "name": "baseResolveDirective"
   },
   {
     "name": "callHook"
@@ -103,6 +100,9 @@
   },
   {
     "name": "concatStringsWithSpace"
+  },
+  {
+    "name": "configureViewWithDirective"
   },
   {
     "name": "createLFrame"
@@ -145,9 +145,6 @@
   },
   {
     "name": "findAttrIndexInNode"
-  },
-  {
-    "name": "generateExpandoInstructionBlock"
   },
   {
     "name": "generateInitialInputs"
@@ -205,9 +202,6 @@
   },
   {
     "name": "getTView"
-  },
-  {
-    "name": "growHostVarsSpace"
   },
   {
     "name": "hasTagAndTypeMatch"
@@ -285,9 +279,6 @@
     "name": "nativeAppendOrInsertBefore"
   },
   {
-    "name": "nativeInsertBefore"
-  },
-  {
     "name": "nextNgElementId"
   },
   {
@@ -304,6 +295,9 @@
   },
   {
     "name": "refreshView"
+  },
+  {
+    "name": "registerHostBindingOpCodes"
   },
   {
     "name": "rememberChangeHistoryAndInvokeOnChangesHook"
@@ -349,9 +343,6 @@
   },
   {
     "name": "setUpAttributes"
-  },
-  {
-    "name": "unwrapRNode"
   },
   {
     "name": "updateTransplantedViewCount"

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -699,13 +699,13 @@
     "name": "addComponentLogic"
   },
   {
-    "name": "addHostBindingsToExpandoInstructions"
-  },
-  {
     "name": "addToArray"
   },
   {
     "name": "addToViewTree"
+  },
+  {
+    "name": "allocExpando"
   },
   {
     "name": "allocLFrame"
@@ -733,9 +733,6 @@
   },
   {
     "name": "baseElement"
-  },
-  {
-    "name": "baseResolveDirective"
   },
   {
     "name": "bindingUpdated"
@@ -784,6 +781,9 @@
   },
   {
     "name": "config"
+  },
+  {
+    "name": "configureViewWithDirective"
   },
   {
     "name": "connectableObservableDescriptor"
@@ -942,9 +942,6 @@
     "name": "fromArray"
   },
   {
-    "name": "generateExpandoInstructionBlock"
-  },
-  {
     "name": "generateInitialInputs"
   },
   {
@@ -1081,9 +1078,6 @@
   },
   {
     "name": "getTView"
-  },
-  {
-    "name": "growHostVarsSpace"
   },
   {
     "name": "handleError"
@@ -1420,6 +1414,9 @@
   },
   {
     "name": "registerDestroyHooksIfSupported"
+  },
+  {
+    "name": "registerHostBindingOpCodes"
   },
   {
     "name": "registerPostOrderHooks"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -232,5 +232,8 @@
   },
   {
     "name": "viewAttachedToChangeDetector"
+  },
+  {
+    "name": "ɵɵtext"
   }
 ]

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -57,6 +57,9 @@
     "name": "_renderCompCount"
   },
   {
+    "name": "allocExpando"
+  },
+  {
     "name": "allocLFrame"
   },
   {
@@ -177,9 +180,6 @@
     "name": "nativeAppendOrInsertBefore"
   },
   {
-    "name": "nativeInsertBefore"
-  },
-  {
     "name": "nextNgElementId"
   },
   {
@@ -193,6 +193,9 @@
   },
   {
     "name": "refreshView"
+  },
+  {
+    "name": "registerHostBindingOpCodes"
   },
   {
     "name": "rememberChangeHistoryAndInvokeOnChangesHook"
@@ -225,15 +228,9 @@
     "name": "setSelectedIndex"
   },
   {
-    "name": "unwrapRNode"
-  },
-  {
     "name": "updateTransplantedViewCount"
   },
   {
     "name": "viewAttachedToChangeDetector"
-  },
-  {
-    "name": "ɵɵtext"
   }
 ]

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -921,9 +921,6 @@
     "name": "addComponentLogic"
   },
   {
-    "name": "addHostBindingsToExpandoInstructions"
-  },
-  {
     "name": "addToArray"
   },
   {
@@ -934,6 +931,9 @@
   },
   {
     "name": "advanceActivatedRouteNodeAndItsChildren"
+  },
+  {
+    "name": "allocExpando"
   },
   {
     "name": "allocLFrame"
@@ -964,9 +964,6 @@
   },
   {
     "name": "baseElement"
-  },
-  {
-    "name": "baseResolveDirective"
   },
   {
     "name": "bindingUpdated"
@@ -1015,6 +1012,9 @@
   },
   {
     "name": "config"
+  },
+  {
+    "name": "configureViewWithDirective"
   },
   {
     "name": "connectableObservableDescriptor"
@@ -1245,9 +1245,6 @@
     "name": "fromArray"
   },
   {
-    "name": "generateExpandoInstructionBlock"
-  },
-  {
     "name": "generateInitialInputs"
   },
   {
@@ -1426,9 +1423,6 @@
   },
   {
     "name": "getToken"
-  },
-  {
-    "name": "growHostVarsSpace"
   },
   {
     "name": "handleError"
@@ -1759,6 +1753,9 @@
   },
   {
     "name": "refreshView"
+  },
+  {
+    "name": "registerHostBindingOpCodes"
   },
   {
     "name": "registerPostOrderHooks"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -177,13 +177,13 @@
     "name": "addComponentLogic"
   },
   {
-    "name": "addHostBindingsToExpandoInstructions"
-  },
-  {
     "name": "addToArray"
   },
   {
     "name": "addToViewTree"
+  },
+  {
+    "name": "allocExpando"
   },
   {
     "name": "allocLFrame"
@@ -208,9 +208,6 @@
   },
   {
     "name": "attachPatchData"
-  },
-  {
-    "name": "baseResolveDirective"
   },
   {
     "name": "bindingUpdated"
@@ -241,6 +238,9 @@
   },
   {
     "name": "concatStringsWithSpace"
+  },
+  {
+    "name": "configureViewWithDirective"
   },
   {
     "name": "createDirectivesInstances"
@@ -322,9 +322,6 @@
   },
   {
     "name": "forwardRef"
-  },
-  {
-    "name": "generateExpandoInstructionBlock"
   },
   {
     "name": "generateInitialInputs"
@@ -430,9 +427,6 @@
   },
   {
     "name": "getTView"
-  },
-  {
-    "name": "growHostVarsSpace"
   },
   {
     "name": "handleError"
@@ -604,6 +598,9 @@
   },
   {
     "name": "refreshView"
+  },
+  {
+    "name": "registerHostBindingOpCodes"
   },
   {
     "name": "registerPostOrderHooks"

--- a/packages/core/test/render3/is_shape_of.ts
+++ b/packages/core/test/render3/is_shape_of.ts
@@ -119,7 +119,7 @@ const ShapeOfTView: ShapeOf<TView> = {
   staticViewQueries: true,
   staticContentQueries: true,
   firstChild: true,
-  expandoInstructions: true,
+  hostBindingOpCodes: true,
   directiveRegistry: true,
   pipeRegistry: true,
   preOrderHooks: true,


### PR DESCRIPTION
**Review last change only.**
This PR builds on https://github.com/angular/angular/pull/39233 and https://github.com/angular/angular/pull/39003



## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
