### PR TITLE
test(compiler): use `yarn bazel` instead of `bazel` in error message

### DIFF
--- a/packages/compiler-cli/test/compliance/test_helpers/check_expectations.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/check_expectations.ts
@@ -49,7 +49,7 @@ export function checkExpectations(
           `The generated file at ${generatedPath} does not exist.\n` +
           'Perhaps there is no matching input source file in the TEST_CASES.json file for this test case.\n' +
           'Or maybe you need to regenerate the GOLDEN_PARTIAL.js file by running:\n\n' +
-          `    bazel run //packages/compiler-cli/test/compliance/test_cases:${
+          `    yarn bazel run //packages/compiler-cli/test/compliance/test_cases:${
               testPath}.golden.update`);
       // Clear the stack so that we get a nice error message
       error.stack = '';


### PR DESCRIPTION
This commit replaces `bazel` with `yarn bazel` in the error message (that instructs to regenerate golden file)
thrown while executing compliance tests. We use `yarn bazel` in other places (so we use the local version of bazel,
not the global one).


## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: error message update in tests.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No