### PR TITLE
refactor(dev-infra): separate retrieving targeted branches from printing them

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -2842,7 +2842,7 @@ function getBranchesFromTargetLabel(label, githubTargetBranch) {
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-function checkTargetBranchesForPr(prNumber, jsonOutput = false) {
+function getTargetBranchesForPr(prNumber) {
     return tslib.__awaiter(this, void 0, void 0, function* () {
         /** The ng-dev configuration. */
         const config = getConfig();
@@ -2869,10 +2869,13 @@ function checkTargetBranchesForPr(prNumber, jsonOutput = false) {
             return;
         }
         /** The target branches based on the target label and branch targetted in the Github UI. */
-        const targets = yield getBranchesFromTargetLabel(targetLabel, githubTargetBranch);
-        // When requested, print a json output to stdout, rather than using standard ng-dev logging.
-        if (jsonOutput) {
-            process.stdout.write(JSON.stringify(targets));
+        return yield getBranchesFromTargetLabel(targetLabel, githubTargetBranch);
+    });
+}
+function printTargetBranchesForPr(prNumber) {
+    return tslib.__awaiter(this, void 0, void 0, function* () {
+        const targets = yield getTargetBranchesForPr(prNumber);
+        if (targets === undefined) {
             return;
         }
         info.group(`PR #${prNumber} will merge into:`);
@@ -2890,22 +2893,16 @@ function checkTargetBranchesForPr(prNumber, jsonOutput = false) {
  */
 /** Builds the command. */
 function builder$5(yargs) {
-    return yargs
-        .positional('pr', {
+    return yargs.positional('pr', {
         description: 'The pull request number',
         type: 'number',
         demandOption: true,
-    })
-        .option('json', {
-        type: 'boolean',
-        default: false,
-        description: 'Print response as json',
     });
 }
 /** Handles the command. */
-function handler$5({ pr, json }) {
+function handler$5({ pr }) {
     return tslib.__awaiter(this, void 0, void 0, function* () {
-        yield checkTargetBranchesForPr(pr, json);
+        yield printTargetBranchesForPr(pr);
     });
 }
 /** yargs command module describing the command.  */

--- a/dev-infra/pr/check-target-branches/check-target-branches.ts
+++ b/dev-infra/pr/check-target-branches/check-target-branches.ts
@@ -12,7 +12,7 @@ import {GitClient} from '../../utils/git/index';
 import {loadAndValidateConfig} from '../merge/config';
 import {getBranchesFromTargetLabel, getTargetLabelFromPullRequest} from '../merge/target-label';
 
-export async function checkTargetBranchesForPr(prNumber: number, jsonOutput = false) {
+export async function getTargetBranchesForPr(prNumber: number) {
   /** The ng-dev configuration. */
   const config = getConfig();
   /** Repo owner and name for the github repository. */
@@ -38,14 +38,15 @@ export async function checkTargetBranchesForPr(prNumber: number, jsonOutput = fa
     return;
   }
   /** The target branches based on the target label and branch targetted in the Github UI. */
-  const targets = await getBranchesFromTargetLabel(targetLabel, githubTargetBranch);
+  return await getBranchesFromTargetLabel(targetLabel, githubTargetBranch);
+}
 
-  // When requested, print a json output to stdout, rather than using standard ng-dev logging.
-  if (jsonOutput) {
-    process.stdout.write(JSON.stringify(targets));
+
+export async function printTargetBranchesForPr(prNumber: number) {
+  const targets = await getTargetBranchesForPr(prNumber);
+  if (targets === undefined) {
     return;
   }
-
   info.group(`PR #${prNumber} will merge into:`);
   targets.forEach(target => info(`- ${target}`));
   info.groupEnd();

--- a/dev-infra/pr/check-target-branches/cli.ts
+++ b/dev-infra/pr/check-target-branches/cli.ts
@@ -8,31 +8,24 @@
 
 import {Arguments, Argv, CommandModule} from 'yargs';
 
-import {checkTargetBranchesForPr} from './check-target-branches';
+import {printTargetBranchesForPr} from './check-target-branches';
 
 export interface CheckTargetBranchesOptions {
   pr: number;
-  json: boolean;
 }
 
 /** Builds the command. */
 function builder(yargs: Argv) {
-  return yargs
-      .positional('pr', {
-        description: 'The pull request number',
-        type: 'number',
-        demandOption: true,
-      })
-      .option('json', {
-        type: 'boolean',
-        default: false,
-        description: 'Print response as json',
-      });
+  return yargs.positional('pr', {
+    description: 'The pull request number',
+    type: 'number',
+    demandOption: true,
+  });
 }
 
 /** Handles the command. */
-async function handler({pr, json}: Arguments<CheckTargetBranchesOptions>) {
-  await checkTargetBranchesForPr(pr, json);
+async function handler({pr}: Arguments<CheckTargetBranchesOptions>) {
+  await printTargetBranchesForPr(pr);
 }
 
 /** yargs command module describing the command.  */


### PR DESCRIPTION
Separate retrieving targeted branches from printing the branches to allow for
other tools to better integrate with the results.