### PR TITLE
fix(core): update expected size for cli-hello-world-ivy-i18n integration test

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -30,8 +30,8 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 135506,
-        "polyfills-es2015": 37248
+        "main-es2015": 136062,
+        "polyfills-es2015": 37392
       }
     }
   },


### PR DESCRIPTION
Update the expected size for cli-hello-world-ivy-i18n after changes to i18n.
