### PR TITLE
refactor(language-service): create findRenameLocations stubs

### DIFF
--- a/packages/language-service/ivy/ts_plugin.ts
+++ b/packages/language-service/ivy/ts_plugin.ts
@@ -61,6 +61,13 @@ export function create(info: ts.server.PluginCreateInfo): ts.LanguageService {
     return undefined;
   }
 
+  function findRenameLocations(
+      fileName: string, position: number, findInStrings: boolean, findInComments: boolean,
+      providePrefixAndSuffixTextForRename?: boolean): readonly ts.RenameLocation[]|undefined {
+    // TODO(atscott): implement
+    return undefined;
+  }
+
   return {
     ...tsLS,
     getSemanticDiagnostics,
@@ -68,5 +75,6 @@ export function create(info: ts.server.PluginCreateInfo): ts.LanguageService {
     getQuickInfoAtPosition,
     getDefinitionAndBoundSpan,
     getReferencesAtPosition,
+    findRenameLocations,
   };
 }

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -120,6 +120,13 @@ export function create(info: tss.server.PluginCreateInfo): tss.LanguageService {
     return undefined;
   }
 
+  function findRenameLocations(
+      fileName: string, position: number, findInStrings: boolean, findInComments: boolean,
+      providePrefixAndSuffixTextForRename?: boolean): readonly ts.RenameLocation[]|undefined {
+    // not implemented in VE Language Service
+    return undefined;
+  }
+
   return {
     // First clone the original TS language service
     ...tsLS,
@@ -131,5 +138,6 @@ export function create(info: tss.server.PluginCreateInfo): tss.LanguageService {
     getDefinitionAndBoundSpan,
     getTypeDefinitionAtPosition,
     getReferencesAtPosition,
+    findRenameLocations,
   };
 }


### PR DESCRIPTION
Create stubs for `findRenameLocations` for both VE and Ivy Language Service
implementations. This will prevent failed requests when it is implemented on the vscode plugin side.
