### PR TITLE
docs: remove prefixed border-radius related properties

### DIFF
--- a/aio/content/examples/ajs-quick-reference/src/app/movie-list.component.css
+++ b/aio/content/examples/ajs-quick-reference/src/app/movie-list.component.css
@@ -11,8 +11,6 @@ table {
   margin:20px;
   border:#ccc 1px solid;
 
-  -moz-border-radius:3px;
-  -webkit-border-radius:3px;
   border-radius:3px;
 }
 table th {
@@ -46,12 +44,8 @@ table tr:last-child td {
   border-bottom:0;
 }
 table tr:last-child td:first-child {
-  -moz-border-radius-bottomleft:3px;
-  -webkit-border-bottom-left-radius:3px;
   border-bottom-left-radius:3px;
 }
 table tr:last-child td:last-child {
-  -moz-border-radius-bottomright:3px;
-  -webkit-border-bottom-right-radius:3px;
   border-bottom-right-radius:3px;
 }


### PR DESCRIPTION
Angular has stopped to support browser that requires these CSS properties.
All supported browsers support standard CSS properties:
* border-radius
* border-bottom-left-radius
* border-bottom-right-radius

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
