### PR TITLE
fix(core): set `ngDevMode` to `false` when calling `enableProdMode()`

### DIFF
--- a/packages/core/src/util/is_dev_mode.ts
+++ b/packages/core/src/util/is_dev_mode.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {global} from './global';
+
 /**
  * This file is used to control if the default rendering pipeline should be `ViewEngine` or `Ivy`.
  *
@@ -44,5 +46,12 @@ export function enableProdMode(): void {
   if (_runModeLocked) {
     throw new Error('Cannot enable prod mode after platform setup.');
   }
+
+  // The below check is there so when ngDevMode is set via terser
+  // `global['ngDevMode'] = false;` is also dropped.
+  if (typeof ngDevMode === undefined || !!ngDevMode) {
+    global['ngDevMode'] = false;
+  }
+
   _devMode = false;
 }


### PR DESCRIPTION
Currently, the global `ngDevMode` is set to false when using the Angular CLI `optimization` option. This option sets the globals via terser using the Compiler CLI private tooling API https://github.com/angular/angular/blob/d39d64c15dcba74aa673cacfc1365bd35a1d4f95/packages/compiler-cli/src/tooling.ts#L25-L34.

It is not documented that users not using the Angular CLI or using Angular Universal without `optimization` need to manually set to `false` as otherwise they will be vulnerable to XHR attacks.

The `ngDevMode` description also mentions that calling `enableProdMode` will set the value to `false`.
https://github.com/angular/angular/blob/4610093c87975b6355f31a9c849351129908783a/packages/core/src/util/ng_dev_mode.ts#L22 which is currently not the case.

Closes #37644