### PR TITLE
fix(dev-infra): fix `yarn symbol-extractor` command

### DIFF
--- a/tools/symbol-extractor/run_all_symbols_extractor_tests.js
+++ b/tools/symbol-extractor/run_all_symbols_extractor_tests.js
@@ -23,7 +23,7 @@ const ALL_TEST_TARGETS =
         'yarn',
         [
           '-s', 'bazel', 'query', '--output', 'label',
-          `kind(nodejs_test, ...) intersect attr("tags", "symbol_extractor", ...)`
+          `'kind(nodejs_test, ...) intersect attr("tags", "symbol_extractor", ...)'`
         ],
         {encoding: 'utf8', shell: true, cwd: path.resolve(__dirname, '../..')})
         .stdout.trim()


### PR DESCRIPTION
The `yarn symbol-extractor:check` and `yarn symbol-extractor:update` commands don't seem to work currently -
the script is unable to calculate the list of relevant targets. Running the `bazel query ...` command used in the
script fails due to the missing quotes around the query argument. This commit fixes the problem by updating the
script to wrap query argument into single quotes.

Noticed this issue while working on #40145.

## PR Type
What kind of change does this PR introduce?

- [x] Other: dev infra


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No