### PR TITLE
test(compiler-cli): improve compliance test performance

### DIFF
--- a/packages/compiler-cli/src/ngtsc/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/index.ts
@@ -7,5 +7,6 @@
  */
 export * from './src/utils';
 export * from './src/cached_source_files';
+export * from './src/compiler_host';
 export * from './src/mock_file_loading';
 export * from './src/runfile_helpers';

--- a/packages/compiler-cli/src/ngtsc/testing/src/compiler_host.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/src/compiler_host.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+import {NgtscCompilerHost} from '../../file_system';
+import {getCachedSourceFile} from './cached_source_files';
+
+/**
+ * A compiler host intended to improve test performance by caching default library source files for
+ * reuse across tests.
+ */
+export class NgtscTestCompilerHost extends NgtscCompilerHost {
+  getSourceFile(fileName: string, languageVersion: ts.ScriptTarget): ts.SourceFile|undefined {
+    const cachedSf = getCachedSourceFile(fileName, () => this.readFile(fileName));
+    if (cachedSf !== null) {
+      return cachedSf;
+    }
+    return super.getSourceFile(fileName, languageVersion);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_helpers/compile_test.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/compile_test.ts
@@ -7,9 +7,9 @@
  */
 import * as ts from 'typescript';
 
-import {AbsoluteFsPath, FileSystem, NgtscCompilerHost} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
 import {initMockFileSystem} from '../../../src/ngtsc/file_system/testing';
-import {loadStandardTestFiles, loadTestDirectory} from '../../../src/ngtsc/testing';
+import {loadStandardTestFiles, loadTestDirectory, NgtscTestCompilerHost} from '../../../src/ngtsc/testing';
 import {Diagnostics, performCompilation} from '../../../src/perform_compile';
 import {CompilerOptions} from '../../../src/transformers/api';
 
@@ -52,7 +52,7 @@ export function compileTest(
   const outDir = getBuildOutputDirectory(fs);
   const options = getOptions(rootDir, outDir, compilerOptions, angularCompilerOptions);
   const rootNames = files.map(f => fs.resolve(f));
-  const host = new NgtscCompilerHost(fs, options);
+  const host = new NgtscTestCompilerHost(fs, options);
   const {diagnostics, emitResult} = performCompilation({rootNames, host, options});
   const emittedFiles = emitResult ? emitResult.emittedFiles!.map(p => fs.resolve(rootDir, p)) : [];
   const errors = parseDiagnostics(diagnostics);

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -12,13 +12,13 @@ import * as ts from 'typescript';
 
 import {createCompilerHost, createProgram} from '../../index';
 import {main, mainDiagnosticsForTest, readNgcCommandLineAndConfiguration} from '../../src/main';
-import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, NgtscCompilerHost, relativeFrom} from '../../src/ngtsc/file_system';
+import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, relativeFrom} from '../../src/ngtsc/file_system';
 import {Folder, MockFileSystem} from '../../src/ngtsc/file_system/testing';
 import {IndexedComponent} from '../../src/ngtsc/indexer';
 import {NgtscProgram} from '../../src/ngtsc/program';
 import {DeclarationNode} from '../../src/ngtsc/reflection';
 import {LazyRoute} from '../../src/ngtsc/routing';
-import {getCachedSourceFile} from '../../src/ngtsc/testing';
+import {NgtscTestCompilerHost} from '../../src/ngtsc/testing';
 import {setWrapHostForTest} from '../../src/transformers/compiler_host';
 
 
@@ -265,16 +265,6 @@ export class NgtscTestEnvironment {
     const host = createCompilerHost({options});
     const program = createProgram({rootNames, host, options});
     return (program as NgtscProgram).getIndexedComponents();
-  }
-}
-
-class NgtscTestCompilerHost extends NgtscCompilerHost {
-  getSourceFile(fileName: string, languageVersion: ts.ScriptTarget): ts.SourceFile|undefined {
-    const cachedSf = getCachedSourceFile(fileName, () => this.readFile(fileName));
-    if (cachedSf !== null) {
-      return cachedSf;
-    }
-    return super.getSourceFile(fileName, languageVersion);
   }
 }
 


### PR DESCRIPTION
The newly built compliance test runner was not using the shared source
file cache that was added in b627f7f02e714f68a2f6ab0724597ad6107db3ce,
which offers a significant performance boost to the compliance test
targets.