### PR TITLE
docs: include template input variables entry in aio glossary

### DIFF
--- a/aio/content/guide/glossary.md
+++ b/aio/content/guide/glossary.md
@@ -945,19 +945,16 @@ A TypeScript-like syntax that Angular evaluates within a [data binding](#data-bi
 
 Read about how to write template expressions in the [template expressions](guide/interpolation#template-expressions) section of the [Interpolation](guide/interpolation) guide.
 
-{@a template-input-variables}
+{@a template-input-variable}
 
 ## template input variable
 
 A _template input variable_ is a variable whose value you can reference _within_ a single instance of the template.
-It is preceded by the keyword `let` and used to provide an input in the template of a [structural directive](guide/structural-directives) (this would be the template of the HTML tag or component that the structural directive is attached to).
+You declare a _template input variable_ using the `let` keyword (`let hero`). 
 
-You declare a _template input variable_ using the `let` keyword (`let hero`).
+It is used to provide an input in the template of a [structural directive](guide/structural-directives). This would be the template of the HTML tag or component that the structural directive is attached to. This template also defines the boundaries of the scope of the _template input variable_: you may reuse the same variable name again in the definition of other structural directives, as long as they have no overlap with the template of the initial one.
 
-You can use the same variable name again in the definition of other structural directives.
-
-Template _input_ and [_reference_](#template-reference-variable) variable names have their own namespaces. The `hero` in `let hero` is never the same
-variable as the `hero` declared as `#hero`.
+Note: template _input_ and [_reference_](#template-reference-variable) variable names have separate namespaces. The `hero` in `let hero` is never the same variable as the `hero` declared as `#hero`.
 
 Read more about _template input variable_ in the [Template input variables](guide/built-in-directives#template-input-variables) section of the [Built-in directives](guide/built-in-directives) guide.
 

--- a/aio/content/guide/glossary.md
+++ b/aio/content/guide/glossary.md
@@ -945,6 +945,22 @@ A TypeScript-like syntax that Angular evaluates within a [data binding](#data-bi
 
 Read about how to write template expressions in the [template expressions](guide/interpolation#template-expressions) section of the [Interpolation](guide/interpolation) guide.
 
+{@a template-input-variables}
+
+## template input variable
+
+A _template input variable_ is a variable whose value you can reference _within_ a single instance of the template.
+It is preceded by the keyword `let` and used to provide an input in the template of a [structural directive](guide/structural-directives) (this would be the template of the HTML tag or component that the structural directive is attached to).
+
+You declare a _template input variable_ using the `let` keyword (`let hero`).
+
+You can use the same variable name again in the definition of other structural directives.
+
+Template _input_ and [_reference_](#template-reference-variable) variable names have their own namespaces. The `hero` in `let hero` is never the same
+variable as the `hero` declared as `#hero`.
+
+Read more about _template input variable_ in the [Template input variables](guide/built-in-directives#template-input-variables) section of the [Built-in directives](guide/built-in-directives) guide.
+
 {@a template-reference-variable}
 
 ## template reference variable


### PR DESCRIPTION
The glossary entry now includes a template input variables entry

Fixes #39783

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #39783


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
