### PR TITLE
test(language-service): run ivy tests in each file system

### DIFF
--- a/packages/language-service/ivy/test/compiler_spec.ts
+++ b/packages/language-service/ivy/test/compiler_spec.ts
@@ -7,29 +7,26 @@
  */
 
 import {absoluteFrom} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 
 import {LanguageServiceTestEnvironment} from './env';
 
-describe('language-service/compiler integration', () => {
-  beforeEach(() => {
-    initMockFileSystem('Native');
-  });
+runInEachFileSystem(
+    () => describe('language-service/compiler integration', () => {
+      it('should show type-checking errors from components with poisoned scopes', () => {
+        // Normally, the Angular compiler suppresses errors from components that belong to NgModules
+        // which themselves have errors (such scopes are considered "poisoned"), to avoid
+        // overwhelming the user with secondary errors that stem from a primary root cause. However,
+        // this prevents the generation of type check blocks and other metadata within the compiler
+        // which drive the Language Service's understanding of components. Therefore in the Language
+        // Service, the compiler is configured to make use of such data even if it's "poisoned".
+        // This test verifies that a component declared in an NgModule with a faulty import still
+        // generates template diagnostics.
 
-  it('should show type-checking errors from components with poisoned scopes', () => {
-    // Normally, the Angular compiler suppresses errors from components that belong to NgModules
-    // which themselves have errors (such scopes are considered "poisoned"), to avoid overwhelming
-    // the user with secondary errors that stem from a primary root cause. However, this prevents
-    // the generation of type check blocks and other metadata within the compiler which drive the
-    // Language Service's understanding of components. Therefore in the Language Service, the
-    // compiler is configured to make use of such data even if it's "poisoned". This test verifies
-    // that a component declared in an NgModule with a faulty import still generates template
-    // diagnostics.
-
-    const file = absoluteFrom('/test.ts');
-    const env = LanguageServiceTestEnvironment.setup([{
-      name: file,
-      contents: `
+        const file = absoluteFrom('/test.ts');
+        const env = LanguageServiceTestEnvironment.setup([{
+          name: file,
+          contents: `
           import {Component, Directive, Input, NgModule} from '@angular/core';
 
           @Component({
@@ -53,35 +50,36 @@ describe('language-service/compiler integration', () => {
           })
           export class Mod {}
         `,
-      isRoot: true,
-    }]);
+          isRoot: true,
+        }]);
 
-    const diags = env.ngLS.getSemanticDiagnostics(file);
-    expect(diags.map(diag => diag.messageText))
-        .toContain(`Type 'number' is not assignable to type 'string'.`);
-  });
+        const diags = env.ngLS.getSemanticDiagnostics(file);
+        expect(diags.map(diag => diag.messageText))
+            .toContain(`Type 'number' is not assignable to type 'string'.`);
+      });
 
-  it('should handle broken imports during incremental build steps', () => {
-    // This test validates that the compiler's incremental APIs correctly handle a broken import
-    // when invoked via the Language Service. Testing this via the LS is important as only the LS
-    // requests Angular analysis in the presence of TypeScript-level errors. In the case of broken
-    // imports this distinction is especially important: Angular's incremental analysis is
-    // built on the the compiler's dependency graph, and this graph must be able to function even
-    // with broken imports.
-    //
-    // The test works by creating a component/module pair where the module imports and declares a
-    // component from a separate file. That component is initially not exported, meaning the
-    // module's import is broken. Angular will correctly complain that the NgModule is declaring a
-    // value which is not statically analyzable.
-    //
-    // Then, the component file is fixed to properly export the component class, and an incremental
-    // build step is performed. The compiler should recognize that the module's previous analysis
-    // is stale, even though it was not able to fully understand the import during the first pass.
+      it('should handle broken imports during incremental build steps', () => {
+        // This test validates that the compiler's incremental APIs correctly handle a broken import
+        // when invoked via the Language Service. Testing this via the LS is important as only the
+        // LS requests Angular analysis in the presence of TypeScript-level errors. In the case of
+        // broken imports this distinction is especially important: Angular's incremental analysis
+        // is built on the the compiler's dependency graph, and this graph must be able to function
+        // even with broken imports.
+        //
+        // The test works by creating a component/module pair where the module imports and declares
+        // a component from a separate file. That component is initially not exported, meaning the
+        // module's import is broken. Angular will correctly complain that the NgModule is declaring
+        // a value which is not statically analyzable.
+        //
+        // Then, the component file is fixed to properly export the component class, and an
+        // incremental build step is performed. The compiler should recognize that the module's
+        // previous analysis is stale, even though it was not able to fully understand the import
+        // during the first pass.
 
-    const moduleFile = absoluteFrom('/mod.ts');
-    const componentFile = absoluteFrom('/cmp.ts');
+        const moduleFile = absoluteFrom('/mod.ts');
+        const componentFile = absoluteFrom('/cmp.ts');
 
-    const componentSource = (isExported: boolean): string => `
+        const componentSource = (isExported: boolean): string => `
       import {Component} from '@angular/core';
 
       @Component({
@@ -91,41 +89,41 @@ describe('language-service/compiler integration', () => {
       ${isExported ? 'export' : ''} class Cmp {}
     `;
 
-    const env = LanguageServiceTestEnvironment.setup([
-      {
-        name: moduleFile,
-        contents: `
+        const env = LanguageServiceTestEnvironment.setup([
+          {
+            name: moduleFile,
+            contents: `
           import {NgModule} from '@angular/core';
-    
+
           import {Cmp} from './cmp';
-    
+
           @NgModule({
             declarations: [Cmp],
           })
           export class Mod {}
         `,
-        isRoot: true,
-      },
-      {
-        name: componentFile,
-        contents: componentSource(/* start with component not exported */ false),
-        isRoot: true,
-      }
-    ]);
+            isRoot: true,
+          },
+          {
+            name: componentFile,
+            contents: componentSource(/* start with component not exported */ false),
+            isRoot: true,
+          }
+        ]);
 
-    // Angular should be complaining about the module not being understandable.
-    const programBefore = env.tsLS.getProgram()!;
-    const moduleSfBefore = programBefore.getSourceFile(moduleFile)!;
-    const ngDiagsBefore = env.ngLS.compilerFactory.getOrCreate().getDiagnostics(moduleSfBefore);
-    expect(ngDiagsBefore.length).toBe(1);
+        // Angular should be complaining about the module not being understandable.
+        const programBefore = env.tsLS.getProgram()!;
+        const moduleSfBefore = programBefore.getSourceFile(moduleFile)!;
+        const ngDiagsBefore = env.ngLS.compilerFactory.getOrCreate().getDiagnostics(moduleSfBefore);
+        expect(ngDiagsBefore.length).toBe(1);
 
-    // Fix the import.
-    env.updateFile(componentFile, componentSource(/* properly export the component */ true));
+        // Fix the import.
+        env.updateFile(componentFile, componentSource(/* properly export the component */ true));
 
-    // Angular should stop complaining about the NgModule.
-    const programAfter = env.tsLS.getProgram()!;
-    const moduleSfAfter = programAfter.getSourceFile(moduleFile)!;
-    const ngDiagsAfter = env.ngLS.compilerFactory.getOrCreate().getDiagnostics(moduleSfAfter);
-    expect(ngDiagsAfter.length).toBe(0);
-  });
-});
+        // Angular should stop complaining about the NgModule.
+        const programAfter = env.tsLS.getProgram()!;
+        const moduleSfAfter = programAfter.getSourceFile(moduleFile)!;
+        const ngDiagsAfter = env.ngLS.compilerFactory.getOrCreate().getDiagnostics(moduleSfAfter);
+        expect(ngDiagsAfter.length).toBe(0);
+      });
+    }));

--- a/packages/language-service/ivy/test/completions_spec.ts
+++ b/packages/language-service/ivy/test/completions_spec.ts
@@ -8,105 +8,115 @@
 
 import {TmplAstNode} from '@angular/compiler';
 import {absoluteFrom, AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import * as ts from 'typescript';
+
 import {DisplayInfoKind} from '../display_parts';
 import {LanguageService} from '../language_service';
 
 import {LanguageServiceTestEnvironment} from './env';
 
-describe('completions', () => {
-  beforeEach(() => {
-    initMockFileSystem('Native');
-  });
+runInEachFileSystem(
+    () => describe('completions', () => {
+      describe('in the global scope', () => {
+        it('should be able to complete an interpolation', () => {
+          const {ngLS, fileName, cursor} = setup('{{ti¦}}', `title!: string; hero!: number;`);
+          const completions =
+              ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
+          expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title', 'hero']);
+        });
 
-  describe('in the global scope', () => {
-    it('should be able to complete an interpolation', () => {
-      const {ngLS, fileName, cursor} = setup('{{ti¦}}', `title!: string; hero!: number;`);
-      const completions = ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
-      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title', 'hero']);
-    });
+        it('should be able to complete an empty interpolation', () => {
+          const {ngLS, fileName, cursor} = setup('{{ ¦ }}', `title!: string; hero!: number;`);
+          const completions =
+              ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
+          expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title', 'hero']);
+        });
 
-    it('should be able to complete an empty interpolation', () => {
-      const {ngLS, fileName, cursor} = setup('{{ ¦ }}', `title!: string; hero!: number;`);
-      const completions = ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
-      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title', 'hero']);
-    });
+        it('should be able to complete a property binding', () => {
+          const {ngLS, fileName, cursor} =
+              setup('<h1 [model]="ti¦"></h1>', `title!: string; hero!: number;`);
+          const completions =
+              ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
+          expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title', 'hero']);
+        });
 
-    it('should be able to complete a property binding', () => {
-      const {ngLS, fileName, cursor} =
-          setup('<h1 [model]="ti¦"></h1>', `title!: string; hero!: number;`);
-      const completions = ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
-      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title', 'hero']);
-    });
+        it('should be able to complete an empty property binding', () => {
+          const {ngLS, fileName, cursor} =
+              setup('<h1 [model]="¦"></h1>', `title!: string; hero!: number;`);
+          const completions =
+              ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
+          expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title', 'hero']);
+        });
 
-    it('should be able to complete an empty property binding', () => {
-      const {ngLS, fileName, cursor} =
-          setup('<h1 [model]="¦"></h1>', `title!: string; hero!: number;`);
-      const completions = ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
-      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title', 'hero']);
-    });
-
-    it('should be able to retrieve details for completions', () => {
-      const {ngLS, fileName, cursor} = setup('{{ti¦}}', `
+        it('should be able to retrieve details for completions', () => {
+          const {ngLS, fileName, cursor} = setup('{{ti¦}}', `
         /** This is the title of the 'AppCmp' Component. */
         title!: string;
         /** This comment should not appear in the output of this test. */
         hero!: number;
       `);
-      const details = ngLS.getCompletionEntryDetails(
-          fileName, cursor, 'title', /* formatOptions */ undefined,
-          /* preferences */ undefined)!;
-      expect(details).toBeDefined();
-      expect(toText(details.displayParts)).toEqual('(property) AppCmp.title: string');
-      expect(toText(details.documentation))
-          .toEqual('This is the title of the \'AppCmp\' Component.');
-    });
+          const details = ngLS.getCompletionEntryDetails(
+              fileName, cursor, 'title', /* formatOptions */ undefined,
+              /* preferences */ undefined)!;
+          expect(details).toBeDefined();
+          expect(toText(details.displayParts)).toEqual('(property) AppCmp.title: string');
+          expect(toText(details.documentation))
+              .toEqual('This is the title of the \'AppCmp\' Component.');
+        });
 
-    it('should return reference completions when available', () => {
-      const {ngLS, fileName, cursor} = setup(`<div #todo></div>{{t¦}}`, `title!: string;`);
-      const completions = ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
-      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
-      expectContain(completions, DisplayInfoKind.REFERENCE, ['todo']);
-    });
+        it('should return reference completions when available', () => {
+          const {ngLS, fileName, cursor} = setup(`<div #todo></div>{{t¦}}`, `title!: string;`);
+          const completions =
+              ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
+          expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
+          expectContain(completions, DisplayInfoKind.REFERENCE, ['todo']);
+        });
 
-    it('should return variable completions when available', () => {
-      const {ngLS, fileName, cursor} = setup(
-          `<div *ngFor="let hero of heroes">
+        it('should return variable completions when available', () => {
+          const {ngLS, fileName, cursor} = setup(
+              `<div *ngFor="let hero of heroes">
             {{h¦}}
           </div>
         `,
-          `heroes!: {name: string}[];`);
-      const completions = ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
-      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['heroes']);
-      expectContain(completions, DisplayInfoKind.VARIABLE, ['hero']);
-    });
+              `heroes!: {name: string}[];`);
+          const completions =
+              ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
+          expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['heroes']);
+          expectContain(completions, DisplayInfoKind.VARIABLE, ['hero']);
+        });
 
-    it('should return completions inside an event binding', () => {
-      const {ngLS, fileName, cursor} = setup(`<button (click)='t¦'></button>`, `title!: string;`);
-      const completions = ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
-      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
-    });
+        it('should return completions inside an event binding', () => {
+          const {ngLS, fileName, cursor} =
+              setup(`<button (click)='t¦'></button>`, `title!: string;`);
+          const completions =
+              ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
+          expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
+        });
 
-    it('should return completions inside an empty event binding', () => {
-      const {ngLS, fileName, cursor} = setup(`<button (click)='¦'></button>`, `title!: string;`);
-      const completions = ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
-      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
-    });
+        it('should return completions inside an empty event binding', () => {
+          const {ngLS, fileName, cursor} =
+              setup(`<button (click)='¦'></button>`, `title!: string;`);
+          const completions =
+              ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
+          expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
+        });
 
-    it('should return completions inside the RHS of a two-way binding', () => {
-      const {ngLS, fileName, cursor} = setup(`<h1 [(model)]="t¦"></h1>`, `title!: string;`);
-      const completions = ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
-      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
-    });
+        it('should return completions inside the RHS of a two-way binding', () => {
+          const {ngLS, fileName, cursor} = setup(`<h1 [(model)]="t¦"></h1>`, `title!: string;`);
+          const completions =
+              ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
+          expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
+        });
 
-    it('should return completions inside an empty RHS of a two-way binding', () => {
-      const {ngLS, fileName, cursor} = setup(`<h1 [(model)]="¦"></h1>`, `title!: string;`);
-      const completions = ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
-      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
-    });
-  });
-});
+        it('should return completions inside an empty RHS of a two-way binding', () => {
+          const {ngLS, fileName, cursor} = setup(`<h1 [(model)]="¦"></h1>`, `title!: string;`);
+          const completions =
+              ngLS.getCompletionsAtPosition(fileName, cursor, /* options */ undefined);
+          expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
+        });
+      });
+    }));
 
 function expectContain(
     completions: ts.CompletionInfo|undefined, kind: ts.ScriptElementKind|DisplayInfoKind,
@@ -144,7 +154,7 @@ function setup(templateWithCursor: string, classContents: string): {
         export class AppCmp {
           ${classContents}
         }
-        
+
         @NgModule({
           declarations: [AppCmp],
         })

--- a/packages/language-service/ivy/test/diagnostic_spec.ts
+++ b/packages/language-service/ivy/test/diagnostic_spec.ts
@@ -7,22 +7,20 @@
  */
 
 import {absoluteFrom} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {LanguageServiceTestEnvironment} from '@angular/language-service/ivy/test/env';
 import * as ts from 'typescript';
+
 import {createModuleWithDeclarations} from './test_utils';
 
-describe('getSemanticDiagnostics', () => {
-  let env: LanguageServiceTestEnvironment;
+runInEachFileSystem(
+    () => describe('getSemanticDiagnostics', () => {
+      let env: LanguageServiceTestEnvironment;
 
-  beforeEach(() => {
-    initMockFileSystem('Native');
-  });
-
-  it('should not produce error for a minimal component defintion', () => {
-    const appFile = {
-      name: absoluteFrom('/app.ts'),
-      contents: `
+      it('should not produce error for a minimal component defintion', () => {
+        const appFile = {
+          name: absoluteFrom('/app.ts'),
+          contents: `
       import {Component, NgModule} from '@angular/core';
 
       @Component({
@@ -30,17 +28,17 @@ describe('getSemanticDiagnostics', () => {
       })
       export class AppComponent {}
     `
-    };
-    env = createModuleWithDeclarations([appFile]);
+        };
+        env = createModuleWithDeclarations([appFile]);
 
-    const diags = env.ngLS.getSemanticDiagnostics(absoluteFrom('/app.ts'));
-    expect(diags.length).toEqual(0);
-  });
+        const diags = env.ngLS.getSemanticDiagnostics(absoluteFrom('/app.ts'));
+        expect(diags.length).toEqual(0);
+      });
 
-  it('should report member does not exist', () => {
-    const appFile = {
-      name: absoluteFrom('/app.ts'),
-      contents: `
+      it('should report member does not exist', () => {
+        const appFile = {
+          name: absoluteFrom('/app.ts'),
+          contents: `
       import {Component, NgModule} from '@angular/core';
 
       @Component({
@@ -48,21 +46,21 @@ describe('getSemanticDiagnostics', () => {
       })
       export class AppComponent {}
     `
-    };
-    env = createModuleWithDeclarations([appFile]);
+        };
+        env = createModuleWithDeclarations([appFile]);
 
-    const diags = env.ngLS.getSemanticDiagnostics(absoluteFrom('/app.ts'));
-    expect(diags.length).toBe(1);
-    const {category, file, start, length, messageText} = diags[0];
-    expect(category).toBe(ts.DiagnosticCategory.Error);
-    expect(file?.fileName).toBe('/app.ts');
-    expect(messageText).toBe(`Property 'nope' does not exist on type 'AppComponent'.`);
-  });
+        const diags = env.ngLS.getSemanticDiagnostics(absoluteFrom('/app.ts'));
+        expect(diags.length).toBe(1);
+        const {category, file, start, length, messageText} = diags[0];
+        expect(category).toBe(ts.DiagnosticCategory.Error);
+        expect(file?.fileName).toBe(absoluteFrom('/app.ts'));
+        expect(messageText).toBe(`Property 'nope' does not exist on type 'AppComponent'.`);
+      });
 
-  it('should process external template', () => {
-    const appFile = {
-      name: absoluteFrom('/app.ts'),
-      contents: `
+      it('should process external template', () => {
+        const appFile = {
+          name: absoluteFrom('/app.ts'),
+          contents: `
       import {Component, NgModule} from '@angular/core';
 
       @Component({
@@ -70,23 +68,23 @@ describe('getSemanticDiagnostics', () => {
       })
       export class AppComponent {}
     `
-    };
-    const templateFile = {
-      name: absoluteFrom('/app.html'),
-      contents: `
+        };
+        const templateFile = {
+          name: absoluteFrom('/app.html'),
+          contents: `
       Hello world!
     `
-    };
+        };
 
-    env = createModuleWithDeclarations([appFile], [templateFile]);
-    const diags = env.ngLS.getSemanticDiagnostics(absoluteFrom('/app.html'));
-    expect(diags).toEqual([]);
-  });
+        env = createModuleWithDeclarations([appFile], [templateFile]);
+        const diags = env.ngLS.getSemanticDiagnostics(absoluteFrom('/app.html'));
+        expect(diags).toEqual([]);
+      });
 
-  it('should report member does not exist in external template', () => {
-    const appFile = {
-      name: absoluteFrom('/app.ts'),
-      contents: `
+      it('should report member does not exist in external template', () => {
+        const appFile = {
+          name: absoluteFrom('/app.ts'),
+          contents: `
       import {Component, NgModule} from '@angular/core';
 
       @Component({
@@ -94,15 +92,15 @@ describe('getSemanticDiagnostics', () => {
       })
       export class AppComponent {}
     `
-    };
-    const templateFile = {name: absoluteFrom('/app.html'), contents: `{{nope}}`};
+        };
+        const templateFile = {name: absoluteFrom('/app.html'), contents: `{{nope}}`};
 
-    env = createModuleWithDeclarations([appFile], [templateFile]);
-    const diags = env.ngLS.getSemanticDiagnostics(absoluteFrom('/app.html'));
-    expect(diags.length).toBe(1);
-    const {category, file, start, length, messageText} = diags[0];
-    expect(category).toBe(ts.DiagnosticCategory.Error);
-    expect(file?.fileName).toBe('/app.html');
-    expect(messageText).toBe(`Property 'nope' does not exist on type 'AppComponent'.`);
-  });
-});
+        env = createModuleWithDeclarations([appFile], [templateFile]);
+        const diags = env.ngLS.getSemanticDiagnostics(absoluteFrom('/app.html'));
+        expect(diags.length).toBe(1);
+        const {category, file, start, length, messageText} = diags[0];
+        expect(category).toBe(ts.DiagnosticCategory.Error);
+        expect(file?.fileName).toBe(absoluteFrom('/app.html'));
+        expect(messageText).toBe(`Property 'nope' does not exist on type 'AppComponent'.`);
+      });
+    }));

--- a/packages/language-service/ivy/test/quick_info_spec.ts
+++ b/packages/language-service/ivy/test/quick_info_spec.ts
@@ -7,8 +7,7 @@
  */
 
 import {absoluteFrom} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {initMockFileSystem, TestFile} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-
+import {runInEachFileSystem, TestFile} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import * as ts from 'typescript/lib/tsserverlibrary';
 
 import {LanguageServiceTestEnvironment} from './env';
@@ -101,385 +100,386 @@ function quickInfoSkeleton(): TestFile[] {
   ];
 }
 
-describe('quick info', () => {
-  let env: LanguageServiceTestEnvironment;
+runInEachFileSystem(
+    () => describe('quick info', () => {
+      let env: LanguageServiceTestEnvironment;
 
-  beforeEach(() => {
-    initMockFileSystem('Native');
-    env = LanguageServiceTestEnvironment.setup(quickInfoSkeleton());
-  });
-
-  describe('elements', () => {
-    it('should work for native elements', () => {
-      expectQuickInfo({
-        templateOverride: `<butt¦on></button>`,
-        expectedSpanText: '<button></button>',
-        expectedDisplayString: '(element) button: HTMLButtonElement'
+      beforeEach(() => {
+        env = LanguageServiceTestEnvironment.setup(quickInfoSkeleton());
       });
-    });
 
-    it('should work for directives which match native element tags', () => {
-      expectQuickInfo({
-        templateOverride: `<butt¦on compound custom-button></button>`,
-        expectedSpanText: '<button compound custom-button></button>',
-        expectedDisplayString: '(directive) AppModule.CompoundCustomButtonDirective'
-      });
-    });
-  });
+      describe('elements', () => {
+        it('should work for native elements', () => {
+          expectQuickInfo({
+            templateOverride: `<butt¦on></button>`,
+            expectedSpanText: '<button></button>',
+            expectedDisplayString: '(element) button: HTMLButtonElement'
+          });
+        });
 
-  describe('templates', () => {
-    it('should return undefined for ng-templates', () => {
-      const {documentation} = expectQuickInfo({
-        templateOverride: `<ng-templ¦ate></ng-template>`,
-        expectedSpanText: '<ng-template></ng-template>',
-        expectedDisplayString: '(template) ng-template'
-      });
-      expect(toText(documentation))
-          .toContain('The `<ng-template>` is an Angular element for rendering HTML.');
-    });
-  });
-
-  describe('directives', () => {
-    it('should work for directives', () => {
-      expectQuickInfo({
-        templateOverride: `<div string-model¦></div>`,
-        expectedSpanText: 'string-model',
-        expectedDisplayString: '(directive) AppModule.StringModel'
-      });
-    });
-
-    it('should work for components', () => {
-      const {documentation} = expectQuickInfo({
-        templateOverride: `<t¦est-comp></test-comp>`,
-        expectedSpanText: '<test-comp></test-comp>',
-        expectedDisplayString: '(component) AppModule.TestComponent'
-      });
-      expect(toText(documentation)).toBe('This Component provides the `test-comp` selector.');
-    });
-
-    it('should work for structural directives', () => {
-      const {documentation} = expectQuickInfo({
-        templateOverride: `<div *¦ngFor="let item of heroes"></div>`,
-        expectedSpanText: 'ngFor',
-        expectedDisplayString: '(directive) NgForOf<Hero, Hero[]>'
-      });
-      expect(toText(documentation)).toContain('A fake version of the NgFor directive.');
-    });
-
-    it('should work for directives with compound selectors, some of which are bindings', () => {
-      expectQuickInfo({
-        templateOverride: `<ng-template ngF¦or let-hero [ngForOf]="heroes">{{hero}}</ng-template>`,
-        expectedSpanText: 'ngFor',
-        expectedDisplayString: '(directive) NgForOf<Hero, Hero[]>'
-      });
-    });
-
-    it('should work for data-let- syntax', () => {
-      expectQuickInfo({
-        templateOverride:
-            `<ng-template ngFor data-let-he¦ro [ngForOf]="heroes">{{hero}}</ng-template>`,
-        expectedSpanText: 'hero',
-        expectedDisplayString: '(variable) hero: Hero'
-      });
-    });
-  });
-
-  describe('bindings', () => {
-    describe('inputs', () => {
-      it('should work for input providers', () => {
-        expectQuickInfo({
-          templateOverride: `<test-comp [tcN¦ame]="name"></test-comp>`,
-          expectedSpanText: 'tcName',
-          expectedDisplayString: '(property) TestComponent.name: string'
+        it('should work for directives which match native element tags', () => {
+          expectQuickInfo({
+            templateOverride: `<butt¦on compound custom-button></button>`,
+            expectedSpanText: '<button compound custom-button></button>',
+            expectedDisplayString: '(directive) AppModule.CompoundCustomButtonDirective'
+          });
         });
       });
 
-      it('should work for bind- syntax', () => {
-        expectQuickInfo({
-          templateOverride: `<test-comp bind-tcN¦ame="name"></test-comp>`,
-          expectedSpanText: 'tcName',
-          expectedDisplayString: '(property) TestComponent.name: string'
-        });
-        expectQuickInfo({
-          templateOverride: `<test-comp data-bind-tcN¦ame="name"></test-comp>`,
-          expectedSpanText: 'tcName',
-          expectedDisplayString: '(property) TestComponent.name: string'
-        });
-      });
-
-      it('should work for structural directive inputs ngForTrackBy', () => {
-        expectQuickInfo({
-          templateOverride: `<div *ngFor="let item of heroes; tr¦ackBy: trackByFn;"></div>`,
-          expectedSpanText: 'trackBy',
-          expectedDisplayString:
-              '(property) NgForOf<Hero, Hero[]>.ngForTrackBy: TrackByFunction<Hero>'
+      describe('templates', () => {
+        it('should return undefined for ng-templates', () => {
+          const {documentation} = expectQuickInfo({
+            templateOverride: `<ng-templ¦ate></ng-template>`,
+            expectedSpanText: '<ng-template></ng-template>',
+            expectedDisplayString: '(template) ng-template'
+          });
+          expect(toText(documentation))
+              .toContain('The `<ng-template>` is an Angular element for rendering HTML.');
         });
       });
 
-      it('should work for structural directive inputs ngForOf', () => {
-        expectQuickInfo({
-          templateOverride: `<div *ngFor="let item o¦f heroes; trackBy: trackByFn;"></div>`,
-          expectedSpanText: 'of',
-          expectedDisplayString:
-              '(property) NgForOf<Hero, Hero[]>.ngForOf: Hero[] | (Hero[] & Iterable<Hero>) | null | undefined'
+      describe('directives', () => {
+        it('should work for directives', () => {
+          expectQuickInfo({
+            templateOverride: `<div string-model¦></div>`,
+            expectedSpanText: 'string-model',
+            expectedDisplayString: '(directive) AppModule.StringModel'
+          });
+        });
+
+        it('should work for components', () => {
+          const {documentation} = expectQuickInfo({
+            templateOverride: `<t¦est-comp></test-comp>`,
+            expectedSpanText: '<test-comp></test-comp>',
+            expectedDisplayString: '(component) AppModule.TestComponent'
+          });
+          expect(toText(documentation)).toBe('This Component provides the `test-comp` selector.');
+        });
+
+        it('should work for structural directives', () => {
+          const {documentation} = expectQuickInfo({
+            templateOverride: `<div *¦ngFor="let item of heroes"></div>`,
+            expectedSpanText: 'ngFor',
+            expectedDisplayString: '(directive) NgForOf<Hero, Hero[]>'
+          });
+          expect(toText(documentation)).toContain('A fake version of the NgFor directive.');
+        });
+
+        it('should work for directives with compound selectors, some of which are bindings', () => {
+          expectQuickInfo({
+            templateOverride:
+                `<ng-template ngF¦or let-hero [ngForOf]="heroes">{{hero}}</ng-template>`,
+            expectedSpanText: 'ngFor',
+            expectedDisplayString: '(directive) NgForOf<Hero, Hero[]>'
+          });
+        });
+
+        it('should work for data-let- syntax', () => {
+          expectQuickInfo({
+            templateOverride:
+                `<ng-template ngFor data-let-he¦ro [ngForOf]="heroes">{{hero}}</ng-template>`,
+            expectedSpanText: 'hero',
+            expectedDisplayString: '(variable) hero: Hero'
+          });
         });
       });
 
-      it('should work for two-way binding providers', () => {
-        expectQuickInfo({
-          templateOverride: `<test-comp string-model [(mo¦del)]="title"></test-comp>`,
-          expectedSpanText: 'model',
-          expectedDisplayString: '(property) StringModel.model: string'
+      describe('bindings', () => {
+        describe('inputs', () => {
+          it('should work for input providers', () => {
+            expectQuickInfo({
+              templateOverride: `<test-comp [tcN¦ame]="name"></test-comp>`,
+              expectedSpanText: 'tcName',
+              expectedDisplayString: '(property) TestComponent.name: string'
+            });
+          });
+
+          it('should work for bind- syntax', () => {
+            expectQuickInfo({
+              templateOverride: `<test-comp bind-tcN¦ame="name"></test-comp>`,
+              expectedSpanText: 'tcName',
+              expectedDisplayString: '(property) TestComponent.name: string'
+            });
+            expectQuickInfo({
+              templateOverride: `<test-comp data-bind-tcN¦ame="name"></test-comp>`,
+              expectedSpanText: 'tcName',
+              expectedDisplayString: '(property) TestComponent.name: string'
+            });
+          });
+
+          it('should work for structural directive inputs ngForTrackBy', () => {
+            expectQuickInfo({
+              templateOverride: `<div *ngFor="let item of heroes; tr¦ackBy: trackByFn;"></div>`,
+              expectedSpanText: 'trackBy',
+              expectedDisplayString:
+                  '(property) NgForOf<Hero, Hero[]>.ngForTrackBy: TrackByFunction<Hero>'
+            });
+          });
+
+          it('should work for structural directive inputs ngForOf', () => {
+            expectQuickInfo({
+              templateOverride: `<div *ngFor="let item o¦f heroes; trackBy: trackByFn;"></div>`,
+              expectedSpanText: 'of',
+              expectedDisplayString:
+                  '(property) NgForOf<Hero, Hero[]>.ngForOf: Hero[] | (Hero[] & Iterable<Hero>) | null | undefined'
+            });
+          });
+
+          it('should work for two-way binding providers', () => {
+            expectQuickInfo({
+              templateOverride: `<test-comp string-model [(mo¦del)]="title"></test-comp>`,
+              expectedSpanText: 'model',
+              expectedDisplayString: '(property) StringModel.model: string'
+            });
+          });
+        });
+
+        describe('outputs', () => {
+          it('should work for event providers', () => {
+            expectQuickInfo({
+              templateOverride: `<test-comp (te¦st)="myClick($event)"></test-comp>`,
+              expectedSpanText: 'test',
+              expectedDisplayString: '(event) TestComponent.testEvent: EventEmitter<string>'
+            });
+          });
+
+          it('should work for on- syntax binding', () => {
+            expectQuickInfo({
+              templateOverride: `<test-comp on-te¦st="myClick($event)"></test-comp>`,
+              expectedSpanText: 'test',
+              expectedDisplayString: '(event) TestComponent.testEvent: EventEmitter<string>'
+            });
+            expectQuickInfo({
+              templateOverride: `<test-comp data-on-te¦st="myClick($event)"></test-comp>`,
+              expectedSpanText: 'test',
+              expectedDisplayString: '(event) TestComponent.testEvent: EventEmitter<string>'
+            });
+          });
+
+          it('should work for $event from EventEmitter', () => {
+            expectQuickInfo({
+              templateOverride: `<div string-model (modelChange)="myClick($e¦vent)"></div>`,
+              expectedSpanText: '$event',
+              expectedDisplayString: '(parameter) $event: string'
+            });
+          });
+
+          it('should work for $event from native element', () => {
+            expectQuickInfo({
+              templateOverride: `<div (click)="myClick($e¦vent)"></div>`,
+              expectedSpanText: '$event',
+              expectedDisplayString: '(parameter) $event: MouseEvent'
+            });
+          });
         });
       });
-    });
 
-    describe('outputs', () => {
-      it('should work for event providers', () => {
-        expectQuickInfo({
-          templateOverride: `<test-comp (te¦st)="myClick($event)"></test-comp>`,
-          expectedSpanText: 'test',
-          expectedDisplayString: '(event) TestComponent.testEvent: EventEmitter<string>'
+      describe('references', () => {
+        it('should work for element reference declarations', () => {
+          const {documentation} = expectQuickInfo({
+            templateOverride: `<div #¦chart></div>`,
+            expectedSpanText: 'chart',
+            expectedDisplayString: '(reference) chart: HTMLDivElement'
+          });
+          expect(toText(documentation))
+              .toEqual(
+                  'Provides special properties (beyond the regular HTMLElement ' +
+                  'interface it also has available to it by inheritance) for manipulating <div> elements.');
+        });
+
+        it('should work for directive references', () => {
+          expectQuickInfo({
+            templateOverride: `<div string-model #dir¦Ref="stringModel"></div>`,
+            expectedSpanText: 'dirRef',
+            expectedDisplayString: '(reference) dirRef: StringModel'
+          });
+        });
+
+        it('should work for ref- syntax', () => {
+          expectQuickInfo({
+            templateOverride: `<div ref-ch¦art></div>`,
+            expectedSpanText: 'chart',
+            expectedDisplayString: '(reference) chart: HTMLDivElement'
+          });
+          expectQuickInfo({
+            templateOverride: `<div data-ref-ch¦art></div>`,
+            expectedSpanText: 'chart',
+            expectedDisplayString: '(reference) chart: HTMLDivElement'
+          });
         });
       });
 
-      it('should work for on- syntax binding', () => {
-        expectQuickInfo({
-          templateOverride: `<test-comp on-te¦st="myClick($event)"></test-comp>`,
-          expectedSpanText: 'test',
-          expectedDisplayString: '(event) TestComponent.testEvent: EventEmitter<string>'
+      describe('variables', () => {
+        it('should work for array members', () => {
+          const {documentation} = expectQuickInfo({
+            templateOverride: `<div *ngFor="let hero of heroes">{{her¦o}}</div>`,
+            expectedSpanText: 'hero',
+            expectedDisplayString: '(variable) hero: Hero'
+          });
+          expect(toText(documentation)).toEqual('The most heroic being.');
         });
-        expectQuickInfo({
-          templateOverride: `<test-comp data-on-te¦st="myClick($event)"></test-comp>`,
-          expectedSpanText: 'test',
-          expectedDisplayString: '(event) TestComponent.testEvent: EventEmitter<string>'
-        });
-      });
 
-      it('should work for $event from EventEmitter', () => {
-        expectQuickInfo({
-          templateOverride: `<div string-model (modelChange)="myClick($e¦vent)"></div>`,
-          expectedSpanText: '$event',
-          expectedDisplayString: '(parameter) $event: string'
+        it('should work for ReadonlyArray members (#36191)', () => {
+          expectQuickInfo({
+            templateOverride: `<div *ngFor="let hero of readonlyHeroes">{{her¦o}}</div>`,
+            expectedSpanText: 'hero',
+            expectedDisplayString: '(variable) hero: Readonly<Hero>'
+          });
         });
-      });
 
-      it('should work for $event from native element', () => {
-        expectQuickInfo({
-          templateOverride: `<div (click)="myClick($e¦vent)"></div>`,
-          expectedSpanText: '$event',
-          expectedDisplayString: '(parameter) $event: MouseEvent'
+        it('should work for const array members (#36191)', () => {
+          expectQuickInfo({
+            templateOverride: `<div *ngFor="let name of constNames">{{na¦me}}</div>`,
+            expectedSpanText: 'name',
+            expectedDisplayString: '(variable) name: { readonly name: "name"; }'
+          });
         });
       });
-    });
-  });
 
-  describe('references', () => {
-    it('should work for element reference declarations', () => {
-      const {documentation} = expectQuickInfo({
-        templateOverride: `<div #¦chart></div>`,
-        expectedSpanText: 'chart',
-        expectedDisplayString: '(reference) chart: HTMLDivElement'
+      describe('pipes', () => {
+        it('should work for pipes', () => {
+          const templateOverride = `<p>The hero's birthday is {{birthday | da¦te: "MM/dd/yy"}}</p>`;
+          expectQuickInfo({
+            templateOverride,
+            expectedSpanText: 'date',
+            expectedDisplayString:
+                '(pipe) DatePipe.transform(value: string | number | Date, format?: string | undefined, timezone?: ' +
+                'string | undefined, locale?: string | undefined): string | null (+2 overloads)'
+          });
+        });
       });
-      expect(toText(documentation))
-          .toEqual(
-              'Provides special properties (beyond the regular HTMLElement ' +
-              'interface it also has available to it by inheritance) for manipulating <div> elements.');
-    });
 
-    it('should work for directive references', () => {
-      expectQuickInfo({
-        templateOverride: `<div string-model #dir¦Ref="stringModel"></div>`,
-        expectedSpanText: 'dirRef',
-        expectedDisplayString: '(reference) dirRef: StringModel'
+      describe('expressions', () => {
+        it('should find members in a text interpolation', () => {
+          expectQuickInfo({
+            templateOverride: `<div>{{ tit¦le }}</div>`,
+            expectedSpanText: 'title',
+            expectedDisplayString: '(property) AppCmp.title: string'
+          });
+        });
+
+        it('should work for accessed property reads', () => {
+          expectQuickInfo({
+            templateOverride: `<div>{{title.len¦gth}}</div>`,
+            expectedSpanText: 'length',
+            expectedDisplayString: '(property) String.length: number'
+          });
+        });
+
+        it('should find members in an attribute interpolation', () => {
+          expectQuickInfo({
+            templateOverride: `<div string-model model="{{tit¦le}}"></div>`,
+            expectedSpanText: 'title',
+            expectedDisplayString: '(property) AppCmp.title: string'
+          });
+        });
+
+        it('should find members of input binding', () => {
+          expectQuickInfo({
+            templateOverride: `<test-comp [tcName]="ti¦tle"></test-comp>`,
+            expectedSpanText: 'title',
+            expectedDisplayString: '(property) AppCmp.title: string'
+          });
+        });
+
+        it('should find input binding on text attribute', () => {
+          expectQuickInfo({
+            templateOverride: `<test-comp tcN¦ame="title"></test-comp>`,
+            expectedSpanText: 'tcName',
+            expectedDisplayString: '(property) TestComponent.name: string'
+          });
+        });
+
+        it('should find members of event binding', () => {
+          expectQuickInfo({
+            templateOverride: `<test-comp (test)="ti¦tle=$event"></test-comp>`,
+            expectedSpanText: 'title',
+            expectedDisplayString: '(property) AppCmp.title: string'
+          });
+        });
+
+        it('should work for method calls', () => {
+          expectQuickInfo({
+            templateOverride: `<div (click)="setT¦itle('title')"></div>`,
+            expectedSpanText: 'setTitle',
+            expectedDisplayString: '(method) AppCmp.setTitle(newTitle: string): void'
+          });
+        });
+
+        it('should work for accessed properties in writes', () => {
+          expectQuickInfo({
+            templateOverride: `<div (click)="hero.i¦d = 2"></div>`,
+            expectedSpanText: 'id',
+            expectedDisplayString: '(property) Hero.id: number'
+          });
+        });
+
+        it('should work for method call arguments', () => {
+          expectQuickInfo({
+            templateOverride: `<div (click)="setTitle(hero.nam¦e)"></div>`,
+            expectedSpanText: 'name',
+            expectedDisplayString: '(property) Hero.name: string'
+          });
+        });
+
+        it('should find members of two-way binding', () => {
+          expectQuickInfo({
+            templateOverride: `<input string-model [(model)]="ti¦tle" />`,
+            expectedSpanText: 'title',
+            expectedDisplayString: '(property) AppCmp.title: string'
+          });
+        });
+
+        it('should find members in a structural directive', () => {
+          expectQuickInfo({
+            templateOverride: `<div *ngIf="anyV¦alue"></div>`,
+            expectedSpanText: 'anyValue',
+            expectedDisplayString: '(property) AppCmp.anyValue: any'
+          });
+        });
+
+        it('should work for members in structural directives', () => {
+          expectQuickInfo({
+            templateOverride: `<div *ngFor="let item of her¦oes; trackBy: trackByFn;"></div>`,
+            expectedSpanText: 'heroes',
+            expectedDisplayString: '(property) AppCmp.heroes: Hero[]'
+          });
+        });
+
+        it('should work for the $any() cast function', () => {
+          expectQuickInfo({
+            templateOverride: `<div>{{$an¦y(title)}}</div>`,
+            expectedSpanText: '$any',
+            expectedDisplayString: '(method) $any: any'
+          });
+        });
+
+        it('should provide documentation', () => {
+          const {cursor} = env.overrideTemplateWithCursor(
+              absoluteFrom('/app.ts'), 'AppCmp', `<div>{{¦title}}</div>`);
+          const quickInfo = env.ngLS.getQuickInfoAtPosition(absoluteFrom('/app.html'), cursor);
+          const documentation = toText(quickInfo!.documentation);
+          expect(documentation).toBe('This is the title of the `AppCmp` Component.');
+        });
       });
-    });
 
-    it('should work for ref- syntax', () => {
-      expectQuickInfo({
-        templateOverride: `<div ref-ch¦art></div>`,
-        expectedSpanText: 'chart',
-        expectedDisplayString: '(reference) chart: HTMLDivElement'
-      });
-      expectQuickInfo({
-        templateOverride: `<div data-ref-ch¦art></div>`,
-        expectedSpanText: 'chart',
-        expectedDisplayString: '(reference) chart: HTMLDivElement'
-      });
-    });
-  });
-
-  describe('variables', () => {
-    it('should work for array members', () => {
-      const {documentation} = expectQuickInfo({
-        templateOverride: `<div *ngFor="let hero of heroes">{{her¦o}}</div>`,
-        expectedSpanText: 'hero',
-        expectedDisplayString: '(variable) hero: Hero'
-      });
-      expect(toText(documentation)).toEqual('The most heroic being.');
-    });
-
-    it('should work for ReadonlyArray members (#36191)', () => {
-      expectQuickInfo({
-        templateOverride: `<div *ngFor="let hero of readonlyHeroes">{{her¦o}}</div>`,
-        expectedSpanText: 'hero',
-        expectedDisplayString: '(variable) hero: Readonly<Hero>'
-      });
-    });
-
-    it('should work for const array members (#36191)', () => {
-      expectQuickInfo({
-        templateOverride: `<div *ngFor="let name of constNames">{{na¦me}}</div>`,
-        expectedSpanText: 'name',
-        expectedDisplayString: '(variable) name: { readonly name: "name"; }'
-      });
-    });
-  });
-
-  describe('pipes', () => {
-    it('should work for pipes', () => {
-      const templateOverride = `<p>The hero's birthday is {{birthday | da¦te: "MM/dd/yy"}}</p>`;
-      expectQuickInfo({
-        templateOverride,
-        expectedSpanText: 'date',
-        expectedDisplayString:
-            '(pipe) DatePipe.transform(value: string | number | Date, format?: string | undefined, timezone?: ' +
-            'string | undefined, locale?: string | undefined): string | null (+2 overloads)'
-      });
-    });
-  });
-
-  describe('expressions', () => {
-    it('should find members in a text interpolation', () => {
-      expectQuickInfo({
-        templateOverride: `<div>{{ tit¦le }}</div>`,
-        expectedSpanText: 'title',
-        expectedDisplayString: '(property) AppCmp.title: string'
-      });
-    });
-
-    it('should work for accessed property reads', () => {
-      expectQuickInfo({
-        templateOverride: `<div>{{title.len¦gth}}</div>`,
-        expectedSpanText: 'length',
-        expectedDisplayString: '(property) String.length: number'
-      });
-    });
-
-    it('should find members in an attribute interpolation', () => {
-      expectQuickInfo({
-        templateOverride: `<div string-model model="{{tit¦le}}"></div>`,
-        expectedSpanText: 'title',
-        expectedDisplayString: '(property) AppCmp.title: string'
-      });
-    });
-
-    it('should find members of input binding', () => {
-      expectQuickInfo({
-        templateOverride: `<test-comp [tcName]="ti¦tle"></test-comp>`,
-        expectedSpanText: 'title',
-        expectedDisplayString: '(property) AppCmp.title: string'
-      });
-    });
-
-    it('should find input binding on text attribute', () => {
-      expectQuickInfo({
-        templateOverride: `<test-comp tcN¦ame="title"></test-comp>`,
-        expectedSpanText: 'tcName',
-        expectedDisplayString: '(property) TestComponent.name: string'
-      });
-    });
-
-    it('should find members of event binding', () => {
-      expectQuickInfo({
-        templateOverride: `<test-comp (test)="ti¦tle=$event"></test-comp>`,
-        expectedSpanText: 'title',
-        expectedDisplayString: '(property) AppCmp.title: string'
-      });
-    });
-
-    it('should work for method calls', () => {
-      expectQuickInfo({
-        templateOverride: `<div (click)="setT¦itle('title')"></div>`,
-        expectedSpanText: 'setTitle',
-        expectedDisplayString: '(method) AppCmp.setTitle(newTitle: string): void'
-      });
-    });
-
-    it('should work for accessed properties in writes', () => {
-      expectQuickInfo({
-        templateOverride: `<div (click)="hero.i¦d = 2"></div>`,
-        expectedSpanText: 'id',
-        expectedDisplayString: '(property) Hero.id: number'
-      });
-    });
-
-    it('should work for method call arguments', () => {
-      expectQuickInfo({
-        templateOverride: `<div (click)="setTitle(hero.nam¦e)"></div>`,
-        expectedSpanText: 'name',
-        expectedDisplayString: '(property) Hero.name: string'
-      });
-    });
-
-    it('should find members of two-way binding', () => {
-      expectQuickInfo({
-        templateOverride: `<input string-model [(model)]="ti¦tle" />`,
-        expectedSpanText: 'title',
-        expectedDisplayString: '(property) AppCmp.title: string'
-      });
-    });
-
-    it('should find members in a structural directive', () => {
-      expectQuickInfo({
-        templateOverride: `<div *ngIf="anyV¦alue"></div>`,
-        expectedSpanText: 'anyValue',
-        expectedDisplayString: '(property) AppCmp.anyValue: any'
-      });
-    });
-
-    it('should work for members in structural directives', () => {
-      expectQuickInfo({
-        templateOverride: `<div *ngFor="let item of her¦oes; trackBy: trackByFn;"></div>`,
-        expectedSpanText: 'heroes',
-        expectedDisplayString: '(property) AppCmp.heroes: Hero[]'
-      });
-    });
-
-    it('should work for the $any() cast function', () => {
-      expectQuickInfo({
-        templateOverride: `<div>{{$an¦y(title)}}</div>`,
-        expectedSpanText: '$any',
-        expectedDisplayString: '(method) $any: any'
-      });
-    });
-
-    it('should provide documentation', () => {
-      const {cursor} = env.overrideTemplateWithCursor(
-          absoluteFrom('/app.ts'), 'AppCmp', `<div>{{¦title}}</div>`);
-      const quickInfo = env.ngLS.getQuickInfoAtPosition(absoluteFrom('/app.html'), cursor);
-      const documentation = toText(quickInfo!.documentation);
-      expect(documentation).toBe('This is the title of the `AppCmp` Component.');
-    });
-  });
-
-  function expectQuickInfo(
-      {templateOverride, expectedSpanText, expectedDisplayString}:
-          {templateOverride: string, expectedSpanText: string, expectedDisplayString: string}):
-      ts.QuickInfo {
-    const {cursor, text} =
-        env.overrideTemplateWithCursor(absoluteFrom('/app.ts'), 'AppCmp', templateOverride);
-    env.expectNoSourceDiagnostics();
-    env.expectNoTemplateDiagnostics(absoluteFrom('/app.ts'), 'AppCmp');
-    const quickInfo = env.ngLS.getQuickInfoAtPosition(absoluteFrom('/app.html'), cursor);
-    expect(quickInfo).toBeTruthy();
-    const {textSpan, displayParts} = quickInfo!;
-    expect(text.substring(textSpan.start, textSpan.start + textSpan.length))
-        .toEqual(expectedSpanText);
-    expect(toText(displayParts)).toEqual(expectedDisplayString);
-    return quickInfo!;
-  }
-});
+      function expectQuickInfo(
+          {templateOverride, expectedSpanText, expectedDisplayString}:
+              {templateOverride: string, expectedSpanText: string, expectedDisplayString: string}):
+          ts.QuickInfo {
+        const {cursor, text} =
+            env.overrideTemplateWithCursor(absoluteFrom('/app.ts'), 'AppCmp', templateOverride);
+        env.expectNoSourceDiagnostics();
+        env.expectNoTemplateDiagnostics(absoluteFrom('/app.ts'), 'AppCmp');
+        const quickInfo = env.ngLS.getQuickInfoAtPosition(absoluteFrom('/app.html'), cursor);
+        expect(quickInfo).toBeTruthy();
+        const {textSpan, displayParts} = quickInfo!;
+        expect(text.substring(textSpan.start, textSpan.start + textSpan.length))
+            .toEqual(expectedSpanText);
+        expect(toText(displayParts)).toEqual(expectedDisplayString);
+        return quickInfo!;
+      }
+    }));
 
 function toText(displayParts?: ts.SymbolDisplayPart[]): string {
   return (displayParts || []).map(p => p.text).join('');

--- a/packages/language-service/ivy/test/references_spec.ts
+++ b/packages/language-service/ivy/test/references_spec.ts
@@ -7,91 +7,88 @@
  */
 
 import {absoluteFrom, absoluteFrom as _} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {initMockFileSystem, TestFile} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {runInEachFileSystem, TestFile} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import * as ts from 'typescript/lib/tsserverlibrary';
 
 import {extractCursorInfo, LanguageServiceTestEnvironment} from './env';
 import {createModuleWithDeclarations, getText} from './test_utils';
 
-describe('find references', () => {
-  let env: LanguageServiceTestEnvironment;
+runInEachFileSystem(
+    () => describe('find references', () => {
+      let env: LanguageServiceTestEnvironment;
 
-  beforeEach(() => {
-    initMockFileSystem('Native');
-  });
-
-  it('gets component member references from TS file', () => {
-    const {text, cursor} = extractCursorInfo(`
+      it('gets component member references from TS file', () => {
+        const {text, cursor} = extractCursorInfo(`
           import {Component} from '@angular/core';
 
           @Component({templateUrl: './app.html'})
           export class AppCmp {
             myP¦rop!: string;
           }`);
-    const appFile = {name: _('/app.ts'), contents: text};
-    const templateFile = {name: _('/app.html'), contents: '{{myProp}}'};
-    env = createModuleWithDeclarations([appFile], [templateFile]);
-    const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-    expect(refs.length).toBe(2);
-    assertFileNames(refs, ['app.html', 'app.ts']);
-    assertTextSpans(refs, ['myProp']);
-  });
+        const appFile = {name: _('/app.ts'), contents: text};
+        const templateFile = {name: _('/app.html'), contents: '{{myProp}}'};
+        env = createModuleWithDeclarations([appFile], [templateFile]);
+        const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+        expect(refs.length).toBe(2);
+        assertFileNames(refs, ['app.html', 'app.ts']);
+        assertTextSpans(refs, ['myProp']);
+      });
 
-  it('gets component member references from TS file and inline template', () => {
-    const {text, cursor} = extractCursorInfo(`
+      it('gets component member references from TS file and inline template', () => {
+        const {text, cursor} = extractCursorInfo(`
           import {Component} from '@angular/core';
 
           @Component({template: '{{myProp}}'})
           export class AppCmp {
             myP¦rop!: string;
           }`);
-    const appFile = {name: _('/app.ts'), contents: text};
-    env = createModuleWithDeclarations([appFile]);
-    const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-    expect(refs.length).toBe(2);
-    assertFileNames(refs, ['app.ts']);
-    assertTextSpans(refs, ['myProp']);
-  });
+        const appFile = {name: _('/app.ts'), contents: text};
+        env = createModuleWithDeclarations([appFile]);
+        const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+        expect(refs.length).toBe(2);
+        assertFileNames(refs, ['app.ts']);
+        assertTextSpans(refs, ['myProp']);
+      });
 
-  it('gets component member references from template', () => {
-    const appFile = {
-      name: _('/app.ts'),
-      contents: `
+      it('gets component member references from template', () => {
+        const appFile = {
+          name: _('/app.ts'),
+          contents: `
           import {Component} from '@angular/core';
 
           @Component({templateUrl: './app.html'})
           export class AppCmp {
             myProp = '';
           }`,
-    };
-    const {text, cursor} = extractCursorInfo('{{myP¦rop}}');
-    const templateFile = {name: _('/app.html'), contents: text};
-    env = createModuleWithDeclarations([appFile], [templateFile]);
-    const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
-    expect(refs.length).toBe(2);
-    assertFileNames(refs, ['app.html', 'app.ts']);
-    assertTextSpans(refs, ['myProp']);
-  });
+        };
+        const {text, cursor} = extractCursorInfo('{{myP¦rop}}');
+        const templateFile = {name: _('/app.html'), contents: text};
+        env = createModuleWithDeclarations([appFile], [templateFile]);
+        const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
+        expect(refs.length).toBe(2);
+        assertFileNames(refs, ['app.html', 'app.ts']);
+        assertTextSpans(refs, ['myProp']);
+      });
 
-  it('should work for method calls', () => {
-    const {text, cursor} = extractCursorInfo(`
+      it('should work for method calls', () => {
+        const {text, cursor} = extractCursorInfo(`
           import {Component} from '@angular/core';
 
           @Component({template: '<div (click)="set¦Title(2)"></div>'})
           export class AppCmp {
             setTitle(s: number) {}
           }`);
-    const appFile = {name: _('/app.ts'), contents: text};
-    env = createModuleWithDeclarations([appFile]);
-    const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-    expect(refs.length).toBe(2);
+        const appFile = {name: _('/app.ts'), contents: text};
+        env = createModuleWithDeclarations([appFile]);
+        const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+        expect(refs.length).toBe(2);
 
-    assertFileNames(refs, ['app.ts']);
-    assertTextSpans(refs, ['setTitle']);
-  });
+        assertFileNames(refs, ['app.ts']);
+        assertTextSpans(refs, ['setTitle']);
+      });
 
-  it('should work for method call arguments', () => {
-    const {text, cursor} = extractCursorInfo(`
+      it('should work for method call arguments', () => {
+        const {text, cursor} = extractCursorInfo(`
           import {Component} from '@angular/core';
 
           @Component({template: '<div (click)="setTitle(ti¦tle)"></div>'})
@@ -99,38 +96,38 @@ describe('find references', () => {
             title = '';
             setTitle(s: string) {}
           }`);
-    const appFile = {name: _('/app.ts'), contents: text};
-    env = createModuleWithDeclarations([appFile]);
-    const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-    expect(refs.length).toBe(2);
+        const appFile = {name: _('/app.ts'), contents: text};
+        env = createModuleWithDeclarations([appFile]);
+        const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+        expect(refs.length).toBe(2);
 
-    assertTextSpans(refs, ['title']);
-  });
+        assertTextSpans(refs, ['title']);
+      });
 
-  it('should work for property writes', () => {
-    const appFile = {
-      name: _('/app.ts'),
-      contents: `
+      it('should work for property writes', () => {
+        const appFile = {
+          name: _('/app.ts'),
+          contents: `
           import {Component} from '@angular/core';
 
           @Component({templateUrl: './app.html' })
           export class AppCmp {
             title = '';
           }`,
-    };
-    const templateFileWithCursor = `<div (click)="ti¦tle = 'newtitle'"></div>`;
-    const {text, cursor} = extractCursorInfo(templateFileWithCursor);
-    const templateFile = {name: _('/app.html'), contents: text};
-    env = createModuleWithDeclarations([appFile], [templateFile]);
-    const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
-    expect(refs.length).toBe(2);
+        };
+        const templateFileWithCursor = `<div (click)="ti¦tle = 'newtitle'"></div>`;
+        const {text, cursor} = extractCursorInfo(templateFileWithCursor);
+        const templateFile = {name: _('/app.html'), contents: text};
+        env = createModuleWithDeclarations([appFile], [templateFile]);
+        const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
+        expect(refs.length).toBe(2);
 
-    assertFileNames(refs, ['app.ts', 'app.html']);
-    assertTextSpans(refs, ['title']);
-  });
+        assertFileNames(refs, ['app.ts', 'app.html']);
+        assertTextSpans(refs, ['title']);
+      });
 
-  it('should work for RHS of property writes', () => {
-    const {text, cursor} = extractCursorInfo(`
+      it('should work for RHS of property writes', () => {
+        const {text, cursor} = extractCursorInfo(`
           import {Component} from '@angular/core';
 
           @Component({template: '<div (click)="title = otherT¦itle"></div>' })
@@ -138,48 +135,49 @@ describe('find references', () => {
             title = '';
             otherTitle = '';
           }`);
-    const appFile = {
-      name: _('/app.ts'),
-      contents: text,
-    };
-    env = createModuleWithDeclarations([appFile]);
-    const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-    expect(refs.length).toBe(2);
+        const appFile = {
+          name: _('/app.ts'),
+          contents: text,
+        };
+        env = createModuleWithDeclarations([appFile]);
+        const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+        expect(refs.length).toBe(2);
 
-    assertFileNames(refs, ['app.ts']);
-    assertTextSpans(refs, ['otherTitle']);
-  });
+        assertFileNames(refs, ['app.ts']);
+        assertTextSpans(refs, ['otherTitle']);
+      });
 
-  it('should work for keyed reads', () => {
-    const {text, cursor} = extractCursorInfo(`
+      it('should work for keyed reads', () => {
+        const {text, cursor} = extractCursorInfo(`
           import {Component} from '@angular/core';
 
           @Component({template: '{{hero["na¦me"]}}' })
           export class AppCmp {
             hero: {name: string} = {name: 'Superman'};
           }`);
-    const appFile = {
-      name: _('/app.ts'),
-      contents: text,
-    };
-    env = createModuleWithDeclarations([appFile]);
-    const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-    // 3 references: the type definition, the value assignment, and the read in the template
-    expect(refs.length).toBe(3);
+        const appFile = {
+          name: _('/app.ts'),
+          contents: text,
+        };
+        env = createModuleWithDeclarations([appFile]);
+        const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+        // 3 references: the type definition, the value assignment, and the read in the template
+        expect(refs.length).toBe(3);
 
-    assertFileNames(refs, ['app.ts']);
-    // TODO(atscott): investigate if we can make the template keyed read be just the 'name' part.
-    // The TypeScript implementation specifically adjusts the span to accommodate string literals:
-    // https://sourcegraph.com/github.com/microsoft/TypeScript@d5779c75d3dd19565b60b9e2960b8aac36d4d635/-/blob/src/services/findAllReferences.ts#L508-512
-    // One possible solution would be to extend `FullTemplateMapping` to include the matched TCB
-    // node and then do the same thing that TS does: if the node is a string, adjust the span.
-    assertTextSpans(refs, ['name', '"name"']);
-  });
+        assertFileNames(refs, ['app.ts']);
+        // TODO(atscott): investigate if we can make the template keyed read be just the 'name'
+        // part. The TypeScript implementation specifically adjusts the span to accommodate string
+        // literals:
+        // https://sourcegraph.com/github.com/microsoft/TypeScript@d5779c75d3dd19565b60b9e2960b8aac36d4d635/-/blob/src/services/findAllReferences.ts#L508-512
+        // One possible solution would be to extend `FullTemplateMapping` to include the matched TCB
+        // node and then do the same thing that TS does: if the node is a string, adjust the span.
+        assertTextSpans(refs, ['name', '"name"']);
+      });
 
-  it('should work for keyed writes', () => {
-    const appFile = {
-      name: _('/app.ts'),
-      contents: `
+      it('should work for keyed writes', () => {
+        const appFile = {
+          name: _('/app.ts'),
+          contents: `
           import {Component} from '@angular/core';
 
           @Component({templateUrl: './app.html' })
@@ -187,73 +185,73 @@ describe('find references', () => {
             hero: {name: string} = {name: 'Superman'};
             batman = 'batman';
           }`,
-    };
-    const templateFileWithCursor = `<div (click)="hero['name'] = bat¦man"></div>`;
-    const {text, cursor} = extractCursorInfo(templateFileWithCursor);
-    const templateFile = {name: _('/app.html'), contents: text};
-    env = createModuleWithDeclarations([appFile], [templateFile]);
-    const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
-    expect(refs.length).toBe(2);
+        };
+        const templateFileWithCursor = `<div (click)="hero['name'] = bat¦man"></div>`;
+        const {text, cursor} = extractCursorInfo(templateFileWithCursor);
+        const templateFile = {name: _('/app.html'), contents: text};
+        env = createModuleWithDeclarations([appFile], [templateFile]);
+        const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
+        expect(refs.length).toBe(2);
 
-    assertFileNames(refs, ['app.ts', 'app.html']);
-    assertTextSpans(refs, ['batman']);
-  });
+        assertFileNames(refs, ['app.ts', 'app.html']);
+        assertTextSpans(refs, ['batman']);
+      });
 
-  describe('references', () => {
-    it('should work for element references', () => {
-      const {text, cursor} = extractCursorInfo(`
+      describe('references', () => {
+        it('should work for element references', () => {
+          const {text, cursor} = extractCursorInfo(`
           import {Component} from '@angular/core';
 
           @Component({template: '<input #myInput /> {{ myIn¦put.value }}'})
           export class AppCmp {
             title = '';
           }`);
-      const appFile = {name: _('/app.ts'), contents: text};
-      env = createModuleWithDeclarations([appFile]);
-      const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-      expect(refs.length).toBe(2);
-      assertTextSpans(refs, ['myInput']);
+          const appFile = {name: _('/app.ts'), contents: text};
+          env = createModuleWithDeclarations([appFile]);
+          const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+          expect(refs.length).toBe(2);
+          assertTextSpans(refs, ['myInput']);
 
-      const originalRefs = env.ngLS.getReferencesAtPosition(_('/app.ts'), cursor)!;
-      // Get the declaration by finding the reference that appears first in the template
-      originalRefs.sort((a, b) => a.textSpan.start - b.textSpan.start);
-      expect(originalRefs[0].isDefinition).toBe(true);
-    });
+          const originalRefs = env.ngLS.getReferencesAtPosition(_('/app.ts'), cursor)!;
+          // Get the declaration by finding the reference that appears first in the template
+          originalRefs.sort((a, b) => a.textSpan.start - b.textSpan.start);
+          expect(originalRefs[0].isDefinition).toBe(true);
+        });
 
-    it('should work for template references', () => {
-      const templateWithCursor = `
+        it('should work for template references', () => {
+          const templateWithCursor = `
               <ng-template #myTemplate >bla</ng-template>
               <ng-container [ngTemplateOutlet]="myTem¦plate"></ng-container>`;
-      const appFile = {
-        name: _('/app.ts'),
-        contents: `
+          const appFile = {
+            name: _('/app.ts'),
+            contents: `
           import {Component} from '@angular/core';
 
           @Component({templateUrl: './app.html'})
           export class AppCmp {
             title = '';
           }`,
-      };
-      const {text, cursor} = extractCursorInfo(templateWithCursor);
-      const templateFile = {name: _('/app.html'), contents: text};
-      env = createModuleWithDeclarations([appFile], [templateFile]);
-      const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
-      expect(refs.length).toBe(2);
-      assertTextSpans(refs, ['myTemplate']);
-      assertFileNames(refs, ['app.html']);
+          };
+          const {text, cursor} = extractCursorInfo(templateWithCursor);
+          const templateFile = {name: _('/app.html'), contents: text};
+          env = createModuleWithDeclarations([appFile], [templateFile]);
+          const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
+          expect(refs.length).toBe(2);
+          assertTextSpans(refs, ['myTemplate']);
+          assertFileNames(refs, ['app.html']);
 
-      const originalRefs = env.ngLS.getReferencesAtPosition(_('/app.html'), cursor)!;
-      // Get the declaration by finding the reference that appears first in the template
-      originalRefs.sort((a, b) => a.textSpan.start - b.textSpan.start);
-      expect(originalRefs[0].isDefinition).toBe(true);
-    });
+          const originalRefs = env.ngLS.getReferencesAtPosition(_('/app.html'), cursor)!;
+          // Get the declaration by finding the reference that appears first in the template
+          originalRefs.sort((a, b) => a.textSpan.start - b.textSpan.start);
+          expect(originalRefs[0].isDefinition).toBe(true);
+        });
 
-    describe('directive references', () => {
-      let appFile: TestFile;
-      let dirFile: TestFile;
+        describe('directive references', () => {
+          let appFile: TestFile;
+          let dirFile: TestFile;
 
-      beforeEach(() => {
-        const dirFileContents = `
+          beforeEach(() => {
+            const dirFileContents = `
             import {Directive} from '@angular/core';
 
             @Directive({selector: '[dir]', exportAs: 'myDir'})
@@ -261,106 +259,106 @@ describe('find references', () => {
               dirValue!: string;
               doSomething() {}
             }`;
-        const appFileContents = `
+            const appFileContents = `
             import {Component} from '@angular/core';
 
             @Component({templateUrl: './app.html'})
             export class AppCmp {}`;
-        appFile = {name: _('/app.ts'), contents: appFileContents};
-        dirFile = {name: _('/dir.ts'), contents: dirFileContents};
+            appFile = {name: _('/app.ts'), contents: appFileContents};
+            dirFile = {name: _('/dir.ts'), contents: dirFileContents};
+          });
+
+          it('should work for usage of reference in template', () => {
+            const templateWithCursor = '<div [dir] #dirRef="myDir"></div> {{ dirR¦ef }}';
+            const {text, cursor} = extractCursorInfo(templateWithCursor);
+            const templateFile = {name: _('/app.html'), contents: text};
+            env = createModuleWithDeclarations([appFile, dirFile], [templateFile]);
+            const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
+            expect(refs.length).toBe(2);
+            assertFileNames(refs, ['app.html']);
+            assertTextSpans(refs, ['dirRef']);
+          });
+
+          it('should work for prop reads of directive references', () => {
+            const fileWithCursor = '<div [dir] #dirRef="myDir"></div> {{ dirRef.dirV¦alue }}';
+            const {text, cursor} = extractCursorInfo(fileWithCursor);
+            const templateFile = {name: _('/app.html'), contents: text};
+            env = createModuleWithDeclarations([appFile, dirFile], [templateFile]);
+            const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
+            expect(refs.length).toBe(2);
+            assertFileNames(refs, ['dir.ts', 'app.html']);
+            assertTextSpans(refs, ['dirValue']);
+          });
+
+          it('should work for safe prop reads', () => {
+            const fileWithCursor = '<div [dir] #dirRef="myDir"></div> {{ dirRef?.dirV¦alue }}';
+            const {text, cursor} = extractCursorInfo(fileWithCursor);
+            const templateFile = {name: _('/app.html'), contents: text};
+            env = createModuleWithDeclarations([appFile, dirFile], [templateFile]);
+            const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
+            expect(refs.length).toBe(2);
+            assertFileNames(refs, ['dir.ts', 'app.html']);
+            assertTextSpans(refs, ['dirValue']);
+          });
+
+          it('should work for safe method calls', () => {
+            const fileWithCursor = '<div [dir] #dirRef="myDir"></div> {{ dirRef?.doSometh¦ing() }}';
+            const {text, cursor} = extractCursorInfo(fileWithCursor);
+            const templateFile = {name: _('/app.html'), contents: text};
+            env = createModuleWithDeclarations([appFile, dirFile], [templateFile]);
+            const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
+            expect(refs.length).toBe(2);
+            assertFileNames(refs, ['dir.ts', 'app.html']);
+            assertTextSpans(refs, ['doSomething']);
+          });
+        });
       });
 
-      it('should work for usage of reference in template', () => {
-        const templateWithCursor = '<div [dir] #dirRef="myDir"></div> {{ dirR¦ef }}';
-        const {text, cursor} = extractCursorInfo(templateWithCursor);
-        const templateFile = {name: _('/app.html'), contents: text};
-        env = createModuleWithDeclarations([appFile, dirFile], [templateFile]);
-        const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
-        expect(refs.length).toBe(2);
-        assertFileNames(refs, ['app.html']);
-        assertTextSpans(refs, ['dirRef']);
-      });
-
-      it('should work for prop reads of directive references', () => {
-        const fileWithCursor = '<div [dir] #dirRef="myDir"></div> {{ dirRef.dirV¦alue }}';
-        const {text, cursor} = extractCursorInfo(fileWithCursor);
-        const templateFile = {name: _('/app.html'), contents: text};
-        env = createModuleWithDeclarations([appFile, dirFile], [templateFile]);
-        const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
-        expect(refs.length).toBe(2);
-        assertFileNames(refs, ['dir.ts', 'app.html']);
-        assertTextSpans(refs, ['dirValue']);
-      });
-
-      it('should work for safe prop reads', () => {
-        const fileWithCursor = '<div [dir] #dirRef="myDir"></div> {{ dirRef?.dirV¦alue }}';
-        const {text, cursor} = extractCursorInfo(fileWithCursor);
-        const templateFile = {name: _('/app.html'), contents: text};
-        env = createModuleWithDeclarations([appFile, dirFile], [templateFile]);
-        const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
-        expect(refs.length).toBe(2);
-        assertFileNames(refs, ['dir.ts', 'app.html']);
-        assertTextSpans(refs, ['dirValue']);
-      });
-
-      it('should work for safe method calls', () => {
-        const fileWithCursor = '<div [dir] #dirRef="myDir"></div> {{ dirRef?.doSometh¦ing() }}';
-        const {text, cursor} = extractCursorInfo(fileWithCursor);
-        const templateFile = {name: _('/app.html'), contents: text};
-        env = createModuleWithDeclarations([appFile, dirFile], [templateFile]);
-        const refs = getReferencesAtPosition(_('/app.html'), cursor)!;
-        expect(refs.length).toBe(2);
-        assertFileNames(refs, ['dir.ts', 'app.html']);
-        assertTextSpans(refs, ['doSomething']);
-      });
-    });
-  });
-
-  describe('variables', () => {
-    it('should work for variable initialized implicitly', () => {
-      const {text, cursor} = extractCursorInfo(`
+      describe('variables', () => {
+        it('should work for variable initialized implicitly', () => {
+          const {text, cursor} = extractCursorInfo(`
           import {Component} from '@angular/core';
 
           @Component({template: '<div *ngFor="let hero of heroes">{{her¦o}}</div>'})
           export class AppCmp {
             heroes: string[] = [];
           }`);
-      const appFile = {name: _('/app.ts'), contents: text};
-      env = createModuleWithDeclarations([appFile]);
-      const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-      expect(refs.length).toBe(2);
-      assertFileNames(refs, ['app.ts']);
-      assertTextSpans(refs, ['hero']);
+          const appFile = {name: _('/app.ts'), contents: text};
+          env = createModuleWithDeclarations([appFile]);
+          const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+          expect(refs.length).toBe(2);
+          assertFileNames(refs, ['app.ts']);
+          assertTextSpans(refs, ['hero']);
 
-      const originalRefs = env.ngLS.getReferencesAtPosition(_('/app.ts'), cursor)!;
-      // Get the declaration by finding the reference that appears first in the template
-      originalRefs.sort((a, b) => a.textSpan.start - b.textSpan.start);
-      expect(originalRefs[0].isDefinition).toBe(true);
-    });
+          const originalRefs = env.ngLS.getReferencesAtPosition(_('/app.ts'), cursor)!;
+          // Get the declaration by finding the reference that appears first in the template
+          originalRefs.sort((a, b) => a.textSpan.start - b.textSpan.start);
+          expect(originalRefs[0].isDefinition).toBe(true);
+        });
 
-    it('should work for renamed variables', () => {
-      const {text, cursor} = extractCursorInfo(`
+        it('should work for renamed variables', () => {
+          const {text, cursor} = extractCursorInfo(`
           import {Component} from '@angular/core';
 
           @Component({template: '<div *ngFor="let hero of heroes; let iRef = index">{{iR¦ef}}</div>'})
           export class AppCmp {
             heroes: string[] = [];
           }`);
-      const appFile = {name: _('/app.ts'), contents: text};
-      env = createModuleWithDeclarations([appFile]);
-      const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-      expect(refs.length).toBe(2);
-      assertFileNames(refs, ['app.ts']);
-      assertTextSpans(refs, ['iRef']);
+          const appFile = {name: _('/app.ts'), contents: text};
+          env = createModuleWithDeclarations([appFile]);
+          const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+          expect(refs.length).toBe(2);
+          assertFileNames(refs, ['app.ts']);
+          assertTextSpans(refs, ['iRef']);
 
-      const originalRefs = env.ngLS.getReferencesAtPosition(_('/app.ts'), cursor)!;
-      // Get the declaration by finding the reference that appears first in the template
-      originalRefs.sort((a, b) => a.textSpan.start - b.textSpan.start);
-      expect(originalRefs[0].isDefinition).toBe(true);
-    });
+          const originalRefs = env.ngLS.getReferencesAtPosition(_('/app.ts'), cursor)!;
+          // Get the declaration by finding the reference that appears first in the template
+          originalRefs.sort((a, b) => a.textSpan.start - b.textSpan.start);
+          expect(originalRefs[0].isDefinition).toBe(true);
+        });
 
-    it('should work for initializer of variable', () => {
-      const dirFile = `
+        it('should work for initializer of variable', () => {
+          const dirFile = `
         import {Directive, Input} from '@angular/core';
 
         export class ExampleContext<T> {
@@ -375,7 +373,7 @@ describe('find references', () => {
             return true;
           }
         }`;
-      const fileWithCursor = `
+          const fileWithCursor = `
         import {Component, NgModule} from '@angular/core';
         import {ExampleDirective} from './example-directive';
 
@@ -386,40 +384,40 @@ describe('find references', () => {
 
         @NgModule({declarations: [AppCmp, ExampleDirective]})
         export class AppModule {}`;
-      const {text, cursor} = extractCursorInfo(fileWithCursor);
-      env = LanguageServiceTestEnvironment.setup([
-        {name: _('/app.ts'), contents: text, isRoot: true},
-        {name: _('/example-directive.ts'), contents: dirFile},
-      ]);
-      env.expectNoSourceDiagnostics();
-      env.expectNoTemplateDiagnostics(absoluteFrom('/app.ts'), 'AppCmp');
-      const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-      expect(refs.length).toBe(2);
-      assertFileNames(refs, ['app.ts', 'example-directive.ts']);
-      assertTextSpans(refs, ['identifier']);
-    });
+          const {text, cursor} = extractCursorInfo(fileWithCursor);
+          env = LanguageServiceTestEnvironment.setup([
+            {name: _('/app.ts'), contents: text, isRoot: true},
+            {name: _('/example-directive.ts'), contents: dirFile},
+          ]);
+          env.expectNoSourceDiagnostics();
+          env.expectNoTemplateDiagnostics(absoluteFrom('/app.ts'), 'AppCmp');
+          const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+          expect(refs.length).toBe(2);
+          assertFileNames(refs, ['app.ts', 'example-directive.ts']);
+          assertTextSpans(refs, ['identifier']);
+        });
 
-    it('should work for prop reads of variables', () => {
-      const {text, cursor} = extractCursorInfo(`
+        it('should work for prop reads of variables', () => {
+          const {text, cursor} = extractCursorInfo(`
             import {Component} from '@angular/core';
 
             @Component({template: '<div *ngFor="let hero of heroes">{{hero.na¦me}}</div>'})
             export class AppCmp {
               heroes: Array<{name: string}> = [];
             }`);
-      const appFile = {name: _('/app.ts'), contents: text};
-      env = createModuleWithDeclarations([appFile]);
-      const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-      expect(refs.length).toBe(2);
-      assertFileNames(refs, ['app.ts']);
-      assertTextSpans(refs, ['name']);
-    });
-  });
+          const appFile = {name: _('/app.ts'), contents: text};
+          env = createModuleWithDeclarations([appFile]);
+          const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+          expect(refs.length).toBe(2);
+          assertFileNames(refs, ['app.ts']);
+          assertTextSpans(refs, ['name']);
+        });
+      });
 
-  describe('pipes', () => {
-    let prefixPipeFile: TestFile;
-    beforeEach(() => {
-      const prefixPipe = `
+      describe('pipes', () => {
+        let prefixPipeFile: TestFile;
+        beforeEach(() => {
+          const prefixPipe = `
         import {Pipe, PipeTransform} from '@angular/core';
 
         @Pipe({ name: 'prefixPipe' })
@@ -430,11 +428,11 @@ describe('find references', () => {
             return '';
           }
         }`;
-      prefixPipeFile = {name: _('/prefix-pipe.ts'), contents: prefixPipe};
-    });
+          prefixPipeFile = {name: _('/prefix-pipe.ts'), contents: prefixPipe};
+        });
 
-    it('should work for pipe names', () => {
-      const appContentsWithCursor = `
+        it('should work for pipe names', () => {
+          const appContentsWithCursor = `
         import {Component} from '@angular/core';
 
         @Component({template: '{{birthday | prefi¦xPipe: "MM/dd/yy"}}'})
@@ -442,17 +440,17 @@ describe('find references', () => {
           birthday = '';
         }
       `;
-      const {text, cursor} = extractCursorInfo(appContentsWithCursor);
-      const appFile = {name: _('/app.ts'), contents: text};
-      env = createModuleWithDeclarations([appFile, prefixPipeFile]);
-      const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-      expect(refs.length).toBe(5);
-      assertFileNames(refs, ['index.d.ts', 'prefix-pipe.ts', 'app.ts']);
-      assertTextSpans(refs, ['transform', 'prefixPipe']);
-    });
+          const {text, cursor} = extractCursorInfo(appContentsWithCursor);
+          const appFile = {name: _('/app.ts'), contents: text};
+          env = createModuleWithDeclarations([appFile, prefixPipeFile]);
+          const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+          expect(refs.length).toBe(5);
+          assertFileNames(refs, ['index.d.ts', 'prefix-pipe.ts', 'app.ts']);
+          assertTextSpans(refs, ['transform', 'prefixPipe']);
+        });
 
-    it('should work for pipe arguments', () => {
-      const appContentsWithCursor = `
+        it('should work for pipe arguments', () => {
+          const appContentsWithCursor = `
         import {Component} from '@angular/core';
 
         @Component({template: '{{birthday | prefixPipe: pr¦efix}}'})
@@ -461,18 +459,18 @@ describe('find references', () => {
           prefix = '';
         }
       `;
-      const {text, cursor} = extractCursorInfo(appContentsWithCursor);
-      const appFile = {name: _('/app.ts'), contents: text};
-      env = createModuleWithDeclarations([appFile, prefixPipeFile]);
-      const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-      expect(refs.length).toBe(2);
-      assertFileNames(refs, ['app.ts']);
-      assertTextSpans(refs, ['prefix']);
-    });
-  });
+          const {text, cursor} = extractCursorInfo(appContentsWithCursor);
+          const appFile = {name: _('/app.ts'), contents: text};
+          env = createModuleWithDeclarations([appFile, prefixPipeFile]);
+          const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+          expect(refs.length).toBe(2);
+          assertFileNames(refs, ['app.ts']);
+          assertTextSpans(refs, ['prefix']);
+        });
+      });
 
-  describe('inputs', () => {
-    const dirFileContents = `
+      describe('inputs', () => {
+        const dirFileContents = `
         import {Directive, Input} from '@angular/core';
 
         @Directive({selector: '[string-model]'})
@@ -480,69 +478,69 @@ describe('find references', () => {
           @Input() model!: string;
           @Input('alias') aliasedModel!: string;
         }`;
-    it('should work from the template', () => {
-      const stringModelTestFile = {name: _('/string-model.ts'), contents: dirFileContents};
-      const {text, cursor} = extractCursorInfo(`
+        it('should work from the template', () => {
+          const stringModelTestFile = {name: _('/string-model.ts'), contents: dirFileContents};
+          const {text, cursor} = extractCursorInfo(`
         import {Component} from '@angular/core';
 
         @Component({template: '<div string-model [mod¦el]="title"></div>'})
         export class AppCmp {
           title = 'title';
         }`);
-      const appFile = {name: _('/app.ts'), contents: text};
-      env = createModuleWithDeclarations([appFile, stringModelTestFile]);
-      const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-      expect(refs.length).toEqual(2);
-      assertFileNames(refs, ['string-model.ts', 'app.ts']);
-      assertTextSpans(refs, ['model']);
-    });
+          const appFile = {name: _('/app.ts'), contents: text};
+          env = createModuleWithDeclarations([appFile, stringModelTestFile]);
+          const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+          expect(refs.length).toEqual(2);
+          assertFileNames(refs, ['string-model.ts', 'app.ts']);
+          assertTextSpans(refs, ['model']);
+        });
 
-    it('should work for text attributes', () => {
-      const stringModelTestFile = {name: _('/string-model.ts'), contents: dirFileContents};
-      const {text, cursor} = extractCursorInfo(`
+        it('should work for text attributes', () => {
+          const stringModelTestFile = {name: _('/string-model.ts'), contents: dirFileContents};
+          const {text, cursor} = extractCursorInfo(`
         import {Component} from '@angular/core';
 
         @Component({template: '<div string-model mod¦el="title"></div>'})
         export class AppCmp {
           title = 'title';
         }`);
-      const appFile = {name: _('/app.ts'), contents: text};
-      env = createModuleWithDeclarations([appFile, stringModelTestFile]);
-      const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-      expect(refs.length).toEqual(2);
-      assertFileNames(refs, ['string-model.ts', 'app.ts']);
-      assertTextSpans(refs, ['model']);
-    });
+          const appFile = {name: _('/app.ts'), contents: text};
+          env = createModuleWithDeclarations([appFile, stringModelTestFile]);
+          const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+          expect(refs.length).toEqual(2);
+          assertFileNames(refs, ['string-model.ts', 'app.ts']);
+          assertTextSpans(refs, ['model']);
+        });
 
-    it('should work from the TS input declaration', () => {
-      const dirFileWithCursor = `
+        it('should work from the TS input declaration', () => {
+          const dirFileWithCursor = `
         import {Directive, Input} from '@angular/core';
 
         @Directive({selector: '[string-model]'})
         export class StringModel {
           @Input() mod¦el!: string;
         }`;
-      const {text, cursor} = extractCursorInfo(dirFileWithCursor);
-      const stringModelTestFile = {name: _('/string-model.ts'), contents: text};
-      const appFile = {
-        name: _('/app.ts'),
-        contents: `
+          const {text, cursor} = extractCursorInfo(dirFileWithCursor);
+          const stringModelTestFile = {name: _('/string-model.ts'), contents: text};
+          const appFile = {
+            name: _('/app.ts'),
+            contents: `
         import {Component} from '@angular/core';
 
         @Component({template: '<div string-model model="title"></div>'})
         export class AppCmp {
           title = 'title';
         }`,
-      };
-      env = createModuleWithDeclarations([appFile, stringModelTestFile]);
-      const refs = getReferencesAtPosition(_('/string-model.ts'), cursor)!;
-      expect(refs.length).toEqual(2);
-      assertFileNames(refs, ['app.ts', 'string-model.ts']);
-      assertTextSpans(refs, ['model']);
-    });
+          };
+          env = createModuleWithDeclarations([appFile, stringModelTestFile]);
+          const refs = getReferencesAtPosition(_('/string-model.ts'), cursor)!;
+          expect(refs.length).toEqual(2);
+          assertFileNames(refs, ['app.ts', 'string-model.ts']);
+          assertTextSpans(refs, ['model']);
+        });
 
-    it('should work for inputs referenced from some other place', () => {
-      const otherDirContents = `
+        it('should work for inputs referenced from some other place', () => {
+          const otherDirContents = `
         import {Directive, Input} from '@angular/core';
         import {StringModel} from './string-model';
 
@@ -554,55 +552,55 @@ describe('find references', () => {
             console.log(this.stringModelRef.mod¦el);
           }
         }`;
-      const {text, cursor} = extractCursorInfo(otherDirContents);
-      const otherDirFile = {name: _('/other-dir.ts'), contents: text};
-      const stringModelTestFile = {
-        name: _('/string-model.ts'),
-        contents: `
+          const {text, cursor} = extractCursorInfo(otherDirContents);
+          const otherDirFile = {name: _('/other-dir.ts'), contents: text};
+          const stringModelTestFile = {
+            name: _('/string-model.ts'),
+            contents: `
         import {Directive, Input} from '@angular/core';
 
         @Directive({selector: '[string-model]'})
         export class StringModel {
           @Input() model!: string;
         }`,
-      };
-      const appFile = {
-        name: _('/app.ts'),
-        contents: `
+          };
+          const appFile = {
+            name: _('/app.ts'),
+            contents: `
         import {Component} from '@angular/core';
 
         @Component({template: '<div string-model other-dir model="title"></div>'})
         export class AppCmp {
           title = 'title';
         }`,
-      };
-      env = createModuleWithDeclarations([appFile, stringModelTestFile, otherDirFile]);
-      const refs = getReferencesAtPosition(_('/other-dir.ts'), cursor)!;
-      expect(refs.length).toEqual(3);
-      assertFileNames(refs, ['app.ts', 'string-model.ts', 'other-dir.ts']);
-      assertTextSpans(refs, ['model']);
-    });
+          };
+          env = createModuleWithDeclarations([appFile, stringModelTestFile, otherDirFile]);
+          const refs = getReferencesAtPosition(_('/other-dir.ts'), cursor)!;
+          expect(refs.length).toEqual(3);
+          assertFileNames(refs, ['app.ts', 'string-model.ts', 'other-dir.ts']);
+          assertTextSpans(refs, ['model']);
+        });
 
-    it('should work with aliases', () => {
-      const stringModelTestFile = {name: _('/string-model.ts'), contents: dirFileContents};
-      const {text, cursor} = extractCursorInfo(`
+        it('should work with aliases', () => {
+          const stringModelTestFile = {name: _('/string-model.ts'), contents: dirFileContents};
+          const {text, cursor} = extractCursorInfo(`
         import {Component} from '@angular/core';
 
         @Component({template: '<div string-model [al¦ias]="title"></div>'})
         export class AppCmp {
           title = 'title';
         }`);
-      const appFile = {name: _('/app.ts'), contents: text};
-      env = createModuleWithDeclarations([appFile, stringModelTestFile]);
-      const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-      expect(refs.length).toEqual(2);
-      assertFileNames(refs, ['string-model.ts', 'app.ts']);
-      assertTextSpans(refs, ['aliasedModel', 'alias']);
-    });
-  });
+          const appFile = {name: _('/app.ts'), contents: text};
+          env = createModuleWithDeclarations([appFile, stringModelTestFile]);
+          const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+          expect(refs.length).toEqual(2);
+          assertFileNames(refs, ['string-model.ts', 'app.ts']);
+          assertTextSpans(refs, ['aliasedModel', 'alias']);
+        });
+      });
 
-  describe('outputs', () => {
-    const dirFile = `
+      describe('outputs', () => {
+        const dirFile = `
         import {Directive, Output, EventEmitter} from '@angular/core';
 
         @Directive({selector: '[string-model]'})
@@ -611,8 +609,8 @@ describe('find references', () => {
           @Output('alias') aliasedModelChange = new EventEmitter<string>();
         }`;
 
-    function generateAppFile(template: string) {
-      return `
+        function generateAppFile(template: string) {
+          return `
         import {Component, NgModule} from '@angular/core';
         import {StringModel} from './string-model';
 
@@ -623,41 +621,41 @@ describe('find references', () => {
 
         @NgModule({declarations: [AppCmp, StringModel]})
         export class AppModule {}`;
-    }
+        }
 
-    it('should work', () => {
-      const {text, cursor} = extractCursorInfo(
-          generateAppFile(`<div string-model (mod¦elChange)="setTitle($event)"></div>`));
-      env = LanguageServiceTestEnvironment.setup([
-        {name: _('/app.ts'), contents: text, isRoot: true},
-        {name: _('/string-model.ts'), contents: dirFile},
-      ]);
-      const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-      expect(refs.length).toEqual(2);
-      assertTextSpans(refs, ['modelChange']);
-    });
+        it('should work', () => {
+          const {text, cursor} = extractCursorInfo(
+              generateAppFile(`<div string-model (mod¦elChange)="setTitle($event)"></div>`));
+          env = LanguageServiceTestEnvironment.setup([
+            {name: _('/app.ts'), contents: text, isRoot: true},
+            {name: _('/string-model.ts'), contents: dirFile},
+          ]);
+          const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+          expect(refs.length).toEqual(2);
+          assertTextSpans(refs, ['modelChange']);
+        });
 
-    it('should work with aliases', () => {
-      const {text, cursor} = extractCursorInfo(
-          generateAppFile(`<div string-model (a¦lias)="setTitle($event)"></div>`));
-      env = LanguageServiceTestEnvironment.setup([
-        {name: _('/app.ts'), contents: text, isRoot: true},
-        {name: _('/string-model.ts'), contents: dirFile},
-      ]);
-      const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
-      expect(refs.length).toEqual(2);
-      assertTextSpans(refs, ['aliasedModelChange', 'alias']);
-    });
-  });
+        it('should work with aliases', () => {
+          const {text, cursor} = extractCursorInfo(
+              generateAppFile(`<div string-model (a¦lias)="setTitle($event)"></div>`));
+          env = LanguageServiceTestEnvironment.setup([
+            {name: _('/app.ts'), contents: text, isRoot: true},
+            {name: _('/string-model.ts'), contents: dirFile},
+          ]);
+          const refs = getReferencesAtPosition(_('/app.ts'), cursor)!;
+          expect(refs.length).toEqual(2);
+          assertTextSpans(refs, ['aliasedModelChange', 'alias']);
+        });
+      });
 
-  describe('directives', () => {
-    it('works for directive classes', () => {
-      const {text, cursor} = extractCursorInfo(`
+      describe('directives', () => {
+        it('works for directive classes', () => {
+          const {text, cursor} = extractCursorInfo(`
       import {Directive} from '@angular/core';
 
       @Directive({selector: '[dir]'})
       export class Di¦r {}`);
-      const appFile = `
+          const appFile = `
         import {Component, NgModule} from '@angular/core';
         import {Dir} from './dir';
 
@@ -668,42 +666,43 @@ describe('find references', () => {
         @NgModule({declarations: [AppCmp, Dir]})
         export class AppModule {}
       `;
-      env = LanguageServiceTestEnvironment.setup([
-        {name: _('/app.ts'), contents: appFile, isRoot: true},
-        {name: _('/dir.ts'), contents: text},
-      ]);
-      const refs = getReferencesAtPosition(_('/dir.ts'), cursor)!;
-      // 4 references are:  class declaration, template usage, app import and use in declarations
-      // list.
-      expect(refs.length).toBe(4);
-      assertTextSpans(refs, ['<div dir>', 'Dir']);
-      assertFileNames(refs, ['app.ts', 'dir.ts']);
-    });
-  });
+          env = LanguageServiceTestEnvironment.setup([
+            {name: _('/app.ts'), contents: appFile, isRoot: true},
+            {name: _('/dir.ts'), contents: text},
+          ]);
+          const refs = getReferencesAtPosition(_('/dir.ts'), cursor)!;
+          // 4 references are:  class declaration, template usage, app import and use in
+          // declarations list.
+          expect(refs.length).toBe(4);
+          assertTextSpans(refs, ['<div dir>', 'Dir']);
+          assertFileNames(refs, ['app.ts', 'dir.ts']);
+        });
+      });
 
-  function getReferencesAtPosition(fileName: string, position: number) {
-    env.expectNoSourceDiagnostics();
-    const result = env.ngLS.getReferencesAtPosition(fileName, position);
-    return result?.map(humanizeReferenceEntry);
-  }
+      function getReferencesAtPosition(fileName: string, position: number) {
+        env.expectNoSourceDiagnostics();
+        const result = env.ngLS.getReferencesAtPosition(fileName, position);
+        return result?.map(humanizeReferenceEntry);
+      }
 
-  function humanizeReferenceEntry(entry: ts.ReferenceEntry): Stringy<ts.DocumentSpan>&
-      Pick<ts.ReferenceEntry, 'isWriteAccess'|'isDefinition'|'isInString'> {
-    const fileContents = env.host.readFile(entry.fileName);
-    if (!fileContents) {
-      throw new Error('Could not read file ${entry.fileName}');
-    }
-    return {
-      ...entry,
-      textSpan: getText(fileContents, entry.textSpan),
-      contextSpan: entry.contextSpan ? getText(fileContents, entry.contextSpan) : undefined,
-      originalTextSpan: entry.originalTextSpan ? getText(fileContents, entry.originalTextSpan) :
-                                                 undefined,
-      originalContextSpan:
-          entry.originalContextSpan ? getText(fileContents, entry.originalContextSpan) : undefined,
-    };
-  }
-});
+      function humanizeReferenceEntry(entry: ts.ReferenceEntry): Stringy<ts.DocumentSpan>&
+          Pick<ts.ReferenceEntry, 'isWriteAccess'|'isDefinition'|'isInString'> {
+        const fileContents = env.host.readFile(entry.fileName);
+        if (!fileContents) {
+          throw new Error('Could not read file ${entry.fileName}');
+        }
+        return {
+          ...entry,
+          textSpan: getText(fileContents, entry.textSpan),
+          contextSpan: entry.contextSpan ? getText(fileContents, entry.contextSpan) : undefined,
+          originalTextSpan: entry.originalTextSpan ? getText(fileContents, entry.originalTextSpan) :
+                                                     undefined,
+          originalContextSpan: entry.originalContextSpan ?
+              getText(fileContents, entry.originalContextSpan) :
+              undefined,
+        };
+      }
+    }));
 
 function assertFileNames(refs: Array<{fileName: string}>, expectedFileNames: string[]) {
   const actualPaths = refs.map(r => r.fileName);


### PR DESCRIPTION
Runs the ivy language servie tests in each file system to improve test
coverage. To do that, we use the existing `runInEachFileSystem` function
from the compiler-cli package.

Pro tip: add `?w=1` to the url to ignore whitespace 👌. All I did was wrap each test in `runInEachFilesystem`, but the auto -formatter indented each line which makes the diff large.

The tradeoff here is that we're getting better coverage of our file IO logic but these tests will take 4x as long to run. Is it really worth it to run these tests in each file system, I thought our ngtsc tests already give us coverage of our file IO logic in different environments.