### PR TITLE
build(docs-infra): upgrade cli command docs sources to 548c6ed3e

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -23,7 +23,7 @@
     "build-local-with-viewengine": "yarn ~~build",
     "prebuild-local-with-viewengine-ci": "node scripts/switch-to-viewengine && yarn setup-local-ci",
     "build-local-with-viewengine-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 70150e3f0",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 548c6ed3e",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#master](https://github.com/angular/angular/tree/master) from [cli-builds#master](https://github.com/angular/cli-builds/tree/master).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/70150e3f0...548c6ed3e):

**Modified**
- help/build.json