### PR TITLE
fix(docs-infra): fix redirecting `rc.angular.io` to `angular.io` when no active RC

### DIFF
--- a/aio/scripts/deploy-to-firebase.js
+++ b/aio/scripts/deploy-to-firebase.js
@@ -18,6 +18,7 @@ module.exports = {
   computeDeploymentsInfo,
   computeInputVars,
   getLatestCommit,
+  getMostRecentMinorBranch,
 };
 
 // Run
@@ -131,47 +132,58 @@ function computeDeploymentsInfo(
     },
   };
 
+  // If the current branch is `master`, deploy as `next`.
   if (currentBranch === 'master') {
     return [deploymentInfoPerTarget.next];
-  } else if (currentBranch === stableBranch) {
-    return [deploymentInfoPerTarget.stable];
-  } else {
-    const stableBranchMajorVersion = computeMajorVersion(stableBranch);
-
-    // Find the branch that has highest minor version for the given `currentBranchMajorVersion`.
-    const mostRecentMinorVersionBranch =
-      // List the branches that start with the major version.
-      getRemoteRefs(`refs/heads/${currentBranchMajorVersion}.*.x`)
-          // Extract the version number.
-          .map(line => line.split('/')[2])
-          // Sort by the minor version.
-          .sort((a, b) => a.split('.')[1] - b.split('.')[1])
-          // Get the highest version.
-          .pop();
-
-    // Do not deploy if it is not the latest branch for the given major version.
-    // NOTE: At this point, we know the current branch is not the stable branch.
-    if (currentBranch !== mostRecentMinorVersionBranch) {
-      return [
-        skipDeployment(
-            `Skipping deploy of branch "${currentBranch}" to Firebase.\n` +
-            'There is a more recent branch with the same major version: ' +
-            `"${mostRecentMinorVersionBranch}"`),
-      ];
-    }
-
-    return (currentBranchMajorVersion < stableBranchMajorVersion) ?
-        // This is the latest minor version for a major that is less than the stable major version:
-        // Deploy as `archive`.
-        [deploymentInfoPerTarget.archive] :
-        // This is the latest minor version for a major that is equal or greater than the stable
-        // major version, but not the stable version itself:
-        // Deploy as `rc`.
-        [deploymentInfoPerTarget.rc];
   }
 
