### PR TITLE
fix(upgrade): avoid memory leak when removing downgraded components

### DIFF
--- a/packages/upgrade/src/common/src/angular1.ts
+++ b/packages/upgrade/src/common/src/angular1.ts
@@ -126,6 +126,7 @@ export type IAugmentedJQuery = Node[]&{
   data?: (name: string, value?: any) => any;
   text?: () => string;
   inheritedData?: (name: string, value?: any) => any;
+  children?: () => IAugmentedJQuery;
   contents?: () => IAugmentedJQuery;
   parent?: () => IAugmentedJQuery;
   empty?: () => void;

--- a/packages/upgrade/src/common/src/downgrade_component.ts
+++ b/packages/upgrade/src/common/src/downgrade_component.ts
@@ -174,8 +174,8 @@ export function downgradeComponent(info: {
 
           const injectorPromise = new ParentInjectorPromise(element);
           const facade = new DowngradeComponentAdapter(
-              element, attrs, scope, ngModel, injector, $injector, $compile, $parse,
-              componentFactory, wrapCallback);
+              element, attrs, scope, ngModel, injector, $compile, $parse, componentFactory,
+              wrapCallback);
 
           const projectableNodes = facade.compileContents();
           facade.createComponent(projectableNodes);

--- a/packages/upgrade/src/common/src/downgrade_component_adapter.ts
+++ b/packages/upgrade/src/common/src/downgrade_component_adapter.ts
@@ -8,7 +8,7 @@
 
 import {ApplicationRef, ChangeDetectorRef, ComponentFactory, ComponentRef, EventEmitter, Injector, OnChanges, SimpleChange, SimpleChanges, StaticProvider, Testability, TestabilityRegistry, Type} from '@angular/core';
 
-import {IAttributes, IAugmentedJQuery, ICompileService, IInjectorService, INgModelController, IParseService, IScope} from './angular1';
+import {IAttributes, IAugmentedJQuery, ICompileService, INgModelController, IParseService, IScope} from './angular1';
 import {PropertyBinding} from './component_info';
 import {$SCOPE} from './constants';
 import {getTypeName, hookupNgModel, strictEquals} from './util';
@@ -33,8 +33,8 @@ export class DowngradeComponentAdapter {
   constructor(
       private element: IAugmentedJQuery, private attrs: IAttributes, private scope: IScope,
       private ngModel: INgModelController, private parentInjector: Injector,
-      private $injector: IInjectorService, private $compile: ICompileService,
-      private $parse: IParseService, private componentFactory: ComponentFactory<any>,
+      private $compile: ICompileService, private $parse: IParseService,
+      private componentFactory: ComponentFactory<any>,
       private wrapCallback: <T>(cb: () => T) => () => T) {
     this.componentScope = scope.$new();
   }
@@ -250,7 +250,6 @@ export class DowngradeComponentAdapter {
  */
 export function groupNodesBySelector(ngContentSelectors: string[], nodes: Node[]): Node[][] {
   const projectableNodes: Node[][] = [];
-  let wildcardNgContentIndex: number;
 
   for (let i = 0, ii = ngContentSelectors.length; i < ii; ++i) {
     projectableNodes[i] = [];

--- a/packages/upgrade/src/common/src/downgrade_component_adapter.ts
+++ b/packages/upgrade/src/common/src/downgrade_component_adapter.ts
@@ -246,7 +246,7 @@ export class DowngradeComponentAdapter {
         // `cleanData()` also will invoke the AngularJS `$destroy` event on the element:
         //   https://github.com/angular/angular.js/blob/2e72ea13fa98bebf6ed4b5e3c45eaf5f990ed16f/src/Angular.js#L1932-L1945
         angularElement.cleanData(this.element);
-        angularElement.cleanData(this.element.children!());
+        angularElement.cleanData((this.element[0] as Element).querySelectorAll('*'));
 
         destroyComponentRef();
       }

--- a/packages/upgrade/src/common/src/downgrade_component_adapter.ts
+++ b/packages/upgrade/src/common/src/downgrade_component_adapter.ts
@@ -8,7 +8,7 @@
 
 import {ApplicationRef, ChangeDetectorRef, ComponentFactory, ComponentRef, EventEmitter, Injector, OnChanges, SimpleChange, SimpleChanges, StaticProvider, Testability, TestabilityRegistry, Type} from '@angular/core';
 
-import {IAttributes, IAugmentedJQuery, ICompileService, INgModelController, IParseService, IScope} from './angular1';
+import {element as angularElement, IAttributes, IAugmentedJQuery, ICompileService, INgModelController, IParseService, IScope} from './angular1';
 import {PropertyBinding} from './component_info';
 import {$SCOPE} from './constants';
 import {getTypeName, hookupNgModel, strictEquals} from './util';
@@ -216,11 +216,38 @@ export class DowngradeComponentAdapter {
     const destroyComponentRef = this.wrapCallback(() => this.componentRef.destroy());
     let destroyed = false;
 
-    this.element.on!('$destroy', () => this.componentScope.$destroy());
+    this.element.on!('$destroy', () => {
+      // The `$destroy` event may have been triggered by the `cleanData()` call in the
+      // `componentScope` `$destroy` handler below. In that case, we don't want to call
+      // `componentScope.$destroy()` again.
+      if (!destroyed) this.componentScope.$destroy();
+    });
     this.componentScope.$on('$destroy', () => {
       if (!destroyed) {
         destroyed = true;
         testabilityRegistry.unregisterApplication(this.componentRef.location.nativeElement);
+
+        // The `componentScope` might be getting destroyed, because an ancestor element is being
+        // removed/destroyed. If that is the case, jqLite/jQuery would normally invoke `cleanData()`
+        // on the removed element and all descendants.
+        //   https://github.com/angular/angular.js/blob/2e72ea13fa98bebf6ed4b5e3c45eaf5f990ed16f/src/jqLite.js#L349-L355
+        //   https://github.com/jquery/jquery/blob/6984d1747623dbc5e87fd6c261a5b6b1628c107c/src/manipulation.js#L182
+        //
+        // Here, however, `destroyComponentRef()` may under some circumstances remove the element
+        // from the DOM and therefore it will no longer be a descendant of the removed element when
+        // `cleanData()` is called. This would result in a memory leak, because the element's data
+        // and event handlers (and all objects directly or indirectly referenced by them) would be
+        // retained.
+        //
+        // To ensure the element is always properly cleaned up, we manually call `cleanData()` on
+        // this element and its descendants before destroying the `ComponentRef`.
+        //
+        // NOTE:
+        // `cleanData()` also will invoke the AngularJS `$destroy` event on the element:
+        //   https://github.com/angular/angular.js/blob/2e72ea13fa98bebf6ed4b5e3c45eaf5f990ed16f/src/Angular.js#L1932-L1945
+        angularElement.cleanData(this.element);
+        angularElement.cleanData(this.element.children!());
+
         destroyComponentRef();
       }
     });

--- a/packages/upgrade/src/common/src/upgrade_helper.ts
+++ b/packages/upgrade/src/common/src/upgrade_helper.ts
@@ -41,8 +41,7 @@ export class UpgradeHelper {
   private readonly $controller: IControllerService;
 
   constructor(
-      private injector: Injector, private name: string, elementRef: ElementRef,
-      directive?: IDirective) {
+      injector: Injector, private name: string, elementRef: ElementRef, directive?: IDirective) {
     this.$injector = injector.get($INJECTOR);
     this.$compile = this.$injector.get($COMPILE);
     this.$controller = this.$injector.get($CONTROLLER);

--- a/packages/upgrade/src/common/test/downgrade_component_adapter_spec.ts
+++ b/packages/upgrade/src/common/test/downgrade_component_adapter_spec.ts
@@ -131,7 +131,6 @@ withEachNg1Version(() => {
         let scope: angular.IScope;  // mock
         let ngModel = undefined as any;
         let parentInjector: Injector;  // testbed
-        let $injector = undefined as any;
         let $compile = undefined as any;
         let $parse = undefined as any;
         let componentFactory: ComponentFactory<any>;  // testbed
@@ -166,8 +165,8 @@ withEachNg1Version(() => {
         parentInjector = TestBed;
 
         return new DowngradeComponentAdapter(
-            element, attrs, scope, ngModel, parentInjector, $injector, $compile, $parse,
-            componentFactory, wrapCallback);
+            element, attrs, scope, ngModel, parentInjector, $compile, $parse, componentFactory,
+            wrapCallback);
       }
 
       beforeEach(() => {

--- a/packages/upgrade/static/test/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_component_spec.ts
@@ -536,7 +536,7 @@ withEachNg1Version(() => {
 
     it('should properly run cleanup when ng1 directive is destroyed', waitForAsync(() => {
          let destroyed = false;
-         @Component({selector: 'ng2', template: '<span>test</span>'})
+         @Component({selector: 'ng2', template: '<ul><li>test1</li><li>test2</li></ul>'})
          class Ng2Component implements OnDestroy {
            ngOnDestroy() {
              destroyed = true;
@@ -565,31 +565,33 @@ withEachNg1Version(() => {
            adapter.bootstrap(element, [ng1Module.name]);
 
            const ng2Element = angular.element(element.querySelector('ng2') as Element);
-           const ng2Children = (ng2Element as any).children!();
+           const ng2Descendants =
+               Array.from(element.querySelectorAll('ng2 li')).map(angular.element);
            let ng2ElementDestroyed = false;
-           let ng2ChildrenDestroyed = false;
+           let ng2DescendantsDestroyed = [false, false];
 
-           ng2Element.data!('foo', 1);
-           ng2Children.data!('bar', 2);
+           ng2Element.data!('test', 42);
+           ng2Descendants.forEach((elem, i) => elem.data!('test', i));
            ng2Element.on!('$destroy', () => ng2ElementDestroyed = true);
-           ng2Children.on!('$destroy', () => ng2ChildrenDestroyed = true);
+           ng2Descendants.forEach(
+               (elem, i) => elem.on!('$destroy', () => ng2DescendantsDestroyed[i] = true));
 
-           expect(element.textContent).toContain('test');
+           expect(element.textContent).toBe('test1test2');
            expect(destroyed).toBe(false);
-           expect(ng2Element.data!('foo')).toBe(1);
-           expect(ng2Children.data!('bar')).toBe(2);
+           expect(ng2Element.data!('test')).toBe(42);
+           ng2Descendants.forEach((elem, i) => expect(elem.data!('test')).toBe(i));
            expect(ng2ElementDestroyed).toBe(false);
-           expect(ng2ChildrenDestroyed).toBe(false);
+           expect(ng2DescendantsDestroyed).toEqual([false, false]);
 
            const $rootScope = adapter.$injector.get('$rootScope');
            $rootScope.$apply('destroyIt = true');
 
-           expect(element.textContent).not.toContain('test');
+           expect(element.textContent).toBe('');
            expect(destroyed).toBe(true);
-           expect(ng2Element.data!('foo')).toBeUndefined();
-           expect(ng2Children.data!('baz')).toBeUndefined();
+           expect(ng2Element.data!('test')).toBeUndefined();
+           ng2Descendants.forEach(elem => expect(elem.data!('test')).toBeUndefined());
            expect(ng2ElementDestroyed).toBe(true);
-           expect(ng2ChildrenDestroyed).toBe(true);
+           expect(ng2DescendantsDestroyed).toEqual([true, true]);
          });
        }));
 

--- a/packages/upgrade/static/test/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_module_spec.ts
@@ -1191,7 +1191,7 @@ withEachNg1Version(() => {
          waitForAsync(() => {
            let destroyed = false;
 
-           @Component({selector: 'ng2', template: '<span>test</span>'})
+           @Component({selector: 'ng2', template: '<ul><li>test1</li><li>test2</li></ul>'})
            class Ng2Component implements OnDestroy {
              ngOnDestroy() {
                destroyed = true;
@@ -1219,34 +1219,34 @@ withEachNg1Version(() => {
            const $injector = angular.bootstrap(element, [ng1Module.name]);
            const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           setTimeout(() => {    // Wait for the module to be bootstrapped.
-             setTimeout(() => {  // Wait for the hostView to be attached (during the `$digest`).
-               const ng2Element = angular.element(element.querySelector('ng2') as Element);
-               const ng2Children = (ng2Element as any).children!();
-               let ng2ElementDestroyed = false;
-               let ng2ChildrenDestroyed = false;
+           setTimeout(() => {  // Wait for the module to be bootstrapped.
+             const ng2Element = angular.element(element.querySelector('ng2') as Element);
+             const ng2Descendants =
+                 Array.from(element.querySelectorAll('ng2 li')).map(angular.element);
+             let ng2ElementDestroyed = false;
+             let ng2DescendantsDestroyed = [false, false];
 
-               ng2Element.data!('foo', 1);
-               ng2Children.data!('bar', 2);
-               ng2Element.on!('$destroy', () => ng2ElementDestroyed = true);
-               ng2Children.on!('$destroy', () => ng2ChildrenDestroyed = true);
+             ng2Element.data!('test', 42);
+             ng2Descendants.forEach((elem, i) => elem.data!('test', i));
+             ng2Element.on!('$destroy', () => ng2ElementDestroyed = true);
+             ng2Descendants.forEach(
+                 (elem, i) => elem.on!('$destroy', () => ng2DescendantsDestroyed[i] = true));
 
-               expect(element.textContent).toContain('test');
-               expect(destroyed).toBe(false);
-               expect(ng2Element.data!('foo')).toBe(1);
-               expect(ng2Children.data!('bar')).toBe(2);
-               expect(ng2ElementDestroyed).toBe(false);
-               expect(ng2ChildrenDestroyed).toBe(false);
+             expect(element.textContent).toBe('test1test2');
+             expect(destroyed).toBe(false);
+             expect(ng2Element.data!('test')).toBe(42);
+             ng2Descendants.forEach((elem, i) => expect(elem.data!('test')).toBe(i));
+             expect(ng2ElementDestroyed).toBe(false);
+             expect(ng2DescendantsDestroyed).toEqual([false, false]);
 
-               $rootScope.$apply('hideNg2 = true');
+             $rootScope.$apply('hideNg2 = true');
 
-               expect(element.textContent).not.toContain('test');
-               expect(destroyed).toBe(true);
-               expect(ng2Element.data!('foo')).toBeUndefined();
-               expect(ng2Children.data!('baz')).toBeUndefined();
-               expect(ng2ElementDestroyed).toBe(true);
-               expect(ng2ChildrenDestroyed).toBe(true);
-             });
+             expect(element.textContent).toBe('');
+             expect(destroyed).toBe(true);
+             expect(ng2Element.data!('test')).toBeUndefined();
+             ng2Descendants.forEach(elem => expect(elem.data!('test')).toBeUndefined());
+             expect(ng2ElementDestroyed).toBe(true);
+             expect(ng2DescendantsDestroyed).toEqual([true, true]);
            });
          }));
 

--- a/packages/upgrade/static/test/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_module_spec.ts
@@ -1187,6 +1187,69 @@ withEachNg1Version(() => {
            });
          }));
 
+      it('should properly run cleanup when a downgraded component is destroyed',
+         waitForAsync(() => {
+           let destroyed = false;
+
+           @Component({selector: 'ng2', template: '<span>test</span>'})
+           class Ng2Component implements OnDestroy {
+             ngOnDestroy() {
+               destroyed = true;
+             }
+           }
+
+           @NgModule({
+             declarations: [Ng2Component],
+             entryComponents: [Ng2Component],
+             imports: [BrowserModule],
+           })
+           class Ng2Module {
+             ngDoBootstrap() {}
+           }
+
+           const bootstrapFn = (extraProviders: StaticProvider[]) =>
+               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+           const ng1Module =
+               angular.module_('ng1', [lazyModuleName])
+                   .directive(
+                       'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
+
+           const element = html('<div><div ng-if="!hideNg2"><ng2></ng2></div></div>');
+           const $injector = angular.bootstrap(element, [ng1Module.name]);
+           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+
+           setTimeout(() => {    // Wait for the module to be bootstrapped.
+             setTimeout(() => {  // Wait for the hostView to be attached (during the `$digest`).
+               const ng2Element = angular.element(element.querySelector('ng2') as Element);
+               const ng2Children = (ng2Element as any).children!();
+               let ng2ElementDestroyed = false;
+               let ng2ChildrenDestroyed = false;
+
+               ng2Element.data!('foo', 1);
+               ng2Children.data!('bar', 2);
+               ng2Element.on!('$destroy', () => ng2ElementDestroyed = true);
+               ng2Children.on!('$destroy', () => ng2ChildrenDestroyed = true);
+
+               expect(element.textContent).toContain('test');
+               expect(destroyed).toBe(false);
+               expect(ng2Element.data!('foo')).toBe(1);
+               expect(ng2Children.data!('bar')).toBe(2);
+               expect(ng2ElementDestroyed).toBe(false);
+               expect(ng2ChildrenDestroyed).toBe(false);
+
+               $rootScope.$apply('hideNg2 = true');
+
+               expect(element.textContent).not.toContain('test');
+               expect(destroyed).toBe(true);
+               expect(ng2Element.data!('foo')).toBeUndefined();
+               expect(ng2Children.data!('baz')).toBeUndefined();
+               expect(ng2ElementDestroyed).toBe(true);
+               expect(ng2ChildrenDestroyed).toBe(true);
+             });
+           });
+         }));
+
       it('should only retrieve the Angular zone once (and cache it for later use)',
          fakeAsync(() => {
            let count = 0;


### PR DESCRIPTION
_This is an alternative to #39921._

##
Previously, due to the way the AngularJS and Angular clean-up processes interfere with each other when removing an AngularJS element that contains a downgraded Angular component, the data associated with the host element of the downgraded component was not removed. This data was kept in an internal AngularJS cache, which prevented the element and component instance from being garbage-collected, leading to memory leaks.

This commit fixes this by ensuring the element data is explicitly removed when cleaning up a downgraded component.

NOTE:
This is essentially the equivalent of #26209 but for downgraded (instead of upgraded) components.

Fixes #39911
Closes #39921