### PR TITLE
fix(platform-browser): sort event manager plugins correctly

### DIFF
--- a/goldens/public-api/platform-browser/platform-browser.d.ts
+++ b/goldens/public-api/platform-browser/platform-browser.d.ts
@@ -27,10 +27,10 @@ export declare abstract class DomSanitizer implements Sanitizer {
 
 export declare function enableDebugTools<T>(ref: ComponentRef<T>): ComponentRef<T>;
 
-export declare const EVENT_MANAGER_PLUGINS: InjectionToken<ɵangular_packages_platform_browser_platform_browser_g[]>;
+export declare const EVENT_MANAGER_PLUGINS: InjectionToken<ɵangular_packages_platform_browser_platform_browser_h[]>;
 
 export declare class EventManager {
-    constructor(plugins: ɵangular_packages_platform_browser_platform_browser_g[], _zone: NgZone);
+    constructor(plugins: ɵangular_packages_platform_browser_platform_browser_h[], _zone: NgZone);
     addEventListener(element: HTMLElement, eventName: string, handler: Function): Function;
     addGlobalEventListener(target: string, eventName: string, handler: Function): Function;
     getZone(): NgZone;

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3037,
-        "main-es2015": 448922,
+        "main-es2015": 449429,
         "polyfills-es2015": 52415
       }
     }

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 140899,
+        "main-es2015": 141414,
         "polyfills-es2015": 36964
       }
     }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #37149

In the current behavior, if you import a module with an event plugin
before `BrowserModule`, then this plugin will never be found. This is
because `DomEventsPlugin` is the only plugin that supports all events and
it will be in front of the plugin that was imported.


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No