### PR TITLE
fix(dev-infra): detect multiple target labels as invalid

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -2782,21 +2782,21 @@ var InvalidTargetLabelError = /** @class */ (function () {
 /** Gets the target label from the specified pull request labels. */
 function getTargetLabelFromPullRequest(config, labels) {
     var e_1, _a;
+    /** List of discovered target labels for the PR. */
+    var matches = [];
     var _loop_1 = function (label) {
         var match = config.labels.find(function (_a) {
             var pattern = _a.pattern;
             return matchesPattern(label, pattern);
         });
         if (match !== undefined) {
-            return { value: match };
+            matches.push(match);
         }
     };
     try {
         for (var labels_1 = tslib.__values(labels), labels_1_1 = labels_1.next(); !labels_1_1.done; labels_1_1 = labels_1.next()) {
             var label = labels_1_1.value;
-            var state_1 = _loop_1(label);
-            if (typeof state_1 === "object")
-                return state_1.value;
+            _loop_1(label);
         }
     }
     catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -2806,7 +2806,13 @@ function getTargetLabelFromPullRequest(config, labels) {
         }
         finally { if (e_1) throw e_1.error; }
     }
-    return null;
+    if (matches.length === 0) {
+        return null;
+    }
+    if (matches.length === 1) {
+        return matches[0];
+    }
+    throw new InvalidTargetLabelError("Unable to determine the target for the PR as it has multiple target labels.");
 }
 /**
  * Gets the branches from the specified target label.

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -2779,20 +2779,6 @@ var InvalidTargetLabelError = /** @class */ (function () {
     }
     return InvalidTargetLabelError;
 }());
-var NoTargetLabelError = /** @class */ (function (_super) {
-    tslib.__extends(NoTargetLabelError, _super);
-    function NoTargetLabelError() {
-        return _super.call(this, 'Unable to determine target for the PR as it has no target label.') || this;
-    }
-    return NoTargetLabelError;
-}(InvalidTargetLabelError));
-var TooManyTargetLabelsError = /** @class */ (function (_super) {
-    tslib.__extends(TooManyTargetLabelsError, _super);
-    function TooManyTargetLabelsError() {
-        return _super.call(this, 'Unable to determine target for the PR as it has multiple target labels.') || this;
-    }
-    return TooManyTargetLabelsError;
-}(InvalidTargetLabelError));
 /** Gets the target label from the specified pull request labels. */
 function getTargetLabelFromPullRequest(config, labels) {
     var e_1, _a;
@@ -2824,9 +2810,9 @@ function getTargetLabelFromPullRequest(config, labels) {
         return matches[0];
     }
     if (matches.length === 0) {
-        throw new NoTargetLabelError();
+        throw new InvalidTargetLabelError('Unable to determine target for the PR as it has no target label.');
     }
-    throw new TooManyTargetLabelsError();
+    throw new InvalidTargetLabelError('Unable to determine target for the PR as it has multiple target labels.');
 }
 /**
  * Gets the branches from the specified target label.
@@ -2889,9 +2875,10 @@ function getTargetBranchesForPr(prNumber) {
         catch (e) {
             if (e instanceof InvalidTargetLabelError) {
                 error(red(e.failureMessage));
+                process.exitCode = 1;
+                return;
             }
-            process.exitCode = 1;
-            return;
+            throw e;
         }
         /** The target branches based on the target label and branch targetted in the Github UI. */
         return yield getBranchesFromTargetLabel(targetLabel, githubTargetBranch);
