### PR TITLE
build(docs-infra): ignore `doc.basePath` when generating keywords for each document

### DIFF
--- a/aio/tools/transforms/angular-base-package/index.js
+++ b/aio/tools/transforms/angular-base-package/index.js
@@ -66,7 +66,7 @@ module.exports = new Package('angular-base', [
 
     generateKeywordsProcessor.ignoreWordsFile = path.resolve(__dirname, 'ignore.words');
     generateKeywordsProcessor.docTypesToIgnore = ['example-region'];
-    generateKeywordsProcessor.propertiesToIgnore = ['renderedContent'];
+    generateKeywordsProcessor.propertiesToIgnore = ['basePath', 'renderedContent'];
   })
 
   // Where do we write the output files?


### PR DESCRIPTION
The `generateKeywords` dgeni processor automatically generates keywords for each document by extracting words from each string property of a `doc` object.

This commit adds `basePath` to the list of ignored properties, so that it is _not_ considered when generating keywords. `basePath` mostly contains the path to some root directory (such as `/home/circleci/ng/packages`) and as such it does not contain useful keywords.

For example, searching for `circleci` will match all API docs, because it happens to be in the `basePath`: https://v10.angular.io/?search=circleci