-  // We should never get here.
-  throw new Error('Failed to determine deployment info.');
+  // Determine if there is an active RC version by checking whether the most recent minor branch is
+  // the stable branch or not.
+  const mostRecentMinorBranch = getMostRecentMinorBranch();
+  const rcBranch = (mostRecentMinorBranch !== stableBranch) ? mostRecentMinorBranch : null;
+
+  // If the current branch is the RC branch, deploy as `rc`.
+  if (currentBranch === rcBranch) {
+    return [deploymentInfoPerTarget.rc];
+  }
+
+  // If the current branch is the stable branch, deploy as `stable`.
+  if (currentBranch === stableBranch) {
+    return [deploymentInfoPerTarget.stable];
+  }
+
+  // If we get here, it means that the current branch is neither `master`, nor the RC or stable
+  // branches. At this point, we may only deploy as `archive` and only if the following criteria are
+  // met:
+  //   1. The current branch must have a major version that is lower than the stable major version.
+  //   2. The current branch must have the highest minor version among all branches with the same
+  //      major version.
+
+  // Do not deploy if it does not have a lower major version than stable.
+  const stableBranchMajorVersion = computeMajorVersion(stableBranch);
+  if (currentBranchMajorVersion >= stableBranchMajorVersion) {
+    return [
+      skipDeployment(
+          `Skipping deploy of branch "${currentBranch}" to Firebase.\n` +
+          'This branch has an equal or higher major version than the stable branch ' +
+          `("${stableBranch}").`),
+    ];
+  }
+
+  // Do not deploy if it is not the latest branch for the given major version.
+  const mostRecentMinorBranchForMajor = getMostRecentMinorBranch(currentBranchMajorVersion);
+  if (currentBranch !== mostRecentMinorBranchForMajor) {
+    return [
+      skipDeployment(
+          `Skipping deploy of branch "${currentBranch}" to Firebase.\n` +
+          'There is a more recent branch with the same major version: ' +
+          `"${mostRecentMinorBranchForMajor}"`),
+    ];
+  }
+
+  // This is the latest minor version for a major that is less than the stable major version:
+  // Deploy as `archive`.
+  return [deploymentInfoPerTarget.archive];
 }
 
 function computeInputVars({
@@ -228,6 +240,23 @@ function deploy(data) {
 
 function getRemoteRefs(refOrPattern, remote = NG_REMOTE_URL) {
   return exec(`git ls-remote ${remote} ${refOrPattern}`, {silent: true}).trim().split('\n');
+}
+
+function getMostRecentMinorBranch(major = '*') {
+  // List the branches that start with the given major version (or any major if none given).
+  return getRemoteRefs(`refs/heads/${major}.*.x`)
+      // Extract the branch name.
+      .map(line => line.split('/')[2])
+      // Filter out branches that are not of the format `<number>.<number>.x`.
+      .filter(name => /^\d+\.\d+\.x$/.test(name))
+      // Sort by version.
+      .sort((a, b) => {
+        const [majorA, minorA] = a.split('.');
+        const [majorB, minorB] = b.split('.');
+        return (majorA - majorB) || (minorA - minorB);
+      })
+      // Get the branch corresponding to the highest version.
+      .pop();
 }
 
 function getLatestCommit(branchName, remote = undefined) {

--- a/aio/scripts/deploy-to-firebase.js
+++ b/aio/scripts/deploy-to-firebase.js
@@ -297,7 +297,7 @@ function redirectToAngularIo() {
 function removeServiceWorker() {
   // Rename the SW manifest (`ngsw.json`). This will cause the ServiceWorker to unregister itself.
   // See https://angular.io/guide/service-worker-devops#fail-safe.
-  mv('dist/ngsw.json', 'dist/ngsw.json.bck');
+  mv('dist/ngsw.json', 'dist/ngsw.json.bak');
 }
 
 function serializeActions(actions) {

--- a/aio/scripts/deploy-to-firebase.js
+++ b/aio/scripts/deploy-to-firebase.js
@@ -155,22 +155,11 @@ function computeDeploymentsInfo(
   // If we get here, it means that the current branch is neither `master`, nor the RC or stable
   // branches. At this point, we may only deploy as `archive` and only if the following criteria are
   // met:
-  //   1. The current branch must have a major version that is lower than the stable major version.
-  //   2. The current branch must have the highest minor version among all branches with the same
+  //   1. The current branch must have the highest minor version among all branches with the same
   //      major version.
+  //   2. The current branch must have a major version that is lower than the stable major version.
 
-  // Do not deploy if it does not have a lower major version than stable.
-  const stableBranchMajorVersion = computeMajorVersion(stableBranch);
-  if (currentBranchMajorVersion >= stableBranchMajorVersion) {
-    return [
-      skipDeployment(
-          `Skipping deploy of branch "${currentBranch}" to Firebase.\n` +
-          'This branch has an equal or higher major version than the stable branch ' +
-          `("${stableBranch}").`),
-    ];
-  }
-
-  // Do not deploy if it is not the latest branch for the given major version.
+  // Do not deploy if it is not the branch with the highest minor for the given major version.
   const mostRecentMinorBranchForMajor = getMostRecentMinorBranch(currentBranchMajorVersion);
   if (currentBranch !== mostRecentMinorBranchForMajor) {
     return [
@@ -181,7 +170,18 @@ function computeDeploymentsInfo(
     ];
   }
 
-  // This is the latest minor version for a major that is less than the stable major version:
+  // Do not deploy if it does not have a lower major version than stable.
+  const stableBranchMajorVersion = computeMajorVersion(stableBranch);
+  if (currentBranchMajorVersion >= stableBranchMajorVersion) {
+    return [
+      skipDeployment(
+          `Skipping deploy of branch "${currentBranch}" to Firebase.\n` +
+          'This branch has an equal or higher major version than the stable branch ' +
+          `("${stableBranch}") and is not the most recent minor branch.`),
+    ];
+  }
+
+  // This is the highest minor version for a major that is lower than the stable major version:
   // Deploy as `archive`.
   return [deploymentInfoPerTarget.archive];
 }

--- a/aio/scripts/deploy-to-firebase.js
+++ b/aio/scripts/deploy-to-firebase.js
@@ -4,7 +4,7 @@
 //
 'use strict';
 
-const {cd, cp, exec, set} = require('shelljs');
+const {cd, cp, exec, mv, sed, set} = require('shelljs');
 
 set('-e');
 
@@ -17,6 +17,7 @@ const NG_REMOTE_URL = `https://github.com/${REPO_SLUG}.git`;
 module.exports = {
   computeDeploymentsInfo,
   computeInputVars,
+  computeMajorVersion,
   getLatestCommit,
   getMostRecentMinorBranch,
 };
@@ -122,6 +123,17 @@ function computeDeploymentsInfo(
       preDeployActions: [build, checkPayloadSize],
       postDeployActions: [testPwaScore],
     },
+    // Config for deploying the stable build to the RC Firebase site when there is no active RC.
+    // See https://github.com/angular/angular/issues/39760 for more info on the purpose of this
+    // special deployment.
+    noActiveRc: {
+      deployEnv: 'stable',
+      projectId: 'angular-io',
+      siteId: 'rc-angular-io-site',
+      deployedUrl: 'https://rc.angular.io/',
+      preDeployActions: [removeServiceWorker, redirectToAngularIo],
+      postDeployActions: [testNoActiveRcDeployment],
+    },
     archive: {
       deployEnv: 'archive',
       projectId: 'angular-io',
@@ -149,7 +161,17 @@ function computeDeploymentsInfo(
 
   // If the current branch is the stable branch, deploy as `stable`.
   if (currentBranch === stableBranch) {
-    return [deploymentInfoPerTarget.stable];
+    return (rcBranch !== null) ?
+      // There is an active RC version. Only deploy to the `stable` project/site.
+      [deploymentInfoPerTarget.stable] :
+      // There is no active RC version. In addition to deploying to the `stable` project/site,
+      // deploy to `rc` to ensure it redirects to `stable`.
+      // See https://github.com/angular/angular/issues/39760 for more info on the purpose of this
+      // special deployment.
+      [
+        deploymentInfoPerTarget.stable,
+        deploymentInfoPerTarget.noActiveRc,
+      ];
   }
 
   // If we get here, it means that the current branch is neither `master`, nor the RC or stable
@@ -263,12 +285,62 @@ function getLatestCommit(branchName, remote = undefined) {
   return getRemoteRefs(branchName, remote)[0].slice(0, 40);
 }
 
+function redirectToAngularIo() {
+  // Update the Firebase hosting configuration redirect all non-file requests (i.e. requests that do
+  // not contain a dot in their last path segment) to `angular.io`.
+  // See https://firebase.google.com/docs/hosting/full-config#redirects.
+  const redirectRule =
+      '{"type": 302, "regex": "^(.*/[^./]*)$", "destination": "https://angular.io:1"}';
+  sed('-i', /(\s*)"redirects": \[/, `$&\n$1  ${redirectRule},\n`, 'firebase.json');
+}
+
+function removeServiceWorker() {
+  // Rename the SW manifest (`ngsw.json`). This will cause the ServiceWorker to unregister itself.
+  // See https://angular.io/guide/service-worker-devops#fail-safe.
+  mv('dist/ngsw.json', 'dist/ngsw.json.bck');
+}
+
 function serializeActions(actions) {
   return actions.map(fn => fn.name).join(', ');
 }
 
 function skipDeployment(reason) {
   return {reason, skipped: true};
+}
+
+function testNoActiveRcDeployment({deployedUrl}) {
+  const deployedOrigin = deployedUrl.replace(/\/$/, '');
+
+  // Ensure a request for `ngsw.json` returns 404.
+  const ngswJsonUrl = `${deployedOrigin}/ngsw.json`;
+  const ngswJsonScript = `https.get('${ngswJsonUrl}', res => console.log(res.statusCode))`;
+  const ngswJsonActualStatusCode = exec(`node --eval "${ngswJsonScript}"`, {silent: true}).trim();
+  const ngswJsonExpectedStatusCode = '404';
+
+  if (ngswJsonActualStatusCode !== ngswJsonExpectedStatusCode) {
+    throw new Error(
+        `Expected '${ngswJsonUrl}' to return a status code of '${ngswJsonExpectedStatusCode}', ` +
+        `but it returned '${ngswJsonActualStatusCode}'.`);
+  }
+
+  // Ensure a request for `foo/bar` is redirected to `https://angular.io/foo/bar`.
+  const fooBarUrl = `${deployedOrigin}/foo/bar?baz=qux`;
+  const fooBarScript =
+      `https.get('${fooBarUrl}', res => console.log(res.statusCode, res.headers.location))`;
+  const [fooBarActualStatusCode, fooBarActualRedirectUrl] =
+      exec(`node --eval "${fooBarScript}"`, {silent: true}).trim().split(' ');
+  const fooBarExpectedStatusCode = '302';
+  const fooBarExpectedRedirectUrl = 'https://angular.io/foo/bar?baz=qux';
+
+  if (fooBarActualStatusCode !== fooBarExpectedStatusCode) {
+    throw new Error(
+        `Expected '${fooBarUrl}' to return a status code of '${fooBarExpectedStatusCode}', but ` +
+        `it returned '${fooBarActualStatusCode}'.`);
+  } else if (fooBarActualRedirectUrl !== fooBarExpectedRedirectUrl) {
+    throw new Error(
+        `Expected '${fooBarUrl}' to be redirected to '${fooBarExpectedRedirectUrl}', but it was ` +
+        `but it was redirected to '${fooBarActualRedirectUrl}'.`);
+  }
 }
 
 function testPwaScore({deployedUrl, minPwaScore}) {

--- a/aio/scripts/deploy-to-firebase.spec.js
+++ b/aio/scripts/deploy-to-firebase.spec.js
@@ -5,6 +5,7 @@ const {execSync} = require('child_process');
 const {
   computeDeploymentsInfo,
   computeInputVars,
+  computeMajorVersion,
   getLatestCommit,
   getMostRecentMinorBranch,
 } = require('./deploy-to-firebase');
@@ -104,7 +105,7 @@ describe('deploy-to-firebase:', () => {
     ]);
   });
 
-  it('stable - deploy success', () => {
+  it('stable - deploy success - active RC', () => {
     expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
@@ -120,6 +121,34 @@ describe('deploy-to-firebase:', () => {
         deployedUrl: 'https://angular.io/',
         preDeployActions: ['function:build', 'function:checkPayloadSize'],
         postDeployActions: ['function:testPwaScore'],
+      },
+    ]);
+  });
+
+  it('stable - deploy success - no active RC', () => {
+    expect(getDeploymentsInfoFor({
+      CI_REPO_OWNER: 'angular',
+      CI_REPO_NAME: 'angular',
+      CI_PULL_REQUEST: 'false',
+      CI_BRANCH: mostRecentMinorBranch,
+      CI_STABLE_BRANCH: mostRecentMinorBranch,
+      CI_COMMIT: latestCommits[mostRecentMinorBranch],
+    })).toEqual([
+      {
+        deployEnv: 'stable',
+        projectId: 'angular-io',
+        siteId: `v${computeMajorVersion(mostRecentMinorBranch)}-angular-io-site`,
+        deployedUrl: 'https://angular.io/',
+        preDeployActions: ['function:build', 'function:checkPayloadSize'],
+        postDeployActions: ['function:testPwaScore'],
+      },
+      {
+        deployEnv: 'stable',
+        projectId: 'angular-io',
+        siteId: 'rc-angular-io-site',
+        deployedUrl: 'https://rc.angular.io/',
+        preDeployActions: ['function:removeServiceWorker', 'function:redirectToAngularIo'],
+        postDeployActions: ['function:testNoActiveRcDeployment'],
       },
     ]);
   });

--- a/aio/scripts/deploy-to-firebase.spec.js
+++ b/aio/scripts/deploy-to-firebase.spec.js
@@ -6,60 +6,70 @@ const {computeDeploymentInfo, computeInputVars, getLatestCommit} = require('./de
 
 
 describe('deploy-to-firebase:', () => {
+  // Helpers
+  const jsonFunctionReplacer = (_key, val) =>
+    (typeof val === 'function') ? `function:${val.name}` : val;
+  const getDeploymentInfoFor = env => {
+    const deploymentInfo = computeDeploymentInfo(computeInputVars(env));
+    return JSON.parse(JSON.stringify(deploymentInfo, jsonFunctionReplacer));
+  };
+
   it('master - skip deploy - not angular', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'notangular',
-    }))).toEqual({
+    })).toEqual({
       skipped: true,
       reason: 'Skipping deploy because this is not angular/angular.',
     });
   });
 
   it('master - skip deploy - angular fork', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'notangular',
       CI_REPO_NAME: 'angular',
-    }))).toEqual({
+    })).toEqual({
       skipped: true,
       reason: 'Skipping deploy because this is not angular/angular.',
     });
   });
 
   it('master - skip deploy - pull request', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'true',
-    }))).toEqual({
+    })).toEqual({
       skipped: true,
       reason: 'Skipping deploy because this is a PR build.',
     });
   });
 
   it('master - deploy success', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: 'master',
       CI_COMMIT: getLatestCommit('master'),
-    }))).toEqual({
+    })).toEqual({
       deployEnv: 'next',
       projectId: 'angular-io',
       siteId: 'next-angular-io-site',
       deployedUrl: 'https://next.angular.io/',
+      preDeployActions: ['function:build', 'function:checkPayloadSize'],
+      postDeployActions: ['function:testPwaScore'],
     });
   });
 
   it('master - skip deploy - commit not HEAD', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: 'master',
       CI_COMMIT: 'DUMMY_TEST_COMMIT',
-    }))).toEqual({
+    })).toEqual({
       skipped: true,
       reason:
           'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
@@ -68,30 +78,32 @@ describe('deploy-to-firebase:', () => {
   });
 
   it('stable - deploy success', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '4.3.x',
       CI_STABLE_BRANCH: '4.3.x',
       CI_COMMIT: getLatestCommit('4.3.x'),
-    }))).toEqual({
+    })).toEqual({
       deployEnv: 'stable',
       projectId: 'angular-io',
       siteId: 'v4-angular-io-site',
       deployedUrl: 'https://angular.io/',
+      preDeployActions: ['function:build', 'function:checkPayloadSize'],
+      postDeployActions: ['function:testPwaScore'],
     });
   });
 
   it('stable - skip deploy - commit not HEAD', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '4.3.x',
       CI_STABLE_BRANCH: '4.3.x',
       CI_COMMIT: 'DUMMY_TEST_COMMIT',
-    }))).toEqual({
+    })).toEqual({
       skipped: true,
       reason:
           'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
@@ -100,48 +112,52 @@ describe('deploy-to-firebase:', () => {
   });
 
   it('archive - deploy success', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.4.x',
       CI_STABLE_BRANCH: '4.3.x',
       CI_COMMIT: getLatestCommit('2.4.x'),
-    }))).toEqual({
+    })).toEqual({
       deployEnv: 'archive',
       projectId: 'angular-io',
       siteId: 'v2-angular-io-site',
       deployedUrl: 'https://v2.angular.io/',
+      preDeployActions: ['function:build', 'function:checkPayloadSize'],
+      postDeployActions: ['function:testPwaScore'],
     });
   });
 
   // v9 used to be special-cased, because it was piloting the Firebase hosting "multisites" setup.
   // See https://angular-team.atlassian.net/browse/DEV-125 for more info.
   it('archive - deploy success (no special case for v9)', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '9.1.x',
       CI_STABLE_BRANCH: '10.0.x',
       CI_COMMIT: getLatestCommit('9.1.x'),
-    }))).toEqual({
+    })).toEqual({
       deployEnv: 'archive',
       projectId: 'angular-io',
       siteId: 'v9-angular-io-site',
       deployedUrl: 'https://v9.angular.io/',
+      preDeployActions: ['function:build', 'function:checkPayloadSize'],
+      postDeployActions: ['function:testPwaScore'],
     });
   });
 
   it('archive - skip deploy - commit not HEAD', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.4.x',
       CI_STABLE_BRANCH: '4.3.x',
       CI_COMMIT: 'DUMMY_TEST_COMMIT',
-    }))).toEqual({
+    })).toEqual({
       skipped: true,
       reason:
           'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
@@ -150,14 +166,14 @@ describe('deploy-to-firebase:', () => {
   });
 
   it('archive - skip deploy - major same as stable, minor less than stable', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.1.x',
       CI_STABLE_BRANCH: '2.2.x',
       CI_COMMIT: getLatestCommit('2.1.x'),
-    }))).toEqual({
+    })).toEqual({
       skipped: true,
       reason:
           'Skipping deploy of branch "2.1.x" to Firebase.\n' +
@@ -166,14 +182,14 @@ describe('deploy-to-firebase:', () => {
   });
 
   it('archive - skip deploy - major lower than stable, minor not latest', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.1.x',
       CI_STABLE_BRANCH: '4.3.x',
       CI_COMMIT: getLatestCommit('2.1.x'),
-    }))).toEqual({
+    })).toEqual({
       skipped: true,
       reason:
           'Skipping deploy of branch "2.1.x" to Firebase.\n' +
@@ -182,46 +198,50 @@ describe('deploy-to-firebase:', () => {
   });
 
   it('rc - deploy success - major higher than stable', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '4.4.x',
       CI_STABLE_BRANCH: '2.2.x',
       CI_COMMIT: getLatestCommit('4.4.x'),
-    }))).toEqual({
+    })).toEqual({
       deployEnv: 'rc',
       projectId: 'angular-io',
       siteId: 'rc-angular-io-site',
       deployedUrl: 'https://rc.angular.io/',
+      preDeployActions: ['function:build', 'function:checkPayloadSize'],
+      postDeployActions: ['function:testPwaScore'],
     });
   });
 
   it('rc - deploy success - major same as stable, minor higher', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.4.x',
       CI_STABLE_BRANCH: '2.2.x',
       CI_COMMIT: getLatestCommit('2.4.x'),
-    }))).toEqual({
+    })).toEqual({
       deployEnv: 'rc',
       projectId: 'angular-io',
       siteId: 'rc-angular-io-site',
       deployedUrl: 'https://rc.angular.io/',
+      preDeployActions: ['function:build', 'function:checkPayloadSize'],
+      postDeployActions: ['function:testPwaScore'],
     });
   });
 
   it('rc - skip deploy - commit not HEAD', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.4.x',
       CI_STABLE_BRANCH: '2.2.x',
       CI_COMMIT: 'DUMMY_TEST_COMMIT',
-    }))).toEqual({
+    })).toEqual({
       skipped: true,
       reason:
           'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
@@ -230,14 +250,14 @@ describe('deploy-to-firebase:', () => {
   });
 
   it('rc - skip deploy - major same as stable, minor not latest', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.1.x',
       CI_STABLE_BRANCH: '2.0.x',
       CI_COMMIT: getLatestCommit('2.1.x'),
-    }))).toEqual({
+    })).toEqual({
       skipped: true,
       reason:
           'Skipping deploy of branch "2.1.x" to Firebase.\n' +
@@ -246,14 +266,14 @@ describe('deploy-to-firebase:', () => {
   });
 
   it('rc - skip deploy - major higher than stable, minor not latest', () => {
-    expect(computeDeploymentInfo(computeInputVars({
+    expect(getDeploymentInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '4.3.x',
       CI_STABLE_BRANCH: '2.4.x',
       CI_COMMIT: getLatestCommit('4.3.x'),
-    }))).toEqual({
+    })).toEqual({
       skipped: true,
       reason:
           'Skipping deploy of branch "4.3.x" to Firebase.\n' +
@@ -273,12 +293,14 @@ describe('deploy-to-firebase:', () => {
     };
     const result = execSync(cmd, {encoding: 'utf8', env}).trim();
     expect(result).toBe(
-        'Git branch        : master\n' +
-        `Git commit        : ${commit}\n` +
-        'Build/deploy mode : next\n' +
-        'Firebase project  : angular-io\n' +
-        'Firebase site     : next-angular-io-site\n' +
-        'Deployment URLs   : https://next.angular.io/\n' +
-        '                    https://next-angular-io-site.web.app/');
+        'Git branch          : master\n' +
+        `Git commit          : ${commit}\n` +
+        'Build/deploy mode   : next\n' +
+        'Firebase project    : angular-io\n' +
+        'Firebase site       : next-angular-io-site\n' +
+        'Pre-deploy actions  : build, checkPayloadSize\n' +
+        'Post-deploy actions : testPwaScore\n' +
+        'Deployment URLs     : https://next.angular.io/\n' +
+        '                      https://next-angular-io-site.web.app/');
   });
 });

--- a/aio/scripts/deploy-to-firebase.spec.js
+++ b/aio/scripts/deploy-to-firebase.spec.js
@@ -231,7 +231,7 @@ describe('deploy-to-firebase:', () => {
     ]);
   });
 
