### PR TITLE
build: define the package building function for ng-dev release tooling

### DIFF
--- a/.ng-dev/release.ts
+++ b/.ng-dev/release.ts
@@ -2,41 +2,31 @@ import {join} from 'path';
 import {exec} from 'shelljs';
 import {ReleaseConfig} from '../dev-infra/release/config';
 
-
-const packages = [
-  'animations',
-  'bazel',
-  'common',
-  'compiler',
-  'compiler-cli',
-  'core',
-  'elements',
-  'forms',
-  'language-service',
-  'localize',
-  'platform-browser',
-  'platform-browser-dynamic',
-  'platform-server',
-  'router',
-  'service-worker',
-  'upgrade',
-];
-
 /** Configuration for the `ng-dev release` command. */
 export const release: ReleaseConfig = {
-  npmPackages: packages.map(pkg => `@angular/${pkg}`),
+  npmPackages: [
+    '@angular/animations',
+    '@angular/bazel',
+    '@angular/common',
+    '@angular/compiler',
+    '@angular/compiler-cli',
+    '@angular/core',
+    '@angular/elements',
+    '@angular/forms',
+    '@angular/language-service',
+    '@angular/localize',
+    '@angular/platform-browser',
+    '@angular/platform-browser-dynamic',
+    '@angular/platform-server',
+    '@angular/router',
+    '@angular/service-worker',
+    '@angular/upgrade',
+  ],
   buildPackages: async () => {
-    const packageTargets = packages.map(pkg => `//packages/${pkg}:npm_package`).join(' ');
-    const buildResult = exec(`yarn -s bazel build --stamp ${packageTargets}`);
-
-    if (buildResult.code !== 0) {
-      throw new Error(`Error occured while building packages:\n${buildResult.stderr}`);
-    }
-
-    return packages.map(pkg => ({
-                          name: `@angular/${pkg}`,
-                          outputPath: `dist/bin/packages/${pkg}/npm_package`,
-                        }))
+    // The buildTargetPackages function is loaded at runtime as the loading the script causes an
+    // invocation of bazel.
+    const {buildTargetPackages} = require(join(__dirname, '../scripts/build/package-builder'));
+    return buildTargetPackages('dist/release-output', false, 'Release');
   },
   // TODO: This can be removed once there is an org-wide tool for changelog generation.
   generateReleaseNotesForHead: async () => {

--- a/.ng-dev/release.ts
+++ b/.ng-dev/release.ts
@@ -2,30 +2,42 @@ import {join} from 'path';
 import {exec} from 'shelljs';
 import {ReleaseConfig} from '../dev-infra/release/config';
 
+
+const packages = [
+  'animations',
+  'bazel',
+  'common',
+  'compiler',
+  'compiler-cli',
+  'core',
+  'elements',
+  'forms',
+  'language-service',
+  'localize',
+  'platform-browser',
+  'platform-browser-dynamic',
+  'platform-server',
+  'router',
+  'service-worker',
+  'upgrade',
+];
+
 /** Configuration for the `ng-dev release` command. */
 export const release: ReleaseConfig = {
-  npmPackages: [
-    '@angular/animations',
-    '@angular/bazel',
-    '@angular/common',
-    '@angular/compiler',
-    '@angular/compiler-cli',
-    '@angular/core',
-    '@angular/elements',
-    '@angular/forms',
-    '@angular/language-service',
-    '@angular/localize',
-    '@angular/platform-browser',
-    '@angular/platform-browser-dynamic',
-    '@angular/platform-server',
-    '@angular/platform-webworker',
-    '@angular/platform-webworker-dynamic',
-    '@angular/router',
-    '@angular/service-worker',
-    '@angular/upgrade',
-  ],
-  // TODO: Implement release package building here.
-  buildPackages: async () => [],
+  npmPackages: packages.map(pkg => `@angular/${pkg}`),
+  buildPackages: async () => {
+    const packageTargets = packages.map(pkg => `//packages/${pkg}:npm_package`).join(' ');
+    const buildResult = exec(`yarn -s bazel build --stamp ${packageTargets}`);
+
+    if (buildResult.code !== 0) {
+      throw new Error(`Error occured while building packages:\n${buildResult.stderr}`);
+    }
+
+    return packages.map(pkg => ({
+                          name: `@angular/${pkg}`,
+                          outputPath: `dist/bin/packages/${pkg}/npm_package`,
+                        }))
+  },
   // TODO: This can be removed once there is an org-wide tool for changelog generation.
   generateReleaseNotesForHead: async () => {
     exec('yarn -s gulp changelog', {cwd: join(__dirname, '../')});

--- a/scripts/build/package-builder.js
+++ b/scripts/build/package-builder.js
@@ -62,6 +62,7 @@ module.exports = {
  * This path should either be absolute or relative to the project root.
  * @param {boolean} enableIvy True, if Ivy should be used.
  * @param {string} description Human-readable description of the build.
+ * @returns {Array<{name: string, outputPath: string}} An list of packages built.
  */
 function buildTargetPackages(destPath, enableIvy, description) {
   console.info('##################################');
@@ -70,6 +71,8 @@ function buildTargetPackages(destPath, enableIvy, description) {
   console.info(`  Mode: ${description}`);
   console.info('##################################');
 
+  /** The list of packages which were built. */
+  const builtPackages = [];
   // List of targets to build, e.g. core, common, compiler, etc. Note that we want to also remove
   // all carriage return (`\r`) characters form the query output, because otherwise the carriage
   // return is part of the bazel target name and bazel will complain.
@@ -97,10 +100,12 @@ function buildTargetPackages(destPath, enableIvy, description) {
       rm('-rf', destDir);
       cp('-R', srcDir, destDir);
       chmod('-R', 'u+w', destDir);
+      builtPackages.push({name: `@angular/${pkg}`, outputPath: destDir});
     }
   });
 
   console.info('');
+  return builtPackages;
 }
 
 /**

--- a/scripts/build/package-builder.js
+++ b/scripts/build/package-builder.js
@@ -62,7 +62,7 @@ module.exports = {
  * This path should either be absolute or relative to the project root.
  * @param {boolean} enableIvy True, if Ivy should be used.
  * @param {string} description Human-readable description of the build.
- * @returns {Array<{name: string, outputPath: string}} An list of packages built.
+ * @returns {Array<{name: string, outputPath: string}} A list of packages built.
  */
 function buildTargetPackages(destPath, enableIvy, description) {
   console.info('##################################');


### PR DESCRIPTION
The packages are built during the release process on demand via a function
defined locally in the ng-dev config.