### PR TITLE
fix(core): remove duplicated noop function

### DIFF
--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -142,8 +142,6 @@ export function getQueryPredicate(
   }
 }
 
-export function noop() {}
-
 export class DefinitionMap {
   values: {key: string, quoted: boolean, value: o.Expression}[] = [];
 

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -8,6 +8,7 @@
 
 import {EventEmitter} from '../event_emitter';
 import {global} from '../util/global';
+import {noop} from '../util/noop';
 import {getNativeRequestAnimationFrame} from '../util/raf';
 
 
@@ -231,7 +232,6 @@ export class NgZone {
   }
 }
 
-function noop() {}
 const EMPTY_PAYLOAD = {};
 
 interface NgZonePrivate extends NgZone {

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -1398,9 +1398,6 @@
     "name": "noop"
   },
   {
-    "name": "noop"
-  },
-  {
     "name": "normalizeValidators"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1722,9 +1722,6 @@
     "name": "noop"
   },
   {
-    "name": "noop"
-  },
-  {
     "name": "normalizeQueryParams"
   },
   {

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -18,6 +18,7 @@ import {TConstants, TNodeType} from '@angular/core/src/render3/interfaces/node';
 import {RComment, RElement, RNode, RText} from '@angular/core/src/render3/interfaces/renderer_dom';
 import {enterView, getLView} from '@angular/core/src/render3/state';
 import {EMPTY_ARRAY} from '@angular/core/src/util/empty';
+import {noop} from '@angular/core/src/util/noop';
 import {stringifyElement} from '@angular/platform-browser/testing/src/browser_util';
 
 import {SWITCH_CHANGE_DETECTOR_REF_FACTORY__POST_R3__ as R3_CHANGE_DETECTOR_REF_FACTORY} from '../../src/change_detection/change_detector_ref';
@@ -85,7 +86,6 @@ export abstract class BaseFixture {
   }
 }
 
-function noop() {}
 /**
  * Fixture for testing template functions in a convenient way.
  *


### PR DESCRIPTION
PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The codebase currently contains several `noop` functions,
and they can end up in the bundle of an application.
A recent commit 6fbe21941d7ad1bab7441e1bf3c667ecffc7a359 tipped us off
as it introduced several `noop` occurrences in the golden symbol files.
After investigating with @petebacondarwin,
we decided to remove the duplicated functions.

## What is the new behavior?


This probably shaves only a few bytes,
but this commit removes the duplicated functions,
by always using the one in `core/src/utils/noop`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
