### PR TITLE
feat(core): add shouldCoalesceChangeDetection option to coalesce change detections

### DIFF
--- a/goldens/public-api/core/core.d.ts
+++ b/goldens/public-api/core/core.d.ts
@@ -619,9 +619,10 @@ export declare class NgZone {
     readonly onMicrotaskEmpty: EventEmitter<any>;
     readonly onStable: EventEmitter<any>;
     readonly onUnstable: EventEmitter<any>;
-    constructor({ enableLongStackTrace, shouldCoalesceEventChangeDetection }: {
+    constructor({ enableLongStackTrace, shouldCoalesceEventChangeDetection, shouldCoalesceRunChangeDetection }: {
         enableLongStackTrace?: boolean | undefined;
         shouldCoalesceEventChangeDetection?: boolean | undefined;
+        shouldCoalesceRunChangeDetection?: boolean | undefined;
     });
     run<T>(fn: (...args: any[]) => T, applyThis?: any, applyArgs?: any[]): T;
     runGuarded<T>(fn: (...args: any[]) => T, applyThis?: any, applyArgs?: any[]): T;

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 140899,
+        "main-es2015": 141516,
         "polyfills-es2015": 36964
       }
     }
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2285,
-        "main-es2015": 241875,
+        "main-es2015": 242417,
         "polyfills-es2015": 36709,
         "5-es2015": 745
       }
