### PR TITLE
ci: fix AIO deployment to multiple Firebase sites

### DIFF
--- a/aio/scripts/deploy-to-firebase.js
+++ b/aio/scripts/deploy-to-firebase.js
@@ -250,11 +250,11 @@ function deploy(data) {
   preDeployActions.forEach(fn => fn(data));
 
   console.log('\n\n\n==== Deploy AIO to Firebase hosting. ====\n');
-  yarn(`firebase use "${projectId}" --token "${firebaseToken}"`);
-  yarn(`firebase target:apply hosting aio "${siteId}" --token "${firebaseToken}"`);
-  yarn(
-      `firebase deploy --only hosting:aio --message "Commit: ${currentCommit}" --non-interactive ` +
-      `--token "${firebaseToken}"`);
+  const firebase = cmd => yarn(`firebase ${cmd} --token "${firebaseToken}"`);
+  firebase(`use "${projectId}"`);
+  firebase('target:clear hosting aio');
+  firebase(`target:apply hosting aio "${siteId}"`);
+  firebase(`deploy --only hosting:aio --message "Commit: ${currentCommit}" --non-interactive`);
 
   console.log('\n\n\n==== Run post-deploy actions. ====\n');
   postDeployActions.forEach(fn => fn(data));


### PR DESCRIPTION
Since #39853, it is possible to deploy to multiple Firebase sites from a single branch. In order to deploy to a site, we need to associate an alias (`aio`) with a site. This is done via the `firebase target:apply` command. However, when the command is called multiple times, it associates the alias with many sites, which subsequently fails during deployment ([example failure][1]), since the `firebase deploy` command does not know what site to deploy to.

This commit fixes the deployment script by ensuring that any previous association with the `aio` alias is cleared (via `firebase target:clear`) before associating it with a site.

[1]: https://circleci.com/gh/angular/angular/871020
