### PR TITLE
fix(docs-infra): speed up ng test

### DIFF
--- a/aio/src/test.ts
+++ b/aio/src/test.ts
@@ -6,6 +6,7 @@ import {
     BrowserDynamicTestingModule,
     platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
+import { ɵDomSharedStylesHost } from '@angular/platform-browser';
 
 declare const require: any;
 
@@ -14,6 +15,13 @@ getTestBed().initTestEnvironment(
     BrowserDynamicTestingModule,
     platformBrowserDynamicTesting()
 );
+
+// TODO: Remove this workaround once we update to an Angular version that includes a fix for
+// https://github.com/angular/angular/issues/31834
+afterEach(() => {
+  getTestBed().inject(ɵDomSharedStylesHost).ngOnDestroy();
+});
+
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

There is currently a known issue with the framework when testing that leaks style.
See https://github.com/angular/angular/issues/31834

A possible temporary workaround is to manually call the service that adds/aremoves the style.
See https://github.com/angular/angular/issues/31834#issuecomment-732153736

This workaround will be unnecessary when https://github.com/angular/angular/pull/38336 lands.

## What is the new behavior?

This speeds up the `ng test` task locally by ~30%:
- before: Executed 649 of 652 (skipped 3) SUCCESS (24.161 secs / 20.072 secs)
- after: Executed 649 of 652 (skipped 3) SUCCESS (17.854 secs / 15.584 secs)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
