### PR TITLE
feat(forms): change methods of Validators to arrow functions

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -196,7 +196,7 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static required(control: AbstractControl): ValidationErrors|null {
+  static required: ValidatorFn = (control: AbstractControl): ValidationErrors|null => {
     return isEmptyInputValue(control.value) ? {'required': true} : null;
   }
 
@@ -221,7 +221,7 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static requiredTrue(control: AbstractControl): ValidationErrors|null {
+  static requiredTrue: ValidatorFn = (control: AbstractControl): ValidationErrors|null => {
     return control.value === true ? null : {'required': true};
   }
 
@@ -261,7 +261,7 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static email(control: AbstractControl): ValidationErrors|null {
+  static email: ValidatorFn = (control: AbstractControl): ValidationErrors|null => {
     if (isEmptyInputValue(control.value)) {
       return null;  // don't validate empty values to allow optional controls
     }
@@ -431,7 +431,7 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static nullValidator(control: AbstractControl): ValidationErrors|null {
+  static nullValidator: ValidatorFn = (control: AbstractControl): ValidationErrors|null => {
     return null;
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe:


## What is the current behavior? What is the new behavior?

TypeScript has a rule [@typescript-eslint/unbound-method](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/unbound-method.md) and angular has [Built-in validator functions](https://angular.io/guide/form-validation#built-in-validator-functions).

We use validator function as below:

```ts
new FormControl(this.hero.name, [
    Validators.required,
    Validators.minLength(4),
])
```

let's see the types of  Validators.required and Validators.minLength.

```ts
class Validators {
    static required(control: AbstractControl): ValidationErrors | null;
    static minLength(minLength: number): ValidatorFn;
}
```

![image](https://user-images.githubusercontent.com/8111351/101648087-6e88ab80-3a74-11eb-802a-06f6ca188ff6.png)
![image](https://user-images.githubusercontent.com/8111351/101648296-a263d100-3a74-11eb-807d-1384bf6db64c.png)

The `Validators.required` is a *class method* and the return type of `Validators.minLength` is a function `ValidatorFn`.

Eslint think a method may contain `this`, and if someone use a direct reference to the method, such as `Validators.required`, the `this`, which in the implementation of the method body, may point to an incorrect object, like `window`/`undefined` or something else.

And eslint think if a function contain this, it will told us by [this parameters](https://www.typescriptlang.org/docs/handbook/functions.html#this-parameters). So we don't have to worry about `this` value pointing problem of `ValidatorFn` and eslint will not blame.

---

Current behavior：
![image](https://user-images.githubusercontent.com/8111351/101649975-6af62400-3a76-11eb-8964-9d3ce303fc00.png)

New behavior: 
![image](https://user-images.githubusercontent.com/8111351/101650120-924cf100-3a76-11eb-9f11-88167499071a.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

It would be better if we can change `class Validators` to `namespace Validators`.