### PR TITLE
docs: fix styles in binding guides

### DIFF
--- a/aio/content/guide/attribute-binding.md
+++ b/aio/content/guide/attribute-binding.md
@@ -328,8 +328,10 @@ There are cases where you need to differentiate the behavior of a [Component](ap
 The [Attribute](api/core/Attribute) parameter decorator is great for passing the value of an HTML attribute to a component/directive constructor via [dependency injection](guide/dependency-injection).
 
 <div class="alert is-helpful">
+
   The injected value captures the value of the specified HTML attribute at that moment.
   Future updates to the attribute value are not reflected in the injected value.
+
 </div>
 
 <code-example 

--- a/aio/content/guide/binding-syntax.md
+++ b/aio/content/guide/binding-syntax.md
@@ -85,7 +85,7 @@ However, the value of the attribute is irrelevant, which is why you cannot enabl
 
 To control the state of the button, set the `disabled` property instead.
 
-Property and attribute comparison
+#### Property and attribute comparison
 
 Though you could technically set the `[attr.disabled]` attribute binding, the values are different in that the property binding must be a boolean value, while its corresponding attribute binding relies on whether the value is `null` or not.
 Consider the following:


### PR DESCRIPTION
One change is concerned with conforming to the `alert` specification from the Angular documentation style guide 🏗️ . The other change does not display the header correctly (Not sure if this is the correct header size though 🤔)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
