### PR TITLE
feat(language-service): watch extended configs for option changes

### DIFF
--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -169,7 +169,8 @@ export function readCommandLineAndConfiguration(
       rootNames: [],
       options: cmdConfig.options,
       errors: cmdErrors,
-      emitFlags: api.EmitFlags.Default
+      emitFlags: api.EmitFlags.Default,
+      allExtendedConfigs: [],
     };
   }
   const config = readConfiguration(project, cmdConfig.options);
@@ -182,7 +183,8 @@ export function readCommandLineAndConfiguration(
     rootNames: config.rootNames,
     options,
     errors: config.errors,
-    emitFlags: config.emitFlags
+    emitFlags: config.emitFlags,
+    allExtendedConfigs: [],
   };
 }
 

--- a/packages/compiler-cli/test/perform_watch_spec.ts
+++ b/packages/compiler-cli/test/perform_watch_spec.ts
@@ -32,7 +32,8 @@ describe('perform watch', () => {
       rootNames: [path.resolve(testSupport.basePath, 'src/index.ts')],
       project: path.resolve(testSupport.basePath, 'src/tsconfig.json'),
       emitFlags: ng.EmitFlags.Default,
-      errors: []
+      errors: [],
+      allExtendedConfigs: [],
     };
   }
 

--- a/packages/language-service/ivy/test/legacy/adapters_spec.ts
+++ b/packages/language-service/ivy/test/legacy/adapters_spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript/lib/tsserverlibrary';
+
+import {LanguageServiceAdapter} from '../../adapters';
+
+import {MockService, setup, TEST_TEMPLATE} from './mock_host';
+
+describe('Language service adapter', () => {
+  let project: ts.server.Project;
+  let service: MockService;
+
+  beforeAll(() => {
+    const {project: _project, service: _service} = setup();
+    project = _project;
+    service = _service;
+  });
+
+  it('should mark template dirty if it has not seen the template before', () => {
+    const adapter = new LanguageServiceAdapter(project);
+    expect(adapter.isTemplateDirty(TEST_TEMPLATE)).toBeTrue();
+  });
+
+  it('should not mark template dirty if template has not changed', () => {
+    const adapter = new LanguageServiceAdapter(project);
+    adapter.readResource(TEST_TEMPLATE);
+    expect(adapter.isTemplateDirty(TEST_TEMPLATE)).toBeFalse();
+  });
+
+  it('should mark template dirty if template has changed', () => {
+    const adapter = new LanguageServiceAdapter(project);
+    service.overwrite(TEST_TEMPLATE, '<p>Hello World</p>');
+    expect(adapter.isTemplateDirty(TEST_TEMPLATE)).toBeTrue();
+  });
+});

--- a/packages/language-service/ivy/test/legacy/mock_host.ts
+++ b/packages/language-service/ivy/test/legacy/mock_host.ts
@@ -82,6 +82,10 @@ export class MockConfigFileFs implements
     this.configFileWatchers.delete(configFile);
   }
 
+  isBeingWatched(configFile: string) {
+    return this.configFileWatchers.has(configFile);
+  }
+
   readFile(file: string, encoding?: string): string|undefined {
     const read = this.configOverwrites.get(file) ?? ts.sys.readFile(file, encoding);
     return read;

--- a/packages/language-service/ivy/test/legacy/mock_host.ts
+++ b/packages/language-service/ivy/test/legacy/mock_host.ts
@@ -79,7 +79,6 @@ export class MockConfigFileFs implements
   deleteConfigFile(configFile: string) {
     this.configOverwrites.delete(configFile);
     this.configFileWatchers.get(configFile)?.deleted();
-    this.configFileWatchers.delete(configFile);
   }
 
   isBeingWatched(configFile: string) {

--- a/packages/language-service/ivy/test/legacy/mock_host.ts
+++ b/packages/language-service/ivy/test/legacy/mock_host.ts
@@ -76,6 +76,12 @@ export class MockConfigFileFs implements
     this.configFileWatchers.get(configFile)?.changed();
   }
 
+  deleteConfigFile(configFile: string) {
+    this.configOverwrites.delete(configFile);
+    this.configFileWatchers.get(configFile)?.deleted();
+    this.configFileWatchers.delete(configFile);
+  }
+
   readFile(file: string, encoding?: string): string|undefined {
     const read = this.configOverwrites.get(file) ?? ts.sys.readFile(file, encoding);
     return read;


### PR DESCRIPTION
Currently the language service watches only the root config file of a
configured project for changes. Of course, for correctness, we should
watch for changes in any relevant config file.

This commit attaches file watchers to the project root config file, and
all known extended config files as determined by `readConfiguration`.
On a change to any config file, refresh the compiler options known by
the Angular LS, and attach file watchers for any newly-extended config
files.
