### PR TITLE
refactor(core): remove isObservable TODO

### DIFF
--- a/packages/core/src/util/lang.ts
+++ b/packages/core/src/util/lang.ts
@@ -19,9 +19,13 @@ export function isPromise<T = any>(obj: any): obj is Promise<T> {
 
 /**
  * Determine if the argument is an Observable
+ *
+ * Strictly this tests that the `obj` is `Subscribable`, since `Observable`
+ * types need additional methods, such as `lift()`. But it is adequate for our
+ * needs since within the Angular framework code we only ever need to use the
+ * `subscribe()` method, and RxJS has mechanisms to wrap `Subscribable` objects
+ * into `Observable` as needed.
  */
 export function isObservable(obj: any|Observable<any>): obj is Observable<any> {
-  // TODO: use isObservable once we update pass rxjs 6.1
-  // https://github.com/ReactiveX/rxjs/blob/master/CHANGELOG.md#610-2018-05-03
   return !!obj && typeof obj.subscribe === 'function';
 }


### PR DESCRIPTION
This commit removes the TODO comment that proposed
that we use the built-in RxJS `isObservable()` function.

This is not a viable approach since the built-in function
requires that the `obj` contains additional methods that
our "observable" types (such as `EventEmitter`) do not
necessarily have.

See #39643 for more information.
