### PR TITLE
fix(core): dynamic onPush component should trigger change detection correctly

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -195,10 +195,11 @@ export function createRootComponentView(
   }
 
   const viewRenderer = rendererFactory.createRenderer(rNode, def);
+  // If the componentDef.onPush is true, we will set the flags to the host view,
+  // so the componentView[FLAGS] will always be LViewFlags.CheckAlways
   const componentView = createLView(
-      rootView, getOrCreateTComponentView(def), null,
-      def.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways, rootView[index], tNode,
-      rendererFactory, viewRenderer, sanitizer || null, null);
+      rootView, getOrCreateTComponentView(def), null, LViewFlags.CheckAlways, rootView[index],
+      tNode, rendererFactory, viewRenderer, sanitizer || null, null);
 
   if (tView.firstCreatePass) {
     diPublicInInjector(getOrCreateNodeInjectorForNode(tNode, rootView), tView, def.type);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -35,7 +35,7 @@ import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_COMPONENT_VIEW, DE
 import {assertPureTNodeType, assertTNodeType} from '../node_assert';
 import {updateTextNode} from '../node_manipulation';
 import {isInlineTemplate, isNodeMatchingSelectorList} from '../node_selector_matcher';
-import {enterView, getBindingsEnabled, getCurrentDirectiveIndex, getCurrentParentTNode, getCurrentTNode, getCurrentTNodePlaceholderOk, getSelectedIndex, isCurrentTNodeParent, isInCheckNoChangesMode, isInI18nBlock, leaveView, setBindingIndex, setBindingRootForHostBindings, setCurrentDirectiveIndex, setCurrentQueryIndex, setCurrentTNode, setIsInCheckNoChangesMode, setSelectedIndex} from '../state';
+import {enterView, getBindingsEnabled, getCurrentDirectiveIndex, getCurrentParentTNode, getCurrentTNode, getCurrentTNodePlaceholderOk, getSelectedIndex, isCurrentTNodeParent, isInCheckNoChangesMode, isInI18nBlock, isOnPushCheckNoChangesEnabled, leaveView, setBindingIndex, setBindingRootForHostBindings, setCurrentDirectiveIndex, setCurrentQueryIndex, setCurrentTNode, setIsInCheckNoChangesMode, setSelectedIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 import {isAnimationProp, mergeHostAttrs} from '../util/attrs_utils';
 import {INTERPOLATION_DELIMITER, renderStringify, stringifyForError} from '../util/misc_utils';
@@ -1675,7 +1675,8 @@ function isLRootViewAndNeedToCheck(lView: any): boolean {
   if (!isLView(lView) || lView[TVIEW].type !== TViewType.Root) {
     return true;
   }
-  if (!(lView[FLAGS] & LViewFlags.CheckAlways) && isInCheckNoChangesMode()) {
+  if (!(lView[FLAGS] & LViewFlags.CheckAlways) && isInCheckNoChangesMode() &&
+      !isOnPushCheckNoChangesEnabled()) {
     return false;
   }
 
@@ -1940,7 +1941,8 @@ export function detectChangesInRootView(lView: LView): void {
 export function checkNoChangesInternal<T>(tView: TView, view: LView, context: T) {
   setIsInCheckNoChangesMode(true);
   try {
-    if (tView.type === TViewType.Root && !(view[FLAGS] & LViewFlags.CheckAlways)) {
+    if (tView.type === TViewType.Root && !(view[FLAGS] & LViewFlags.CheckAlways) &&
+        !isOnPushCheckNoChangesEnabled()) {
       // This is a root view of the OnPush component, we need to skip the change detection
       // code path to keep the current behavior.
       // TODO: @JiaLiPassion, need to fix this later since this is a bug.
@@ -1964,7 +1966,8 @@ export function checkNoChangesInternal<T>(tView: TView, view: LView, context: T)
 export function checkNoChangesInRootView(lView: LView): void {
   setIsInCheckNoChangesMode(true);
   try {
-    if (lView[TVIEW].type === TViewType.Root && !(lView[FLAGS] & LViewFlags.CheckAlways)) {
+    if (lView[TVIEW].type === TViewType.Root && !(lView[FLAGS] & LViewFlags.CheckAlways) &&
+        !isOnPushCheckNoChangesEnabled()) {
       // This is a root view of the OnPush component, we need to skip the change detection
       // code path to keep the current behavior.
       // TODO: @JiaLiPassion, need to fix this later since this is a bug.

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -13,6 +13,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {ivyEnabled} from '@angular/private/testing';
 import {BehaviorSubject} from 'rxjs';
+import {setIsOnPushCheckNoChangesEnabled} from '../../src/render3/state';
 
 describe('change detection', () => {
   describe('embedded views', () => {
@@ -1638,543 +1639,558 @@ describe('change detection', () => {
       // });
     });
 
-    describe('OnPush', () => {
-      @Component({template: '...', changeDetection: ChangeDetectionStrategy.OnPush})
-      class MyApp {
-        a: string = 'a';
-        b: string = 'b';
-        c: string = 'c';
-        unstableBooleanExpression: boolean = true;
-        unstableStringExpression: string = 'initial';
-        unstableColorExpression: string = 'red';
-        unstableStyleMapExpression: {[key: string]: string;} = {'color': 'red', 'margin': '10px'};
-        unstableClassMapExpression: {[key: string]: boolean;} = {'classA': true, 'classB': false};
+    const iOnPushCheckNoChangesEnabledOptions = [false, true];
+    iOnPushCheckNoChangesEnabledOptions.forEach(isOnPushCheckNoChangesEnabled => {
+      // isOnPushCheckNoChangesEnabled option only works for Ivy
+      isOnPushCheckNoChangesEnabled = ivyEnabled && isOnPushCheckNoChangesEnabled;
+      describe(`isOnPushCheckNoChangesEnabled = ${isOnPushCheckNoChangesEnabled}`, () => {
+        beforeEach(() => {
+          setIsOnPushCheckNoChangesEnabled(isOnPushCheckNoChangesEnabled);
+        });
+        afterEach(() => {
+          setIsOnPushCheckNoChangesEnabled(false);
+        });
+        describe('OnPush', () => {
+          @Component({template: '...', changeDetection: ChangeDetectionStrategy.OnPush})
+          class MyApp {
+            a: string = 'a';
+            b: string = 'b';
+            c: string = 'c';
+            unstableBooleanExpression: boolean = true;
+            unstableStringExpression: string = 'initial';
+            unstableColorExpression: string = 'red';
+            unstableStyleMapExpression:
+                {[key: string]: string;} = {'color': 'red', 'margin': '10px'};
+            unstableClassMapExpression:
+                {[key: string]: boolean;} = {'classA': true, 'classB': false};
 
-        ngAfterViewChecked() {
-          this.unstableBooleanExpression = false;
-          this.unstableStringExpression = 'changed';
-          this.unstableColorExpression = 'green';
-          this.unstableStyleMapExpression = {'color': 'green', 'margin': '20px'};
-          this.unstableClassMapExpression = {'classA': false, 'classB': true};
-        }
-      }
+            ngAfterViewChecked() {
+              this.unstableBooleanExpression = false;
+              this.unstableStringExpression = 'changed';
+              this.unstableColorExpression = 'green';
+              this.unstableStyleMapExpression = {'color': 'green', 'margin': '20px'};
+              this.unstableClassMapExpression = {'classA': false, 'classB': true};
+            }
+          }
 
-      function initComponent(overrides: {[key: string]: any}): ComponentFixture<MyApp> {
-        TestBed.configureTestingModule({declarations: [MyApp]});
-        TestBed.overrideComponent(MyApp, {set: overrides});
-        const fixture = TestBed.createComponent(MyApp);
-        fixture.detectChanges();
-        return fixture;
-      }
+          function initComponent(overrides: {[key: string]: any}): ComponentFixture<MyApp> {
+            TestBed.configureTestingModule({declarations: [MyApp]});
+            TestBed.overrideComponent(MyApp, {set: overrides});
+            const fixture = TestBed.createComponent(MyApp);
+            fixture.detectChanges();
+            return fixture;
+          }
 
-      function initWithTemplate(template: string) {
-        return initComponent({template});
-      }
-      function initWithHostBindings(bindings: {[key: string]: string}) {
-        return initComponent({host: bindings});
-      }
+          function initWithTemplate(template: string) {
+            return initComponent({template});
+          }
+          function initWithHostBindings(bindings: {[key: string]: string}) {
+            return initComponent({host: bindings});
+          }
 
-      it('should include field name in case of property binding', () => {
-        const message = ivyEnabled ?
-            `Previous value for 'id': 'initial'. Current value: 'changed'` :
-            `Previous value: 'id: initial'. Current value: 'id: changed'`;
-        expect(() => initWithTemplate('<div [id]="unstableStringExpression"></div>'))
-            .not.toThrowError(new RegExp(message));
-      });
+          it('should include field name in case of property binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'id': 'initial'. Current value: 'changed'` :
+                `Previous value: 'id: initial'. Current value: 'id: changed'`;
+            let r = expect(() => initWithTemplate('<div [id]="unstableStringExpression"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should include field name in case of property interpolation', () => {
-        const message = ivyEnabled ?
-            `Previous value for 'id': 'Expressions: a and initial!'. Current value: 'Expressions: a and changed!'` :
-            `Previous value: 'id: Expressions: a and initial!'. Current value: 'id: Expressions: a and changed!'`;
-        expect(
-            () => initWithTemplate(
-                '<div id="Expressions: {{ a }} and {{ unstableStringExpression }}!"></div>'))
-            .not.toThrowError(new RegExp(message));
-      });
+          it('should include field name in case of property interpolation', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'id': 'Expressions: a and initial!'. Current value: 'Expressions: a and changed!'` :
+                `Previous value: 'id: Expressions: a and initial!'. Current value: 'id: Expressions: a and changed!'`;
+            let r = expect(
+                () => initWithTemplate(
+                    '<div id="Expressions: {{ a }} and {{ unstableStringExpression }}!"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should include field name in case of attribute binding', () => {
-        const message = ivyEnabled ?
-            `Previous value for 'attr.id': 'initial'. Current value: 'changed'` :
-            `Previous value: 'id: initial'. Current value: 'id: changed'`;
-        expect(() => initWithTemplate('<div [attr.id]="unstableStringExpression"></div>'))
-            .not.toThrowError(new RegExp(message));
-      });
+          it('should include field name in case of attribute binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'attr.id': 'initial'. Current value: 'changed'` :
+                `Previous value: 'id: initial'. Current value: 'id: changed'`;
+            let r =
+                expect(() => initWithTemplate('<div [attr.id]="unstableStringExpression"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should include field name in case of attribute interpolation', () => {
-        const message = ivyEnabled ?
-            `Previous value for 'attr.id': 'Expressions: a and initial!'. Current value: 'Expressions: a and changed!'` :
-            `Previous value: 'id: Expressions: a and initial!'. Current value: 'id: Expressions: a and changed!'`;
-        expect(
-            () => initWithTemplate(
-                '<div attr.id="Expressions: {{ a }} and {{ unstableStringExpression }}!"></div>'))
-            .not.toThrowError(new RegExp(message));
-      });
+          it('should include field name in case of attribute interpolation', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'attr.id': 'Expressions: a and initial!'. Current value: 'Expressions: a and changed!'` :
+                `Previous value: 'id: Expressions: a and initial!'. Current value: 'id: Expressions: a and changed!'`;
+            let r = expect(
+                () => initWithTemplate(
+                    '<div attr.id="Expressions: {{ a }} and {{ unstableStringExpression }}!"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should only display a value of an expression that was changed in text interpolation',
-         () => {
-           expect(
-               () => initWithTemplate('Expressions: {{ a }} and {{ unstableStringExpression }}!'))
-               .not.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
-         });
+          it('should only display a value of an expression that was changed in text interpolation',
+             () => {
+               let r = expect(
+                   () => initWithTemplate(
+                       'Expressions: {{ a }} and {{ unstableStringExpression }}!'));
+               r = isOnPushCheckNoChangesEnabled ? r : r.not;
+               r.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
+             });
 
-      it('should only display a value of an expression that was changed in text interpolation ' +
-             'that follows an element with property interpolation',
-         () => {
-           expect(() => {
-             initWithTemplate(`
+          it('should only display a value of an expression that was changed in text interpolation ' +
+                 'that follows an element with property interpolation',
+             () => {
+               let r = expect(() => {
+                 initWithTemplate(`
              <div id="Prop interpolation: {{ aVal }}"></div>
              Text interpolation: {{ unstableStringExpression }}.
            `);
-           }).not.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
-         });
+               });
+               r = isOnPushCheckNoChangesEnabled ? r : r.not;
+               r.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
+             });
 
-      it('should include style prop name in case of style binding', () => {
-        const message = ivyEnabled ? `Previous value for 'color': 'red'. Current value: 'green'` :
-                                     `Previous value: 'color: red'. Current value: 'color: green'`;
-        expect(() => initWithTemplate('<div [style.color]="unstableColorExpression"></div>'))
-            .not.toThrowError(new RegExp(message));
-      });
+          it('should include style prop name in case of style binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'color': 'red'. Current value: 'green'` :
+                `Previous value: 'color: red'. Current value: 'color: green'`;
+            let r = expect(
+                () => initWithTemplate('<div [style.color]="unstableColorExpression"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should include class name in case of class binding', () => {
-        const message = ivyEnabled ?
-            `Previous value for 'someClass': 'true'. Current value: 'false'` :
-            `Previous value: 'someClass: true'. Current value: 'someClass: false'`;
-        expect(() => initWithTemplate('<div [class.someClass]="unstableBooleanExpression"></div>'))
-            .not.toThrowError(new RegExp(message));
-      });
+          it('should include class name in case of class binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'someClass': 'true'. Current value: 'false'` :
+                `Previous value: 'someClass: true'. Current value: 'someClass: false'`;
+            let r = expect(
+                () =>
+                    initWithTemplate('<div [class.someClass]="unstableBooleanExpression"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should only display a value of an expression that was changed in text interpolation inside i18n block',
-         () => {
-           expect(
-               () => initWithTemplate('<div i18n>Expression: {{ unstableStringExpression }}</div>'))
-               .not.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
-         });
+          it('should only display a value of an expression that was changed in text interpolation inside i18n block',
+             () => {
+               let r = expect(
+                   () => initWithTemplate(
+                       '<div i18n>Expression: {{ unstableStringExpression }}</div>'));
+               r = isOnPushCheckNoChangesEnabled ? r : r.not;
+               r.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
+             });
 
-      it('should only display a value of an expression for interpolation inside an i18n property',
-         () => {
-           expect(
-               () => initWithTemplate(
-                   '<div i18n-title title="Expression: {{ unstableStringExpression }}"></div>'))
-               .not.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
-         });
+          it('should only display a value of an expression for interpolation inside an i18n property',
+             () => {
+               let r = expect(
+                   () => initWithTemplate(
+                       '<div i18n-title title="Expression: {{ unstableStringExpression }}"></div>'));
+               r = isOnPushCheckNoChangesEnabled ? r : r.not;
+               r.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
+             });
 
-      it('should include field name in case of host property binding', () => {
-        const message = ivyEnabled ?
-            `Previous value for 'id': 'initial'. Current value: 'changed'` :
-            `Previous value: 'id: initial'. Current value: 'id: changed'`;
-        // TODO: @JiaLiPassion, check ViewEngine behavior
-        let r = expect(() => initWithHostBindings({'[id]': 'unstableStringExpression'}));
-        r = ivyEnabled ? r.not : r;
-        r.toThrowError(new RegExp(message));
-      });
+          it('should include field name in case of host property binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'id': 'initial'. Current value: 'changed'` :
+                `Previous value: 'id: initial'. Current value: 'id: changed'`;
+            // TODO: @JiaLiPassion, check ViewEngine behavior
+            let r = expect(() => initWithHostBindings({'[id]': 'unstableStringExpression'}));
+            r = ivyEnabled && !isOnPushCheckNoChangesEnabled ? r.not : r;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should include style prop name in case of host style bindings', () => {
-        const message = ivyEnabled ? `Previous value for 'color': 'red'. Current value: 'green'` :
-                                     `Previous value: 'color: red'. Current value: 'color: green'`;
-        // TODO: @JiaLiPassion, check ViewEngine behavior
-        let r = expect(() => initWithHostBindings({'[style.color]': 'unstableColorExpression'}));
-        r = ivyEnabled ? r.not : r;
-        r.toThrowError(new RegExp(message));
-      });
+          it('should include style prop name in case of host style bindings', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'color': 'red'. Current value: 'green'` :
+                `Previous value: 'color: red'. Current value: 'color: green'`;
+            // TODO: @JiaLiPassion, check ViewEngine behavior
+            let r =
+                expect(() => initWithHostBindings({'[style.color]': 'unstableColorExpression'}));
+            r = ivyEnabled && !isOnPushCheckNoChangesEnabled ? r.not : r;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should include class name in case of host class bindings', () => {
-        const message = ivyEnabled ?
-            `Previous value for 'someClass': 'true'. Current value: 'false'` :
-            `Previous value: 'someClass: true'. Current value: 'someClass: false'`;
-        // TODO: @JiaLiPassion, check ViewEngine behavior
-        let r =
-            expect(() => initWithHostBindings({'[class.someClass]': 'unstableBooleanExpression'}));
-        r = ivyEnabled ? r.not : r;
-        r.toThrowError(new RegExp(message));
-      });
+          it('should include class name in case of host class bindings', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'someClass': 'true'. Current value: 'false'` :
+                `Previous value: 'someClass: true'. Current value: 'someClass: false'`;
+            // TODO: @JiaLiPassion, check ViewEngine behavior
+            let r = expect(
+                () => initWithHostBindings({'[class.someClass]': 'unstableBooleanExpression'}));
+            r = ivyEnabled && !isOnPushCheckNoChangesEnabled ? r.not : r;
+            r.toThrowError(new RegExp(message));
+          });
+        });
 
-      // Note: the tests below currently fail in Ivy, but not in VE. VE behavior is correct and
-      // Ivy's logic should be fixed by the upcoming styling refactor, we keep these tests to verify
-      // that.
-      //
-      // it('should not throw for style maps', () => {
-      //  expect(() => initWithTemplate('<div [style]="unstableStyleMapExpression"></div>'))
-      //      .not.toThrowError();
-      // });
-      //
-      // it('should not throw for class maps', () => {
-      //   expect(() => initWithTemplate('<div [class]="unstableClassMapExpression"></div>'))
-      //       .not.toThrowError();
-      // });
-      //
-      // it('should not throw for style maps as host bindings', () => {
-      //   expect(() => initWithHostBindings({'[style]': 'unstableStyleMapExpression'}))
-      //       .not.toThrowError();
-      // });
-      //
-      // it('should not throw for class maps as host binding', () => {
-      //   expect(() => initWithHostBindings({'[class]': 'unstableClassMapExpression'}))
-      //       .not.toThrowError();
-      // });
-    });
+        describe('OnPush child', () => {
+          @Component({template: '<child></child>'})
+          class MyApp {
+          }
 
-    describe('OnPush child', () => {
-      @Component({template: '<child></child>'})
-      class MyApp {
-      }
+          @Component(
+              {selector: 'child', template: '...', changeDetection: ChangeDetectionStrategy.OnPush})
+          class Child {
+            a: string = 'a';
+            b: string = 'b';
+            c: string = 'c';
+            unstableBooleanExpression: boolean = true;
+            unstableStringExpression: string = 'initial';
+            unstableColorExpression: string = 'red';
+            unstableStyleMapExpression:
+                {[key: string]: string;} = {'color': 'red', 'margin': '10px'};
+            unstableClassMapExpression:
+                {[key: string]: boolean;} = {'classA': true, 'classB': false};
 
-      @Component(
-          {selector: 'child', template: '...', changeDetection: ChangeDetectionStrategy.OnPush})
-      class Child {
-        a: string = 'a';
-        b: string = 'b';
-        c: string = 'c';
-        unstableBooleanExpression: boolean = true;
-        unstableStringExpression: string = 'initial';
-        unstableColorExpression: string = 'red';
-        unstableStyleMapExpression: {[key: string]: string;} = {'color': 'red', 'margin': '10px'};
-        unstableClassMapExpression: {[key: string]: boolean;} = {'classA': true, 'classB': false};
+            ngAfterViewChecked() {
+              this.unstableBooleanExpression = false;
+              this.unstableStringExpression = 'changed';
+              this.unstableColorExpression = 'green';
+              this.unstableStyleMapExpression = {'color': 'green', 'margin': '20px'};
+              this.unstableClassMapExpression = {'classA': false, 'classB': true};
+            }
+          }
 
-        ngAfterViewChecked() {
-          this.unstableBooleanExpression = false;
-          this.unstableStringExpression = 'changed';
-          this.unstableColorExpression = 'green';
-          this.unstableStyleMapExpression = {'color': 'green', 'margin': '20px'};
-          this.unstableClassMapExpression = {'classA': false, 'classB': true};
-        }
-      }
+          function initComponent(overrides: {[key: string]: any}): ComponentFixture<MyApp> {
+            TestBed.configureTestingModule({declarations: [MyApp, Child]});
+            TestBed.overrideComponent(Child, {set: overrides});
+            const fixture = TestBed.createComponent(MyApp);
+            fixture.detectChanges();
+            return fixture;
+          }
 
-      function initComponent(overrides: {[key: string]: any}): ComponentFixture<MyApp> {
-        TestBed.configureTestingModule({declarations: [MyApp, Child]});
-        TestBed.overrideComponent(Child, {set: overrides});
-        const fixture = TestBed.createComponent(MyApp);
-        fixture.detectChanges();
-        return fixture;
-      }
+          function initWithTemplate(template: string) {
+            return initComponent({template});
+          }
+          function initWithHostBindings(bindings: {[key: string]: string}) {
+            return initComponent({host: bindings});
+          }
 
-      function initWithTemplate(template: string) {
-        return initComponent({template});
-      }
-      function initWithHostBindings(bindings: {[key: string]: string}) {
-        return initComponent({host: bindings});
-      }
+          it('should include field name in case of property binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'id': 'initial'. Current value: 'changed'` :
+                `Previous value: 'id: initial'. Current value: 'id: changed'`;
+            let r = expect(() => initWithTemplate('<div [id]="unstableStringExpression"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should include field name in case of property binding', () => {
-        const message = ivyEnabled ?
-            `Previous value for 'id': 'initial'. Current value: 'changed'` :
-            `Previous value: 'id: initial'. Current value: 'id: changed'`;
-        expect(() => initWithTemplate('<div [id]="unstableStringExpression"></div>'))
-            .not.toThrowError(new RegExp(message));
-      });
+          it('should include field name in case of property interpolation', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'id': 'Expressions: a and initial!'. Current value: 'Expressions: a and changed!'` :
+                `Previous value: 'id: Expressions: a and initial!'. Current value: 'id: Expressions: a and changed!'`;
+            let r = expect(
+                () => initWithTemplate(
+                    '<div id="Expressions: {{ a }} and {{ unstableStringExpression }}!"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should include field name in case of property interpolation', () => {
-        const message = ivyEnabled ?
-            `Previous value for 'id': 'Expressions: a and initial!'. Current value: 'Expressions: a and changed!'` :
-            `Previous value: 'id: Expressions: a and initial!'. Current value: 'id: Expressions: a and changed!'`;
-        expect(
-            () => initWithTemplate(
-                '<div id="Expressions: {{ a }} and {{ unstableStringExpression }}!"></div>'))
-            .not.toThrowError(new RegExp(message));
-      });
+          it('should include field name in case of attribute binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'attr.id': 'initial'. Current value: 'changed'` :
+                `Previous value: 'id: initial'. Current value: 'id: changed'`;
+            let r =
+                expect(() => initWithTemplate('<div [attr.id]="unstableStringExpression"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should include field name in case of attribute binding', () => {
-        const message = ivyEnabled ?
-            `Previous value for 'attr.id': 'initial'. Current value: 'changed'` :
-            `Previous value: 'id: initial'. Current value: 'id: changed'`;
-        expect(() => initWithTemplate('<div [attr.id]="unstableStringExpression"></div>'))
-            .not.toThrowError(new RegExp(message));
-      });
+          it('should include field name in case of attribute interpolation', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'attr.id': 'Expressions: a and initial!'. Current value: 'Expressions: a and changed!'` :
+                `Previous value: 'id: Expressions: a and initial!'. Current value: 'id: Expressions: a and changed!'`;
+            let r = expect(
+                () => initWithTemplate(
+                    '<div attr.id="Expressions: {{ a }} and {{ unstableStringExpression }}!"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should include field name in case of attribute interpolation', () => {
-        const message = ivyEnabled ?
-            `Previous value for 'attr.id': 'Expressions: a and initial!'. Current value: 'Expressions: a and changed!'` :
-            `Previous value: 'id: Expressions: a and initial!'. Current value: 'id: Expressions: a and changed!'`;
-        expect(
-            () => initWithTemplate(
-                '<div attr.id="Expressions: {{ a }} and {{ unstableStringExpression }}!"></div>'))
-            .not.toThrowError(new RegExp(message));
-      });
+          it('should only display a value of an expression that was changed in text interpolation',
+             () => {
+               let r = expect(
+                   () => initWithTemplate(
+                       'Expressions: {{ a }} and {{ unstableStringExpression }}!'));
+               r = isOnPushCheckNoChangesEnabled ? r : r.not;
+               r.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
+             });
 
-      it('should only display a value of an expression that was changed in text interpolation',
-         () => {
-           expect(
-               () => initWithTemplate('Expressions: {{ a }} and {{ unstableStringExpression }}!'))
-               .not.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
-         });
-
-      it('should only display a value of an expression that was changed in text interpolation ' +
-             'that follows an element with property interpolation',
-         () => {
-           expect(() => {
-             initWithTemplate(`
+          it('should only display a value of an expression that was changed in text interpolation ' +
+                 'that follows an element with property interpolation',
+             () => {
+               let r = expect(() => {
+                 initWithTemplate(`
              <div id="Prop interpolation: {{ aVal }}"></div>
              Text interpolation: {{ unstableStringExpression }}.
            `);
-           }).not.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
-         });
+               });
+               r = isOnPushCheckNoChangesEnabled ? r : r.not;
+               r.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
+             });
 
-      it('should include style prop name in case of style binding', () => {
-        const message = ivyEnabled ? `Previous value for 'color': 'red'. Current value: 'green'` :
-                                     `Previous value: 'color: red'. Current value: 'color: green'`;
-        expect(() => initWithTemplate('<div [style.color]="unstableColorExpression"></div>'))
-            .not.toThrowError(new RegExp(message));
-      });
+          it('should include style prop name in case of style binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'color': 'red'. Current value: 'green'` :
+                `Previous value: 'color: red'. Current value: 'color: green'`;
+            let r = expect(
+                () => initWithTemplate('<div [style.color]="unstableColorExpression"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should include class name in case of class binding', () => {
-        const message = ivyEnabled ?
-            `Previous value for 'someClass': 'true'. Current value: 'false'` :
-            `Previous value: 'someClass: true'. Current value: 'someClass: false'`;
-        expect(() => initWithTemplate('<div [class.someClass]="unstableBooleanExpression"></div>'))
-            .not.toThrowError(new RegExp(message));
-      });
+          it('should include class name in case of class binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'someClass': 'true'. Current value: 'false'` :
+                `Previous value: 'someClass: true'. Current value: 'someClass: false'`;
+            let r = expect(
+                () =>
+                    initWithTemplate('<div [class.someClass]="unstableBooleanExpression"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should only display a value of an expression that was changed in text interpolation inside i18n block',
-         () => {
-           expect(
-               () => initWithTemplate('<div i18n>Expression: {{ unstableStringExpression }}</div>'))
-               .not.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
-         });
+          it('should only display a value of an expression that was changed in text interpolation inside i18n block',
+             () => {
+               let r = expect(
+                   () => initWithTemplate(
+                       '<div i18n>Expression: {{ unstableStringExpression }}</div>'));
+               r = isOnPushCheckNoChangesEnabled ? r : r.not;
+               r.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
+             });
 
-      it('should only display a value of an expression for interpolation inside an i18n property',
-         () => {
-           expect(
-               () => initWithTemplate(
-                   '<div i18n-title title="Expression: {{ unstableStringExpression }}"></div>'))
-               .not.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
-         });
+          it('should only display a value of an expression for interpolation inside an i18n property',
+             () => {
+               let r = expect(
+                   () => initWithTemplate(
+                       '<div i18n-title title="Expression: {{ unstableStringExpression }}"></div>'));
+               r = isOnPushCheckNoChangesEnabled ? r : r.not;
+               r.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
+             });
 
-      it('should include field name in case of host property binding', () => {
-        const message = ivyEnabled ?
-            `Previous value for 'id': 'initial'. Current value: 'changed'` :
-            `Previous value: 'id: initial'. Current value: 'id: changed'`;
-        // @TODO: JiaLiPassion: Host bindings are executed at parent component?
-        expect(() => initWithHostBindings({'[id]': 'unstableStringExpression'}))
-            .toThrowError(new RegExp(message));
-      });
+          it('should include field name in case of host property binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'id': 'initial'. Current value: 'changed'` :
+                `Previous value: 'id: initial'. Current value: 'id: changed'`;
+            let r = expect(() => initWithHostBindings({'[id]': 'unstableStringExpression'}));
+            // @TODO: JiaLiPassion: Host bindings are executed at parent component?
+            r = !isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should include style prop name in case of host style bindings', () => {
-        const message = ivyEnabled ? `Previous value for 'color': 'red'. Current value: 'green'` :
-                                     `Previous value: 'color: red'. Current value: 'color: green'`;
-        // @TODO: JiaLiPassion: Host bindings are executed at parent component?
-        expect(() => initWithHostBindings({'[style.color]': 'unstableColorExpression'}))
-            .toThrowError(new RegExp(message));
-      });
+          it('should include style prop name in case of host style bindings', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'color': 'red'. Current value: 'green'` :
+                `Previous value: 'color: red'. Current value: 'color: green'`;
+            // @TODO: JiaLiPassion: Host bindings are executed at parent component?
+            let r =
+                expect(() => initWithHostBindings({'[style.color]': 'unstableColorExpression'}));
+            r = !isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-      it('should include class name in case of host class bindings', () => {
-        const message = ivyEnabled ?
-            `Previous value for 'someClass': 'true'. Current value: 'false'` :
-            `Previous value: 'someClass: true'. Current value: 'someClass: false'`;
-        // @TODO: JiaLiPassion: Host bindings are executed at parent component?
-        expect(() => initWithHostBindings({'[class.someClass]': 'unstableBooleanExpression'}))
-            .toThrowError(new RegExp(message));
-      });
+          it('should include class name in case of host class bindings', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'someClass': 'true'. Current value: 'false'` :
+                `Previous value: 'someClass: true'. Current value: 'someClass: false'`;
+            // @TODO: JiaLiPassion: Host bindings are executed at parent component?
+            let r = expect(
+                () => initWithHostBindings({'[class.someClass]': 'unstableBooleanExpression'}));
+            r = !isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
+        });
 
-      // Note: the tests below currently fail in Ivy, but not in VE. VE behavior is correct and
-      // Ivy's logic should be fixed by the upcoming styling refactor, we keep these tests to verify
-      // that.
-      //
-      // it('should not throw for style maps', () => {
-      //  expect(() => initWithTemplate('<div [style]="unstableStyleMapExpression"></div>'))
-      //      .not.toThrowError();
-      // });
-      //
-      // it('should not throw for class maps', () => {
-      //   expect(() => initWithTemplate('<div [class]="unstableClassMapExpression"></div>'))
-      //       .not.toThrowError();
-      // });
-      //
-      // it('should not throw for style maps as host bindings', () => {
-      //   expect(() => initWithHostBindings({'[style]': 'unstableStyleMapExpression'}))
-      //       .not.toThrowError();
-      // });
-      //
-      // it('should not throw for class maps as host binding', () => {
-      //   expect(() => initWithHostBindings({'[class]': 'unstableClassMapExpression'}))
-      //       .not.toThrowError();
-      // });
-    });
-  });
+        describe('OnPush dynamic child', () => {
+          @Component({template: '<ng-container #innerContainer></ng-container>'})
+          class MyApp {
+            @ViewChild('innerContainer', {read: ViewContainerRef})
+            innerContainer!: ViewContainerRef;
 
-  describe('OnPush dynamic child', () => {
-    @Component({template: '<ng-container #innerContainer></ng-container>'})
-    class MyApp {
-      @ViewChild('innerContainer', {read: ViewContainerRef}) innerContainer!: ViewContainerRef;
+            constructor(public cfr: ComponentFactoryResolver, public injector: Injector) {}
+          }
 
-      constructor(public cfr: ComponentFactoryResolver, public injector: Injector) {}
-    }
+          @Component(
+              {selector: 'child', template: '...', changeDetection: ChangeDetectionStrategy.OnPush})
+          class Child {
+            a: string = 'a';
+            b: string = 'b';
+            c: string = 'c';
+            unstableBooleanExpression: boolean = true;
+            unstableStringExpression: string = 'initial';
+            unstableColorExpression: string = 'red';
+            unstableStyleMapExpression:
+                {[key: string]: string;} = {'color': 'red', 'margin': '10px'};
+            unstableClassMapExpression:
+                {[key: string]: boolean;} = {'classA': true, 'classB': false};
 
-    @Component(
-        {selector: 'child', template: '...', changeDetection: ChangeDetectionStrategy.OnPush})
-    class Child {
-      a: string = 'a';
-      b: string = 'b';
-      c: string = 'c';
-      unstableBooleanExpression: boolean = true;
-      unstableStringExpression: string = 'initial';
-      unstableColorExpression: string = 'red';
-      unstableStyleMapExpression: {[key: string]: string;} = {'color': 'red', 'margin': '10px'};
-      unstableClassMapExpression: {[key: string]: boolean;} = {'classA': true, 'classB': false};
+            ngAfterViewChecked() {
+              this.unstableBooleanExpression = false;
+              this.unstableStringExpression = 'changed';
+              this.unstableColorExpression = 'green';
+              this.unstableStyleMapExpression = {'color': 'green', 'margin': '20px'};
+              this.unstableClassMapExpression = {'classA': false, 'classB': true};
+            }
+          }
 
-      ngAfterViewChecked() {
-        this.unstableBooleanExpression = false;
-        this.unstableStringExpression = 'changed';
-        this.unstableColorExpression = 'green';
-        this.unstableStyleMapExpression = {'color': 'green', 'margin': '20px'};
-        this.unstableClassMapExpression = {'classA': false, 'classB': true};
-      }
-    }
+          @NgModule({declarations: [Child], entryComponents: [Child]})
+          class ChildModule {
+          }
 
-    @NgModule({declarations: [Child], entryComponents: [Child]})
-    class ChildModule {
-    }
+          function initComponent(overrides: {[key: string]: any}): ComponentFixture<MyApp> {
+            TestBed.configureTestingModule({imports: [ChildModule], declarations: [MyApp]});
+            TestBed.overrideComponent(Child, {set: overrides});
+            const fixture = TestBed.createComponent(MyApp);
+            fixture.detectChanges();
+            const child = fixture.componentInstance.cfr.resolveComponentFactory(Child).create(
+                fixture.componentInstance.injector);
+            fixture.componentInstance.innerContainer.insert(child.hostView);
+            fixture.detectChanges();
+            return fixture;
+          }
 
-    function initComponent(overrides: {[key: string]: any}): ComponentFixture<MyApp> {
-      TestBed.configureTestingModule({imports: [ChildModule], declarations: [MyApp]});
-      TestBed.overrideComponent(Child, {set: overrides});
-      const fixture = TestBed.createComponent(MyApp);
-      fixture.detectChanges();
-      const child = fixture.componentInstance.cfr.resolveComponentFactory(Child).create(
-          fixture.componentInstance.injector);
-      fixture.componentInstance.innerContainer.insert(child.hostView);
-      fixture.detectChanges();
-      return fixture;
-    }
+          function initWithTemplate(template: string) {
+            return initComponent({template});
+          }
+          function initWithHostBindings(bindings: {[key: string]: string}) {
+            return initComponent({host: bindings});
+          }
 
-    function initWithTemplate(template: string) {
-      return initComponent({template});
-    }
-    function initWithHostBindings(bindings: {[key: string]: string}) {
-      return initComponent({host: bindings});
-    }
+          it('should include field name in case of property binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'id': 'initial'. Current value: 'changed'` :
+                `Previous value: 'id: initial'. Current value: 'id: changed'`;
+            let r = expect(() => initWithTemplate('<div [id]="unstableStringExpression"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-    it('should include field name in case of property binding', () => {
-      const message = ivyEnabled ? `Previous value for 'id': 'initial'. Current value: 'changed'` :
-                                   `Previous value: 'id: initial'. Current value: 'id: changed'`;
-      expect(() => initWithTemplate('<div [id]="unstableStringExpression"></div>'))
-          .not.toThrowError(new RegExp(message));
-    });
+          it('should include field name in case of property interpolation', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'id': 'Expressions: a and initial!'. Current value: 'Expressions: a and changed!'` :
+                `Previous value: 'id: Expressions: a and initial!'. Current value: 'id: Expressions: a and changed!'`;
+            let r = expect(
+                () => initWithTemplate(
+                    '<div id="Expressions: {{ a }} and {{ unstableStringExpression }}!"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-    it('should include field name in case of property interpolation', () => {
-      const message = ivyEnabled ?
-          `Previous value for 'id': 'Expressions: a and initial!'. Current value: 'Expressions: a and changed!'` :
-          `Previous value: 'id: Expressions: a and initial!'. Current value: 'id: Expressions: a and changed!'`;
-      expect(
-          () => initWithTemplate(
-              '<div id="Expressions: {{ a }} and {{ unstableStringExpression }}!"></div>'))
-          .not.toThrowError(new RegExp(message));
-    });
+          it('should include field name in case of attribute binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'attr.id': 'initial'. Current value: 'changed'` :
+                `Previous value: 'id: initial'. Current value: 'id: changed'`;
+            let r =
+                expect(() => initWithTemplate('<div [attr.id]="unstableStringExpression"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-    it('should include field name in case of attribute binding', () => {
-      const message = ivyEnabled ?
-          `Previous value for 'attr.id': 'initial'. Current value: 'changed'` :
-          `Previous value: 'id: initial'. Current value: 'id: changed'`;
-      expect(() => initWithTemplate('<div [attr.id]="unstableStringExpression"></div>'))
-          .not.toThrowError(new RegExp(message));
-    });
+          it('should include field name in case of attribute interpolation', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'attr.id': 'Expressions: a and initial!'. Current value: 'Expressions: a and changed!'` :
+                `Previous value: 'id: Expressions: a and initial!'. Current value: 'id: Expressions: a and changed!'`;
+            let r = expect(
+                () => initWithTemplate(
+                    '<div attr.id="Expressions: {{ a }} and {{ unstableStringExpression }}!"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
 
-    it('should include field name in case of attribute interpolation', () => {
-      const message = ivyEnabled ?
-          `Previous value for 'attr.id': 'Expressions: a and initial!'. Current value: 'Expressions: a and changed!'` :
-          `Previous value: 'id: Expressions: a and initial!'. Current value: 'id: Expressions: a and changed!'`;
-      expect(
-          () => initWithTemplate(
-              '<div attr.id="Expressions: {{ a }} and {{ unstableStringExpression }}!"></div>'))
-          .not.toThrowError(new RegExp(message));
-    });
+          it('should only display a value of an expression that was changed in text interpolation',
+             () => {
+               let r = expect(
+                   () => initWithTemplate(
+                       'Expressions: {{ a }} and {{ unstableStringExpression }}!'));
+               r = isOnPushCheckNoChangesEnabled ? r : r.not;
+               r.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
+             });
 
-    it('should only display a value of an expression that was changed in text interpolation',
-       () => {
-         expect(() => initWithTemplate('Expressions: {{ a }} and {{ unstableStringExpression }}!'))
-             .not.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
-       });
-
-    it('should only display a value of an expression that was changed in text interpolation ' +
-           'that follows an element with property interpolation',
-       () => {
-         expect(() => {
-           initWithTemplate(`
+          it('should only display a value of an expression that was changed in text interpolation ' +
+                 'that follows an element with property interpolation',
+             () => {
+               let r = expect(() => {
+                 initWithTemplate(`
              <div id="Prop interpolation: {{ aVal }}"></div>
              Text interpolation: {{ unstableStringExpression }}.
            `);
-         }).not.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
-       });
+               });
+               r = isOnPushCheckNoChangesEnabled ? r : r.not;
+               r.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
+             });
 
-    it('should include style prop name in case of style binding', () => {
-      const message = ivyEnabled ? `Previous value for 'color': 'red'. Current value: 'green'` :
-                                   `Previous value: 'color: red'. Current value: 'color: green'`;
-      expect(() => initWithTemplate('<div [style.color]="unstableColorExpression"></div>'))
-          .not.toThrowError(new RegExp(message));
+          it('should include style prop name in case of style binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'color': 'red'. Current value: 'green'` :
+                `Previous value: 'color: red'. Current value: 'color: green'`;
+            let r = expect(
+                () => initWithTemplate('<div [style.color]="unstableColorExpression"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
+
+          it('should include class name in case of class binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'someClass': 'true'. Current value: 'false'` :
+                `Previous value: 'someClass: true'. Current value: 'someClass: false'`;
+            let r = expect(
+                () =>
+                    initWithTemplate('<div [class.someClass]="unstableBooleanExpression"></div>'));
+            r = isOnPushCheckNoChangesEnabled ? r : r.not;
+            r.toThrowError(new RegExp(message));
+          });
+
+          it('should only display a value of an expression that was changed in text interpolation inside i18n block',
+             () => {
+               let r = expect(
+                   () => initWithTemplate(
+                       '<div i18n>Expression: {{ unstableStringExpression }}</div>'));
+               r = isOnPushCheckNoChangesEnabled ? r : r.not;
+               r.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
+             });
+
+          it('should only display a value of an expression for interpolation inside an i18n property',
+             () => {
+               let r = expect(
+                   () => initWithTemplate(
+                       '<div i18n-title title="Expression: {{ unstableStringExpression }}"></div>'));
+               r = isOnPushCheckNoChangesEnabled ? r : r.not;
+               r.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
+             });
+
+          it('should include field name in case of host property binding', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'id': 'initial'. Current value: 'changed'` :
+                `Previous value: 'id: initial'. Current value: 'id: changed'`;
+            // TODO: @JiaLiPassion, check ViewEngine behavior
+            let r = expect(() => initWithHostBindings({'[id]': 'unstableStringExpression'}));
+            r = ivyEnabled && !isOnPushCheckNoChangesEnabled ? r.not : r;
+            r.toThrowError(new RegExp(message));
+          });
+
+          it('should include style prop name in case of host style bindings', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'color': 'red'. Current value: 'green'` :
+                `Previous value: 'color: red'. Current value: 'color: green'`;
+            // TODO: @JiaLiPassion, check ViewEngine behavior
+            let r =
+                expect(() => initWithHostBindings({'[style.color]': 'unstableColorExpression'}));
+            r = ivyEnabled && !isOnPushCheckNoChangesEnabled ? r.not : r;
+            r.toThrowError(new RegExp(message));
+          });
+
+          it('should include class name in case of host class bindings', () => {
+            const message = ivyEnabled ?
+                `Previous value for 'someClass': 'true'. Current value: 'false'` :
+                `Previous value: 'someClass: true'. Current value: 'someClass: false'`;
+            // TODO: @JiaLiPassion, check ViewEngine behavior
+            let r = expect(
+                () => initWithHostBindings({'[class.someClass]': 'unstableBooleanExpression'}));
+            r = ivyEnabled && !isOnPushCheckNoChangesEnabled ? r.not : r;
+            r.toThrowError(new RegExp(message));
+          });
+        });
+      });
     });
-
-    it('should include class name in case of class binding', () => {
-      const message = ivyEnabled ?
-          `Previous value for 'someClass': 'true'. Current value: 'false'` :
-          `Previous value: 'someClass: true'. Current value: 'someClass: false'`;
-      expect(() => initWithTemplate('<div [class.someClass]="unstableBooleanExpression"></div>'))
-          .not.toThrowError(new RegExp(message));
-    });
-
-    it('should only display a value of an expression that was changed in text interpolation inside i18n block',
-       () => {
-         expect(
-             () => initWithTemplate('<div i18n>Expression: {{ unstableStringExpression }}</div>'))
-             .not.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
-       });
-
-    it('should only display a value of an expression for interpolation inside an i18n property',
-       () => {
-         expect(
-             () => initWithTemplate(
-                 '<div i18n-title title="Expression: {{ unstableStringExpression }}"></div>'))
-             .not.toThrowError(/Previous value: '.*?initial'. Current value: '.*?changed'/);
-       });
-
-    it('should include field name in case of host property binding', () => {
-      const message = ivyEnabled ? `Previous value for 'id': 'initial'. Current value: 'changed'` :
-                                   `Previous value: 'id: initial'. Current value: 'id: changed'`;
-      // TODO: @JiaLiPassion, check ViewEngine behavior
-      let r = expect(() => initWithHostBindings({'[id]': 'unstableStringExpression'}));
-      r = ivyEnabled ? r.not : r;
-      r.toThrowError(new RegExp(message));
-    });
-
-    it('should include style prop name in case of host style bindings', () => {
-      const message = ivyEnabled ? `Previous value for 'color': 'red'. Current value: 'green'` :
-                                   `Previous value: 'color: red'. Current value: 'color: green'`;
-      // TODO: @JiaLiPassion, check ViewEngine behavior
-      let r = expect(() => initWithHostBindings({'[style.color]': 'unstableColorExpression'}));
-      r = ivyEnabled ? r.not : r;
-      r.toThrowError(new RegExp(message));
-    });
-
-    it('should include class name in case of host class bindings', () => {
-      const message = ivyEnabled ?
-          `Previous value for 'someClass': 'true'. Current value: 'false'` :
-          `Previous value: 'someClass: true'. Current value: 'someClass: false'`;
-      // TODO: @JiaLiPassion, check ViewEngine behavior
-      let r =
-          expect(() => initWithHostBindings({'[class.someClass]': 'unstableBooleanExpression'}));
-      r = ivyEnabled ? r.not : r;
-      r.toThrowError(new RegExp(message));
-    });
-
-    // Note: the tests below currently fail in Ivy, but not in VE. VE behavior is correct and
-    // Ivy's logic should be fixed by the upcoming styling refactor, we keep these tests to verify
-    // that.
-    //
-    // it('should not throw for style maps', () => {
-    //  expect(() => initWithTemplate('<div [style]="unstableStyleMapExpression"></div>'))
-    //      .not.toThrowError();
-    // });
-    //
-    // it('should not throw for class maps', () => {
-    //   expect(() => initWithTemplate('<div [class]="unstableClassMapExpression"></div>'))
-    //       .not.toThrowError();
-    // });
-    //
-    // it('should not throw for style maps as host bindings', () => {
-    //   expect(() => initWithHostBindings({'[style]': 'unstableStyleMapExpression'}))
-    //       .not.toThrowError();
-    // });
-    //
-    // it('should not throw for class maps as host binding', () => {
-    //   expect(() => initWithHostBindings({'[class]': 'unstableClassMapExpression'}))
-    //       .not.toThrowError();
-    // });
   });
 });

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -220,10 +220,10 @@ describe('change detection', () => {
       fixture.detectChanges(false);
       expect(fixture.nativeElement).toHaveText('0|dynamic');
 
-      // update model in the OnPush component - should update UI
+      // update model in the OnPush component - should update UI in Ivy
       fixture.componentInstance.counter = 1;
       fixture.detectChanges(false);
-      expect(fixture.nativeElement).toHaveText('1|dynamic');
+      expect(fixture.nativeElement).toHaveText(ivyEnabled ? '1|dynamic' : '0|dynamic');
     });
 
     it('should support re-enterant change detection', () => {
@@ -517,9 +517,9 @@ describe('change detection', () => {
 
         dynamicCompRef.instance.name = 'dynamic name updated';
         appComp.cdr.detectChanges();
-        // Dynamic component is OnPush, should not refresh from parent's change detection
+        // In Ivy, dynamic component is OnPush, should not refresh from parent's change detection
         // And the doCheckCount should not be updated either.
-        expect(dynamicCompRef.instance.doCheckCount).toBe(1);
+        expect(dynamicCompRef.instance.doCheckCount).toBe(ivyEnabled ? 1 : 2);
       });
 
       it('should trigger change detection from change detection of self', () => {
@@ -562,7 +562,7 @@ describe('change detection', () => {
             dynamicCompRef.instance.name = 'dynamic name updated';
             appComp.cdr.detectChanges();
             // Dynamic component is OnPush, should not refresh from parent's change detection
-            expect(dynamicCompRef.instance.doCheckCount).toBe(1);
+            expect(dynamicCompRef.instance.doCheckCount).toBe(ivyEnabled ? 1 : 2);
           });
 
           it('should trigger change detection from change detection of self', () => {
@@ -1219,7 +1219,7 @@ describe('change detection', () => {
         // Dynamic onPush component detectChanges() should update the component
         fixture.componentInstance.value = 'two';
         fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toEqual('two - two');
+        expect(fixture.nativeElement.textContent).toEqual(ivyEnabled ? 'two - two' : 'one - two');
       });
 
       it('async pipe should trigger CD for embedded views where the declaration and insertion views are different',

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -249,6 +249,12 @@
     "name": "isInlineTemplate"
   },
   {
+    "name": "isLRootViewAndNeedToCheck"
+  },
+  {
+    "name": "isLView"
+  },
+  {
     "name": "isNodeMatchingSelector"
   },
   {

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -1197,6 +1197,9 @@
     "name": "isLContainer"
   },
   {
+    "name": "isLRootViewAndNeedToCheck"
+  },
+  {
     "name": "isLView"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -168,6 +168,12 @@
     "name": "isInCheckNoChangesMode"
   },
   {
+    "name": "isLRootViewAndNeedToCheck"
+  },
+  {
+    "name": "isLView"
+  },
+  {
     "name": "isProceduralRenderer"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1533,6 +1533,9 @@
     "name": "isLContainer"
   },
   {
+    "name": "isLRootViewAndNeedToCheck"
+  },
+  {
     "name": "isLView"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -498,6 +498,9 @@
     "name": "isLContainer"
   },
   {
+    "name": "isLRootViewAndNeedToCheck"
+  },
+  {
     "name": "isLView"
   },
   {


### PR DESCRIPTION
Close #36667, #39524, #39545.

`dynamic` and `bootstrap` components has a parent `host view` as the placeholder.
And also all the hooks are registered to the tView of the `host view`, not the component view.
Running change detection from the `host view` has several issues.

1. componentRef.changeDetectorRef.detectChanges()/markForCheck() will not update the component. Since componentRef.changeDetectorRef is the RootViewRef of the hostView.

```
@component({
  selector: 'dynamic',
  template: `{{name}}`,
  changeDetection: ChangeDetectionStrategy.OnPush
})
export class Dynamic  {
  name = 'initial name';
}

@component({
  selector: 'my-app',
  template: `
    <b>Expected</b>: "initial name" changes to "changed name" after 2s<br>
    <b>Actual</b>:<br>
  `,
  changeDetection: ChangeDetectionStrategy.OnPush
})
export class AppComponent  {
  constructor(private _vcRef: ViewContainerRef,
     private _cfr: ComponentFactoryResolver, private _injector: Injector) {}

  ngOnInit() {
    const cmptRef = this._cfr.resolveComponentFactory(Dynamic).create(this._injector);
    this._vcRef.insert(cmptRef.hostView);

    setTimeout(() => {
        cmptRef.instance.name = 'changed name';
        console.log('changing name');
       // cmptRef.changeDetectorRef is the RootViewRef of the hostView
        cmptRef.changeDetectorRef.detectChanges();
    }, 2000);
  }
}
```

![Screen Shot 2020-11-03 at 0 28 37](https://user-images.githubusercontent.com/1442575/97886646-305ce580-1d6c-11eb-948a-d8a699c58004.png)


2. The hooks (such as ngOnCheck) is executed, but the component is not updated. Since the hooks are registered to the tView of the hostView.

```
import {
  Component,
  NgModule,
  ViewContainerRef,
  ComponentFactoryResolver,
  Injector,
  ChangeDetectionStrategy,
  DoCheck
} from "@angular/core";
import { BrowserModule } from "@angular/platform-browser";

import { timer } from "rxjs";

@component({
  selector: "dynamic",
  template: `
    {{ name }}
  `,
  changeDetection: ChangeDetectionStrategy.OnPush
})
export class Dynamic implements DoCheck {
  name = "initial name";

  ngDoCheck() {
    console.log("docheck dynamic");
  }
}

@component({
  selector: "my-app",
  template: `
    <b>Expected</b>: "initial name" changes to "changed name" after 2s<br />
    <b>Actual</b>:<br />
  `,
  changeDetection: ChangeDetectionStrategy.OnPush
})
export class AppComponent {
  constructor(
    private _vcRef: ViewContainerRef,
    private _cfr: ComponentFactoryResolver,
    private _injector: Injector
  ) {}

  ngOnInit() {
    const cmptRef = this._cfr
      .resolveComponentFactory(Dynamic)
      .create(this._injector);
    this._vcRef.insert(cmptRef.hostView);

    setTimeout(() => {
      cmptRef.instance.name = "changed name";
      console.log("changing name");
      cmptRef.changeDetectorRef.detectChanges();
    }, 2000);
  }
}

@NgModule({
  imports: [BrowserModule],
  declarations: [AppComponent, Dynamic],
  entryComponents: [Dynamic],
  bootstrap: [AppComponent]
})
export class AppModule {}

```

![Screen Shot 2020-11-03 at 0 31 22](https://user-images.githubusercontent.com/1442575/97886671-3c48a780-1d6c-11eb-9a16-7364e81c02a2.png)

3. dev mode will only trigger change detection once for the `onPush` component.

```
      @Component({
        template: `
          <button (click)="noop()">Trigger change detection</button>
          <div>{{increment('componentView')}}</div>
        `,
        changeDetection: ChangeDetectionStrategy.OnPush
      })
      class App {
        increment() {
          counters++;
        }
        noop() {}
      }
      const fixture = TestBed.createComponent(App);
      fixture.detectChanges();
      expect(counters).toEqual(2); // current behavior is 1 
```
The reason is App is a OnPush component with a hostView, calling fixture.detectChanges() will run a detectChanges() and checkNoChanges() .
And the App component is onPush, so the checkNoChanges() run will ignore App component, so the counters will be 1
Which is not correct.
```
it('works', () => {
      @Component({
        template: '{{message}}',
        changeDetection: ChangeDetectionStrategy.OnPush
      })
      class OnPushCmp {
        @Input() message = 'initial';
        ngAfterViewInit() {
          this.message = 'updated';
        }
      }
      const comp = TestBed.configureTestingModule({declarations: [OnPushCmp]}).createComponent(OnPushCmp);
      expect(() => comp.detectChanges()).toThrow(); // current behavior is not throw.
    });
```
The reason is the same, the checkNoChanges() will skip the OnPushCmp, so the ExpressionChanged error is not thrown.

## This PR update several points.

1. When create a dynamic component, we create a host view and a component view.
We consider these 2 views a single unit,
if the component is OnPush, we set the Dirty flag to the host view to make it a an OnPush View,
 and set the CheckAlways flag to the component.

![Screen Shot 2020-11-03 at 20 50 03](https://user-images.githubusercontent.com/1442575/97982996-edf0e280-1e17-11eb-8b8b-191720b6c351.png)

2. About handling `OnPush` in `checkNoChanges()`, the current behavior is `OnPush` component will not execute the `checkNoChanges()` since the `Dirty` flag is cleared in the `detectChanges()`, so the `ExpressionChanged` error will not be thrown for `OnPush` component, which is a bug, but to fix it, it will be a `breaking` change for the existing apps, so this PR also add some logic to keep the current `buggy` behavior. so I also created another commit to add a `isOnPushCheckNoChangesEnabled` option to enable `checkNoChanges` for the `OnPush` component https://github.com/angular/angular/pull/39463/commits/4dcf5bdab2cfeded3adafba19329e7772ae217a7
