### PR TITLE
fix(dev-infra): verify the version of generated build artifacts

### DIFF
--- a/dev-infra/release/publish/actions.ts
+++ b/dev-infra/release/publish/actions.ts
@@ -503,6 +503,9 @@ export abstract class ReleaseAction {
     await invokeYarnInstallCommand(this.projectDir);
     const builtPackages = await invokeReleaseBuildCommand();
 
+    // Verify the packages built are the correct version.
+    await this._verifyPackageVersions(newVersion, builtPackages);
+
     // Create a Github release for the new version.
     await this._createGithubReleaseForVersion(newVersion, versionBumpCommitSha);
 
@@ -536,5 +539,19 @@ export abstract class ReleaseAction {
     const {data} =
         await this.git.github.repos.getCommit({...this.git.remoteParams, ref: commitSha});
     return data.commit.message.startsWith(getCommitMessageForRelease(version));
+  }
+
+  /** Verify the version of each generated package exact matches the specified version. */
+  private async _verifyPackageVersions(version: semver.SemVer, packages: BuiltPackage[]) {
+    for (const pkg of packages) {
+      const {version: packageJsonVersion} =
+          JSON.parse(await fs.readFile(join(pkg.outputPath, 'package.json'), 'utf8'));
+      if (version.compare(packageJsonVersion) !== 0) {
+        error(red('The built package version does not match the version being released.'));
+        error(`  Release Version:   ${version.version}`);
+        error(`  Generated Version: ${version.version}`);
+        throw new FatalReleaseActionError();
+      }
+    }
   }
 }

--- a/dev-infra/release/publish/actions.ts
+++ b/dev-infra/release/publish/actions.ts
@@ -549,7 +549,7 @@ export abstract class ReleaseAction {
       if (version.compare(packageJsonVersion) !== 0) {
         error(red('The built package version does not match the version being released.'));
         error(`  Release Version:   ${version.version}`);
-        error(`  Generated Version: ${version.version}`);
+        error(`  Generated Version: ${packageJsonVersion}`);
         throw new FatalReleaseActionError();
       }
     }

--- a/dev-infra/release/publish/test/test-utils.ts
+++ b/dev-infra/release/publish/test/test-utils.ts
@@ -89,13 +89,17 @@ export function setupReleaseActionForTesting<T extends ReleaseAction>(
   spyOn(console, 'promptConfirm').and.resolveTo(true);
 
   // Fake all external commands for the release tool.
-  spyOn(npm, 'runNpmPublish').and.resolveTo(true);
+  spyOn(npm, 'runNpmPublish').and.resolveTo();
   spyOn(externalCommands, 'invokeSetNpmDistCommand').and.resolveTo();
   spyOn(externalCommands, 'invokeYarnInstallCommand').and.resolveTo();
   spyOn(externalCommands, 'invokeReleaseBuildCommand').and.resolveTo([
     {name: '@angular/pkg1', outputPath: `${testTmpDir}/dist/pkg1`},
     {name: '@angular/pkg2', outputPath: `${testTmpDir}/dist/pkg2`}
   ]);
+
+  // Fake checking the package versions since we don't actually create packages to check against in
+  // the publish tests.
+  spyOn(ReleaseAction.prototype, '_verifyPackageVersions' as any).and.resolveTo();
 
   // Create an empty changelog and a `package.json` file so that file system
   // interactions with the project directory do not cause exceptions.


### PR DESCRIPTION
Verify the version of the generated build artifacts to ensure that
the version published to NPM is the version we expect.
