### PR TITLE
Revert "ci: update pullapprove config to add comp labels"

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -229,10 +229,6 @@ groups:
           'aio/content/guide/route-animations.md',
           'aio/content/guide/transition-and-triggers.md'
           ])
-    labels:
-      pending: "comp: animations"
-      approved: "comp: animations"
-      rejected: "comp: animations"
     reviewers:
       users:
         - crisbeto
@@ -258,10 +254,6 @@ groups:
           'aio/content/guide/aot-metadata-errors.md',
           'aio/content/guide/template-typecheck.md '
           ])
-    labels:
-      pending: "comp: compiler"
-      approved: "comp: compiler"
-      rejected: "comp: compiler"
     reviewers:
       users:
         - alxhub
@@ -278,10 +270,6 @@ groups:
       - *can-be-global-approved
       - *can-be-global-docs-approved
       - files.include('packages/compiler-cli/ngcc/**')
-    labels:
-      pending: "comp: ngcc"
-      approved: "comp: ngcc"
-      rejected: "comp: ngcc"
     reviewers:
       users:
         - alxhub
@@ -299,10 +287,6 @@ groups:
       - *can-be-global-approved
       - *can-be-global-docs-approved
       - files.include("packages/core/schematics/**")
-    labels:
-      pending: "comp: migrations"
-      approved: "comp: migrations"
-      rejected: "comp: migrations"
     reviewers:
       users:
         - alxhub
@@ -322,9 +306,11 @@ groups:
         contains_any_globs(files.exclude("packages/core/schematics/**"), [
           'packages/core/**',
           'packages/examples/core/**',
+          'packages/common/**',
           'packages/platform-browser/**',
           'packages/examples/platform-browser/**',
           'packages/platform-browser-dynamic/**',
+          'packages/examples/common/**',
           'packages/docs/**',
           'aio/content/guide/accessibility.md',
           'aio/content/examples/accessibility/**',
@@ -438,44 +424,12 @@ groups:
           'aio/content/examples/user-input/**',
           'aio/content/images/guide/user-input/**'
           ])
-    labels:
-      pending: "comp: core"
-      approved: "comp: core"
-      rejected: "comp: core"
     reviewers:
       users:
         - alxhub
         - AndrewKushnir
         - atscott
         - ~kara  # do not request reviews from Kara, but allow her to approve PRs
-        - mhevery
-        - jessicajaniuk
-        # OOO as of 2020-09-28 - pkozlowski-opensource
-
-
-  # =========================================================
-  #  Framework: Common
-  # =========================================================
-  fw-common:
-    <<: *defaults
-    conditions:
-      - *can-be-global-approved
-      - *can-be-global-docs-approved
-      - >
-        contains_any_globs(files.exclude("packages/core/schematics/**"), [
-          'packages/common/**',
-          'packages/examples/common/**',
-          ])
-    labels:
-      pending: "comp: common"
-      approved: "comp: common"
-      rejected: "comp: common"
-    reviewers:
-      users:
-        - alxhub
-        - AndrewKushnir
-        - atscott
-        - ~kara # do not request reviews from Kara, but allow her to approve PRs
         - mhevery
         - jessicajaniuk
         # OOO as of 2020-09-28 - pkozlowski-opensource
@@ -497,10 +451,6 @@ groups:
           'aio/content/examples/http/**',
           'aio/content/images/guide/http/**'
           ])
-    labels:
-      pending: "comp: common/http"
-      approved: "comp: common/http"
-      rejected: "comp: common/http"
     reviewers:
       users:
         - alxhub
@@ -522,10 +472,6 @@ groups:
           'aio/content/images/guide/elements/**',
           'aio/content/guide/elements.md'
           ])
-    labels:
-      pending: "comp: elements"
-      approved: "comp: elements"
-      rejected: "comp: elements"
     reviewers:
       users:
         - andrewseguin
@@ -560,10 +506,6 @@ groups:
           'aio/content/examples/reactive-forms/**',
           'aio/content/images/guide/reactive-forms/**'
           ])
-    labels:
-      pending: "comp: forms"
-      approved: "comp: forms"
-      rejected: "comp: forms"
     reviewers:
       users:
         - AndrewKushnir
@@ -596,10 +538,6 @@ groups:
           'aio/content/guide/i18n.md',
           'aio/content/examples/i18n/**'
           ])
-    labels:
-      pending: "comp: i18n"
-      approved: "comp: i18n"
-      rejected: "comp: i18n"
     reviewers:
       users:
         - AndrewKushnir
@@ -621,10 +559,6 @@ groups:
           'aio/content/guide/universal.md',
           'aio/content/examples/universal/**'
           ])
