### PR TITLE
feat(core): schematic to migrate invalid interpolation-like markup

### DIFF
--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -13,6 +13,7 @@ pkg_npm(
         "//packages/core/schematics/migrations/abstract-control-parent",
         "//packages/core/schematics/migrations/dynamic-queries",
         "//packages/core/schematics/migrations/initial-navigation",
+        "//packages/core/schematics/migrations/invalid-interpolations",
         "//packages/core/schematics/migrations/missing-injectable",
         "//packages/core/schematics/migrations/module-with-providers",
         "//packages/core/schematics/migrations/move-document",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -80,8 +80,8 @@
       "description": "Updates the `initialNavigation` property for `RouterModule.forRoot`.",
       "factory": "./migrations/initial-navigation/index"
     },
-    "migration-v12-invalid-interpolations": {
-      "version": "12",
+    "migration-v11-1-invalid-interpolations": {
+      "version": "11.1.0-beta",
       "description": "Fixes interpolation-like markup not accepted by the compiler parser.",
       "factory": "./migrations/invalid-interpolations/index"
     }

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -79,6 +79,11 @@
       "version": "11.0.0-beta",
       "description": "Updates the `initialNavigation` property for `RouterModule.forRoot`.",
       "factory": "./migrations/initial-navigation/index"
+    },
+    "migration-v12-invalid-interpolations": {
+      "version": "12",
+      "description": "Fixes interpolation-like markup not accepted by the compiler parser.",
+      "factory": "./migrations/invalid-interpolations/index"
     }
   }
 }

