### PR TITLE
docs: WebStorm does not need @angular/language-service anymore

### DIFF
--- a/aio/content/guide/language-service.md
+++ b/aio/content/guide/language-service.md
@@ -64,36 +64,9 @@ In the marketplace, search for Angular Language Service extension, and click the
 
 ### WebStorm
 
-In [WebStorm](https://www.jetbrains.com/webstorm/), you must install the language service package as a project dependency.
+In [WebStorm](https://www.jetbrains.com/webstorm/), enable the plugin [Angular and AngularJS](https://plugins.jetbrains.com/plugin/6971-angular-and-angularjs).
 
-1. Add the following to your `devDependencies` in your project's `package.json`
-
-<code-example language="json" header="package.json">
-devDependencies {
-  "@angular/language-service": "^6.0.0"
-}
-</code-example>
-
-2. In the terminal window at the root of your project, install the `devDependencies` with `npm` or `yarn`:
-
-```sh
-npm install
-```
-*OR*
-
-```sh
-yarn
-```
-
-*OR*
-
-```sh
-yarn install
-```
-
-When Angular sees this dev dependency, it provides the language service in the WebStorm environment.
-WebStorm then gives you colorization inside the template and autocomplete in addition to the Angular Language Service.
-
+Since WebStorm 2019.1, the `@angular/language-service` is not required anymore and should be removed from your `package.json`.
 
 ### Sublime Text
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We told to install the language service.

## What is the new behavior?

We tell to use the integrated plugin instead.

Since WebStorm 2019.1, all of Angular Compiler validations has been implemented
as inspections, which has some additional benefits of being able to provide some
basic quick fixes like adding missing selector property, or something as neat as
auto-module import.

See https://intellij-support.jetbrains.com/hc/en-us/community/posts/360009914880

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
