### PR TITLE
docs: remove -webkit-transition-timing-function CSS property

### DIFF
--- a/aio/src/styles/1-layouts/_sidenav.scss
+++ b/aio/src/styles/1-layouts/_sidenav.scss
@@ -125,7 +125,6 @@ button.vertical-menu-item {
     padding-left: 0;
     max-height: 4000px; // Arbitrary max-height. Can increase if needed. Must have measurement to transition height.
     transition: visibility 500ms, opacity 500ms, max-height 500ms;
-    -webkit-transition-timing-function: ease-in-out;
     transition-timing-function: ease-in-out;
   }
 
@@ -136,7 +135,6 @@ button.vertical-menu-item {
     opacity: 0;
     max-height: 1px; // Must have measurement to transition height.
     transition: visibility 275ms, opacity 275ms, max-height 280ms;
-    -webkit-transition-timing-function: ease-out;
     transition-timing-function: ease-out;
   }
 }


### PR DESCRIPTION
Angular has stopped to support browser that requires that CSS property.
All supported browsers support standard transition-timing-function CSS property

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
