### PR TITLE
fix animations: replace copy of query selector node list from "spread(...)" to "for" to avoid callstack error

### DIFF
--- a/packages/animations/browser/src/render/shared.ts
+++ b/packages/animations/browser/src/render/shared.ts
@@ -183,12 +183,13 @@ if (_isNode || typeof Element !== 'undefined') {
   _query = (element: any, selector: string, multi: boolean): any[] => {
     let results: any[] = [];
     if (multi) {
-      results.push(...element.querySelectorAll(selector));
+      const elems = element.querySelectorAll(selector);
+      for(let i = 0; i < elems.length; i++) {
+        results.push(elems[i]);
+      }
     } else {
       const elm = element.querySelector(selector);
-      if (elm) {
-        results.push(elm);
-      }
+      results = elm ? [elm] : [];
     }
     return results;
   };

--- a/packages/animations/browser/src/render/shared.ts
+++ b/packages/animations/browser/src/render/shared.ts
@@ -184,7 +184,7 @@ if (_isNode || typeof Element !== 'undefined') {
     let results: any[] = [];
     if (multi) {
       const elems = element.querySelectorAll(selector);
-      for(let i = 0; i < elems.length; i++) {
+      for (let i = 0; i < elems.length; i++) {
         results.push(elems[i]);
       }
     } else {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #38551


## What is the new behavior?
**Spread syntax(`...`)** exceeds stake size in browsers. The following work workbench demonstrates the limitation both in **chrome** and **firefox**:

https://jsbench.me/r1khehfd20/1

As per @AleksanderBodurri workbench example, the performance increases slightly with **for loop** compared to the rest:

https://jsbench.me/grkhenmtkb/1

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Fixes #38551
