### PR TITLE
fix(dev-infra): run fetches in the git client in quiet mode

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -2765,7 +2765,7 @@ function checkOutPullRequestLocally(prNumber, githubToken, opts = {}) {
         try {
             // Fetch the branch at the commit of the PR, and check it out in a detached state.
             info(`Checking out PR #${prNumber} from ${fullHeadRef}`);
-            git.run(['fetch', headRefUrl, headRefName]);
+            git.run(['fetch', '-q', headRefUrl, headRefName]);
             git.run(['checkout', '--detach', 'FETCH_HEAD']);
         }
         catch (e) {
@@ -3453,7 +3453,7 @@ var MergeStrategy = /** @class */ (function () {
         });
         // Fetch all target branches with a single command. We don't want to fetch them
         // individually as that could cause an unnecessary slow-down.
-        this.git.run(tslib.__spread(['fetch', '-f', this.git.repoGitUrl], fetchRefspecs, extraRefspecs));
+        this.git.run(tslib.__spread(['fetch', '-q', '-f', this.git.repoGitUrl], fetchRefspecs, extraRefspecs));
     };
     /** Pushes the given target branches upstream. */
     MergeStrategy.prototype.pushTargetBranchesUpstream = function (names) {
@@ -4174,11 +4174,11 @@ function rebasePr(prNumber, githubToken, config = getConfig()) {
         try {
             // Fetch the branch at the commit of the PR, and check it out in a detached state.
             info(`Checking out PR #${prNumber} from ${fullHeadRef}`);
-            git.run(['fetch', headRefUrl, headRefName]);
+            git.run(['fetch', '-q', headRefUrl, headRefName]);
             git.run(['checkout', '--detach', 'FETCH_HEAD']);
             // Fetch the PRs target branch and rebase onto it.
             info(`Fetching ${fullBaseRef} to rebase #${prNumber} on`);
-            git.run(['fetch', baseRefUrl, baseRefName]);
+            git.run(['fetch', '-q', baseRefUrl, baseRefName]);
             info(`Attempting to rebase PR #${prNumber} on ${fullBaseRef}`);
             const rebaseResult = git.runGraceful(['rebase', 'FETCH_HEAD']);
             // If the rebase was clean, push the rebased PR up to the authors fork.
@@ -5498,7 +5498,7 @@ class ReleaseAction {
     /** Checks out an upstream branch with a detached head. */
     checkoutUpstreamBranch(branchName) {
         return tslib.__awaiter(this, void 0, void 0, function* () {
-            this.git.run(['fetch', this.git.repoGitUrl, branchName]);
+            this.git.run(['fetch', '-q', this.git.repoGitUrl, branchName]);
             this.git.run(['checkout', 'FETCH_HEAD', '--detach']);
         });
     }

--- a/dev-infra/pr/common/checkout-pr.ts
+++ b/dev-infra/pr/common/checkout-pr.ts
@@ -102,7 +102,7 @@ export async function checkOutPullRequestLocally(
   try {
     // Fetch the branch at the commit of the PR, and check it out in a detached state.
     info(`Checking out PR #${prNumber} from ${fullHeadRef}`);
-    git.run(['fetch', headRefUrl, headRefName]);
+    git.run(['fetch', '-q', headRefUrl, headRefName]);
     git.run(['checkout', '--detach', 'FETCH_HEAD']);
   } catch (e) {
     git.checkout(previousBranchOrRevision, true);

--- a/dev-infra/pr/merge/strategies/strategy.ts
+++ b/dev-infra/pr/merge/strategies/strategy.ts
@@ -124,7 +124,7 @@ export abstract class MergeStrategy {
     });
     // Fetch all target branches with a single command. We don't want to fetch them
     // individually as that could cause an unnecessary slow-down.
-    this.git.run(['fetch', '-f', this.git.repoGitUrl, ...fetchRefspecs, ...extraRefspecs]);
+    this.git.run(['fetch', '-q', '-f', this.git.repoGitUrl, ...fetchRefspecs, ...extraRefspecs]);
   }
 
   /** Pushes the given target branches upstream. */

--- a/dev-infra/pr/rebase/index.ts
+++ b/dev-infra/pr/rebase/index.ts
@@ -84,12 +84,12 @@ export async function rebasePr(
   try {
     // Fetch the branch at the commit of the PR, and check it out in a detached state.
     info(`Checking out PR #${prNumber} from ${fullHeadRef}`);
-    git.run(['fetch', headRefUrl, headRefName]);
+    git.run(['fetch', '-q', headRefUrl, headRefName]);
     git.run(['checkout', '--detach', 'FETCH_HEAD']);
 
     // Fetch the PRs target branch and rebase onto it.
     info(`Fetching ${fullBaseRef} to rebase #${prNumber} on`);
-    git.run(['fetch', baseRefUrl, baseRefName]);
+    git.run(['fetch', '-q', baseRefUrl, baseRefName]);
     info(`Attempting to rebase PR #${prNumber} on ${fullBaseRef}`);
     const rebaseResult = git.runGraceful(['rebase', 'FETCH_HEAD']);
 

--- a/dev-infra/release/publish/actions.ts
+++ b/dev-infra/release/publish/actions.ts
@@ -350,7 +350,7 @@ export abstract class ReleaseAction {
 
   /** Checks out an upstream branch with a detached head. */
   protected async checkoutUpstreamBranch(branchName: string) {
-    this.git.run(['fetch', this.git.repoGitUrl, branchName]);
+    this.git.run(['fetch', '-q', this.git.repoGitUrl, branchName]);
     this.git.run(['checkout', 'FETCH_HEAD', '--detach']);
   }
 

--- a/dev-infra/utils/testing/virtual-git-client.ts
+++ b/dev-infra/utils/testing/virtual-git-client.ts
@@ -105,7 +105,7 @@ export class VirtualGitClient extends GitClient {
 
   /** Handler for the `git fetch` command. */
   private _fetch(rawArgs: string[]) {
-    const args = parseArgs(rawArgs, {boolean: ['f', 'force']});
+    const args = parseArgs(rawArgs, {boolean: ['f', 'force', 'q']});
     const [repoUrl, refspec] = args._;
     const force = args['f'] || args['force'];
     const ref = this._unwrapRefspec(refspec);

--- a/dev-infra/utils/testing/virtual-git-client.ts
+++ b/dev-infra/utils/testing/virtual-git-client.ts
@@ -105,7 +105,7 @@ export class VirtualGitClient extends GitClient {
 
   /** Handler for the `git fetch` command. */
   private _fetch(rawArgs: string[]) {
-    const args = parseArgs(rawArgs, {boolean: ['f', 'force', 'q']});
+    const args = parseArgs(rawArgs, {boolean: ['f', 'force', 'q', 'quiet']});
     const [repoUrl, refspec] = args._;
     const force = args['f'] || args['force'];
     const ref = this._unwrapRefspec(refspec);


### PR DESCRIPTION
When fetch is run in normal mode, the `git-fetch-pack` plumbing command
outputs progress to stderr.  Since this is unnecessary progress
information for `ng-dev` usages and should be suppressed instead.
