### PR TITLE
fix(service-worker): correctly handle failed cache-busted request

### DIFF
--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -390,9 +390,9 @@ export abstract class AssetGroup {
       // Fetch the resource from the network (possibly hitting the HTTP cache).
       let response = await this.safeFetch(req);
 
-      // Decide whether a cache-busted request is necessary. A cache-busted request is necessary iff
-      // the request was successful but the hash of the retrieved contents does not match the
-      // canonical hash from the manifest.
+      // Decide whether a cache-busted request is necessary. A cache-busted request is necessary
+      // only if the request was successful but the hash of the retrieved contents does not match
+      // the canonical hash from the manifest.
       let makeCacheBustedRequest = response.ok;
       if (makeCacheBustedRequest) {
         // The request was successful. A cache-busted request is only necessary if the hashes

--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -388,18 +388,17 @@ export abstract class AssetGroup {
       // a stale response.
 
       // Fetch the resource from the network (possibly hitting the HTTP cache).
-      const networkResult = await this.safeFetch(req);
+      let response = await this.safeFetch(req);
 
-      // Decide whether a cache-busted request is necessary. It might be for two independent
-      // reasons: either the non-cache-busted request failed (hopefully transiently) or if the
-      // hash of the content retrieved does not match the canonical hash from the manifest. It's
-      // only valid to access the content of the first response if the request was successful.
-      let makeCacheBustedRequest: boolean = !networkResult.ok;
-      if (networkResult.ok) {
+      // Decide whether a cache-busted request is necessary. A cache-busted request is necessary iff
+      // the request was successful but the hash of the retrieved contents does not match the
+      // canonical hash from the manifest.
+      let makeCacheBustedRequest = response.ok;
+      if (makeCacheBustedRequest) {
         // The request was successful. A cache-busted request is only necessary if the hashes
-        // don't match. Compare them, making sure to clone the response so it can be used later
-        // if it proves to be valid.
-        const fetchedHash = sha1Binary(await networkResult.clone().arrayBuffer());
+        // don't match.
+        // (Make sure to clone the response so it can be used later if it proves to be valid.)
+        const fetchedHash = sha1Binary(await response.clone().arrayBuffer());
         makeCacheBustedRequest = (fetchedHash !== canonicalHash);
       }
 
@@ -411,39 +410,34 @@ export abstract class AssetGroup {
         // request will differentiate these two situations.
         // TODO: handle case where the URL has parameters already (unlikely for assets).
         const cacheBustReq = this.adapter.newRequest(this.cacheBust(req.url));
-        const cacheBustedResult = await this.safeFetch(cacheBustReq);
+        response = await this.safeFetch(cacheBustReq);
 
-        // If the response was unsuccessful, there's nothing more that can be done.
-        if (!cacheBustedResult.ok) {
-          if (cacheBustedResult.status === 404) {
-            throw new SwUnrecoverableStateError(
-                `Failed to retrieve hashed resource from the server. (AssetGroup: ${
-                    this.config.name} | URL: ${url})`);
-          } else {
-            throw new SwCriticalError(
-                `Response not Ok (cacheBustedFetchFromNetwork): cache busted request for ${
-                    req.url} returned response ${cacheBustedResult.status} ${
-                    cacheBustedResult.statusText}`);
+        // If the response was successful, check the contents against the canonical hash.
+        if (response.ok) {
+          // Hash the contents.
+          // (Make sure to clone the response so it can be used later if it proves to be valid.)
+          const cacheBustedHash = sha1Binary(await response.clone().arrayBuffer());
+
+          // If the cache-busted version doesn't match, then the manifest is not an accurate
+          // representation of the server's current set of files, and the SW should give up.
+          if (canonicalHash !== cacheBustedHash) {
+            throw new SwCriticalError(`Hash mismatch (cacheBustedFetchFromNetwork): ${
+                req.url}: expected ${canonicalHash}, got ${cacheBustedHash} (after cache busting)`);
           }
         }
-
-        // Hash the contents.
-        const cacheBustedHash = sha1Binary(await cacheBustedResult.clone().arrayBuffer());
-
-        // If the cache-busted version doesn't match, then the manifest is not an accurate
-        // representation of the server's current set of files, and the SW should give up.
-        if (canonicalHash !== cacheBustedHash) {
-          throw new SwCriticalError(`Hash mismatch (cacheBustedFetchFromNetwork): ${
-              req.url}: expected ${canonicalHash}, got ${cacheBustedHash} (after cache busting)`);
-        }
-
-        // If it does match, then use the cache-busted result.
-        return cacheBustedResult;
       }
 
-      // Excellent, the version from the network matched on the first try, with no need for
-      // cache-busting. Use it.
-      return networkResult;
+      // At this point, `response` is either successful with a matching hash or is unsuccessful.
+      // Before returning it, check whether it failed with a 404 status. This would signify an
+      // unrecoverable state.
+      if (!response.ok && (response.status === 404)) {
+        throw new SwUnrecoverableStateError(
+            `Failed to retrieve hashed resource from the server. (AssetGroup: ${
+                this.config.name} | URL: ${url})`);
+      }
+
+      // Return the response (successful or unsuccessful).
+      return response;
     } else {
       // This URL doesn't exist in our hash database, so it must be requested directly.
       return this.safeFetch(req);


### PR DESCRIPTION
Since 5be4edfa17120ab1b9c9e8d87b7b539cdd180a25, a failing cache-busted network request (such as requests for fetching an uncached asset) will cause the ServiceWorker to incorrectly enter a degraded `EXISTING_CLIENTS_ONLY` mode. A failing network request could be caused by many reasons, including the client or server being offline, and does not necessarily signify a broken ServiceWorker state.

This commit fixes the logic in `cacheBustedFetchFromNetwork()` to correctly handle errors in network requests.
For more details on the problem and the implemented fix see #39775.

Fixes #39775.
