### PR TITLE
fix(core): mark Trusted Types as declarations

### DIFF
--- a/packages/compiler/src/output/output_jit_trusted_types.ts
+++ b/packages/compiler/src/output/output_jit_trusted_types.ts
@@ -28,24 +28,25 @@ import {global} from '../util';
  * will keep Angular's public API surface free of references to Trusted Types.
  * For internal and semi-private APIs that need to reference Trusted Types, the
  * minimal type definitions for the Trusted Types API provided by this module
- * should be used instead.
+ * should be used instead. They are marked as "declare" to prevent them from
+ * being renamed by compiler optimization.
  *
  * Adapted from
  * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/trusted-types/index.d.ts
  * but restricted to the API surface used within Angular.
  */
 
-export type TrustedScript = {
-  __brand__: 'TrustedScript'
-};
+export declare interface TrustedScript {
+  __brand__: 'TrustedScript';
+}
 
-export interface TrustedTypePolicyFactory {
+export declare interface TrustedTypePolicyFactory {
   createPolicy(policyName: string, policyOptions: {
     createScript?: (input: string) => string,
   }): TrustedTypePolicy;
 }
 
-export interface TrustedTypePolicy {
+export declare interface TrustedTypePolicy {
   createScript(input: string): TrustedScript;
 }
 

--- a/packages/core/src/util/security/trusted_type_defs.ts
+++ b/packages/core/src/util/security/trusted_type_defs.ts
@@ -17,24 +17,25 @@
  * will keep Angular's public API surface free of references to Trusted Types.
  * For internal and semi-private APIs that need to reference Trusted Types, the
  * minimal type definitions for the Trusted Types API provided by this module
- * should be used instead.
+ * should be used instead. They are marked as "declare" to prevent them from
+ * being renamed by compiler optimization.
  *
  * Adapted from
  * https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/trusted-types/index.d.ts
  * but restricted to the API surface used within Angular.
  */
 
-export type TrustedHTML = {
-  __brand__: 'TrustedHTML'
-};
-export type TrustedScript = {
-  __brand__: 'TrustedScript'
-};
-export type TrustedScriptURL = {
-  __brand__: 'TrustedScriptURL'
-};
+export declare interface TrustedHTML {
+  __brand__: 'TrustedHTML';
+}
+export declare interface TrustedScript {
+  __brand__: 'TrustedScript';
+}
+export declare interface TrustedScriptURL {
+  __brand__: 'TrustedScriptURL';
+}
 
-export interface TrustedTypePolicyFactory {
+export declare interface TrustedTypePolicyFactory {
   createPolicy(policyName: string, policyOptions: {
     createHTML?: (input: string) => string,
     createScript?: (input: string) => string,
@@ -43,7 +44,7 @@ export interface TrustedTypePolicyFactory {
   getAttributeType(tagName: string, attribute: string): string|null;
 }
 
-export interface TrustedTypePolicy {
+export declare interface TrustedTypePolicy {
   createHTML(input: string): TrustedHTML;
   createScript(input: string): TrustedScript;
   createScriptURL(input: string): TrustedScriptURL;


### PR DESCRIPTION
Angular-internal type definitions for Trusted Types were added in #39211.
When compiled using the Closure compiler with certain optimization
flags, identifiers from these type definitions (such as createPolicy)
are currently uglified and renamed to shorter strings. This causes
Angular applications compiled in this way to fail to create a Trusted
Types policy, and fall back to using strings.

To fix this, mark the internal Trusted Types definitions as declarations
using the "declare" keyword.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
