### PR TITLE
fix(animations): implement getPosition in browser animation builder

### DIFF
--- a/packages/animations/src/players/animation_group_player.ts
+++ b/packages/animations/src/players/animation_group_player.ts
@@ -148,12 +148,13 @@ export class AnimationGroupPlayer implements AnimationPlayer {
   }
 
   getPosition(): number {
-    let min = 0;
-    this.players.forEach(player => {
-      const p = player.getPosition();
-      min = Math.min(p, min);
-    });
-    return min;
+    const longestPlayer =
+        this.players.reduce((longestSoFar: AnimationPlayer|null, player: AnimationPlayer) => {
+          const newPlayerIsLongest =
+              longestSoFar === null || player.totalTime > longestSoFar.totalTime;
+          return newPlayerIsLongest ? player : longestSoFar;
+        }, null);
+    return longestPlayer != null ? longestPlayer.getPosition() : 0;
   }
 
   beforeDestroy(): void {

--- a/packages/animations/src/players/animation_player.ts
+++ b/packages/animations/src/players/animation_player.ts
@@ -124,6 +124,7 @@ export class NoopAnimationPlayer implements AnimationPlayer {
   private _started = false;
   private _destroyed = false;
   private _finished = false;
+  private _position = 0;
   public parentPlayer: AnimationPlayer|null = null;
   public readonly totalTime: number;
   constructor(duration: number = 0, delay: number = 0) {
@@ -184,9 +185,11 @@ export class NoopAnimationPlayer implements AnimationPlayer {
     }
   }
   reset(): void {}
-  setPosition(position: number): void {}
+  setPosition(position: number): void {
+    this._position = this.totalTime ? position * this.totalTime : 1;
+  }
   getPosition(): number {
-    return 0;
+    return this.totalTime ? this._position / this.totalTime : 1;
   }
 
   /** @internal */

--- a/packages/animations/test/animation_group_player_spec.ts
+++ b/packages/animations/test/animation_group_player_spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {fakeAsync} from '@angular/core/testing';
+import {NoopAnimationPlayer} from '../src/animations';
+import {AnimationGroupPlayer} from '../src/players/animation_group_player';
+
+
+describe('AnimationGroupPlayer', () => {
+  it('should getPosition of an empty group', fakeAsync(() => {
+       const players: NoopAnimationPlayer[] = [];
+       const groupPlayer = new AnimationGroupPlayer(players);
+       expect(groupPlayer.getPosition()).toBe(0);
+     }));
+
+  it('should getPosition of a single player in a group', fakeAsync(() => {
+       const player = new NoopAnimationPlayer(5, 5);
+       player.setPosition(0.2);
+       const players = [player];
+       const groupPlayer = new AnimationGroupPlayer(players);
+       expect(groupPlayer.getPosition()).toBe(0.2);
+     }));
+
+  it('should getPosition based on the longest player in the group', fakeAsync(() => {
+       const longestPlayer = new NoopAnimationPlayer(5, 5);
+       longestPlayer.setPosition(0.2);
+       const players = [
+         new NoopAnimationPlayer(1, 4),
+         new NoopAnimationPlayer(4, 1),
+         new NoopAnimationPlayer(7, 0),
+         longestPlayer,
+         new NoopAnimationPlayer(1, 1),
+       ];
+       const groupPlayer = new AnimationGroupPlayer(players);
+       expect(groupPlayer.getPosition()).toBe(0.2);
+     }));
+});

--- a/packages/platform-browser/animations/src/animation_builder.ts
+++ b/packages/platform-browser/animations/src/animation_builder.ts
@@ -111,7 +111,7 @@ export class RendererAnimationPlayer implements AnimationPlayer {
   }
 
   getPosition(): number {
-    return 0;
+    return this._renderer.engine.players[+this.id]?.getPosition() ?? 0;
   }
 
   public totalTime = 0;


### PR DESCRIPTION
Accidently closed #28264 re-opening it here.

Forward `getPosition` to `animation_group_player`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
