### PR TITLE
docs(zone.js): update release doc

### DIFF
--- a/packages/zone.js/DEVELOPER.md
+++ b/packages/zone.js/DEVELOPER.md
@@ -92,12 +92,12 @@ Create a dry run build to make sure everything is ready.
 yarn bazel --output_base=$(mktemp -d) run //packages/zone.js:npm_package.pack --workspace_status_command="echo BUILD_SCM_VERSION $VERSION"
 ```
 
-If everything looks good commit the changes and push them to your origin to create a PR.
+If everything looks good, commit the changes and push them to your origin to create a PR.
 
 ```
-git co -b "release_${TAG}"
+git checkout -b "release_${TAG}"
 git add packages/zone.js/CHANGELOG.md packages/zone.js/package.json
-git ci -m "release: cut the ${TAG} release"
+git commit -m "release: cut the ${TAG} release"
 git push origin "release_${TAG}"
 ```
 
@@ -114,7 +114,7 @@ export VERSION=`(node -e "console.log(require('./packages/zone.js/package.json')
 export TAG="zone.js-${VERSION}"
 export SHA=`git log upstream/master --oneline -n 1000 | grep "release: cut the ${TAG} release" | cut -f 1 -d " "`
 echo "Releasing '$VERSION' which will be tagged as '$TAG' from SHA '$SHA'."
-git co ${SHA}
+git checkout ${SHA}
 npm login --registry https://wombat-dressing-room.appspot.com
 yarn bazel -- run --config=release -- //packages/zone.js:npm_package.publish --access public --tag latest
 git tag ${TAG} ${SHA}


### PR DESCRIPTION
In the current release doc, we are using some shortcut of `git` command
such as `git ci` `git co`, so in this PR we are updating them
to the normal command, so these commands will work event without
these shortcuts.

