### PR TITLE
fix(localize): render placeholder types in extracted XLIFF files

### DIFF
--- a/packages/localize/src/tools/test/extract/integration/main_spec.ts
+++ b/packages/localize/src/tools/test/extract/integration/main_spec.ts
@@ -202,9 +202,9 @@ runInEachFileSystem(() => {
                  `        </context-group>`,
                  `      </trans-unit>`,
                  `      <trans-unit id="2932901491976224757" datatype="html">`,
-                 `        <source>pre<x id="START_TAG_SPAN" equiv-text="&apos;&lt;span&gt;&apos;"/>` +
-                     `inner-pre<x id="START_BOLD_TEXT" equiv-text="&apos;&lt;b&gt;&apos;"/>bold<x id="CLOSE_BOLD_TEXT" equiv-text="&apos;&lt;/b&gt;&apos;"/>` +
-                     `inner-post<x id="CLOSE_TAG_SPAN" equiv-text="&apos;&lt;/span&gt;&apos;"/>post</source>`,
+                 `        <source>pre<x id="START_TAG_SPAN" ctype="x-span" equiv-text="&apos;&lt;span&gt;&apos;"/>` +
+                     `inner-pre<x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&apos;&lt;b&gt;&apos;"/>bold<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&apos;&lt;/b&gt;&apos;"/>` +
+                     `inner-post<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&apos;&lt;/span&gt;&apos;"/>post</source>`,
                  `        <context-group purpose="location">`,
                  `          <context context-type="sourcefile">test_files/test.js</context>`,
                  `          <context context-type="linenumber">9,10</context>`,
@@ -279,8 +279,8 @@ runInEachFileSystem(() => {
               `        <note category="location">test_files/test.js:9,10</note>`,
               `      </notes>`,
               `      <segment>`,
-              `        <source>pre<pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN" dispStart="&apos;&lt;span&gt;&apos;" dispEnd="&apos;&lt;/span&gt;&apos;">` +
-                  `inner-pre<pc id="1" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" dispStart="&apos;&lt;b&gt;&apos;" dispEnd="&apos;&lt;/b&gt;&apos;">bold</pc>` +
+              `        <source>pre<pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN" type="other" dispStart="&apos;&lt;span&gt;&apos;" dispEnd="&apos;&lt;/span&gt;&apos;">` +
+                  `inner-pre<pc id="1" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt" dispStart="&apos;&lt;b&gt;&apos;" dispEnd="&apos;&lt;/b&gt;&apos;">bold</pc>` +
                   `inner-post</pc>post</source>`,
               `      </segment>`,
               `    </unit>`,

--- a/packages/localize/src/tools/test/extract/translation_files/xliff1_translation_serializer_spec.ts
+++ b/packages/localize/src/tools/test/extract/translation_files/xliff1_translation_serializer_spec.ts
@@ -99,18 +99,18 @@ runInEachFileSystem(() => {
               `        <source>a<x id="PH" equiv-text="placeholder + 1"/>b<x id="PH_1"/>c</source>`,
               `      </trans-unit>`,
               `      <trans-unit id="67890" datatype="html">`,
-              `        <source>a<x id="START_TAG_SPAN"/><x id="CLOSE_TAG_SPAN"/>c</source>`,
+              `        <source>a<x id="START_TAG_SPAN" ctype="x-span"/><x id="CLOSE_TAG_SPAN" ctype="x-span"/>c</source>`,
               `        <note priority="1" from="description">some description</note>`,
               `      </trans-unit>`,
               `      <trans-unit id="38705" datatype="html">`,
-              `        <source>a<x id="START_TAG_SPAN"/><x id="CLOSE_TAG_SPAN"/>c</source>`,
+              `        <source>a<x id="START_TAG_SPAN" ctype="x-span"/><x id="CLOSE_TAG_SPAN" ctype="x-span"/>c</source>`,
               `        <context-group purpose="location">`,
               `          <context context-type="sourcefile">file.ts</context>`,
               `          <context context-type="linenumber">3,4</context>`,
               `        </context-group>`,
               `      </trans-unit>`,
               `      <trans-unit id="13579" datatype="html">`,
-              `        <source><x id="START_BOLD_TEXT"/>b<x id="CLOSE_BOLD_TEXT"/></source>`,
+              `        <source><x id="START_BOLD_TEXT" ctype="x-b"/>b<x id="CLOSE_BOLD_TEXT" ctype="x-b"/></source>`,
               `      </trans-unit>`,
               `      <trans-unit id="24680" datatype="html">`,
               `        <source>a</source>`,
@@ -128,7 +128,7 @@ runInEachFileSystem(() => {
               `        <source>pre-ICU {VAR_SELECT, select, a {a} b {<x id="INTERPOLATION"/>} c {pre <x id="INTERPOLATION_1"/> post}} post-ICU</source>`,
               `      </trans-unit>`,
               `      <trans-unit id="100001" datatype="html">`,
-              `        <source>{VAR_PLURAL, plural, one {<x id="START_BOLD_TEXT"/>something bold<x id="CLOSE_BOLD_TEXT"/>} other {pre <x id="START_TAG_SPAN"/>middle<x id="CLOSE_TAG_SPAN"/> post}}</source>`,
+              `        <source>{VAR_PLURAL, plural, one {<x id="START_BOLD_TEXT" ctype="x-b"/>something bold<x id="CLOSE_BOLD_TEXT" ctype="x-b"/>} other {pre <x id="START_TAG_SPAN" ctype="x-span"/>middle<x id="CLOSE_TAG_SPAN" ctype="x-span"/> post}}</source>`,
               `      </trans-unit>`,
               `    </body>`,
               `  </file>`,
@@ -229,6 +229,64 @@ runInEachFileSystem(() => {
               `  </file>`,
               `</xliff>\n`,
             ].join('\n'));
+          });
+
+          it('should render the "ctype" for line breaks', () => {
+            const serializer = new Xliff1TranslationSerializer(
+                'xx', absoluteFrom('/project'), useLegacyIds, options);
+            const output = serializer.serialize([mockMessage('1', ['a', 'b'], ['LINE_BREAK'], {})]);
+            expect(output).toContain(
+                '<source>a<x id="LINE_BREAK" ctype="lb"/>b</source>',
+            );
+          });
+
+          it('should render the "ctype" for images', () => {
+            const serializer = new Xliff1TranslationSerializer(
+                'xx', absoluteFrom('/project'), useLegacyIds, options);
+            const output = serializer.serialize([mockMessage('2', ['a', 'b'], ['TAG_IMG'], {})]);
+            expect(output).toContain(
+                '<source>a<x id="TAG_IMG" ctype="image"/>b</source>',
+            );
+          });
+
+          it('should render the "ctype" for bold elements', () => {
+            const serializer = new Xliff1TranslationSerializer(
+                'xx', absoluteFrom('/project'), useLegacyIds, options);
+            const output = serializer.serialize(
+                [mockMessage('3', ['a', 'b', 'c'], ['START_BOLD_TEXT', 'CLOSE_BOLD_TEXT'], {})]);
+            expect(output).toContain(
+                '<source>a<x id="START_BOLD_TEXT" ctype="x-b"/>b<x id="CLOSE_BOLD_TEXT" ctype="x-b"/>c</source>',
+            );
+          });
+
+          it('should render the "ctype" for headings', () => {
+            const serializer = new Xliff1TranslationSerializer(
+                'xx', absoluteFrom('/project'), useLegacyIds, options);
+            const output = serializer.serialize([mockMessage(
+                '4', ['a', 'b', 'c'], ['START_HEADING_LEVEL1', 'CLOSE_HEADING_LEVEL1'], {})]);
+            expect(output).toContain(
+                '<source>a<x id="START_HEADING_LEVEL1" ctype="x-h1"/>b<x id="CLOSE_HEADING_LEVEL1" ctype="x-h1"/>c</source>',
+            );
+          });
+
+          it('should render the "ctype" for span elements', () => {
+            const serializer = new Xliff1TranslationSerializer(
+                'xx', absoluteFrom('/project'), useLegacyIds, options);
+            const output = serializer.serialize(
+                [mockMessage('5', ['a', 'b', 'c'], ['START_TAG_SPAN', 'CLOSE_TAG_SPAN'], {})]);
+            expect(output).toContain(
+                '<source>a<x id="START_TAG_SPAN" ctype="x-span"/>b<x id="CLOSE_TAG_SPAN" ctype="x-span"/>c</source>',
+            );
+          });
+
+          it('should render the "ctype" for div elements', () => {
+            const serializer = new Xliff1TranslationSerializer(
+                'xx', absoluteFrom('/project'), useLegacyIds, options);
+            const output = serializer.serialize(
+                [mockMessage('6', ['a', 'b', 'c'], ['START_TAG_DIV', 'CLOSE_TAG_DIV'], {})]);
+            expect(output).toContain(
+                '<source>a<x id="START_TAG_DIV" ctype="x-div"/>b<x id="CLOSE_TAG_DIV" ctype="x-div"/>c</source>',
+            );
           });
         });
       });

--- a/packages/localize/src/tools/test/extract/translation_files/xliff2_translation_serializer_spec.ts
+++ b/packages/localize/src/tools/test/extract/translation_files/xliff2_translation_serializer_spec.ts
@@ -108,7 +108,7 @@ runInEachFileSystem(() => {
               `        <note category="description">some description</note>`,
               `      </notes>`,
               `      <segment>`,
-              `        <source>a<pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN"></pc>c</source>`,
+              `        <source>a<pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN" type="other"></pc>c</source>`,
               `      </segment>`,
               `    </unit>`,
               `    <unit id="location-only">`,
@@ -116,12 +116,12 @@ runInEachFileSystem(() => {
               `        <note category="location">file.ts:3,4</note>`,
               `      </notes>`,
               `      <segment>`,
-              `        <source>a<pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN"></pc>c</source>`,
+              `        <source>a<pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN" type="other"></pc>c</source>`,
               `      </segment>`,
               `    </unit>`,
               `    <unit id="13579">`,
               `      <segment>`,
-              `        <source><pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT">b</pc></source>`,
+              `        <source><pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt">b</pc></source>`,
               `      </segment>`,
               `    </unit>`,
               `    <unit id="24680">`,
@@ -151,7 +151,7 @@ runInEachFileSystem(() => {
               `    </unit>`,
               `    <unit id="100001">`,
               `      <segment>`,
-              `        <source>{VAR_PLURAL, plural, one {<pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT">something bold</pc>} other {pre <pc id="1" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN">middle</pc> post}}</source>`,
+              `        <source>{VAR_PLURAL, plural, one {<pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt">something bold</pc>} other {pre <pc id="1" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN" type="other">middle</pc> post}}</source>`,
               `      </segment>`,
               `    </unit>`,
               `  </file>`,
@@ -242,6 +242,64 @@ runInEachFileSystem(() => {
               `  </file>`,
               `</xliff>\n`,
             ].join('\n'));
+          });
+
+          it('should render the "type" for line breaks', () => {
+            const serializer = new Xliff2TranslationSerializer(
+                'xx', absoluteFrom('/project'), useLegacyIds, options);
+            const output = serializer.serialize([mockMessage('1', ['a', 'b'], ['LINE_BREAK'], {})]);
+            expect(output).toContain(
+                '<source>a<ph id="0" equiv="LINE_BREAK" type="fmt"/>b</source>',
+            );
+          });
+
+          it('should render the "type" for images', () => {
+            const serializer = new Xliff2TranslationSerializer(
+                'xx', absoluteFrom('/project'), useLegacyIds, options);
+            const output = serializer.serialize([mockMessage('2', ['a', 'b'], ['TAG_IMG'], {})]);
+            expect(output).toContain(
+                '<source>a<ph id="0" equiv="TAG_IMG" type="image"/>b</source>',
+            );
+          });
+
+          it('should render the "type" for bold elements', () => {
+            const serializer = new Xliff2TranslationSerializer(
+                'xx', absoluteFrom('/project'), useLegacyIds, options);
+            const output = serializer.serialize(
+                [mockMessage('3', ['a', 'b', 'c'], ['START_BOLD_TEXT', 'CLOSE_BOLD_TEXT'], {})]);
+            expect(output).toContain(
+                '<source>a<pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt">b</pc>c</source>',
+            );
+          });
+
+          it('should render the "type" for heading elements', () => {
+            const serializer = new Xliff2TranslationSerializer(
+                'xx', absoluteFrom('/project'), useLegacyIds, options);
+            const output = serializer.serialize([mockMessage(
+                '4', ['a', 'b', 'c'], ['START_HEADING_LEVEL1', 'CLOSE_HEADING_LEVEL1'], {})]);
+            expect(output).toContain(
+                '<source>a<pc id="0" equivStart="START_HEADING_LEVEL1" equivEnd="CLOSE_HEADING_LEVEL1" type="other">b</pc>c</source>',
+            );
+          });
+
+          it('should render the "type" for span elements', () => {
+            const serializer = new Xliff2TranslationSerializer(
+                'xx', absoluteFrom('/project'), useLegacyIds, options);
+            const output = serializer.serialize(
+                [mockMessage('5', ['a', 'b', 'c'], ['START_TAG_SPAN', 'CLOSE_TAG_SPAN'], {})]);
+            expect(output).toContain(
+                '<source>a<pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN" type="other">b</pc>c</source>',
+            );
+          });
+
+          it('should render the "type" for div elements', () => {
+            const serializer = new Xliff2TranslationSerializer(
+                'xx', absoluteFrom('/project'), useLegacyIds, options);
+            const output = serializer.serialize(
+                [mockMessage('6', ['a', 'b', 'c'], ['START_TAG_DIV', 'CLOSE_TAG_DIV'], {})]);
+            expect(output).toContain(
+                '<source>a<pc id="0" equivStart="START_TAG_DIV" equivEnd="CLOSE_TAG_DIV" type="other">b</pc>c</source>',
+            );
           });
         });
       });


### PR DESCRIPTION
The previous ViewEngine extraction tooling added `ctype` and `type`
attributes to XLIFF 1.2 and 2.0 translation files, respectively.

This commit adds this to the new $localize based extraction tooling.
Since the new extraction tooling works from the compiled output rather
than having direct access to the template content, the placeholder types
must be inferred from the name of the placeholder.  This is considered
reasonable, since it already does this to compute opening and closing
tag placeholders.

Fixes #38791
