### PR TITLE
fix(dev-infra): ensure hashbang is present in both published and local ng-devs

### DIFF
--- a/dev-infra/BUILD.bazel
+++ b/dev-infra/BUILD.bazel
@@ -26,12 +26,19 @@ ts_library(
 
 rollup_bundle(
     name = "cli_rollup",
+    args = [
+        "--plugin",
+        "rollup-plugin-hashbang",
+    ],
     entry_point = ":cli.ts",
     format = "cjs",
     silent = True,
     sourcemap = "false",
     deps = [
         ":cli",
+        # TODO(josephperrott): Determine if this plugin is the best method for ensuring the hashbang
+        # in both local and published use case.
+        "@npm//rollup-plugin-hashbang",
     ],
 )
 

--- a/dev-infra/cli.ts
+++ b/dev-infra/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright Google LLC All Rights Reserved.

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 'use strict';
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
@@ -6777,13 +6778,6 @@ function convertReferenceChainToString(chain) {
     return chain.join(' → ');
 }
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 yargs.scriptName('ng-dev')
     .middleware(captureLogOutputForCommand)
     .demandCommand()

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "nock": "^13.0.3",
     "ora": "^5.0.0",
     "rewire": "2.5.2",
+    "rollup-plugin-hashbang": "^2.2.2",
     "sauce-connect": "https://saucelabs.com/downloads/sc-4.6.2-linux.tar.gz",
     "semver": "^6.3.0",
     "ts-node": "^8.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10087,6 +10087,13 @@ magic-string@0.25.7, magic-string@^0.25.2:
   dependencies:
     sourcemap-codec "^1.4.4"
 
+magic-string@^0.22.4:
+  version "0.22.5"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.5.tgz#8e9cf5afddf44385c1da5bc2a6a0dbd10b03657e"
+  integrity sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==
+  dependencies:
+    vlq "^0.2.2"
+
 make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -13349,6 +13356,13 @@ rollup-plugin-commonjs@^10.1.0:
     resolve "^1.11.0"
     rollup-pluginutils "^2.8.1"
 
+rollup-plugin-hashbang@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-hashbang/-/rollup-plugin-hashbang-2.2.2.tgz#971fc49b452e63f9dfdc75f79ae7256b3485e750"
+  integrity sha512-Yxw9ogeK3KncG1e4CvK0I0IKVBNeJP+DTZS3bExGTfGjw0WP1C7xxbY7LtRd8IKx4fFf53hz7XR1XG7UV6xqCw==
+  dependencies:
+    magic-string "^0.22.4"
+
 rollup-plugin-node-resolve@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz#730f93d10ed202473b1fb54a5997a7db8c6d8523"
@@ -15817,6 +15831,11 @@ vlq@0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.2.tgz#e316d5257b40b86bb43cb8d5fea5d7f54d6b0ca1"
   integrity sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE=
+
+vlq@^0.2.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
+  integrity sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==
 
 vm-browserify@^1.0.1:
   version "1.1.2"


### PR DESCRIPTION
The node hash bang was incidentally removed in the published `ng-dev`, it should
be included to allow for the command to be run without having to specify node.
