### PR TITLE
refactor(language-service): move template parse diagnostics to template type checker

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -466,6 +466,7 @@ export class NgCompiler {
     let typeCheckingConfig: TypeCheckingConfig;
     if (this.fullTemplateTypeCheck) {
       typeCheckingConfig = {
+        parseErrorsOnly: false,
         applyTemplateContextGuards: strictTemplates,
         checkQueries: false,
         checkTemplateBodies: true,
@@ -495,6 +496,7 @@ export class NgCompiler {
       };
     } else {
       typeCheckingConfig = {
+        parseErrorsOnly: !this.options.ivyTemplateTypeCheck,
         applyTemplateContextGuards: false,
         checkQueries: false,
         checkTemplateBodies: false,
@@ -559,11 +561,6 @@ export class NgCompiler {
   }
 
   private getTemplateDiagnostics(): ReadonlyArray<ts.Diagnostic> {
-    // Skip template type-checking if it's disabled.
-    if (this.options.ivyTemplateTypeCheck === false && !this.fullTemplateTypeCheck) {
-      return [];
-    }
-
     const compilation = this.ensureAnalyzed();
 
     // Get the diagnostics.

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -80,6 +80,12 @@ export interface TypeCtorMetadata {
 
 export interface TypeCheckingConfig {
   /**
+   * Supersedes all other options. If true, only produces diagnostics from template parse errors.
+   * Otherwise, proceeds with template type checking as configured.
+   */
+  parseErrorsOnly: boolean;
+
+  /**
    * Whether to check the left-hand side type of binding operations.
    *
    * For example, if this is `false` then the expression `[input]="expr"` will have `expr` type-

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/context.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ParseSourceFile, R3TargetBinder, SchemaMetadata, TmplAstNode} from '@angular/compiler';
+import {ParseError, ParseSourceFile, R3TargetBinder, SchemaMetadata, TmplAstNode} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {Reference} from '../../imports';
@@ -40,7 +40,8 @@ export interface TypeCheckContext {
       ref: Reference<ClassDeclaration<ts.ClassDeclaration>>,
       binder: R3TargetBinder<TypeCheckableDirectiveMeta>, template: TmplAstNode[],
       pipes: Map<string, Reference<ClassDeclaration<ts.ClassDeclaration>>>,
-      schemas: SchemaMetadata[], sourceMapping: TemplateSourceMapping, file: ParseSourceFile): void;
+      schemas: SchemaMetadata[], sourceMapping: TemplateSourceMapping, file: ParseSourceFile,
+      parseErrors: ParseError[]|null): void;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -202,8 +202,8 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
   }
 
   /**
-   * Retrieve type-checking diagnostics from the given `ts.SourceFile` using the most recent
-   * type-checking program.
+   * Retrieve type-checking and template parse diagnostics from the given `ts.SourceFile` using the
+   * most recent type-checking program.
    */
   getDiagnosticsForFile(sf: ts.SourceFile, optimizeFor: OptimizeFor): ts.Diagnostic[] {
     switch (optimizeFor) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BoundTarget, ParseSourceFile, R3TargetBinder, SchemaMetadata, TmplAstNode} from '@angular/compiler';
+import {BoundTarget, ParseError, ParseSourceFile, R3TargetBinder, SchemaMetadata, TmplAstNode} from '@angular/compiler';
+import {ErrorCode, ngErrorCode} from '@angular/compiler-cli/src/ngtsc/diagnostics';
 import * as ts from 'typescript';
 
 import {absoluteFromSourceFile, AbsoluteFsPath} from '../../file_system';
@@ -14,7 +15,7 @@ import {NoopImportRewriter, Reference, ReferenceEmitter} from '../../imports';
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
 import {ImportManager} from '../../translator';
 import {ComponentToShimMappingStrategy, TemplateId, TemplateSourceMapping, TypeCheckableDirectiveMeta, TypeCheckBlockMetadata, TypeCheckContext, TypeCheckingConfig, TypeCtorMetadata} from '../api';
-import {TemplateDiagnostic} from '../diagnostics';
+import {makeTemplateDiagnostic, TemplateDiagnostic} from '../diagnostics';
 
 import {DomSchemaChecker, RegistryDomSchemaChecker} from './dom';
 import {Environment} from './environment';
@@ -108,6 +109,8 @@ export interface PendingShimData {
    * Map of `TemplateId` to information collected about the template as it's ingested.
    */
   templates: Map<TemplateId, TemplateData>;
+
+  templateParseDiagnostics: TemplateDiagnostic[];
 }
 
 /**
@@ -135,6 +138,7 @@ export interface TypeCheckingHost {
   /**
    * Check if the given component has had its template overridden, and retrieve the new template
    * nodes if so.
+   * TODO(Ayaz): store parse errors from overridden template
    */
   getTemplateOverride(sfPath: AbsoluteFsPath, node: ts.ClassDeclaration): TmplAstNode[]|null;
 
@@ -205,9 +209,16 @@ export class TypeCheckContextImpl implements TypeCheckContext {
       ref: Reference<ClassDeclaration<ts.ClassDeclaration>>,
       binder: R3TargetBinder<TypeCheckableDirectiveMeta>, template: TmplAstNode[],
       pipes: Map<string, Reference<ClassDeclaration<ts.ClassDeclaration>>>,
-      schemas: SchemaMetadata[], sourceMapping: TemplateSourceMapping,
-      file: ParseSourceFile): void {
+      schemas: SchemaMetadata[], sourceMapping: TemplateSourceMapping, file: ParseSourceFile,
+      parseErrors: ParseError[]|null): void {
     if (!this.host.shouldCheckComponent(ref.node)) {
+      return;
+    }
+    if (parseErrors !== null) {
+      this.produceTemplateParseDiagnostics(ref, parseErrors, sourceMapping);
+    }
+    // Skip template type-checking if it's disabled.
+    if (this.config.parseErrorsOnly) {
       return;
     }
 
@@ -292,6 +303,32 @@ export class TypeCheckContextImpl implements TypeCheckContext {
       // The class can be type-checked externally as normal.
       shimData.file.addTypeCheckBlock(ref, meta, shimData.domSchemaChecker, shimData.oobRecorder);
     }
+  }
+
+  private produceTemplateParseDiagnostics(
+      ref: Reference<ClassDeclaration<ts.ClassDeclaration>>, parseErrors: ParseError[],
+      sourceMapping: TemplateSourceMapping): void {
+    // TODO(Ayaz): get parse errors from template override
+    const fileData = this.dataForFile(ref.node.getSourceFile());
+    const shimData = this.pendingShimForComponent(ref.node);
+    const templateId = fileData.sourceManager.getTemplateId(ref.node);
+
+    // If there are any template parsing errors, convert them to `ts.Diagnostic`s for display.
+    shimData.templateParseDiagnostics = parseErrors.map(error => {
+      const span = error.span;
+
+      if (span.start.offset === span.end.offset) {
+        // Template errors can contain zero-length spans, if the error occurs at a single point.
+        // However, TypeScript does not handle displaying a zero-length diagnostic very well, so
+        // increase the ending offset by 1 for such errors, to ensure the position is shown in the
+        // diagnostic.
+        span.end.offset++;
+      }
+
+      return makeTemplateDiagnostic(
+          templateId, sourceMapping, span, ts.DiagnosticCategory.Error,
+          ngErrorCode(ErrorCode.TEMPLATE_PARSE_ERROR), error.msg);
+    });
   }
 
   /**
@@ -379,6 +416,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
           genesisDiagnostics: [
             ...pendingShimData.domSchemaChecker.diagnostics,
             ...pendingShimData.oobRecorder.diagnostics,
+            ...pendingShimData.templateParseDiagnostics,
           ],
           hasInlines: pendingFileData.hasInlines,
           path: pendingShimData.file.fileName,
@@ -413,6 +451,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
       fileData.shimData.set(shimPath, {
         domSchemaChecker: new RegistryDomSchemaChecker(fileData.sourceManager),
         oobRecorder: new OutOfBandDiagnosticRecorderImpl(fileData.sourceManager),
+        templateParseDiagnostics: [],
         file: new TypeCheckFile(
             shimPath, this.config, this.refEmitter, this.reflector, this.compilerHost),
         templates: new Map<TemplateId, TemplateData>(),

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -314,7 +314,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
     const templateId = fileData.sourceManager.getTemplateId(ref.node);
 
     // If there are any template parsing errors, convert them to `ts.Diagnostic`s for display.
-    shimData.templateParseDiagnostics = parseErrors.map(error => {
+    const templateDiagnostics = parseErrors.map(error => {
       const span = error.span;
 
       if (span.start.offset === span.end.offset) {
@@ -329,6 +329,9 @@ export class TypeCheckContextImpl implements TypeCheckContext {
           templateId, sourceMapping, span, ts.DiagnosticCategory.Error,
           ngErrorCode(ErrorCode.TEMPLATE_PARSE_ERROR), error.msg);
     });
+
+    // And add the `ts.Diagnostics` to the shim. Shims can contain more than one template.
+    shimData.templateParseDiagnostics.push(...templateDiagnostics);
   }
 
   /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -165,6 +165,7 @@ export function ngForTypeCheckTarget(): TypeCheckingTarget {
 }
 
 export const ALL_ENABLED_CONFIG: TypeCheckingConfig = {
+  parseErrorsOnly: false,
   applyTemplateContextGuards: true,
   checkQueries: false,
   checkTemplateBodies: true,
@@ -407,7 +408,7 @@ export function setup(targets: TypeCheckingTarget[], overrides: {
           node: classRef.node.name,
         };
 
-        ctx.addTemplate(classRef, binder, nodes, pipes, [], sourceMapping, templateFile);
+        ctx.addTemplate(classRef, binder, nodes, pipes, [], sourceMapping, templateFile, errors);
       }
     }
   });

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -717,6 +717,7 @@ describe('type check blocks', () => {
       hasNgTemplateContextGuard: true,
     }];
     const BASE_CONFIG: TypeCheckingConfig = {
+      parseErrorsOnly: false,
       applyTemplateContextGuards: true,
       checkQueries: false,
       checkTemplateBodies: true,

--- a/packages/language-service/ivy/test/diagnostic_spec.ts
+++ b/packages/language-service/ivy/test/diagnostic_spec.ts
@@ -131,4 +131,48 @@ describe('getSemanticDiagnostics', () => {
         .toBe(
             `Parser Error: Bindings cannot contain assignments at column 8 in [{{nope = true}}] in /app.html@0:0`);
   });
+
+  it('should report parse errors of components defined in the same ts file', () => {
+    const appFile = {
+      name: absoluteFrom('/app.ts'),
+      contents: `
+      import {Component, NgModule} from '@angular/core';
+
+      @Component({ templateUrl: './app1.html' })
+      export class AppComponent1 { nope = false; }
+
+      @Component({ templateUrl: './app2.html' })
+      export class AppComponent2 { nope = false; }
+    `
+    };
+    const templateFile1 = {name: absoluteFrom('/app1.html'), contents: `{{nope = false}}`};
+    const templateFile2 = {name: absoluteFrom('/app2.html'), contents: `{{nope = true}}`};
+
+    const moduleFile = {
+      name: absoluteFrom('/app-module.ts'),
+      contents: `
+        import {NgModule} from '@angular/core';
+        import {CommonModule} from '@angular/common';
+        import {AppComponent, AppComponent2} from './app';
+
+        @NgModule({
+          declarations: [AppComponent, AppComponent2],
+          imports: [CommonModule],
+        })
+        export class AppModule {}
+    `,
+      isRoot: true
+    };
+
+    const env =
+        LanguageServiceTestEnvironment.setup([moduleFile, appFile, templateFile1, templateFile2]);
+
+    const diags = env.ngLS.getSemanticDiagnostics(absoluteFrom('/app.ts'));
+    expect(diags.length).toEqual(2);
+
+    expect(diags.map(x => x.messageText).sort()).toEqual([
+      'Parser Error: Bindings cannot contain assignments at column 8 in [{{nope = false}}] in /app1.html@0:0',
+      'Parser Error: Bindings cannot contain assignments at column 8 in [{{nope = true}}] in /app2.html@0:0'
+    ]);
+  })
 });


### PR DESCRIPTION

Rather than template diagnostics being produced from two different locations
(`ComponentDecoratorHandler` and `templateTypeChecker`), we have refactored
this to have `TemplateDiagnostics` be produced only by the `templateTypeChecker`.

This also makes the template parse diagnostics available to the language
service `getSemanticDiagnostics` as currently implemented.