-  it('archive - skip deploy - major same as stable, minor less than stable', () => {
+  it('archive - skip deploy - major same as stable, minor lower than stable', () => {
     expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
@@ -249,7 +249,7 @@ describe('deploy-to-firebase:', () => {
     ]);
   });
 
-  it('archive - skip deploy - major lower than stable, minor not latest', () => {
+  it('archive - skip deploy - major lower than stable, minor not highest for major', () => {
     expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
@@ -287,7 +287,7 @@ describe('deploy-to-firebase:', () => {
     ]);
   });
 
-  it('rc - deploy success - major same as stable, minor higher', () => {
+  it('rc - deploy success - major same as stable, minor highest for major', () => {
     // Create a stable branch name that has the same major and lower minor than
     // `mostRecentMinorBranch`.
     // NOTE: Since `mostRecentMinorBranch` can have a minor version of `0`, we may end up with `-1`
@@ -332,7 +332,7 @@ describe('deploy-to-firebase:', () => {
     ]);
   });
 
-  it('rc - skip deploy - major same as stable, minor not latest', () => {
+  it('rc - skip deploy - major same as stable, minor not highest for major', () => {
     expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
@@ -350,7 +350,7 @@ describe('deploy-to-firebase:', () => {
     ]);
   });
 
-  it('rc - skip deploy - major higher than stable, minor not latest', () => {
+  it('rc - skip deploy - major higher than stable, minor not highest for major', () => {
     expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
@@ -368,7 +368,7 @@ describe('deploy-to-firebase:', () => {
     ]);
   });
 
-  it('rc - skip deploy - major higher than stable but lower than most recent, minor latest', () => {
+  it('rc - skip deploy - major higher than stable but not highest, minor highest for major', () => {
     expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',

--- a/aio/scripts/deploy-to-firebase.spec.js
+++ b/aio/scripts/deploy-to-firebase.spec.js
@@ -2,283 +2,317 @@
 'use strict';
 
 const {execSync} = require('child_process');
-const {computeDeploymentInfo, computeInputVars, getLatestCommit} = require('./deploy-to-firebase');
+const {computeDeploymentsInfo, computeInputVars, getLatestCommit} = require('./deploy-to-firebase');
 
 
 describe('deploy-to-firebase:', () => {
   // Helpers
   const jsonFunctionReplacer = (_key, val) =>
     (typeof val === 'function') ? `function:${val.name}` : val;
-  const getDeploymentInfoFor = env => {
-    const deploymentInfo = computeDeploymentInfo(computeInputVars(env));
-    return JSON.parse(JSON.stringify(deploymentInfo, jsonFunctionReplacer));
+  const getDeploymentsInfoFor = env => {
+    const deploymentsInfo = computeDeploymentsInfo(computeInputVars(env));
+    return JSON.parse(JSON.stringify(deploymentsInfo, jsonFunctionReplacer));
   };
 
   it('master - skip deploy - not angular', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'notangular',
-    })).toEqual({
-      skipped: true,
-      reason: 'Skipping deploy because this is not angular/angular.',
-    });
+    })).toEqual([
+      {
+        skipped: true,
+        reason: 'Skipping deploy because this is not angular/angular.',
+      },
+    ]);
   });
 
   it('master - skip deploy - angular fork', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'notangular',
       CI_REPO_NAME: 'angular',
-    })).toEqual({
-      skipped: true,
-      reason: 'Skipping deploy because this is not angular/angular.',
-    });
+    })).toEqual([
+      {
+        skipped: true,
+        reason: 'Skipping deploy because this is not angular/angular.',
+      },
+    ]);
   });
 
   it('master - skip deploy - pull request', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'true',
-    })).toEqual({
-      skipped: true,
-      reason: 'Skipping deploy because this is a PR build.',
-    });
+    })).toEqual([
+      {
+        skipped: true,
+        reason: 'Skipping deploy because this is a PR build.',
+      },
+    ]);
   });
 
   it('master - deploy success', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: 'master',
       CI_COMMIT: getLatestCommit('master'),
-    })).toEqual({
-      deployEnv: 'next',
-      projectId: 'angular-io',
-      siteId: 'next-angular-io-site',
-      deployedUrl: 'https://next.angular.io/',
-      preDeployActions: ['function:build', 'function:checkPayloadSize'],
-      postDeployActions: ['function:testPwaScore'],
-    });
+    })).toEqual([
+      {
+        deployEnv: 'next',
+        projectId: 'angular-io',
+        siteId: 'next-angular-io-site',
+        deployedUrl: 'https://next.angular.io/',
+        preDeployActions: ['function:build', 'function:checkPayloadSize'],
+        postDeployActions: ['function:testPwaScore'],
+      },
+    ]);
   });
 
   it('master - skip deploy - commit not HEAD', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: 'master',
       CI_COMMIT: 'DUMMY_TEST_COMMIT',
-    })).toEqual({
-      skipped: true,
-      reason:
-          'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
-          `(${getLatestCommit('master')}).`,
-    });
+    })).toEqual([
+      {
+        skipped: true,
+        reason:
+            'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
+            `(${getLatestCommit('master')}).`,
+      },
+    ]);
   });
 
   it('stable - deploy success', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '4.3.x',
       CI_STABLE_BRANCH: '4.3.x',
       CI_COMMIT: getLatestCommit('4.3.x'),
-    })).toEqual({
-      deployEnv: 'stable',
-      projectId: 'angular-io',
-      siteId: 'v4-angular-io-site',
-      deployedUrl: 'https://angular.io/',
-      preDeployActions: ['function:build', 'function:checkPayloadSize'],
-      postDeployActions: ['function:testPwaScore'],
-    });
+    })).toEqual([
+      {
+        deployEnv: 'stable',
+        projectId: 'angular-io',
+        siteId: 'v4-angular-io-site',
+        deployedUrl: 'https://angular.io/',
+        preDeployActions: ['function:build', 'function:checkPayloadSize'],
+        postDeployActions: ['function:testPwaScore'],
+      },
+    ]);
   });
 
   it('stable - skip deploy - commit not HEAD', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '4.3.x',
       CI_STABLE_BRANCH: '4.3.x',
       CI_COMMIT: 'DUMMY_TEST_COMMIT',
-    })).toEqual({
-      skipped: true,
-      reason:
-          'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
-          `(${getLatestCommit('4.3.x')}).`,
-    });
+    })).toEqual([
+      {
+        skipped: true,
+        reason:
+            'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
+            `(${getLatestCommit('4.3.x')}).`,
+      },
+    ]);
   });
 
   it('archive - deploy success', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.4.x',
       CI_STABLE_BRANCH: '4.3.x',
       CI_COMMIT: getLatestCommit('2.4.x'),
-    })).toEqual({
-      deployEnv: 'archive',
-      projectId: 'angular-io',
-      siteId: 'v2-angular-io-site',
-      deployedUrl: 'https://v2.angular.io/',
-      preDeployActions: ['function:build', 'function:checkPayloadSize'],
-      postDeployActions: ['function:testPwaScore'],
-    });
+    })).toEqual([
+      {
+        deployEnv: 'archive',
+        projectId: 'angular-io',
+        siteId: 'v2-angular-io-site',
+        deployedUrl: 'https://v2.angular.io/',
+        preDeployActions: ['function:build', 'function:checkPayloadSize'],
+        postDeployActions: ['function:testPwaScore'],
+      },
+    ]);
   });
 
   // v9 used to be special-cased, because it was piloting the Firebase hosting "multisites" setup.
   // See https://angular-team.atlassian.net/browse/DEV-125 for more info.
   it('archive - deploy success (no special case for v9)', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '9.1.x',
       CI_STABLE_BRANCH: '10.0.x',
       CI_COMMIT: getLatestCommit('9.1.x'),
-    })).toEqual({
-      deployEnv: 'archive',
-      projectId: 'angular-io',
-      siteId: 'v9-angular-io-site',
-      deployedUrl: 'https://v9.angular.io/',
-      preDeployActions: ['function:build', 'function:checkPayloadSize'],
-      postDeployActions: ['function:testPwaScore'],
-    });
+    })).toEqual([
+      {
+        deployEnv: 'archive',
+        projectId: 'angular-io',
+        siteId: 'v9-angular-io-site',
+        deployedUrl: 'https://v9.angular.io/',
+        preDeployActions: ['function:build', 'function:checkPayloadSize'],
+        postDeployActions: ['function:testPwaScore'],
+      },
+    ]);
   });
 
   it('archive - skip deploy - commit not HEAD', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.4.x',
       CI_STABLE_BRANCH: '4.3.x',
       CI_COMMIT: 'DUMMY_TEST_COMMIT',
-    })).toEqual({
-      skipped: true,
-      reason:
-          'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
-          `(${getLatestCommit('2.4.x')}).`,
-    });
+    })).toEqual([
+      {
+        skipped: true,
+        reason:
+            'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
+            `(${getLatestCommit('2.4.x')}).`,
+      },
+    ]);
   });
 
   it('archive - skip deploy - major same as stable, minor less than stable', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.1.x',
       CI_STABLE_BRANCH: '2.2.x',
       CI_COMMIT: getLatestCommit('2.1.x'),
-    })).toEqual({
-      skipped: true,
-      reason:
-          'Skipping deploy of branch "2.1.x" to Firebase.\n' +
-          'There is a more recent branch with the same major version: "2.4.x"',
-    });
+    })).toEqual([
+      {
+        skipped: true,
+        reason:
+            'Skipping deploy of branch "2.1.x" to Firebase.\n' +
+            'There is a more recent branch with the same major version: "2.4.x"',
+      },
+    ]);
   });
 
   it('archive - skip deploy - major lower than stable, minor not latest', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.1.x',
       CI_STABLE_BRANCH: '4.3.x',
       CI_COMMIT: getLatestCommit('2.1.x'),
-    })).toEqual({
-      skipped: true,
-      reason:
-          'Skipping deploy of branch "2.1.x" to Firebase.\n' +
-          'There is a more recent branch with the same major version: "2.4.x"',
-    });
+    })).toEqual([
+      {
+        skipped: true,
+        reason:
+            'Skipping deploy of branch "2.1.x" to Firebase.\n' +
+            'There is a more recent branch with the same major version: "2.4.x"',
+      },
+    ]);
   });
 
   it('rc - deploy success - major higher than stable', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '4.4.x',
       CI_STABLE_BRANCH: '2.2.x',
       CI_COMMIT: getLatestCommit('4.4.x'),
-    })).toEqual({
-      deployEnv: 'rc',
-      projectId: 'angular-io',
-      siteId: 'rc-angular-io-site',
-      deployedUrl: 'https://rc.angular.io/',
-      preDeployActions: ['function:build', 'function:checkPayloadSize'],
-      postDeployActions: ['function:testPwaScore'],
-    });
+    })).toEqual([
+      {
+        deployEnv: 'rc',
+        projectId: 'angular-io',
+        siteId: 'rc-angular-io-site',
+        deployedUrl: 'https://rc.angular.io/',
+        preDeployActions: ['function:build', 'function:checkPayloadSize'],
+        postDeployActions: ['function:testPwaScore'],
+      },
+    ]);
   });
 
   it('rc - deploy success - major same as stable, minor higher', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.4.x',
       CI_STABLE_BRANCH: '2.2.x',
       CI_COMMIT: getLatestCommit('2.4.x'),
-    })).toEqual({
-      deployEnv: 'rc',
-      projectId: 'angular-io',
-      siteId: 'rc-angular-io-site',
-      deployedUrl: 'https://rc.angular.io/',
-      preDeployActions: ['function:build', 'function:checkPayloadSize'],
-      postDeployActions: ['function:testPwaScore'],
-    });
+    })).toEqual([
+      {
+        deployEnv: 'rc',
+        projectId: 'angular-io',
+        siteId: 'rc-angular-io-site',
+        deployedUrl: 'https://rc.angular.io/',
+        preDeployActions: ['function:build', 'function:checkPayloadSize'],
+        postDeployActions: ['function:testPwaScore'],
+      },
+    ]);
   });
 
   it('rc - skip deploy - commit not HEAD', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.4.x',
       CI_STABLE_BRANCH: '2.2.x',
       CI_COMMIT: 'DUMMY_TEST_COMMIT',
-    })).toEqual({
-      skipped: true,
-      reason:
-          'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
-          `(${getLatestCommit('2.4.x')}).`,
-    });
+    })).toEqual([
+      {
+        skipped: true,
+        reason:
+            'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
+            `(${getLatestCommit('2.4.x')}).`,
+      },
+    ]);
   });
 
   it('rc - skip deploy - major same as stable, minor not latest', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.1.x',
       CI_STABLE_BRANCH: '2.0.x',
       CI_COMMIT: getLatestCommit('2.1.x'),
-    })).toEqual({
-      skipped: true,
-      reason:
-          'Skipping deploy of branch "2.1.x" to Firebase.\n' +
-          'There is a more recent branch with the same major version: "2.4.x"',
-    });
+    })).toEqual([
+      {
+        skipped: true,
+        reason:
+            'Skipping deploy of branch "2.1.x" to Firebase.\n' +
+            'There is a more recent branch with the same major version: "2.4.x"',
+      },
+    ]);
   });
 
   it('rc - skip deploy - major higher than stable, minor not latest', () => {
-    expect(getDeploymentInfoFor({
+    expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '4.3.x',
       CI_STABLE_BRANCH: '2.4.x',
       CI_COMMIT: getLatestCommit('4.3.x'),
-    })).toEqual({
-      skipped: true,
-      reason:
-          'Skipping deploy of branch "4.3.x" to Firebase.\n' +
-          'There is a more recent branch with the same major version: "4.4.x"',
-    });
+    })).toEqual([
+      {
+        skipped: true,
+        reason:
+            'Skipping deploy of branch "4.3.x" to Firebase.\n' +
+            'There is a more recent branch with the same major version: "4.4.x"',
+      },
+    ]);
   });
 
   it('integration - should run the main script without error', () => {
@@ -293,6 +327,12 @@ describe('deploy-to-firebase:', () => {
     };
     const result = execSync(cmd, {encoding: 'utf8', env}).trim();
     expect(result).toBe(
+        'Total deployments: 1\n' +
+        '\n' +
+        '\n' +
+        '\n' +
+        'Deployment 1 of 1\n' +
+        '-----------------\n' +
         'Git branch          : master\n' +
         `Git commit          : ${commit}\n` +
         'Build/deploy mode   : next\n' +

--- a/aio/scripts/deploy-to-firebase.spec.js
+++ b/aio/scripts/deploy-to-firebase.spec.js
@@ -6,6 +6,16 @@ const {computeDeploymentsInfo, computeInputVars, getLatestCommit} = require('./d
 
 
 describe('deploy-to-firebase:', () => {
+  // Pre-computed latest commits to avoid unnecessary re-computations.
+  const latestCommits = {
+    master: getLatestCommit('master'),
+    '2.1.x': getLatestCommit('2.1.x'),
+    '2.4.x': getLatestCommit('2.4.x'),
+    '4.3.x': getLatestCommit('4.3.x'),
+    '4.4.x': getLatestCommit('4.4.x'),
+    '9.1.x': getLatestCommit('9.1.x'),
+  };
+
   // Helpers
   const jsonFunctionReplacer = (_key, val) =>
     (typeof val === 'function') ? `function:${val.name}` : val;
@@ -57,7 +67,7 @@ describe('deploy-to-firebase:', () => {
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: 'master',
-      CI_COMMIT: getLatestCommit('master'),
+      CI_COMMIT: latestCommits.master,
     })).toEqual([
       {
         deployEnv: 'next',
@@ -82,7 +92,7 @@ describe('deploy-to-firebase:', () => {
         skipped: true,
         reason:
             'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
-            `(${getLatestCommit('master')}).`,
+            `(${latestCommits.master}).`,
       },
     ]);
   });
@@ -94,7 +104,7 @@ describe('deploy-to-firebase:', () => {
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '4.3.x',
       CI_STABLE_BRANCH: '4.3.x',
-      CI_COMMIT: getLatestCommit('4.3.x'),
+      CI_COMMIT: latestCommits['4.3.x'],
     })).toEqual([
       {
         deployEnv: 'stable',
@@ -120,7 +130,7 @@ describe('deploy-to-firebase:', () => {
         skipped: true,
         reason:
             'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
-            `(${getLatestCommit('4.3.x')}).`,
+            `(${latestCommits['4.3.x']}).`,
       },
     ]);
   });
@@ -132,7 +142,7 @@ describe('deploy-to-firebase:', () => {
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.4.x',
       CI_STABLE_BRANCH: '4.3.x',
-      CI_COMMIT: getLatestCommit('2.4.x'),
+      CI_COMMIT: latestCommits['2.4.x'],
     })).toEqual([
       {
         deployEnv: 'archive',
@@ -154,7 +164,7 @@ describe('deploy-to-firebase:', () => {
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '9.1.x',
       CI_STABLE_BRANCH: '10.0.x',
-      CI_COMMIT: getLatestCommit('9.1.x'),
+      CI_COMMIT: latestCommits['9.1.x'],
     })).toEqual([
       {
         deployEnv: 'archive',
@@ -180,7 +190,7 @@ describe('deploy-to-firebase:', () => {
         skipped: true,
         reason:
             'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
-            `(${getLatestCommit('2.4.x')}).`,
+            `(${latestCommits['2.4.x']}).`,
       },
     ]);
   });
@@ -192,7 +202,7 @@ describe('deploy-to-firebase:', () => {
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.1.x',
       CI_STABLE_BRANCH: '2.2.x',
-      CI_COMMIT: getLatestCommit('2.1.x'),
+      CI_COMMIT: latestCommits['2.1.x'],
     })).toEqual([
       {
         skipped: true,
@@ -210,7 +220,7 @@ describe('deploy-to-firebase:', () => {
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.1.x',
       CI_STABLE_BRANCH: '4.3.x',
-      CI_COMMIT: getLatestCommit('2.1.x'),
+      CI_COMMIT: latestCommits['2.1.x'],
     })).toEqual([
       {
         skipped: true,
@@ -228,7 +238,7 @@ describe('deploy-to-firebase:', () => {
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '4.4.x',
       CI_STABLE_BRANCH: '2.2.x',
-      CI_COMMIT: getLatestCommit('4.4.x'),
+      CI_COMMIT: latestCommits['4.4.x'],
     })).toEqual([
       {
         deployEnv: 'rc',
@@ -248,7 +258,7 @@ describe('deploy-to-firebase:', () => {
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.4.x',
       CI_STABLE_BRANCH: '2.2.x',
-      CI_COMMIT: getLatestCommit('2.4.x'),
+      CI_COMMIT: latestCommits['2.4.x'],
     })).toEqual([
       {
         deployEnv: 'rc',
@@ -274,7 +284,7 @@ describe('deploy-to-firebase:', () => {
         skipped: true,
         reason:
             'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
-            `(${getLatestCommit('2.4.x')}).`,
+            `(${latestCommits['2.4.x']}).`,
       },
     ]);
   });
@@ -286,7 +296,7 @@ describe('deploy-to-firebase:', () => {
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '2.1.x',
       CI_STABLE_BRANCH: '2.0.x',
-      CI_COMMIT: getLatestCommit('2.1.x'),
+      CI_COMMIT: latestCommits['2.1.x'],
     })).toEqual([
       {
         skipped: true,
@@ -304,7 +314,7 @@ describe('deploy-to-firebase:', () => {
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: '4.3.x',
       CI_STABLE_BRANCH: '2.4.x',
-      CI_COMMIT: getLatestCommit('4.3.x'),
+      CI_COMMIT: latestCommits['4.3.x'],
     })).toEqual([
       {
         skipped: true,
@@ -316,14 +326,13 @@ describe('deploy-to-firebase:', () => {
   });
 
   it('integration - should run the main script without error', () => {
-    const commit = getLatestCommit('master');
     const cmd = `"${process.execPath}" "${__dirname}/deploy-to-firebase" --dry-run`;
     const env = {
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
       CI_BRANCH: 'master',
-      CI_COMMIT: commit,
+      CI_COMMIT: latestCommits.master,
     };
     const result = execSync(cmd, {encoding: 'utf8', env}).trim();
     expect(result).toBe(
@@ -334,7 +343,7 @@ describe('deploy-to-firebase:', () => {
         'Deployment 1 of 1\n' +
         '-----------------\n' +
         'Git branch          : master\n' +
-        `Git commit          : ${commit}\n` +
+        `Git commit          : ${latestCommits.master}\n` +
         'Build/deploy mode   : next\n' +
         'Firebase project    : angular-io\n' +
         'Firebase site       : next-angular-io-site\n' +

--- a/aio/scripts/deploy-to-firebase.spec.js
+++ b/aio/scripts/deploy-to-firebase.spec.js
@@ -2,11 +2,17 @@
 'use strict';
 
 const {execSync} = require('child_process');
-const {computeDeploymentsInfo, computeInputVars, getLatestCommit} = require('./deploy-to-firebase');
+const {
+  computeDeploymentsInfo,
+  computeInputVars,
+  getLatestCommit,
+  getMostRecentMinorBranch,
+} = require('./deploy-to-firebase');
 
 
 describe('deploy-to-firebase:', () => {
-  // Pre-computed latest commits to avoid unnecessary re-computations.
+  // Pre-computed values to avoid unnecessary re-computations.
+  const mostRecentMinorBranch = getMostRecentMinorBranch();
   const latestCommits = {
     master: getLatestCommit('master'),
     '2.1.x': getLatestCommit('2.1.x'),
@@ -14,6 +20,7 @@ describe('deploy-to-firebase:', () => {
     '4.3.x': getLatestCommit('4.3.x'),
     '4.4.x': getLatestCommit('4.4.x'),
     '9.1.x': getLatestCommit('9.1.x'),
+    [mostRecentMinorBranch]: getLatestCommit(mostRecentMinorBranch),
   };
 
   // Helpers
@@ -208,7 +215,7 @@ describe('deploy-to-firebase:', () => {
         skipped: true,
         reason:
             'Skipping deploy of branch "2.1.x" to Firebase.\n' +
-            'There is a more recent branch with the same major version: "2.4.x"',
+            'This branch has an equal or higher major version than the stable branch ("2.2.x").',
       },
     ]);
   });
@@ -236,9 +243,9 @@ describe('deploy-to-firebase:', () => {
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
-      CI_BRANCH: '4.4.x',
+      CI_BRANCH: mostRecentMinorBranch,
       CI_STABLE_BRANCH: '2.2.x',
-      CI_COMMIT: latestCommits['4.4.x'],
+      CI_COMMIT: latestCommits[mostRecentMinorBranch],
     })).toEqual([
       {
         deployEnv: 'rc',
@@ -252,13 +259,20 @@ describe('deploy-to-firebase:', () => {
   });
 
   it('rc - deploy success - major same as stable, minor higher', () => {
+    // Create a stable branch name that has the same major and lower minor than
+    // `mostRecentMinorBranch`.
+    // NOTE: Since `mostRecentMinorBranch` can have a minor version of `0`, we may end up with `-1`
+    //       as the minor version for stable. This is a hack, but it works ¯\_(ツ)_/¯
+    const stableBranch = mostRecentMinorBranch.replace(
+        /^(\d+)\.(\d+)\.x$/, (_, major, minor) => `${major}.${minor - 1}.x`);
+
     expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
-      CI_BRANCH: '2.4.x',
-      CI_STABLE_BRANCH: '2.2.x',
-      CI_COMMIT: latestCommits['2.4.x'],
+      CI_BRANCH: mostRecentMinorBranch,
+      CI_STABLE_BRANCH: stableBranch,
+      CI_COMMIT: latestCommits[mostRecentMinorBranch],
     })).toEqual([
       {
         deployEnv: 'rc',
@@ -276,7 +290,7 @@ describe('deploy-to-firebase:', () => {
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
-      CI_BRANCH: '2.4.x',
+      CI_BRANCH: mostRecentMinorBranch,
       CI_STABLE_BRANCH: '2.2.x',
       CI_COMMIT: 'DUMMY_TEST_COMMIT',
     })).toEqual([
@@ -284,7 +298,7 @@ describe('deploy-to-firebase:', () => {
         skipped: true,
         reason:
             'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
-            `(${latestCommits['2.4.x']}).`,
+            `(${latestCommits[mostRecentMinorBranch]}).`,
       },
     ]);
   });
@@ -302,7 +316,7 @@ describe('deploy-to-firebase:', () => {
         skipped: true,
         reason:
             'Skipping deploy of branch "2.1.x" to Firebase.\n' +
-            'There is a more recent branch with the same major version: "2.4.x"',
+            'This branch has an equal or higher major version than the stable branch ("2.0.x").',
       },
     ]);
   });
@@ -320,7 +334,25 @@ describe('deploy-to-firebase:', () => {
         skipped: true,
         reason:
             'Skipping deploy of branch "4.3.x" to Firebase.\n' +
-            'There is a more recent branch with the same major version: "4.4.x"',
+            'This branch has an equal or higher major version than the stable branch ("2.4.x").',
+      },
+    ]);
+  });
+
+  it('rc - skip deploy - major higher than stable but lower than most recent, minor latest', () => {
+    expect(getDeploymentsInfoFor({
+      CI_REPO_OWNER: 'angular',
+      CI_REPO_NAME: 'angular',
+      CI_PULL_REQUEST: 'false',
+      CI_BRANCH: '4.4.x',
+      CI_STABLE_BRANCH: '2.4.x',
+      CI_COMMIT: latestCommits['4.4.x'],
+    })).toEqual([
+      {
+        skipped: true,
+        reason:
+            'Skipping deploy of branch "4.4.x" to Firebase.\n' +
+            'This branch has an equal or higher major version than the stable branch ("2.4.x").',
       },
     ]);
   });

--- a/aio/scripts/deploy-to-firebase.spec.js
+++ b/aio/scripts/deploy-to-firebase.spec.js
@@ -215,7 +215,7 @@ describe('deploy-to-firebase:', () => {
         skipped: true,
         reason:
             'Skipping deploy of branch "2.1.x" to Firebase.\n' +
-            'This branch has an equal or higher major version than the stable branch ("2.2.x").',
+            'There is a more recent branch with the same major version: "2.4.x"',
       },
     ]);
   });
@@ -316,7 +316,7 @@ describe('deploy-to-firebase:', () => {
         skipped: true,
         reason:
             'Skipping deploy of branch "2.1.x" to Firebase.\n' +
-            'This branch has an equal or higher major version than the stable branch ("2.0.x").',
+            'There is a more recent branch with the same major version: "2.4.x"',
       },
     ]);
   });
@@ -334,7 +334,7 @@ describe('deploy-to-firebase:', () => {
         skipped: true,
         reason:
             'Skipping deploy of branch "4.3.x" to Firebase.\n' +
-            'This branch has an equal or higher major version than the stable branch ("2.4.x").',
+            'There is a more recent branch with the same major version: "4.4.x"',
       },
     ]);
   });

--- a/aio/scripts/deploy-to-firebase.spec.js
+++ b/aio/scripts/deploy-to-firebase.spec.js
@@ -352,7 +352,8 @@ describe('deploy-to-firebase:', () => {
         skipped: true,
         reason:
             'Skipping deploy of branch "4.4.x" to Firebase.\n' +
-            'This branch has an equal or higher major version than the stable branch ("2.4.x").',
+            'This branch has an equal or higher major version than the stable branch ("2.4.x") ' +
+            'and is not the most recent minor branch.',
       },
     ]);
   });


### PR DESCRIPTION
Currently there is an issue with redirecting `rc.angular.io` to `angular.io` when there is no active RC. If a user has visited `rc.angular.io` before and has a ServiceWorker registered for that subdomain, they will never "see" the redirect to `angular.io`.

This PR fixes the problem by doing an additional deployment from the stable branch to the `rc-angular-io-site` Firebase site when there is no active RC. This additional deployment will ensure that:
1. Users will be temporarily redirected from `rc.angular.io` to `angular.io`.
2. Users with a registered ServiceWorker (who don't see the redirect) will have their ServiceWorker unregistered on the next visit.
3. The content on both sites is identical.

See #39760 for more details on the problem and the solution.

NOTE:
As mentioned in #39760, for this fix to take affect, we need to remove the redirect from `rc.angular.io` to `angular.io` in the Firebase console for site `rc-angular-io-site`.

Fixes #39760.

##
This PR also contains some other fixes and refactorings. See individual commits for more details.