### PR TITLE
fix(common): cleanup location change listeners when the root view is removed

### DIFF
--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -96,11 +96,12 @@ export declare function getLocaleWeekEndRange(locale: string): [WeekDay, WeekDay
 
 export declare function getNumberOfCurrencyDigits(code: string): number;
 
-export declare class HashLocationStrategy extends LocationStrategy {
+export declare class HashLocationStrategy extends LocationStrategy implements OnDestroy {
     constructor(_platformLocation: PlatformLocation, _baseHref?: string);
     back(): void;
     forward(): void;
     getBaseHref(): string;
+    ngOnDestroy(): void;
     onPopState(fn: LocationChangeListener): void;
     path(includeHash?: boolean): string;
     prepareExternalUrl(internal: string): string;
@@ -324,11 +325,12 @@ export declare enum NumberSymbol {
     CurrencyGroup = 13
 }
 
-export declare class PathLocationStrategy extends LocationStrategy {
+export declare class PathLocationStrategy extends LocationStrategy implements OnDestroy {
     constructor(_platformLocation: PlatformLocation, href?: string);
     back(): void;
     forward(): void;
     getBaseHref(): string;
+    ngOnDestroy(): void;
     onPopState(fn: LocationChangeListener): void;
     path(includeHash?: boolean): string;
     prepareExternalUrl(internal: string): string;
@@ -355,8 +357,8 @@ export declare abstract class PlatformLocation {
     abstract forward(): void;
     abstract getBaseHrefFromDOM(): string;
     abstract getState(): unknown;
-    abstract onHashChange(fn: LocationChangeListener): void;
-    abstract onPopState(fn: LocationChangeListener): void;
+    abstract onHashChange(fn: LocationChangeListener): () => void;
+    abstract onPopState(fn: LocationChangeListener): () => void;
     abstract pushState(state: any, title: string, url: string): void;
     abstract replaceState(state: any, title: string, url: string): void;
 }

--- a/goldens/public-api/common/testing/testing.d.ts
+++ b/goldens/public-api/common/testing/testing.d.ts
@@ -33,8 +33,8 @@ export declare class MockPlatformLocation implements PlatformLocation {
     forward(): void;
     getBaseHrefFromDOM(): string;
     getState(): unknown;
-    onHashChange(fn: LocationChangeListener): void;
-    onPopState(fn: LocationChangeListener): void;
+    onHashChange(fn: LocationChangeListener): () => void;
+    onPopState(fn: LocationChangeListener): () => void;
     pushState(state: any, title: string, newUrl: string): void;
     replaceState(state: any, title: string, newUrl: string): void;
 }

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -11,18 +11,18 @@
   "aio-local": {
     "master": {
       "uncompressed": {
-        "runtime-es2015": 3033,
-        "main-es2015": 447349,
-        "polyfills-es2015": 52493
+        "runtime-es2015": 3037,
+        "main-es2015": 447848,
+        "polyfills-es2015": 52415
       }
     }
   },
   "aio-local-viewengine": {
     "master": {
       "uncompressed": {
-        "runtime-es2015": 3153,
-        "main-es2015": 431137,
-        "polyfills-es2015": 52493
+        "runtime-es2015": 3157,
+        "main-es2015": 431758,
+        "polyfills-es2015": 52415
       }
     }
   }

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2285,
-        "main-es2015": 241837,
+        "main-es2015": 241972,
         "polyfills-es2015": 36709,
         "5-es2015": 745
       }
@@ -48,10 +48,10 @@
   "cli-hello-world-lazy-rollup": {
     "master": {
       "uncompressed": {
-        "runtime-es2015": 2289,
-        "main-es2015": 218507,
-        "polyfills-es2015": 36723,
-        "5-es2015": 781
+        "runtime-es2015": 2285,
+        "main-es2015": 218998,
+        "polyfills-es2015": 36709,
+        "5-es2015": 777
       }
     }
   },

--- a/packages/common/src/location/hash_location_strategy.ts
+++ b/packages/common/src/location/hash_location_strategy.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, Optional} from '@angular/core';
+import {Inject, Injectable, OnDestroy, Optional} from '@angular/core';
 import {APP_BASE_HREF, LocationStrategy} from './location_strategy';
 import {LocationChangeListener, PlatformLocation} from './platform_location';
 import {joinWithSlash, normalizeQueryParams} from './util';
@@ -32,8 +32,10 @@ import {joinWithSlash, normalizeQueryParams} from './util';
  * @publicApi
  */
 @Injectable()
-export class HashLocationStrategy extends LocationStrategy {
+export class HashLocationStrategy extends LocationStrategy implements OnDestroy {
   private _baseHref: string = '';
+  private _removeListenerFns: (() => void)[] = [];
+
   constructor(
       private _platformLocation: PlatformLocation,
       @Optional() @Inject(APP_BASE_HREF) _baseHref?: string) {
@@ -43,9 +45,15 @@ export class HashLocationStrategy extends LocationStrategy {
     }
   }
 
+  ngOnDestroy(): void {
+    while (this._removeListenerFns.length) {
+      this._removeListenerFns.pop()!();
+    }
+  }
+
   onPopState(fn: LocationChangeListener): void {
-    this._platformLocation.onPopState(fn);
-    this._platformLocation.onHashChange(fn);
+    this._removeListenerFns.push(
+        this._platformLocation.onPopState(fn), this._platformLocation.onHashChange(fn));
   }
 
   getBaseHref(): string {

--- a/packages/common/src/location/platform_location.ts
+++ b/packages/common/src/location/platform_location.ts
@@ -40,8 +40,14 @@ import {DOCUMENT} from '../dom_tokens';
 export abstract class PlatformLocation {
   abstract getBaseHrefFromDOM(): string;
   abstract getState(): unknown;
-  abstract onPopState(fn: LocationChangeListener): void;
-  abstract onHashChange(fn: LocationChangeListener): void;
+  /**
+   * Returns a function that, when executed, removes the `popstate` event handler.
+   */
+  abstract onPopState(fn: LocationChangeListener): () => void;
+  /**
+   * Returns a function that, when executed, removes the `hashchange` event handler.
+   */
+  abstract onHashChange(fn: LocationChangeListener): () => void;
 
   abstract get href(): string;
   abstract get protocol(): string;
@@ -122,12 +128,16 @@ export class BrowserPlatformLocation extends PlatformLocation {
     return getDOM().getBaseHref(this._doc)!;
   }
 
-  onPopState(fn: LocationChangeListener): void {
-    getDOM().getGlobalEventTarget(this._doc, 'window').addEventListener('popstate', fn, false);
+  onPopState(fn: LocationChangeListener): () => void {
+    const window = getDOM().getGlobalEventTarget(this._doc, 'window');
+    window.addEventListener('popstate', fn, false);
+    return () => window.removeEventListener('popstate', fn);
   }
 
-  onHashChange(fn: LocationChangeListener): void {
-    getDOM().getGlobalEventTarget(this._doc, 'window').addEventListener('hashchange', fn, false);
+  onHashChange(fn: LocationChangeListener): () => void {
+    const window = getDOM().getGlobalEventTarget(this._doc, 'window');
+    window.addEventListener('hashchange', fn, false);
+    return () => window.removeEventListener('hashchange', fn);
   }
 
   get href(): string {

--- a/packages/common/testing/src/mock_platform_location.ts
+++ b/packages/common/testing/src/mock_platform_location.ts
@@ -153,13 +153,15 @@ export class MockPlatformLocation implements PlatformLocation {
     return this.baseHref;
   }
 
-  onPopState(fn: LocationChangeListener): void {
+  onPopState(fn: LocationChangeListener): () => void {
     // No-op: a state stack is not implemented, so
     // no events will ever come.
+    return () => {};
   }
 
-  onHashChange(fn: LocationChangeListener): void {
+  onHashChange(fn: LocationChangeListener): () => void {
     this.hashUpdate.subscribe(fn);
+    return () => {};
   }
 
   get href(): string {

--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -70,13 +70,15 @@ export class ServerPlatformLocation implements PlatformLocation {
     return getDOM().getBaseHref(this._doc)!;
   }
 
-  onPopState(fn: LocationChangeListener): void {
+  onPopState(fn: LocationChangeListener): () => void {
     // No-op: a state stack is not implemented, so
     // no events will ever come.
+    return () => {};
   }
 
-  onHashChange(fn: LocationChangeListener): void {
+  onHashChange(fn: LocationChangeListener): () => void {
     this._hashUpdate.subscribe(fn);
+    return () => {};
   }
 
   get url(): string {

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_BASE_HREF, DOCUMENT, Location, ɵgetDOM as getDOM} from '@angular/common';
+import {APP_BASE_HREF, DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
 import {ApplicationRef, Component, CUSTOM_ELEMENTS_SCHEMA, destroyPlatform, NgModule} from '@angular/core';
 import {inject} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
@@ -367,6 +367,33 @@ describe('bootstrap', () => {
     expect(window.pageYOffset).toBeGreaterThanOrEqual(8900);
     expect(window.pageYOffset).toBeLessThan(9000);
     done();
+  });
+
+  it('should cleanup "popstate" and "hashchange" listeners', async () => {
+    @NgModule({
+      imports: [BrowserModule, RouterModule.forRoot([])],
+      declarations: [RootCmp],
+      bootstrap: [RootCmp],
+      providers: testProviders,
+    })
+    class TestModule {
+    }
+
+    spyOn(window, 'addEventListener').and.callThrough();
+    spyOn(window, 'removeEventListener').and.callThrough();
+
+    const ngModuleRef = await platformBrowserDynamic().bootstrapModule(TestModule);
+    ngModuleRef.destroy();
+
+    expect(window.addEventListener).toHaveBeenCalledTimes(2);
+
+    expect(window.addEventListener)
+        .toHaveBeenCalledWith('popstate', jasmine.any(Function), jasmine.any(Boolean));
+    expect(window.addEventListener)
+        .toHaveBeenCalledWith('hashchange', jasmine.any(Function), jasmine.any(Boolean));
+
+    expect(window.removeEventListener).toHaveBeenCalledWith('popstate', jasmine.any(Function));
+    expect(window.removeEventListener).toHaveBeenCalledWith('hashchange', jasmine.any(Function));
   });
 
   function waitForNavigationToComplete(router: Router): Promise<any> {


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31546

In the current behavior Angular doesn't cleanup `popstate` and `hashchange` event listeners when the root view gets destroyed when calling `ngModuleRef.destroy()`. This entails duplicating event handlers every time the application is bootstrapped again.


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No



## Other information
