### PR TITLE
fix(core): Call `onDestroy` in production mode as well

### DIFF
--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -19,7 +19,7 @@ import {assertTNodeType} from '../node_assert';
 import {getCurrentDirectiveDef, getCurrentTNode, getLView, getTView} from '../state';
 import {getComponentLViewByIndex, getNativeByTNode, unwrapRNode} from '../util/view_utils';
 
-import {getLCleanup, getTViewCleanup, handleError, loadComponentRenderer, markViewDirty} from './shared';
+import {getOrCreateLViewCleanup, getOrCreateTViewCleanup, handleError, loadComponentRenderer, markViewDirty} from './shared';
 
 
 
@@ -120,12 +120,12 @@ function listenerInternal(
     eventTargetResolver?: GlobalTargetResolver): void {
   const isTNodeDirectiveHost = isDirectiveHost(tNode);
   const firstCreatePass = tView.firstCreatePass;
-  const tCleanup: false|any[] = firstCreatePass && getTViewCleanup(tView);
+  const tCleanup: false|any[] = firstCreatePass && getOrCreateTViewCleanup(tView);
 
   // When the ɵɵlistener instruction was generated and is executed we know that there is either a
   // native listener or a directive output on this element. As such we we know that we will have to
   // register a listener and store its cleanup function on LView.
-  const lCleanup = getLCleanup(lView);
+  const lCleanup = getOrCreateLViewCleanup(lView);
 
   ngDevMode && assertTNodeType(tNode, TNodeType.AnyRNode | TNodeType.AnyContainer);
 

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -758,19 +758,19 @@ export function locateHostElement(
  */
 export function storeCleanupWithContext(
     tView: TView, lView: LView, context: any, cleanupFn: Function): void {
-  const lCleanup = getLCleanup(lView);
+  const lCleanup = getOrCreateLViewCleanup(lView);
   if (context === null) {
     // If context is null that this is instance specific callback. These callbacks can only be
     // inserted after template shared instances. For this reason in ngDevMode we freeze the TView.
     if (ngDevMode) {
-      Object.freeze(getTViewCleanup(tView));
+      Object.freeze(getOrCreateTViewCleanup(tView));
     }
     lCleanup.push(cleanupFn);
   } else {
     lCleanup.push(context);
 
     if (tView.firstCreatePass) {
-      getTViewCleanup(tView).push(cleanupFn, lCleanup.length - 1);
+      getOrCreateTViewCleanup(tView).push(cleanupFn, lCleanup.length - 1);
     }
   }
 }
@@ -2004,12 +2004,12 @@ export function storePropertyBindingMetadata(
 
 export const CLEAN_PROMISE = _CLEAN_PROMISE;
 
-export function getLCleanup(view: LView): any[] {
+export function getOrCreateLViewCleanup(view: LView): any[] {
   // top level variables should not be exported for performance reasons (PERF_NOTES.md)
   return view[CLEANUP] || (view[CLEANUP] = ngDevMode ? new LCleanup() : []);
 }
 
-export function getTViewCleanup(tView: TView): any[] {
+export function getOrCreateTViewCleanup(tView: TView): any[] {
   return tView.cleanup || (tView.cleanup = ngDevMode ? new TCleanup() : []);
 }
 

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -479,12 +479,12 @@ function processCleanups(tView: TView, lView: LView): void {
         tCleanup[i].call(context);
       }
     }
-    if (lCleanup !== null) {
-      for (let i = lastLCleanupIndex + 1; i < lCleanup.length; i++) {
-        const instanceCleanupFn = lCleanup[i];
-        ngDevMode && assertFunction(instanceCleanupFn, 'Expecting instance cleanup function.');
-        instanceCleanupFn();
-      }
+  }
+  if (lCleanup !== null) {
+    for (let i = lastLCleanupIndex + 1; i < lCleanup.length; i++) {
+      const instanceCleanupFn = lCleanup[i];
+      ngDevMode && assertFunction(instanceCleanupFn, 'Expecting instance cleanup function.');
+      instanceCleanupFn();
     }
     lView[CLEANUP] = null;
   }

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -303,55 +303,71 @@ describe('component', () => {
        expect(wrapperEls.length).toBe(2);  // other elements are preserved
      });
 
-  it('should invoke `onDestroy` callbacks of dynamically created component', () => {
-    let wasOnDestroyCalled = false;
-    @Component({
-      selector: '[comp]',
-      template: 'comp content',
-    })
-    class DynamicComponent {
-    }
+  describe('with ngDevMode', () => {
+    const _global: {ngDevMode: any} = global as any;
+    let saveNgDevMode!: typeof ngDevMode;
+    beforeEach(() => saveNgDevMode = ngDevMode);
+    afterEach(() => _global.ngDevMode = saveNgDevMode);
+    // In dev mode we have some additional logic to freeze `TView.cleanup` array
+    // (see `storeCleanupWithContext` function).
+    // The tests below verify that this action doesn't trigger any change in behaviour
+    // for prod mode. See https://github.com/angular/angular/issues/40105.
+    ['ngDevMode off', 'ngDevMode on'].forEach((mode) => {
+      it('should invoke `onDestroy` callbacks of dynamically created component with ' + mode,
+         () => {
+           if (mode === 'ngDevMode off') {
+             _global.ngDevMode = false;
+           }
+           let wasOnDestroyCalled = false;
+           @Component({
+             selector: '[comp]',
+             template: 'comp content',
+           })
+           class DynamicComponent {
+           }
 
-    @NgModule({
-      declarations: [DynamicComponent],
-      entryComponents: [DynamicComponent],  // needed only for ViewEngine
-    })
-    class TestModule {
-    }
+           @NgModule({
+             declarations: [DynamicComponent],
+             entryComponents: [DynamicComponent],  // needed only for ViewEngine
+           })
+           class TestModule {
+           }
 
-    @Component({
-      selector: 'button',
-      template: '<div id="app-root" #anchor></div>',
-    })
-    class App {
-      @ViewChild('anchor', {read: ViewContainerRef}) anchor!: ViewContainerRef;
+           @Component({
+             selector: 'button',
+             template: '<div id="app-root" #anchor></div>',
+           })
+           class App {
+             @ViewChild('anchor', {read: ViewContainerRef}) anchor!: ViewContainerRef;
 
-      constructor(private cfr: ComponentFactoryResolver, private injector: Injector) {}
+             constructor(private cfr: ComponentFactoryResolver, private injector: Injector) {}
 
-      create() {
-        const factory = this.cfr.resolveComponentFactory(DynamicComponent);
-        const componentRef = factory.create(this.injector);
-        componentRef.onDestroy(() => {
-          wasOnDestroyCalled = true;
-        });
-        this.anchor.insert(componentRef.hostView);
-      }
+             create() {
+               const factory = this.cfr.resolveComponentFactory(DynamicComponent);
+               const componentRef = factory.create(this.injector);
+               componentRef.onDestroy(() => {
+                 wasOnDestroyCalled = true;
+               });
+               this.anchor.insert(componentRef.hostView);
+             }
 
-      clear() {
-        this.anchor.clear();
-      }
-    }
+             clear() {
+               this.anchor.clear();
+             }
+           }
 
-    TestBed.configureTestingModule({imports: [TestModule], declarations: [App]});
-    const fixture = TestBed.createComponent(App);
-    fixture.detectChanges();
+           TestBed.configureTestingModule({imports: [TestModule], declarations: [App]});
+           const fixture = TestBed.createComponent(App);
+           fixture.detectChanges();
 
-    // Add ComponentRef to ViewContainerRef instance.
-    fixture.componentInstance.create();
-    // Clear ViewContainerRef to invoke `onDestroy` callbacks on ComponentRef.
-    fixture.componentInstance.clear();
+           // Add ComponentRef to ViewContainerRef instance.
+           fixture.componentInstance.create();
+           // Clear ViewContainerRef to invoke `onDestroy` callbacks on ComponentRef.
+           fixture.componentInstance.clear();
 
-    expect(wasOnDestroyCalled).toBeTrue();
+           expect(wasOnDestroyCalled).toBeTrue();
+         });
+    });
   });
 
   describe('invalid host element', () => {

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -1020,9 +1020,6 @@
     "name": "getInjectorIndex"
   },
   {
-    "name": "getLCleanup"
-  },
-  {
     "name": "getLView"
   },
   {
@@ -1051,6 +1048,9 @@
   },
   {
     "name": "getOrCreateInjectable"
+  },
+  {
+    "name": "getOrCreateLViewCleanup"
   },
   {
     "name": "getOrCreateNodeInjectorForNode"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1335,9 +1335,6 @@
     "name": "getInjectorIndex"
   },
   {
-    "name": "getLCleanup"
-  },
-  {
     "name": "getLView"
   },
   {
@@ -1368,6 +1365,9 @@
     "name": "getOrCreateInjectable"
   },
   {
+    "name": "getOrCreateLViewCleanup"
+  },
+  {
     "name": "getOrCreateNodeInjectorForNode"
   },
   {
@@ -1375,6 +1375,9 @@
   },
   {
     "name": "getOrCreateTNode"
+  },
+  {
+    "name": "getOrCreateTViewCleanup"
   },
   {
     "name": "getOrCreateViewRefs"
@@ -1441,9 +1444,6 @@
   },
   {
     "name": "getTView"
-  },
-  {
-    "name": "getTViewCleanup"
   },
   {
     "name": "getToken"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -378,9 +378,6 @@
     "name": "getInjectorIndex"
   },
   {
-    "name": "getLCleanup"
-  },
-  {
     "name": "getLView"
   },
   {
@@ -403,6 +400,9 @@
   },
   {
     "name": "getOrCreateInjectable"
+  },
+  {
+    "name": "getOrCreateLViewCleanup"
   },
   {
     "name": "getOrCreateNodeInjectorForNode"


### PR DESCRIPTION
PR #39876 introduced an error where the `onDestroy` of `ComponentRef` would only get called if `ngDevMode` was set to true. This was because in dev mode we would freeze `TCleanup` to verify that no more static cleanup would get added to `TCleanup` array. This ensured that `TCleanup` was always present in dev mode. In production the `TCleanup` would get created only when needed. The resulting cleanup code was incorrectly indented and would only run if `TCleanup` was present causing this issue.

Fix #40105
\## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
