### PR TITLE
ci: update l2 triage label configuration for pull requests

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -187,8 +187,6 @@ triagePR:
   # arrays of labels that determine if a PR has been fully triaged
   l2TriageLabels:
     -
-      - "effort*"
-      - "risk*"
       - "comp: *"
 
 # options for rerunning CI


### PR DESCRIPTION
This updates the angular-robot.yml to remove two labels from
l2TriageLabels for PRs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently PRs have L2 Triage that includes risk* and effort*, which are not in use.

Issue Number: N/A


## What is the new behavior?
PR L2 Triage will no longer include those two labels.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

