### PR TITLE
fix(http): queue jsonp <script> tag onLoad event handler in microtask

### DIFF
--- a/packages/common/http/test/jsonp_spec.ts
+++ b/packages/common/http/test/jsonp_spec.ts
@@ -45,6 +45,16 @@ const SAMPLE_REQ = new HttpRequest<never>('JSONP', '/test');
       runOnlyCallback(home, {data: 'This is a test'});
       document.mockLoad();
     });
+    // Issue #39496
+    it('handles a request with callback call wrapped in promise', done => {
+      backend.handle(SAMPLE_REQ).subscribe(() => {
+        done();
+      });
+      Promise.resolve().then(() => {
+        runOnlyCallback(home, {data: 'This is a test'});
+      });
+      document.mockLoad();
+    });
     it('handles an error response properly', done => {
       const error = new Error('This is a test error');
       backend.handle(SAMPLE_REQ).pipe(toArray()).subscribe(undefined, (err: HttpErrorResponse) => {


### PR DESCRIPTION
 

Fixes #39496

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #39496

Before this change, when trying to load a JSONP script that calls the JSONP callback inside a setTimeout function, it will fail in Internet Explorer 11 and EdgeHTML.

## What is the new behavior?

This commit changes the event handler on the script tag to be queued with setTimeout. This ensures that the aforementioned browsers will first evaluate the loaded script calling the JSONP callback and only then run the load handler which does the tear down of the callback function and script tag.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
