### PR TITLE
fix(compiler): disallow i18n of security-sensitive attributes

### DIFF
--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -321,8 +321,6 @@ export class Identifiers {
   static sanitizeUrlOrResourceUrl:
       o.ExternalReference = {name: 'ɵɵsanitizeUrlOrResourceUrl', moduleName: CORE};
   static trustConstantHtml: o.ExternalReference = {name: 'ɵɵtrustConstantHtml', moduleName: CORE};
-  static trustConstantScript:
-      o.ExternalReference = {name: 'ɵɵtrustConstantScript', moduleName: CORE};
   static trustConstantResourceUrl:
       o.ExternalReference = {name: 'ɵɵtrustConstantResourceUrl', moduleName: CORE};
 }

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -14,6 +14,7 @@ import * as html from '../../../ml_parser/ast';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../../ml_parser/interpolation_config';
 import {ParseTreeResult} from '../../../ml_parser/parser';
 import * as o from '../../../output/output_ast';
+import {isTrustedTypesSink} from '../../../schema/trusted_types_sinks';
 
 import {hasI18nAttrs, I18N_ATTR, I18N_ATTR_PREFIX, icuFromI18nMessage} from './util';
 
@@ -90,9 +91,13 @@ export class I18nMetaVisitor implements html.Visitor {
 
         } else if (attr.name.startsWith(I18N_ATTR_PREFIX)) {
           // 'i18n-*' attributes
-          const key = attr.name.slice(I18N_ATTR_PREFIX.length);
-          attrsMeta[key] = attr.value;
-
+          const name = attr.name.slice(I18N_ATTR_PREFIX.length);
+          if (isTrustedTypesSink(element.name, name)) {
+            this._reportError(
+                attr, `Translating attribute '${name}' is disallowed for security reasons.`);
+          } else {
+            attrsMeta[name] = attr.value;
+          }
         } else {
           // non-i18n attributes
           attrs.push(attr);

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -2073,7 +2073,22 @@ export function parseTemplate(
   const i18nMetaVisitor = new I18nMetaVisitor(
       interpolationConfig, /* keepI18nAttrs */ !preserveWhitespaces,
       enableI18nLegacyMessageIdFormat);
-  rootNodes = html.visitAll(i18nMetaVisitor, rootNodes);
+  const i18nMetaResult = i18nMetaVisitor.visitAllWithErrors(rootNodes);
+
+  if (i18nMetaResult.errors && i18nMetaResult.errors.length > 0) {
+    return {
+      interpolationConfig,
+      preserveWhitespaces,
+      template,
+      errors: i18nMetaResult.errors,
+      nodes: [],
+      styleUrls: [],
+      styles: [],
+      ngContentSelectors: []
+    };
+  }
+
+  rootNodes = i18nMetaResult.rootNodes;
 
   if (!preserveWhitespaces) {
     rootNodes = html.visitAll(new WhitespaceVisitor(), rootNodes);

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -2156,8 +2156,7 @@ function trustedConstAttribute(tagName: string, attr: t.TextAttribute): o.Expres
     switch (elementRegistry.securityContext(tagName, attr.name, /* isAttribute */ true)) {
       case core.SecurityContext.HTML:
         return o.importExpr(R3.trustConstantHtml).callFn([value], attr.valueSpan);
-      case core.SecurityContext.SCRIPT:
-        return o.importExpr(R3.trustConstantScript).callFn([value], attr.valueSpan);
+      // NB: no SecurityContext.SCRIPT here, as the corresponding tags are stripped by the compiler.
       case core.SecurityContext.RESOURCE_URL:
         return o.importExpr(R3.trustConstantResourceUrl).callFn([value], attr.valueSpan);
       default:

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -19,7 +19,7 @@ import {SecurityContext} from '../core';
 //
 // =================================================================================================
 
-/** Map from tagName|propertyName SecurityContext. Properties applying to all tags use '*'. */
+/** Map from tagName|propertyName to SecurityContext. Properties applying to all tags use '*'. */
 let _SECURITY_SCHEMA!: {[k: string]: SecurityContext};
 
 export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {

--- a/packages/compiler/src/schema/trusted_types_sinks.ts
+++ b/packages/compiler/src/schema/trusted_types_sinks.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Set of tagName|propertyName corresponding to Trusted Types sinks. Properties applying to all
+ * tags use '*'.
+ *
+ * Extracted from, and should be kept in sync with
+ * https://w3c.github.io/webappsec-trusted-types/dist/spec/#integrations
+ */
+const TRUSTED_TYPES_SINKS = new Set<string>([
+  // NOTE: All strings in this set *must* be lowercase!
+
+  // TrustedHTML
+  'iframe|srcdoc',
+  '*|innerhtml',
+  '*|outerhtml',
+
+  // NB: no TrustedScript here, as the corresponding tags are stripped by the compiler.
+
+  // TrustedScriptURL
+  'embed|src',
+  'object|codebase',
+  'object|data',
+]);
+
+/**
+ * isTrustedTypesSink returns true if the given property on the given DOM tag is a Trusted Types
+ * sink. In that case, use `ElementSchemaRegistry.securityContext` to determine which particular
+ * Trusted Type is required for values passed to the sink:
+ * - SecurityContext.HTML corresponds to TrustedHTML
+ * - SecurityContext.RESOURCE_URL corresponds to TrustedScriptURL
+ */
+export function isTrustedTypesSink(tagName: string, propName: string): boolean {
+  // Make sure comparisons are case insensitive, so that case differences between attribute and
+  // property names do not have a security impact.
+  tagName = tagName.toLowerCase();
+  propName = propName.toLowerCase();
+
+  return TRUSTED_TYPES_SINKS.has(tagName + '|' + propName) ||
+      TRUSTED_TYPES_SINKS.has('*|' + propName);
+}

--- a/packages/compiler/test/schema/trusted_types_sinks_spec.ts
+++ b/packages/compiler/test/schema/trusted_types_sinks_spec.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {isTrustedTypesSink} from '@angular/compiler/src/schema/trusted_types_sinks';
+import {describe, expect, it} from '@angular/core/testing/src/testing_internal';
+
+{
+  describe('isTrustedTypesSink', () => {
+    it('should classify Trusted Types sinks', () => {
+      expect(isTrustedTypesSink('iframe', 'srcdoc')).toBeTrue();
+      expect(isTrustedTypesSink('p', 'innerHTML')).toBeTrue();
+      expect(isTrustedTypesSink('embed', 'src')).toBeTrue();
+      expect(isTrustedTypesSink('a', 'href')).toBeFalse();
+      expect(isTrustedTypesSink('base', 'href')).toBeFalse();
+      expect(isTrustedTypesSink('div', 'style')).toBeFalse();
+    });
+
+    it('should classify Trusted Types sinks case insensitive', () => {
+      expect(isTrustedTypesSink('p', 'iNnErHtMl')).toBeTrue();
+      expect(isTrustedTypesSink('p', 'formaction')).toBeFalse();
+      expect(isTrustedTypesSink('p', 'formAction')).toBeFalse();
+    });
+
+    it('should classify attributes as Trusted Types sinks', () => {
+      expect(isTrustedTypesSink('p', 'innerHtml')).toBeTrue();
+      expect(isTrustedTypesSink('p', 'formaction')).toBeFalse();
+    });
+  });
+}

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -295,7 +295,6 @@ export {
   ɵɵsanitizeUrlOrResourceUrl,
   ɵɵtrustConstantHtml,
   ɵɵtrustConstantResourceUrl,
-  ɵɵtrustConstantScript,
 } from './sanitization/sanitization';
 export {
   noSideEffects as ɵnoSideEffects,

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -168,7 +168,6 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵsanitizeUrl': sanitization.ɵɵsanitizeUrl,
        'ɵɵsanitizeUrlOrResourceUrl': sanitization.ɵɵsanitizeUrlOrResourceUrl,
        'ɵɵtrustConstantHtml': sanitization.ɵɵtrustConstantHtml,
-       'ɵɵtrustConstantScript': sanitization.ɵɵtrustConstantScript,
        'ɵɵtrustConstantResourceUrl': sanitization.ɵɵtrustConstantResourceUrl,
 
        'ɵɵngDeclareDirective': partial.ɵɵngDeclareDirective,

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -11,7 +11,7 @@ import {SANITIZER} from '../render3/interfaces/view';
 import {getLView} from '../render3/state';
 import {renderStringify} from '../render3/util/misc_utils';
 import {TrustedHTML, TrustedScript, TrustedScriptURL} from '../util/security/trusted_type_defs';
-import {trustedHTMLFromString, trustedScriptFromString, trustedScriptURLFromString} from '../util/security/trusted_types';
+import {trustedHTMLFromString, trustedScriptURLFromString} from '../util/security/trusted_types';
 import {trustedHTMLFromStringBypass, trustedScriptFromStringBypass, trustedScriptURLFromStringBypass} from '../util/security/trusted_types_bypass';
 
 import {allowSanitizationBypassAndThrow, BypassType, unwrapSafeValue} from './bypass';
@@ -157,21 +157,6 @@ export function ɵɵsanitizeScript(unsafeScript: any): TrustedScript|string {
  */
 export function ɵɵtrustConstantHtml(html: string): TrustedHTML|string {
   return trustedHTMLFromString(html);
-}
-
-/**
- * Promotes the given constant string to a TrustedScript.
- * @param script constant string containing a trusted script.
- * @returns TrustedScript wrapping `script`.
- *
- * @security This is a security-sensitive function and should only be used to
- * convert constant values of attributes and properties found in
- * application-provided Angular templates to TrustedScript.
- *
- * @codeGenApi
- */
-export function ɵɵtrustConstantScript(script: string): TrustedScript|string {
-  return trustedScriptFromString(script);
 }
 
 /**

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -283,5 +283,31 @@ function declareTests(config?: {useJit: boolean}) {
         expect(e.innerHTML).toEqual('also  evil');
       });
     });
+
+    onlyInIvy('Trusted Types are only supported in Ivy').describe('translation', () => {
+      it('should throw error on security-sensitive attributes with constant values', () => {
+        const template = `<iframe srcdoc="foo" i18n-srcdoc></iframe>`;
+        TestBed.overrideComponent(SecuredComponent, {set: {template}});
+
+        expect(() => TestBed.createComponent(SecuredComponent))
+            .toThrowError(/Translating attribute 'srcdoc' is disallowed for security reasons./);
+      });
+
+      it('should throw error on security-sensitive attributes with interpolated values', () => {
+        const template = `<object i18n-data data="foo{{bar}}baz"></object>`;
+        TestBed.overrideComponent(SecuredComponent, {set: {template}});
+
+        expect(() => TestBed.createComponent(SecuredComponent))
+            .toThrowError(/Translating attribute 'data' is disallowed for security reasons./);
+      });
+
+      it('should throw error on security-sensitive attributes with bound values', () => {
+        const template = `<div [innerHTML]="foo" i18n-innerHTML></div>`;
+        TestBed.overrideComponent(SecuredComponent, {set: {template}});
+
+        expect(() => TestBed.createComponent(SecuredComponent))
+            .toThrowError(/Translating attribute 'innerHTML' is disallowed for security reasons./);
+      });
+    });
   });
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [X] Other... Please describe: Security improvements.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

It is currently possible to mark security-sensitive attributes for i18n translation, e.g.:
```
<embed src="https://google.com" i18n-src />
```

This is a feature that should have very little use, but at the same time introduces complexity and security risk in the i18n pipeline.

## What is the new behavior?

The above template now generates a parsing error:
```
Error: src/app/app.component.html:69:35 - error NG5002: Translating attribute 'src' is disallowed for security reasons.

69   <embed src="https://google.com" i18n-src />
                                     ~~~~~~~~
```

(The same error occurs when using `ng extract-i18n`.)

Note that this only applies to attributes/properties that are relevant to Trusted Types, which are now enumerated in trusted_types_schema.ts:
- `frame.srcdoc`
- `*.innerHTML`
- `*.outerHTML`
- `embed.src`
- `object.codebase`
- `object.data`

These can be considered the most risky attributes/properties in terms of XSS. (Note that the script tag, inline event handlers, and other attributes/properties of a script context are not relevant here as they are already forbidden or stripped out by the compiler.)

Piggyback:
- Remove `trustConstScript`, as it was never needed.
- Use the new trusted_types_schema to reduce the number of constants that are converted to Trusted Types, and thus improve tree-shakability.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
This seems to be used extremely rarely. Sifting through GitHub search results for [i18n-src](https://github.com/search?q=i18n-src&type=Code) only reveals a [single result](https://github.com/IUNO-TDM/JuiceMarketplaceWebsite/blob/9028632b9aadd36413fdda0a2ac16477196aca83/JuiceMarketplaceWebsite-app/src/app/landingpage/start/start.component.html#L60) that might be affected by this change. (Note that e.g. `<img i18n-src` is not affected, since it is not a security-sensitive attribute.)

For applications that need to migrate away from this pattern, translation can be done in the corresponding TS file and regular interpolation used in the Angular template instead.

## Other information
