### PR TITLE
fix(core): `QueryList` does not fire changes if the underlying list did not change.

### DIFF
--- a/packages/core/src/linker/query_list.ts
+++ b/packages/core/src/linker/query_list.ts
@@ -9,7 +9,7 @@
 import {Observable} from 'rxjs';
 
 import {EventEmitter} from '../event_emitter';
-import {flatten} from '../util/array_utils';
+import {flattenIntoExisting} from '../util/array_utils';
 import {getSymbolIterator} from '../util/symbol';
 
 function symbolIterator<T>(this: QueryList<T>): Iterator<T> {
@@ -135,13 +135,21 @@ export class QueryList<T> implements Iterable<T> {
    * occurs.
    *
    * @param resultsTree The query results to store
+   * @returns `true` only if the new `resultTree` resulted in a different query set.
+   *          (It could be that a new `resultTree` produces the same sat in which case we don't want
+   *          to create noise.)
    */
-  reset(resultsTree: Array<T|any[]>): void {
-    this._results = flatten(resultsTree);
-    (this as {dirty: boolean}).dirty = false;
-    (this as {length: number}).length = this._results.length;
-    (this as {last: T}).last = this._results[this.length - 1];
-    (this as {first: T}).first = this._results[0];
+  reset(resultsTree: Array<T|any[]>): boolean {
+    debugger;
+    if (flattenIntoExisting(resultsTree, this._results)) {
+      (this as {dirty: boolean}).dirty = false;
+      (this as {length: number}).length = this._results.length;
+      (this as {last: T}).last = this._results[this.length - 1];
+      (this as {first: T}).first = this._results[0];
+      return true;
+    } else {
+      return false;
+    }
   }
 
   /**

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -434,8 +434,9 @@ export function ɵɵqueryRefresh(queryList: QueryList<any>): boolean {
       const result = tQuery.crossesNgTemplate ?
           collectQueryResults(tView, lView, queryIndex, []) :
           materializeViewResults(tView, lView, tQuery, queryIndex);
-      queryList.reset(result);
-      queryList.notifyOnChanges();
+      if (queryList.reset(result)) {
+        queryList.notifyOnChanges();
+      }
     }
     return true;
   }

--- a/packages/core/test/util/array_utils_spec.ts
+++ b/packages/core/test/util/array_utils_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {arrayIndexOfSorted, arrayInsert, arrayInsert2, arrayInsertSorted, arrayRemoveSorted, arraySplice, flatten, KeyValueArray, keyValueArrayDelete, keyValueArrayGet, keyValueArrayIndexOf, keyValueArraySet} from '../../src/util/array_utils';
+import {arrayIndexOfSorted, arrayInsert, arrayInsert2, arrayInsertSorted, arrayRemoveSorted, arraySplice, flatten, flattenIntoExisting, KeyValueArray, keyValueArrayDelete, keyValueArrayGet, keyValueArrayIndexOf, keyValueArraySet} from '../../src/util/array_utils';
 
 describe('array_utils', () => {
   describe('flatten', () => {
@@ -25,6 +25,44 @@ describe('array_utils', () => {
       expect(flatten([1, [2, [3]], [4]])).toEqual([1, 2, 3, 4]);
       expect(flatten([1, [2, [3]], [[[4]]]])).toEqual([1, 2, 3, 4]);
       expect(flatten([1, [], 2])).toEqual([1, 2]);
+    });
+  });
+
+  describe('flattenIntoExisting', () => {
+    it('should detectNoChanges on empty set', () => {
+      const dst: string[] = [];
+      expect(flattenIntoExisting([], dst)).toBeFalse();
+      expect(dst).toEqual([]);
+    });
+
+    it('should detectChanges and remove extra', () => {
+      const dst: string[] = ['extra', 'another'];
+      expect(flattenIntoExisting([], dst)).toBeTrue();
+      expect(dst).toEqual([]);
+    });
+
+    it('should detectNoChanges on flat input', () => {
+      const dst: string[] = ['a', 'b'];
+      expect(flattenIntoExisting(['a', 'b'], dst)).toBeFalse();
+      expect(dst).toEqual(['a', 'b']);
+    });
+
+    it('should detectNoChanges on hierarchical input', () => {
+      const dst: string[] = ['a', 'b'];
+      expect(flattenIntoExisting([['a'], 'b', []], dst)).toBeFalse();
+      expect(dst).toEqual(['a', 'b']);
+    });
+
+    it('should detectChanges and trim on hierarchical input', () => {
+      const dst: string[] = ['a', 'c', 'b'];
+      expect(flattenIntoExisting([['a'], 'b', []], dst)).toBeTrue();
+      expect(dst).toEqual(['a', 'b']);
+    });
+
+    it('should detectNoChanges on nested value', () => {
+      const dst: string[] = [];
+      expect(flattenIntoExisting([['a']], dst)).toBeTrue();
+      expect(dst).toEqual(['a']);
     });
   });
 


### PR DESCRIPTION
Previous implementation would fire changes `QueryList.changes.subscribe`
even if underlying list did not change. Such situation can arise if a
`LView` is inserted or removed, causing `QueryList` to recompute, but
the recompute results in the same exact `QueryList` result. In such
a case we don't want to fire a change event (as there is no change.)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
