### PR TITLE
feat(dev-infra): support --mode flag for building environment stamp 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -47,8 +47,12 @@ build --nobuild_runfile_links
 # Releases should always be stamped with version control info
 # This command assumes node on the path and is a workaround for
 # https://github.com/bazelbuild/bazel/issues/4802
-build:release --workspace_status_command="yarn -s ng-dev release build-env-stamp"
+build:release --workspace_status_command="yarn -s ng-dev release build-env-stamp --mode=release"
 build:release --stamp
+
+# Snapshots should also be stamped with version control information.
+build:snapshot --workspace_status_command="yarn -s ng-dev release build-env-stamp --mode=snapshot"
+build:snapshot --stamp
 
 ###############################
 # Output                      #

--- a/.ng-dev/release.ts
+++ b/.ng-dev/release.ts
@@ -26,7 +26,7 @@ export const release: ReleaseConfig = {
     // The buildTargetPackages function is loaded at runtime as the loading the script causes an
     // invocation of bazel.
     const {buildTargetPackages} = require(join(__dirname, '../scripts/build/package-builder'));
-    return buildTargetPackages('dist/release-output', false, 'Release');
+    return buildTargetPackages('dist/release-output', false, 'Release', true);
   },
   // TODO: This can be removed once there is an org-wide tool for changelog generation.
   generateReleaseNotesForHead: async () => {

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -6557,7 +6557,12 @@ function exec$1(cmd) {
 function hasLocalChanges() {
     return !!exec$1(`git status --untracked-files=no --porcelain`);
 }
-/** Get the version based on the most recent semver tag. */
+/**
+ * Get the version for generated packages.
+ *
+ * In snapshot mode, the version is based on the most recent semver tag.
+ * In release mode, the version is based on the base package.json version.
+ */
 function getSCMVersion(mode) {
     if (mode === 'release') {
         const packageJsonPath = path.join(getRepoBaseDir(), 'package.json');

--- a/dev-infra/release/BUILD.bazel
+++ b/dev-infra/release/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
         "//dev-infra/release/publish",
         "//dev-infra/release/set-dist-tag",
         "//dev-infra/utils",
+        "@npm//@types/node",
         "@npm//@types/yargs",
         "@npm//yargs",
     ],

--- a/dev-infra/release/cli.ts
+++ b/dev-infra/release/cli.ts
@@ -10,7 +10,7 @@ import * as yargs from 'yargs';
 import {ReleaseBuildCommandModule} from './build/cli';
 import {ReleasePublishCommandModule} from './publish/cli';
 import {ReleaseSetDistTagCommand} from './set-dist-tag/cli';
-import {buildEnvStamp} from './stamping/env-stamp';
+import {BuildEnvStampCommand} from './stamping/cli';
 
 /** Build the parser for the release commands. */
 export function buildReleaseParser(localYargs: yargs.Argv) {
@@ -20,7 +20,5 @@ export function buildReleaseParser(localYargs: yargs.Argv) {
       .command(ReleasePublishCommandModule)
       .command(ReleaseBuildCommandModule)
       .command(ReleaseSetDistTagCommand)
-      .command(
-          'build-env-stamp', 'Build the environment stamping information', {},
-          () => buildEnvStamp());
+      .command(BuildEnvStampCommand);
 }

--- a/dev-infra/release/stamping/cli.ts
+++ b/dev-infra/release/stamping/cli.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Arguments, Argv, CommandModule} from 'yargs';
+
+import {buildEnvStamp, EnvStampMode} from './env-stamp';
+
+
+export interface Options {
+  mode: EnvStampMode;
+}
+
+function builder(args: Argv): Argv<Options> {
+  return args.option('mode', {
+    demandOption: true,
+    description: 'Whether the env-stamp should be built for a snapshot or release',
+    choices: ['snapshot' as const, 'release' as const]
+  });
+}
+
+async function handler({mode}: Arguments<Options>) {
+  buildEnvStamp(mode);
+}
+
+/** CLI command module for building the environment stamp. */
+export const BuildEnvStampCommand: CommandModule<{}, Options> = {
+  builder,
+  handler,
+  command: 'build-env-stamp',
+  describe: 'Build the environment stamping information',
+};

--- a/dev-infra/release/stamping/env-stamp.ts
+++ b/dev-infra/release/stamping/env-stamp.ts
@@ -43,7 +43,12 @@ function hasLocalChanges() {
   return !!exec(`git status --untracked-files=no --porcelain`);
 }
 
-/** Get the version based on the most recent semver tag. */
+/**
+ * Get the version for generated packages.
+ *
+ * In snapshot mode, the version is based on the most recent semver tag.
+ * In release mode, the version is based on the base package.json version.
+ */
 function getSCMVersion(mode: EnvStampMode) {
   if (mode === 'release') {
     const packageJsonPath = join(getRepoBaseDir(), 'package.json');

--- a/dev-infra/release/stamping/env-stamp.ts
+++ b/dev-infra/release/stamping/env-stamp.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {join} from 'path';
+
+import {getRepoBaseDir} from '../../utils/config';
 import {exec as _exec} from '../../utils/shelljs';
+
+export type EnvStampMode = 'snapshot'|'release';
 
 /**
  * Log the environment variables expected by bazel for stamping.
@@ -18,13 +23,13 @@ import {exec as _exec} from '../../utils/shelljs';
  * Note: git operations, especially git status, take a long time inside mounted docker volumes
  * in Windows or OSX hosts (https://github.com/docker/for-win/issues/188).
  */
-export function buildEnvStamp() {
+export function buildEnvStamp(mode: EnvStampMode) {
   console.info(`BUILD_SCM_BRANCH ${getCurrentBranch()}`);
   console.info(`BUILD_SCM_COMMIT_SHA ${getCurrentSha()}`);
   console.info(`BUILD_SCM_HASH ${getCurrentSha()}`);
   console.info(`BUILD_SCM_LOCAL_CHANGES ${hasLocalChanges()}`);
   console.info(`BUILD_SCM_USER ${getCurrentGitUser()}`);
-  console.info(`BUILD_SCM_VERSION ${getSCMVersion()}`);
+  console.info(`BUILD_SCM_VERSION ${getSCMVersion(mode)}`);
   process.exit(0);
 }
 
@@ -39,10 +44,18 @@ function hasLocalChanges() {
 }
 
 /** Get the version based on the most recent semver tag. */
-function getSCMVersion() {
-  const version = exec(`git describe --match [0-9]*.[0-9]*.[0-9]* --abbrev=7 --tags HEAD`);
-  return `${version.replace(/-([0-9]+)-g/, '+$1.sha-')}${
-      (hasLocalChanges() ? '.with-local-changes' : '')}`;
+function getSCMVersion(mode: EnvStampMode) {
+  if (mode === 'release') {
+    const packageJsonPath = join(getRepoBaseDir(), 'package.json');
+    const {version} = require(packageJsonPath);
+    return version;
+  }
+  if (mode === 'snapshot') {
+    const version = exec(`git describe --match [0-9]*.[0-9]*.[0-9]* --abbrev=7 --tags HEAD`);
+    return `${version.replace(/-([0-9]+)-g/, '+$1.sha-')}${
+        (hasLocalChanges() ? '.with-local-changes' : '')}`;
+  }
+  return '0.0.0';
 }
 
 /** Get the current SHA of HEAD. */

--- a/scripts/build/package-builder.js
+++ b/scripts/build/package-builder.js
@@ -62,9 +62,10 @@ module.exports = {
  * This path should either be absolute or relative to the project root.
  * @param {boolean} enableIvy True, if Ivy should be used.
  * @param {string} description Human-readable description of the build.
+ * @param {boolean?} isRelease True, if the build should be stamped for a release.
  * @returns {Array<{name: string, outputPath: string}} A list of packages built.
  */
-function buildTargetPackages(destPath, enableIvy, description) {
+function buildTargetPackages(destPath, enableIvy, description, isRelease) {
   console.info('##################################');
   console.info(`${scriptPath}:`);
   console.info('  Building @angular/* npm packages');
@@ -80,9 +81,10 @@ function buildTargetPackages(destPath, enableIvy, description) {
       bazelCmd} query --output=label "attr('tags', '\\[.*release-with-framework.*\\]', //packages/...) intersect kind('ng_package|pkg_npm', //packages/...)"`;
   const targets = exec(getTargetsCmd, true).split(/\r?\n/);
 
-  // Use `--config=release` so that snapshot builds get published with embedded version info.
-  exec(`${bazelCmd} build --config=release --config=${enableIvy ? 'ivy' : 'view-engine'} ${
-      targets.join(' ')}`);
+  // Use either `--config=snapshot` or `--config=release` so that builds are created with the
+  // correct embedded version info.
+  exec(`${bazelCmd} build --config=${isRelease ? 'release' : 'snapshot'} --config=${
+      enableIvy ? 'ivy' : 'view-engine'} ${targets.join(' ')}`);
 
   // Create the output directory.
   const absDestPath = resolve(baseDir, destPath);

--- a/scripts/build/package-builder.js
+++ b/scripts/build/package-builder.js
@@ -65,7 +65,7 @@ module.exports = {
  * @param {boolean?} isRelease True, if the build should be stamped for a release.
  * @returns {Array<{name: string, outputPath: string}} A list of packages built.
  */
-function buildTargetPackages(destPath, enableIvy, description, isRelease) {
+function buildTargetPackages(destPath, enableIvy, description, isRelease = false) {
   console.info('##################################');
   console.info(`${scriptPath}:`);
   console.info('  Building @angular/* npm packages');


### PR DESCRIPTION
When building the environment stamp, support two modes: release and snapshot

The release mode will always stamp using the current version of in the root package.json
and in snapshot mode will use a version stamp expressing a version based on the tag and
the number of commits from the tag.