### PR TITLE
refactor(compiler): parse bindings "by hand" rather than via regex

### DIFF
--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -19,7 +19,7 @@ import {PreparsedElementType, preparseElement} from '../template_parser/template
 import * as t from './r3_ast';
 import {I18N_ICU_VAR_PREFIX, isI18nRootNode} from './view/i18n/util';
 
-const BIND_NAME_REGEXP = /^(?:(?:(bind-)|(let-)|(ref-|#)|(on-)|(bindon-)|(@))(.*))$/;
+const BIND_NAME_REGEXP = /^(?:(bind-)|(let-)|(ref-|#)|(on-)|(bindon-)|(@))(.*)$/;
 
 // Group 1 = "bind-"
 const KW_BIND_IDX = 1;
@@ -390,28 +390,29 @@ class HtmlAstToIvyAst implements html.Visitor {
       delims = DELIMS.EVENT;
     }
     if (delims &&
-        // NB: older versions of the parser would match a start/end delimited
+        // NOTE: older versions of the parser would match a start/end delimited
         // binding iff the property name was terminated by the ending delimiter
         // and the identifier in the binding was non-empty.
         // TODO(ayazhafiz): update this to handle malformed bindings.
         name.endsWith(delims.end) && name.length > delims.start.length + delims.end.length) {
-      const ident = name.substring(delims.start.length, name.length - delims.end.length);
+      const identifier = name.substring(delims.start.length, name.length - delims.end.length);
       if (delims.start === DELIMS.BANANA_BOX.start) {
-        const keySpan = createKeySpan(srcSpan, delims.start, ident);
+        const keySpan = createKeySpan(srcSpan, delims.start, identifier);
         this.bindingParser.parsePropertyBinding(
-            ident, value, false, srcSpan, absoluteOffset, attribute.valueSpan, matchableAttributes,
-            parsedProperties, keySpan);
+            identifier, value, false, srcSpan, absoluteOffset, attribute.valueSpan,
+            matchableAttributes, parsedProperties, keySpan);
         this.parseAssignmentEvent(
-            ident, value, srcSpan, attribute.valueSpan, matchableAttributes, boundEvents);
+            identifier, value, srcSpan, attribute.valueSpan, matchableAttributes, boundEvents);
       } else if (delims.start === DELIMS.PROPERTY.start) {
-        const keySpan = createKeySpan(srcSpan, delims.start, ident);
+        const keySpan = createKeySpan(srcSpan, delims.start, identifier);
         this.bindingParser.parsePropertyBinding(
-            ident, value, false, srcSpan, absoluteOffset, attribute.valueSpan, matchableAttributes,
-            parsedProperties, keySpan);
+            identifier, value, false, srcSpan, absoluteOffset, attribute.valueSpan,
+            matchableAttributes, parsedProperties, keySpan);
       } else {
         const events: ParsedEvent[] = [];
         this.bindingParser.parseEvent(
-            ident, value, srcSpan, attribute.valueSpan || srcSpan, matchableAttributes, events);
+            identifier, value, srcSpan, attribute.valueSpan || srcSpan, matchableAttributes,
+            events);
         addEvents(events, boundEvents);
       }
 


### PR DESCRIPTION
To support recovery of malformed binding property names like `([a)`,
`[a`, or `()`, the binding parser needs to be more permissive w.r.t. the
kinds of bindings it can detect. This is difficult to do maintainably
with a regex, but is trivial with a "hand-rolled" string parser. This
commit refactors render3's binding attribute parsing to use this method
for multi-delimited bindings (namely via the `()`, `[]`, and `[()]`)
syntax, making the way recovery of malformed bindings in a future patch.

Note that we can keep using a regex for prefix-only binding syntax
(e.g. `bind-`, `ref-`) because validation of the binding is complete
once we have matched the prefix, and the only thing left to do is check
that the binding identifier is non-empty, which is trivial.

Part of #38596

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
