### PR TITLE
feat(dev-infra): prompt caretaker to confirm the merge branches on merge

### DIFF
--- a/dev-infra/pr/merge/messages.ts
+++ b/dev-infra/pr/merge/messages.ts
@@ -11,5 +11,11 @@ import {PullRequest} from './pull-request';
 
 export function getCaretakerNotePromptMessage(pullRequest: PullRequest): string {
   return red('Pull request has a caretaker note applied. Please make sure you read it.') +
-      `\nQuick link to PR: ${pullRequest.url}`;
+      `\nQuick link to PR: ${pullRequest.url}\nDo you want to proceed merging?`;
+}
+
+export function getTargettedBranchesConfirmationPromptMessage(pullRequest: PullRequest): string {
+  const targetBranchListAsString = pullRequest.targetBranches.map(b => ` - ${b}\n`).join('');
+  return `Pull request #${pullRequest.prNumber} will merge into:\n${
+      targetBranchListAsString}\nDo you want to proceed merging?`;
 }

--- a/dev-infra/pr/merge/task.ts
+++ b/dev-infra/pr/merge/task.ts
@@ -9,9 +9,9 @@
 import {promptConfirm} from '../../utils/console';
 import {GitClient, GitCommandError} from '../../utils/git';
 
-import {MergeConfig, MergeConfigWithRemote} from './config';
+import {MergeConfigWithRemote} from './config';
 import {PullRequestFailure} from './failures';
-import {getCaretakerNotePromptMessage} from './messages';
+import {getCaretakerNotePromptMessage, getTargettedBranchesConfirmationPromptMessage} from './messages';
 import {isPullRequest, loadAndValidatePullRequest,} from './pull-request';
 import {GithubApiMergeStrategy} from './strategies/api-merge';
 import {AutosquashMergeStrategy} from './strategies/autosquash-merge';
@@ -78,11 +78,16 @@ export class PullRequestMergeTask {
       return {status: MergeStatus.FAILED, failure: pullRequest};
     }
 
+
+    if (!await promptConfirm(getTargettedBranchesConfirmationPromptMessage(pullRequest))) {
+      return {status: MergeStatus.USER_ABORTED};
+    }
+
+
     // If the pull request has a caretaker note applied, raise awareness by prompting
     // the caretaker. The caretaker can then decide to proceed or abort the merge.
     if (pullRequest.hasCaretakerNote &&
-        !await promptConfirm(
-            getCaretakerNotePromptMessage(pullRequest) + `\nDo you want to proceed merging?`)) {
+        !await promptConfirm(getCaretakerNotePromptMessage(pullRequest))) {
       return {status: MergeStatus.USER_ABORTED};
     }
 


### PR DESCRIPTION
Perviously, it was not immediately clear what branches a PR would merge
into during the merge process.  This prompt allows for caretakers to
understand and acknowledge where the PR will merge to.
