### PR TITLE
docs: fix builder section of generated angular.json file for libs

### DIFF
--- a/aio/content/guide/creating-libraries.md
+++ b/aio/content/guide/creating-libraries.md
@@ -38,7 +38,7 @@ When you generate a new library, the workspace configuration file, `angular.json
     "prefix": "lib",
     "architect": {
       "build": {
-        "builder": "@angular-devkit/build-ng-packagr:build",
+        "builder": "@angular-devkit/build-angular:ng-packagr",
         ...
 </code-example>
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

On the Getting started section, the generated angular.json snippet shows:

```
"builder": "@angular-devkit/build-ng-packagr:build",
```

when it should be:

```
"builder": "@angular-devkit/build-angular:ng-packagr",
```

Issue Number: #39887


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
