### PR TITLE
test(forms): add disabled only boxed value

### DIFF
--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -45,6 +45,13 @@ describe('FormControl', () => {
       expect(c.status).toBe('DISABLED');
     });
 
+    it('should not treat objects as boxed values when `disabled` field is present, but `value` is missing',
+       () => {
+         const c = new FormControl({disabled: true});
+         expect(c.value).toEqual({disabled: true});
+         expect(c.disabled).toBe(false);
+       });
+
     it('should honor boxed value with disabled control when validating', () => {
       const c = new FormControl({value: '', disabled: true}, Validators.required);
       expect(c.disabled).toBe(true);


### PR DESCRIPTION
The state of the `formControl` changes depending on the existing of two properties `value` and `disabled`. I think it is necessary to add a test in which the `formState` object will have only one property: `disabled`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe: unit test


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
No new behavior


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
