### PR TITLE
fix(language-service): do not return external template that does not exist

### DIFF
--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -29,8 +29,16 @@ export function getExternalFiles(project: tss.server.Project): string[] {
     return [];
   }
   const ngLsHost = PROJECT_MAP.get(project);
-  ngLsHost?.getAnalyzedModules();
-  return ngLsHost?.getExternalTemplates() || [];
+  if (ngLsHost === undefined) {
+    return [];
+  }
+  ngLsHost.getAnalyzedModules();
+  return ngLsHost.getExternalTemplates().filter(fileName => {
+    // TODO(kyliau): Remove this when the following PR lands on the version of
+    // TypeScript used in this repo.
+    // https://github.com/microsoft/TypeScript/pull/41737
+    return project.fileExists(fileName);
+  });
 }
 
 export function create(info: tss.server.PluginCreateInfo): tss.LanguageService {

--- a/packages/language-service/test/ts_plugin_spec.ts
+++ b/packages/language-service/test/ts_plugin_spec.ts
@@ -21,6 +21,7 @@ const mockProject = {
     },
   },
   hasRoots: () => true,
+  fileExists: () => true,
 } as any;
 
 describe('plugin', () => {
@@ -135,6 +136,12 @@ describe('plugin', () => {
     expect(externalTemplates).toEqual([
       '/app/test.ng',
     ]);
+  });
+
+  it('should not return external template that does not exist', () => {
+    spyOn(mockProject, 'fileExists').and.returnValue(false);
+    const externalTemplates = getExternalFiles(mockProject);
+    expect(externalTemplates.length).toBe(0);
   });
 });
 


### PR DESCRIPTION
There is a bug in tsserver that causes it to crash when it tries to create
script info for an external template that does not exist.

I've submitted an upstream PR
https://github.com/microsoft/TypeScript/pull/41737 to fix this, but before
the commit lands in the stable release, we'll have to workaround the issue
in language service.

Close https://github.com/angular/vscode-ng-language-service/issues/1001

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
