### PR TITLE
docs: move hierarchical injectors to reference section

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -245,11 +245,6 @@
               "tooltip": "Angular's dependency injection system creates and delivers dependent services to Angular-created classes."
             },
             {
-              "url": "guide/hierarchical-dependency-injection",
-              "title": "Hierarchical Injectors",
-              "tooltip": "An injector tree parallels the component tree and supports nested dependencies."
-            },
-            {
               "url": "guide/dependency-injection-providers",
               "title": "DI Providers",
               "tooltip": "More about the different kinds of providers."
@@ -922,6 +917,11 @@
                   "tooltip": "How observables compare to promises and other message passing techniques."
                 }
               ]
+            },
+            {
+              "url": "guide/hierarchical-dependency-injection",
+              "title": "Hierarchical Injectors",
+              "tooltip": "An injector tree parallels the component tree and supports nested dependencies."
             }
           ]
         },


### PR DESCRIPTION
Moves hierarchical injectors to the reference section of the left nav, out of the main concepts section because it is conceptual and reference-based rather than task-based.