### PR TITLE
ci: update angular-robot config for L2 triage of PRs

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -187,7 +187,6 @@ triagePR:
   # arrays of labels that determine if a PR has been fully triaged
   l2TriageLabels:
     -
-      - "type: *"
       - "effort*"
       - "risk*"
       - "comp: *"


### PR DESCRIPTION
With the update to our labeling scheme across the repository, the L2 triage
labels for PRs needs to be updated to no longer require a label type which
doesn't exist: `type: *`
