### PR TITLE
refactor(language-service): create getReferencesAtPosition stubs

### DIFF
--- a/packages/language-service/ivy/ts_plugin.ts
+++ b/packages/language-service/ivy/ts_plugin.ts
@@ -56,11 +56,17 @@ export function create(info: ts.server.PluginCreateInfo): ts.LanguageService {
     }
   }
 
+  function getReferencesAtPosition(fileName: string, position: number) {
+    // TODO(atscott): implement references
+    return undefined;
+  }
+
   return {
     ...tsLS,
     getSemanticDiagnostics,
     getTypeDefinitionAtPosition,
     getQuickInfoAtPosition,
     getDefinitionAndBoundSpan,
+    getReferencesAtPosition,
   };
 }

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -115,6 +115,11 @@ export function create(info: tss.server.PluginCreateInfo): tss.LanguageService {
     return undefined;
   }
 
+  function getReferencesAtPosition(fileName: string, position: number) {
+    // Not implemented in VE Language Service
+    return undefined;
+  }
+
   return {
     // First clone the original TS language service
     ...tsLS,
@@ -125,5 +130,6 @@ export function create(info: tss.server.PluginCreateInfo): tss.LanguageService {
     getDefinitionAtPosition,
     getDefinitionAndBoundSpan,
     getTypeDefinitionAtPosition,
+    getReferencesAtPosition,
   };
 }


### PR DESCRIPTION
Create stubs for getTypeDefinitionAtPosition for both VE and Ivy Language Service
implementations. This will prevent failed requests when it is implemented on the vscode plugin side.
