### PR TITLE
docs: add `enableI18nLegacyMessageIdFormat` option to Angular compile…

### DIFF
--- a/aio/content/guide/angular-compiler-options.md
+++ b/aio/content/guide/angular-compiler-options.md
@@ -77,6 +77,19 @@ When `false`, disables this rewriting, requiring the rewriting to be done manual
 
 When `true`, the compiler does not check the TypeScript version and does not report an error when an unsupported version of TypeScript is used. Not recommended, as unsupported versions of TypeScript might have undefined behavior. Default is `false`.
 
+### `enableI18nLegacyMessageIdFormat`
+
+Instructs the Angular template compiler to generate legacy ids for messages that are tagged in templates by the `i18n` attribute.
+See [Localizing your app](guide/i18n#mark-text-for-translations) for more information about marking messages for localization.
+
+Set this option to `false` unless your project relies upon translations that were previously generated using legacy ids. Default is `true`.
+
+The pre-Ivy message extraction tooling generated a variety of legacy formats for extracted message ids.
+These message formats have a number of issues, such as whitespace handling and reliance upon information inside the original HTML of a template.
+
+The new message format is more resilient to whitespace changes, is the same across all translation file formats, and can be generated directly from calls to `$localize`.
+This allows `$localize` messages in application code to use the same id as identical `i18n` messages in component templates.
+
 ### `enableIvy`
 
 Enables the [Ivy](guide/ivy) compilation and rendering pipeline. Default is `true`, as of version 9. In version 9, you can [opt out of Ivy](guide/ivy#opting-out-of-angular-ivy) to continue using the previous compiler, View Engine.

--- a/aio/content/guide/typescript-configuration.md
+++ b/aio/content/guide/typescript-configuration.md
@@ -20,6 +20,12 @@ that are important to Angular developers, including details about the following 
 A given Angular workspace contains several TypeScript configuration files.
 At the root `tsconfig.json` file specifies the base TypeScript and Angular compiler options that all projects in the workspace inherit.
 
+<div class="alert is-helpful">
+
+See the [Angular compiler options](guide/angular-compiler-options) guide for information about what Angular specific options are available.
+
+</div>
+
 The TypeScript and Angular have a wide range of options which can be used to configure type-checking features and generated output.
 For more information, see the [Configuration inheritance with extends](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#configuration-inheritance-with-extends) section of the TypeScript documentation.
 


### PR DESCRIPTION
…r options guide

The ViewEngine message extraction generated a variety of legacy formats
for extracted message ids. These formats have a number of issues related
to whitespace handling and reliance upon information inside the original
HTML of a template. The new message format is more resilient, and can be
generated directly from calls to `$localize`. This allows messages in
application code to have the same id as identical messages in templates.

As a first step in migrating projects away from the legacy id format
for i18n messages, newly generated projects now turn off the legacy ids.
See https://github.com/angular/angular-cli/pull/19232.

This commit updates the documentation to include information about this
option, since it is now publicly exposed in new CLI projects.
