### PR TITLE
fix(forms): more precise control cleanup

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1003,13 +1003,37 @@
     "packages/core/testing/src/test_bed.ts"
   ],
   [
+    "packages/forms/src/directives/abstract_control_directive.ts",
+    "packages/forms/src/model.ts",
+    "packages/forms/src/directives/shared.ts"
+  ],
+  [
+    "packages/forms/src/directives/abstract_control_directive.ts",
+    "packages/forms/src/model.ts",
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/directives/abstract_form_group_directive.ts",
+    "packages/forms/src/directives/control_container.ts"
+  ],
+  [
+    "packages/forms/src/directives/abstract_control_directive.ts",
+    "packages/forms/src/model.ts",
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/directives/abstract_form_group_directive.ts",
+    "packages/forms/src/directives/control_container.ts",
+    "packages/forms/src/directives/form_interface.ts",
+    "packages/forms/src/directives/ng_control.ts"
+  ],
+  [
     "packages/forms/src/directives/abstract_form_group_directive.ts",
     "packages/forms/src/directives/control_container.ts",
     "packages/forms/src/directives/form_interface.ts"
   ],
   [
     "packages/forms/src/directives/abstract_form_group_directive.ts",
-    "packages/forms/src/directives/form_interface.ts"
+    "packages/forms/src/directives/control_container.ts",
+    "packages/forms/src/directives/form_interface.ts",
+    "packages/forms/src/model.ts",
+    "packages/forms/src/directives/shared.ts"
   ],
   [
     "packages/forms/src/directives/abstract_form_group_directive.ts",
@@ -1017,59 +1041,13 @@
   ],
   [
     "packages/forms/src/directives/abstract_form_group_directive.ts",
-    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/model.ts",
+    "packages/forms/src/directives/shared.ts"
+  ],
+  [
     "packages/forms/src/directives/control_container.ts",
-    "packages/forms/src/directives/form_interface.ts"
-  ],
-  [
-    "packages/forms/src/directives/abstract_form_group_directive.ts",
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/directives/ng_control.ts",
-    "packages/forms/src/directives/control_container.ts",
-    "packages/forms/src/directives/form_interface.ts"
-  ],
-  [
-    "packages/forms/src/directives/abstract_form_group_directive.ts",
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_name.ts"
-  ],
-  [
-    "packages/forms/src/directives/abstract_form_group_directive.ts",
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
-    "packages/forms/src/directives/control_container.ts",
-    "packages/forms/src/directives/form_interface.ts"
-  ],
-  [
-    "packages/forms/src/directives/abstract_form_group_directive.ts",
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
-    "packages/forms/src/directives/control_container.ts",
-    "packages/forms/src/directives/form_interface.ts"
-  ],
-  [
-    "packages/forms/src/directives/abstract_form_group_directive.ts",
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
-    "packages/forms/src/directives/form_interface.ts"
-  ],
-  [
-    "packages/forms/src/directives/abstract_form_group_directive.ts",
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
-    "packages/forms/src/directives/reactive_directives/form_control_name.ts"
-  ],
-  [
-    "packages/forms/src/directives/abstract_form_group_directive.ts",
-    "packages/forms/src/directives/shared.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
-    "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
-    "packages/forms/src/directives/reactive_directives/form_control_name.ts",
-    "packages/forms/src/directives/control_container.ts",
-    "packages/forms/src/directives/form_interface.ts"
+    "packages/forms/src/directives/form_interface.ts",
+    "packages/forms/src/directives/ng_control.ts"
   ],
   [
     "packages/forms/src/directives/ng_form.ts",
@@ -1088,6 +1066,14 @@
     "packages/forms/src/directives/reactive_directives/form_control_name.ts"
   ],
   [
+    "packages/forms/src/directives/reactive_directives/form_control_directive.ts",
+    "packages/forms/src/model.ts",
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
+    "packages/forms/src/directives/reactive_directives/form_control_name.ts"
+  ],
+  [
     "packages/forms/src/directives/reactive_directives/form_control_name.ts",
     "packages/forms/src/directives/reactive_directives/form_group_directive.ts"
   ],
@@ -1103,11 +1089,24 @@
     "packages/forms/src/directives/reactive_directives/form_group_directive.ts"
   ],
   [
+    "packages/forms/src/directives/reactive_directives/form_control_name.ts",
+    "packages/forms/src/model.ts",
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_directive.ts"
+  ],
+  [
     "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
     "packages/forms/src/directives/reactive_directives/form_group_name.ts"
   ],
   [
     "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/directives/reactive_directives/form_group_name.ts"
+  ],
+  [
+    "packages/forms/src/directives/reactive_directives/form_group_directive.ts",
+    "packages/forms/src/model.ts",
     "packages/forms/src/directives/shared.ts",
     "packages/forms/src/directives/reactive_directives/form_group_name.ts"
   ],
