### PR TITLE
fix(localize): serialize all the message locations to XLIFF

### DIFF
--- a/packages/localize/src/tools/src/extract/translation_files/utils.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/utils.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {ɵMessageId, ɵParsedMessage, ɵSourceLocation} from '@angular/localize';
+
+/**
+ * Consolidate an array of messages into a map from message id to an array of messages with that id.
+ *
+ * @param messages the messages to consolidate.
+ * @param getMessageId a function that will compute the message id of a message.
+ */
+export function consolidateMessages(
+    messages: ɵParsedMessage[],
+    getMessageId: (message: ɵParsedMessage) => string): Map<ɵMessageId, ɵParsedMessage[]> {
+  const consolidateMessages = new Map<ɵMessageId, ɵParsedMessage[]>();
+  for (const message of messages) {
+    const id = getMessageId(message);
+    if (!consolidateMessages.has(id)) {
+      consolidateMessages.set(id, [message]);
+    } else {
+      consolidateMessages.get(id)!.push(message);
+    }
+  }
+  return consolidateMessages;
+}
+
+/**
+ * Does the given message have a location property?
+ */
+export function hasLocation(message: ɵParsedMessage): message is ɵParsedMessage&
+    {location: ɵSourceLocation} {
+  return message.location !== undefined;
+}

--- a/packages/localize/src/tools/test/extract/translation_files/xliff2_translation_serializer_spec.ts
+++ b/packages/localize/src/tools/test/extract/translation_files/xliff2_translation_serializer_spec.ts
@@ -158,6 +158,91 @@ runInEachFileSystem(() => {
               `</xliff>\n`,
             ].join('\n'));
           });
+
+          it('should convert a set of parsed messages into an XML string', () => {
+            const messageLocation1: ɵSourceLocation = {
+              start: {line: 0, column: 5},
+              end: {line: 0, column: 10},
+              file: absoluteFrom('/project/file-1.ts'),
+              text: 'message text'
+            };
+
+            const messageLocation2: ɵSourceLocation = {
+              start: {line: 3, column: 2},
+              end: {line: 4, column: 7},
+              file: absoluteFrom('/project/file-2.ts'),
+              text: 'message text'
+            };
+
+            const messageLocation3: ɵSourceLocation = {
+              start: {line: 0, column: 5},
+              end: {line: 0, column: 10},
+              file: absoluteFrom('/project/file-3.ts'),
+              text: 'message text'
+            };
+
+            const messageLocation4: ɵSourceLocation = {
+              start: {line: 3, column: 2},
+              end: {line: 4, column: 7},
+              file: absoluteFrom('/project/file-4.ts'),
+              text: 'message text'
+            };
+
+            const messages: ɵParsedMessage[] = [
+              mockMessage('1234', ['message text'], [], {location: messageLocation1}),
+              mockMessage('1234', ['message text'], [], {location: messageLocation2}),
+              mockMessage('1234', ['message text'], [], {
+                location: messageLocation3,
+                legacyIds: ['87654321FEDCBA0987654321FEDCBA0987654321', '563965274788097516']
+              }),
+              mockMessage(
+                  '1234', ['message text'], [], {location: messageLocation4, customId: 'other'}),
+            ];
+            const serializer = new Xliff2TranslationSerializer(
+                'xx', absoluteFrom('/project'), useLegacyIds, options);
+            const output = serializer.serialize(messages);
+
+            // Note that in this test the third message will match the first two if legacyIds is
+            // false. Otherwise it will be a separate message on its own.
+
+            expect(output).toEqual([
+              `<?xml version="1.0" encoding="UTF-8" ?>`,
+              `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="xx">`,
+              `  <file id="ngi18n" original="ng.template"${toAttributes(options)}>`,
+              `    <unit id="1234">`,
+              `      <notes>`,
+              `        <note category="location">file-1.ts:1</note>`,
+              `        <note category="location">file-2.ts:4,5</note>`,
+              ...useLegacyIds ? [] : ['        <note category="location">file-3.ts:1</note>'],
+              `      </notes>`,
+              `      <segment>`,
+              `        <source>message text</source>`,
+              `      </segment>`,
+              `    </unit>`,
+              ...useLegacyIds ?
+                  [
+                    `    <unit id="563965274788097516">`,
+                    `      <notes>`,
+                    `        <note category="location">file-3.ts:1</note>`,
+                    `      </notes>`,
+                    `      <segment>`,
+                    `        <source>message text</source>`,
+                    `      </segment>`,
+                    `    </unit>`,
+                  ] :
+                  [],
+              `    <unit id="other">`,
+              `      <notes>`,
+              `        <note category="location">file-4.ts:4,5</note>`,
+              `      </notes>`,
+              `      <segment>`,
+              `        <source>message text</source>`,
+              `      </segment>`,
+              `    </unit>`,
+              `  </file>`,
+              `</xliff>\n`,
+            ].join('\n'));
+          });
         });
       });
     });


### PR DESCRIPTION
Previously only the first message, for each id, was serialized
which meant that additional message location information
was lost.

Now all the message locations are included in the serialized
messages.

Fixes #39330
