### PR TITLE
fix(router): migration incorrectly replacing deprecated key

### DIFF
--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -72,7 +72,7 @@
     },
     "migration-v11-router-preserve-query-params": {
       "version": "11.0.0-beta",
-      "description": "NavigationExtras.preserveQueryParams has been removed as of Angular version 11.  This migration replaces any usages with the appropriate assignment of the queryParamsHandler key.",
+      "description": "NavigationExtras.preserveQueryParams has been removed as of Angular version 11.  This migration replaces any usages with the appropriate assignment of the queryParamsHandling key.",
       "factory": "./migrations/router-preserve-query-params/index"
     },
     "migration-v11-router-initial-navigation-options": {

--- a/packages/core/schematics/migrations/router-preserve-query-params/README.md
+++ b/packages/core/schematics/migrations/router-preserve-query-params/README.md
@@ -2,7 +2,7 @@
 
 Previously the `NatigationExtras` property of `preserveQueryParams` defined what should be done with
 query parameters on navigation.  This migration updates the usages of `preserveQueryParams` to
-instead use the `queryParamsHandler` property.
+instead use the `queryParamsHandling` property.
 
 #### Before
 ```ts
@@ -29,7 +29,7 @@ export class MyComponent {
   constructor(private _router: Router) {}
 
   goHome() {
-    this._router.navigate('/', { queryParamsHandler: 'preserve', skipLocationChange: 'foo' });
+    this._router.navigate('/', { queryParamsHandling: 'preserve', skipLocationChange: 'foo' });
   }
 }
 ```

--- a/packages/core/schematics/migrations/router-preserve-query-params/util.ts
+++ b/packages/core/schematics/migrations/router-preserve-query-params/util.ts
@@ -56,7 +56,7 @@ export function migrateLiteral(
     return ts.updateObjectLiteral(
         node,
         propertiesToKeep.concat(
-            ts.createPropertyAssignment('queryParamsHandler', ts.createIdentifier(`'preserve'`))));
+            ts.createPropertyAssignment('queryParamsHandling', ts.createIdentifier(`'preserve'`))));
   }
 
   return ts.updateObjectLiteral(node, propertiesToKeep);

--- a/packages/core/schematics/test/preserve_query_params_migration_spec.ts
+++ b/packages/core/schematics/test/preserve_query_params_migration_spec.ts
@@ -71,7 +71,7 @@ describe('NavigationExtras preserveQueryParams migration', () => {
       await runMigration();
 
       const content = tree.readContent('/index.ts');
-      expect(content).toContain(`this._router.navigate('/', { queryParamsHandler: 'preserve' });`);
+      expect(content).toContain(`this._router.navigate('/', { queryParamsHandling: 'preserve' });`);
     });
 
     it('`createUrlTree` function', async () => {
@@ -114,7 +114,7 @@ describe('NavigationExtras preserveQueryParams migration', () => {
 
       const content = tree.readContent('/index.ts');
       expect(content).toContain(
-          `const config = { replaceUrl: true, fragment: 'foo', state: {}, queryParamsHandler: 'preserve' };`);
+          `const config = { replaceUrl: true, fragment: 'foo', state: {}, queryParamsHandling: 'preserve' };`);
     });
 
     it('should remove when the value is `false`', async () => {
@@ -178,7 +178,7 @@ describe('NavigationExtras preserveQueryParams migration', () => {
 
       const content = tree.readContent('/index.ts');
       expect(content).toContain(
-          `this._router.navigate('/', { replaceUrl: true, fragment: 'foo', state: {}, queryParamsHandler: 'preserve' });`);
+          `this._router.navigate('/', { replaceUrl: true, fragment: 'foo', state: {}, queryParamsHandling: 'preserve' });`);
     });
 
     it('should remove when the value is `false`', async () => {


### PR DESCRIPTION
In #38762 we added a migration to replace the deprecated `preserveQueryParams` option with `queryParamsHandling`, however due to a typo, we ended up replacing it with `queryParamsHandler` which is invalid.

Fixes #39755.
