### PR TITLE
fix(compiler): recover event parse when animation event name is empty

### DIFF
--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -443,21 +443,19 @@ export class BindingParser {
     const matches = splitAtPeriod(name, [name, '']);
     const eventName = matches[0];
     const phase = matches[1].toLowerCase();
-    if (phase) {
-      switch (phase) {
-        case 'start':
-        case 'done':
-          const ast = this._parseAction(expression, handlerSpan);
-          targetEvents.push(new ParsedEvent(
-              eventName, phase, ParsedEventType.Animation, ast, sourceSpan, handlerSpan, keySpan));
-          break;
+    const ast = this._parseAction(expression, handlerSpan);
+    targetEvents.push(new ParsedEvent(
+        eventName, phase, ParsedEventType.Animation, ast, sourceSpan, handlerSpan, keySpan));
 
-        default:
-          this._reportError(
-              `The provided animation output phase value "${phase}" for "@${
-                  eventName}" is not supported (use start or done)`,
-              sourceSpan);
-          break;
+    if (eventName.length === 0) {
+      this._reportError(`Animation event name is missing in binding`, sourceSpan);
+    }
+    if (phase) {
+      if (phase !== 'start' && phase !== 'done') {
+        this._reportError(
+            `The provided animation output phase value "${phase}" for "@${
+                eventName}" is not supported (use start or done)`,
+            sourceSpan);
       }
     } else {
       this._reportError(

--- a/packages/compiler/test/render3/view/util.ts
+++ b/packages/compiler/test/render3/view/util.ts
@@ -78,15 +78,17 @@ export function toStringExpression(expr: e.AST): string {
 
 // Parse an html string to IVY specific info
 export function parseR3(
-    input: string, options: {preserveWhitespaces?: boolean, leadingTriviaChars?: string[]} = {}):
-    Render3ParseResult {
+    input: string,
+    options: {preserveWhitespaces?: boolean,
+              leadingTriviaChars?: string[],
+              ignoreError?: boolean} = {}): Render3ParseResult {
   const htmlParser = new HtmlParser();
 
   const parseResult = htmlParser.parse(
       input, 'path:://to/template',
       {tokenizeExpansionForms: true, leadingTriviaChars: options.leadingTriviaChars});
 
-  if (parseResult.errors.length > 0) {
+  if (parseResult.errors.length > 0 && !options.ignoreError) {
     const msg = parseResult.errors.map(e => e.toString()).join('\n');
     throw new Error(msg);
   }
@@ -105,7 +107,7 @@ export function parseR3(
       new BindingParser(expressionParser, DEFAULT_INTERPOLATION_CONFIG, schemaRegistry, null, []);
   const r3Result = htmlAstToRender3Ast(htmlNodes, bindingParser);
 
-  if (r3Result.errors.length > 0) {
+  if (r3Result.errors.length > 0 && !options.ignoreError) {
     const msg = r3Result.errors.map(e => e.toString()).join('\n');
     throw new Error(msg);
   }


### PR DESCRIPTION
Now when the animation trigger output event is missing its phase value name, the `BoundEvent` will be ignored, but it's useful for completion in language service.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
