### PR TITLE
fix(common): change the week-numbering year format from `r` -> `Y`

### DIFF
--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -13,7 +13,7 @@ export const ISO8601_DATE_REGEX =
 //    1        2       3         4          5          6          7          8  9     10      11
 const NAMED_FORMATS: {[localeId: string]: {[format: string]: string}} = {};
 const DATE_FORMATS_SPLIT =
-    /((?:[^GyrMLwWdEabBhHmsSzZO']+)|(?:'(?:[^']|'')*')|(?:G{1,5}|y{1,4}|r{1,4}|M{1,5}|L{1,5}|w{1,2}|W{1}|d{1,2}|E{1,6}|a{1,5}|b{1,5}|B{1,5}|h{1,2}|H{1,2}|m{1,2}|s{1,2}|S{1,3}|z{1,4}|Z{1,5}|O{1,4}))([\s\S]*)/;
+    /((?:[^GyYMLwWdEabBhHmsSzZO']+)|(?:'(?:[^']|'')*')|(?:G{1,5}|y{1,4}|Y{1,4}|M{1,5}|L{1,5}|w{1,2}|W{1}|d{1,2}|E{1,6}|a{1,5}|b{1,5}|B{1,5}|h{1,2}|H{1,2}|m{1,2}|s{1,2}|S{1,3}|z{1,4}|Z{1,5}|O{1,4}))([\s\S]*)/;
 
 enum ZoneWidth {
   Short,
@@ -451,21 +451,21 @@ function getDateFormatter(format: string): DateFormatter|null {
       break;
 
     // 1 digit representation of the week-numbering year, e.g. (AD 1 => 1, AD 199 => 199)
-    case 'r':
+    case 'Y':
       formatter = weekNumberingYearGetter(1);
       break;
     // 2 digit representation of the week-numbering year, padded (00-99). (e.g. AD 2001 => 01, AD
     // 2010 => 10)
-    case 'rr':
+    case 'YY':
       formatter = weekNumberingYearGetter(2, true);
       break;
     // 3 digit representation of the week-numbering year, padded (000-999). (e.g. AD 1 => 001, AD
     // 2010 => 2010)
-    case 'rrr':
+    case 'YYY':
       formatter = weekNumberingYearGetter(3);
       break;
     // 4 digit representation of the week-numbering year (e.g. AD 1 => 0001, AD 2010 => 2010)
-    case 'rrrr':
+    case 'YYYY':
       formatter = weekNumberingYearGetter(4);
       break;
 

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -65,10 +65,10 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  *  |                    | yy          | Numeric: 2 digits + zero padded                               | 02, 20, 01, 17, 73                                         |
  *  |                    | yyy         | Numeric: 3 digits + zero padded                               | 002, 020, 201, 2017, 20173                                 |
  *  |                    | yyyy        | Numeric: 4 digits or more + zero padded                       | 0002, 0020, 0201, 2017, 20173                              |
- *  | Week-numbering year| r           | Numeric: minimum digits                                       | 2, 20, 201, 2017, 20173                                    |
- *  |                    | rr          | Numeric: 2 digits + zero padded                               | 02, 20, 01, 17, 73                                         |
- *  |                    | rrr         | Numeric: 3 digits + zero padded                               | 002, 020, 201, 2017, 20173                                 |
- *  |                    | rrrr        | Numeric: 4 digits or more + zero padded                       | 0002, 0020, 0201, 2017, 20173                              |
+ *  | Week-numbering year| Y           | Numeric: minimum digits                                       | 2, 20, 201, 2017, 20173                                    |
+ *  |                    | YY          | Numeric: 2 digits + zero padded                               | 02, 20, 01, 17, 73                                         |
+ *  |                    | YYY         | Numeric: 3 digits + zero padded                               | 002, 020, 201, 2017, 20173                                 |
+ *  |                    | YYYY        | Numeric: 4 digits or more + zero padded                       | 0002, 0020, 0201, 2017, 20173                              |
  *  | Month              | M           | Numeric: 1 digit                                              | 9, 12                                                      |
  *  |                    | MM          | Numeric: 2 digits + zero padded                               | 09, 12                                                     |
  *  |                    | MMM         | Abbreviated                                                   | Sep                                                        |

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -95,10 +95,10 @@ describe('Format date', () => {
         yy: '15',
         yyy: '2015',
         yyyy: '2015',
-        r: '2015',
-        rr: '15',
-        rrr: '2015',
-        rrrr: '2015',
+        Y: '2015',
+        YY: '15',
+        YYY: '2015',
+        YYYY: '2015',
         M: '6',
         MM: '06',
         MMM: 'Jun',
@@ -157,10 +157,10 @@ describe('Format date', () => {
         yy: '15',
         yyy: '2015',
         yyyy: '2015',
-        r: '2015',
-        rr: '15',
-        rrr: '2015',
-        rrrr: '2015',
+        Y: '2015',
+        YY: '15',
+        YYY: '2015',
+        YYYY: '2015',
         M: '1',
         MM: '01',
         MMM: 'Jan',
@@ -373,10 +373,10 @@ describe('Format date', () => {
     // https://github.com/angular/angular/issues/38739
     it('should return correct ISO 8601 week-numbering year for dates close to year end/beginning',
        () => {
-         expect(formatDate('2013-12-27', 'rrrr', 'en')).toEqual('2013');
-         expect(formatDate('2013-12-29', 'rrrr', 'en')).toEqual('2014');
-         expect(formatDate('2010-01-02', 'rrrr', 'en')).toEqual('2009');
-         expect(formatDate('2010-01-04', 'rrrr', 'en')).toEqual('2010');
+         expect(formatDate('2013-12-27', 'YYYY', 'en')).toEqual('2013');
+         expect(formatDate('2013-12-29', 'YYYY', 'en')).toEqual('2014');
+         expect(formatDate('2010-01-02', 'YYYY', 'en')).toEqual('2009');
+         expect(formatDate('2010-01-04', 'YYYY', 'en')).toEqual('2010');
        });
   });
 });


### PR DESCRIPTION
This commit updates the week-numbering year format from `r` -> `Y` based on the description in
http://www.unicode.org/reports/tr35/tr35-dates.html#dfst-year.

Note: this is not a breaking change, since the week-numbering year format was introduced in
v11.0.0-next.3 (https://github.com/angular/angular/commit/984ed39195d8291f0da0c2747a45761144e6daa2) and the major version that contains that change was not released yet.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No