### PR TITLE
ci(docs-infra): enable the Selenium Promise Manager in e2e tests to a void flakiness on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,7 +447,7 @@ jobs:
         # Run examples tests. The "CIRCLE_NODE_INDEX" will be set if "parallelism" is enabled.
         # Since the parallelism is set to "5", there will be five parallel CircleCI containers.
         # with either "0", "1", etc as node index. This can be passed to the "--shard" argument.
-      - run: yarn --cwd aio example-e2e --setup --local <<# parameters.viewengine >>--viewengine<</ parameters.viewengine >> --cliSpecsConcurrency=5 --shard=${CIRCLE_NODE_INDEX}/${CIRCLE_NODE_TOTAL} --retry 2
+      - run: yarn --cwd aio example-e2e --setup --local <<# parameters.viewengine >>--viewengine<</ parameters.viewengine >> --cliSpecsConcurrency=5 --shard=${CIRCLE_NODE_INDEX}/${CIRCLE_NODE_TOTAL}
 
   # This job should only be run on PR builds, where `CI_PULL_REQUEST` is not `false`.
   aio_preview:

--- a/aio/tests/e2e/protractor.conf.js
+++ b/aio/tests/e2e/protractor.conf.js
@@ -21,7 +21,12 @@ exports.config = {
     },
   },
   directConnect: true,
-  SELENIUM_PROMISE_MANAGER: false,
+  // Keep the Selenium Promise Manager enabled to avoid flakiness on CI.
+  // See https://github.com/angular/angular/issues/39872 for more details.
+  //
+  // TODO(gkalpak): Set this back to `false` to align with CLI-generated apps when the flakiness is
+  //                fixed in the future.
+  SELENIUM_PROMISE_MANAGER: true,
   baseUrl: 'http://localhost:4200/',
   framework: 'jasmine',
   jasmineNodeOpts: {


### PR DESCRIPTION
Since we turned off the Selenium Promise Manager in #39600, the AIO e2e tests have started flaking on CI. After trying out several things, the only change that seems to eliminate the flakiness is turning the Selenium Promise Manager back on (see #39873 for more details).

This commit turns the Selenium Project Manager on to get rid of the flakiness.

Fixes #39872.
