### PR TITLE
refactor(compiler): clean up i18n attribute generation logic

### DIFF
--- a/packages/compiler/src/render3/view/i18n/util.ts
+++ b/packages/compiler/src/render3/view/i18n/util.ts
@@ -50,11 +50,6 @@ export function hasI18nMeta(node: t.Node&{i18n?: i18n.I18nMeta}): boolean {
   return !!node.i18n;
 }
 
-export function isBoundI18nAttribute(node: t.TextAttribute|
-                                     t.BoundAttribute): node is t.BoundAttribute {
-  return node.i18n !== undefined && node instanceof t.BoundAttribute;
-}
-
 export function hasI18nAttrs(element: html.Element): boolean {
   return element.attrs.some((attr: html.Attribute) => isI18nAttribute(attr.name));
 }


### PR DESCRIPTION
This is follow-up from [an earlier discussion](https://github.com/angular/angular/pull/39408#discussion_r511908358). After some testing, it looks like the type of `Element.attributes` was correct in specifying that it only has `TextAttribute` instances. This means that the extra checks that filter out `BoundAttribute` instances from the array isn't necessary. There is another loop a bit further down that actually extracts the bound i18n attributes.
