### PR TITLE
ci: correctly rebase PRs for branches contain a slash (/)

### DIFF
--- a/.circleci/rebase-pr.js
+++ b/.circleci/rebase-pr.js
@@ -92,7 +92,7 @@ async function _main() {
  * likely correct branch will be the first one encountered in the list.
  */
 function getRefFromBranchList(gitOutput) {
-  const branches = gitOutput.split('\n').map(b => b.split('/').slice(1).join('').trim());
+  const branches = gitOutput.split('\n').map(b => b.split('/').slice(1).join('/').trim());
   return branches.sort((a, b) => {
     if (a === 'master') {
       return -1;


### PR DESCRIPTION
Previously, due to a bug in `rebase-pr.js`, PRs for branches containing a slash (/) in their name would fail to be rebased ([example failure][1]).

This commit ensures that such branch names are handled correctly.

[1]: https://circleci.com/gh/angular/angular/884503
