### PR TITLE
docs: use SimpleChanges in component interaction guide

### DIFF
--- a/aio/content/examples/component-interaction/src/app/version-child.component.ts
+++ b/aio/content/examples/component-interaction/src/app/version-child.component.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:forin */
 // #docregion
-import { Component, Input, OnChanges, SimpleChange } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 
 @Component({
   selector: 'app-version-child',
@@ -17,7 +17,7 @@ export class VersionChildComponent implements OnChanges {
   @Input() minor: number;
   changeLog: string[] = [];
 
-  ngOnChanges(changes: {[propKey: string]: SimpleChange}) {
+  ngOnChanges(changes: SimpleChanges) {
     const log: string[] = [];
     for (const propName in changes) {
       const changedProp = changes[propName];

--- a/aio/content/examples/testing/src/app/demo/demo.ts
+++ b/aio/content/examples/testing/src/app/demo/demo.ts
@@ -4,7 +4,7 @@ import { Component, ContentChildren, Directive, EventEmitter,
          HostBinding, HostListener,
          OnInit, OnChanges, OnDestroy,
          Pipe, PipeTransform,
-         SimpleChange } from '@angular/core';
+         SimpleChanges } from '@angular/core';
 
 import { of } from 'rxjs';
 import { delay } from 'rxjs/operators';
@@ -309,7 +309,7 @@ export class MyIfChildComponent implements OnInit, OnChanges, OnDestroy {
     this.changeLog.push('ngOnDestroy called');
   }
 
-  ngOnChanges(changes: {[propertyName: string]: SimpleChange}) {
+  ngOnChanges(changes: SimpleChanges) {
     for (const propName in changes) {
       this.ngOnChangesCounter += 1;
       const prop = changes[propName];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The [example ](https://angular.io/guide/component-interaction#intercept-input-property-changes-with-ngonchanges)of the component interaction guide currently uses the `SimpleChange` interface.

Issue Number: N/A


## What is the new behavior?
The example uses the [SimpleChanges](https://angular.io/api/core/SimpleChanges) interface for explaining the `ngOnChanges` method.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
