### PR TITLE
test(compiler-cli): migrate providers compliance tests

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/GOLDEN_PARTIAL.js
@@ -1,0 +1,174 @@
+/****************************************************************************************************
+ * PARTIAL FILE: providers_feature_providers_and_view_providers.js
+ ****************************************************************************************************/
+import { Component, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+class Greeter {
+}
+class GreeterEN {
+    greet() {
+        return 'Hi';
+    }
+}
+export class MyComponent {
+}
+MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ version: 1, type: MyComponent, selector: "my-component", providers: [GreeterEN, { provide: Greeter, useClass: GreeterEN }], ngImport: i0, template: { source: '<div></div>', isInline: true }, viewProviders: [GreeterEN] });
+/*@__PURE__*/ (function () { i0.ɵsetClassMetadata(MyComponent, [{
+        type: Component,
+        args: [{
+                selector: 'my-component',
+                template: '<div></div>',
+                providers: [GreeterEN, { provide: Greeter, useClass: GreeterEN }],
+                viewProviders: [GreeterEN]
+            }]
+    }], null, null); })();
+export class MyModule {
+}
+MyModule.ɵmod = i0.ɵɵdefineNgModule({ type: MyModule });
+MyModule.ɵinj = i0.ɵɵdefineInjector({ factory: function MyModule_Factory(t) { return new (t || MyModule)(); } });
+(function () { (typeof ngJitMode === "undefined" || ngJitMode) && i0.ɵɵsetNgModuleScope(MyModule, { declarations: [MyComponent] }); })();
+/*@__PURE__*/ (function () { i0.ɵsetClassMetadata(MyModule, [{
+        type: NgModule,
+        args: [{ declarations: [MyComponent] }]
+    }], null, null); })();
+
+/****************************************************************************************************
+ * PARTIAL FILE: providers_feature_providers_and_view_providers.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    static ɵfac: i0.ɵɵFactoryDef<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MyComponent, "my-component", never, {}, {}, never, never>;
+}
+export declare class MyModule {
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MyModule, [typeof MyComponent], never, never>;
+    static ɵinj: i0.ɵɵInjectorDef<MyModule>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: providers_feature_providers_only.js
+ ****************************************************************************************************/
+import { Component, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+class Greeter {
+}
+class GreeterEN {
+    greet() {
+        return 'Hi';
+    }
+}
+export class MyComponent {
+}
+MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ version: 1, type: MyComponent, selector: "my-component", providers: [GreeterEN, { provide: Greeter, useClass: GreeterEN }], ngImport: i0, template: { source: '<div></div>', isInline: true } });
+/*@__PURE__*/ (function () { i0.ɵsetClassMetadata(MyComponent, [{
+        type: Component,
+        args: [{
+                selector: 'my-component',
+                template: '<div></div>',
+                providers: [GreeterEN, { provide: Greeter, useClass: GreeterEN }]
+            }]
+    }], null, null); })();
+export class MyModule {
+}
+MyModule.ɵmod = i0.ɵɵdefineNgModule({ type: MyModule });
+MyModule.ɵinj = i0.ɵɵdefineInjector({ factory: function MyModule_Factory(t) { return new (t || MyModule)(); } });
+(function () { (typeof ngJitMode === "undefined" || ngJitMode) && i0.ɵɵsetNgModuleScope(MyModule, { declarations: [MyComponent] }); })();
+/*@__PURE__*/ (function () { i0.ɵsetClassMetadata(MyModule, [{
+        type: NgModule,
+        args: [{ declarations: [MyComponent] }]
+    }], null, null); })();
+
+/****************************************************************************************************
+ * PARTIAL FILE: providers_feature_providers_only.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    static ɵfac: i0.ɵɵFactoryDef<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MyComponent, "my-component", never, {}, {}, never, never>;
+}
+export declare class MyModule {
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MyModule, [typeof MyComponent], never, never>;
+    static ɵinj: i0.ɵɵInjectorDef<MyModule>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: providers_feature_view_providers_only.js
+ ****************************************************************************************************/
+import { Component, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+class Greeter {
+}
+class GreeterEN {
+    greet() {
+        return 'Hi';
+    }
+}
+export class MyComponent {
+}
+MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ version: 1, type: MyComponent, selector: "my-component", ngImport: i0, template: { source: '<div></div>', isInline: true }, viewProviders: [GreeterEN] });
+/*@__PURE__*/ (function () { i0.ɵsetClassMetadata(MyComponent, [{
+        type: Component,
+        args: [{ selector: 'my-component', template: '<div></div>', viewProviders: [GreeterEN] }]
+    }], null, null); })();
+export class MyModule {
+}
+MyModule.ɵmod = i0.ɵɵdefineNgModule({ type: MyModule });
+MyModule.ɵinj = i0.ɵɵdefineInjector({ factory: function MyModule_Factory(t) { return new (t || MyModule)(); } });
+(function () { (typeof ngJitMode === "undefined" || ngJitMode) && i0.ɵɵsetNgModuleScope(MyModule, { declarations: [MyComponent] }); })();
+/*@__PURE__*/ (function () { i0.ɵsetClassMetadata(MyModule, [{
+        type: NgModule,
+        args: [{ declarations: [MyComponent] }]
+    }], null, null); })();
+
+/****************************************************************************************************
+ * PARTIAL FILE: providers_feature_view_providers_only.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    static ɵfac: i0.ɵɵFactoryDef<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MyComponent, "my-component", never, {}, {}, never, never>;
+}
+export declare class MyModule {
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MyModule, [typeof MyComponent], never, never>;
+    static ɵinj: i0.ɵɵInjectorDef<MyModule>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: providers_feature_no_providers.js
+ ****************************************************************************************************/
+import { Component, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComponent {
+}
+MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ version: 1, type: MyComponent, selector: "my-component", ngImport: i0, template: { source: '<div></div>', isInline: true } });
+/*@__PURE__*/ (function () { i0.ɵsetClassMetadata(MyComponent, [{
+        type: Component,
+        args: [{ selector: 'my-component', template: '<div></div>' }]
+    }], null, null); })();
+export class MyModule {
+}
+MyModule.ɵmod = i0.ɵɵdefineNgModule({ type: MyModule });
+MyModule.ɵinj = i0.ɵɵdefineInjector({ factory: function MyModule_Factory(t) { return new (t || MyModule)(); } });
+(function () { (typeof ngJitMode === "undefined" || ngJitMode) && i0.ɵɵsetNgModuleScope(MyModule, { declarations: [MyComponent] }); })();
+/*@__PURE__*/ (function () { i0.ɵsetClassMetadata(MyModule, [{
+        type: NgModule,
+        args: [{ declarations: [MyComponent] }]
+    }], null, null); })();
+
+/****************************************************************************************************
+ * PARTIAL FILE: providers_feature_no_providers.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    static ɵfac: i0.ɵɵFactoryDef<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDefWithMeta<MyComponent, "my-component", never, {}, {}, never, never>;
+}
+export declare class MyModule {
+    static ɵmod: i0.ɵɵNgModuleDefWithMeta<MyModule, [typeof MyComponent], never, never>;
+    static ɵinj: i0.ɵɵInjectorDef<MyModule>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/TEST_CASES.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "../test_case_schema.json",
+  "cases": [
+    {
+      "description": "should emit the ProvidersFeature feature when providers and viewProviders are used",
+      "inputFiles": [
+        "providers_feature_providers_and_view_providers.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "providers_feature_providers_and_view_providers_features.js",
+              "generated": "providers_feature_providers_and_view_providers.js"
+            }
+          ],
+          "failureMessage": "Incorrect features"
+        }
+      ]
+    },
+    {
+      "description": "should emit the ProvidersFeature feature when providers only",
+      "inputFiles": [
+        "providers_feature_providers_only.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "providers_feature_providers_only_features.js",
+              "generated": "providers_feature_providers_only.js"
+            }
+          ],
+          "failureMessage": "Incorrect features"
+        }
+      ]
+    },
+    {
+      "description": "should emit the ProvidersFeature feature when viewProviders only",
+      "inputFiles": [
+        "providers_feature_view_providers_only.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "providers_feature_view_providers_only_features.js",
+              "generated": "providers_feature_view_providers_only.js"
+            }
+          ],
+          "failureMessage": "Incorrect features"
+        }
+      ]
+    },
+    {
+      "description": "should not emit the ProvidersFeature feature when no providers",
+      "inputFiles": [
+        "providers_feature_no_providers.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "providers_feature_no_providers_definition.js",
+              "generated": "providers_feature_no_providers.js"
+            }
+          ],
+          "failureMessage": "Incorrect definition"
+        },
+        {
+          "files": [
+            {
+              "expected": "providers_feature_no_providers_factory.js",
+              "generated": "providers_feature_no_providers.js"
+            }
+          ],
+          "failureMessage": "Incorrect factory"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_no_providers.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_no_providers.ts
@@ -1,0 +1,9 @@
+import {Component, NgModule} from '@angular/core';
+
+@Component({selector: 'my-component', template: '<div></div>'})
+export class MyComponent {
+}
+
+@NgModule({declarations: [MyComponent]})
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_no_providers_definition.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_no_providers_definition.js
@@ -1,0 +1,12 @@
+MyComponent.ɵcmp = i0.ɵɵdefineComponent({
+  type: MyComponent,
+  selectors: [["my-component"]],
+  decls: 1,
+  vars: 0,
+  template: function MyComponent_Template(rf, ctx) {
+    if (rf & 1) {
+      i0.ɵɵelement(0, "div");
+    }
+  },
+  encapsulation: 2
+});

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_no_providers_factory.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_no_providers_factory.js
@@ -1,0 +1,1 @@
+MyComponent.ɵfac = function MyComponent_Factory(t) { return new (t || MyComponent)(); };

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_providers_and_view_providers.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_providers_and_view_providers.ts
@@ -1,0 +1,24 @@
+import {Component, NgModule} from '@angular/core';
+
+abstract class Greeter {
+  abstract greet(): string;
+}
+
+class GreeterEN implements Greeter {
+  greet() {
+    return 'Hi';
+  }
+}
+
+@Component({
+  selector: 'my-component',
+  template: '<div></div>',
+  providers: [GreeterEN, {provide: Greeter, useClass: GreeterEN}],
+  viewProviders: [GreeterEN]
+})
+export class MyComponent {
+}
+
+@NgModule({declarations: [MyComponent]})
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_providers_and_view_providers_features.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_providers_and_view_providers_features.js
@@ -1,0 +1,1 @@
+features: [i0.ɵɵProvidersFeature([GreeterEN, {provide: Greeter, useClass: GreeterEN}], [GreeterEN])],

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_providers_only.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_providers_only.ts
@@ -1,0 +1,23 @@
+import {Component, NgModule} from '@angular/core';
+
+abstract class Greeter {
+  abstract greet(): string;
+}
+
+class GreeterEN implements Greeter {
+  greet() {
+    return 'Hi';
+  }
+}
+
+@Component({
+  selector: 'my-component',
+  template: '<div></div>',
+  providers: [GreeterEN, {provide: Greeter, useClass: GreeterEN}]
+})
+export class MyComponent {
+}
+
+@NgModule({declarations: [MyComponent]})
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_providers_only_features.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_providers_only_features.js
@@ -1,0 +1,1 @@
+features: [i0.ɵɵProvidersFeature([GreeterEN, {provide: Greeter, useClass: GreeterEN}])],

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_view_providers_only.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_view_providers_only.ts
@@ -1,0 +1,19 @@
+import {Component, NgModule} from '@angular/core';
+
+abstract class Greeter {
+  abstract greet(): string;
+}
+
+class GreeterEN implements Greeter {
+  greet() {
+    return 'Hi';
+  }
+}
+
+@Component({selector: 'my-component', template: '<div></div>', viewProviders: [GreeterEN]})
+export class MyComponent {
+}
+
+@NgModule({declarations: [MyComponent]})
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_view_providers_only_features.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_providers/providers_feature_view_providers_only_features.js
@@ -1,0 +1,1 @@
+features: [i0.ɵɵProvidersFeature([], [GreeterEN])],


### PR DESCRIPTION
Migrates the `r3_view_compiler_providers` compliance tests to the new format.