### PR TITLE
fix(forms): ensure OnPush ancestors are marked dirty when the promise resolves

### DIFF
--- a/goldens/public-api/forms/forms.d.ts
+++ b/goldens/public-api/forms/forms.d.ts
@@ -406,7 +406,7 @@ export declare class NgModel extends NgControl implements OnChanges, OnDestroy {
     get path(): string[];
     update: EventEmitter<any>;
     viewModel: any;
-    constructor(parent: ControlContainer, validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[], valueAccessors: ControlValueAccessor[]);
+    constructor(parent: ControlContainer, validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[], valueAccessors: ControlValueAccessor[], _changeDetectorRef: ChangeDetectorRef | null);
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     viewToModelUpdate(newValue: any): void;

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, EventEmitter, forwardRef, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges} from '@angular/core';
+import {ChangeDetectorRef, Directive, EventEmitter, forwardRef, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges} from '@angular/core';
 
 import {FormControl, FormHooks} from '../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
@@ -208,7 +208,8 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
       @Optional() @Self() @Inject(NG_VALIDATORS) validators: (Validator|ValidatorFn)[],
       @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) asyncValidators:
           (AsyncValidator|AsyncValidatorFn)[],
-      @Optional() @Self() @Inject(NG_VALUE_ACCESSOR) valueAccessors: ControlValueAccessor[]) {
+      @Optional() @Self() @Inject(NG_VALUE_ACCESSOR) valueAccessors: ControlValueAccessor[],
+      @Optional() @Inject(ChangeDetectorRef) private _changeDetectorRef: ChangeDetectorRef|null) {
     super();
     this._parent = parent;
     this._setValidators(validators);
@@ -313,6 +314,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
   private _updateValue(value: any): void {
     resolvedPromise.then(() => {
       this.control.setValue(value, {emitViewToModelChange: false});
+      this._changeDetectorRef?.markForCheck();
     });
   }
 
@@ -327,6 +329,8 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
       } else if (!isDisabled && this.control.disabled) {
         this.control.enable();
       }
+
+      this._changeDetectorRef?.markForCheck();
     });
   }
 }

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -321,7 +321,8 @@ class CustomValidatorDirective implements Validator {
         personControlGroupDir = new NgModelGroup(form, [], []);
         personControlGroupDir.name = 'person';
 
-        loginControlDir = new NgModel(personControlGroupDir, null!, null!, [defaultAccessor]);
+        loginControlDir =
+            new NgModel(personControlGroupDir, null!, null!, [defaultAccessor], null!);
         loginControlDir.name = 'login';
         loginControlDir.valueAccessor = new DummyControlValueAccessor();
       });
@@ -546,7 +547,7 @@ class CustomValidatorDirective implements Validator {
 
       beforeEach(() => {
         ngModel = new NgModel(
-            null!, [Validators.required], [asyncValidator('expected')], [defaultAccessor]);
+            null!, [Validators.required], [asyncValidator('expected')], [defaultAccessor], null!);
         ngModel.valueAccessor = new DummyControlValueAccessor();
         control = ngModel.control;
       });
@@ -579,7 +580,7 @@ class CustomValidatorDirective implements Validator {
       });
 
       it('should throw when no value accessor with named control', () => {
-        const namedDir = new NgModel(null!, null!, null!, null!);
+        const namedDir = new NgModel(null!, null!, null!, null!, null!);
         namedDir.name = 'one';
 
         expect(() => namedDir.ngOnChanges({}))
@@ -587,7 +588,7 @@ class CustomValidatorDirective implements Validator {
       });
 
       it('should throw when no value accessor with unnamed control', () => {
-        const unnamedDir = new NgModel(null!, null!, null!, null!);
+        const unnamedDir = new NgModel(null!, null!, null!, null!, null!);
 
         expect(() => unnamedDir.ngOnChanges({}))
             .toThrowError(

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, EventEmitter, Input, Output, Type, ViewChild} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Directive, EventEmitter, Input, Output, Type, ViewChild} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from '@angular/core/testing';
 import {AbstractControl, ControlValueAccessor, FormControl, FormGroup, FormsModule, NG_VALIDATORS, NG_VALUE_ACCESSOR, NgControl, NgForm, NgModel, ReactiveFormsModule, Validators} from '@angular/forms';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
@@ -1097,6 +1097,66 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
                  expect(fixture.componentInstance.name).toEqual('Carson');
                });
              });
+           }));
+      });
+
+      describe('`ngModel` value accessor inside an OnPush component', () => {
+        it('should run change detection and update the value', fakeAsync(async () => {
+             @Component({
+               selector: 'parent',
+               template: '<child [ngModel]="value"></child>',
+               changeDetection: ChangeDetectionStrategy.OnPush,
+             })
+             class Parent {
+               value!: string;
+
+               constructor(private ref: ChangeDetectorRef) {}
+
+               setTimeoutAndChangeValue(): void {
+                 setTimeout(() => {
+                   this.value = 'Carson';
+                   this.ref.detectChanges();
+                 }, 50);
+               }
+             }
+
+             @Component({
+               selector: 'child',
+               template: 'Value: {{ value }}',
+               providers: [{provide: NG_VALUE_ACCESSOR, useExisting: Child, multi: true}]
+             })
+             class Child implements ControlValueAccessor {
+               value!: string;
+
+               writeValue(value: string): void {
+                 this.value = value;
+               }
+
+               registerOnChange(): void {}
+
+               registerOnTouched(): void {}
+             }
+
+             const fixture = initTest(Parent, Child);
+             fixture.componentInstance.value = 'Nancy';
+             fixture.detectChanges();
+
+             await fixture.whenStable();
+             fixture.detectChanges();
+             await fixture.whenStable();
+
+             const child = fixture.debugElement.query(By.css('child'));
+             // Let's ensure that the initial value has been set, because previously
+             // it wasn't set inside an `OnPush` component.
+             expect(child.nativeElement.innerHTML).toEqual('Value: Nancy');
+
+             fixture.componentInstance.setTimeoutAndChangeValue();
+             tick(50);
+
+             fixture.detectChanges();
+             await fixture.whenStable();
+
+             expect(child.nativeElement.innerHTML).toEqual('Value: Carson');
            }));
       });
     });


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: #10816

Currently, `ngModel` calls` setValue` after the `resolvedPromise` is resolved. This means that change detection will not be run for this component if it's inside an OnPush component, because it is not marked as dirty.

## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No