### PR TITLE
fix(core): Support extending differs from root `NgModule`

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3153,
-        "main-es2015": 431696,
+        "main-es2015": 431137,
         "polyfills-es2015": 52493
       }
     }

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 140921,
+        "main-es2015": 140333,
         "polyfills-es2015": 36964
       }
     }

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -855,7 +855,13 @@
     "name": "defaultIterableDiffers"
   },
   {
+    "name": "defaultIterableDiffersFactory"
+  },
+  {
     "name": "defaultKeyValueDiffers"
+  },
+  {
+    "name": "defaultKeyValueDiffersFactory"
   },
   {
     "name": "defaultScheduler"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1122,7 +1122,13 @@
     "name": "defaultIterableDiffers"
   },
   {
+    "name": "defaultIterableDiffersFactory"
+  },
+  {
     "name": "defaultKeyValueDiffers"
+  },
+  {
+    "name": "defaultKeyValueDiffersFactory"
   },
   {
     "name": "defaultMalformedUriErrorHandler"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -282,6 +282,9 @@
     "name": "defaultErrorLogger"
   },
   {
+    "name": "defaultIterableDiffersFactory"
+  },
+  {
     "name": "defaultScheduler"
   },
   {

--- a/packages/core/test/change_detection/differs/keyvalue_differs_spec.ts
+++ b/packages/core/test/change_detection/differs/keyvalue_differs_spec.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers, NgModule} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+
+describe('KeyValueDiffers', function() {
+  it('should support .extend in root NgModule', () => {
+    const DIFFER: KeyValueDiffer<any, any> = {} as any;
+    const log: string[] = [];
+    class MyKeyValueDifferFactory implements KeyValueDifferFactory {
+      supports(objects: any): boolean {
+        log.push('supports', objects);
+        return true;
+      }
+      create<K, V>(): KeyValueDiffer<K, V> {
+        log.push('create');
+        return DIFFER;
+      }
+    }
+
+
+    @NgModule({providers: [KeyValueDiffers.extend([new MyKeyValueDifferFactory()])]})
+    class MyModule {
+    }
+
+    TestBed.configureTestingModule({imports: [MyModule]});
+    const differs = TestBed.inject(KeyValueDiffers);
+    const differ = differs.find('VALUE').create();
+    expect(differ).toEqual(DIFFER);
+    expect(log).toEqual(['supports', 'VALUE', 'create']);
+  });
+});


### PR DESCRIPTION
Differs tries to inject parent differ in order to support extending.
This does not work in the 'root' injector as the provider overrides the
default injector. The fix is to just assume standard set of providers
and extend those instead.

PR Close #25015
Issue close #11309 `Can't extend IterableDiffers`
Issue close #18554 `IterableDiffers.extend is not AOT compatible` (This is fixed because we no longer have an arrow function in the  factory but a proper function which can be imported.)


## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
