### PR TITLE
ci: update NgBot config to include more labels that indicate that ticket is triaged

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -165,6 +165,12 @@ triage:
     -
       - "discussion"
       - "comp: *"
+    -
+      - "needs clarification"
+      - "comp: *"
+    -
+      - "needs reproduction"
+      - "comp: *"
 
 # options for the triage PR plugin
 triagePR:


### PR DESCRIPTION
This commit updates the config of NgBot to treat tickets that have "needs clarification" or
"needs reproduction" labels on them as triaged.


## PR Type
What kind of change does this PR introduce?

- [x] CI related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No