### PR TITLE
docs(events.ts): Fix ActivationEnd link

### DIFF
--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -468,7 +468,7 @@ export class Scroll {
  * phase of routing successfuly.
  * * [ChildActivationEnd](api/router/ChildActivationEnd): When the router finishes
  * activating a route's children.
- * * [ActivationEnd](api/router/ActivationStart): When the router finishes activating a route.
+ * * [ActivationEnd](api/router/ActivationEnd): When the router finishes activating a route.
  * * [NavigationEnd](api/router/NavigationEnd): When navigation ends successfully.
  * * [NavigationCancel](api/router/NavigationCancel): When navigation is canceled.
  * * [NavigationError](api/router/NavigationError): When navigation fails


### PR DESCRIPTION
ActivationEnd Router Event goes to ActivationEnd and not to ActivationStart section

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
ActivationEnd link goes to ActivationStart section


## What is the new behavior?
ActivationEnd now goes to ActivationEnd section

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
