### PR TITLE
test(language-service): Make project service a singleton

### DIFF
--- a/packages/language-service/ivy/test/mock_host.ts
+++ b/packages/language-service/ivy/test/mock_host.ts
@@ -69,23 +69,31 @@ export const host: ts.server.ServerHost = {
 };
 
 /**
+ * Constructing a project service is expensive (~2.5s on MacBook Pro), so it
+ * should be a singleton service shared throughout all tests.
+ */
+let projectService: ts.server.ProjectService;
+
+/**
  * Create a ConfiguredProject and an actual program for the test project located
  * in packages/language-service/test/project. Project creation exercises the
  * actual code path, but a mock host is used for the filesystem to intercept
  * and modify test files.
  */
 export function setup() {
-  const projectService = new ts.server.ProjectService({
-    host,
-    logger,
-    cancellationToken: ts.server.nullCancellationToken,
-    useSingleInferredProject: true,
-    useInferredProjectPerProjectRoot: true,
-    typingsInstaller: ts.server.nullTypingsInstaller,
-  });
-  // Opening APP_COMPONENT forces a new ConfiguredProject to be created based
-  // on the tsconfig.json in the test project.
-  projectService.openClientFile(APP_COMPONENT);
+  if (!projectService) {
+    projectService = new ts.server.ProjectService({
+      host,
+      logger,
+      cancellationToken: ts.server.nullCancellationToken,
+      useSingleInferredProject: true,
+      useInferredProjectPerProjectRoot: true,
+      typingsInstaller: ts.server.nullTypingsInstaller,
+    });
+    // Opening APP_COMPONENT forces a new ConfiguredProject to be created based
+    // on the tsconfig.json in the test project.
+    projectService.openClientFile(APP_COMPONENT);
+  }
   const project = projectService.findProject(TSCONFIG);
   if (!project) {
     throw new Error(`Failed to create project for ${TSCONFIG}`);


### PR DESCRIPTION
Constructing a project service is expensive. Making it a singleton could
speed up tests considerably.

On my MacBook Pro, test execution went from 24.4s to 14.5s (~40% improvement).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
