### PR TITLE
Allow for opting a single PR out of PullApprove

### DIFF
--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -12,7 +12,7 @@ export const merge: DevInfraMergeConfig['merge'] = async api => {
     githubApiMerge: false,
     claSignedLabel: 'cla: yes',
     mergeReadyLabel: /^action: merge(-assistance)?/,
-    caretakerNoteLabel: 'action: merge-assistance',
+    caretakerNoteLabel: /^(action: merge-assistance)|(PullApprove: disable)/,
     commitMessageFixupLabel: 'commit message fixup',
     // We can pick any of the NPM packages as we are in a monorepo where all packages are
     // published together with the same version and branching.

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -103,6 +103,8 @@ meta:
 github_api_version: "shadow-cat-preview"
 
 pullapprove_conditions:
+  # For PRs which are still being worked on, either still in draft mode or indicated through WIP in
+  # title or label, PullApprove stays in a pending state until its ready for review.
   - condition: "'WIP' not in title"
     unmet_status: pending
     explanation: "Waiting to send reviews as PR is WIP"
@@ -112,6 +114,10 @@ pullapprove_conditions:
   - condition: "not draft"
     unmet_status: pending
     explanation: "Waiting to send reviews as PR is in draft"
+  # Disable PullApprove on specific PRs by adding the `PullApprove: disable` label
+  - condition: "'PullApprove: disable' not in labels"
+    unmet_status: success
+    explanation: "PullApprove skipped because of 'PullApprove: disable' label"
 
 
 groups:


### PR DESCRIPTION
Alowing for disabling PullApprove on a single PR via adding a label allows
for an escape hatch if PullApprove is not acting as expected, or for cases
where reviews can be stepped over in obvious situations, such as a revert.
