### PR TITLE
refactor(compiler-cli): add script to update all golden partial files

### DIFF
--- a/packages/compiler-cli/test/compliance/README.md
+++ b/packages/compiler-cli/test/compliance/README.md
@@ -163,6 +163,11 @@ bazel run //packages/compiler-cli/test/compliance/test_cases:<path/to/test_case>
 where to replace `<path/to/test_case>` with the path (relative to `test_cases`) of the directory
 that contains the `GOLDEN_PARTIAL.js` to update.
 
+To update all golden partial files, the following command can be run:
+
+```sh
+node packages/compiler-cli/test/compliance/update_all_goldens.js
+```
 
 ## Debugging test-cases
 

--- a/packages/compiler-cli/test/compliance/partial/partial_compliance_goldens.bzl
+++ b/packages/compiler-cli/test/compliance/partial/partial_compliance_goldens.bzl
@@ -56,7 +56,6 @@ def partial_compliance_golden(filePath):
             "ivy-only",
             # TODO(josephperrott): Begin running these tests on windows after updating to rules_nodejs 3.0
             "no-windows",
-            "golden",
         ],
         name = "%s.golden" % path,
         src = "//packages/compiler-cli/test/compliance/test_cases:%s/GOLDEN_PARTIAL.js" % path,

--- a/packages/compiler-cli/test/compliance/partial/partial_compliance_goldens.bzl
+++ b/packages/compiler-cli/test/compliance/partial/partial_compliance_goldens.bzl
@@ -56,6 +56,7 @@ def partial_compliance_golden(filePath):
             "ivy-only",
             # TODO(josephperrott): Begin running these tests on windows after updating to rules_nodejs 3.0
             "no-windows",
+            "golden",
         ],
         name = "%s.golden" % path,
         src = "//packages/compiler-cli/test/compliance/test_cases:%s/GOLDEN_PARTIAL.js" % path,

--- a/packages/compiler-cli/test/compliance/update_all_goldens.js
+++ b/packages/compiler-cli/test/compliance/update_all_goldens.js
@@ -12,7 +12,7 @@ const {exec} = require('shelljs');
 
 process.stdout.write('Gathering all partial golden update targets');
 const queryCommand =
-    `yarn -s bazel query --output label 'kind(nodejs_binary, packages/compiler-cli/test/compliance/test_cases:*) intersect attr("tags", "golden", ...)'`;
+    `yarn -s bazel query --output label 'filter('golden.update', kind(nodejs_binary, //packages/compiler-cli/test/compliance/test_cases:*))'`;
 const allUpdateTargets =
     exec(queryCommand, {silent: true}).trim().split('\n').map(test => test.trim());
 process.stdout.clearLine();

--- a/packages/compiler-cli/test/compliance/update_all_goldens.js
+++ b/packages/compiler-cli/test/compliance/update_all_goldens.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// tslint:disable:no-console
+const {exec} = require('shelljs');
+
+process.stdout.write('Gathering all partial golden update targets');
+const queryCommand =
+    `yarn -s bazel query --output label 'kind(nodejs_binary, packages/compiler-cli/test/compliance/test_cases:*) intersect attr("tags", "golden", ...)'`;
+const allUpdateTargets =
+    exec(queryCommand, {silent: true}).trim().split('\n').map(test => test.trim());
+process.stdout.clearLine();
+process.stdout.cursorTo(0);
+
+for (const [index, target] of allUpdateTargets.entries()) {
+  const progress = `${index + 1} / ${allUpdateTargets.length}`;
+  process.stdout.write(`[${progress}] Running: ${target}`);
+  const commandResult = exec(`yarn -s bazel run ${target}`, {silent: true});
+  process.stdout.clearLine();
+  process.stdout.cursorTo(0);
+  if (commandResult.code) {
+    console.error(`[${progress}] Failed run: ${target}`);
+    console.group();
+    console.error(commandResult.stdout || commandResult.stderr);
+    console.groupEnd();
+  } else {
+    console.log(`[${progress}] Successful run: ${target}`);
+  }
+}


### PR DESCRIPTION
The golden files for the partial compliance tests need to be updated
with individual Bazel run invocations, which is not very ergonomic when
a large number of golden files need to updated. This commit adds a
script to query the Bazel targets that update the goldens and then runs
those targets sequentially.