### PR TITLE
10.2.x fix elements cd on push

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3037,
-        "main-es2015": 447742,
+        "main-es2015": 447914,
         "polyfills-es2015": 52415
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3157,
-        "main-es2015": 431750,
+        "main-es2015": 431981,
         "polyfills-es2015": 52415
       }
     }

--- a/integration/ng_elements/e2e/app.e2e-spec.ts
+++ b/integration/ng_elements/e2e/app.e2e-spec.ts
@@ -1,22 +1,42 @@
-import { browser, element, ExpectedConditions as EC, by } from 'protractor';
+import {browser, by, element, ElementFinder, ExpectedConditions as EC} from 'protractor';
 
 browser.waitForAngularEnabled(false);
 describe('Element E2E Tests', function () {
   describe('Hello World Elements', () => {
-    const helloWorldEl = element(by.css('hello-world-el'));
-
     beforeEach(() => browser.get('hello-world.html'));
 
-    it('should display "Hello World!"', function () {
-      expect(helloWorldEl.getText()).toEqual('Hello World!');
+    describe('(with default view encapsulation)', () => {
+      const helloWorldEl = element(by.css('hello-world-el'));
+
+      it('should display "Hello World!"', function () {
+        expect(helloWorldEl.getText()).toBe('Hello World!');
+      });
+
+      it('should display "Hello Foo!" via name attribute', function () {
+        const input = element(by.css('input[type=text]'));
+        input.sendKeys('Foo');
+
+        // Make tests less flaky on CI by waiting up to 5s for the element text to be updated.
+        browser.wait(EC.textToBePresentInElement(helloWorldEl, 'Hello Foo!'), 5000);
+      });
     });
 
-    it('should display "Hello Foo!" via name attribute', function () {
-      const input = element(by.css('input[type=text]'));
-      input.sendKeys('Foo');
+    describe('(with `ShadowDom` view encapsulation)', () => {
+      const helloWorldShadowEl = element(by.css('hello-world-shadow-el'));
+      const getShadowDomText = (el: ElementFinder) =>
+        browser.executeScript('return arguments[0].shadowRoot.textContent', el);
 
-      // Make tests less flaky on CI by waiting up to 5s for the element text to be updated.
-      browser.wait(EC.textToBePresentInElement(helloWorldEl, 'Hello Foo!'), 5000);
+      it('should display "Hello World!"', function () {
+        expect(getShadowDomText(helloWorldShadowEl)).toBe('Hello World!');
+      });
+
+      it('should display "Hello Foo!" via name attribute', function () {
+        const input = element(by.css('input[type=text]'));
+        input.sendKeys('Foo');
+
+        // Make tests less flaky on CI by waiting up to 5s for the element text to be updated.
+        browser.wait(async () => await getShadowDomText(helloWorldShadowEl) === 'Hello Foo!', 5000);
+      });
     });
   });
 });

--- a/integration/ng_elements/e2e/app.e2e-spec.ts
+++ b/integration/ng_elements/e2e/app.e2e-spec.ts
@@ -5,7 +5,7 @@ describe('Element E2E Tests', function () {
   describe('Hello World Elements', () => {
     beforeEach(() => browser.get('hello-world.html'));
 
-    describe('(with default view encapsulation)', () => {
+    describe('(with default CD strategy and view encapsulation)', () => {
       const helloWorldEl = element(by.css('hello-world-el'));
 
       it('should display "Hello World!"', function () {
@@ -18,6 +18,22 @@ describe('Element E2E Tests', function () {
 
         // Make tests less flaky on CI by waiting up to 5s for the element text to be updated.
         browser.wait(EC.textToBePresentInElement(helloWorldEl, 'Hello Foo!'), 5000);
+      });
+    });
+
+    describe('(with `OnPush` CD strategy)', () => {
+      const helloWorldOnpushEl = element(by.css('hello-world-onpush-el'));
+
+      it('should display "Hello World!"', function () {
+        expect(helloWorldOnpushEl.getText()).toBe('Hello World!');
+      });
+
+      it('should display "Hello Foo!" via name attribute', function () {
+        const input = element(by.css('input[type=text]'));
+        input.sendKeys('Foo');
+
+        // Make tests less flaky on CI by waiting up to 5s for the element text to be updated.
+        browser.wait(EC.textToBePresentInElement(helloWorldOnpushEl, 'Hello Foo!'), 5000);
       });
     });
 

--- a/integration/ng_elements/src/app.ts
+++ b/integration/ng_elements/src/app.ts
@@ -2,17 +2,29 @@ import {Injector, NgModule} from '@angular/core';
 import {createCustomElement} from '@angular/elements';
 import {BrowserModule} from '@angular/platform-browser';
 
-import {HelloWorldComponent, HelloWorldShadowComponent, TestCardComponent} from './elements';
+import {HelloWorldComponent, HelloWorldOnpushComponent, HelloWorldShadowComponent, TestCardComponent} from './elements';
 
 
 @NgModule({
-  declarations: [HelloWorldComponent, HelloWorldShadowComponent, TestCardComponent],
-  entryComponents: [HelloWorldComponent, HelloWorldShadowComponent, TestCardComponent],
+  declarations: [
+    HelloWorldComponent,
+    HelloWorldOnpushComponent,
+    HelloWorldShadowComponent,
+    TestCardComponent,
+  ],
+  entryComponents: [
+    HelloWorldComponent,
+    HelloWorldOnpushComponent,
+    HelloWorldShadowComponent,
+    TestCardComponent,
+  ],
   imports: [BrowserModule],
 })
 export class AppModule {
   constructor(injector: Injector) {
     customElements.define('hello-world-el', createCustomElement(HelloWorldComponent, {injector}));
+    customElements.define(
+        'hello-world-onpush-el', createCustomElement(HelloWorldOnpushComponent, {injector}));
     customElements.define(
         'hello-world-shadow-el', createCustomElement(HelloWorldShadowComponent, {injector}));
     customElements.define('test-card', createCustomElement(TestCardComponent, {injector}));

--- a/integration/ng_elements/src/app.ts
+++ b/integration/ng_elements/src/app.ts
@@ -11,7 +11,7 @@ import {HelloWorldComponent, HelloWorldShadowComponent, TestCardComponent} from 
   imports: [BrowserModule],
 })
 export class AppModule {
-  constructor(private injector: Injector) {
+  constructor(injector: Injector) {
     customElements.define('hello-world-el', createCustomElement(HelloWorldComponent, {injector}));
     customElements.define(
         'hello-world-shadow-el', createCustomElement(HelloWorldShadowComponent, {injector}));

--- a/integration/ng_elements/src/elements.ts
+++ b/integration/ng_elements/src/elements.ts
@@ -2,7 +2,7 @@ import {Component, Input, ViewEncapsulation} from '@angular/core';
 
 @Component({
   selector: 'hello-world-el',
-  template: `Hello {{name}}!`,
+  template: 'Hello {{name}}!',
 })
 export class HelloWorldComponent {
   @Input() name: string = 'World';
@@ -10,13 +10,12 @@ export class HelloWorldComponent {
 
 @Component({
   selector: 'hello-world-shadow-el',
-  template: `Hello {{name}}!`,
-  encapsulation: ViewEncapsulation.ShadowDom
+  template: 'Hello {{name}}!',
+  encapsulation: ViewEncapsulation.ShadowDom,
 })
 export class HelloWorldShadowComponent {
   @Input() name: string = 'World';
 }
-
 
 @Component({
   selector: 'test-card',
@@ -29,7 +28,6 @@ export class HelloWorldShadowComponent {
       <slot name="card-footer"></slot>
     </footer>`,
   encapsulation: ViewEncapsulation.ShadowDom,
-  styles: []
 })
 export class TestCardComponent {
 }

--- a/integration/ng_elements/src/elements.ts
+++ b/integration/ng_elements/src/elements.ts
@@ -1,10 +1,19 @@
-import {Component, Input, ViewEncapsulation} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
 
 @Component({
   selector: 'hello-world-el',
   template: 'Hello {{name}}!',
 })
 export class HelloWorldComponent {
+  @Input() name: string = 'World';
+}
+
+@Component({
+  selector: 'hello-world-onpush-el',
+  template: 'Hello {{name}}!',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HelloWorldOnpushComponent {
   @Input() name: string = 'World';
 }
 

--- a/integration/ng_elements/src/hello-world.html
+++ b/integration/ng_elements/src/hello-world.html
@@ -10,8 +10,8 @@
 <body>
   <input type="text">
   <hello-world-el></hello-world-el>
+  <hello-world-shadow-el></hello-world-shadow-el>
   <script src="dist/bundle.js"></script>
-
 </body>
 
 </html>

--- a/integration/ng_elements/src/hello-world.html
+++ b/integration/ng_elements/src/hello-world.html
@@ -10,6 +10,7 @@
 <body>
   <input type="text">
   <hello-world-el></hello-world-el>
+  <hello-world-onpush-el></hello-world-onpush-el>
   <hello-world-shadow-el></hello-world-shadow-el>
   <script src="dist/bundle.js"></script>
 </body>

--- a/integration/ng_elements/src/main.ts
+++ b/integration/ng_elements/src/main.ts
@@ -3,8 +3,11 @@ import {AppModuleNgFactory} from './app.ngfactory';
 
 platformBrowser().bootstrapModuleFactory(AppModuleNgFactory, {ngZone: 'noop'});
 
-const input = document.querySelector('input');
-const helloWorld = document.querySelector('hello-world-el');
-if(input && helloWorld){
-  input.addEventListener('input', () => helloWorld.setAttribute('name', input.value));
-}
+const input = document.querySelector('input')!;
+const helloWorld = document.querySelector('hello-world-el')!;
+const helloWorldShadow = document.querySelector('hello-world-shadow-el')!;
+
+input.addEventListener('input', () => {
+  helloWorld.setAttribute('name', input.value);
+  helloWorldShadow.setAttribute('name', input.value);
+});

--- a/integration/ng_elements/src/main.ts
+++ b/integration/ng_elements/src/main.ts
@@ -5,9 +5,11 @@ platformBrowser().bootstrapModuleFactory(AppModuleNgFactory, {ngZone: 'noop'});
 
 const input = document.querySelector('input')!;
 const helloWorld = document.querySelector('hello-world-el')!;
+const helloWorldOnpush = document.querySelector('hello-world-onpush-el')!;
 const helloWorldShadow = document.querySelector('hello-world-shadow-el')!;
 
 input.addEventListener('input', () => {
   helloWorld.setAttribute('name', input.value);
+  helloWorldOnpush.setAttribute('name', input.value);
   helloWorldShadow.setAttribute('name', input.value);
 });

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, Injector, NgModuleRef, NgZone, SimpleChange, SimpleChanges, Type} from '@angular/core';
+import {ApplicationRef, ChangeDetectorRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, Injector, NgModuleRef, NgZone, SimpleChange, SimpleChanges, Type} from '@angular/core';
 import {fakeAsync, tick} from '@angular/core/testing';
 import {Subject} from 'rxjs';
 
@@ -180,8 +180,11 @@ describe('ComponentFactoryNgElementStrategy', () => {
   });
 
   describe('when inputs change and is connected', () => {
+    let viewChangeDetectorRef: ChangeDetectorRef;
+
     beforeEach(() => {
       strategy.connect(document.createElement('div'));
+      viewChangeDetectorRef = componentRef.injector.get(ChangeDetectorRef);
     });
 
     it('should be set on the component instance', () => {
@@ -207,6 +210,22 @@ describe('ComponentFactoryNgElementStrategy', () => {
          strategy.setInputValue('barBar', 'barBar-1');
          tick(16);  // scheduler waits 16ms if RAF is unavailable
          expect(componentRef.changeDetectorRef.detectChanges).toHaveBeenCalledTimes(2);
+       }));
+
+    it('should not detect changes if the input is set to the same value', fakeAsync(() => {
+         (componentRef.changeDetectorRef.detectChanges as jasmine.Spy).calls.reset();
+
+         strategy.setInputValue('fooFoo', 'fooFoo-1');
+         strategy.setInputValue('barBar', 'barBar-1');
+         tick(16);  // scheduler waits 16ms if RAF is unavailable
+         expect(componentRef.changeDetectorRef.detectChanges).toHaveBeenCalledTimes(1);
+
+         (componentRef.changeDetectorRef.detectChanges as jasmine.Spy).calls.reset();
+
+         strategy.setInputValue('fooFoo', 'fooFoo-1');
+         strategy.setInputValue('barBar', 'barBar-1');
+         tick(16);  // scheduler waits 16ms if RAF is unavailable
+         expect(componentRef.changeDetectorRef.detectChanges).not.toHaveBeenCalled();
        }));
 
     it('should call ngOnChanges', fakeAsync(() => {
@@ -246,6 +265,22 @@ describe('ComponentFactoryNgElementStrategy', () => {
          });
        }));
 
+    it('should not call ngOnChanges if the inout is set to the same value', fakeAsync(() => {
+         const ngOnChangesSpy = spyOn(componentRef.instance, 'ngOnChanges');
+
+         strategy.setInputValue('fooFoo', 'fooFoo-1');
+         strategy.setInputValue('barBar', 'barBar-1');
+         tick(16);  // scheduler waits 16ms if RAF is unavailable
+         expect(ngOnChangesSpy).toHaveBeenCalledTimes(1);
+
+         ngOnChangesSpy.calls.reset();
+
+         strategy.setInputValue('fooFoo', 'fooFoo-1');
+         strategy.setInputValue('barBar', 'barBar-1');
+         tick(16);  // scheduler waits 16ms if RAF is unavailable
+         expect(ngOnChangesSpy).not.toHaveBeenCalled();
+       }));
+
     it('should not try to call ngOnChanges if not present on the component', fakeAsync(() => {
          const factory2 = new FakeComponentFactory(FakeComponentWithoutNgOnChanges);
          const strategy2 = new ComponentNgElementStrategy(factory2, injector);
@@ -260,6 +295,71 @@ describe('ComponentFactoryNgElementStrategy', () => {
          // If the strategy would have tried to call `component.ngOnChanges()`, an error would have
          // been thrown and `changeDetectorRef2.detectChanges()` would not have been called.
          expect(changeDetectorRef2.detectChanges).toHaveBeenCalledTimes(1);
+       }));
+
+    it('should mark the view for check', fakeAsync(() => {
+         expect(viewChangeDetectorRef.markForCheck).not.toHaveBeenCalled();
+
+         strategy.setInputValue('fooFoo', 'fooFoo-1');
+         tick(16);  // scheduler waits 16ms if RAF is unavailable
+
+         expect(viewChangeDetectorRef.markForCheck).toHaveBeenCalledTimes(1);
+       }));
+
+    it('should mark the view for check once for multiple input changes', fakeAsync(() => {
+         strategy.setInputValue('fooFoo', 'fooFoo-1');
+         strategy.setInputValue('barBar', 'barBar-1');
+         tick(16);  // scheduler waits 16ms if RAF is unavailable
+
+         expect(viewChangeDetectorRef.markForCheck).toHaveBeenCalledTimes(1);
+       }));
+
+    it('should mark the view for check twice for changes in different rounds with previous values',
+       fakeAsync(() => {
+         strategy.setInputValue('fooFoo', 'fooFoo-1');
+         strategy.setInputValue('barBar', 'barBar-1');
+         tick(16);  // scheduler waits 16ms if RAF is unavailable
+
+         expect(viewChangeDetectorRef.markForCheck).toHaveBeenCalledTimes(1);
+
+         strategy.setInputValue('fooFoo', 'fooFoo-2');
+         strategy.setInputValue('barBar', 'barBar-2');
+         tick(16);  // scheduler waits 16ms if RAF is unavailable
+
+         expect(viewChangeDetectorRef.markForCheck).toHaveBeenCalledTimes(2);
+       }));
+
+    it('should mark the view for check even if ngOnChanges is not present on the component',
+       fakeAsync(() => {
+         const factory2 = new FakeComponentFactory(FakeComponentWithoutNgOnChanges);
+         const strategy2 = new ComponentNgElementStrategy(factory2, injector);
+         const viewChangeDetectorRef2 = factory2.componentRef.injector.get(ChangeDetectorRef);
+
+         strategy2.connect(document.createElement('div'));
+         (viewChangeDetectorRef2.markForCheck as jasmine.Spy).calls.reset();
+
+         strategy2.setInputValue('fooFoo', 'fooFoo-1');
+         expect(() => tick(16)).not.toThrow();  // scheduler waits 16ms if RAF is unavailable
+
+         // If the strategy would have tried to call `component.ngOnChanges()`, an error would have
+         // been thrown and `viewChangeDetectorRef2.markForCheck()` would not have been called.
+         expect(viewChangeDetectorRef2.markForCheck).toHaveBeenCalledTimes(1);
+       }));
+
+    it('should not mark the view for check if the input is set to the same value', fakeAsync(() => {
+         (viewChangeDetectorRef.markForCheck as jasmine.Spy).calls.reset();
+
+         strategy.setInputValue('fooFoo', 'fooFoo-1');
+         strategy.setInputValue('barBar', 'barBar-1');
+         tick(16);  // scheduler waits 16ms if RAF is unavailable
+         expect(viewChangeDetectorRef.markForCheck).toHaveBeenCalledTimes(1);
+
+         (viewChangeDetectorRef.markForCheck as jasmine.Spy).calls.reset();
+
+         strategy.setInputValue('fooFoo', 'fooFoo-1');
+         strategy.setInputValue('barBar', 'barBar-1');
+         tick(16);  // scheduler waits 16ms if RAF is unavailable
+         expect(viewChangeDetectorRef.markForCheck).not.toHaveBeenCalled();
        }));
   });
 
@@ -345,6 +445,9 @@ export class FakeComponentFactory<T extends Type<any>> extends ComponentFactory<
       {
         changeDetectorRef: jasmine.createSpyObj('changeDetectorRef', ['detectChanges']),
         hostView: {},
+        injector: jasmine.createSpyObj('injector', {
+          get: jasmine.createSpyObj('viewChangeDetectorRef', ['markForCheck']),
+        }),
         instance: new this.ComponentClass(),
       });
 

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -329,14 +329,15 @@ export class FakeComponent {
 
 export class FakeComponentFactory extends ComponentFactory<any> {
   componentRef: any = jasmine.createSpyObj(
-      'componentRef', ['instance', 'changeDetectorRef', 'hostView', 'destroy']);
-
-  constructor() {
-    super();
-    this.componentRef.instance = new FakeComponent();
-    this.componentRef.changeDetectorRef =
-        jasmine.createSpyObj('changeDetectorRef', ['detectChanges']);
-  }
+      'componentRef',
+      // Method spies.
+      ['destroy'],
+      // Property spies.
+      {
+        changeDetectorRef: jasmine.createSpyObj('changeDetectorRef', ['detectChanges']),
+        hostView: {},
+        instance: new FakeComponent(),
+      });
 
   get selector(): string {
     return 'fake-component';

--- a/packages/elements/test/create-custom-element_spec.ts
+++ b/packages/elements/test/create-custom-element_spec.ts
@@ -68,7 +68,7 @@ if (browserDetection.supportsCustomElements) {
       expect(strategy.getInputValue('barBar')).toBe('value-barbar');
     });
 
-    it('should work even if when the constructor is not called (due to polyfill)', () => {
+    it('should work even if the constructor is not called (due to polyfill)', () => {
       // Some polyfills (e.g. `document-register-element`) do not call the constructor of custom
       // elements. Currently, all the constructor does is initialize the `injector` property. This
       // test simulates not having called the constructor by "unsetting" the property.


### PR DESCRIPTION
_This is a backport of #39452 to the 10.2.x branch._

##
As with regular Angular components, Angular elements are expected to have their views update when inputs change.

Previously, Angular Elements views where not update if the underlying component used the `OnPush` change detection strategy.

This commit fixes this by calling `markForCheck()` on the component view's `ChangeDetectorRef`.

NOTE:
This is similar to how `@angular/upgrade` does it: https://github.com/angular/angular/blob/3236ae0ee118d0734c90fa9f3767435396213470/packages/upgrade/src/common/src/downgrade_component_adapter.ts#L146.

Fixes #38948.

##
This PR also contains some commit the fix/improve the `elements` tests (both unit and e2e tests). See individual commits for more details.