### PR TITLE
test(compiler-cli): resolve test failure

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -3340,16 +3340,13 @@ describe('compiler compliance', () => {
 
          // The setClassMetadata call should look like this.
          const setClassMetadata = `
-            …
-            (function() {
-              i0.ɵsetClassMetadata(Comp, [{
-                type: Component,
-                args: [{
-                  template: '',
-                  providers: [{ provide: token, useExisting: Comp }],
-                }]
-              }], null, null);
-            })();
+           …
+          (function() {
+            i0.ɵsetClassMetadata(Comp, [{
+              type: Component,
+              args: [{
+                template: '',
+                providers: [{ provide: token, useExisting: Comp }]
           `;
 
          const result = compile(files, angularFiles, {target: ts.ScriptTarget.ES5});


### PR DESCRIPTION
Narrows down an assertion in one of our tests so it's less prone to failure due to extra commas.