### PR TITLE
build: use "outFiles" in .vscode/launch.json to speed up debugging sessions

### DIFF
--- a/.vscode/recommended-launch.json
+++ b/.vscode/recommended-launch.json
@@ -16,6 +16,7 @@
       "remoteRoot": "${workspaceRoot}",
       "stopOnEntry": false,
       "timeout": 600000,
+      "outFiles": ["${workspaceFolder}/bazel-out/**/angular/**/*.js"],
     },
     {
       "name": "Attach to bazel test ... --config=debug (no source maps)",
@@ -29,6 +30,7 @@
       "remoteRoot": "${workspaceRoot}",
       "stopOnEntry": false,
       "timeout": 600000,
+      "outFiles": ["${workspaceFolder}/bazel-out/**/angular/**/*.js"],
     },
     {
       "name": "IVY:packages/core/test/acceptance",
@@ -46,6 +48,7 @@
       "restart": true,
       "sourceMaps": true,
       "timeout": 600000,
+      "outFiles": ["${workspaceFolder}/bazel-out/**/angular/**/*.js"],
     },
     {
       "name": "IVY:packages/core/test/render3",
@@ -63,6 +66,7 @@
       "restart": true,
       "sourceMaps": true,
       "timeout": 600000,
+      "outFiles": ["${workspaceFolder}/bazel-out/**/angular/**/*.js"],
     },
     {
       "name": "IVY:packages/core/test",
@@ -80,6 +84,7 @@
       "restart": true,
       "sourceMaps": true,
       "timeout": 600000,
+      "outFiles": ["${workspaceFolder}/bazel-out/**/angular/**/*.js"],
     },
   ]
 }


### PR DESCRIPTION
This commit adds the "outFiles" config options into the `.vscode/recommended-launch.json`, which helps speed up
the startup time of a debugging session by limiting the number of files that should be loaded.

## PR Type
What kind of change does this PR introduce?

- [x] Build related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No