### PR TITLE
fix(language-service): return all typecheck files via getExternalFiles

### DIFF
--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -242,9 +242,11 @@ function getOrCreateTypeCheckScriptInfo(
     // attempt to fetch the content from disk and fail.
     scriptInfo = projectService.getOrCreateScriptInfoForNormalizedPath(
         ts.server.toNormalizedPath(tcf),
-        true,              // openedByClient
-        '',                // fileContent
-        ts.ScriptKind.TS,  // scriptKind
+        true,  // openedByClient
+        '',    // fileContent
+        // script info added by plugins should be marked as external, see
+        // https://github.com/microsoft/TypeScript/blob/b217f22e798c781f55d17da72ed099a9dee5c650/src/compiler/program.ts#L1897-L1899
+        ts.ScriptKind.External,  // scriptKind
     );
     if (!scriptInfo) {
       throw new Error(`Failed to create script info for ${tcf}`);

--- a/packages/language-service/ivy/test/legacy/mock_host.ts
+++ b/packages/language-service/ivy/test/legacy/mock_host.ts
@@ -243,9 +243,9 @@ export class MockService {
     }
     const newScriptInfo = this.ps.getOrCreateScriptInfoForNormalizedPath(
         ts.server.toNormalizedPath(fileName),
-        true,                    // openedByClient
-        '',                      // fileContent
-        ts.ScriptKind.External,  // scriptKind
+        true,                   // openedByClient
+        '',                     // fileContent
+        ts.ScriptKind.Unknown,  // scriptKind
     );
     if (!newScriptInfo) {
       throw new Error(`Failed to create new script info for ${fileName}`);

--- a/packages/language-service/ivy/test/legacy/ts_plugin_spec.ts
+++ b/packages/language-service/ivy/test/legacy/ts_plugin_spec.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {LanguageService} from '../../language_service';
+import {getExternalFiles} from '../../ts_plugin';
+
+import {APP_COMPONENT, setup} from './mock_host';
+
+describe('getExternalFiles()', () => {
+  it('should return all typecheck files', () => {
+    const {project, tsLS} = setup();
+    let externalFiles = getExternalFiles(project);
+    // Initially there are no external files because Ivy compiler hasn't done
+    // a global analysis
+    expect(externalFiles).toEqual([]);
+    // Trigger global analysis
+    const ngLS = new LanguageService(project, tsLS);
+    ngLS.getSemanticDiagnostics(APP_COMPONENT);
+    // Now that global analysis is run, we should have all the typecheck files
+    externalFiles = getExternalFiles(project);
+    expect(externalFiles.length).toBe(1);
+    expect(externalFiles[0].endsWith('app.component.ngtypecheck.ts')).toBeTrue();
+  });
+});

--- a/packages/language-service/ivy/ts_plugin.ts
+++ b/packages/language-service/ivy/ts_plugin.ts
@@ -120,3 +120,19 @@ export function create(info: ts.server.PluginCreateInfo): ts.LanguageService {
     getCompletionEntrySymbol,
   };
 }
+
+export function getExternalFiles(project: ts.server.Project): string[] {
+  if (!project.hasRoots()) {
+    return [];  // project has not been initialized
+  }
+  const typecheckFiles: string[] = [];
+  for (const scriptInfo of project.getScriptInfos()) {
+    if (scriptInfo.scriptKind === ts.ScriptKind.External) {
+      // script info for typecheck file is marked as external, see
+      // getOrCreateTypeCheckScriptInfo() in
+      // packages/language-service/ivy/language_service.ts
+      typecheckFiles.push(scriptInfo.fileName);
+    }
+  }
+  return typecheckFiles;
+}


### PR DESCRIPTION
We need a means to preserve typecheck files when a project is reloaded,
otherwise the Ivy compiler will throw an error when it fails to find them in the program.
(The compiler is told by the IncrementalDriver that the tcfs exist.)
This commit implements `getExternalFiles()` called by the language
server to achieve this goal.

For more info see https://github.com/angular/vscode-ng-language-service/issues/1030

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