@@ -1116,17 +1115,28 @@
     "packages/forms/src/directives/shared.ts"
   ],
   [
+    "packages/forms/src/directives/reactive_directives/form_group_name.ts",
+    "packages/forms/src/model.ts",
+    "packages/forms/src/directives/shared.ts"
+  ],
+  [
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/model.ts"
+  ],
+  [
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/validators.ts",
     "packages/forms/src/directives/validators.ts",
+    "packages/forms/src/model.ts"
+  ],
+  [
+    "packages/forms/src/directives/shared.ts",
+    "packages/forms/src/validators.ts",
     "packages/forms/src/model.ts"
   ],
   [
     "packages/forms/src/directives/validators.ts",
     "packages/forms/src/validators.ts"
-  ],
-  [
-    "packages/forms/src/directives/validators.ts",
-    "packages/forms/src/validators.ts",
-    "packages/forms/src/model.ts"
   ],
   [
     "packages/language-service/src/completions.ts",

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -1455,10 +1455,10 @@
     "name": "remove"
   },
   {
-    "name": "removeDir"
+    "name": "removeFromArray"
   },
   {
-    "name": "removeFromArray"
+    "name": "removeListItem"
   },
   {
     "name": "renderComponent"

--- a/packages/forms/src/directives/abstract_control_directive.ts
+++ b/packages/forms/src/directives/abstract_control_directive.ts
@@ -230,6 +230,30 @@ export abstract class AbstractControlDirective {
     return this._composedAsyncValidatorFn || null;
   }
 
+  /*
+   * The set of callbacks to be invoked when directive instance is being destroyed.
+   */
+  private _onDestroyCallbacks: (() => void)[] = [];
+
+  /**
+   * Internal function to register callbacks that should be invoked
+   * when directive instance is being destroyed.
+   * @internal
+   */
+  _registerOnDestroy(fn: () => void): void {
+    this._onDestroyCallbacks.push(fn);
+  }
+
+  /**
+   * Internal function to invoke all registered "on destroy" callbacks.
+   * Note: calling this function also clears the list of callbacks.
+   * @internal
+   */
+  _invokeOnDestroyCallbacks(): void {
+    this._onDestroyCallbacks.forEach(fn => fn());
+    this._onDestroyCallbacks = [];
+  }
+
   /**
    * @description
    * Resets the control with the provided value if the control is present.

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -16,7 +16,7 @@ import {Form} from './form_interface';
 import {NgControl} from './ng_control';
 import {NgModel} from './ng_model';
 import {NgModelGroup} from './ng_model_group';
-import {removeDir, setUpControl, setUpFormContainer, syncPendingControls} from './shared';
+import {removeListItem, setUpControl, setUpFormContainer, syncPendingControls} from './shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from './validators';
 
 export const formDirectiveProvider: any = {
@@ -217,7 +217,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
       if (container) {
         container.removeControl(dir.name);
       }
-      removeDir<NgModel>(this._directives, dir);
+      removeListItem(this._directives, dir);
     });
   }
 

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -13,7 +13,7 @@ import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {ControlContainer} from '../control_container';
 import {Form} from '../form_interface';
 import {ReactiveErrors} from '../reactive_errors';
-import {cleanUpControl, cleanUpValidators, removeDir, setUpControl, setUpFormContainer, setUpValidators, syncPendingControls} from '../shared';
+import {cleanUpControl, cleanUpValidators, removeListItem, setUpControl, setUpFormContainer, setUpValidators, syncPendingControls} from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
 
 import {FormControlName} from './form_control_name';
@@ -161,7 +161,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
    * @param dir The `FormControlName` directive instance.
    */
   removeControl(dir: FormControlName): void {
-    removeDir<FormControlName>(this.directives, dir);
+    removeListItem(this.directives, dir);
   }
 
   /**

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -9,6 +9,7 @@
 import {EventEmitter} from '@angular/core';
 import {Observable} from 'rxjs';
 
+import {removeListItem} from './directives/shared';
 import {AsyncValidatorFn, ValidationErrors, ValidatorFn} from './directives/validators';
 import {composeAsyncValidators, composeValidators, toObservable} from './validators';
 
@@ -1269,12 +1270,11 @@ export class FormControl extends AbstractControl {
   }
 
   /**
+   * Internal function to unregister a change events listener.
    * @internal
    */
-  _clearChangeFns(): void {
-    this._onChange = [];
-    this._onDisabledChange = [];
-    this._onCollectionChange = () => {};
+  _unregisterOnChange(fn: Function): void {
+    removeListItem(this._onChange, fn);
   }
 
   /**
@@ -1284,6 +1284,14 @@ export class FormControl extends AbstractControl {
    */
   registerOnDisabledChange(fn: (isDisabled: boolean) => void): void {
     this._onDisabledChange.push(fn);
+  }
+
+  /**
+   * Internal function to unregister a disabled event listener.
+   * @internal
+   */
+  _unregisterOnDisabledChange(fn: (isDisabled: boolean) => void): void {
+    removeListItem(this._onDisabledChange, fn);
   }
 
   /**


### PR DESCRIPTION
Currently when an instance of the `FormControlName` directive is destroyed, the Forms package invokes
the `cleanUpControl` to clear all directive-specific logic (such as validators, onChange handlers,
etc) from a bound control. The logic of the `cleanUpControl` function should revert all setup
performed by the `setUpControl` function. However the `cleanUpControl` is too aggressive and removes
all callbacks related to the onChange and disabled state handling. This is causing problems when
a form control is bound to multiple FormControlName` directives, causing other instances of that
directive to stop working correctly when the first one is destroyed.

This commit updates the cleanup logic to only remove callbacks added while setting up a control
for a given directive instance.

The fix is needed to allow adding `cleanUpControl` function to other places where cleanup is needed
(missing this function calls in some other places causes memory leak issues).


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No