### PR TITLE
fix(core): remove application from the testability registry when the root view is removed

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2285,
-        "main-es2015": 241879,
+        "main-es2015": 242455,
         "polyfills-es2015": 36709,
         "5-es2015": 745
       }

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -804,7 +804,6 @@ export class ApplicationRef {
 
   /** @internal */
   ngOnDestroy() {
-    // TODO(alxhub): Dispose of the NgZone.
     this._views.slice().forEach((view) => view.destroy());
     this._onMicrotaskEmptySubscription.unsubscribe();
   }

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -248,7 +248,6 @@ export function injectComponentFactoryResolver(): viewEngine_ComponentFactoryRes
  *
  */
 export class ComponentRef<T> extends viewEngine_ComponentRef<T> {
-  destroyCbs: (() => void)[]|null = [];
   instance: T;
   hostView: ViewRef<T>;
   changeDetectorRef: ViewEngine_ChangeDetectorRef;
@@ -269,16 +268,10 @@ export class ComponentRef<T> extends viewEngine_ComponentRef<T> {
   }
 
   destroy(): void {
-    if (this.destroyCbs) {
-      this.destroyCbs.forEach(fn => fn());
-      this.destroyCbs = null;
-      !this.hostView.destroyed && this.hostView.destroy();
-    }
+    this.hostView.destroy();
   }
 
   onDestroy(callback: () => void): void {
-    if (this.destroyCbs) {
-      this.destroyCbs.push(callback);
-    }
+    this.hostView.onDestroy(callback);
   }
 }

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -19,7 +19,7 @@ import {assertTNodeType} from '../node_assert';
 import {getCurrentDirectiveDef, getCurrentTNode, getLView, getTView} from '../state';
 import {getComponentLViewByIndex, getNativeByTNode, unwrapRNode} from '../util/view_utils';
 
-import {getLCleanup, handleError, loadComponentRenderer, markViewDirty} from './shared';
+import {getLCleanup, getTViewCleanup, handleError, loadComponentRenderer, markViewDirty} from './shared';
 
 
 
@@ -120,7 +120,7 @@ function listenerInternal(
     eventTargetResolver?: GlobalTargetResolver): void {
   const isTNodeDirectiveHost = isDirectiveHost(tNode);
   const firstCreatePass = tView.firstCreatePass;
-  const tCleanup: false|any[] = firstCreatePass && (tView.cleanup || (tView.cleanup = []));
+  const tCleanup: false|any[] = firstCreatePass && getTViewCleanup(tView);
 
   // When the ɵɵlistener instruction was generated and is executed we know that there is either a
   // native listener or a directive output on this element. As such we we know that we will have to

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -163,8 +163,11 @@ export interface LView extends Array<any> {
    *
    * These change per LView instance, so they cannot be stored on TView. Instead,
    * TView.cleanup saves an index to the necessary context in this array.
+   *
+   * After `LView` is created it is possible to attach additional instance specific functions at the
+   * end of the `lView[CLENUP]` because we know that no more `T` level cleanup functions will be
+   * addeded here.
    */
-  // TODO: flatten into LView[]
   [CLEANUP]: any[]|null;
 
   /**

--- a/packages/core/src/util/assert.ts
+++ b/packages/core/src/util/assert.ts
@@ -31,6 +31,12 @@ export function assertString(actual: any, msg: string): asserts actual is string
   }
 }
 
+export function assertFunction(actual: any, msg: string): asserts actual is Function {
+  if (!(typeof actual === 'function')) {
+    throwError(msg, actual === null ? 'null' : typeof actual, 'function', '===');
+  }
+}
+
 export function assertEqual<T>(actual: T, expected: T, msg: string) {
   if (!(actual == expected)) {
     throwError(msg, actual, expected, '==');

--- a/packages/core/test/acceptance/bootstrap_spec.ts
+++ b/packages/core/test/acceptance/bootstrap_spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {COMPILER_OPTIONS, Component, destroyPlatform, NgModule, ViewEncapsulation} from '@angular/core';
+import {ApplicationRef, COMPILER_OPTIONS, Component, destroyPlatform, NgModule, TestabilityRegistry, ViewEncapsulation} from '@angular/core';
+import {expect} from '@angular/core/testing/src/testing_internal';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {onlyInIvy, withBody} from '@angular/private/testing';
@@ -150,6 +151,81 @@ describe('bootstrap', () => {
          expect(document.body.innerHTML).toContain('a b');
          ngModuleRef.destroy();
        }));
+
+    describe('ApplicationRef cleanup', () => {
+      it('should cleanup ApplicationRef when Injector is destroyed',
+         withBody('<my-app></my-app>', async () => {
+           const TestModule = createComponentAndModule();
+
+           const ngModuleRef = await platformBrowserDynamic().bootstrapModule(TestModule);
+           const appRef = ngModuleRef.injector.get(ApplicationRef);
+           const testabilityRegistry = ngModuleRef.injector.get(TestabilityRegistry);
+
+           expect(appRef.components.length).toBe(1);
+           expect(testabilityRegistry.getAllRootElements().length).toBe(1);
+
+           ngModuleRef.destroy();  // also destroys an Injector instance.
+
+           expect(appRef.components.length).toBe(0);
+           expect(testabilityRegistry.getAllRootElements().length).toBe(0);
+         }));
+
+      it('should cleanup ApplicationRef when ComponentRef is destroyed',
+         withBody('<my-app></my-app>', async () => {
+           const TestModule = createComponentAndModule();
+
+           const ngModuleRef = await platformBrowserDynamic().bootstrapModule(TestModule);
+           const appRef = ngModuleRef.injector.get(ApplicationRef);
+           const testabilityRegistry = ngModuleRef.injector.get(TestabilityRegistry);
+           const componentRef = appRef.components[0];
+
+           expect(appRef.components.length).toBe(1);
+           expect(testabilityRegistry.getAllRootElements().length).toBe(1);
+
+           componentRef.destroy();
+
+           expect(appRef.components.length).toBe(0);
+           expect(testabilityRegistry.getAllRootElements().length).toBe(0);
+         }));
+
+      it('should not throw in case ComponentRef is destroyed and Injector is destroyed after that',
+         withBody('<my-app></my-app>', async () => {
+           const TestModule = createComponentAndModule();
+
+           const ngModuleRef = await platformBrowserDynamic().bootstrapModule(TestModule);
+           const appRef = ngModuleRef.injector.get(ApplicationRef);
+           const testabilityRegistry = ngModuleRef.injector.get(TestabilityRegistry);
+           const componentRef = appRef.components[0];
+
+           expect(appRef.components.length).toBe(1);
+           expect(testabilityRegistry.getAllRootElements().length).toBe(1);
+
+           componentRef.destroy();
+           ngModuleRef.destroy();  // also destroys an Injector instance.
+
+           expect(appRef.components.length).toBe(0);
+           expect(testabilityRegistry.getAllRootElements().length).toBe(0);
+         }));
+
+      it('should not throw in case Injector is destroyed and ComponentRef is destroyed after that',
+         withBody('<my-app></my-app>', async () => {
+           const TestModule = createComponentAndModule();
+
+           const ngModuleRef = await platformBrowserDynamic().bootstrapModule(TestModule);
+           const appRef = ngModuleRef.injector.get(ApplicationRef);
+           const testabilityRegistry = ngModuleRef.injector.get(TestabilityRegistry);
+           const componentRef = appRef.components[0];
+
+           expect(appRef.components.length).toBe(1);
+           expect(testabilityRegistry.getAllRootElements().length).toBe(1);
+
+           ngModuleRef.destroy();  // also destroys an Injector instance.
+           componentRef.destroy();
+
+           expect(appRef.components.length).toBe(0);
+           expect(testabilityRegistry.getAllRootElements().length).toBe(0);
+         }));
+    });
 
     onlyInIvy('options cannot be changed in Ivy').describe('changing bootstrap options', () => {
       beforeEach(() => {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1437,6 +1437,9 @@
     "name": "getTView"
   },
   {
+    "name": "getTViewCleanup"
+  },
+  {
     "name": "getToken"
   },
   {


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #22106


## What is the new behavior?

In the new behavior Angular removes applications from the testability registry when the root view gets destroyed. This eliminates a memory leak, because before that the `TestabilityRegistry` holds references to HTML elements, thus they cannot be GCed.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No