### PR TITLE
Correct equivalent for enabled initial navigation

### DIFF
--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -236,7 +236,7 @@ export function provideRoutes(routes: Routes): any {
  * The following values have been [deprecated](guide/releases#deprecation-practices) since v11,
  * and should not be used for new applications.
  *
- * * 'enabled' - This option is 1:1 replaceable with `enabledNonBlocking`.
+ * * 'enabled' - This option is 1:1 replaceable with `enabledBlocking`.
  *
  * @see `forRoot()`
  *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

With regard to the proven functionality, I believe that the correct equivalent for `enabled` should be` enabledBlocking` and not `enabledNonBlocking`.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [x] No