### PR TITLE
Compiler "neverEmit" mode for faster turnarounds on external template updates

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
@@ -1,4 +1,3 @@
-import {NoopReferencesRegistry} from '..';
 /**
  * @license
  * Copyright Google LLC All Rights Reserved.
@@ -6,6 +5,8 @@ import {NoopReferencesRegistry} from '..';
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+
+import {NoopReferencesRegistry} from '..';
 import {CycleAnalyzer, ImportGraph} from '../../cycles';
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
 import {absoluteFrom} from '../../file_system';

--- a/packages/compiler-cli/src/ngtsc/core/api/src/adapter.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/adapter.ts
@@ -68,6 +68,16 @@ export interface NgCompilerAdapter extends
   readonly ignoreForEmit: Set<ts.SourceFile>;
 
   /**
+   * Whether the compiler is being run in a context where the consumer will never emit compilation
+   * results. Useful in contexts where only frontend analysis is needed, like an indexer or language
+   * service.
+   *
+   * This is stricter than `ignoreForEmit` and used to elide work that is otherwise needed for emit.
+   * Changing `neverEmit` between runs of the compiler is not sound.
+   */
+  readonly neverEmit: boolean;
+
+  /**
    * A tracker for usage of symbols in `.ngfactory` shims.
    *
    * This can be left `null` if such shims are not a part of the `ts.Program`.

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -611,7 +611,12 @@ export class NgCompiler {
         // remote scoping feature which is activated in the event of potential import cycles. Thus,
         // the module depends not only on the transitive dependencies of the component, but on its
         // resources as well.
-        depGraph.addTransitiveResources(ngModuleFile, file);
+        // Note, however, that the remote scoping feature is only needed for purposes of emit. This
+        // means we can safely elide such transient resource dependencies in cases where the
+        // component has been marked no-emit.
+        if (!this.adapter.neverEmit) {
+          depGraph.addTransitiveResources(ngModuleFile, file);
+        }
 
         // A change to any directive/pipe in the compilation scope should cause the component to be
         // invalidated.

--- a/packages/compiler-cli/src/ngtsc/core/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/host.ts
@@ -93,7 +93,8 @@ export class NgCompilerHost extends DelegatingCompilerHost implements
       delegate: ExtendedTsCompilerHost, inputFiles: ReadonlyArray<string>,
       rootDirs: ReadonlyArray<AbsoluteFsPath>, private shimAdapter: ShimAdapter,
       private shimTagger: ShimReferenceTagger, entryPoint: AbsoluteFsPath|null,
-      factoryTracker: FactoryTracker|null, diagnostics: ts.Diagnostic[]) {
+      factoryTracker: FactoryTracker|null, diagnostics: ts.Diagnostic[],
+      readonly neverEmit = false) {
     super(delegate);
 
     this.factoryTracker = factoryTracker;
@@ -134,7 +135,7 @@ export class NgCompilerHost extends DelegatingCompilerHost implements
    */
   static wrap(
       delegate: ts.CompilerHost, inputFiles: ReadonlyArray<string>, options: NgCompilerOptions,
-      oldProgram: ts.Program|null): NgCompilerHost {
+      oldProgram: ts.Program|null, neverEmit = false): NgCompilerHost {
     // TODO(alxhub): remove the fallback to allowEmptyCodegenFiles after verifying that the rest of
     // our build tooling is no longer relying on it.
     const allowEmptyCodegenFiles = options.allowEmptyCodegenFiles || false;
@@ -214,7 +215,7 @@ export class NgCompilerHost extends DelegatingCompilerHost implements
         new ShimReferenceTagger(perFileShimGenerators.map(gen => gen.extensionPrefix));
     return new NgCompilerHost(
         delegate, inputFiles, rootDirs, shimAdapter, shimTagger, entryPoint, factoryTracker,
-        diagnostics);
+        diagnostics, neverEmit);
   }
 
   /**

--- a/packages/compiler-cli/src/ngtsc/core/test/compiler_test.ts
+++ b/packages/compiler-cli/src/ngtsc/core/test/compiler_test.ts
@@ -262,7 +262,7 @@ runInEachFileSystem(() => {
     });
 
     describe('ignore for emit', () => {
-      fit('modules should not depend on transient resource deps in neverEmit mode', () => {
+      it('modules should not depend on transient resource deps in neverEmit mode', () => {
         const COMPONENT = _('/cmp.ts');
         const MODULE = _('/mod.ts');
         fs.writeFile(COMPONENT, `

--- a/packages/language-service/ivy/language_service_adapter.ts
+++ b/packages/language-service/ivy/language_service_adapter.ts
@@ -14,6 +14,7 @@ import * as ts from 'typescript/lib/tsserverlibrary';
 import {isTypeScriptFile} from './utils';
 
 export class LanguageServiceAdapter implements NgCompilerAdapter {
+  readonly neverEmit = true;
   readonly entryPoint = null;
   readonly constructionDiagnostics: ts.Diagnostic[] = [];
   readonly ignoreForEmit: Set<ts.SourceFile> = new Set();


### PR DESCRIPTION
See individual commits for details, and https://docs.google.com/document/d/1l1UUMC4vzrIqY1-S_jJ-LT-iJJWEVZcDhcUP8yJlubg/edit?usp=sharing.

Part one of streamlining incremental builds + diagnostics for the language service, and sunsetting `overrideTemplate` on the template typechecker.