### PR TITLE
fix(core): take @Host into account while processing `useFactory` arguments

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 140333,
+        "main-es2015": 140871,
         "polyfills-es2015": 36964
       }
     }

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -11,13 +11,14 @@ import '../util/ng_dev_mode';
 import {AbstractType, Type} from '../interface/type';
 import {getClosureSafeProperty} from '../util/property';
 import {stringify} from '../util/stringify';
+
 import {resolveForwardRef} from './forward_ref';
 import {getInjectImplementation, injectRootLimpMode} from './inject_switch';
 import {InjectionToken} from './injection_token';
 import {Injector} from './injector';
 import {InjectFlags} from './interface/injector';
 import {ValueProvider} from './interface/provider';
-import {Inject, Optional, Self, SkipSelf} from './metadata';
+import {Host, Inject, Optional, Self, SkipSelf} from './metadata';
 
 
 const _THROW_IF_NOT_FOUND = {};
@@ -151,6 +152,8 @@ export function injectArgs(types: (Type<any>|InjectionToken<any>|any[])[]): any[
           flags |= InjectFlags.SkipSelf;
         } else if (meta instanceof Self || meta.ngMetadataName === 'Self' || meta === Self) {
           flags |= InjectFlags.Self;
+        } else if (meta instanceof Host || meta.ngMetadataName === 'Host' || meta === Host) {
+          flags |= InjectFlags.Host;
         } else if (meta instanceof Inject || meta === Inject) {
           type = meta.token;
         } else {

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -237,6 +237,9 @@
     "name": "FormsModule"
   },
   {
+    "name": "Host"
+  },
+  {
     "name": "INJECTOR"
   },
   {

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -6,6 +6,9 @@
     "name": "EMPTY_ARRAY"
   },
   {
+    "name": "Host"
+  },
+  {
     "name": "INJECTOR"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -291,6 +291,9 @@
     "name": "HashLocationStrategy"
   },
   {
+    "name": "Host"
+  },
+  {
     "name": "INITIAL_VALUE"
   },
   {


### PR DESCRIPTION
DI provider can be defined via `useFactory` function, which may have arguments configured via `deps` array.
The `deps` array may contain DI flags represented by DI decorators (such as `@Self`, `@SkipSelf`, etc). Prior to this
commit, having the `@Host` decorator in `deps` array resulted in runtime error in Ivy. The problem was that the `@Host`
decorator was not taken into account while `useFactory` argument list was constructed, the `@Host` decorator was
treated as a token that should be looked up.

This commit updates the logic which prepares `useFactory` arguments to recognize the `@Host` decorator.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No