### PR TITLE
Change async pipe's default value from null to undefined

### DIFF
--- a/aio/src/app/custom-elements/search/file-not-found-search.component.spec.ts
+++ b/aio/src/app/custom-elements/search/file-not-found-search.component.spec.ts
@@ -37,7 +37,7 @@ describe('FileNotFoundSearchComponent', () => {
 
   it('should pass through any results to the `aio-search-results` component', () => {
     const searchResultsComponent = fixture.debugElement.query(By.directive(SearchResultsComponent)).componentInstance;
-    expect(searchResultsComponent.searchResults).toBe(null);
+    expect(searchResultsComponent.searchResults).toBeFalsy();
 
     const results = { query: 'base initial url', results: []};
     searchResultSubject.next(results);

--- a/aio/src/app/shared/search-results/search-results.component.ts
+++ b/aio/src/app/shared/search-results/search-results.component.ts
@@ -20,7 +20,7 @@ export class SearchResultsComponent implements OnChanges {
    * The results to display
    */
   @Input()
-  searchResults: SearchResults | null = null;
+  searchResults: SearchResults | null | undefined = null;
 
   /**
    * Emitted when the user selects a search result
@@ -34,7 +34,7 @@ export class SearchResultsComponent implements OnChanges {
   searchAreas: SearchArea[] = [];
 
   ngOnChanges() {
-    if (this.searchResults === null) {
+    if (this.searchResults === undefined || this.searchResults === null) {
       this.searchState = SearchState.InProgress;
     } else if (this.searchResults.results.length) {
       this.searchState = SearchState.ResultsFound;
@@ -52,7 +52,7 @@ export class SearchResultsComponent implements OnChanges {
   }
 
   // Map the search results into groups by area
-  private processSearchResults(search: SearchResults | null) {
+  private processSearchResults(search: SearchResults | null | undefined) {
     if (!search) {
       return [];
     }

--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -3,9 +3,9 @@ export declare const APP_BASE_HREF: InjectionToken<string>;
 export declare class AsyncPipe implements OnDestroy, PipeTransform {
     constructor(_ref: ChangeDetectorRef);
     ngOnDestroy(): void;
-    transform<T>(obj: Subscribable<T> | Promise<T>): T | null;
+    transform<T>(obj: Subscribable<T> | Promise<T>): T | undefined;
     transform<T>(obj: null | undefined): null;
-    transform<T>(obj: Subscribable<T> | Promise<T> | null | undefined): T | null;
+    transform<T>(obj: Subscribable<T> | Promise<T> | null | undefined): T | null | undefined;
 }
 
 export declare class CommonModule {

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -44,8 +44,8 @@ import {SpyChangeDetectorRef} from '../spies';
       });
 
       describe('transform', () => {
-        it('should return null when subscribing to an observable', () => {
-          expect(pipe.transform(subscribable)).toBe(null);
+        it('should return undefined when subscribing to an observable', () => {
+          expect(pipe.transform(subscribable)).toBe(undefined);
         });
 
         it('should return the latest available value',
@@ -78,12 +78,12 @@ import {SpyChangeDetectorRef} from '../spies';
 
              const newEmitter = new EventEmitter();
              const newSubscribable = wrapSubscribable(newEmitter);
-             expect(pipe.transform(newSubscribable)).toBe(null);
+             expect(pipe.transform(newSubscribable)).toBe(undefined);
              emitter.emit(message);
 
              // this should not affect the pipe
              setTimeout(() => {
-               expect(pipe.transform(newSubscribable)).toBe(null);
+               expect(pipe.transform(newSubscribable)).toBe(undefined);
                async.done();
              }, 0);
            }));
@@ -122,7 +122,7 @@ import {SpyChangeDetectorRef} from '../spies';
              emitter.emit(message);
 
              setTimeout(() => {
-               expect(pipe.transform(subscribable)).toBe(null);
+               expect(pipe.transform(subscribable)).toBe(undefined);
                async.done();
              }, 0);
            }));
@@ -149,8 +149,8 @@ import {SpyChangeDetectorRef} from '../spies';
       });
 
       describe('transform', () => {
-        it('should return null when subscribing to a promise', () => {
-          expect(pipe.transform(promise)).toBe(null);
+        it('should return undefined when subscribing to a promise', () => {
+          expect(pipe.transform(promise)).toBe(undefined);
         });
 
         it('should return the latest available value',
@@ -182,12 +182,12 @@ import {SpyChangeDetectorRef} from '../spies';
              pipe.transform(promise);
 
              promise = new Promise<any>(() => {});
-             expect(pipe.transform(promise)).toBe(null);
+             expect(pipe.transform(promise)).toBe(undefined);
 
              resolve(message);
 
              setTimeout(() => {
-               expect(pipe.transform(promise)).toBe(null);
+               expect(pipe.transform(promise)).toBe(undefined);
                async.done();
              }, timer);
            }));
@@ -212,14 +212,14 @@ import {SpyChangeDetectorRef} from '../spies';
           it('should dispose of the existing source',
              inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
                pipe.transform(promise);
-               expect(pipe.transform(promise)).toBe(null);
+               expect(pipe.transform(promise)).toBe(undefined);
                resolve(message);
 
 
                setTimeout(() => {
                  expect(pipe.transform(promise)).toEqual(message);
                  pipe.ngOnDestroy();
-                 expect(pipe.transform(promise)).toBe(null);
+                 expect(pipe.transform(promise)).toBe(undefined);
                  async.done();
                }, timer);
              }));

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -114,7 +114,7 @@ function declareTests(config?: {useJit: boolean}) {
            const dir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir) as MyDir;
 
            fixture.detectChanges();
-           expect(dir.setterCalls).toEqual({'a': null, 'b': 2});
+           expect(dir.setterCalls).toEqual({'a': undefined, 'b': 2});
            expect(Object.keys(dir.changes)).toEqual(['a', 'b']);
 
            dir.setterCalls = {};

--- a/packages/examples/common/ngIf/ts/e2e_test/ngIf_spec.ts
+++ b/packages/examples/common/ngIf/ts/e2e_test/ngIf_spec.ts
@@ -67,7 +67,7 @@ describe('ngIf', () => {
       browser.get(URL);
       waitForElement(comp);
       expect(element.all(by.css(comp)).get(0).getText())
-          .toEqual('Next User\nWaiting... (user is null)');
+          .toEqual('Next User\nWaiting... (user is )');
       element(by.css(comp + ' button')).click();
       expect(element.all(by.css(comp)).get(0).getText()).toEqual('Next User\nHello Smith, John!');
     });


### PR DESCRIPTION
Changes async pipe's default value from `null` to `undefined`. It is an incorrect approach to return `null` when the actual value is unknown. The convention is to use `undefined` for a variable that has not yet been assigned a value, whereas `null` is an assignment value and represents no value (more details for example on [Stack Overflow](https://stackoverflow.com/questions/5076944/what-is-the-difference-between-null-and-undefined-in-javascript)).


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Angular's async pipe subscribes to Observables and Promises and returns the latest value. But when there is no value yet, it returns `null`. This can lead to some unexpected issues, for example imagine a component with an input like this:
```
@Input() number?: number
```
The component can then be used in a template without any problems like this (where myNumber is type of `number`):
```
<number-component [number]="myNumber"></number-component>
```
But when myNumber would be of type `Observable<number>` and we'd like to use it with the async pipe, it would lead to `null` being passed to the number component instead of `undefined`:
```
<number-component [number]="myNumber | async"></number-component>
```

A typical use case for this is firing an async HTTP request, displaying some loading element for value of `undefined`, a value for the actual value, and anything else ("no data", error, ...) for `null`. The current async pipe breaks this pattern and can cause a headache finding what went wrong as this is not the expected behavior.

Issue Number: #16982

## What is the new behavior?
The async pipe now returns `undefined` by default before an actual value is emitted. It still returns `null` for inputs of type `null` and `undefined` to keep it consistent with other pipes (PR #37447).

This PR follows @mhevery's [comment](https://github.com/angular/angular/issues/16982#issuecomment-688987110) to see how breaking it is. As discussed in the issue #16982, it is not fully clear whether this should be a fix or a feature.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The async pipe now returns `undefined` as the default value. Requires a fix  if you performed a check for the `null` value before, but this check was likely needed solely because of this unconventional behavior.

## Other information

I've also updated the doc comment that this pipe returns `undefined` before the first emit, as I was lacking this information about `null` there before.