### PR TITLE
docs: remove unused CSS rule

### DIFF
--- a/aio/content/examples/toh-pt5/src/app/app.component.css
+++ b/aio/content/examples/toh-pt5/src/app/app.component.css
@@ -3,11 +3,6 @@ h1 {
   font-size: 1.2em;
   margin-bottom: 0;
 }
-h2 {
-  font-size: 2em;
-  margin-top: 0;
-  padding-top: 0;
-}
 nav a {
   padding: 5px 10px;
   text-decoration: none;

--- a/aio/content/examples/toh-pt6/src/app/app.component.css
+++ b/aio/content/examples/toh-pt6/src/app/app.component.css
@@ -3,11 +3,6 @@ h1 {
   font-size: 1.2em;
   margin-bottom: 0;
 }
-h2 {
-  font-size: 2em;
-  margin-top: 0;
-  padding-top: 0;
-}
 nav a {
   padding: 5px 10px;
   text-decoration: none;

--- a/aio/content/examples/universal/src/app/app.component.css
+++ b/aio/content/examples/universal/src/app/app.component.css
@@ -3,11 +3,6 @@ h1 {
   font-size: 1.2em;
   margin-bottom: 0;
 }
-h2 {
-  font-size: 2em;
-  margin-top: 0;
-  padding-top: 0;
-}
 nav a {
   padding: 5px 10px;
   text-decoration: none;


### PR DESCRIPTION
Removed rule don't affect their component views.
The reason - the templates don't contain elements to which that rule is applied.
See https://angular.io/guide/view-encapsulation for more details

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
