### PR TITLE
docs(core): change URL to shadow dom spec

### DIFF
--- a/packages/core/src/metadata/view.ts
+++ b/packages/core/src/metadata/view.ts
@@ -40,7 +40,7 @@ export enum ViewEncapsulation {
    * Use Shadow DOM to encapsulate styles.
    *
    * For the DOM this means using modern [Shadow
-   * DOM](https://w3c.github.io/webcomponents/spec/shadow/) and
+   * DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM) and
    * creating a ShadowRoot for Component's Host Element.
    */
   ShadowDom = 3


### PR DESCRIPTION
The old URL (https://w3c.github.io/webcomponents/spec/shadow/) is no longer available, so I searched for the best fitting alternative to provide proper W3 documentation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Fixes #39822.