### PR TITLE
fix(core): better handling of invalid values in `[class]` arrays

### DIFF
--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -3733,6 +3733,80 @@ describe('styling', () => {
       expect(fixture.nativeElement.textContent).toEqual('className = unbound');
     });
   });
+
+  onlyInIvy('[class] logic is slightly different in Ivy')
+      .describe('handling of invalid input', () => {
+        it('should throw if empty class names are present in `[class]` arrays', () => {
+          @Component({
+            selector: 'comp',
+            template: `<div [class]="['a', '']"></div>`,
+          })
+          class App {
+          }
+
+          TestBed.configureTestingModule({declarations: [App]});
+          expect(() => {
+            const fixture = TestBed.createComponent(App);
+            fixture.detectChanges();
+          }).toThrowError(/Expected class array item to be a non-empty string \(in \["a",""\]\)/)
+        });
+
+        it('should throw if empty class names are present in `[class]` arrays in host bindings',
+           () => {
+             @Component({
+               selector: 'comp',
+               template: '...',
+               host: {'[class]': `['a', '']`},
+             })
+             class App {
+             }
+
+             TestBed.configureTestingModule({declarations: [App]});
+             expect(() => {
+               const fixture = TestBed.createComponent(App);
+               fixture.detectChanges();
+             }).toThrowError(/Expected class array item to be a non-empty string \(in \["a",""\]\)/)
+           });
+
+        [true, false, 0, null, undefined, {}, []].forEach(input => {
+          it(`should throw if ${input} is used inside \`[class]\` arrays`, () => {
+            @Component({
+              selector: 'comp',
+              template: `<div [class]="[klass]"></div>`,
+            })
+            class App {
+              klass = input;
+            }
+
+            TestBed.configureTestingModule({declarations: [App]});
+            expect(() => {
+              const fixture = TestBed.createComponent(App);
+              fixture.detectChanges();
+            })
+                .toThrowError(new RegExp(
+                    `Expected class array item to have 'string' type, but got '${typeof input}'`));
+          });
+
+          it(`should throw if ${input} is used inside \`[class]\` arrays in host bindings`, () => {
+            @Component({
+              selector: 'comp',
+              template: '...',
+              host: {'[class]': '[klass]'},
+            })
+            class App {
+              klass = input;
+            }
+
+            TestBed.configureTestingModule({declarations: [App]});
+            expect(() => {
+              const fixture = TestBed.createComponent(App);
+              fixture.detectChanges();
+            })
+                .toThrowError(new RegExp(
+                    `Expected class array item to have 'string' type, but got '${typeof input}'`));
+          });
+        });
+      });
 });
 
 function assertStyleCounters(countForSet: number, countForRemove: number) {

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -3748,7 +3748,7 @@ describe('styling', () => {
           expect(() => {
             const fixture = TestBed.createComponent(App);
             fixture.detectChanges();
-          }).toThrowError(/Expected class array item to be a non-empty string \(in \["a",""\]\)/)
+          }).toThrowError(/Expected class array item to be a non-empty string \(in \["a",""\]\)/);
         });
 
         it('should throw if empty class names are present in `[class]` arrays in host bindings',
@@ -3765,10 +3765,18 @@ describe('styling', () => {
              expect(() => {
                const fixture = TestBed.createComponent(App);
                fixture.detectChanges();
-             }).toThrowError(/Expected class array item to be a non-empty string \(in \["a",""\]\)/)
+             })
+                 .toThrowError(
+                     /Expected class array item to be a non-empty string \(in \["a",""\]\)/);
            });
 
-        [true, false, 0, null, undefined, {}, []].forEach(input => {
+        // TODO: add a test for '  c  '
+        // TODO: add a note on how this used to work in VE
+        // TODO: add a comment for `.trim()`
+        // TODO: enable some of the tests for VE (that throw)?
+
+        const INVALID_CLASS_ARRAY_INPUTS = [true, false, 0, null, undefined, {}, []];
+        INVALID_CLASS_ARRAY_INPUTS.forEach(input => {
           it(`should throw if ${input} is used inside \`[class]\` arrays`, () => {
             @Component({
               selector: 'comp',


### PR DESCRIPTION
Currently when a set of classes is represented by an array (e.g. `<div [class]="['a', 'b']">`), there is no
validation for empty and non-string values and as a result, the framework crashes without meaningful errors.

This commit updates the logic to:

- throw more meaningful errors to indicate what is wrong with the input
- handle a case when a value contains leading/trailing whitespaces (e.g. `<div [class]="[' a ']">`) and trims these
whitespaces before further processing (otherwise such values can not be handled by DOM's ClassList correctly).


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No