### PR TITLE
fix(forms): more precise handling of `onCollectionChange` callbacks

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -67,6 +67,12 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
   private _oldForm: FormGroup|undefined;
 
   /**
+   * Callback that should be invoked when controls in FormGroup or FormArray collection change
+   * (added or removed). This is needed to trigger corresponding DOM updates.
+   */
+  private _onCollectionChange = () => this._updateDomValue();
+
+  /**
    * @description
    * Tracks the list of added `FormControlName` instances
    */
@@ -282,9 +288,9 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
   }
 
   private _updateRegistrations() {
-    this.form._registerOnCollectionChange(() => this._updateDomValue());
+    this.form._registerOnCollectionChange(this._onCollectionChange);
     if (this._oldForm) {
-      this._oldForm._registerOnCollectionChange(() => {});
+      this._oldForm._unregisterOnCollectionChange(this._onCollectionChange);
     }
   }
 

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -64,7 +64,10 @@ export function cleanUpControl(control: FormControl|null, dir: NgControl) {
 
   if (control) {
     dir._invokeOnDestroyCallbacks();
-    control._registerOnCollectionChange(() => {});
+    // The logic below clears all `onCollectionChange` callbacks from a given form control, when
+    // technically we should only detach callbacks added by a given directive. Consider updating
+    // this logic in the future to do a more precise cleanup here.
+    control._clearOnCollectionChange();
   }
 }
 

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -79,6 +79,23 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
         expect(form.value).toEqual({'login': 'updatedValue'});
       });
+
+      it('should update DOM correctly for shared FormGroups', () => {
+        const fixture = initTest(MultipleFormGroups);
+        fixture.detectChanges();
+
+        const sharedGroup = fixture.componentInstance.group;
+        const newControl = new FormControl('UPDATED VALUE');
+
+        // Replace existing control with a new one.
+        sharedGroup.setControl('login', newControl);
+        fixture.detectChanges();
+
+        // Verify that both inputs were updated with a new value.
+        const getValueFor = (id: string) => fixture.nativeElement.querySelector(id).value;
+        expect(getValueFor('#first')).toBe('UPDATED VALUE');
+        expect(getValueFor('#second')).toBe('UPDATED VALUE');
+      });
     });
 
     describe('re-bound form groups', () => {
@@ -2909,6 +2926,22 @@ class FormControlCheckboxRequiredValidator {
 class UniqLoginWrapper {
   // TODO(issue/24571): remove '!'.
   form!: FormGroup;
+}
+
+@Component({
+  selector: 'multiple-form-groups',
+  template: `
+    <div [formGroup]="group">
+      <input type="text" formControlName="login" id="first">
+    </div>
+    <div [formGroup]="group">
+      <input type="text" formControlName="login" id="second">
+    </div>
+  `
+})
+class MultipleFormGroups {
+  visible = true;
+  group = new FormGroup({login: new FormControl('INITIAL VALUE')});
 }
 
 @Component({


### PR DESCRIPTION
Form controls have internal API that allows subscribing to changes in a data collection (for FormGroups and
FormArrays), when a new control is added to a collection or existing one is removed. This internal API is used
inside FormGroupDirective to trigger DOM updates. The problem with the current API is that there is no way to
append a callback or remove a particular one (for ex. a callback that belongs to a directive that is being
removed). Instead, new `onCollectionChange` callback always resets existing one.

This commit updates the logic of `onCollectionChange` callback handling to provide an ability to add and remove
particular callbacks without loosing previous callbacks. It resolves some of the problems in case a FormGroup
instance is shared between different instances of Forms directives as well as allowing for better cleanup
mechanisms to be implemented in followup PRs.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No