### PR TITLE
Allow suppression of `GitClient`s verbose logging and clean up output `caretaker check`

### DIFF
--- a/dev-infra/caretaker/check/check.ts
+++ b/dev-infra/caretaker/check/check.ts
@@ -21,6 +21,8 @@ export async function checkServiceStatuses(githubToken: string) {
   const config = getCaretakerConfig();
   /** The GitClient for interacting with git and Github. */
   const git = new GitClient(githubToken, config);
+  // Prevent logging of the git commands being executed during the check.
+  GitClient.LOG_COMMANDS = false;
 
   // TODO(josephperrott): Allow these checks to be loaded in parallel.
   await printServiceStatuses();

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -502,7 +502,7 @@ var GithubApiRequestError = /** @class */ (function (_super) {
 var GithubClient = /** @class */ (function (_super) {
     tslib.__extends(GithubClient, _super);
     function GithubClient(token) {
-        var _this =
+        var _this = 
         // Pass in authentication token to base Octokit class.
         _super.call(this, { auth: token }) || this;
         /** The current user based on checking against the Github API. */
@@ -581,7 +581,7 @@ var GithubGraphqlClient = /** @class */ (function () {
 var GitCommandError = /** @class */ (function (_super) {
     tslib.__extends(GitCommandError, _super);
     function GitCommandError(client, args) {
-        var _this =
+        var _this = 
         // Errors are not guaranteed to be caught. To ensure that we don't
         // accidentally leak the Github token that might be used in a command,
         // we sanitize the command that will be part of the error message.
@@ -653,7 +653,7 @@ var GitClient = /** @class */ (function () {
         // Note that we do not want to print the token if it is contained in the command. It's common
         // to share errors with others if the tool failed, and we do not want to leak tokens.
         printFn('Executing: git', this.omitGithubTokenFromMessage(args.join(' ')));
-        var result = child_process.spawnSync('git', args, tslib.__assign(tslib.__assign({ cwd: this._projectRoot, stdio: 'pipe' }, options), {
+        var result = child_process.spawnSync('git', args, tslib.__assign(tslib.__assign({ cwd: this._projectRoot, stdio: 'pipe' }, options), { 
             // Encoding is always `utf8` and not overridable. This ensures that this method
             // always returns `string` as output instead of buffers.
             encoding: 'utf8' }));
@@ -760,6 +760,8 @@ var GitClient = /** @class */ (function () {
             return scopes.split(',').map(function (scope) { return scope.trim(); });
         });
     };
+    /** Whether verbose logging of Git actions should be used. */
+    GitClient.LOG_COMMANDS = true;
     return GitClient;
 }());
 
@@ -791,7 +793,7 @@ function getCaretakerConfig() {
 class ReleaseTrain {
     constructor(
     /** Name of the branch for this release-train. */
-    branchName,
+    branchName, 
     /** Most recent version for this release train. */
     version) {
         this.branchName = branchName;
@@ -1408,6 +1410,8 @@ function checkServiceStatuses(githubToken) {
         const config = getCaretakerConfig();
         /** The GitClient for interacting with git and Github. */
         const git = new GitClient(githubToken, config);
+        // Prevent logging of the git commands being executed during the check.
+        GitClient.LOG_COMMANDS = false;
         // TODO(josephperrott): Allow these checks to be loaded in parallel.
         yield printServiceStatuses();
         yield printGithubTasks(git, config.caretaker);
@@ -3049,7 +3053,7 @@ function validateMergeConfig(config) {
 var PullRequestFailure = /** @class */ (function () {
     function PullRequestFailure(
     /** Human-readable message for the failure */
-    message,
+    message, 
     /** Whether the failure is non-fatal and can be forcibly ignored. */
     nonFatal) {
         if (nonFatal === void 0) { nonFatal = false; }

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -502,7 +502,7 @@ var GithubApiRequestError = /** @class */ (function (_super) {
 var GithubClient = /** @class */ (function (_super) {
     tslib.__extends(GithubClient, _super);
     function GithubClient(token) {
-        var _this = 
+        var _this =
         // Pass in authentication token to base Octokit class.
         _super.call(this, { auth: token }) || this;
         /** The current user based on checking against the Github API. */
@@ -581,7 +581,7 @@ var GithubGraphqlClient = /** @class */ (function () {
 var GitCommandError = /** @class */ (function (_super) {
     tslib.__extends(GitCommandError, _super);
     function GitCommandError(client, args) {
-        var _this = 
+        var _this =
         // Errors are not guaranteed to be caught. To ensure that we don't
         // accidentally leak the Github token that might be used in a command,
         // we sanitize the command that will be part of the error message.
@@ -647,14 +647,13 @@ var GitClient = /** @class */ (function () {
     GitClient.prototype.runGraceful = function (args, options) {
         if (options === void 0) { options = {}; }
         // To improve the debugging experience in case something fails, we print all executed Git
-        // commands unless the `stdio` is explicitly set to `ignore` (which is equivalent to silent).
+        // commands to better understand the git actions occuring. Depending on the command being
+        // executed, this debugging information should be logged at different logging levels.
+        var printFn = (!GitClient.LOG_COMMANDS || options.stdio === 'ignore') ? debug : info;
         // Note that we do not want to print the token if it is contained in the command. It's common
         // to share errors with others if the tool failed, and we do not want to leak tokens.
-        // TODO: Add support for configuring this on a per-client basis. Some tools do not want
-        // to print the Git command messages to the console at all (e.g. to maintain clean output).
-        var printFn = options.stdio !== 'ignore' ? info : debug;
         printFn('Executing: git', this.omitGithubTokenFromMessage(args.join(' ')));
-        var result = child_process.spawnSync('git', args, tslib.__assign(tslib.__assign({ cwd: this._projectRoot, stdio: 'pipe' }, options), { 
+        var result = child_process.spawnSync('git', args, tslib.__assign(tslib.__assign({ cwd: this._projectRoot, stdio: 'pipe' }, options), {
             // Encoding is always `utf8` and not overridable. This ensures that this method
             // always returns `string` as output instead of buffers.
             encoding: 'utf8' }));
@@ -792,7 +791,7 @@ function getCaretakerConfig() {
 class ReleaseTrain {
     constructor(
     /** Name of the branch for this release-train. */
-    branchName, 
+    branchName,
     /** Most recent version for this release train. */
     version) {
         this.branchName = branchName;
@@ -3050,7 +3049,7 @@ function validateMergeConfig(config) {
 var PullRequestFailure = /** @class */ (function () {
     function PullRequestFailure(
     /** Human-readable message for the failure */
-    message, 
+    message,
     /** Whether the failure is non-fatal and can be forcibly ignored. */
     nonFatal) {
         if (nonFatal === void 0) { nonFatal = false; }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "symbol-extractor:update": "node tools/symbol-extractor/run_all_symbols_extractor_tests.js accept",
     "ts-circular-deps:check": "yarn -s ng-dev ts-circular-deps check --config ./packages/circular-deps-test.conf.js",
     "ts-circular-deps:approve": "yarn -s ng-dev ts-circular-deps approve --config ./packages/circular-deps-test.conf.js",
-    "ng-dev": "node dev-infra/ng-dev"
+    "ng-dev": "node dev-infra/ng-dev",
+    "ng-dev:dev": "ts-node --transpile-only -- dev-infra/cli.ts"
   },
   "// 1": "dependencies are used locally and by bazel",
   "dependencies": {


### PR DESCRIPTION
See individual commits.