### PR TITLE
docs: Match browser name with custom launcher name in karma

### DIFF
--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -238,7 +238,7 @@ We'll be using [Headless Chrome](https://developers.google.com/web/updates/2017/
 
 * In the Karma configuration file, `karma.conf.js`, add a custom launcher called ChromeHeadlessCI below browsers:
 ```
-browsers: ['Chrome'],
+browsers: ['ChromeHeadlessCI'],
 customLaunchers: {
   ChromeHeadlessCI: {
     base: 'ChromeHeadless',


### PR DESCRIPTION
The browser being launched needs to match the custom launcher name.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
As per the existing code sample, karma triggers the original "Chrome" executable. And the `--no-sandbox` CLI flag does not get passed. This breaks the test execution if the user is running in a CI environment that doesn't support sandboxing.

Issue Number: N/A


## What is the new behavior?
Updated sample picks up the custom launcher with CLI flag, which is the intended use-case when defining a custom launcher for CI.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A