### PR TITLE
fix(router): Ensure all outlets are used when commands has a prefix

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1377,9 +1377,6 @@
     "name": "getParentInjectorView"
   },
   {
-    "name": "getPath"
-  },
-  {
     "name": "getPathIndexShift"
   },
   {
@@ -1489,6 +1486,9 @@
   },
   {
     "name": "isArrayLike"
+  },
+  {
+    "name": "isCommandWithOutlets"
   },
   {
     "name": "isComponentDef"

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -186,13 +186,6 @@ function createPositionApplyingDoubleDots(
   return new Position(g, false, ci - dd);
 }
 
-function getPath(command: any): any {
-  if (isCommandWithOutlets(command)) {
-    return command.outlets[PRIMARY_OUTLET];
-  }
-  return `${command}`;
-}
-
 function getOutlets(commands: any[]): {[k: string]: any[]} {
   if (isCommandWithOutlets(commands[0])) {
     return commands[0].outlets;
@@ -259,7 +252,14 @@ function prefixedWith(segmentGroup: UrlSegmentGroup, startIndex: number, command
   while (currentPathIndex < segmentGroup.segments.length) {
     if (currentCommandIndex >= commands.length) return noMatch;
     const path = segmentGroup.segments[currentPathIndex];
-    const curr = getPath(commands[currentCommandIndex]);
+    const command = commands[currentCommandIndex];
+    // Do not try to consume command as part of the prefixing if it has outlets because it can
+    // contain outlets other than the one being processed. Consuming the outlets command would
+    // result in other outlets being ignored.
+    if (isCommandWithOutlets(command)) {
+      break;
+    }
+    const curr = `${command}`;
     const next =
         currentCommandIndex < commands.length - 1 ? commands[currentCommandIndex + 1] : null;
 
@@ -298,7 +298,7 @@ function createNewSegmentGroup(
       continue;
     }
 
-    const curr = getPath(command);
+    const curr = isCommandWithOutlets(command) ? command.outlets[PRIMARY_OUTLET] : `${command}`;
     const next = (i < commands.length - 1) ? commands[i + 1] : null;
     if (curr && next && isMatrixParams(next)) {
       paths.push(new UrlSegment(curr, stringify(next)));

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -150,13 +150,13 @@ describe('createUrlTree', () => {
       expect(serializer.serialize(t)).toEqual('/parent/child');
     });
 
-    xit('should support updating secondary and primary outlets with prefix', () => {
+    it('should support updating secondary and primary outlets with prefix', () => {
       const p = serializer.parse('/parent/child');
       const t = createRoot(p, ['parent', {outlets: {primary: 'child', secondary: 'popup'}}]);
       expect(serializer.serialize(t)).toEqual('/parent/(child//secondary:popup)');
     });
 
-    xit('should support updating two outlets at the same time relative to non-root segment', () => {
+    it('should support updating two outlets at the same time relative to non-root segment', () => {
       const p = serializer.parse('/parent/child');
       const t = create(
           p.root.children[PRIMARY_OUTLET], 0 /* relativeTo: 'parent' */, p,


### PR DESCRIPTION
Note: Easiest to review is per-commit. 

Commit 1: A refactor only. No functional changes. Also documents behavior with tests and coherent example config.
Commit 2: Small change to allow tests from commit 1 to pass.

When there is a primary outlet present in the outlets map and the object is also prefixed
with some other commands, the current logic only uses the primary outlet and ignores
the others. This change ensures that all outlets are respected at the
segment level when prefixed with other commands.

Fixes issue that prevented navigation in #39401. 
Partially addressed #13523 - That issue, along with #15718, stem from a general difficulty to change outlets because one has to specify the change using the correct segment 'level' (see tests named `should not clear secondary outlet when at root and prefix is used` and `should not clear non-root secondary outlet when command is targeting root`). Additionally, it's still not possible to change two outlets that appear at different levels in the config in a single navigation.