### PR TITLE
feat(common): allow any Subscribable in async pipe

### DIFF
--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -3,9 +3,9 @@ export declare const APP_BASE_HREF: InjectionToken<string>;
 export declare class AsyncPipe implements OnDestroy, PipeTransform {
     constructor(_ref: ChangeDetectorRef);
     ngOnDestroy(): void;
-    transform<T>(obj: Observable<T> | Promise<T>): T | null;
+    transform<T>(obj: Subscribable<T> | Promise<T>): T | null;
     transform<T>(obj: null | undefined): null;
-    transform<T>(obj: Observable<T> | Promise<T> | null | undefined): T | null;
+    transform<T>(obj: Subscribable<T> | Promise<T> | null | undefined): T | null;
 }
 
 export declare class CommonModule {

--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -6,19 +6,20 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, EventEmitter, OnDestroy, Pipe, PipeTransform, ɵisObservable, ɵisPromise} from '@angular/core';
-import {Observable, SubscriptionLike} from 'rxjs';
+import {ChangeDetectorRef, EventEmitter, OnDestroy, Pipe, PipeTransform, ɵisPromise, ɵisSubscribable} from '@angular/core';
+import {Subscribable, Unsubscribable} from 'rxjs';
+
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
 interface SubscriptionStrategy {
-  createSubscription(async: Observable<any>|Promise<any>, updateLatestValue: any): SubscriptionLike
+  createSubscription(async: Subscribable<any>|Promise<any>, updateLatestValue: any): Unsubscribable
       |Promise<any>;
-  dispose(subscription: SubscriptionLike|Promise<any>): void;
-  onDestroy(subscription: SubscriptionLike|Promise<any>): void;
+  dispose(subscription: Unsubscribable|Promise<any>): void;
+  onDestroy(subscription: Unsubscribable|Promise<any>): void;
 }
 
