### PR TITLE
ci: only check testing directories within packages/ for fw-testing

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -657,7 +657,7 @@ groups:
       - *can-be-global-docs-approved
       - >
         contains_any_globs(files.exclude('packages/compiler-cli/**'), [
-          '**/testing/**',
+          'packages/**/testing/**',
           'aio/content/guide/testing.md',
           'aio/content/guide/test-debugging.md',
           'aio/content/guide/testing-attribute-directives.md',


### PR DESCRIPTION
The fw-testing group should only match on testing directories within the
framework packages, previously it was also matching in other areas of
the codebase.
