### PR TITLE
refactor: remove references to removed IE shims

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,7 +24,6 @@ filegroup(
         "//packages/zone.js/bundles:zone-testing.umd.js",
         "//packages/zone.js/bundles:task-tracking.umd.js",
         "//:test-events.js",
-        "//:third_party/shims_for_IE.js",
         # Including systemjs because it defines `__eval`, which produces correct stack traces.
         "@npm//:node_modules/systemjs/dist/system.src.js",
         "@npm//:node_modules/reflect-metadata/Reflect.js",

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -46,7 +46,6 @@ module.exports = function(config) {
 
       // Including systemjs because it defines `__eval`, which produces correct stack traces.
       'test-events.js',
-      'third_party/shims_for_IE.js',
       'node_modules/systemjs/dist/system.src.js',
 
       // Serve polyfills necessary for testing the `elements` package.

--- a/packages/router/karma.conf.js
+++ b/packages/router/karma.conf.js
@@ -28,7 +28,6 @@ module.exports = function(config) {
       // Polyfills.
       'node_modules/core-js/client/core.js',
       'node_modules/reflect-metadata/Reflect.js',
-      'third_party/shims_for_IE.js',
 
       // System.js for module loading
       'node_modules/systemjs/dist/system-polyfills.js',


### PR DESCRIPTION
In commit 4ca1c736bb020de166b6a1fbfb9fe264602ccd5c, the `third_party/shims_for_IE.js` file was removed, as it was no longer
needed.

This commit removes some remaining references to that file.
