### PR TITLE
fix: source-maps - consistent paths to inline content

### DIFF
--- a/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file_loader.ts
+++ b/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file_loader.ts
@@ -193,8 +193,11 @@ export class SourceFileLoader {
     const sourceRoot = this.fs.resolve(
         this.fs.dirname(basePath), this.replaceSchemeWithPath(map.sourceRoot || ''));
     return map.sources.map((source, index) => {
-      const path = this.fs.resolve(sourceRoot, this.replaceSchemeWithPath(source));
       const content = map.sourcesContent && map.sourcesContent[index] || null;
+      const path = this.fs.resolve(
+          sourceRoot,
+          content !== null ? this.fs.basename(source) : this.replaceSchemeWithPath(source));
+
       // The origin of this source file is "inline" if we extracted it from the source-map's
       // `sourcesContent`, except when the source-map itself was "provided" in-memory.
       // An inline source file is treated as if it were from the file-system if the source-map that

--- a/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file_loader.ts
+++ b/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file_loader.ts
@@ -14,7 +14,7 @@ import {ContentOrigin} from './content_origin';
 import {MapAndPath, RawSourceMap, SourceMapInfo} from './raw_source_map';
 import {SourceFile} from './source_file';
 
-const SCHEME_MATCHER = /^([a-z][a-z0-9.-]*):\/\//i;
+const SCHEME_MATCHER = /^([a-z][a-z0-9.-]*):\/\/(.*)$/i;
 
 /**
  * This class can be used to load a source file, its associated source map and any upstream sources.
@@ -268,6 +268,8 @@ export class SourceFileLoader {
    */
   private replaceSchemeWithPath(path: string): string {
     return path.replace(
-        SCHEME_MATCHER, (_: string, scheme: string) => this.schemeMap[scheme.toLowerCase()] || '');
+        SCHEME_MATCHER,
+        (_: string, scheme: string, rest: string) =>
+            this.fs.join(this.schemeMap[scheme.toLowerCase()] || '/', rest));
   }
 }

--- a/packages/compiler-cli/src/ngtsc/sourcemaps/test/source_file_loader_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/sourcemaps/test/source_file_loader_spec.ts
@@ -400,83 +400,94 @@ runInEachFileSystem(() => {
            expect(logger.logs.warn.length).toEqual(0);
          });
 
-      for (const {scheme, mappedPath} of
-               [{scheme: 'WEBPACK://', mappedPath: '/foo/src/index.ts'},
-                {scheme: 'webpack://', mappedPath: '/foo/src/index.ts'},
-                {scheme: 'missing://', mappedPath: '/src/index.ts'},
-      ]) {
-        it(`should handle source paths that are protocol mapped [scheme:"${
-               scheme}"] with inline content`,
-           () => {
-             fs.ensureDir(_('/foo/src'));
+      describe('with inline content', () => {
+        for (const {scheme, mappedPath} of
+                 [{scheme: 'WEBPACK', mappedPath: '/foo/src/index.ts'},
+                  {scheme: 'webpack', mappedPath: '/foo/src/index.ts'},
+                  // When the content is inline, and the source has a scheme that is missing from
+                  // the `schemeMap` then we just resolve the basename against the `sourceRoot`.
+                  {scheme: 'missing', mappedPath: '/foo/src/index.ts'},
+        ]) {
+          it(`should handle source paths that are protocol mapped [scheme:"${scheme}"]`, () => {
+            fs.ensureDir(_('/foo/src'));
 
-             const indexSourceMap = createRawSourceMap({
-               file: 'index.js',
-               sources: [`${scheme}/src/index.ts`],
-               'sourcesContent': ['original content']
-             });
-             fs.writeFile(_('/foo/src/index.js.map'), JSON.stringify(indexSourceMap));
-             const sourceFile =
-                 registry.loadSourceFile(_('/foo/src/index.js'), 'generated content');
-             if (sourceFile === null) {
-               return fail('Expected source file to be defined');
-             }
-             const originalSource = sourceFile.sources[0];
-             if (originalSource === null) {
-               return fail('Expected source file to be defined');
-             }
-             expect(originalSource.contents).toEqual('original content');
-             expect(originalSource.sourcePath).toEqual(_(mappedPath));
-             expect(originalSource.rawMap).toBe(null);
-             expect(originalSource.sources).toEqual([]);
-           });
+            const indexSourceMap = createRawSourceMap({
+              file: 'index.js',
+              sources: [`${scheme}://src/index.ts`],
+              'sourcesContent': ['original content']
+            });
+            fs.writeFile(_('/foo/src/index.js.map'), JSON.stringify(indexSourceMap));
+            const sourceFile = registry.loadSourceFile(_('/foo/src/index.js'), 'generated content');
+            if (sourceFile === null) {
+              return fail('Expected source file to be defined');
+            }
+            const originalSource = sourceFile.sources[0];
+            if (originalSource === null) {
+              return fail(
+                  `Expected source file at ${sourceFile.rawMap!.map.sources[0]} to be defined`);
+            }
+            expect(originalSource.contents).toEqual('original content');
+            expect(originalSource.sourcePath).toEqual(_(mappedPath));
+            expect(originalSource.rawMap).toBe(null);
+            expect(originalSource.sources).toEqual([]);
+          });
+        }
 
-        it(`should handle source paths that are protocol mapped [scheme:"${
-               scheme}"] with external content`,
-           () => {
-             fs.ensureDir(_('/foo/src'));
-             fs.ensureDir(fs.dirname(_(mappedPath)));
-             fs.writeFile(_(mappedPath), 'original content');
-
-             const indexSourceMap = createRawSourceMap({
-               file: 'index.js',
-               sources: [`${scheme}/src/index.ts`],
-             });
-             fs.writeFile(_('/foo/src/index.js.map'), JSON.stringify(indexSourceMap));
-             const sourceFile =
-                 registry.loadSourceFile(_('/foo/src/index.js'), 'generated content');
-             if (sourceFile === null) {
-               return fail('Expected source file to be defined');
-             }
-             const originalSource = sourceFile.sources[0];
-             if (originalSource === null) {
-               return fail('Expected source file to be defined');
-             }
-             expect(originalSource.contents).toEqual('original content');
-             expect(originalSource.sourcePath).toEqual(_(mappedPath));
-             expect(originalSource.rawMap).toEqual(null);
-             expect(originalSource.sources).toEqual([]);
-           });
-      }
-
-      it('should use consistent source-file paths for inline sources', () => {
-        fs.ensureDir(_('/foo/src'));
-        const sourceMap = createRawSourceMap({
-          file: 'index.js',
-          sources: ['../../../../../bar.js'],
-          sourcesContent: ['bar contents']
+        it('should use consistent source-file paths for inline sources', () => {
+          fs.ensureDir(_('/foo/src'));
+          const sourceMap = createRawSourceMap({
+            file: 'index.js',
+            sources: ['../../../../../bar.js'],
+            sourcesContent: ['bar contents']
+          });
+          fs.writeFile(_('/foo/src/index.js.map'), JSON.stringify(sourceMap));
+          const sourceFile = registry.loadSourceFile(_('/foo/src/index.js'), 'some content');
+          if (sourceFile === null) {
+            return fail('Expected source file to be defined');
+          }
+          if (sourceFile.rawMap === null) {
+            return fail('Expected source file source-map to be defined');
+          }
+          expect(sourceFile.rawMap.map).toEqual(sourceMap);
+          expect(sourceFile.sources.length).toEqual(1);
+          expect(sourceFile.sources[0]!.sourcePath).toEqual(_('/foo/src/bar.js'));
         });
-        fs.writeFile(_('/foo/src/index.js.map'), JSON.stringify(sourceMap));
-        const sourceFile = registry.loadSourceFile(_('/foo/src/index.js'), 'some content');
-        if (sourceFile === null) {
-          return fail('Expected source file to be defined');
+      });
+
+      describe('with external content', () => {
+        for (const {scheme, mappedPath} of
+                 [{scheme: 'WEBPACK', mappedPath: '/foo/src/index.ts'},
+                  {scheme: 'webpack', mappedPath: '/foo/src/index.ts'},
+                  // When the content is external, and the source has a scheme that is missing from
+                  // the `schemeMap` then we just strip the schema and resolve against the
+                  // `sourceRoot`.
+                  {scheme: 'missing', mappedPath: '/src/index.ts'},
+        ]) {
+          it(`should handle source paths that are protocol mapped [scheme:"${scheme}"]`, () => {
+            fs.ensureDir(_('/foo/src'));
+            fs.ensureDir(fs.dirname(_(mappedPath)));
+            fs.writeFile(_(mappedPath), 'original content');
+
+            const indexSourceMap = createRawSourceMap({
+              file: 'index.js',
+              sources: [`${scheme}://src/index.ts`],
+            });
+            fs.writeFile(_('/foo/src/index.js.map'), JSON.stringify(indexSourceMap));
+            const sourceFile = registry.loadSourceFile(_('/foo/src/index.js'), 'generated content');
+            if (sourceFile === null) {
+              return fail('Expected source file to be defined');
+            }
+            const originalSource = sourceFile.sources[0];
+            if (originalSource === null) {
+              return fail(
+                  `Expected source file at ${sourceFile.rawMap!.map.sources[0]} to be defined`);
+            }
+            expect(originalSource.contents).toEqual('original content');
+            expect(originalSource.sourcePath).toEqual(_(mappedPath));
+            expect(originalSource.rawMap).toEqual(null);
+            expect(originalSource.sources).toEqual([]);
+          });
         }
-        if (sourceFile.rawMap === null) {
-          return fail('Expected source file source-map to be defined');
-        }
-        expect(sourceFile.rawMap.map).toEqual(sourceMap);
-        expect(sourceFile.sources.length).toEqual(1);
-        expect(sourceFile.sources[0]!.sourcePath).toEqual(_('/foo/src/bar.js'));
       });
     });
   });


### PR DESCRIPTION
Previously, if a source-map contained inline content, the internal path used for
the source file could be inconsistent depending upon the location of the source-map
file that is referencing the source.

Now inline source is assigned a consistent file path, rather than relying upon the
path provided in the source-map. Since the source content is provided inline
this should have no impact on the use of the flattened source-map by tools.

Fixes #39293