### PR TITLE
refactor(core): remove `expandoStartIndex` workaround

### DIFF
--- a/packages/core/src/render3/assert.ts
+++ b/packages/core/src/render3/assert.ts
@@ -121,16 +121,12 @@ export function assertIndexInDeclRange(lView: LView, index: number) {
 
 export function assertIndexInVarsRange(lView: LView, index: number) {
   const tView = lView[1];
-  assertBetween(
-      tView.bindingStartIndex,
-      (tView as any as {originalExpandoStartIndex: number}).originalExpandoStartIndex, index);
+  assertBetween(tView.bindingStartIndex, tView.expandoStartIndex, index);
 }
 
 export function assertIndexInExpandoRange(lView: LView, index: number) {
   const tView = lView[1];
-  assertBetween(
-      (tView as any as {originalExpandoStartIndex: number}).originalExpandoStartIndex, lView.length,
-      index);
+  assertBetween(tView.expandoStartIndex, lView.length, index);
 }
 
 export function assertBetween(lower: number, upper: number, index: number) {

--- a/packages/core/src/render3/instructions/lview_debug.ts
+++ b/packages/core/src/render3/instructions/lview_debug.ts
@@ -159,16 +159,6 @@ export const TViewConstructor = class TView implements ITView {
   get type_(): string {
     return TViewTypeAsString[this.type] || `TViewType.?${this.type}?`;
   }
-
-  /**
-   * Returns initial value of `expandoStartIndex`.
-   */
-  // FIXME(misko): `originalExpandoStartIndex` should not be needed because it should be the same as
-  // `expandoStartIndex`. However `expandoStartIndex` is misnamed as it changes as more items get
-  // allocated in expando.
-  get originalExpandoStartIndex(): number {
-    return HEADER_OFFSET + this._decls + this._vars;
-  }
 };
 
 class TNode implements ITNode {
@@ -515,18 +505,13 @@ export class LViewDebug implements ILViewDebug {
   }
 
   get vars(): LViewDebugRange {
-    const tView = this.tView;
     return toLViewRange(
-        tView, this._raw_lView, tView.bindingStartIndex,
-        (tView as any as {originalExpandoStartIndex: number}).originalExpandoStartIndex);
+        this.tView, this._raw_lView, this.tView.bindingStartIndex, this.tView.expandoStartIndex);
   }
 
   get expando(): LViewDebugRange {
-    const tView = this.tView as any as {_decls: number, _vars: number};
     return toLViewRange(
-        this.tView, this._raw_lView,
-        (tView as any as {originalExpandoStartIndex: number}).originalExpandoStartIndex,
-        this._raw_lView.length);
+        this.tView, this._raw_lView, this.tView.expandoStartIndex, this._raw_lView.length);
   }
 
   /**


### PR DESCRIPTION
This commit removes a workaround to calculate the `expandoStartIndex` value. That workaround was needed
because the `expandoStartIndex` was updated previously, so it pointed at the wrong location. The problem
was fixed in PR #39301 and the workaround is no longer needed.


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No