### PR TITLE
docs(core): update a typo in the comment of ngZoneEventCoalescing

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -263,7 +263,7 @@ export interface BootstrapOptions {
    * coalesced and the change detection will be triggered multiple times.
    * And if this option be set to true, the change detection will be
    * triggered async by scheduling a animation frame. So in the case above,
-   * the change detection will only be trigged once.
+   * the change detection will only be triggered once.
    */
   ngZoneEventCoalescing?: boolean;
 }


### PR DESCRIPTION
Fix a typo in the comment of `ngZoneEventCoalescing`