### PR TITLE
build: update peerDependencies of zone.js to 0.10~0.11

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
   },
   "peerDependencies": {
     "rxjs": "^6.5.3",
-    "zone.js": "~0.11.3"
+    "zone.js": "^0.10.2 || ^0.11.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`@angular/core` support zone.js `^0.10.2 and ^0.11.3`, so this PR updates the
peerDependencies to `^0.10.2 || ^ 0.11.3`, and the app will not show warning about
peer denepdency not consistent when using zone.js 0.10.x version.
