### PR TITLE
docs(docs-infra): remove link to constructor article

### DIFF
--- a/aio/content/guide/lifecycle-hooks.md
+++ b/aio/content/guide/lifecycle-hooks.md
@@ -305,11 +305,6 @@ Use the `ngOnInit()` method to perform the following initialization tasks.
   An `ngOnInit()` is a good place for a component to fetch its initial data.
   For an example, see the [Tour of Heroes tutorial](tutorial/toh-pt4#oninit).
 
-  <div class="alert is-helpful">
-
-  In [Flaw: Constructor does Real Work](http://misko.hevery.com/code-reviewers-guide/flaw-constructor-does-real-work/), Misko Hevery, Angular team lead, explains why you should avoid complex constructor logic.
-
-  </div>
 
 * Set up the component after Angular sets the input properties.
   Constructors should do no more than set the initial local variables to simple values.


### PR DESCRIPTION
remove the link to the article called Flaw: Constructor does real work by Misko

Fixes #39106

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
When you click on the link, you are directed to http://misko.hevery.com/code-reviewers-guide/flaw-constructor-does-real-work/  where you will see an error that says "Error establishing a database connection"

Issue Number: #39106 

## What is the new behavior? 
The link and verbiage has been removed completely as per @aikidave instruction


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
