### PR TITLE
fix(language-service): report non-template diagnostics

### DIFF
--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -58,11 +58,12 @@ export class LanguageService {
     const compiler = this.compilerFactory.getOrCreateWithChangedFile(fileName);
     const ttc = compiler.getTemplateTypeChecker();
     const diagnostics: ts.Diagnostic[] = [];
+
     if (isTypeScriptFile(fileName)) {
       const program = compiler.getNextProgram();
       const sourceFile = program.getSourceFile(fileName);
       if (sourceFile) {
-        diagnostics.push(...ttc.getDiagnosticsForFile(sourceFile, OptimizeFor.SingleFile));
+        diagnostics.push(...compiler.getDiagnostics(sourceFile));
       }
     } else {
       const components = compiler.getComponentsWithTemplateFile(fileName);

--- a/packages/language-service/ivy/test/diagnostic_spec.ts
+++ b/packages/language-service/ivy/test/diagnostic_spec.ts
@@ -174,4 +174,23 @@ describe('getSemanticDiagnostics', () => {
       'Parser Error: Bindings cannot contain assignments at column 8 in [{{nope = true}}] in /app2.html@0:0'
     ]);
   });
+
+  it('reports a diagnostic for a component without a template', () => {
+    const appFile = {
+      name: absoluteFrom('/app.ts'),
+      contents: `
+      import {Component} from '@angular/core';
+
+      @Component({})
+      export class MyComponent {}
+    `
+    };
+
+    const env = createModuleWithDeclarations([appFile]);
+    const diags = env.ngLS.getSemanticDiagnostics(absoluteFrom('/app.ts'));
+
+    expect(diags.map(x => x.messageText)).toEqual([
+      'component is missing a template',
+    ]);
+  });
 });


### PR DESCRIPTION
Previously the language service would provide diagnostics using the
template type checker. This was good for getting template diagnostics,
but it missed out on other diagnostics found by the trait compiler
during analysis.

This commit adds additional (non-template) diagnostics to the language
service by sourcing them from the angular compiler, which provides both
template diagnostics from the template type checker and other
diagnostics found during analysis.

The trade-off is that we will no longer be using the optimization for a single file.