### PR TITLE
feat(dev-infra): provide tooling to check what branches a pr targets

### DIFF
--- a/dev-infra/pr/BUILD.bazel
+++ b/dev-infra/pr/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
     module_name = "@angular/dev-infra-private/pr",
     visibility = ["//dev-infra:__subpackages__"],
     deps = [
+        "//dev-infra/pr/check-target-branches",
         "//dev-infra/pr/checkout",
         "//dev-infra/pr/discover-new-conflicts",
         "//dev-infra/pr/merge",

--- a/dev-infra/pr/check-target-branches/BUILD.bazel
+++ b/dev-infra/pr/check-target-branches/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@npm//@bazel/typescript:index.bzl", "ts_library")
+
+ts_library(
+    name = "check-target-branches",
+    srcs = glob(["*.ts"]),
+    module_name = "@angular/dev-infra-private/pr/check-target-branches",
+    visibility = ["//dev-infra:__subpackages__"],
+    deps = [
+        "//dev-infra/pr/merge",
+        "//dev-infra/utils",
+        "@npm//@types/yargs",
+    ],
+)

--- a/dev-infra/pr/check-target-branches/check-target-branches.ts
+++ b/dev-infra/pr/check-target-branches/check-target-branches.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getConfig} from '../../utils/config';
+import {error, info, red} from '../../utils/console';
+import {GitClient} from '../../utils/git/index';
+import {loadAndValidateConfig} from '../merge/config';
+import {getBranchesFromTargetLabel, getTargetLabelFromPullRequest} from '../merge/target-label';
+
+export async function checkTargetBranchesForPr(prNumber: number, jsonOutput = false) {
+  /** The ng-dev configuration. */
+  const config = getConfig();
+  /** Repo owner and name for the github repository. */
+  const {owner, name: repo} = config.github;
+  /** The git client to get a Github API service instance. */
+  const git = new GitClient(undefined, config);
+  /** The validated merge config. */
+  const {config: mergeConfig, errors} = await loadAndValidateConfig(config, git.github);
+  if (errors !== undefined) {
+    throw Error(`Invalid configuration found: ${errors}`);
+  }
+  /** The current state of the pull request from Github. */
+  const prData = (await git.github.pulls.get({owner, repo, pull_number: prNumber})).data;
+  /** The list of labels on the PR as strings. */
+  const labels = prData.labels.map(l => l.name);
+  /** The branch targetted via the Github UI. */
+  const githubTargetBranch = prData.base.ref;
+  /** The active label which is being used for targetting the PR. */
+  const targetLabel = getTargetLabelFromPullRequest(mergeConfig!, labels);
+  if (targetLabel === null) {
+    error(red(`No target label was found on pr #${prNumber}`));
+    process.exitCode = 1;
+    return;
+  }
+  /** The target branches based on the target label and branch targetted in the Github UI. */
+  const targets = await getBranchesFromTargetLabel(targetLabel, githubTargetBranch);
+
+  // When requested, print a json output to stdout, rather than using standard ng-dev logging.
+  if (jsonOutput) {
+    process.stdout.write(JSON.stringify(targets));
+    return;
+  }
+
+  info.group(`PR #${prNumber} will merge into:`);
+  targets.forEach(target => info(`- ${target}`));
+  info.groupEnd();
+}

--- a/dev-infra/pr/check-target-branches/cli.ts
+++ b/dev-infra/pr/check-target-branches/cli.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Arguments, Argv, CommandModule} from 'yargs';
+
+import {checkTargetBranchesForPr} from './check-target-branches';
+
+export interface CheckTargetBranchesOptions {
+  pr: number;
+  json: boolean;
+}
+
+/** Builds the command. */
+function builder(yargs: Argv) {
+  return yargs
+      .positional('pr', {
+        description: 'The pull request number',
+        type: 'number',
+        demandOption: true,
+      })
+      .option('json', {
+        type: 'boolean',
+        default: false,
+        description: 'Print response as json',
+      });
+}
+
+/** Handles the command. */
+async function handler({pr, json}: Arguments<CheckTargetBranchesOptions>) {
+  await checkTargetBranchesForPr(pr, json);
+}
+
+/** yargs command module describing the command.  */
+export const CheckTargetBranchesModule: CommandModule<{}, CheckTargetBranchesOptions> = {
+  handler,
+  builder,
+  command: 'check-target-branches <pr>',
+  describe: 'Check a PR to determine what branches it is currently targeting',
+};

--- a/dev-infra/pr/cli.ts
+++ b/dev-infra/pr/cli.ts
@@ -8,6 +8,7 @@
 
 import * as yargs from 'yargs';
 
+import {CheckTargetBranchesModule} from './check-target-branches/cli';
 import {CheckoutCommandModule} from './checkout/cli';
 import {buildDiscoverNewConflictsCommand, handleDiscoverNewConflictsCommand} from './discover-new-conflicts/cli';
 import {buildMergeCommand, handleMergeCommand} from './merge/cli';
@@ -26,5 +27,6 @@ export function buildPrParser(localYargs: yargs.Argv) {
       .command(
           'rebase <pr-number>', 'Rebase a pending PR and push the rebased commits back to Github',
           buildRebaseCommand, handleRebaseCommand)
-      .command(CheckoutCommandModule);
+      .command(CheckoutCommandModule)
+      .command(CheckTargetBranchesModule);
 }


### PR DESCRIPTION
Create a command in the `ng-dev` toolset that allows user's to check
what branches a PR will merge into based on its targeting.
