### PR TITLE
fix(forms): retain the disabled status on the most parent form group if the child value has been updated

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -630,11 +630,11 @@ export abstract class AbstractControl {
     // parent's dirtiness based on the children.
     const skipPristineCheck = this._parentMarkedDirty(opts.onlySelf);
 
-    (this as {status: string}).status = DISABLED;
     (this as {errors: ValidationErrors | null}).errors = null;
     this._forEachChild((control: AbstractControl) => {
       control.disable({...opts, onlySelf: true});
     });
+    (this as {status: string}).status = DISABLED;
     this._updateValue();
 
     if (opts.emitEvent !== false) {

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -1529,6 +1529,28 @@ describe('FormGroup', () => {
       expect(c2.disabled).toBe(false);
     });
 
+    it('should retain the disabled status on the most parent form group if the value has been updated on child control',
+       () => {
+         const c1 = new FormControl(null);
+         const c2 = new FormControl(null);
+         const g = new FormGroup({one: c1, two: c2});
+
+         c1.valueChanges.subscribe(() => {
+           c2.setValue('new!');
+         });
+
+         expect(c1.disabled).toBe(false);
+         expect(c2.disabled).toBe(false);
+         expect(g.disabled).toBe(false);
+
+         g.disable();
+
+         expect(c2.value).toEqual('new!');
+         expect(c1.disabled).toBe(true);
+         expect(c2.disabled).toBe(true);
+         expect(g.disabled).toBe(true);
+       });
+
     it('should ignore disabled controls in validation', () => {
       const g = new FormGroup({
         nested: new FormGroup({one: new FormControl(null, Validators.required)}),


### PR DESCRIPTION
Currently, calling `disable()` on the `FormGroup` also calls `disable()` on all child controls.
The problem is that if the value changes in the `valueChanges` callback of some child control, then the `status`
will be equal to a different value, but not `DISABLED`, since the `status` is updated before the `valueChanges`
emits on child controls.

This commit sets the `status` property to `DISABLED` inside the `disable()` method after the `valueChanges` emits
on child controls. Because if the value changes inside the `valueChanges`, then the `updateValueAndValidity()` method
will recalculate the status and the most parent form group will have an invalid `status` compairing to its children.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
- [x] Bugfix


## What is the current behavior?
Issue Number: #31924


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No