### PR TITLE
fix(core): ensure sanitizer works if DOMParser return null body

### DIFF
--- a/packages/core/test/sanitization/html_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/html_sanitizer_spec.ts
@@ -252,5 +252,14 @@ function sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): string {
             .toMatch(/<a href="unsafe:(&#12288;)?javascript:alert\(1\)">CLICKME<\/a>/);
       });
     }
+
+    if (isDOMParserAvailable()) {
+      it('should work even if DOMParser returns a null body', () => {
+        // Simulate `DOMParser.parseFromString()` returning a null body.
+        // See https://github.com/angular/angular/issues/39834
+        spyOn(window.DOMParser.prototype, 'parseFromString').and.returnValue({body: null} as any);
+        expect(sanitizeHtml(defaultDoc, 'Hello, World')).toEqual('Hello, World');
+      });
+    }
   });
 }


### PR DESCRIPTION
In some browsers, notably a mobile version of webkit on iPad, the
result of calling `DOMParser.parseFromString()` returns a document
whose `body` property is null until the next tick of the browser.
Since this is of no use to us for sanitization, we now fall back to the
"inert document" strategy for this case.

Fixes #39834