### PR TITLE
build(docs-infra): upgrade cli command docs sources to b5fa18881

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -23,7 +23,7 @@
     "build-local-with-viewengine": "yarn ~~build",
     "prebuild-local-with-viewengine-ci": "node scripts/switch-to-viewengine && yarn setup-local-ci",
     "build-local-with-viewengine-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js bfcad1d71",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js b5fa18881",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#10.2.x](https://github.com/angular/angular/tree/10.2.x) from [cli-builds#10.2.x](https://github.com/angular/cli-builds/tree/10.2.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/bfcad1d71...b5fa18881):

**Modified**
- help/build.json
- help/generate.json
- help/serve.json
- help/test.json
- help/update.json
- help/xi18n.json

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/bfcad1d71...b5fa18881) since PR #39380:

**Modified**
- help/build.json
- help/generate.json
- help/serve.json
- help/test.json
- help/update.json
- help/xi18n.json

##
Closes #39380