-    labels:
-      pending: "comp: server"
-      approved: "comp: server"
-      rejected: "comp: server"
     reviewers:
       users:
         - alxhub
@@ -650,10 +584,6 @@ groups:
           'aio/content/examples/router/**',
           'aio/content/images/guide/router/**'
           ])
-    labels:
-      pending: "comp: router"
-      approved: "comp: router"
-      rejected: "comp: router"
     reviewers:
       users:
         - atscott
@@ -680,10 +610,6 @@ groups:
           'aio/content/guide/service-worker-intro.md',
           'aio/content/images/guide/service-worker/**'
           ])
-    labels:
-      pending: "comp: service-worker"
-      approved: "comp: service-worker"
-      rejected: "comp: service-worker"
     reviewers:
       users:
         - alxhub
@@ -716,10 +642,6 @@ groups:
           'aio/content/guide/ajs-quick-reference.md',
           'aio/content/examples/ajs-quick-reference/**'
           ])
-    labels:
-      pending: "comp: upgrade"
-      approved: "comp: upgrade"
-      rejected: "comp: upgrade"
     reviewers:
       users:
         - gkalpak
@@ -749,10 +671,6 @@ groups:
           'aio/content/examples/testing/**',
           'aio/content/images/guide/testing/**'
           ])
-    labels:
-      pending: "comp: testing"
-      approved: "comp: testing"
-      rejected: "comp: testing"
     reviewers:
       users:
         - AndrewKushnir
@@ -771,10 +689,6 @@ groups:
         contains_any_globs(files, [
           'modules/benchmarks/**'
           ])
-    labels:
-      pending: "comp: performance"
-      approved: "comp: performance"
-      rejected: "comp: performance"
     reviewers:
       users:
         - IgorMinar
@@ -823,10 +737,6 @@ groups:
         - mhevery
         - jelbourn
         # OOO as of 2020-09-28 - pkozlowski-opensource
-    labels:
-      pending: "comp: security"
-      approved: "comp: security"
-      rejected: "comp: security"
     reviews:
       request: -1   # request reviews from everyone
       required: 2   # require at least 2 approvals
@@ -845,10 +755,6 @@ groups:
         contains_any_globs(files, [
           'packages/bazel/**',
           ])
-    labels:
-      pending: "comp: bazel"
-      approved: "comp: bazel"
-      rejected: "comp: bazel"
     reviewers:
       users:
         - IgorMinar
@@ -870,10 +776,6 @@ groups:
           'aio/content/guide/language-service.md',
           'aio/content/images/guide/language-service/**'
           ])
-    labels:
-      pending: "comp: language-service"
-      approved: "comp: language-service"
-      rejected: "comp: language-service"
     reviewers:
       users:
         - ayazhafiz
@@ -894,10 +796,6 @@ groups:
           'packages/zone.js/**',
           'aio/content/guide/zone.md'
           ])
-    labels:
-      pending: "comp: zones"
-      approved: "comp: zones"
-      rejected: "comp: zones"
     reviewers:
       users:
         - JiaLiPassion
@@ -914,10 +812,6 @@ groups:
         contains_any_globs(files, [
           'packages/misc/angular-in-memory-web-api/**',
           ])
-    labels:
-      pending: "comp: in-memory-web-api"
-      approved: "comp: in-memory-web-api"
-      rejected: "comp: in-memory-web-api"
     reviewers:
       users:
         - IgorMinar
@@ -935,10 +829,6 @@ groups:
         contains_any_globs(files, [
           'packages/benchpress/**'
           ])
-    labels:
-      pending: "comp: benchpress"
-      approved: "comp: benchpress"
-      rejected: "comp: benchpress"
     reviewers:
       users:
         - alxhub
@@ -956,10 +846,6 @@ groups:
         contains_any_globs(files, [
           'integration/**'
           ])
-    labels:
-      pending: "comp: testing"
-      approved: "comp: testing"
-      rejected: "comp: testing"
     reviewers:
       users:
         - IgorMinar
@@ -993,10 +879,6 @@ groups:
           'aio/content/start/**',
           'aio/content/images/guide/start/**'
           ])
-    labels:
-      pending: "comp: examples"
-      approved: "comp: examples"
-      rejected: "comp: examples"
     reviewers:
       users:
         - aikidave
@@ -1022,10 +904,6 @@ groups:
           'aio/content/license.md',
           'aio/content/navigation.json'
           ])
-    labels:
-      pending: "comp: docs"
-      approved: "comp: docs"
-      rejected: "comp: docs"
     reviewers:
       users:
         - aikidave
