### PR TITLE
perf(animations): use `ngDevMode` to tree-shake warning

### DIFF
--- a/packages/animations/browser/src/render/css_keyframes/css_keyframes_driver.ts
+++ b/packages/animations/browser/src/render/css_keyframes/css_keyframes_driver.ts
@@ -21,7 +21,6 @@ const TAB_SPACE = ' ';
 export class CssKeyframesDriver implements AnimationDriver {
   private _count = 0;
   private readonly _head: any = document.querySelector('head');
-  private _warningIssued = false;
 
   validateStyleProperty(prop: string): boolean {
     return validateStyleProperty(prop);
@@ -79,8 +78,8 @@ export class CssKeyframesDriver implements AnimationDriver {
   animate(
       element: any, keyframes: ɵStyleData[], duration: number, delay: number, easing: string,
       previousPlayers: AnimationPlayer[] = [], scrubberAccessRequested?: boolean): AnimationPlayer {
-    if (scrubberAccessRequested) {
-      this._notifyFaultyScrubber();
+    if ((typeof ngDevMode === 'undefined' || ngDevMode) && scrubberAccessRequested) {
+      notifyFaultyScrubber();
     }
 
     const previousCssKeyframePlayers = <CssKeyframesPlayer[]>previousPlayers.filter(
@@ -117,15 +116,6 @@ export class CssKeyframesDriver implements AnimationDriver {
     player.onDestroy(() => removeElement(kfElm));
     return player;
   }
-
-  private _notifyFaultyScrubber() {
-    if (!this._warningIssued) {
-      console.warn(
-          '@angular/animations: please load the web-animations.js polyfill to allow programmatic access...\n',
-          '  visit https://bit.ly/IWukam to learn more about using the web-animation-js polyfill.');
-      this._warningIssued = true;
-    }
-  }
 }
 
 function flattenKeyframesIntoStyles(keyframes: null|{[key: string]: any}|
@@ -145,4 +135,13 @@ function flattenKeyframesIntoStyles(keyframes: null|{[key: string]: any}|
 
 function removeElement(node: any) {
   node.parentNode.removeChild(node);
+}
+
+let warningIssued = false;
+function notifyFaultyScrubber(): void {
+  if (warningIssued) return;
+  console.warn(
+      '@angular/animations: please load the web-animations.js polyfill to allow programmatic access...\n',
+      '  visit https://bit.ly/IWukam to learn more about using the web-animation-js polyfill.');
+  warningIssued = true;
 }


### PR DESCRIPTION
This commit adds `ngDevMode` guard to show warning only
in dev mode (similar to how things work in other parts of Ivy runtime code).
The `ngDevMode` flag helps to tree-shake this warning from production builds
(in dev mode everything will work as it works right now) to decrease production bundle size.

## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No