### PR TITLE
fix(dev-infra): delay checking if a closed pr has been merged by 30 seconds

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -5340,7 +5340,8 @@ function getPullRequestState(api, id) {
         // update the closed pull request to be associated with the closing commit.
         // Note: a Date constructed with `null` creates an object at 0 time, which will never be greater
         // than the current date time.
-        if (new Date(data.closed_at).getTime() + THIRTY_SECONDS_IN_MS < new Date().getTime()) {
+        if (data.closed_at !== null &&
+            (new Date(data.closed_at).getTime() < Date.now() - THIRTY_SECONDS_IN_MS)) {
             return (yield isPullRequestClosedWithAssociatedCommit(api, id)) ? 'merged' : 'closed';
         }
         return 'open';

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -5327,6 +5327,8 @@ const findOwnedForksOfRepoQuery = typedGraphqlify.params({
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+/** Thirty seconds in milliseconds. */
+const THIRY_SECONDS_IN_MS = 30000;
 /** Gets whether a given pull request has been merged. */
 function getPullRequestState(api, id) {
     return tslib.__awaiter(this, void 0, void 0, function* () {
@@ -5334,12 +5336,14 @@ function getPullRequestState(api, id) {
         if (data.merged) {
             return 'merged';
         }
-        else if (data.closed_at !== null) {
+        // Check if the PR was closed more than 30 seconds ago, this extra time gives Github time to
+        // update the closed pull request to be associated with the closing commit.
+        // Note: a Date constructed with `null` creates an object at 0 time, which will never be greater
+        // than the current date time.
+        if (new Date(data.closed_at).getTime() - THIRY_SECONDS_IN_MS > new Date().getTime()) {
             return (yield isPullRequestClosedWithAssociatedCommit(api, id)) ? 'merged' : 'closed';
         }
-        else {
-            return 'open';
-        }
+        return 'open';
     });
 }
 /**

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -5328,7 +5328,7 @@ const findOwnedForksOfRepoQuery = typedGraphqlify.params({
  * found in the LICENSE file at https://angular.io/license
  */
 /** Thirty seconds in milliseconds. */
-const THIRY_SECONDS_IN_MS = 30000;
+const THIRTY_SECONDS_IN_MS = 30000;
 /** Gets whether a given pull request has been merged. */
 function getPullRequestState(api, id) {
     return tslib.__awaiter(this, void 0, void 0, function* () {
@@ -5340,7 +5340,7 @@ function getPullRequestState(api, id) {
         // update the closed pull request to be associated with the closing commit.
         // Note: a Date constructed with `null` creates an object at 0 time, which will never be greater
         // than the current date time.
-        if (new Date(data.closed_at).getTime() - THIRY_SECONDS_IN_MS > new Date().getTime()) {
+        if (new Date(data.closed_at).getTime() + THIRTY_SECONDS_IN_MS > new Date().getTime()) {
             return (yield isPullRequestClosedWithAssociatedCommit(api, id)) ? 'merged' : 'closed';
         }
         return 'open';

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -5340,7 +5340,7 @@ function getPullRequestState(api, id) {
         // update the closed pull request to be associated with the closing commit.
         // Note: a Date constructed with `null` creates an object at 0 time, which will never be greater
         // than the current date time.
-        if (new Date(data.closed_at).getTime() + THIRTY_SECONDS_IN_MS > new Date().getTime()) {
+        if (new Date(data.closed_at).getTime() + THIRTY_SECONDS_IN_MS < new Date().getTime()) {
             return (yield isPullRequestClosedWithAssociatedCommit(api, id)) ? 'merged' : 'closed';
         }
         return 'open';

--- a/dev-infra/release/publish/pull-request-state.ts
+++ b/dev-infra/release/publish/pull-request-state.ts
@@ -25,7 +25,7 @@ export async function getPullRequestState(api: GitClient, id: number): Promise<P
   // update the closed pull request to be associated with the closing commit.
   // Note: a Date constructed with `null` creates an object at 0 time, which will never be greater
   // than the current date time.
-  if (new Date(data.closed_at).getTime() + THIRTY_SECONDS_IN_MS > new Date().getTime()) {
+  if (new Date(data.closed_at).getTime() + THIRTY_SECONDS_IN_MS < new Date().getTime()) {
     return await isPullRequestClosedWithAssociatedCommit(api, id) ? 'merged' : 'closed';
   }
   return 'open';

--- a/dev-infra/release/publish/pull-request-state.ts
+++ b/dev-infra/release/publish/pull-request-state.ts
@@ -9,6 +9,9 @@
 import * as Octokit from '@octokit/rest';
 import {GitClient} from '../../utils/git/index';
 
+/** Thirty seconds in milliseconds. */
+const THIRY_SECONDS_IN_MS = 30000;
+
 /** State of a pull request in Github. */
 export type PullRequestState = 'merged'|'closed'|'open';
 
@@ -17,11 +20,15 @@ export async function getPullRequestState(api: GitClient, id: number): Promise<P
   const {data} = await api.github.pulls.get({...api.remoteParams, pull_number: id});
   if (data.merged) {
     return 'merged';
-  } else if (data.closed_at !== null) {
-    return await isPullRequestClosedWithAssociatedCommit(api, id) ? 'merged' : 'closed';
-  } else {
-    return 'open';
   }
+  // Check if the PR was closed more than 30 seconds ago, this extra time gives Github time to
+  // update the closed pull request to be associated with the closing commit.
+  // Note: a Date constructed with `null` creates an object at 0 time, which will never be greater
+  // than the current date time.
+  if (new Date(data.closed_at).getTime() - THIRY_SECONDS_IN_MS > new Date().getTime()) {
+    return await isPullRequestClosedWithAssociatedCommit(api, id) ? 'merged' : 'closed';
+  }
+  return 'open';
 }
 
 /**

--- a/dev-infra/release/publish/pull-request-state.ts
+++ b/dev-infra/release/publish/pull-request-state.ts
@@ -10,7 +10,7 @@ import * as Octokit from '@octokit/rest';
 import {GitClient} from '../../utils/git/index';
 
 /** Thirty seconds in milliseconds. */
-const THIRY_SECONDS_IN_MS = 30000;
+const THIRTY_SECONDS_IN_MS = 30000;
 
 /** State of a pull request in Github. */
 export type PullRequestState = 'merged'|'closed'|'open';
@@ -25,7 +25,7 @@ export async function getPullRequestState(api: GitClient, id: number): Promise<P
   // update the closed pull request to be associated with the closing commit.
   // Note: a Date constructed with `null` creates an object at 0 time, which will never be greater
   // than the current date time.
-  if (new Date(data.closed_at).getTime() - THIRY_SECONDS_IN_MS > new Date().getTime()) {
+  if (new Date(data.closed_at).getTime() + THIRTY_SECONDS_IN_MS > new Date().getTime()) {
     return await isPullRequestClosedWithAssociatedCommit(api, id) ? 'merged' : 'closed';
   }
   return 'open';

--- a/dev-infra/release/publish/pull-request-state.ts
+++ b/dev-infra/release/publish/pull-request-state.ts
@@ -25,7 +25,8 @@ export async function getPullRequestState(api: GitClient, id: number): Promise<P
   // update the closed pull request to be associated with the closing commit.
   // Note: a Date constructed with `null` creates an object at 0 time, which will never be greater
   // than the current date time.
-  if (new Date(data.closed_at).getTime() + THIRTY_SECONDS_IN_MS < new Date().getTime()) {
+  if (data.closed_at !== null &&
+      (new Date(data.closed_at).getTime() < Date.now() - THIRTY_SECONDS_IN_MS)) {
     return await isPullRequestClosedWithAssociatedCommit(api, id) ? 'merged' : 'closed';
   }
   return 'open';


### PR DESCRIPTION
Delaying the check if a closed PR was closed by a merge or just closed by 30 seconds
allows for Github to have time to update the PR to be associated to the commit which
closed the PR.  Without this delay, a race condition can exist in which we check for
how a PR was closed before this association is made.