--- a/packages/core/schematics/migrations/invalid-interpolations/BUILD.bazel
+++ b/packages/core/schematics/migrations/invalid-interpolations/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//tools:defaults.bzl", "ts_library")
+
+ts_library(
+    name = "invalid-interpolations",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+    deps = [
+        "//packages/compiler",
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/core",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)

--- a/packages/core/schematics/migrations/invalid-interpolations/BUILD.bazel
+++ b/packages/core/schematics/migrations/invalid-interpolations/BUILD.bazel
@@ -15,6 +15,5 @@ ts_library(
         "@npm//@angular-devkit/core",
         "@npm//@angular-devkit/schematics",
         "@npm//@types/node",
-        "@npm//typescript",
     ],
 )

--- a/packages/core/schematics/migrations/invalid-interpolations/README.md
+++ b/packages/core/schematics/migrations/invalid-interpolations/README.md
@@ -1,0 +1,15 @@
+## Invalid interpolation-like markup
+
+This schematic fixes interpolation-like markup no longer accepted by
+the Anuglar compiler since invalidated by #39107.
+
+Previously, the angular parser would not match markup like
+`{{ 1 + 2 }` or `{{ 1 + 2 }<!-- -->}` to be partial (but malformed)
+interpolations, an implementation detail that some developers may have
+relied on to treat interpolation-like markup as text.
+
+However, this kind of markup may be ambiguous, and since #39107, is not
+well-formed. In such cases it is preferred to use an interpolation
+directly or escape interpolation delimiters (e.g. `{{ '{{' }} 1 + 2
+{{ '}}' }}`). This commit provides fixes for malformed cases so as to
+ease migration for applications relying on the previous implementation.

--- a/packages/core/schematics/migrations/invalid-interpolations/README.md
+++ b/packages/core/schematics/migrations/invalid-interpolations/README.md
@@ -1,9 +1,9 @@
 ## Invalid interpolation-like markup
 
 This schematic fixes interpolation-like markup no longer accepted by
-the Anuglar compiler since invalidated by #39107.
+the Angular compiler since invalidated by [#39107](https://github.com/angular/angular/pull/39107).
 
-Previously, the angular parser would not match markup like
+Previously, the Angular parser would not match markup like
 `{{ 1 + 2 }` or `{{ 1 + 2 }<!-- -->}` to be partial (but malformed)
 interpolations, an implementation detail that some developers may have
 relied on to treat interpolation-like markup as text.

--- a/packages/core/schematics/migrations/invalid-interpolations/index.ts
+++ b/packages/core/schematics/migrations/invalid-interpolations/index.ts
@@ -8,7 +8,7 @@
 
 import {logging, normalize} from '@angular-devkit/core';
 import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
-import {AbsoluteSourceSpan} from '@angular/compiler';
+import {AbsoluteSourceSpan, DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler';
 import {relative} from 'path';
 
 import {computeLineStartsMap, getLineAndCharacterFromPosition} from '../../utils/line_mappings';
@@ -110,6 +110,12 @@ function fixInvalidInterpolations(
 function getFixesByFile(templates: ResolvedTemplate[]): Map<string, FixedTemplate[]> {
   const fixesByFile = new Map<string, FixedTemplate[]>();
   for (const template of templates) {
+    if (template.interpolationConfig !== DEFAULT_INTERPOLATION_CONFIG) {
+      // This schematic is only concerned with the default interpolation config
+      // delimited by {{ / }}; do not attempt to fix custom interpolations.
+      continue;
+    }
+
     const templateFix = fixInterpolations(template);
     if (templateFix === null) {
       continue;

--- a/packages/core/schematics/migrations/invalid-interpolations/index.ts
+++ b/packages/core/schematics/migrations/invalid-interpolations/index.ts
@@ -123,7 +123,13 @@ function getFixesByFile(templates: ResolvedTemplate[]): Map<string, FixedTemplat
 
     const file = template.filePath;
     if (fixesByFile.has(file)) {
-      fixesByFile.get(file)!.push(templateFix);
+      if (template.inline) {
+        // External templates may be referenced multiple times in the project
+        // (e.g. if shared between components), but we only want to record them
+        // once. On the other hand, an inline template resides in a TS file that
+        // may contain multiple inline templates.
+        fixesByFile.get(file)!.push(templateFix);
+      }
     } else {
       fixesByFile.set(file, [templateFix]);
     }

--- a/packages/core/schematics/migrations/invalid-interpolations/index.ts
+++ b/packages/core/schematics/migrations/invalid-interpolations/index.ts
@@ -26,7 +26,7 @@ interface FixedTemplate {
 
 interface InvalidInterpolation {
   original: string;
-  span: AbsoluteSourceSpan,
+  span: AbsoluteSourceSpan;
 }
 
 /** Entry point for the V8 template variable assignment schematic. */
@@ -68,7 +68,7 @@ function fixInvalidInterpolations(
     const origFileContent = tree.read(treeFilePath)?.toString();
     if (origFileContent === undefined) {
       logger.error(
-          'Failed to read file containing template; cannot apply fixes for invalid interpolations.')
+          'Failed to read file containing template; cannot apply fixes for invalid interpolations.');
       return;
     }
 

--- a/packages/core/schematics/migrations/invalid-interpolations/index.ts
+++ b/packages/core/schematics/migrations/invalid-interpolations/index.ts
@@ -60,7 +60,7 @@ function fixInvalidInterpolations(
           // via a "template:" or "templateUrl:" key
           f.text.includes('template'));
   for (const sf of sourceFiles) {
-    templateVisitor.visitNode(sf)
+    templateVisitor.visitNode(sf);
   }
 
   const collectedFixes: string[] = [];

--- a/packages/core/schematics/migrations/invalid-interpolations/index.ts
+++ b/packages/core/schematics/migrations/invalid-interpolations/index.ts
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {logging, normalize} from '@angular-devkit/core';
+import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
+import {AbsoluteSourceSpan} from '@angular/compiler';
+import {relative} from 'path';
+
+import {computeLineStartsMap, getLineAndCharacterFromPosition} from '../../utils/line_mappings';
+import {NgComponentTemplateVisitor, ResolvedTemplate} from '../../utils/ng_component_template';
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {createMigrationProgram} from '../../utils/typescript/compiler_host';
+
+type Logger = logging.LoggerApi;
+
+interface FixedTemplate {
+  origTemplate: ResolvedTemplate;
+  newContent: string;
+  invalidInterpolations: InvalidInterpolation[];
+}
+
+interface InvalidInterpolation {
+  original: string;
+  span: AbsoluteSourceSpan,
+}
+
+/** Entry point for the V8 template variable assignment schematic. */
+export default function(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+
+    if (!buildPaths.length && !testPaths.length) {
+      throw new SchematicsException(
+          'Could not find any project config file; cannot check for invalid interpolations.');
+    }
+
+    const logger = context.logger.createChild('Invalid Interpolation Fixer');
+    for (const tsconfigPath of [...buildPaths, ...testPaths]) {
+      fixInvalidInterpolations(tree, tsconfigPath, basePath, logger);
+    }
+  };
+}
+
+/**
+ * Detects, fixes, and informs user of malformed interpolation-like strings in
+ * all templates in the project.
+ */
+function fixInvalidInterpolations(
+    tree: Tree, tsconfigPath: string, basePath: string, logger: Logger) {
+  const {program} = createMigrationProgram(tree, tsconfigPath, basePath);
+  const typeChecker = program.getTypeChecker();
+  const templateVisitor = new NgComponentTemplateVisitor(typeChecker);
+  const sourceFiles = program.getSourceFiles().filter(
+      f => !f.isDeclarationFile && !program.isSourceFileFromExternalLibrary(f));
+  sourceFiles.forEach(sourceFile => templateVisitor.visitNode(sourceFile));
+
+  const collectedFixes: string[] = [];
+  const fixesByFile = getFixesByFile(templateVisitor.resolvedTemplates);
+
+  fixesByFile.forEach((fixes, absFilePath) => {
+    const treeFilePath = normalize(relative(basePath, absFilePath));
+    const origFileContent = tree.read(treeFilePath)?.toString();
+    if (origFileContent === undefined) {
+      logger.error(
+          'Failed to read file containing template; cannot apply fixes for invalid interpolations.')
+      return;
+    }
+
+    // Apply fixes for each template in the current file.
+    const updater = tree.beginUpdate(treeFilePath);
+    for (const fix of fixes) {
+      updater.remove(fix.origTemplate.start, fix.origTemplate.content.length);
+      updater.insertLeft(fix.origTemplate.start, fix.newContent);
+    }
+    tree.commitUpdate(updater);
+
+    // Record detected malformed interpolation-like content
+    const lineStartsMap = computeLineStartsMap(origFileContent);
+    for (const tmplFix of fixes) {
+      for (const {span, original} of tmplFix.invalidInterpolations) {
+        const {line, character} = getLineAndCharacterFromPosition(lineStartsMap, span.start);
+        collectedFixes.push(`${treeFilePath}@${line + 1}:${character + 1}: ${original}`);
+      }
+    }
+  });
+
+  if (collectedFixes.length > 0) {
+    logger.info('---- Invalid Interpolation schematic ----');
+    logger.info('Malformed interpolation-like markup like "{{ 1 }" or "{{ 1 }<!-- -->}"');
+    logger.info('are no longer valid. Interpolation delimiters should be escaped explicitly,');
+    logger.info(`for example as in "{{ '{{' }} 1 {{ '}}' }}".`);
+    logger.info('');
+    logger.info('This schematic has detected and fixed the following malformed interpolations:');
+    for (const fix of collectedFixes) {
+      logger.info(`    ${fix}`);
+    }
+  }
+}
+
+/**
+ * Returns fixes for nodes in a template containing invalid interpolations,
+ * grouped by file.
+ */
+function getFixesByFile(templates: ResolvedTemplate[]): Map<string, FixedTemplate[]> {
+  const fixesByFile = new Map<string, FixedTemplate[]>();
+  for (const template of templates) {
+    const templateFix = fixInterpolations(template);
+    if (templateFix === null) {
+      continue;
+    }
+
+    const file = template.filePath;
+    if (fixesByFile.has(file)) {
+      fixesByFile.get(file)!.push(templateFix);
+    } else {
+      fixesByFile.set(file, [templateFix]);
+    }
+  }
+
+  return fixesByFile;
+}
+
+const RE_INTERPOLATIONS: ReadonlyArray<[RegExp, string]> = [
+  // Matching an interpolation:
+  //
+  // {{((?:[^}'"]|'[^']*?'|"[^"]*?")*?)}
+  //        ^^^^^^                    match everything except a }, ", or '
+  //               ^^^^^^^^ ^^^^^^^^  or any quoted string
+
+  // Replace "{{expr}<!-- cmt -->}" with "{{ '{{' }} expr {{ '}}' }}".
+  // The former is a little-known pattern previously used to display an
+  // iterpolation literally, but that does not longer parse. The latter would
+  // still parse.
+  [
+    /{{((?:'[^']*?'|"[^"]*?"|[^}'"])*?)}<!--.*-->}/g,
+    //                                 ^^^^^^^^^^^ match a comment b/w braces
+    `{{ '{{' }}$1{{ '}}' }}`
+  ],
+
+  // Replace "{{expr}" with "{{ '{{' }} expr {{ '}' }}".
+  [/{{((?:'[^']*?'|"[^"]*?"|[^}'"])*?)}(?!})/g, `{{ '{{' }}$1{{ '}' }}`],
+  //                                  ^^^^^^ match a singularly-terminated interpolation
+];
+
+/**
+ * Finds all invalid interpolation-like markup in a template, returning a `FixedTemplate` if 1+
+ * invalid interpolations are found, and `null` otherwise.
+ */
+function fixInterpolations(template: ResolvedTemplate): FixedTemplate|null {
+  let newContent = template.content;
+  const invalidInterpolations: InvalidInterpolation[] = [];
+  for (const [reInterpolation, replacement] of RE_INTERPOLATIONS) {
+    // First detect invalid interpolations, then fix all of them.
+    let match;
+    while (match = reInterpolation.exec(newContent)) {
+      const start = template.start + match.index;
+      const end = start + match[0].length;
+      invalidInterpolations.push({span: new AbsoluteSourceSpan(start, end), original: match[0]});
+    }
+
+    newContent = newContent.replace(reInterpolation, replacement);
+  }
+
+  if (invalidInterpolations.length === 0) {
+    return null;
+  }
+
+  return {
+    origTemplate: template,
+    newContent,
+    invalidInterpolations,
+  };
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -11,6 +11,7 @@ ts_library(
         "//packages/core/schematics/migrations/abstract-control-parent",
         "//packages/core/schematics/migrations/dynamic-queries",
         "//packages/core/schematics/migrations/initial-navigation",
+        "//packages/core/schematics/migrations/invalid-interpolations",
         "//packages/core/schematics/migrations/missing-injectable",
         "//packages/core/schematics/migrations/module-with-providers",
         "//packages/core/schematics/migrations/move-document",

--- a/packages/core/schematics/test/invalid_interpolations_migration_spec.ts
+++ b/packages/core/schematics/test/invalid_interpolations_migration_spec.ts
@@ -1,0 +1,214 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import * as shx from 'shelljs';
+
+fdescribe('invalid interpolation migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+  let logs: string[];
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', require.resolve('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile('/tsconfig.json', JSON.stringify({
+      compilerOptions: {
+        lib: ['es2015'],
+      },
+    }));
+    writeFile('/angular.json', JSON.stringify({
+      projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
+    }));
+
+    logs = [];
+    runner.logger.subscribe(logEntry => {
+      logs.push(logEntry.message);
+    });
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematicAsync('migration-v12-invalid-interpolations', {}, tree).toPromise();
+  }
+
+  it('should fix interpolations with only one terminating brace', async () => {
+    writeFile('/index.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`
+          <div>{{ 1 + 2 }</div> {{ 5 + 6 }
+        \`;
+      })
+      class Test {}
+    `);
+
+    await runMigration();
+
+    expect(tree.readContent('/index.ts')).toBe(`
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`
+          <div>{{ '{{' }} 1 + 2 {{ '}' }}</div> {{ '{{' }} 5 + 6 {{ '}' }}
+        \`;
+      })
+      class Test {}
+    `);
+
+    expect(logs).toEqual(jasmine.arrayContaining([
+      '    index.ts@6:16: {{ 1 + 2 }',
+      '    index.ts@6:33: {{ 5 + 6 }',
+    ]));
+  });
+
+  it('should fix interpolations with interpolations with comment between terminating braces',
+     async () => {
+       writeFile('/index.ts', `
+         import {Component} from '@angular/core';
+
+         @Component({
+           template: \`
+             {{ 1 + 2 }<!---->} is a literal
+             <span>{{ 3 }<!-- so is this one -->}</span>
+           \`;
+         })
+         class Test {}
+       `);
+
+       await runMigration();
+
+       expect(tree.readContent('/index.ts')).toBe(`
+         import {Component} from '@angular/core';
+
+         @Component({
+           template: \`
+             {{ '{{' }} 1 + 2 {{ '}}' }} is a literal
+             <span>{{ '{{' }} 3 {{ '}}' }}</span>
+           \`;
+         })
+         class Test {}
+       `);
+
+       expect(logs).toEqual(jasmine.arrayContaining([
+         '    index.ts@6:14: {{ 1 + 2 }<!---->}',
+         '    index.ts@7:20: {{ 3 }<!-- so is this one -->}',
+       ]));
+     });
+
+  it('should fix mixed types of invalid interpolations', async () => {
+    writeFile('/index.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`
+          {{ 1 + 2 }<!---->}
+          {{ 1 + 2 }
+        \`;
+      })
+      class Test {}
+
+      @Component({
+        template: \`
+          {{ 1 + 2 }<!---->}
+          {{ 1 + 2 }
+        \`;
+      })
+      class Test2 {}
+    `);
+
+    await runMigration();
+
+    expect(tree.readContent('/index.ts')).toBe(`
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`
+          {{ '{{' }} 1 + 2 {{ '}}' }}
+          {{ '{{' }} 1 + 2 {{ '}' }}
+        \`;
+      })
+      class Test {}
+
+      @Component({
+        template: \`
+          {{ '{{' }} 1 + 2 {{ '}}' }}
+          {{ '{{' }} 1 + 2 {{ '}' }}
+        \`;
+      })
+      class Test2 {}
+    `);
+  });
+
+  it('should not replace valid interpolations', async () => {
+    const contents = `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`
+          {{ 1 + 2 }}
+          <span>{{ 3 }} or {{ '{' + "a" + '}' }}</span> or {{ "{{" + "b" + "}}" }}
+        \`;
+      })
+      class Test {}
+    `;
+    writeFile('/index.ts', contents);
+
+    await runMigration();
+
+    expect(tree.readContent('/index.ts')).toBe(contents);
+  });
+
+  it('should fix invalid interpolations in external templates', async () => {
+    writeFile('/index.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        templateUrl: './template.html',
+      })
+      class Test {}
+    `);
+    writeFile('/template.html', `
+      <span>{{ 'Hello' }}</span>
+      {{ 1 + 2 }<!---->}
+      {{ 1 + 2 }
+    `);
+
+    await runMigration();
+
+    expect(tree.readContent('/template.html')).toBe(`
+      <span>{{ 'Hello' }}</span>
+      {{ '{{' }} 1 + 2 {{ '}}' }}
+      {{ '{{' }} 1 + 2 {{ '}' }}
+    `);
+  });
+});

--- a/packages/core/schematics/test/invalid_interpolations_migration_spec.ts
+++ b/packages/core/schematics/test/invalid_interpolations_migration_spec.ts
@@ -12,7 +12,7 @@ import {HostTree} from '@angular-devkit/schematics';
 import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
 import * as shx from 'shelljs';
 
-fdescribe('invalid interpolation migration', () => {
+describe('invalid interpolation migration', () => {
   let runner: SchematicTestRunner;
   let host: TempScopedNodeJsSyncHost;
   let tree: UnitTestTree;

--- a/packages/core/schematics/test/invalid_interpolations_migration_spec.ts
+++ b/packages/core/schematics/test/invalid_interpolations_migration_spec.ts
@@ -111,8 +111,8 @@ describe('invalid interpolation migration', () => {
 
          @Component({
            template: \`
-             {{ '{{' }} 1 + 2 {{ '}}' }} is a literal
-             <span>{{ '{{' }} 3 {{ '}}' }}</span>
+             {{ '{{' }} 1 + 2 {{ '}}' }}<!----> is a literal
+             <span>{{ '{{' }} 3 {{ '}}' }}<!-- so is this one --></span>
            \`;
          })
          class Test {}
@@ -152,7 +152,7 @@ describe('invalid interpolation migration', () => {
 
       @Component({
         template: \`
-          {{ '{{' }} 1 + 2 {{ '}}' }}
+          {{ '{{' }} 1 + 2 {{ '}}' }}<!---->
           {{ '{{' }} 1 + 2 {{ '}' }}
         \`;
       })
@@ -160,7 +160,7 @@ describe('invalid interpolation migration', () => {
 
       @Component({
         template: \`
-          {{ '{{' }} 1 + 2 {{ '}}' }}
+          {{ '{{' }} 1 + 2 {{ '}}' }}<!---->
           {{ '{{' }} 1 + 2 {{ '}' }}
         \`;
       })
@@ -176,6 +176,10 @@ describe('invalid interpolation migration', () => {
         template: \`
           {{ 1 + 2 }}
           <span>{{ 3 }} or {{ '{' + "a" + '}' }}</span> or {{ "{{" + "b" + "}}" }}
+          or {{ '{{ b }' }}
+          or {{ '    {{ b }    ' }}
+          or {{ '{{ b }<!-- cmt -->' }}
+          or {{ '    {{ b }<!-- cmt -->    ' }}
         \`;
       })
       class Test {}
@@ -256,7 +260,7 @@ describe('invalid interpolation migration', () => {
 
     expect(tree.readContent('/template.html')).toBe(`
       <span>{{ 'Hello' }}</span>
-      {{ '{{' }} 1 + 2 {{ '}}' }}
+      {{ '{{' }} 1 + 2 {{ '}}' }}<!---->
       {{ '{{' }} 1 + 2 {{ '}' }}
     `);
   });
@@ -289,7 +293,7 @@ describe('invalid interpolation migration', () => {
 
        expect(tree.readContent('/template.html')).toBe(`
          <span>{{ 'Hello' }}</span>
-         {{ '{{' }} 1 + 2 {{ '}}' }}
+         {{ '{{' }} 1 + 2 {{ '}}' }}<!---->
          {{ '{{' }} 1 + 2 {{ '}' }}
        `);
      });

--- a/packages/core/schematics/test/invalid_interpolations_migration_spec.ts
+++ b/packages/core/schematics/test/invalid_interpolations_migration_spec.ts
@@ -56,7 +56,7 @@ describe('invalid interpolation migration', () => {
   }
 
   function runMigration() {
-    return runner.runSchematicAsync('migration-v12-invalid-interpolations', {}, tree).toPromise();
+    return runner.runSchematicAsync('migration-v11-1-invalid-interpolations', {}, tree).toPromise();
   }
 
   it('should fix interpolations with only one terminating brace', async () => {

--- a/packages/core/schematics/test/invalid_interpolations_migration_spec.ts
+++ b/packages/core/schematics/test/invalid_interpolations_migration_spec.ts
@@ -260,4 +260,37 @@ describe('invalid interpolation migration', () => {
       {{ '{{' }} 1 + 2 {{ '}' }}
     `);
   });
+
+  it('should correctly fix invalid interpolations in external templates shared between components',
+     async () => {
+       writeFile('/index.ts', `
+         import {Component} from '@angular/core';
+
+         @Component({
+           templateUrl: './template.html',
+         })
+         class Test {}
+       `);
+       writeFile('/index2.ts', `
+         import {Component} from '@angular/core';
+
+         @Component({
+           templateUrl: './template.html',
+         })
+         class Test2 {}
+       `);
+       writeFile('/template.html', `
+         <span>{{ 'Hello' }}</span>
+         {{ 1 + 2 }<!---->}
+         {{ 1 + 2 }
+       `);
+
+       await runMigration();
+
+       expect(tree.readContent('/template.html')).toBe(`
+         <span>{{ 'Hello' }}</span>
+         {{ '{{' }} 1 + 2 {{ '}}' }}
+         {{ '{{' }} 1 + 2 {{ '}' }}
+       `);
+     });
 });

--- a/packages/core/schematics/test/invalid_interpolations_migration_spec.ts
+++ b/packages/core/schematics/test/invalid_interpolations_migration_spec.ts
@@ -188,6 +188,26 @@ describe('invalid interpolation migration', () => {
     expect(tree.readContent('/index.ts')).toBe(contents);
   });
 
+  it('should not modify templates with custom interpolation config', async () => {
+    const contents = `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`
+          {{ 1 + 2 }
+          [[ 1 + 2 ]
+        \`,
+        interpolation: ['[[', ']]'],
+      })
+      class Test {}
+    `;
+    writeFile('/index.ts', contents);
+
+    await runMigration();
+
+    expect(tree.readContent('/index.ts')).toBe(contents);
+  });
+
   it('should fix invalid interpolations in external templates', async () => {
     writeFile('/index.ts', `
       import {Component} from '@angular/core';


### PR DESCRIPTION
This commit introduces a schematic that fixes interpolation-like markup
no longer accepted by the Anuglar compiler since invalidated by #39107.

Previously, the angular parser would not match markup like
`{{ 1 + 2 }` or `{{ 1 + 2 }<!-- -->}` to be partial (but malformed)
interpolations, an implementation detail that some developers may have
relied on to treat interpolation-like markup as text.

However, this kind of markup may be ambiguous, and since #39107, is not
well-formed. In such cases it is preferred to use an interpolation
directly or escape interpolation delimiters (e.g. `{{ '{{' }} 1 + 2
{{ '}}' }}`). This commit provides fixes for malformed cases so as to
ease migration for applications relying on the previous implementation.

Part of #38596

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
