### PR TITLE
ci(docs-infra): improve the logs of the `deploy_aio` CI job

### DIFF
--- a/aio/scripts/deploy-to-firebase.js
+++ b/aio/scripts/deploy-to-firebase.js
@@ -4,7 +4,7 @@
 //
 'use strict';
 
-const {cd, cp, exec: _exec, set} = require('shelljs');
+const {cd, cp, exec, set} = require('shelljs');
 
 set('-e');
 
@@ -187,13 +187,8 @@ function deploy(
   yarn(`test-pwa-score "${deployedUrl}" "${minPwaScore}"`);
 }
 
-function exec(cmd, opts) {
-  // Using `silent: true` to ensure no secret env variables are printed.
-  return _exec(cmd, {silent: true, ...opts}).trim();
-}
-
 function getRemoteRefs(refOrPattern, remote = NG_REMOTE_URL) {
-  return exec(`git ls-remote ${remote} ${refOrPattern}`).split('\n');
+  return exec(`git ls-remote ${remote} ${refOrPattern}`, {silent: true}).trim().split('\n');
 }
 
 function getLatestCommit(branchName, remote = undefined) {
@@ -206,5 +201,10 @@ function skipDeployment(reason) {
 
 function yarn(cmd) {
   // Using `--silent` to ensure no secret env variables are printed.
+  //
+  // NOTE:
+  // This is not strictly necessary, since CircleCI will mask secret environment variables in the
+  // output (see https://circleci.com/docs/2.0/env-vars/#secrets-masking), but is an extra
+  // precaution.
   return exec(`yarn --silent ${cmd}`);
 }

--- a/aio/scripts/deploy-to-firebase.js
+++ b/aio/scripts/deploy-to-firebase.js
@@ -31,6 +31,7 @@ if (require.main === module) {
   } else {
     console.log(
         `Git branch        : ${inputVars.currentBranch}\n` +
+        `Git commit        : ${inputVars.currentCommit}\n` +
         `Build/deploy mode : ${deploymentInfo.deployEnv}\n` +
         `Firebase project  : ${deploymentInfo.projectId}\n` +
         `Firebase site     : ${deploymentInfo.siteId}\n` +

--- a/aio/scripts/deploy-to-firebase.spec.js
+++ b/aio/scripts/deploy-to-firebase.spec.js
@@ -262,17 +262,19 @@ describe('deploy-to-firebase:', () => {
   });
 
   it('integration - should run the main script without error', () => {
+    const commit = getLatestCommit('master');
     const cmd = `"${process.execPath}" "${__dirname}/deploy-to-firebase" --dry-run`;
     const env = {
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: 'master',
-      CI_COMMIT: getLatestCommit('master')
+      CI_COMMIT: commit,
     };
     const result = execSync(cmd, {encoding: 'utf8', env}).trim();
     expect(result).toBe(
         'Git branch        : master\n' +
+        `Git commit        : ${commit}\n` +
         'Build/deploy mode : next\n' +
         'Firebase project  : angular-io\n' +
         'Firebase site     : next-angular-io-site\n' +


### PR DESCRIPTION
This PR improves the logs for the `deploy_aio` CI job, that to deploys AIO to Firebase, making it easier to diagnose failures. See the individual commits for more details.