### PR TITLE
build: ensure script that build the Zone.js package can be run from any directory

### DIFF
--- a/docs/BAZEL.md
+++ b/docs/BAZEL.md
@@ -120,7 +120,7 @@ Apple+Shift+D on Mac) and click on the green play icon next to the configuration
 
 Open `external` directory which contains everything that bazel downloaded while executing the workspace file:
 ```sh
-open $(bazel info output_base)/external
+open $(yarn -s bazel info output_base)/external
 ```
 
 See subcommands that bazel executes (helpful for debugging):
@@ -130,7 +130,7 @@ yarn bazel build //packages/core:package -s
 
 To debug nodejs_binary executable paths uncomment `find . -name rollup 1>&2` (~ line 96) in
 ```sh
-open $(bazel info output_base)/external/build_bazel_rules_nodejs/internal/node_launcher.sh
+open $(yarn -s bazel info output_base)/external/build_bazel_rules_nodejs/internal/node_launcher.sh
 ```
 
 ## Stamping

--- a/scripts/build/package-builder.js
+++ b/scripts/build/package-builder.js
@@ -116,15 +116,17 @@ function buildTargetPackages(destPath, enableIvy, description) {
  *
  * @param {string} cmd The command to run.
  * @param {boolean} [captureStdout=false] Whether to return the output of the command.
+ * @param {import('child_process').ExecSyncOptions} [options] The options to pass to `execSync()`.
  * @return {string | undefined} The captured stdout output if `captureStdout: true` or `undefined`.
  */
-function exec(cmd, captureStdout) {
+function exec(cmd, captureStdout, options) {
   const output = execSync(cmd, {
     stdio: [
       /* stdin  */ 'inherit',
       /* stdout */ captureStdout ? 'pipe' : 'inherit',
       /* stderr */ 'inherit',
     ],
+    ...options,
   });
 
   if (captureStdout) {

--- a/scripts/build/zone-js-builder.js
+++ b/scripts/build/zone-js-builder.js
@@ -48,7 +48,7 @@ function buildZoneJsPackage(destPath) {
 
   // Also create an archive so we can test the package itself.
   // Currently, the `npm_package.pack` rule does not work on Windows, so run `npm pack` directly.
-  exec(`npm pack ${buildOutputDir}`);
+  exec(`npm pack ${buildOutputDir}`, false, {cwd: baseDir});
 
   console.info(`# Copy npm_package artifacts to ${distTargetDir}`);
   rm('-rf', distTargetDir);


### PR DESCRIPTION
The scripts that build the Angular and Zone.js NPM packages rely on absolute paths in order to work correctly regardless of what the current working directory is when the scripts are invoked. However, the `npm pack` command executed in the `zone-js-builder.js` script outputs the generated `.tgz` archive in the current working directory. This causes the script to fail when invoked for any working directory other than the project root directory.

This commit fixes this by ensuring the `npm pack` command is run with the project root directory as the working directory. This allows the build scripts to run correctly regardless of the working directory they are invoked from.
