### PR TITLE
build: add husky ignored files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ baseline.json
 
 # CLDR data
 tools/gulp-tasks/cldr/cldr-data/
+
+# Husky
+.husky/_


### PR DESCRIPTION
Ahead of upgrading to husky v5, adding the shell file location
to .gitignore to prevent it from randomly showing up when devs
checkout older branches.