@@ -48,10 +48,10 @@
   "cli-hello-world-lazy-rollup": {
     "master": {
       "uncompressed": {
-        "runtime-es2015": 2285,
-        "main-es2015": 218340,
-        "polyfills-es2015": 36709,
-        "5-es2015": 777
+        "runtime-es2015": 2289,
+        "main-es2015": 218507,
+        "polyfills-es2015": 36723,
+        "5-es2015": 781
       }
     }
   },

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -119,7 +119,11 @@ export class NgZone {
   readonly onError: EventEmitter<any> = new EventEmitter(false);
 
 
-  constructor({enableLongStackTrace = false, shouldCoalesceEventChangeDetection = false}) {
+  constructor({
+    enableLongStackTrace = false,
+    shouldCoalesceEventChangeDetection = false,
+    shouldCoalesceRunChangeDetection = false
+  }) {
     if (typeof Zone == 'undefined') {
       throw new Error(`In this configuration Angular requires Zone.js`);
     }
@@ -141,8 +145,11 @@ export class NgZone {
     if (enableLongStackTrace && (Zone as any)['longStackTraceZoneSpec']) {
       self._inner = self._inner.fork((Zone as any)['longStackTraceZoneSpec']);
     }
-
-    self.shouldCoalesceEventChangeDetection = shouldCoalesceEventChangeDetection;
+    // if shouldCoalesceRunChangeDetection is true, all tasks including event tasks will be
+    // coalesced, so shouldCoalesceEventChangeDetection option is not necessary and can be skipped.
+    self.shouldCoalesceEventChangeDetection =
+        !shouldCoalesceRunChangeDetection && shouldCoalesceEventChangeDetection;
+    self.shouldCoalesceRunChangeDetection = shouldCoalesceRunChangeDetection;
     self.lastRequestAnimationFrameId = -1;
     self.nativeRequestAnimationFrame = getNativeRequestAnimationFrame().nativeRequestAnimationFrame;
     forkInnerZoneWithAngularBehavior(self);
@@ -241,11 +248,49 @@ interface NgZonePrivate extends NgZone {
   hasPendingMicrotasks: boolean;
   lastRequestAnimationFrameId: number;
   isStable: boolean;
+  /**
+   * Optionally specify coalescing event change detections or not.
+   * Consider the following case.
+   *
+   * <div (click)="doSomething()">
+   *   <button (click)="doSomethingElse()"></button>
+   * </div>
+   *
+   * When button is clicked, because of the event bubbling, both
+   * event handlers will be called and 2 change detections will be
+   * triggered. We can coalesce such kind of events to trigger
+   * change detection only once.
+   *
+   * By default, this option will be false. So the events will not be
+   * coalesced and the change detection will be triggered multiple times.
+   * And if this option be set to true, the change detection will be
+   * triggered async by scheduling it in an animation frame. So in the case above,
+   * the change detection will only be trigged once.
+   */
   shouldCoalesceEventChangeDetection: boolean;
+  /**
+   * Optionally specify if `NgZone#run()` method invocations should be coalesced
+   * into a single change detection.
+   *
+   * Consider the following case.
+   *
+   * for (let i = 0; i < 10; i ++) {
+   *   ngZone.run(() => {
+   *     // do something
+   *   });
+   * }
+   *
+   * This case triggers the change detection multiple times.
+   * With ngZoneRunCoalescing options, all change detections in an event loops trigger only once.
+   * In addition, the change detection executes in requestAnimation.
+   *
+   */
+  shouldCoalesceRunChangeDetection: boolean;
+
   nativeRequestAnimationFrame: (callback: FrameRequestCallback) => number;
 
-  // Cache of  "fake" top eventTask. This is done so that we don't need to schedule a new task every
-  // time we want to run a `checkStable`.
+  // Cache a  "fake" top eventTask so you don't need to schedule a new task every
+  // time you run a `checkStable`.
   fakeTopEventTask: Task;
 }
 
@@ -297,12 +342,9 @@ function forkInnerZoneWithAngularBehavior(zone: NgZonePrivate) {
   const delayChangeDetectionForEventsDelegate = () => {
     delayChangeDetectionForEvents(zone);
   };
-  const maybeDelayChangeDetection = !!zone.shouldCoalesceEventChangeDetection &&
-      zone.nativeRequestAnimationFrame && delayChangeDetectionForEventsDelegate;
   zone._inner = zone._inner.fork({
     name: 'angular',
-    properties:
-        <any>{'isAngularZone': true, 'maybeDelayChangeDetection': maybeDelayChangeDetection},
+    properties: <any>{'isAngularZone': true},
     onInvokeTask:
         (delegate: ZoneDelegate, current: Zone, target: Zone, task: Task, applyThis: any,
          applyArgs: any): any => {
@@ -310,13 +352,13 @@ function forkInnerZoneWithAngularBehavior(zone: NgZonePrivate) {
             onEnter(zone);
             return delegate.invokeTask(target, task, applyThis, applyArgs);
           } finally {
-            if (maybeDelayChangeDetection && task.type === 'eventTask') {
-              maybeDelayChangeDetection();
+            if ((zone.shouldCoalesceEventChangeDetection && task.type === 'eventTask') ||
+                zone.shouldCoalesceRunChangeDetection) {
+              delayChangeDetectionForEventsDelegate();
             }
             onLeave(zone);
           }
         },
-
 
     onInvoke:
         (delegate: ZoneDelegate, current: Zone, target: Zone, callback: Function, applyThis: any,
@@ -325,6 +367,9 @@ function forkInnerZoneWithAngularBehavior(zone: NgZonePrivate) {
             onEnter(zone);
             return delegate.invoke(target, callback, applyThis, applyArgs, source);
           } finally {
+            if (zone.shouldCoalesceRunChangeDetection) {
+              delayChangeDetectionForEventsDelegate();
+            }
             onLeave(zone);
           }
         },
@@ -355,7 +400,8 @@ function forkInnerZoneWithAngularBehavior(zone: NgZonePrivate) {
 
 function updateMicroTaskStatus(zone: NgZonePrivate) {
   if (zone._hasPendingMicrotasks ||
-      (zone.shouldCoalesceEventChangeDetection && zone.lastRequestAnimationFrameId !== -1)) {
+      ((zone.shouldCoalesceEventChangeDetection || zone.shouldCoalesceRunChangeDetection) &&
+       zone.lastRequestAnimationFrameId !== -1)) {
     zone.hasPendingMicrotasks = true;
   } else {
     zone.hasPendingMicrotasks = false;

--- a/packages/platform-browser/test/dom/events/event_manager_spec.ts
+++ b/packages/platform-browser/test/dom/events/event_manager_spec.ts
@@ -335,46 +335,130 @@ describe('EventManager', () => {
     expect(receivedEvent).toBe(null);
   });
 
-  it('should only trigger one Change detection when bubbling', (done: DoneFn) => {
-    doc = getDOM().supportsDOMEvents() ? document : getDOM().createHtmlDocument();
-    zone = new NgZone({shouldCoalesceEventChangeDetection: true});
-    domEventPlugin = new DomEventsPlugin(doc);
-    const element = el('<div></div>');
-    const child = el('<div></div>');
-    element.appendChild(child);
-    doc.body.appendChild(element);
-    const dispatchedEvent = createMouseEvent('click');
-    let receivedEvents: any = [];
-    let stables: any = [];
-    const handler = (e: any) => {
-      receivedEvents.push(e);
-    };
-    const manager = new EventManager([domEventPlugin], zone);
-    let removerChild: any;
-    let removerParent: any;
+  it('should only trigger one Change detection when bubbling with shouldCoalesceEventChangeDetection = true',
+     (done: DoneFn) => {
+       doc = getDOM().supportsDOMEvents() ? document : getDOM().createHtmlDocument();
+       zone = new NgZone({shouldCoalesceEventChangeDetection: true});
+       domEventPlugin = new DomEventsPlugin(doc);
+       const element = el('<div></div>');
+       const child = el('<div></div>');
+       element.appendChild(child);
+       doc.body.appendChild(element);
+       const dispatchedEvent = createMouseEvent('click');
+       let receivedEvents: any = [];
+       let stables: any = [];
+       const handler = (e: any) => {
+         receivedEvents.push(e);
+       };
+       const manager = new EventManager([domEventPlugin], zone);
+       let removerChild: any;
+       let removerParent: any;
 
-    zone.run(() => {
-      removerChild = manager.addEventListener(child, 'click', handler);
-      removerParent = manager.addEventListener(element, 'click', handler);
-    });
-    zone.onStable.subscribe((isStable: any) => {
-      stables.push(isStable);
-    });
-    getDOM().dispatchEvent(child, dispatchedEvent);
-    requestAnimationFrame(() => {
-      expect(receivedEvents.length).toBe(2);
-      expect(stables.length).toBe(1);
+       zone.run(() => {
+         removerChild = manager.addEventListener(child, 'click', handler);
+         removerParent = manager.addEventListener(element, 'click', handler);
+       });
+       zone.onStable.subscribe((isStable: any) => {
+         stables.push(isStable);
+       });
+       getDOM().dispatchEvent(child, dispatchedEvent);
+       requestAnimationFrame(() => {
+         expect(receivedEvents.length).toBe(2);
+         expect(stables.length).toBe(1);
 
-      removerChild && removerChild();
-      removerParent && removerParent();
-      done();
-    });
-  });
+         removerChild && removerChild();
+         removerParent && removerParent();
+         done();
+       });
+     });
+
+  it('should only trigger one Change detection when bubbling with shouldCoalesceRunChangeDetection = true',
+     (done: DoneFn) => {
+       doc = getDOM().supportsDOMEvents() ? document : getDOM().createHtmlDocument();
+       zone = new NgZone({shouldCoalesceRunChangeDetection: true});
+       domEventPlugin = new DomEventsPlugin(doc);
+       const element = el('<div></div>');
+       const child = el('<div></div>');
+       element.appendChild(child);
+       doc.body.appendChild(element);
+       const dispatchedEvent = createMouseEvent('click');
+       let receivedEvents: any = [];
+       let stables: any = [];
+       const handler = (e: any) => {
+         receivedEvents.push(e);
+       };
+       const manager = new EventManager([domEventPlugin], zone);
+       let removerChild: any;
+       let removerParent: any;
+
+       zone.run(() => {
+         removerChild = manager.addEventListener(child, 'click', handler);
+         removerParent = manager.addEventListener(element, 'click', handler);
+       });
+       zone.onStable.subscribe((isStable: any) => {
+         stables.push(isStable);
+       });
+       getDOM().dispatchEvent(child, dispatchedEvent);
+       requestAnimationFrame(() => {
+         expect(receivedEvents.length).toBe(2);
+         expect(stables.length).toBe(1);
+
+         removerChild && removerChild();
+         removerParent && removerParent();
+         done();
+       });
+     });
 
   it('should not drain micro tasks queue too early with shouldCoalesceEventChangeDetection=true',
      (done: DoneFn) => {
        doc = getDOM().supportsDOMEvents() ? document : getDOM().createHtmlDocument();
        zone = new NgZone({shouldCoalesceEventChangeDetection: true});
+       domEventPlugin = new DomEventsPlugin(doc);
+       const element = el('<div></div>');
+       const child = el('<div></div>');
+       doc.body.appendChild(element);
+       const dispatchedClickEvent = createMouseEvent('click');
+       const dispatchedBlurEvent: FocusEvent =
+           getDOM().getDefaultDocument().createEvent('FocusEvent');
+       dispatchedBlurEvent.initEvent('blur', true, true);
+       let logs: any = [];
+       const handler = () => {};
+
+       const blurHandler = (e: any) => {
+         logs.push('blur');
+       };
+       const manager = new EventManager([domEventPlugin], zone);
+       let removerParent: any;
+       let removerChildFocus: any;
+
+       zone.run(() => {
+         removerParent = manager.addEventListener(element, 'click', handler);
+         removerChildFocus = manager.addEventListener(child, 'blur', blurHandler);
+       });
+       const sub = zone.onStable.subscribe(() => {
+         logs.push('begin');
+         Promise.resolve().then(() => {
+           logs.push('promise resolved');
+         });
+         element.appendChild(child);
+         getDOM().dispatchEvent(child, dispatchedBlurEvent);
+         sub.unsubscribe();
+         logs.push('end');
+       });
+       getDOM().dispatchEvent(element, dispatchedClickEvent);
+       requestAnimationFrame(() => {
+         expect(logs).toEqual(['begin', 'blur', 'end', 'promise resolved']);
+
+         removerParent && removerParent();
+         removerChildFocus && removerChildFocus();
+         done();
+       });
+     });
+
+  it('should not drain micro tasks queue too early with shouldCoalesceRunChangeDetection=true',
+     (done: DoneFn) => {
+       doc = getDOM().supportsDOMEvents() ? document : getDOM().createHtmlDocument();
+       zone = new NgZone({shouldCoalesceRunChangeDetection: true});
        domEventPlugin = new DomEventsPlugin(doc);
        const element = el('<div></div>');
        const child = el('<div></div>');


### PR DESCRIPTION
Close #39348

Now `NgZone` has an option `shouldCoalesceEventChangeDetection` to coalesce
multiple event handler's change detections to one async change detection.

And there are some cases other than `event handler` have the same issues.
In #39348, the case like this.

```
// This code results in one change detection occurring per
// ngZone.run() call. This is entirely feasible, and can be a serious
// performance issue.
for (let i = 0; i < 100; i++) {
  this.ngZone.run(() => {
    // do something
  });
}
```

So such kind of case will trigger multiple change detections.
And now with Ivy, we have a new `markDirty()` API will schedule
a requestAnimationFrame to trigger change detection and also coalesce
the change detections in the same event loop, `markDirty()` API doesn't
only take care `event handler` but also all other cases `sync/macroTask/..`

So this PR add a new option to coalesce change detections for all cases.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:
