### PR TITLE
fix(core): throw an error when no elements found by DebugElement.query

### DIFF
--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -1136,7 +1136,7 @@ describe('AppComponent', () => {
     describe('progress bar', () => {
       const SHOW_DELAY = 200;
       const HIDE_DELAY = 500;
-      const getProgressBar = () => fixture.debugElement.query(By.directive(MatProgressBar));
+      const getProgressBar = () => fixture.debugElement.queryAll(By.directive(MatProgressBar))[0] ?? null;
       const initializeAndCompleteNavigation = () => {
         initializeTest(false);
         triggerDocViewerEvent('docReady');

--- a/aio/src/app/custom-elements/code/code.component.spec.ts
+++ b/aio/src/app/custom-elements/code/code.component.spec.ts
@@ -197,7 +197,7 @@ describe('CodeComponent', () => {
   describe('copy button', () => {
 
     function getButton() {
-      const btnDe = fixture.debugElement.query(By.css('button'));
+      const btnDe = fixture.debugElement.queryAll(By.css('button'))[0] ?? null;
       return btnDe ? btnDe.nativeElement : null;
     }
 

--- a/aio/src/app/custom-elements/live-example/live-example.component.spec.ts
+++ b/aio/src/app/custom-elements/live-example/live-example.component.spec.ts
@@ -194,12 +194,12 @@ describe('LiveExampleComponent', () => {
   describe('when embedded', () => {
 
     function getDownloadAnchor() {
-      const anchor = liveExampleDe.query(By.css('p > a'));
+      const anchor = liveExampleDe.queryAll(By.css('p > a'))[0] ?? null;
       return anchor && anchor.nativeElement as HTMLAnchorElement;
     }
 
     function getEmbeddedStackblitzComponent() {
-      const compDe = liveExampleDe.query(By.directive(EmbeddedStackblitzComponent));
+      const compDe = liveExampleDe.queryAll(By.directive(EmbeddedStackblitzComponent))[0] ?? null;
       return compDe && compDe.componentInstance as EmbeddedStackblitzComponent;
     }
 

--- a/aio/src/app/custom-elements/toc/toc.component.spec.ts
+++ b/aio/src/app/custom-elements/toc/toc.component.spec.ts
@@ -15,18 +15,18 @@ describe('TocComponent', () => {
   let page: {
     listItems: DebugElement[];
     tocHeading: DebugElement;
-    tocHeadingButtonEmbedded: DebugElement;
-    tocH1Heading: DebugElement;
-    tocMoreButton: DebugElement;
+    tocHeadingButtonEmbedded: DebugElement|null;
+    tocH1Heading: DebugElement|null;
+    tocMoreButton: DebugElement|null;
   };
 
   function setPage(): typeof page {
     return {
       listItems: tocComponentDe.queryAll(By.css('ul.toc-list>li')),
       tocHeading: tocComponentDe.query(By.css('.toc-heading')),
-      tocHeadingButtonEmbedded: tocComponentDe.query(By.css('button.toc-heading.embedded')),
-      tocH1Heading: tocComponentDe.query(By.css('.h1')),
-      tocMoreButton: tocComponentDe.query(By.css('button.toc-more-items')),
+      tocHeadingButtonEmbedded: tocComponentDe.queryAll(By.css('button.toc-heading.embedded'))[0] ?? null,
+      tocH1Heading: tocComponentDe.queryAll(By.css('.h1'))[0] ?? null,
+      tocMoreButton: tocComponentDe.queryAll(By.css('button.toc-more-items'))[0] ?? null,
     };
   }
 
@@ -174,7 +174,7 @@ describe('TocComponent', () => {
         describe('after click tocHeading button', () => {
 
           beforeEach(() => {
-            page.tocHeadingButtonEmbedded.nativeElement.click();
+            page.tocHeadingButtonEmbedded!.nativeElement.click();
             fixture.detectChanges();
           });
 
@@ -191,13 +191,13 @@ describe('TocComponent', () => {
           });
 
           it('should be "collapsed" after clicking again', () => {
-            page.tocHeadingButtonEmbedded.nativeElement.click();
+            page.tocHeadingButtonEmbedded!.nativeElement.click();
             fixture.detectChanges();
             expect(tocComponent.isCollapsed).toEqual(true);
           });
 
           it('should not scroll after clicking again', () => {
-            page.tocHeadingButtonEmbedded.nativeElement.click();
+            page.tocHeadingButtonEmbedded!.nativeElement.click();
             fixture.detectChanges();
             expect(scrollToTopSpy).not.toHaveBeenCalled();
           });
@@ -206,7 +206,7 @@ describe('TocComponent', () => {
         describe('after click tocMore button', () => {
 
           beforeEach(() => {
-            page.tocMoreButton.nativeElement.click();
+            page.tocMoreButton!.nativeElement.click();
             fixture.detectChanges();
           });
 
@@ -223,19 +223,19 @@ describe('TocComponent', () => {
           });
 
           it('should be "collapsed" after clicking again', () => {
-            page.tocMoreButton.nativeElement.click();
+            page.tocMoreButton!.nativeElement.click();
             fixture.detectChanges();
             expect(tocComponent.isCollapsed).toEqual(true);
           });
 
           it('should be "collapsed" after clicking tocHeadingButton', () => {
-            page.tocMoreButton.nativeElement.click();
+            page.tocMoreButton!.nativeElement.click();
             fixture.detectChanges();
             expect(tocComponent.isCollapsed).toEqual(true);
           });
 
           it('should scroll after clicking again', () => {
-            page.tocMoreButton.nativeElement.click();
+            page.tocMoreButton!.nativeElement.click();
             fixture.detectChanges();
             expect(scrollToTopSpy).toHaveBeenCalled();
           });

--- a/aio/src/app/shared/select/select.component.spec.ts
+++ b/aio/src/app/shared/select/select.component.spec.ts
@@ -180,8 +180,8 @@ function getButtonSymbol(): HTMLElement | null {
 }
 
 function getOptionContainer(): HTMLUListElement|null {
-  const de = element.query(By.css('ul'));
-  return de && de.nativeElement;
+  const de = element.queryAll(By.css('ul'));
+  return de[0] ? de[0].nativeElement : null;
 }
 
 function getOptions(): HTMLLIElement[] {

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -150,7 +150,10 @@ export class DebugElement__PRE_R3__ extends DebugNode__PRE_R3__ implements Debug
 
   query(predicate: Predicate<DebugElement>): DebugElement {
     const results = this.queryAll(predicate);
-    return results[0] || null;
+    if (results.length === 0) {
+      throw new Error('No elements found.');
+    }
+    return results[0];
   }
 
   queryAll(predicate: Predicate<DebugElement>): DebugElement[] {
@@ -406,6 +409,9 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
 
   query(predicate: Predicate<DebugElement>): DebugElement {
     const results = this.queryAll(predicate);
+    if (results.length === 0) {
+      throw new Error('No elements found.');
+    }
     return results[0] || null;
   }
 

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -260,6 +260,12 @@ class TestCmptWithPropBindings {
 class TestCmptWithPropInterpolation {
 }
 
+@Component({
+  template: ``,
+})
+class UnusedComp {
+}
+
 {
   describe('debug element', () => {
     let fixture: ComponentFixture<any>;
@@ -287,6 +293,7 @@ class TestCmptWithPropInterpolation {
           TestCmptWithPropInterpolation,
           TestCmptWithRenderer,
           WithTitleDir,
+          UnusedComp,
         ],
         providers: [Logger],
         schemas: [NO_ERRORS_SCHEMA],
@@ -435,6 +442,22 @@ class TestCmptWithPropInterpolation {
       expect(hasClass(childTestEls[1].nativeElement, 'parentnested')).toBe(true);
       expect(hasClass(childTestEls[2].nativeElement, 'child')).toBe(true);
       expect(hasClass(childTestEls[3].nativeElement, 'childnested')).toBe(true);
+    });
+
+    it('should throw an error when that css query matches no children', () => {
+      fixture = TestBed.createComponent(ParentComp);
+      fixture.detectChanges();
+
+      expect(() => fixture.debugElement.query(By.css('not-existing')))
+          .toThrowError('No elements found.');
+    });
+
+    it('should throw an error when that directive query matches no children', () => {
+      fixture = TestBed.createComponent(ParentComp);
+      fixture.detectChanges();
+
+      expect(() => fixture.debugElement.query(By.directive(UnusedComp)))
+          .toThrowError('No elements found.');
     });
 
     it('should query projected child elements by directive', () => {
@@ -664,7 +687,7 @@ class TestCmptWithPropInterpolation {
       });
     });
 
-    describe('DebugElement.query doesn\'t fail on elements outside Angular context', () => {
+    describe('DebugElement.queryAll doesn\'t fail on elements outside Angular context', () => {
       @Component({template: '<div></div>'})
       class NativeEl {
         constructor(private elementRef: ElementRef) {}
@@ -685,47 +708,47 @@ class TestCmptWithPropInterpolation {
       });
 
       it('when searching for elements by name', () => {
-        expect(() => el.query(e => e.name === 'any search text')).not.toThrow();
+        expect(() => el.queryAll(e => e.name === 'any search text')).not.toThrow();
       });
 
       it('when searching for elements by their attributes', () => {
-        expect(() => el.query(e => e.attributes!['name'] === 'any attribute')).not.toThrow();
+        expect(() => el.queryAll(e => e.attributes!['name'] === 'any attribute')).not.toThrow();
       });
 
       it('when searching for elements by their classes', () => {
-        expect(() => el.query(e => e.classes['any class'] === true)).not.toThrow();
+        expect(() => el.queryAll(e => e.classes['any class'] === true)).not.toThrow();
       });
 
       it('when searching for elements by their styles', () => {
-        expect(() => el.query(e => e.styles['any style'] === 'any value')).not.toThrow();
+        expect(() => el.queryAll(e => e.styles['any style'] === 'any value')).not.toThrow();
       });
 
       it('when searching for elements by their properties', () => {
-        expect(() => el.query(e => e.properties['any prop'] === 'any value')).not.toThrow();
+        expect(() => el.queryAll(e => e.properties['any prop'] === 'any value')).not.toThrow();
       });
 
       it('when searching by componentInstance', () => {
-        expect(() => el.query(e => e.componentInstance === null)).not.toThrow();
+        expect(() => el.queryAll(e => e.componentInstance === null)).not.toThrow();
       });
 
       it('when searching by context', () => {
-        expect(() => el.query(e => e.context === null)).not.toThrow();
+        expect(() => el.queryAll(e => e.context === null)).not.toThrow();
       });
 
       it('when searching by listeners', () => {
-        expect(() => el.query(e => e.listeners.length === 0)).not.toThrow();
+        expect(() => el.queryAll(e => e.listeners.length === 0)).not.toThrow();
       });
 
       it('when searching by references', () => {
-        expect(() => el.query(e => e.references === null)).not.toThrow();
+        expect(() => el.queryAll(e => e.references === null)).not.toThrow();
       });
 
       it('when searching by providerTokens', () => {
-        expect(() => el.query(e => e.providerTokens.length === 0)).not.toThrow();
+        expect(() => el.queryAll(e => e.providerTokens.length === 0)).not.toThrow();
       });
 
       it('when searching by injector', () => {
-        expect(() => el.query(e => e.injector === null)).not.toThrow();
+        expect(() => el.queryAll(e => e.injector === null)).not.toThrow();
       });
 
       onlyInIvy('VE does not match elements created outside Angular context')

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -1163,8 +1163,8 @@ describe('TestBed', () => {
              fixture = TestBed.createComponent(RootCmp);
              fixture.detectChanges();
 
-             childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp));
-             expect(childCmpInstance).toBeNull();
+             expect(() => fixture.debugElement.query(By.directive(ChildCmp)))
+                 .toThrowError('No elements found.');
              expect(fixture.nativeElement.textContent).toBe('');
 
              TestBed.resetTestingModule();
@@ -1178,8 +1178,8 @@ describe('TestBed', () => {
              fixture = TestBed.createComponent(RootCmp);
              fixture.detectChanges();
 
-             childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp));
-             expect(childCmpInstance).toBeNull();
+             expect(() => fixture.debugElement.query(By.directive(ChildCmp)))
+                 .toThrowError('No elements found.');
              expect(fixture.nativeElement.textContent).toBe('');
            });
 

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -205,8 +205,8 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = newForm;
         fixture.detectChanges();
 
-        emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
-        expect(emailInput as any).toBe(null);  // TODO: Review use of `any` here (#19904)
+        expect(() => fixture.debugElement.query(By.css('[formControlName="email"]')))
+            .toThrowError('No elements found.');
       });
 
       it('should strip array controls that are not found', () => {

--- a/packages/platform-browser/testing/src/matchers.ts
+++ b/packages/platform-browser/testing/src/matchers.ts
@@ -281,10 +281,12 @@ _global.beforeEach(function() {
             };
           }
 
-          const found = !!actualFixture.debugElement.query(By.directive(expectedComponentType));
-          return found ?
-              {pass: true} :
-              {pass: false, message: msgFn(`Expected ${expectedComponentType.name} to show`)};
+          try {
+            actualFixture.debugElement.query(By.directive(expectedComponentType));
+            return {pass: true};
+          } catch {
+            return {pass: false, message: msgFn(`Expected ${expectedComponentType.name} to show`)};
+          }
         }
       };
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #22449

Supersedes #32365

Currently, DebugElement.query 's return type is only DebugElement but actually, it returns DebugElement | null.

## What is the new behavior?

It returns only non-null `DebugElement`. If no children found, it will throw an error.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: Despite its typing is returning non-null `DebugElement`, `DebugElement.query` returned null when that predicate didn't match any children,. Currently, it throws an error to align the typing.

This breaking change is not too impactful because if this change causes an error, users should have already raised a run-time exception due to an unexpected null.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

cc/ @petebacondarwin 