-class ObservableStrategy implements SubscriptionStrategy {
-  createSubscription(async: Observable<any>, updateLatestValue: any): SubscriptionLike {
+class SubscribableStrategy implements SubscriptionStrategy {
+  createSubscription(async: Subscribable<any>, updateLatestValue: any): Unsubscribable {
     return async.subscribe({
       next: updateLatestValue,
       error: (e: any) => {
@@ -27,11 +28,11 @@ class ObservableStrategy implements SubscriptionStrategy {
     });
   }
 
-  dispose(subscription: SubscriptionLike): void {
+  dispose(subscription: Unsubscribable): void {
     subscription.unsubscribe();
   }
 
-  onDestroy(subscription: SubscriptionLike): void {
+  onDestroy(subscription: Unsubscribable): void {
     subscription.unsubscribe();
   }
 }
@@ -49,7 +50,7 @@ class PromiseStrategy implements SubscriptionStrategy {
 }
 
 const _promiseStrategy = new PromiseStrategy();
-const _observableStrategy = new ObservableStrategy();
+const _subscribableStrategy = new SubscribableStrategy();
 
 /**
  * @ngModule CommonModule
@@ -82,8 +83,8 @@ const _observableStrategy = new ObservableStrategy();
 export class AsyncPipe implements OnDestroy, PipeTransform {
   private _latestValue: any = null;
 
-  private _subscription: SubscriptionLike|Promise<any>|null = null;
-  private _obj: Observable<any>|Promise<any>|EventEmitter<any>|null = null;
+  private _subscription: Unsubscribable|Promise<any>|null = null;
+  private _obj: Subscribable<any>|Promise<any>|EventEmitter<any>|null = null;
   private _strategy: SubscriptionStrategy = null!;
 
   constructor(private _ref: ChangeDetectorRef) {}
@@ -94,10 +95,10 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
     }
   }
 
-  transform<T>(obj: Observable<T>|Promise<T>): T|null;
+  transform<T>(obj: Subscribable<T>|Promise<T>): T|null;
   transform<T>(obj: null|undefined): null;
-  transform<T>(obj: Observable<T>|Promise<T>|null|undefined): T|null;
-  transform<T>(obj: Observable<T>|Promise<T>|null|undefined): T|null {
+  transform<T>(obj: Subscribable<T>|Promise<T>|null|undefined): T|null;
+  transform<T>(obj: Subscribable<T>|Promise<T>|null|undefined): T|null {
     if (!this._obj) {
       if (obj) {
         this._subscribe(obj);
@@ -113,20 +114,20 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
     return this._latestValue;
   }
 
-  private _subscribe(obj: Observable<any>|Promise<any>|EventEmitter<any>): void {
+  private _subscribe(obj: Subscribable<any>|Promise<any>|EventEmitter<any>): void {
     this._obj = obj;
     this._strategy = this._selectStrategy(obj);
     this._subscription = this._strategy.createSubscription(
         obj, (value: Object) => this._updateLatestValue(obj, value));
   }
 
-  private _selectStrategy(obj: Observable<any>|Promise<any>|EventEmitter<any>): any {
+  private _selectStrategy(obj: Subscribable<any>|Promise<any>|EventEmitter<any>): any {
     if (ɵisPromise(obj)) {
       return _promiseStrategy;
     }
 
-    if (ɵisObservable(obj)) {
-      return _observableStrategy;
+    if (ɵisSubscribable(obj)) {
+      return _subscribableStrategy;
     }
 
     throw invalidPipeArgumentError(AsyncPipe, obj);

--- a/packages/common/test/BUILD.bazel
+++ b/packages/common/test/BUILD.bazel
@@ -32,6 +32,7 @@ ts_library(
         "//packages/platform-browser-dynamic",
         "//packages/platform-browser/testing",
         "//packages/private/testing",
+        "@npm//rxjs",
     ],
 )
 

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -29,7 +29,7 @@ export {_sanitizeHtml as ɵ_sanitizeHtml} from './sanitization/html_sanitizer';
 export {_sanitizeUrl as ɵ_sanitizeUrl} from './sanitization/url_sanitizer';
 export {makeDecorator as ɵmakeDecorator} from './util/decorators';
 export {global as ɵglobal} from './util/global';
-export {isObservable as ɵisObservable, isPromise as ɵisPromise} from './util/lang';
+export {isObservable as ɵisObservable, isPromise as ɵisPromise, isSubscribable as ɵisSubscribable} from './util/lang';
 export {stringify as ɵstringify} from './util/stringify';
 export {clearOverrides as ɵclearOverrides, initServicesIfNeeded as ɵinitServicesIfNeeded, overrideComponentView as ɵoverrideComponentView, overrideProvider as ɵoverrideProvider} from './view/index';
 export {NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from './view/provider';

--- a/packages/core/src/util/lang.ts
+++ b/packages/core/src/util/lang.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Observable} from 'rxjs';
+import {Observable, Subscribable} from 'rxjs';
 
 /**
  * Determine if the argument is shaped like a Promise
@@ -18,6 +18,13 @@ export function isPromise<T = any>(obj: any): obj is Promise<T> {
 }
 
 /**
+ * Determine if the argument is a Subscribable
+ */
+export function isSubscribable(obj: any|Subscribable<any>): obj is Subscribable<any> {
+  return !!obj && typeof obj.subscribe === 'function';
+}
+
+/**
  * Determine if the argument is an Observable
  *
  * Strictly this tests that the `obj` is `Subscribable`, since `Observable`
@@ -26,6 +33,5 @@ export function isPromise<T = any>(obj: any): obj is Promise<T> {
  * `subscribe()` method, and RxJS has mechanisms to wrap `Subscribable` objects
  * into `Observable` as needed.
  */
-export function isObservable(obj: any|Observable<any>): obj is Observable<any> {
-  return !!obj && typeof obj.subscribe === 'function';
-}
+export const isObservable =
+    isSubscribable as ((obj: any|Observable<any>) => obj is Observable<any>);


### PR DESCRIPTION
As only methods from the [Subscribable interface](https://rxjs.dev/api/index/interface/Subscribable) are currently used in the implementation of the [async pipe](https://angular.io/api/common/AsyncPipe), it makes sense to make it explicit so that it works successfully (regarding type-checking) with any other implementation instead of only Observable.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The following component does not compile successfully:

```ts
import { Component, Input } from '@angular/core';
import { Subscribable } from 'rxjs';

@Component({
  selector: 'hello',
  template: `Hello {{ nameSubscribable | async }}`
})
export class HelloComponent  {
  @Input() nameSubscribable: Subscribable<any>;
  // Note that it works fine when replacing the above line with:
  // @Input() nameSubscribable: any;
}
```

Here is the compilation error:
```
No overload matches this call.
The last overload gave the following error.
Argument of type 'Subscribable<any>' is not assignable to parameter of type 'Promise<unknown>'.
Type 'Subscribable<any>' is missing the following properties from type 'Promise<unknown>': then, catch, [Symbol.toStringTag], finally
```

(cf https://stackblitz.com/edit/angular-ivy-fypzxs?file=src/app/hello.component.ts )

## What is the new behavior?

The compilation of the previous component is successful.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The important part of this PR is about changing the input type from `Observable` to `Subscribable` in async pipe.
For consistency, I have renamed some local variables to contain `subscribable` instead of `observable`.
In `packages/core/src/util/lang.ts`, I have added the `isSubscribable` function that does the same thing as `isObservable` but, in case the `TODO` mentioned in `isObservable` is implemented those two methods would be different.