@@ -1053,10 +931,6 @@ groups:
           'aio/content/guide/rx-library.md',
           'aio/content/examples/rx-library/**'
           ])
-    labels:
-      pending: "comp: docs"
-      approved: "comp: docs"
-      rejected: "comp: docs"
     reviewers:
       users:
         - alxhub
@@ -1090,10 +964,6 @@ groups:
           'aio/content/guide/ivy-compatibility.md',
           'aio/content/guide/ivy-compatibility-examples.md'
           ])
-    labels:
-      pending: "comp: docs"
-      approved: "comp: docs"
-      rejected: "comp: docs"
     reviewers:
       users:
         - IgorMinar
@@ -1120,10 +990,6 @@ groups:
         - clydin
         - kyliau
         - IgorMinar
-    labels:
-      pending: "comp: compiler"
-      approved: "comp: compiler"
-      rejected: "comp: compiler"
     reviews:
       request: -1   # request reviews from everyone
       required: 2   # require at least 2 approvals
@@ -1158,10 +1024,6 @@ groups:
           'aio/content/guide/migration-update-module-and-target-compiler-options.md',
           'aio/content/guide/migration-update-libraries-tslib.md',
           ])
-    labels:
-      pending: "comp: docs"
-      approved: "comp: docs"
-      rejected: "comp: docs"
     reviewers:
       users:
         - alan-agius4
@@ -1184,10 +1046,6 @@ groups:
           'aio/content/guide/libraries.md',
           'aio/content/guide/using-libraries.md'
           ])
-    labels:
-      pending: "comp: docs"
-      approved: "comp: docs"
-      rejected: "comp: docs"
     reviewers:
       users:
         - alan-agius4
@@ -1211,10 +1069,6 @@ groups:
           'aio/content/images/guide/schematics/**',
           'aio/content/examples/schematics-for-libraries/**'
           ])
-    labels:
-      pending: "comp: docs"
-      approved: "comp: docs"
-      rejected: "comp: docs"
     reviewers:
       users:
         - alan-agius4
@@ -1245,10 +1099,6 @@ groups:
           'aio/content/images/guide/docs-style-guide/**',
           'aio/content/guide/visual-studio-2015.md'
           ])
-    labels:
-      pending: "comp: docs-infra"
-      approved: "comp: docs-infra"
-      rejected: "comp: docs-infra"
     reviewers:
       users:
         - gkalpak
@@ -1316,10 +1166,6 @@ groups:
           '**/*.bzl',
           '**/*.bazel'
           ])
-    labels:
-      pending: "comp: dev-infra"
-      approved: "comp: dev-infra"
-      rejected: "comp: dev-infra"
     reviewers:
       users:
         # OOO as of 2020-09-28 - devversion
@@ -1357,10 +1203,6 @@ groups:
         - jelbourn
         - petebacondarwin
         # OOO as of 2020-09-28 - pkozlowski-opensource
-    labels:
-      pending: "comp: docs/api"
-      approved: "comp: docs/api"
-      rejected: "comp: docs/api"
     reviews:
       request: 4 # Request reviews from four people
       required: 3 # Require that three people approve
@@ -1389,10 +1231,6 @@ groups:
         - jelbourn
         - petebacondarwin
         # OOO as of 2020-09-28 - pkozlowski-opensource
-    labels:
-      pending: "comp: build & ci"
-      approved: "comp: build & ci"
-      rejected: "comp: build & ci"
     reviews:
       request: 4 # Request reviews from four people
       required: 2 # Require that two people approve
@@ -1412,10 +1250,6 @@ groups:
         contains_any_globs(files, [
           'goldens/circular-deps/packages.json'
         ])
-    labels:
-      pending: "comp: build & ci"
-      approved: "comp: build & ci"
-      rejected: "comp: build & ci"
     reviewers:
       users:
         - AndrewKushnir
@@ -1442,10 +1276,6 @@ groups:
         contains_any_globs(files, [
           '.pullapprove.yml'
           ])
-    labels:
-      pending: "comp: build & ci"
-      approved: "comp: build & ci"
-      rejected: "comp: build & ci"
     reviewers:
       users:
         - AndrewKushnir


### PR DESCRIPTION
The PullApprove labeling is unfortunately removing labels rather than
adding them.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
This reverts commit 9f8ccd577f481a3ca4508287ec06cdf863561f69. 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
PullApprove is unfortunately removing labels rather than adding them.

Issue Number: N/A


## What is the new behavior?
This restores the previous PullApprove behavior of not auto adding / removing labels.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
