### PR TITLE
docs: remove -webkit-box-sizing and -moz-box-sizing

### DIFF
--- a/aio/content/examples/testing/src/app/dashboard/dashboard.component.css
+++ b/aio/content/examples/testing/src/app/dashboard/dashboard.component.css
@@ -2,8 +2,6 @@
   float: left;
 }
 *, *::after, *::before {
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
 h3 {

--- a/aio/content/examples/toh-pt5/src/app/dashboard/dashboard.component.css
+++ b/aio/content/examples/toh-pt5/src/app/dashboard/dashboard.component.css
@@ -11,8 +11,6 @@ a {
   text-decoration: none;
 }
 *, *::after, *::before {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 h3 {

--- a/aio/content/examples/toh-pt6/src/app/dashboard/dashboard.component.css
+++ b/aio/content/examples/toh-pt6/src/app/dashboard/dashboard.component.css
@@ -11,8 +11,6 @@ a {
   text-decoration: none;
 }
 *, *::after, *::before {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 h3 {

--- a/aio/content/examples/universal/src/app/dashboard/dashboard.component.css
+++ b/aio/content/examples/universal/src/app/dashboard/dashboard.component.css
@@ -11,8 +11,6 @@ a {
   text-decoration: none;
 }
 *, *::after, *::before {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 h3 {


### PR DESCRIPTION
Angular has stopped to support browser that requires these CSS properties.
All supported browsers support standard box-sizing CSS property

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
