### PR TITLE
fix(compiler-cli): avoid duplicate diagnostics about unknown pipes

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
@@ -73,6 +73,12 @@ export interface OutOfBandDiagnosticRecorder {
 export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecorder {
   private _diagnostics: TemplateDiagnostic[] = [];
 
+  /**
+   * Tracks which `BindingPipe` nodes have already been recorded as invalid, so only one diagnostic
+   * is ever produced per node.
+   */
+  private recordedPipes = new Set<BindingPipe>();
+
   constructor(private resolver: TemplateSourceResolver) {}
 
   get diagnostics(): ReadonlyArray<TemplateDiagnostic> {
@@ -90,6 +96,10 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
   }
 
   missingPipe(templateId: TemplateId, ast: BindingPipe): void {
+    if (this.recordedPipes.has(ast)) {
+      return;
+    }
+
     const mapping = this.resolver.getSourceMapping(templateId);
     const errorMsg = `No pipe found with name '${ast.name}'.`;
 
@@ -101,6 +111,7 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
     this._diagnostics.push(makeTemplateDiagnostic(
         templateId, mapping, sourceSpan, ts.DiagnosticCategory.Error,
         ngErrorCode(ErrorCode.MISSING_PIPE), errorMsg));
+    this.recordedPipes.add(ast);
   }
 
   illegalAssignmentToTemplateVar(


### PR DESCRIPTION
TCB generation occasionally transforms binding expressions twice, which can
result in a `BindingPipe` operation being `resolve()`'d multiple times. When
the pipe does not exist, this caused multiple OOB diagnostics to be recorded
about the missing pipe.

This commit fixes the problem by making the OOB recorder track which pipe
expressions have had diagnostics produced already, and only producing them
once per expression.