@@ -3357,9 +3344,6 @@ var PullRequestFailure = /** @class */ (function () {
     };
     PullRequestFailure.notMergeReady = function () {
         return new this("Not marked as merge ready.");
-    };
-    PullRequestFailure.noTargetLabel = function () {
-        return new this("No target branch could be determined. Please ensure a target label is set.");
     };
     PullRequestFailure.mismatchingTargetBranch = function (allowedBranches) {
         return new this("Pull request is set to wrong base branch. Please update the PR in the Github UI " +

--- a/dev-infra/pr/check-target-branches/check-target-branches.ts
+++ b/dev-infra/pr/check-target-branches/check-target-branches.ts
@@ -38,9 +38,10 @@ export async function getTargetBranchesForPr(prNumber: number) {
   } catch (e) {
     if (e instanceof InvalidTargetLabelError) {
       error(red(e.failureMessage));
+      process.exitCode = 1;
+      return;
     }
-    process.exitCode = 1;
-    return;
+    throw e;
   }
   /** The target branches based on the target label and branch targetted in the Github UI. */
   return await getBranchesFromTargetLabel(targetLabel, githubTargetBranch);

--- a/dev-infra/pr/merge/defaults/integration.spec.ts
+++ b/dev-infra/pr/merge/defaults/integration.spec.ts
@@ -87,8 +87,10 @@ describe('default target labels', () => {
     if (labels === undefined) {
       labels = await computeTargetLabels();
     }
-    const label = getTargetLabelFromPullRequest({labels}, [name]);
-    if (label === null) {
+    let label: TargetLabel;
+    try {
+      label = getTargetLabelFromPullRequest({labels}, [name]);
+    } catch (error) {
       return null;
     }
     return await getBranchesFromTargetLabel(label, githubTargetBranch);

--- a/dev-infra/pr/merge/failures.ts
+++ b/dev-infra/pr/merge/failures.ts
@@ -34,10 +34,6 @@ export class PullRequestFailure {
     return new this(`Not marked as merge ready.`);
   }
 
-  static noTargetLabel() {
-    return new this(`No target branch could be determined. Please ensure a target label is set.`);
-  }
-
   static mismatchingTargetBranch(allowedBranches: string[]) {
     return new this(
         `Pull request is set to wrong base branch. Please update the PR in the Github UI ` +

--- a/dev-infra/pr/merge/pull-request.ts
+++ b/dev-infra/pr/merge/pull-request.ts
@@ -9,6 +9,7 @@
 import * as Octokit from '@octokit/rest';
 
 import {GitClient} from '../../utils/git/index';
+import {TargetLabel} from './config';
 
 import {PullRequestFailure} from './failures';
 import {matchesPattern} from './string-pattern';
@@ -61,9 +62,14 @@ export async function loadAndValidatePullRequest(
     return PullRequestFailure.claUnsigned();
   }
 
-  const targetLabel = getTargetLabelFromPullRequest(config, labels);
-  if (targetLabel === null) {
-    return PullRequestFailure.noTargetLabel();
+  let targetLabel: TargetLabel;
+  try {
+    targetLabel = getTargetLabelFromPullRequest(config, labels);
+  } catch (error) {
+    if (error instanceof InvalidTargetLabelError) {
+      return new PullRequestFailure(error.failureMessage);
+    }
+    throw error;
   }
 
   const {data: {state}} =

--- a/dev-infra/pr/merge/target-label.ts
+++ b/dev-infra/pr/merge/target-label.ts
@@ -28,13 +28,22 @@ export class InvalidTargetLabelError {
 /** Gets the target label from the specified pull request labels. */
 export function getTargetLabelFromPullRequest(
     config: Pick<MergeConfig, 'labels'>, labels: string[]): TargetLabel|null {
+  /** List of discovered target labels for the PR. */
+  const matches = [];
   for (const label of labels) {
     const match = config.labels.find(({pattern}) => matchesPattern(label, pattern));
     if (match !== undefined) {
-      return match;
+      matches.push(match);
     }
   }
-  return null;
+  if (matches.length === 0) {
+    return null;
+  }
+  if (matches.length === 1) {
+    return matches[0];
+  }
+  throw new InvalidTargetLabelError(
+      `Unable to determine the target for the PR as it has multiple target labels.`);
 }
 
 /**

--- a/dev-infra/pr/merge/target-label.ts
+++ b/dev-infra/pr/merge/target-label.ts
@@ -25,9 +25,21 @@ export class InvalidTargetLabelError {
   constructor(public failureMessage: string) {}
 }
 
+export class NoTargetLabelError extends InvalidTargetLabelError {
+  constructor() {
+    super('Unable to determine target for the PR as it has no target label.');
+  }
+}
+
+export class TooManyTargetLabelsError extends InvalidTargetLabelError {
+  constructor() {
+    super('Unable to determine target for the PR as it has multiple target labels.');
+  }
+}
+
 /** Gets the target label from the specified pull request labels. */
 export function getTargetLabelFromPullRequest(
-    config: Pick<MergeConfig, 'labels'>, labels: string[]): TargetLabel|null {
+    config: Pick<MergeConfig, 'labels'>, labels: string[]): TargetLabel {
   /** List of discovered target labels for the PR. */
   const matches = [];
   for (const label of labels) {
@@ -36,14 +48,13 @@ export function getTargetLabelFromPullRequest(
       matches.push(match);
     }
   }
-  if (matches.length === 0) {
-    return null;
-  }
   if (matches.length === 1) {
     return matches[0];
   }
-  throw new InvalidTargetLabelError(
-      `Unable to determine the target for the PR as it has multiple target labels.`);
+  if (matches.length === 0) {
+    throw new NoTargetLabelError();
+  }
+  throw new TooManyTargetLabelsError();
 }
 
 /**

--- a/dev-infra/pr/merge/target-label.ts
+++ b/dev-infra/pr/merge/target-label.ts
@@ -25,18 +25,6 @@ export class InvalidTargetLabelError {
   constructor(public failureMessage: string) {}
 }
 
-export class NoTargetLabelError extends InvalidTargetLabelError {
-  constructor() {
-    super('Unable to determine target for the PR as it has no target label.');
-  }
-}
-
-export class TooManyTargetLabelsError extends InvalidTargetLabelError {
-  constructor() {
-    super('Unable to determine target for the PR as it has multiple target labels.');
-  }
-}
-
 /** Gets the target label from the specified pull request labels. */
 export function getTargetLabelFromPullRequest(
     config: Pick<MergeConfig, 'labels'>, labels: string[]): TargetLabel {
@@ -52,9 +40,11 @@ export function getTargetLabelFromPullRequest(
     return matches[0];
   }
   if (matches.length === 0) {
-    throw new NoTargetLabelError();
+    throw new InvalidTargetLabelError(
+        'Unable to determine target for the PR as it has no target label.');
   }
-  throw new TooManyTargetLabelsError();
+  throw new InvalidTargetLabelError(
+      'Unable to determine target for the PR as it has multiple target labels.');
 }
 
 /**


### PR DESCRIPTION
When multiple target labels are applied to a PR, it should be considered
invalid as our tooling does not support a single PR targetting multiple
trains/versions.
