### PR TITLE
refactor(compiler-cli): include linker entry-points in NPM package

### DIFF
--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -60,6 +60,8 @@ pkg_npm(
     ],
     deps = [
         ":compiler-cli",
+        "//packages/compiler-cli/linker",
+        "//packages/compiler-cli/linker/babel",
         "//packages/compiler-cli/ngcc",
         "//packages/compiler-cli/src/ngtsc/file_system/testing",
         "//packages/compiler-cli/src/ngtsc/logging/testing",


### PR DESCRIPTION
The linker entry-points were not previously exposed in the NPM Bazel
target so they were omitted from the bundle. This commit adds the
necessary entry-points to the compiler-cli's npm_package target.