### PR TITLE
fix(animations): replace copy of query selector node-list from "spread" to "for"

### DIFF
--- a/packages/animations/browser/src/render/shared.ts
+++ b/packages/animations/browser/src/render/shared.ts
@@ -183,7 +183,17 @@ if (_isNode || typeof Element !== 'undefined') {
   _query = (element: any, selector: string, multi: boolean): any[] => {
     let results: any[] = [];
     if (multi) {
-      results.push(...element.querySelectorAll(selector));
+      // DO NOT REFACTOR TO USE SPREAD SYNTAX.
+      // For element queries that return sufficiently large NodeList objects,
+      // using spread syntax to populate the results array causes a RangeError
+      // due to the call stack limit being reached. `Array.from` can not be used
+      // as well, since NodeList is not iterable in IE 11, see
+      // https://developer.mozilla.org/en-US/docs/Web/API/NodeList
+      // More info is available in #38551.
+      const elems = element.querySelectorAll(selector);
+      for (let i = 0; i < elems.length; i++) {
+        results.push(elems[i]);
+      }
     } else {
       const elm = element.querySelector(selector);
       if (elm) {


### PR DESCRIPTION
The **animation driver** fails to query a large number of **query selectors**.  Limitation varies across all browsers.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #38551


## What is the new behavior?

**Spread syntax(...)** exceeds stake size in browsers. The following workbench demonstrates the limitation both in chrome and firefox:

https://jsbench.me/r1khehfd20/1

As per @AleksanderBodurri workbench example, the performance increases slightly with **for loop** compared to the rest:

https://jsbench.me/grkhenmtkb/1

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Fixes #38551
