### PR TITLE
ci: decrease payload size limit for AIO tests

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3033,
-        "main-es2015": 448538,
+        "main-es2015": 447906,
         "polyfills-es2015": 52493
       }
     }


### PR DESCRIPTION
This commit updates the payload size limit for the AIO tests. This is likely an effect of the changes from
PR #39600 that was merged earlier.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No