### PR TITLE
fix(core): Ensure OnPush ancestors are marked dirty when events occur

### DIFF
--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -193,6 +193,10 @@ function listenerInternal(
       lCleanup.push(listenerFn);
       tCleanup && tCleanup.push(eventName, idxOrTargetGetter, lCleanupIndex, useCapture);
     }
+  } else {
+    // Even if there is no native listener to add, we still need to wrap the listener so that OnPush
+    // ancestors are marked dirty when an event occurs.
+    listenerFn = wrapListener(tNode, lView, listenerFn, false /** preventDefault */);
   }
 
   // subscribe to directive outputs


### PR DESCRIPTION
We currently only wrap the event listener in the function which ensures
ancestors are marked for check when the listener is placed on an element
that has a native method for listening to an event. We actually need to do
this wrapping in all cases so that events that are attached to non-rendered
template items (`ng-template` and `ng-container`) also mark ancestors for check
when they receive the event.

fixes #39832
