### PR TITLE
fix(dev-infra): correct the environment variable to skip husky during 

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -4208,7 +4208,7 @@ function mergePullRequest(prNumber, githubToken, projectRoot, config) {
                 case 0:
                     // Set the environment variable to skip all git commit hooks triggered by husky. We are unable to
                     // rely on `--no-verify` as some hooks still run, notably the `prepare-commit-msg` hook.
-                    process.env['HUSKY_SKIP_HOOKS'] = '1';
+                    process.env['HUSKY'] = '0';
                     return [4 /*yield*/, createPullRequestMergeTask(githubToken, projectRoot, config)];
                 case 1:
                     api = _a.sent();

--- a/dev-infra/pr/merge/index.ts
+++ b/dev-infra/pr/merge/index.ts
@@ -34,7 +34,7 @@ export async function mergePullRequest(
     config?: MergeConfigWithRemote) {
   // Set the environment variable to skip all git commit hooks triggered by husky. We are unable to
   // rely on `--no-verify` as some hooks still run, notably the `prepare-commit-msg` hook.
-  process.env['HUSKY_SKIP_HOOKS'] = '1';
+  process.env['HUSKY'] = '0';
 
   const api = await createPullRequestMergeTask(githubToken, projectRoot, config);
 


### PR DESCRIPTION
With the migration to husky@5, the environment variable used to skip husky changed from
`HUSKY_SKIP_HOOKS` to `HUSKY`.  To continue skipping husky during the merge process as
expected, the environment variable used is updated.
