### PR TITLE
build: bring .gitignore on patch in line with master and rc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ baseline.json
 
 # Ignore .history for the xyz.local-history VSCode extension
 .history
+
+# CLDR data
+tools/gulp-tasks/cldr/cldr-data/
+
+# Husky
+.husky/_


### PR DESCRIPTION
Adds the two missing entries from .gitignore to the .gitignore file
on the patch branch
