### PR TITLE
fix(router): remove duplicated getOutlet function

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1380,9 +1380,6 @@
     "name": "getOutlet"
   },
   {
-    "name": "getOutlet"
-  },
-  {
     "name": "getOwnDefinition"
   },
   {

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -14,6 +14,7 @@ import {ActivatedRouteSnapshot, inheritedParamsDataResolve, ParamsInheritanceStr
 import {defaultUrlMatcher, PRIMARY_OUTLET} from './shared';
 import {mapChildrenIntoArray, UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
 import {forEach, last} from './utils/collection';
+import {getOutlet} from './utils/config';
 import {TreeNode} from './utils/tree';
 
 class NoMatch {}
@@ -326,10 +327,6 @@ function emptyPathMatch(
   }
 
   return r.path === '' && r.redirectTo === undefined;
-}
-
-function getOutlet(route: Route): string {
-  return route.outlet || PRIMARY_OUTLET;
 }
 
 function getData(route: Route): Data {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The codebase currently contains two `getOutlet` functions,
and they can end up in the bundle of an application.
A recent commit 6fbe21941d7ad1bab7441e1bf3c667ecffc7a359 tipped us off
as it introduced several `noop` occurrences in the golden symbol files.
After investigating with @petebacondarwin,
we decided to remove the duplicated functions.

## What is the new behavior?

This probably shaves only a few bytes,
but this commit removes the duplicated functions,
by always using the one in `router/src/utils/config`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
