### PR TITLE
build: remove redundant `node_repositories` dictionary from `node_repositories` rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,11 +21,6 @@ check_rules_nodejs_version(minimum_version_string = "2.2.0")
 
 # Setup the Node.js toolchain
 node_repositories(
-    node_repositories = {
-        "12.14.1-darwin_amd64": ("node-v12.14.1-darwin-x64.tar.gz", "node-v12.14.1-darwin-x64", "0be10a28737527a1e5e3784d3ad844d742fe8b0718acd701fd48f718fd3af78f"),
-        "12.14.1-linux_amd64": ("node-v12.14.1-linux-x64.tar.xz", "node-v12.14.1-linux-x64", "07cfcaa0aa9d0fcb6e99725408d9e0b07be03b844701588e3ab5dbc395b98e1b"),
-        "12.14.1-windows_amd64": ("node-v12.14.1-win-x64.zip", "node-v12.14.1-win-x64", "1f96ccce3ba045ecea3f458e189500adb90b8bc1a34de5d82fc10a5bf66ce7e3"),
-    },
     node_version = "12.14.1",
     package_json = ["//:package.json"],
 )

--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -27,11 +27,6 @@ load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install
 node_repositories(
     # Use same node version as root angular WORKSPACE since
     # we share node_module packages and some require node >= 10.15.0
-    node_repositories = {
-        "12.14.1-darwin_amd64": ("node-v12.14.1-darwin-x64.tar.gz", "node-v12.14.1-darwin-x64", "0be10a28737527a1e5e3784d3ad844d742fe8b0718acd701fd48f718fd3af78f"),
-        "12.14.1-linux_amd64": ("node-v12.14.1-linux-x64.tar.xz", "node-v12.14.1-linux-x64", "07cfcaa0aa9d0fcb6e99725408d9e0b07be03b844701588e3ab5dbc395b98e1b"),
-        "12.14.1-windows_amd64": ("node-v12.14.1-win-x64.zip", "node-v12.14.1-win-x64", "1f96ccce3ba045ecea3f458e189500adb90b8bc1a34de5d82fc10a5bf66ce7e3"),
-    },
     node_version = "12.14.1",
     yarn_version = "1.12.1",
 )


### PR DESCRIPTION
According to a [discussion with Alex Eagle][1], the `node_repositories` dictionary is no longer necessary, since the `node_repositories` rule will ensure all Node.js versions are available.

From the [`node_repositories` docs][2]:

> By default, if this attribute has no items, we’ll use a list of all public NodeJS releases.

[1]: https://angular-team.slack.com/archives/C042EU9T5/p1606841390116500?thread_ts=1606838958.115000&cid=C042EU9T5
[2]: https://bazelbuild.github.io/rules_nodejs/Built-ins.html#node_repositories-node_repositories
