### PR TITLE
refactor(compiler-cli): accept a host for reading project configuration

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/api/src/interfaces.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/interfaces.ts
@@ -7,6 +7,7 @@
  */
 
 import * as ts from 'typescript';
+import {AbsoluteFsPath} from '../../../file_system';
 
 /**
  * A host backed by a build system which has a unified view of the module namespace.
@@ -62,4 +63,11 @@ export interface LazyRoute {
   route: string;
   module: {name: string, filePath: string};
   referencedModule: {name: string, filePath: string};
+}
+
+export interface ReadConfigurationHost extends
+    Pick<ExtendedTsCompilerHost, 'fileExists'|'readFile'> {
+  calcProjectFileAndBasePath(project: string):
+      {projectFile: AbsoluteFsPath, basePath: AbsoluteFsPath};
+  resolveConfigFilePath(relativeTo: string, ...paths: string[]): AbsoluteFsPath;
 }

--- a/packages/compiler-cli/src/ngtsc/core/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/host.ts
@@ -272,4 +272,8 @@ export class NgCompilerHost extends DelegatingCompilerHost implements
   get unifiedModulesHost(): UnifiedModulesHost|null {
     return this.fileNameToModuleName !== undefined ? this as UnifiedModulesHost : null;
   }
+
+  directoryExists = (path: string): boolean => {
+    return ts.sys.directoryExists(path);
+  };
 }

--- a/packages/language-service/ivy/BUILD.bazel
+++ b/packages/language-service/ivy/BUILD.bazel
@@ -16,6 +16,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/typecheck",
         "//packages/compiler-cli/src/ngtsc/typecheck/api",
         "//packages/language-service/common",
+        "@npm//@types/node",
         "@npm//typescript",
     ],
 )

--- a/packages/language-service/ivy/test/language_service_spec.ts
+++ b/packages/language-service/ivy/test/language_service_spec.ts
@@ -6,19 +6,45 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {parseNgCompilerOptions} from '../language_service';
+import {LanguageService} from '../language_service';
 
-import {setup} from './mock_host';
+import {setup, TSCONFIG} from './mock_host';
 
-const {project} = setup();
+describe('parse compiler options', () => {
+  const {project, tsLS, configFileFs} = setup();
+  let ngLs: LanguageService;
 
-describe('parseNgCompilerOptions', () => {
-  it('should read angularCompilerOptions in tsconfig.json', () => {
-    const options = parseNgCompilerOptions(project);
-    expect(options).toEqual(jasmine.objectContaining({
+  beforeEach(() => {
+    ngLs = new LanguageService(project, tsLS);
+  });
+
+  afterEach(() => {
+    configFileFs.clear();
+  });
+
+  it('should initialize with angularCompilerOptions from tsconfig.json', () => {
+    expect(ngLs.getCompilerOptions()).toEqual(jasmine.objectContaining({
       enableIvy: true,  // default for ivy is true
       strictTemplates: true,
       strictInjectionParameters: true,
+    }));
+  });
+
+  it('should reparse angularCompilerOptions on tsconfig.json change', () => {
+    expect(ngLs.getCompilerOptions()).toEqual(jasmine.objectContaining({
+      enableIvy: true,  // default for ivy is true
+      strictTemplates: true,
+      strictInjectionParameters: true,
+    }));
+
+    configFileFs.overwriteConfigFile(TSCONFIG, `{
+       "angularCompilerOptions": {
+         "strictTemplates": false
+       }
+     }`);
+
+    expect(ngLs.getCompilerOptions()).toEqual(jasmine.objectContaining({
+      strictTemplates: false,
     }));
   });
 });

--- a/packages/language-service/ivy/test/mock_host.ts
+++ b/packages/language-service/ivy/test/mock_host.ts
@@ -41,31 +41,94 @@ const NOOP_FILE_WATCHER: ts.FileWatcher = {
   close() {}
 };
 
-export const host: ts.server.ServerHost = {
-  ...ts.sys,
-  readFile(absPath: string, encoding?: string): string |
-      undefined {
-        return ts.sys.readFile(absPath, encoding);
-      },
-  watchFile(path: string, callback: ts.FileWatcherCallback): ts.FileWatcher {
-    return NOOP_FILE_WATCHER;
-  },
-  watchDirectory(path: string, callback: ts.DirectoryWatcherCallback): ts.FileWatcher {
-    return NOOP_FILE_WATCHER;
-  },
-  setTimeout() {
-    throw new Error('setTimeout is not implemented');
-  },
-  clearTimeout() {
-    throw new Error('clearTimeout is not implemented');
-  },
-  setImmediate() {
-    throw new Error('setImmediate is not implemented');
-  },
-  clearImmediate() {
-    throw new Error('clearImmediate is not implemented');
-  },
-};
+class MockWatcher implements ts.FileWatcher {
+  constructor(
+      private readonly fileName: string,
+      private readonly cb: ts.FileWatcherCallback,
+      readonly close: () => void,
+  ) {}
+
+  changed() {
+    this.cb(this.fileName, ts.FileWatcherEventKind.Changed);
+  }
+
+  deleted() {
+    this.cb(this.fileName, ts.FileWatcherEventKind.Deleted);
+  }
+}
+
+/**
+ * A mock file system impacting configuration files.
+ * Queries for all other files are deferred to the underlying filesystem.
+ */
+class MockConfigFileFs implements Pick<ts.server.ServerHost, 'readFile'|'fileExists'|'watchFile'> {
+  private configOverwrites: Map<string, string> = new Map();
+  private configFileWatchers = new Map<string, MockWatcher>();
+
+  overwriteConfigFile(configFile: string, contents: string) {
+    if (!configFile.endsWith('.json')) {
+      throw new Error(`${configFile} is not a configuration file.`);
+    }
+    this.configOverwrites.set(configFile, contents);
+    this.configFileWatchers.get(configFile)?.changed();
+  }
+
+  readFile(file: string, encoding?: string): string|undefined {
+    return this.configOverwrites.get(file) ?? ts.sys.readFile(file, encoding);
+  }
+
+  fileExists(file: string): boolean {
+    return this.configOverwrites.has(file) || ts.sys.fileExists(file);
+  }
+
+  watchFile(path: string, callback: ts.FileWatcherCallback) {
+    if (!path.endsWith('.json')) {
+      // We only care about watching config files.
+      return NOOP_FILE_WATCHER;
+    }
+    const watcher = new MockWatcher(path, callback, () => {
+      this.configFileWatchers.delete(path);
+    });
+    this.configFileWatchers.set(path, watcher);
+    return watcher;
+  }
+
+  clear() {
+    this.configOverwrites.clear();
+    this.configFileWatchers.clear();
+  }
+}
+
+function createHost(configFileFs: MockConfigFileFs): ts.server.ServerHost {
+  return {
+    ...ts.sys,
+    fileExists(absPath: string): boolean {
+      return configFileFs.fileExists(absPath);
+    },
+    readFile(absPath: string, encoding?: string): string |
+        undefined {
+          return configFileFs.readFile(absPath, encoding);
+        },
+    watchFile(path: string, callback: ts.FileWatcherCallback): ts.FileWatcher {
+      return configFileFs.watchFile(path, callback);
+    },
+    watchDirectory(path: string, callback: ts.DirectoryWatcherCallback): ts.FileWatcher {
+      return NOOP_FILE_WATCHER;
+    },
+    setTimeout() {
+      throw new Error('setTimeout is not implemented');
+    },
+    clearTimeout() {
+      throw new Error('clearTimeout is not implemented');
+    },
+    setImmediate() {
+      throw new Error('setImmediate is not implemented');
+    },
+    clearImmediate() {
+      throw new Error('clearImmediate is not implemented');
+    },
+  };
+}
 
 /**
  * Create a ConfiguredProject and an actual program for the test project located
@@ -74,8 +137,9 @@ export const host: ts.server.ServerHost = {
  * and modify test files.
  */
 export function setup() {
+  const configFileFs = new MockConfigFileFs();
   const projectService = new ts.server.ProjectService({
-    host,
+    host: createHost(configFileFs),
     logger,
     cancellationToken: ts.server.nullCancellationToken,
     useSingleInferredProject: true,
@@ -95,6 +159,7 @@ export function setup() {
     service: new MockService(project, projectService),
     project,
     tsLS,
+    configFileFs,
   };
 }
 


### PR DESCRIPTION
Currently the `readConfiguration` function in the compiler relies on the
file system to perform disk utilities needed to read determine a project
configuration file and read it. This poses a challenge for the language
service, which would like to use `readConfiguration` to watch and read
configurations dependent on extended tsconfigs (#39134). Challenges are
at least twofold:

1. To test this, the langauge service would need to provide to the
   compiler a mock file system.
2. The language service uses file system utilities primarily through
   TypeScript's `Project` abstraction. In general this should correspond
   to the underlying file system, but it may differ and it is better to
   go through one channel when possible.

As discussed in the LS sync, we decided to provide to
`readConfiguration` a host that would take of reading configuration as
needed for the use case of the caller. A first attempt was to put this
on `NgCompilerAdapter`, but this is not elegant because it introduces a
`CompilerAdatpter` dependency where there is no need for one (e.g. when
creating a watch mode host).

To be honest, I am not in love with the `ReadConfigurationHost`
delivered in this patch. I think it may be less hassle in the long term
and more ergonomic to create a `FileSystem` abstraction on a per-project
basis, delivered to the compiler whenever a new langauge service is
created. Let me know what you think.

Unblocks #39134
