### PR TITLE
fix(core): unsubscribe from the `onError` when the root view is removed

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -350,12 +350,17 @@ export class PlatformRef {
       if (!exceptionHandler) {
         throw new Error('No ErrorHandler. Is platform module (BrowserModule) included?');
       }
-      moduleRef.onDestroy(() => remove(this._modules, moduleRef));
-      ngZone!.runOutsideAngular(() => ngZone!.onError.subscribe({
-        next: (error: any) => {
-          exceptionHandler.handleError(error);
-        }
-      }));
+      ngZone!.runOutsideAngular(() => {
+        const subscription = ngZone!.onError.subscribe({
+          next: (error: any) => {
+            exceptionHandler.handleError(error);
+          }
+        });
+        moduleRef.onDestroy(() => {
+          remove(this._modules, moduleRef);
+          subscription.unsubscribe();
+        });
+      });
       return _callAndReportToErrorHandler(exceptionHandler, ngZone!, () => {
         const initStatus: ApplicationInitStatus = moduleRef.injector.get(ApplicationInitStatus);
         initStatus.runInitializers();

--- a/packages/core/test/acceptance/bootstrap_spec.ts
+++ b/packages/core/test/acceptance/bootstrap_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, COMPILER_OPTIONS, Component, destroyPlatform, NgModule, TestabilityRegistry, ViewEncapsulation} from '@angular/core';
+import {ApplicationRef, COMPILER_OPTIONS, Component, destroyPlatform, NgModule, NgZone, TestabilityRegistry, ViewEncapsulation} from '@angular/core';
 import {expect} from '@angular/core/testing/src/testing_internal';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
@@ -224,6 +224,22 @@ describe('bootstrap', () => {
 
            expect(appRef.components.length).toBe(0);
            expect(testabilityRegistry.getAllRootElements().length).toBe(0);
+         }));
+    });
+
+    describe('PlatformRef cleanup', () => {
+      it('should unsubscribe from `onError` when Injector is destroyed',
+         withBody('<my-app></my-app>', async () => {
+           const TestModule = createComponentAndModule();
+
+           const ngModuleRef = await platformBrowserDynamic().bootstrapModule(TestModule);
+           const ngZone = ngModuleRef.injector.get(NgZone);
+
+           expect(ngZone.onError.observers.length).toBe(1);
+
+           ngModuleRef.destroy();
+
+           expect(ngZone.onError.observers.length).toBe(0);
          }));
     });
 


### PR DESCRIPTION


## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
At the moment, when creating a root module, a subscription to the `onError` subject is also created. It captures the scope where `NgModuleRef` is created and prevents it from being garbage collected. Also note that this `NgModuleRef` has a reference to the root module instance (e.g. `AppModule`), which also prevents it from being GC'd.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No