### PR TITLE
docs: correct appearance of numbering

### DIFF
--- a/aio/content/guide/zone.md
+++ b/aio/content/guide/zone.md
@@ -108,7 +108,7 @@ To understand how change detection works, first consider when the application ne
 
 <code-example path="user-input/src/app/click-me.component.ts" region="click-me-component" header="src/app/click-me.component.ts"></code-example>
 
-1. HTTP Data Request. You can also get data from a server through an HTTP request. For example:
+3. HTTP Data Request. You can also get data from a server through an HTTP request. For example:
 
 ```typescript
 @Component({


### PR DESCRIPTION
docs: correct appearance of numbering

There was an "ordered list" that was appearing as 1,2,1,4,5,6 due to a code block interrupting the flow. This fixes the list to appear as 1,2,3,4,5,6.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Numbering appears with a `1` instead of a `3` for the third item in a list.


## What is the new behavior?

Correct number for third item.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
