### PR TITLE
docs(browser-support): fix Android 10 codename

### DIFF
--- a/aio/content/guide/browser-support.md
+++ b/aio/content/guide/browser-support.md
@@ -80,7 +80,7 @@ Angular supports most recent browsers. This includes the following specific vers
     </td>
 
     <td>
-      X (10.0), Pie (9.0), Oreo (8.0), Nougat (7.0)
+      Q (10.0), Pie (9.0), Oreo (8.0), Nougat (7.0)
     </td>
   </tr>
 


### PR DESCRIPTION
Change Android 10's codename from "X" to "Q"

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The codename for Android 10.0 is "X" in https://angular.io/guide/browser-support


## What is the new behavior?

The codename for Android 10.0 is "Q" in https://angular.io/guide/browser-support

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
