### PR TITLE
fix(docs-infra): support recovering from unrecoverable SW states

### DIFF
--- a/aio/src/app/shared/location.service.spec.ts
+++ b/aio/src/app/shared/location.service.spec.ts
@@ -1,10 +1,8 @@
 import { Injector } from '@angular/core';
 import { Location, LocationStrategy, PlatformLocation } from '@angular/common';
 import { MockLocationStrategy } from '@angular/common/testing';
-import { Subject } from 'rxjs';
 
 import { GaService } from 'app/shared/ga.service';
-import { SwUpdatesService } from 'app/sw-updates/sw-updates.service';
 import { LocationService } from './location.service';
 import { ScrollService } from './scroll.service';
 
@@ -12,25 +10,22 @@ describe('LocationService', () => {
   let injector: Injector;
   let location: MockLocationStrategy;
   let service: LocationService;
-  let swUpdates: MockSwUpdatesService;
   let scrollService: MockScrollService;
 
   beforeEach(() => {
     injector = Injector.create({
       providers: [
-        { provide: LocationService, deps: [GaService, Location, ScrollService, PlatformLocation, SwUpdatesService] },
+        { provide: LocationService, deps: [GaService, Location, ScrollService, PlatformLocation] },
         { provide: Location, deps: [LocationStrategy, PlatformLocation] },
         { provide: GaService, useClass: TestGaService, deps: [] },
         { provide: LocationStrategy, useClass: MockLocationStrategy, deps: [] },
         { provide: PlatformLocation, useClass: MockPlatformLocation, deps: [] },
-        { provide: SwUpdatesService, useClass: MockSwUpdatesService, deps: [] },
         { provide: ScrollService, useClass: MockScrollService, deps: [] }
       ]
     });
 
     location = injector.get(LocationStrategy) as unknown as MockLocationStrategy;
     service = injector.get(LocationService);
-    swUpdates = injector.get(SwUpdatesService) as unknown as MockSwUpdatesService;
     scrollService = injector.get(ScrollService);
   });
 
@@ -244,7 +239,7 @@ describe('LocationService', () => {
     });
   });
 
