### PR TITLE
fix(core): set `ngDevMode` to `false` when calling `enableProdMode()`

### DIFF
--- a/packages/core/src/util/is_dev_mode.ts
+++ b/packages/core/src/util/is_dev_mode.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {global} from './global';
+
 /**
  * This file is used to control if the default rendering pipeline should be `ViewEngine` or `Ivy`.
  *
@@ -44,5 +46,12 @@ export function enableProdMode(): void {
   if (_runModeLocked) {
     throw new Error('Cannot enable prod mode after platform setup.');
   }
+
+  // The below check is there so when ngDevMode is set via terser
+  // `global['ngDevMode'] = false;` is also dropped.
+  if (typeof ngDevMode === undefined || !!ngDevMode) {
+    global['ngDevMode'] = false;
+  }
+
   _devMode = false;
 }

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -21,7 +21,7 @@
     "mocha": "^3.1.2",
     "mock-require": "3.0.3",
     "promises-aplus-tests": "^2.1.2",
-    "typescript": "~3.4.2"
+    "typescript": "~3.8.3"
   },
   "scripts": {
     "electrontest": "cd test/extra && node electron.js",


### PR DESCRIPTION
The `ngDevMode` description also mentions that calling `enableProdMode` will set this the value to `false`.
https://github.com/angular/angular/blob/4610093c87975b6355f31a9c849351129908783a/packages/core/src/util/ng_dev_mode.ts#L22 which is currently not the case.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
