### PR TITLE
refactor(compiler-cli): Store inline templates and styles in the reso…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
@@ -18,18 +18,49 @@ import {getDeclaration, makeProgram} from '../../testing';
 import {ResourceLoader} from '../src/api';
 import {ComponentDecoratorHandler} from '../src/component';
 
-export class NoopResourceLoader implements ResourceLoader {
-  resolve(): string {
-    throw new Error('Not implemented.');
+export class StubResourceLoader implements ResourceLoader {
+  resolve(v: string): string {
+    return v;
   }
   canPreload = false;
-  load(): string {
-    throw new Error('Not implemented');
+  load(v: string): string {
+    return '';
   }
   preload(): Promise<void>|undefined {
     throw new Error('Not implemented');
   }
 }
+
+function setup(program: ts.Program, options: ts.CompilerOptions, host: ts.CompilerHost) {
+  const checker = program.getTypeChecker();
+  const reflectionHost = new TypeScriptReflectionHost(checker);
+  const evaluator = new PartialEvaluator(reflectionHost, checker, /* dependencyTracker */ null);
+  const moduleResolver =
+      new ModuleResolver(program, options, host, /* moduleResolutionCache */ null);
+  const importGraph = new ImportGraph(moduleResolver);
+  const cycleAnalyzer = new CycleAnalyzer(importGraph);
+  const metaRegistry = new LocalMetadataRegistry();
+  const dtsReader = new DtsMetadataReader(checker, reflectionHost);
+  const scopeRegistry = new LocalModuleScopeRegistry(
+      metaRegistry, new MetadataDtsModuleScopeResolver(dtsReader, null), new ReferenceEmitter([]),
+      null);
+  const metaReader = new CompoundMetadataReader([metaRegistry, dtsReader]);
+  const refEmitter = new ReferenceEmitter([]);
+  const injectableRegistry = new InjectableClassRegistry(reflectionHost);
+  const resourceRegistry = new ResourceRegistry();
+
+  const handler = new ComponentDecoratorHandler(
+      reflectionHost, evaluator, metaRegistry, metaReader, scopeRegistry, scopeRegistry,
+      resourceRegistry,
+      /* isCore */ false, new StubResourceLoader(), /* rootDirs */['/'],
+      /* defaultPreserveWhitespaces */ false, /* i18nUseExternalIds */ true,
+      /* enableI18nLegacyMessageIdFormat */ false,
+      /* i18nNormalizeLineEndingsInICUs */ undefined, moduleResolver, cycleAnalyzer, refEmitter,
+      NOOP_DEFAULT_IMPORT_RECORDER, /* depTracker */ null, injectableRegistry,
+      /* annotateForClosureCompiler */ false);
+  return {reflectionHost, handler};
+}
+
 runInEachFileSystem(() => {
   describe('ComponentDecoratorHandler', () => {
     let _: typeof absoluteFrom;
@@ -51,31 +82,7 @@ runInEachFileSystem(() => {
       `
         },
       ]);
-      const checker = program.getTypeChecker();
-      const reflectionHost = new TypeScriptReflectionHost(checker);
-      const evaluator = new PartialEvaluator(reflectionHost, checker, /* dependencyTracker */ null);
-      const moduleResolver =
-          new ModuleResolver(program, options, host, /* moduleResolutionCache */ null);
-      const importGraph = new ImportGraph(moduleResolver);
-      const cycleAnalyzer = new CycleAnalyzer(importGraph);
-      const metaRegistry = new LocalMetadataRegistry();
-      const dtsReader = new DtsMetadataReader(checker, reflectionHost);
-      const scopeRegistry = new LocalModuleScopeRegistry(
-          metaRegistry, new MetadataDtsModuleScopeResolver(dtsReader, null),
-          new ReferenceEmitter([]), null);
-      const metaReader = new CompoundMetadataReader([metaRegistry, dtsReader]);
-      const refEmitter = new ReferenceEmitter([]);
-      const injectableRegistry = new InjectableClassRegistry(reflectionHost);
-
-      const handler = new ComponentDecoratorHandler(
-          reflectionHost, evaluator, metaRegistry, metaReader, scopeRegistry, scopeRegistry,
-          new ResourceRegistry(),
-          /* isCore */ false, new NoopResourceLoader(), /* rootDirs */[''],
-          /* defaultPreserveWhitespaces */ false, /* i18nUseExternalIds */ true,
-          /* enableI18nLegacyMessageIdFormat */ false,
-          /* i18nNormalizeLineEndingsInICUs */ undefined, moduleResolver, cycleAnalyzer, refEmitter,
-          NOOP_DEFAULT_IMPORT_RECORDER, /* depTracker */ null, injectableRegistry,
-          /* annotateForClosureCompiler */ false);
+      const {reflectionHost, handler} = setup(program, options, host);
       const TestCmp = getDeclaration(program, _('/entry.ts'), 'TestCmp', isNamedClassDeclaration);
       const detected = handler.detect(TestCmp, reflectionHost.getDecoratorsOfDeclaration(TestCmp));
       if (detected === undefined) {
@@ -93,6 +100,104 @@ runInEachFileSystem(() => {
         expect(diag.file.fileName.endsWith('entry.ts')).toBe(true);
         expect(diag.start).toBe(detected.metadata.args![0].getStart());
       }
+    });
+
+    it('should keep track of inline template', () => {
+      const template = '<span>inline</span>';
+      const {program, options, host} = makeProgram([
+        {
+          name: _('/node_modules/@angular/core/index.d.ts'),
+          contents: 'export const Component: any;',
+        },
+        {
+          name: _('/entry.ts'),
+          contents: `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: '${template}',
+          }) class TestCmp {}
+      `
+        },
+      ]);
+      const {reflectionHost, handler} = setup(program, options, host);
+      const TestCmp = getDeclaration(program, _('/entry.ts'), 'TestCmp', isNamedClassDeclaration);
+      const detected = handler.detect(TestCmp, reflectionHost.getDecoratorsOfDeclaration(TestCmp));
+      if (detected === undefined) {
+        return fail('Failed to recognize @Component');
+      }
+      const {analysis} = handler.analyze(TestCmp, detected.metadata);
+      expect(analysis?.resources.template.path).toBeNull();
+      expect(analysis?.resources.template.expression.getText()).toEqual(`'${template}'`);
+    });
+
+    it('should keep track of external template', () => {
+      const templateUrl = '/myTemplate.ng.html';
+      const {program, options, host} = makeProgram([
+        {
+          name: _('/node_modules/@angular/core/index.d.ts'),
+          contents: 'export const Component: any;',
+        },
+        {
+          name: _(templateUrl),
+          contents: '<div>hello world</div>',
+        },
+        {
+          name: _('/entry.ts'),
+          contents: `
+          import {Component} from '@angular/core';
+
+          @Component({
+            templateUrl: '${templateUrl}',
+          }) class TestCmp {}
+      `
+        },
+      ]);
+      const {reflectionHost, handler} = setup(program, options, host);
+      const TestCmp = getDeclaration(program, _('/entry.ts'), 'TestCmp', isNamedClassDeclaration);
+      const detected = handler.detect(TestCmp, reflectionHost.getDecoratorsOfDeclaration(TestCmp));
+      if (detected === undefined) {
+        return fail('Failed to recognize @Component');
+      }
+      const {analysis} = handler.analyze(TestCmp, detected.metadata);
+      expect(analysis?.resources.template.path).toContain(templateUrl);
+      expect(analysis?.resources.template.expression.getText()).toContain(`'${templateUrl}'`);
+    });
+
+    it('should keep track of internal and external styles', () => {
+      const {program, options, host} = makeProgram([
+        {
+          name: _('/node_modules/@angular/core/index.d.ts'),
+          contents: 'export const Component: any;',
+        },
+        {
+          name: _('/myStyle.css'),
+          contents: '<div>hello world</div>',
+        },
+        {
+          name: _('/entry.ts'),
+          contents: `
+          import {Component} from '@angular/core';
+
+          // These are ignored because we only attempt to store string literals
+          const ignoredStyleUrl = 'asdlfkj';
+          const ignoredStyle = '';
+          @Component({
+            template: '',
+            styleUrls: ['/myStyle.css', ignoredStyleUrl],
+            styles: ['a { color: red; }', 'b { color: blue; }', ignoredStyle, ...[ignoredStyle]],
+          }) class TestCmp {}
+      `
+        },
+      ]);
+      const {reflectionHost, handler} = setup(program, options, host);
+      const TestCmp = getDeclaration(program, _('/entry.ts'), 'TestCmp', isNamedClassDeclaration);
+      const detected = handler.detect(TestCmp, reflectionHost.getDecoratorsOfDeclaration(TestCmp));
+      if (detected === undefined) {
+        return fail('Failed to recognize @Component');
+      }
+      const {analysis} = handler.analyze(TestCmp, detected.metadata);
+      expect(analysis?.resources.styles.size).toBe(3);
     });
   });
 

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -261,6 +261,9 @@ export class NgCompiler {
     const {resourceRegistry} = this.ensureAnalyzed();
     const styles = resourceRegistry.getStyles(classDecl);
     const template = resourceRegistry.getTemplate(classDecl);
+    if (template === null) {
+      return null;
+    }
 
     return {styles, template};
   }


### PR DESCRIPTION
…urce registry

The Language Service is not only interested in external resources, but
also inline styles and templates. By storing the expression of the
inline resources, we can more easily determine if a given position is
part of the inline template/style expression.
