### PR TITLE
refactor(compiler): remove support for TypeScript 3.9

### DIFF
--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -28,7 +28,7 @@
     "@angular/compiler-cli": "0.0.0-PLACEHOLDER",
     "@bazel/typescript": ">=1.0.0",
     "terser": "^4.3.1",
-    "typescript": ">=3.9 <4.1",
+    "typescript": ">=4.0 <4.1",
     "rollup": ">=1.20.0",
     "rollup-plugin-commonjs": ">=9.0.0",
     "rollup-plugin-node-resolve": ">=4.2.0",

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@angular/compiler": "0.0.0-PLACEHOLDER",
-    "typescript": ">=3.9 <4.1"
+    "typescript": ">=4.0 <4.1"
   },
   "engines": {
     "node": ">=10.0"

--- a/packages/compiler-cli/src/typescript_support.ts
+++ b/packages/compiler-cli/src/typescript_support.ts
@@ -12,7 +12,7 @@ import {compareVersions} from './diagnostics/typescript_version';
  * Minimum supported TypeScript version
  * ∀ supported typescript version v, v >= MIN_TS_VERSION
  */
-const MIN_TS_VERSION = '3.9.2';
+const MIN_TS_VERSION = '4.0.0';
 
 /**
  * Supremum of supported TypeScript versions

--- a/packages/compiler-cli/src/typescript_support.ts
+++ b/packages/compiler-cli/src/typescript_support.ts
@@ -11,6 +11,9 @@ import {compareVersions} from './diagnostics/typescript_version';
 /**
  * Minimum supported TypeScript version
  * ∀ supported typescript version v, v >= MIN_TS_VERSION
+ *
+ * Note: this check is disabled in g3, search for
+ * `angularCompilerOptions.disableTypeScriptVersionCheck` config param value in g3.
  */
 const MIN_TS_VERSION = '4.0.0';
 
@@ -18,6 +21,9 @@ const MIN_TS_VERSION = '4.0.0';
  * Supremum of supported TypeScript versions
  * ∀ supported typescript version v, v < MAX_TS_VERSION
  * MAX_TS_VERSION is not considered as a supported TypeScript version
+ *
+ * Note: this check is disabled in g3, search for
+ * `angularCompilerOptions.disableTypeScriptVersionCheck` config param value in g3.
  */
 const MAX_TS_VERSION = '4.1.0';
 
@@ -36,9 +42,8 @@ export function restoreTypeScriptVersionForTesting(): void {
 }
 
 /**
- * Checks whether a given version ∈ [minVersion, maxVersion[
- * An error will be thrown if the following statements are simultaneously true:
- * - the given version ∉ [minVersion, maxVersion[,
+ * Checks whether a given version ∈ [minVersion, maxVersion[.
+ * An error will be thrown when the given version ∉ [minVersion, maxVersion[.
  *
  * @param version The version on which the check will be performed
  * @param minVersion The lower bound version. A valid version needs to be greater than minVersion


### PR DESCRIPTION
This commit removes TypeScript 3.9 support.

NOTE: corresponding TS 3.9 integration tests will be removed later in a followup cleanup PR.

BREAKING CHANGE:

TypeScript 3.9 is no longer supported, please upgrade to TypeScript 4.0.


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No