### PR TITLE
docs: tView.preOrderHooks and tView.preOrderCheckHooks docs update

### DIFF
--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -663,7 +663,8 @@ export interface TView {
    * instance can be found in `LView`) and hook functions. TNode index is followed by the directive
    * index and a hook function. If there are multiple hooks for a given TNode, the TNode index is
    * not repeated and the next lifecycle hook information is stored right after the previous hook
-   * function.
+   * function. This is done so that at runtime the system can efficiently iterate over all of the
+   * functions to invoke without having to make any decisions/lookups.
    */
   preOrderHooks: HookData|null;
 

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -659,16 +659,18 @@ export interface TView {
    * Array of ngOnInit, ngOnChanges and ngDoCheck hooks that should be executed for this view in
    * creation mode.
    *
-   * Even indices: Directive index
-   * Odd indices: Hook function
+   * This array has a flat structure and contains TNode indices, directive indices (where an
+   * instance can be found in `LView`) and hook functions. TNode index is followed by the directive
+   * index and a hook function. If there are multiple hooks for a given TNode, the TNode index is
+   * not repeated and the next lifecycle hook information is stored right after the previous hook
+   * function.
    */
   preOrderHooks: HookData|null;
 
   /**
    * Array of ngOnChanges and ngDoCheck hooks that should be executed for this view in update mode.
    *
-   * Even indices: Directive index
-   * Odd indices: Hook function
+   * This array has the same structure as the `preOrderHooks` one.
    */
   preOrderCheckHooks: HookData|null;
 
@@ -759,8 +761,7 @@ export interface TView {
 
   /**
    * An array of indices pointing to directives with content queries alongside with the
-   * corresponding
-   * query index. Each entry in this array is a tuple of:
+   * corresponding query index. Each entry in this array is a tuple of:
    * - index of the first content query index declared by a given directive;
    * - index of a directive.
    *


### PR DESCRIPTION
This commit updates the docs for the `tView.preOrderHooks` and `tView.preOrderCheckHooks` TView fields. Current docs are not up-to-date as it was pointed out in #39439.

Closes #39439.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Documentation content changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No