### PR TITLE
fix(router): activate components within Angular zone

### DIFF
--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {NgZone} from '@angular/core';
 import {MonoTypeOperatorFunction} from 'rxjs';
 import {map} from 'rxjs/operators';
 
@@ -19,12 +20,22 @@ import {forEach} from '../utils/collection';
 import {nodeChildrenAsMap, TreeNode} from '../utils/tree';
 
 export const activateRoutes =
-    (rootContexts: ChildrenOutletContexts, routeReuseStrategy: RouteReuseStrategy,
+    (ngZone: NgZone, rootContexts: ChildrenOutletContexts, routeReuseStrategy: RouteReuseStrategy,
      forwardEvent: (evt: Event) => void): MonoTypeOperatorFunction<NavigationTransition> =>
         map(t => {
-          new ActivateRoutes(
-              routeReuseStrategy, t.targetRouterState!, t.currentRouterState, forwardEvent)
-              .activate(rootContexts);
+          const activateRoutes = new ActivateRoutes(
+              routeReuseStrategy, t.targetRouterState!, t.currentRouterState, forwardEvent);
+          if (NgZone.isInAngularZone()) {
+            activateRoutes.activate(rootContexts);
+          } else {
+            // The below methods are invoked within Angular zone since guards or
+            // resolves might leave Angular zone via `zone.runOutsideAngular(...)`.
+            // Thus, routes will be activated outside Angular zone and change detection
+            // will not work properly.
+            ngZone.run(() => {
+              activateRoutes.activate(rootContexts);
+            });
+          }
           return t;
         });
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -385,6 +385,7 @@ export class Router {
   private configLoader: RouterConfigLoader;
   private ngModule: NgModuleRef<any>;
   private console: Console;
+  private ngZone: NgZone;
   private isNgZoneEnabled: boolean = false;
 
   /**
@@ -487,8 +488,8 @@ export class Router {
 
     this.ngModule = injector.get(NgModuleRef);
     this.console = injector.get(Console);
-    const ngZone = injector.get(NgZone);
-    this.isNgZoneEnabled = ngZone instanceof NgZone;
+    this.ngZone = injector.get(NgZone);
+    this.isNgZoneEnabled = this.ngZone instanceof NgZone;
 
     this.resetConfig(config);
     this.currentUrlTree = createEmptyUrlTree();
@@ -796,7 +797,7 @@ export class Router {
                      }),
 
                      activateRoutes(
-                         this.rootContexts, this.routeReuseStrategy,
+                         this.ngZone, this.rootContexts, this.routeReuseStrategy,
                          (evt: Event) => this.triggerEvent(evt)),
 
                      tap({


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #37223

In the current behavior if the guard leaves the zone, then subsequent functions will also be called outside Angular zone, especially `activateRoutes(...)` which activates components.


## What is the new behavior?

In the new behavior components are explicitly activated within Angular zone to not break change detection.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No