-  describe('go', () => {
+  describe('go()', () => {
 
     it('should update the location', () => {
       service.go('some-new-url');
@@ -295,19 +290,19 @@ describe('LocationService', () => {
       expect(goExternalSpy).toHaveBeenCalledWith(externalUrl);
     });
 
-    it('should do a "full page navigation" and remove the stored scroll position when navigating to ' +
-      'internal URLs only if a ServiceWorker update has been activated', () => {
+    it('should do a "full page navigation" if requested and remove the stored scroll position ' +
+        'when navigating to internal URLs only', () => {
       const goExternalSpy = spyOn(service, 'goExternal');
       const removeStoredScrollInfoSpy = spyOn(scrollService, 'removeStoredScrollInfo');
 
-      // Internal URL - No ServiceWorker update
+      // Internal URL - No full page navigation requested
       service.go('some-internal-url');
       expect(removeStoredScrollInfoSpy).not.toHaveBeenCalled();
       expect(goExternalSpy).not.toHaveBeenCalled();
       expect(location.path(true)).toEqual('some-internal-url');
 
-      // Internal URL - ServiceWorker update
-      swUpdates.updateActivated.next('foo');
+      // Internal URL - Full page navigation requested
+      service.fullPageNavigationNeeded();
       service.go('other-internal-url');
       expect(goExternalSpy).toHaveBeenCalledWith('other-internal-url');
       expect(removeStoredScrollInfoSpy).toHaveBeenCalled();
@@ -319,13 +314,13 @@ describe('LocationService', () => {
       const externalUrl = 'http://some/far/away/land';
       const otherExternalUrl = 'http://some/far/far/away/land';
 
-      // External URL - No ServiceWorker update
+      // External URL - No full page navigation requested
       service.go(externalUrl);
       expect(removeStoredScrollInfoSpy).not.toHaveBeenCalled();
       expect(goExternalSpy).toHaveBeenCalledWith(externalUrl);
 
-      // External URL - ServiceWorker update
-      swUpdates.updateActivated.next('foo');
+      // External URL - Full page navigation requested
+      service.fullPageNavigationNeeded();
       service.go(otherExternalUrl);
       expect(removeStoredScrollInfoSpy).not.toHaveBeenCalled();
       expect(goExternalSpy).toHaveBeenCalledWith(otherExternalUrl);
@@ -341,7 +336,7 @@ describe('LocationService', () => {
 
   });
 
-  describe('search', () => {
+  describe('search()', () => {
     it('should read the query from the current location.path', () => {
       location.simulatePopState('a/b/c?foo=bar&moo=car');
       expect(service.search()).toEqual({ foo: 'bar', moo: 'car' });
@@ -378,7 +373,7 @@ describe('LocationService', () => {
     });
   });
 
-  describe('setSearch', () => {
+  describe('setSearch()', () => {
     let platformLocation: MockPlatformLocation;
 
     beforeEach(() => {
@@ -416,7 +411,7 @@ describe('LocationService', () => {
     });
   });
 
-  describe('handleAnchorClick', () => {
+  describe('handleAnchorClick()', () => {
     let anchor: HTMLAnchorElement;
 
     beforeEach(() => {
@@ -628,10 +623,6 @@ describe('LocationService', () => {
 class MockPlatformLocation {
   pathname = 'a/b/c';
   replaceState = jasmine.createSpy('PlatformLocation.replaceState');
-}
-
-class MockSwUpdatesService {
-  updateActivated = new Subject<string>();
 }
 
 class MockScrollService {

--- a/aio/src/app/shared/location.service.ts
+++ b/aio/src/app/shared/location.service.ts
@@ -5,7 +5,6 @@ import { ReplaySubject } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 
 import { GaService } from 'app/shared/ga.service';
-import { SwUpdatesService } from 'app/sw-updates/sw-updates.service';
 import { ScrollService } from './scroll.service';
 
 @Injectable()
@@ -13,7 +12,7 @@ export class LocationService {
 
   private readonly urlParser = document.createElement('a');
   private urlSubject = new ReplaySubject<string>(1);
-  private swUpdateActivated = false;
+  private fullPageNavigation = false;
 
   currentUrl = this.urlSubject
     .pipe(map(url => this.stripSlashes(url)));
@@ -27,16 +26,22 @@ export class LocationService {
     private gaService: GaService,
     private location: Location,
     private scrollService: ScrollService,
-    private platformLocation: PlatformLocation,
-    swUpdates: SwUpdatesService) {
+    private platformLocation: PlatformLocation) {
 
     this.urlSubject.next(location.path(true));
 
     this.location.subscribe(state => {
       return this.urlSubject.next(state.url || '');
     });
+  }
 
-    swUpdates.updateActivated.subscribe(() => this.swUpdateActivated = true);
+  /**
+   * Signify that a full page navigation is needed (instead of a regular in-app navigation).
+   *
+   * This will happen on the next user-initiated navigation.
+   */
+  fullPageNavigationNeeded(): void {
+    this.fullPageNavigation = true;
   }
 
   // TODO: ignore if url-without-hash-or-search matches current location?
@@ -46,9 +51,9 @@ export class LocationService {
     if (/^http/.test(url)) {
       // Has http protocol so leave the site
       this.goExternal(url);
-    } else if (this.swUpdateActivated) {
-      // (Do a "full page navigation" if a ServiceWorker update has been activated)
-      // We need to remove stored Position in order to be sure to scroll to the Top position
+    } else if (this.fullPageNavigation) {
+      // Do a "full page navigation".
+      // We need to remove the stored scroll position to ensure we scroll to the top.
       this.scrollService.removeStoredScrollInfo();
       this.goExternal(url);
     } else {
@@ -118,7 +123,6 @@ export class LocationService {
    * `AppComponent`, whose element contains all the of the application and so captures all
    * link clicks both inside and outside the `DocViewerComponent`.
    */
-
   handleAnchorClick(anchor: HTMLAnchorElement, button = 0, ctrlKey = false, metaKey = false) {
 
     // Check for modifier keys and non-left-button, which indicate the user wants to control navigation

--- a/aio/src/app/shared/location.service.ts
+++ b/aio/src/app/shared/location.service.ts
@@ -70,6 +70,10 @@ export class LocationService {
     window.location.replace(url);
   }
 
+  reloadPage(): void {
+    window.location.reload();
+  }
+
   private stripSlashes(url: string) {
     return url.replace(/^\/+/, '').replace(/\/+(\?|#|$)/, '$1');
   }

--- a/aio/src/app/sw-updates/sw-updates.service.spec.ts
+++ b/aio/src/app/sw-updates/sw-updates.service.spec.ts
@@ -4,6 +4,7 @@ import { SwUpdate } from '@angular/service-worker';
 import { Subject } from 'rxjs';
 
 import { Logger } from 'app/shared/logger.service';
+import { MockLogger } from 'testing/logger.service';
 import { SwUpdatesService } from './sw-updates.service';
 
 
@@ -202,10 +203,6 @@ describe('SwUpdatesService', () => {
 // Mocks
 class MockApplicationRef {
   isStable = new Subject<boolean>();
-}
-
-class MockLogger {
-  log = jasmine.createSpy('MockLogger.log');
 }
 
 class MockSwUpdate {

--- a/aio/src/app/sw-updates/sw-updates.service.spec.ts
+++ b/aio/src/app/sw-updates/sw-updates.service.spec.ts
@@ -26,10 +26,10 @@ describe('SwUpdatesService', () => {
   //   to call them inside each test's zone.
   const setup = (isSwUpdateEnabled: boolean) => {
     injector = Injector.create({providers: [
-      { provide: ApplicationRef, useClass: MockApplicationRef },
-      { provide: LocationService, useFactory: () => new MockLocationService('') },
-      { provide: Logger, useClass: MockLogger },
-      { provide: SwUpdate, useFactory: () => new MockSwUpdate(isSwUpdateEnabled) },
+      { provide: ApplicationRef, useClass: MockApplicationRef, deps: [] },
+      { provide: LocationService, useFactory: () => new MockLocationService(''), deps: [] },
+      { provide: Logger, useClass: MockLogger, deps: [] },
+      { provide: SwUpdate, useFactory: () => new MockSwUpdate(isSwUpdateEnabled), deps: [] },
       { provide: SwUpdatesService, deps: [ApplicationRef, LocationService, Logger, SwUpdate] }
     ]});
 

--- a/aio/src/app/sw-updates/sw-updates.service.spec.ts
+++ b/aio/src/app/sw-updates/sw-updates.service.spec.ts
@@ -3,7 +3,9 @@ import { discardPeriodicTasks, fakeAsync, tick } from '@angular/core/testing';
 import { SwUpdate } from '@angular/service-worker';
 import { Subject } from 'rxjs';
 
+import { LocationService } from 'app/shared/location.service';
 import { Logger } from 'app/shared/logger.service';
+import { MockLocationService } from 'testing/location.service';
 import { MockLogger } from 'testing/logger.service';
 import { SwUpdatesService } from './sw-updates.service';
 
@@ -11,6 +13,7 @@ import { SwUpdatesService } from './sw-updates.service';
 describe('SwUpdatesService', () => {
   let injector: Injector;
   let appRef: MockApplicationRef;
+  let location: MockLocationService;
   let service: SwUpdatesService;
   let swu: MockSwUpdate;
   let checkInterval: number;
@@ -23,13 +26,15 @@ describe('SwUpdatesService', () => {
   //   to call them inside each test's zone.
   const setup = (isSwUpdateEnabled: boolean) => {
     injector = Injector.create({providers: [
-      { provide: ApplicationRef, useClass: MockApplicationRef, deps: [] },
-      { provide: Logger, useClass: MockLogger, deps: [] },
-      { provide: SwUpdate, useFactory: () => new MockSwUpdate(isSwUpdateEnabled), deps: [] },
-      { provide: SwUpdatesService, deps: [ApplicationRef, Logger, SwUpdate] }
+      { provide: ApplicationRef, useClass: MockApplicationRef },
+      { provide: LocationService, useFactory: () => new MockLocationService('') },
+      { provide: Logger, useClass: MockLogger },
+      { provide: SwUpdate, useFactory: () => new MockSwUpdate(isSwUpdateEnabled) },
+      { provide: SwUpdatesService, deps: [ApplicationRef, LocationService, Logger, SwUpdate] }
     ]});
 
     appRef = injector.get(ApplicationRef) as unknown as MockApplicationRef;
+    location = injector.get(LocationService) as unknown as MockLocationService;
     service = injector.get(SwUpdatesService);
     swu = injector.get(SwUpdate) as unknown as MockSwUpdate;
     checkInterval = (service as any).checkInterval;
@@ -100,16 +105,18 @@ describe('SwUpdatesService', () => {
     discardPeriodicTasks();
   })));
 
-  it('should emit on `updateActivated` when an update has been activated', run(() => {
-    const activatedVersions: (string|undefined)[] = [];
-    service.updateActivated.subscribe(v => activatedVersions.push(v));
-
+  it('should request a full page navigation when an update has been activated', run(() => {
     swu.$$availableSubj.next({available: {hash: 'foo'}});
-    swu.$$activatedSubj.next({current: {hash: 'bar'}});
-    swu.$$availableSubj.next({available: {hash: 'baz'}});
-    swu.$$activatedSubj.next({current: {hash: 'qux'}});
+    expect(location.fullPageNavigationNeeded).toHaveBeenCalledTimes(0);
 
-    expect(activatedVersions).toEqual(['bar', 'qux']);
+    swu.$$activatedSubj.next({current: {hash: 'bar'}});
+    expect(location.fullPageNavigationNeeded).toHaveBeenCalledTimes(1);
+
+    swu.$$availableSubj.next({available: {hash: 'baz'}});
+    expect(location.fullPageNavigationNeeded).toHaveBeenCalledTimes(1);
+
+    swu.$$activatedSubj.next({current: {hash: 'qux'}});
+    expect(location.fullPageNavigationNeeded).toHaveBeenCalledTimes(2);
   }));
 
   describe('when `SwUpdate` is not enabled', () => {
@@ -135,16 +142,13 @@ describe('SwUpdatesService', () => {
       expect(swu.activateUpdate).not.toHaveBeenCalled();
     })));
 
-    it('should never emit on `updateActivated`', runDeactivated(() => {
-      const activatedVersions: (string|undefined)[] = [];
-      service.updateActivated.subscribe(v => activatedVersions.push(v));
-
+    it('should never request a full page navigation', runDeactivated(() => {
       swu.$$availableSubj.next({available: {hash: 'foo'}});
       swu.$$activatedSubj.next({current: {hash: 'bar'}});
       swu.$$availableSubj.next({available: {hash: 'baz'}});
       swu.$$activatedSubj.next({current: {hash: 'qux'}});
 
-      expect(activatedVersions).toEqual([]);
+      expect(location.fullPageNavigationNeeded).not.toHaveBeenCalled();
     }));
   });
 
@@ -185,17 +189,17 @@ describe('SwUpdatesService', () => {
       expect(swu.activateUpdate).not.toHaveBeenCalled();
     })));
 
-    it('should stop emitting on `updateActivated`', run(() => {
-      const activatedVersions: (string|undefined)[] = [];
-      service.updateActivated.subscribe(v => activatedVersions.push(v));
-
+    it('should stop requesting full page navigations when updates are activated', run(() => {
       swu.$$availableSubj.next({available: {hash: 'foo'}});
       swu.$$activatedSubj.next({current: {hash: 'bar'}});
+      expect(location.fullPageNavigationNeeded).toHaveBeenCalledTimes(1);
+
       service.ngOnDestroy();
+      location.fullPageNavigationNeeded.calls.reset();
+
       swu.$$availableSubj.next({available: {hash: 'baz'}});
       swu.$$activatedSubj.next({current: {hash: 'qux'}});
-
-      expect(activatedVersions).toEqual(['bar']);
+      expect(location.fullPageNavigationNeeded).not.toHaveBeenCalled();
     }));
   });
 });

--- a/aio/src/app/sw-updates/sw-updates.service.ts
+++ b/aio/src/app/sw-updates/sw-updates.service.ts
@@ -51,6 +51,14 @@ export class SwUpdatesService implements OnDestroy {
             takeUntil(this.onDestroy),
         )
         .subscribe(() => location.fullPageNavigationNeeded());
+
+    // Request an immediate page reload once an unrecoverable state has been detected.
+    this.swu.unrecoverable
+        .pipe(
+            tap(evt => this.log(`Unrecoverable state: ${evt.reason}\nReloading...`)),
+            takeUntil(this.onDestroy),
+        )
+        .subscribe(() => location.reloadPage());
   }
 
   ngOnDestroy() {

--- a/aio/src/app/sw-updates/sw-updates.service.ts
+++ b/aio/src/app/sw-updates/sw-updates.service.ts
@@ -1,8 +1,9 @@
 import { ApplicationRef, Injectable, OnDestroy } from '@angular/core';
 import { SwUpdate } from '@angular/service-worker';
-import { concat, interval, NEVER, Observable, Subject } from 'rxjs';
-import { first, map, takeUntil, tap } from 'rxjs/operators';
+import { concat, interval, Subject } from 'rxjs';
+import { first, takeUntil, tap } from 'rxjs/operators';
 
+import { LocationService } from 'app/shared/location.service';
 import { Logger } from 'app/shared/logger.service';
 
 
@@ -19,12 +20,10 @@ export class SwUpdatesService implements OnDestroy {
   private checkInterval = 1000 * 60 * 60 * 6;  // 6 hours
   private onDestroy = new Subject<void>();
 
-  /** Emit the version hash whenever an update is activated. */
-  updateActivated: Observable<string>;
-
-  constructor(appRef: ApplicationRef, private logger: Logger, private swu: SwUpdate) {
+  constructor(
+      appRef: ApplicationRef, location: LocationService, private logger: Logger,
+      private swu: SwUpdate) {
     if (!swu.isEnabled) {
-      this.updateActivated = NEVER.pipe(takeUntil(this.onDestroy));
       return;
     }
 
@@ -45,12 +44,13 @@ export class SwUpdatesService implements OnDestroy {
         )
         .subscribe(() => this.swu.activateUpdate());
 
-    // Notify about activated updates.
-    this.updateActivated = this.swu.activated.pipe(
-        tap(evt => this.log(`Update activated: ${JSON.stringify(evt)}`)),
-        map(evt => evt.current.hash),
-        takeUntil(this.onDestroy),
-    );
+    // Request a full page navigation once an update has been activated.
+    this.swu.activated
+        .pipe(
+            tap(evt => this.log(`Update activated: ${JSON.stringify(evt)}`)),
+            takeUntil(this.onDestroy),
+        )
+        .subscribe(() => location.fullPageNavigationNeeded());
   }
 
   ngOnDestroy() {

--- a/aio/src/testing/location.service.ts
+++ b/aio/src/testing/location.service.ts
@@ -8,6 +8,7 @@ export class MockLocationService {
   currentPath = this.currentUrl.pipe(map(url => url.match(/[^?#]*/)![0]));
   search = jasmine.createSpy('search').and.returnValue({});
   setSearch = jasmine.createSpy('setSearch');
+  fullPageNavigationNeeded = jasmine.createSpy('Location.fullPageNavigationNeeded');
   go = jasmine.createSpy('Location.go').and
               .callFake((url: string) => this.urlSubject.next(url));
   goExternal = jasmine.createSpy('Location.goExternal');

--- a/aio/src/testing/location.service.ts
+++ b/aio/src/testing/location.service.ts
@@ -13,6 +13,7 @@ export class MockLocationService {
               .callFake((url: string) => this.urlSubject.next(url));
   goExternal = jasmine.createSpy('Location.goExternal');
   replace = jasmine.createSpy('Location.replace');
+  reloadPage = jasmine.createSpy('Location.reloadPage');
   handleAnchorClick = jasmine.createSpy('Location.handleAnchorClick')
       .and.returnValue(false); // prevent click from causing a browser navigation
 

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3033,
-        "main-es2015": 447565,
+        "main-es2015": 447766,
         "polyfills-es2015": 52343
       }
     }
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3033,
-        "main-es2015": 447774,
+        "main-es2015": 447975,
         "polyfills-es2015": 52493
       }
     }

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3033,
-        "main-es2015": 448327,
+        "main-es2015": 447565,
         "polyfills-es2015": 52343
       }
     }
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3033,
-        "main-es2015": 448538,
+        "main-es2015": 447774,
         "polyfills-es2015": 52493
       }
     }


### PR DESCRIPTION
~~This sits on top of (and therefore is blocked by) #39600.~~ _Rebased on master after #39600 was merged._

##
Occasionally, the SW would end up in a broken state where some of the eagerly cached resources of an older version were available in the local cache, but others (such as lazy-loaded bundles) were not. This would leave the app in a broken state and a blank screen would be displayed. See #28114 for a more detailed discussion.

This commit takes advantage of the newly introduced (in v11) [SwUpdate#unrecoverable][1] API to detect these bad states and recover by doing a full page reload whenever an [UnrecoverableStateEvent][2] is emitted.

Partially addresses #28114.

NOTE:
Currently, `SwUpdate.unrecoverable` only works if the app has already bootstrapped; i.e. if only lazy-loaded bundles have been purged from the cache.
That should be fine in practice, since the cache entries are removed in least-recently-used order. Thus the eagerly loaded bundles will be the last to be removed from the cache (which rarely happens in practice).

[1]: https://v11.angular.io/api/service-worker/SwUpdate#unrecoverable
[2]: https://v11.angular.io/api/service-worker/UnrecoverableStateEvent