### PR TITLE
docs: update optimization and source map section

### DIFF
--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -361,34 +361,149 @@ Files in that folder, such as `src/style-paths/_variables.scss`, can be imported
 Note that you will also need to add any styles or scripts to the `test` builder if you need them for unit tests.
 See also [Using runtime-global libraries inside your app](guide/using-libraries#using-runtime-global-libraries-inside-your-app).
 
+### Optimization configuration
 
-{@a optimize-and-srcmap}
+The `optimization` browser builder option can be either a Boolean or an Object for more fine-grained configuration. This option enables various optimizations of the build output.
+Including minification of scripts and styles, tree-shaking, dead-code elimination, inlining of critical CSS and fonts inlining.
 
-### Optimization and source map configuration
+There are several options that can be used to fine-grained the optimization of an application.
 
-The `optimization` and `sourceMap` browser builder options can be either a Boolean or an Object for more fine-grained configuration.
-In this section we will explain how to fine tune these options.
+<table class="is-full-width is-fixed-layout">
+<thead>
+<tr>
+<th>Option</th>
+<th width="40%">Description</th>
+<th>Value Type</th>
+<th>Default Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>scripts</code></td>
+<td>Enables optimization of the scripts output.</td>
+<td><code class="no-auto-link">boolean</code></td>
+<td><code>true</code></td>
+</tr>
+<tr>
+<td><code>styles</code></td>
+<td>Enables optimization of the scripts output.</td>
+<td><code>boolean|<a href="#styles-optimization-options">Styles optimization options</a></code></td>
+<td><code>true</code></td>
+</tr>
+<tr>
+<td><code>fonts</code></td>
+<td>Enables optimization for fonts.<br><strong>Note:</strong> This requires internet access.</td>
+<td><code class="no-auto-link">boolean|<a href="#fonts-optimization-options">Fonts optimization options</a></code></td>
+<td><code>true</code></td>
+</tr>
+</tbody>
+</table>
 
-* The `optimization` option applies to scripts, styles and fonts. You can supply a value such as the following to apply optimization to one or the other:
+#### Styles optimization options
+<table class="is-full-width is-fixed-layout">
+<thead>
+<tr>
+<th>Option</th>
+<th width="40%">Description</th>
+<th>Value Type</th>
+<th>Default Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>minify</code></td>
+<td>Minify CSS definitions by removing extraneous whitespace and comments, merging identifiers and minimizing values.</td>
+<td><code class="no-auto-link">boolean</code></td>
+<td><code>true</code></td>
+</tr>
+<tr>
+<td><code>inlineCritical</code></td>
+<td>Extract and inline critical CSS definitions to improve first paint time.</td>
+<td><code class="no-auto-link">boolean</code></td>
+<td><code>false</code></td>
+</tr>
+</tbody>
+</table>
+
+#### Fonts optimization options
+<table class="is-full-width is-fixed-layout">
+<thead>
+<tr>
+<th>Option</th>
+<th width="40%">Description</th>
+<th>Value Type</th>
+<th>Default Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>inline</code></td>
+<td>Reduce render blocking requests by inlining external Google fonts and icons CSS definitions in the application's HTML index file.<br><strong>Note:</strong>This requires internet access.</td>
+<td><code class="no-auto-link">boolean</code></td>
+<td><code>true</code></td>
+</tr>
+</tbody>
+</table>
+
+
+You can supply a value such as the following to apply optimization to one or the other:
 
 <code-example language="json">
 
   "optimization": { 
     "scripts": true,
-    "styles": false,
+    "styles": {
+      "minify": true,
+      "inlineCritical": true
+    },
     "fonts": true
   }
 
 </code-example>
 
-<div class="alert is-important">
+### Source map configuration
 
-  Fonts optimization requires internet access.
-  When enabled, render blocking requests will be reduced by inlining external Google fonts and icons CSS definitions in the application's HTML index file. 
+The `sourceMap` browser builder option can be either a Boolean or an Object for more fine-grained configuration to control the source maps of an application.
 
-</div>
+<table class="is-full-width is-fixed-layout">
+<thead>
+<tr>
+<th>Option</th>
+<th width="40%">Description</th>
+<th>Value Type</th>
+<th>Default Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>scripts</code></td>
+<td>Output source maps for all scripts.</td>
+<td><code class="no-auto-link">boolean</code></td>
+<td><code>true</code></td>
+</tr>
+<tr>
+<td><code>styles</code></td>
+<td>Output source maps for all styles.</td>
+<td><code class="no-auto-link">boolean</code></td>
+<td><code>true</code></td>
+</tr>
+<tr>
+<td><code>vendor</code></td>
+<td>Resolve vendor packages source maps.</td>
+<td><code class="no-auto-link">boolean</code></td>
+<td><code>false</code></td>
+</tr>
+<tr>
+<td><code>hidden</code></td>
+<td>Output source maps used for error reporting tools.</td>
+<td><code class="no-auto-link">boolean</code></td>
+<td><code>false</code></td>
+</tr>
+</tbody>
+</table>
 
-* The `sourceMap` option applies for both scripts and styles. You can also choose to output hidden source maps, or resolve vendor package source maps:
+
+You can supply a value such as the following to apply sourceMap to one or the other:
 
 <code-example language="json">
 

--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -461,6 +461,13 @@ You can supply a value such as the following to apply optimization to one or the
 
 </code-example>
 
+<div class="alert is-helpful">
+
+   For [Universal](guide/glossary#universal), you can reduce the code rendered in the HTML page by
+   setting styles optimization to `true`.
+
+</div>
+
 ### Source map configuration
 
 The `sourceMap` browser builder option can be either a Boolean or an Object for more fine-grained configuration to control the source maps of an application.
@@ -503,7 +510,7 @@ The `sourceMap` browser builder option can be either a Boolean or an Object for 
 </table>
 
 
-You can supply a value such as the following to apply sourceMap to one or the other:
+You can supply a value such as the following to output source maps to one or the other:
 
 <code-example language="json">
 
@@ -521,8 +528,5 @@ You can supply a value such as the following to apply sourceMap to one or the ot
    When using hidden source maps, source maps will not be referenced in the bundle.
    These are useful if you only want source maps to map error stack traces in error reporting tools,
    but don't want to expose your source maps in the browser developer tools.
-
-   For [Universal](guide/glossary#universal), you can reduce the code rendered in the HTML page by
-   setting styles optimization to `true` and styles source maps to `false`.
 
 </div>

--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -363,10 +363,15 @@ See also [Using runtime-global libraries inside your app](guide/using-libraries#
 
 ### Optimization configuration
 
-The `optimization` browser builder option can be either a Boolean or an Object for more fine-grained configuration. This option enables various optimizations of the build output.
-Including minification of scripts and styles, tree-shaking, dead-code elimination, inlining of critical CSS and fonts inlining.
+The `optimization` browser builder option can be either a Boolean or an Object for more fine-tune configuration. This option enables various optimizations of the build output, including:
 
-There are several options that can be used to fine-grained the optimization of an application.
+- Minification of scripts and styles
+- Tree-shaking
+- Dead-code elimination
+- Inlining of critical CSS
+- Fonts inlining
+
+There are several options that can be used to fine-tune the optimization of an application.
 
 <table class="is-full-width is-fixed-layout">
 <thead>
@@ -418,7 +423,7 @@ There are several options that can be used to fine-grained the optimization of a
 </tr>
 <tr>
 <td><code>inlineCritical</code></td>
-<td>Extract and inline critical CSS definitions to improve first paint time.</td>
+<td>Extract and inline critical CSS definitions to improve <a href="https://web.dev/first-contentful-paint/">First Contentful Paint.</td>
 <td><code class="no-auto-link">boolean</code></td>
 <td><code>false</code></td>
 </tr>
@@ -438,7 +443,7 @@ There are several options that can be used to fine-grained the optimization of a
 <tbody>
 <tr>
 <td><code>inline</code></td>
-<td>Reduce render blocking requests by inlining external Google fonts and icons CSS definitions in the application's HTML index file.<br><strong>Note:</strong>This requires internet access.</td>
+<td>Reduce <a href="https://web.dev/render-blocking-resources/">render blocking requests</a> by inlining external Google fonts and icons CSS definitions in the application's HTML index file.<br><strong>Note:</strong>This requires internet access.</td>
 <td><code class="no-auto-link">boolean</code></td>
 <td><code>true</code></td>
 </tr>
@@ -470,7 +475,7 @@ You can supply a value such as the following to apply optimization to one or the
 
 ### Source map configuration
 
-The `sourceMap` browser builder option can be either a Boolean or an Object for more fine-grained configuration to control the source maps of an application.
+The `sourceMap` browser builder option can be either a Boolean or an Object for more fine-tune configuration to control the source maps of an application.
 
 <table class="is-full-width is-fixed-layout">
 <thead>
@@ -510,7 +515,7 @@ The `sourceMap` browser builder option can be either a Boolean or an Object for 
 </table>
 
 
-You can supply a value such as the following to output source maps to one or the other:
+The example below shows how to toggle one or more values to configure the source map outputs:
 
 <code-example language="json">
 


### PR DESCRIPTION
With this change we split the optimization and source map configuration section section into two, improve it overall by adding the options a table and add the new options (`inlineCritical` and `minify`) that have been introduced in CLI version 11.1
