### PR TITLE
Support two-way bindings in Ivy native language service

### DIFF
--- a/packages/language-service/ivy/completions.ts
+++ b/packages/language-service/ivy/completions.ts
@@ -31,6 +31,7 @@ export enum CompletionNodeContext {
   ElementAttributeKey,
   ElementAttributeValue,
   EventValue,
+  TwoWayBinding,
 }
 
 /**
@@ -415,7 +416,8 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
   }
 
   private isElementAttributeCompletion(): this is ElementAttributeCompletionBuilder {
-    return this.nodeContext === CompletionNodeContext.ElementAttributeKey &&
+    return (this.nodeContext === CompletionNodeContext.ElementAttributeKey ||
+            this.nodeContext === CompletionNodeContext.TwoWayBinding) &&
         (this.node instanceof TmplAstElement || this.node instanceof TmplAstBoundAttribute ||
          this.node instanceof TmplAstTextAttribute || this.node instanceof TmplAstBoundEvent);
   }
@@ -458,6 +460,10 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
           break;
         case AttributeCompletionKind.DirectiveInput:
           if (this.node instanceof TmplAstBoundEvent) {
+            continue;
+          }
+          if (!completion.twoWayBindingSupported &&
+              this.nodeContext === CompletionNodeContext.TwoWayBinding) {
             continue;
           }
           break;

--- a/packages/language-service/ivy/definitions.ts
+++ b/packages/language-service/ivy/definitions.ts
@@ -41,17 +41,29 @@ export class DefinitionBuilder {
       }
       return getDefinitionForExpressionAtPosition(fileName, position, this.compiler);
     }
-    const definitionMeta = this.getDefinitionMetaAtPosition(templateInfo, position);
-    // The `$event` of event handlers would point to the $event parameter in the shim file, as in
-    // `_outputHelper(_t3["x"]).subscribe(function ($event): any { $event }) ;`
-    // If we wanted to return something for this, it would be more appropriate for something like
-    // `getTypeDefinition`.
-    if (definitionMeta === undefined || isDollarEvent(definitionMeta.node)) {
+    const definitionMetas = this.getDefinitionMetaAtPosition(templateInfo, position);
+    if (definitionMetas === undefined) {
+      return undefined;
+    }
+    const definitions: ts.DefinitionInfo[] = [];
+    for (const definitionMeta of definitionMetas) {
+      // The `$event` of event handlers would point to the $event parameter in the shim file, as in
+      // `_outputHelper(_t3["x"]).subscribe(function ($event): any { $event }) ;`
+      // If we wanted to return something for this, it would be more appropriate for something like
+      // `getTypeDefinition`.
+      if (isDollarEvent(definitionMeta.node)) {
+        continue;
+      }
+
+      definitions.push(
+          ...(this.getDefinitionsForSymbol({...definitionMeta, ...templateInfo}) ?? []));
+    }
+
+    if (definitions.length === 0) {
       return undefined;
     }
 
-    const definitions = this.getDefinitionsForSymbol({...definitionMeta, ...templateInfo});
-    return {definitions, textSpan: getTextSpanOfNode(definitionMeta.node)};
+    return {definitions, textSpan: getTextSpanOfNode(definitionMetas[0].node)};
   }
 
   private getDefinitionsForSymbol({symbol, node, parent, component}: DefinitionMeta&
@@ -123,42 +135,55 @@ export class DefinitionBuilder {
     if (templateInfo === undefined) {
       return;
     }
-    const definitionMeta = this.getDefinitionMetaAtPosition(templateInfo, position);
-    if (definitionMeta === undefined) {
+    const definitionMetas = this.getDefinitionMetaAtPosition(templateInfo, position);
+    if (definitionMetas === undefined) {
       return undefined;
     }
 
-    const {symbol, node} = definitionMeta;
-    switch (symbol.kind) {
-      case SymbolKind.Directive:
-      case SymbolKind.DomBinding:
-      case SymbolKind.Element:
-      case SymbolKind.Template:
-        return this.getTypeDefinitionsForTemplateInstance(symbol, node);
-      case SymbolKind.Output:
-      case SymbolKind.Input: {
-        const bindingDefs = this.getTypeDefinitionsForSymbols(...symbol.bindings);
-        // Also attempt to get directive matches for the input name. If there is a directive that
-        // has the input name as part of the selector, we want to return that as well.
-        const directiveDefs = this.getDirectiveTypeDefsForBindingNode(
-            node, definitionMeta.parent, templateInfo.component);
-        return [...bindingDefs, ...directiveDefs];
-      }
-      case SymbolKind.Pipe: {
-        if (symbol.tsSymbol !== null) {
-          return this.getTypeDefinitionsForSymbols(symbol);
-        } else {
-          // If there is no `ts.Symbol` for the pipe transform, we want to return the
-          // type definition (the pipe class).
-          return this.getTypeDefinitionsForSymbols(symbol.classSymbol);
+    const definitions: ts.DefinitionInfo[] = [];
+    for (const {symbol, node, parent} of definitionMetas) {
+      switch (symbol.kind) {
+        case SymbolKind.Directive:
+        case SymbolKind.DomBinding:
+        case SymbolKind.Element:
+        case SymbolKind.Template:
+          definitions.push(...this.getTypeDefinitionsForTemplateInstance(symbol, node));
+          break;
+        case SymbolKind.Output:
+        case SymbolKind.Input: {
+          const bindingDefs = this.getTypeDefinitionsForSymbols(...symbol.bindings);
+          definitions.push(...bindingDefs);
+          // Also attempt to get directive matches for the input name. If there is a directive that
+          // has the input name as part of the selector, we want to return that as well.
+          const directiveDefs =
+              this.getDirectiveTypeDefsForBindingNode(node, parent, templateInfo.component);
+          definitions.push(...directiveDefs);
+          break;
+        }
+        case SymbolKind.Pipe: {
+          if (symbol.tsSymbol !== null) {
+            definitions.push(...this.getTypeDefinitionsForSymbols(symbol));
+          } else {
+            // If there is no `ts.Symbol` for the pipe transform, we want to return the
+            // type definition (the pipe class).
+            definitions.push(...this.getTypeDefinitionsForSymbols(symbol.classSymbol));
+          }
+          break;
+        }
+        case SymbolKind.Reference:
+          definitions.push(
+              ...this.getTypeDefinitionsForSymbols({shimLocation: symbol.targetLocation}));
+          break;
+        case SymbolKind.Expression:
+          definitions.push(...this.getTypeDefinitionsForSymbols(symbol));
+          break;
+        case SymbolKind.Variable: {
+          definitions.push(
+              ...this.getTypeDefinitionsForSymbols({shimLocation: symbol.initializerLocation}));
+          break;
         }
       }
-      case SymbolKind.Reference:
-        return this.getTypeDefinitionsForSymbols({shimLocation: symbol.targetLocation});
-      case SymbolKind.Expression:
-        return this.getTypeDefinitionsForSymbols(symbol);
-      case SymbolKind.Variable:
-        return this.getTypeDefinitionsForSymbols({shimLocation: symbol.initializerLocation});
+      return definitions;
     }
   }
 
@@ -221,21 +246,26 @@ export class DefinitionBuilder {
   }
 
   private getDefinitionMetaAtPosition({template, component}: TemplateInfo, position: number):
-      DefinitionMeta|undefined {
+      DefinitionMeta[]|undefined {
     const target = getTargetAtPosition(template, position);
     if (target === null) {
       return undefined;
     }
     const {context, parent} = target;
 
-    const node =
-        context.kind === TargetNodeKind.TwoWayBindingContext ? context.nodes[0] : context.node;
+    const nodes =
+        context.kind === TargetNodeKind.TwoWayBindingContext ? context.nodes : [context.node];
 
-    const symbol = this.compiler.getTemplateTypeChecker().getSymbolOfNode(node, component);
-    if (symbol === null) {
-      return undefined;
+
+    const definitionMetas: DefinitionMeta[] = [];
+    for (const node of nodes) {
+      const symbol = this.compiler.getTemplateTypeChecker().getSymbolOfNode(node, component);
+      if (symbol === null) {
+        continue;
+      }
+      definitionMetas.push({node, parent, symbol});
     }
-    return {node, parent, symbol};
+    return definitionMetas.length > 0 ? definitionMetas : undefined;
   }
 }
 

--- a/packages/language-service/ivy/definitions.ts
+++ b/packages/language-service/ivy/definitions.ts
@@ -12,7 +12,7 @@ import {isExternalResource} from '@angular/compiler-cli/src/ngtsc/metadata';
 import {DirectiveSymbol, DomBindingSymbol, ElementSymbol, ShimLocation, Symbol, SymbolKind, TemplateSymbol} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import * as ts from 'typescript';
 
-import {getTargetAtPosition} from './template_target';
+import {getTargetAtPosition, TargetNodeKind} from './template_target';
 import {findTightestNode, getParentClassDeclaration} from './ts_utils';
 import {flatMap, getDirectiveMatchesForAttribute, getDirectiveMatchesForElementTag, getTemplateInfoAtPosition, getTextSpanOfNode, isDollarEvent, isTypeScriptFile, TemplateInfo, toTextSpan} from './utils';
 
@@ -226,14 +226,16 @@ export class DefinitionBuilder {
     if (target === null) {
       return undefined;
     }
-    const {nodeInContext, parent} = target;
+    const {context, parent} = target;
 
-    const symbol =
-        this.compiler.getTemplateTypeChecker().getSymbolOfNode(nodeInContext.node, component);
+    const node =
+        context.kind === TargetNodeKind.TwoWayBindingContext ? context.nodes[0] : context.node;
+
+    const symbol = this.compiler.getTemplateTypeChecker().getSymbolOfNode(node, component);
     if (symbol === null) {
       return undefined;
     }
-    return {node: nodeInContext.node, parent, symbol};
+    return {node, parent, symbol};
   }
 }
 

--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -133,6 +133,8 @@ export class LanguageService {
       return null;
     }
 
+    // For two-way bindings, we actually only need to be concerned with the bound attribute because
+    // the bindings in the template are written with the attribute name, not the event name.
     const node = positionDetails.context.kind === TargetNodeKind.TwoWayBindingContext ?
         positionDetails.context.nodes[0] :
         positionDetails.context.node;
@@ -272,6 +274,8 @@ function nodeContextFromTarget(target: TargetContext): CompletionNodeContext {
     case TargetNodeKind.ElementInBodyContext:
       // Completions in element bodies are for new attributes.
       return CompletionNodeContext.ElementAttributeKey;
+    case TargetNodeKind.TwoWayBindingContext:
+      return CompletionNodeContext.TwoWayBinding;
     case TargetNodeKind.AttributeInKeyContext:
       return CompletionNodeContext.ElementAttributeKey;
     case TargetNodeKind.AttributeInValueContext:

--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -105,6 +105,9 @@ export class LanguageService {
       return undefined;
     }
 
+    // Because we can only show 1 quick info, just use the bound attribute if the target is a two
+    // way binding. We may consider concatenating additional display parts from the other target
+    // nodes or representing the two way binding in some other manner in the future.
     const node = positionDetails.context.kind === TargetNodeKind.TwoWayBindingContext ?
         positionDetails.context.nodes[0] :
         positionDetails.context.node;

--- a/packages/language-service/ivy/template_target.ts
+++ b/packages/language-service/ivy/template_target.ts
@@ -156,11 +156,6 @@ export function getTargetAtPosition(template: t.Node[], position: number): Templ
     }
   }
 
-  let parent: t.Node|e.AST|null = null;
-  if (path.length >= 2) {
-    parent = path[path.length - 2];
-  }
-
   // Given the candidate node, determine the full targeted context.
   let nodeInContext: TargetContext;
   if (candidate instanceof e.AST) {
@@ -191,7 +186,16 @@ export function getTargetAtPosition(template: t.Node[], position: number): Templ
       (candidate instanceof t.BoundAttribute || candidate instanceof t.BoundEvent ||
        candidate instanceof t.TextAttribute) &&
       candidate.keySpan !== undefined) {
-    if (isWithin(position, candidate.keySpan)) {
+    const previousCandidate = path[path.length - 2];
+    if (candidate instanceof t.BoundEvent && previousCandidate instanceof t.BoundAttribute &&
+        candidate.name === previousCandidate.name + 'Change') {
+      const boundAttribute: t.BoundAttribute = previousCandidate;
+      const boundEvent: t.BoundEvent = candidate;
+      nodeInContext = {
+        kind: TargetNodeKind.TwoWayBindingContext,
+        nodes: [boundAttribute, boundEvent],
+      };
+    } else if (isWithin(position, candidate.keySpan)) {
       nodeInContext = {
         kind: TargetNodeKind.AttributeInKeyContext,
         node: candidate,
@@ -207,6 +211,13 @@ export function getTargetAtPosition(template: t.Node[], position: number): Templ
       kind: TargetNodeKind.RawTemplateNode,
       node: candidate,
     };
+  }
+
+  let parent: t.Node|e.AST|null = null;
+  if (nodeInContext.kind === TargetNodeKind.TwoWayBindingContext && path.length >= 3) {
+    parent = path[path.length - 3];
+  } else if (path.length >= 2) {
+    parent = path[path.length - 2];
   }
 
   return {position, context: nodeInContext, template: context, parent};
@@ -247,20 +258,25 @@ class TemplateTargetVisitor implements t.Visitor {
   private constructor(private readonly position: number) {}
 
   visit(node: t.Node) {
-    const last: t.Node|e.AST|undefined = this.path[this.path.length - 1];
-    if (last && isTemplateNodeWithKeyAndValue(last) && isWithin(this.position, last.keySpan)) {
-      // We've already identified that we are within a `keySpan` of a node.
-      // We should stop processing nodes at this point to prevent matching
-      // any other nodes. This can happen when the end span of a different node
-      // touches the start of the keySpan for the candidate node. Because
-      // our `isWithin` logic is inclusive on both ends, we can match both nodes.
-      return;
-    }
     const {start, end} = getSpanIncludingEndTag(node);
     if (!isWithin(this.position, {start, end})) {
       return;
     }
 
+    const last: t.Node|e.AST|undefined = this.path[this.path.length - 1];
+    const withinKeySpanOfLastNode =
+        last && isTemplateNodeWithKeyAndValue(last) && isWithin(this.position, last.keySpan);
+    const withinKeySpanOfCurrentNode =
+        isTemplateNodeWithKeyAndValue(node) && isWithin(this.position, node.keySpan);
+    if (withinKeySpanOfLastNode && !withinKeySpanOfCurrentNode) {
+      // We've already identified that we are within a `keySpan` of a node.
+      // Unless we are _also_ in the `keySpan` of the current node (happens with two way bindings),
+      // we should stop processing nodes at this point to prevent matching any other nodes. This can
+      // happen when the end span of a different node touches the start of the keySpan for the
+      // candidate node. Because our `isWithin` logic is inclusive on both ends, we can match both
+      // nodes.
+      return;
+    }
     if (isTemplateNodeWithKeyAndValue(node) && !isWithinKeyValue(this.position, node)) {
       // If cursor is within source span but not within key span or value span,
       // do not return the node.
@@ -272,31 +288,33 @@ class TemplateTargetVisitor implements t.Visitor {
   }
 
   visitElement(element: t.Element) {
+    this.visitElementOrTemplate(element);
+  }
+
+
+  visitTemplate(template: t.Template) {
+    this.visitElementOrTemplate(template);
+  }
+
+  visitElementOrTemplate(element: t.Template|t.Element) {
     this.visitAll(element.attributes);
     this.visitAll(element.inputs);
     this.visitAll(element.outputs);
+    if (element instanceof t.Template) {
+      this.visitAll(element.templateAttrs);
+    }
     this.visitAll(element.references);
-    const last: t.Node|e.AST|undefined = this.path[this.path.length - 1];
+    if (element instanceof t.Template) {
+      this.visitAll(element.variables);
+    }
+
     // If we get here and have not found a candidate node on the element itself, proceed with
     // looking for a more specific node on the element children.
-    if (last === element) {
-      this.visitAll(element.children);
+    if (this.path[this.path.length - 1] !== element) {
+      return;
     }
-  }
 
-  visitTemplate(template: t.Template) {
-    this.visitAll(template.attributes);
-    this.visitAll(template.inputs);
-    this.visitAll(template.outputs);
-    this.visitAll(template.templateAttrs);
-    this.visitAll(template.references);
-    this.visitAll(template.variables);
-    const last: t.Node|e.AST|undefined = this.path[this.path.length - 1];
-    // If we get here and have not found a candidate node on the template itself, proceed with
-    // looking for a more specific node on the template children.
-    if (last === template) {
-      this.visitAll(template.children);
-    }
+    this.visitAll(element.children);
   }
 
   visitContent(content: t.Content) {
@@ -321,18 +339,6 @@ class TemplateTargetVisitor implements t.Visitor {
   }
 
   visitBoundEvent(event: t.BoundEvent) {
-    const isTwoWayBinding =
-        this.path.some(n => n instanceof t.BoundAttribute && event.name === n.name + 'Change');
-    if (isTwoWayBinding) {
-      // For two-way binding aka banana-in-a-box, there are two matches:
-      // BoundAttribute and BoundEvent. Both have the same spans. We choose to
-      // return BoundAttribute because it matches the identifier name verbatim.
-      // TODO: For operations like go to definition, ideally we want to return
-      // both.
-      this.path.pop();  // remove bound event from the AST path
-      return;
-    }
-
     // An event binding with no value (e.g. `(event|)`) parses to a `BoundEvent` with a
     // `LiteralPrimitive` handler with value `'ERROR'`, as opposed to a property binding with no
     // value which has an `EmptyExpr` as its value. This is a synthetic node created by the binding

--- a/packages/language-service/ivy/test/legacy/definitions_spec.ts
+++ b/packages/language-service/ivy/test/legacy/definitions_spec.ts
@@ -43,7 +43,7 @@ describe('definitions', () => {
       const {position} =
           service.overwriteInlineTemplate(APP_COMPONENT, `<ng-templ¦ate></ng-template>`);
       const definitionAndBoundSpan = ngLS.getDefinitionAndBoundSpan(APP_COMPONENT, position);
-      expect(definitionAndBoundSpan!.definitions).toEqual([]);
+      expect(definitionAndBoundSpan).toBeUndefined();
     });
   });
 
@@ -181,17 +181,14 @@ describe('definitions', () => {
           templateOverride: `<test-comp string-model [(mo¦del)]="title"></test-comp>`,
           expectedSpanText: 'model',
         });
-        // TODO(atscott): This should really return 2 definitions, 1 for the input and 1 for the
-        // output.
-        //  The TemplateTypeChecker also only returns the first match in the TCB for a given
-        //  sourceSpan so even if we also requested the TmplAstBoundEvent, we'd still get back the
-        //  symbol for the
-        //  @Input because the input appears first in the TCB and they have the same sourceSpan.
-        expect(definitions!.length).toEqual(1);
+        expect(definitions!.length).toEqual(2);
 
-        const [def] = definitions;
-        expect(def.textSpan).toEqual('model');
-        expect(def.contextSpan).toEqual(`@Input() model: string = 'model';`);
+        const [inputDef, outputDef] = definitions;
+        expect(inputDef.textSpan).toEqual('model');
+        expect(inputDef.contextSpan).toEqual(`@Input() model: string = 'model';`);
+        expect(outputDef.textSpan).toEqual('modelChange');
+        expect(outputDef.contextSpan)
+            .toEqual(`@Output() modelChange: EventEmitter<string> = new EventEmitter();`);
       });
     });
 
@@ -245,12 +242,11 @@ describe('definitions', () => {
 
   describe('references', () => {
     it('should work for element reference declarations', () => {
-      const definitions = getDefinitionsAndAssertBoundSpan({
-        templateOverride: `<div #cha¦rt></div>{{chart}}`,
-        expectedSpanText: 'chart',
-      });
+      const {position} =
+          service.overwriteInlineTemplate(APP_COMPONENT, `<div #cha¦rt></div>{{chart}}`);
+      const definitionAndBoundSpan = ngLS.getDefinitionAndBoundSpan(APP_COMPONENT, position);
       // We're already at the definition, so nothing is returned
-      expect(definitions).toEqual([]);
+      expect(definitionAndBoundSpan).toBeUndefined();
     });
 
     it('should work for element reference uses', () => {

--- a/packages/language-service/ivy/test/legacy/template_target_spec.ts
+++ b/packages/language-service/ivy/test/legacy/template_target_spec.ts
@@ -10,7 +10,7 @@ import {ParseError, parseTemplate} from '@angular/compiler';
 import * as e from '@angular/compiler/src/expression_parser/ast';  // e for expression AST
 import * as t from '@angular/compiler/src/render3/r3_ast';         // t for template AST
 
-import {getTargetAtPosition, TargetNodeKind} from '../../template_target';
+import {getTargetAtPosition, SingleNodeTarget, TargetNodeKind} from '../../template_target';
 import {isExpressionNode, isTemplateNode} from '../../utils';
 
 interface ParseResult {
@@ -36,8 +36,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate element in opening tag', () => {
     const {errors, nodes, position} = parse(`<di¦v></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Element);
   });
@@ -45,8 +45,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate element in closing tag', () => {
     const {errors, nodes, position} = parse(`<div></di¦v>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Element);
   });
@@ -54,8 +54,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate element when cursor is at the beginning', () => {
     const {errors, nodes, position} = parse(`<¦div></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Element);
   });
@@ -63,8 +63,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate element when cursor is at the end', () => {
     const {errors, nodes, position} = parse(`<div¦></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Element);
   });
@@ -72,8 +72,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate attribute key', () => {
     const {errors, nodes, position} = parse(`<div cla¦ss="foo"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.TextAttribute);
   });
@@ -81,8 +81,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate attribute value', () => {
     const {errors, nodes, position} = parse(`<div class="fo¦o"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     // TODO: Note that we do not have the ability to detect the RHS (yet)
     expect(node).toBeInstanceOf(t.TextAttribute);
@@ -91,8 +91,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate bound attribute key', () => {
     const {errors, nodes, position} = parse(`<test-cmp [fo¦o]="bar"></test-cmp>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.BoundAttribute);
   });
@@ -100,8 +100,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate bound attribute value', () => {
     const {errors, nodes, position} = parse(`<test-cmp [foo]="b¦ar"></test-cmp>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
   });
@@ -116,8 +116,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate bound event key', () => {
     const {errors, nodes, position} = parse(`<test-cmp (fo¦o)="bar()"></test-cmp>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.BoundEvent);
   });
@@ -125,8 +125,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate bound event value', () => {
     const {errors, nodes, position} = parse(`<test-cmp (foo)="b¦ar()"></test-cmp>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.MethodCall);
   });
@@ -134,8 +134,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate element children', () => {
     const {errors, nodes, position} = parse(`<div><sp¦an></span></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Element);
     expect((node as t.Element).name).toBe('span');
@@ -144,8 +144,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate element reference', () => {
     const {errors, nodes, position} = parse(`<div #my¦div></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Reference);
   });
@@ -153,8 +153,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template text attribute', () => {
     const {errors, nodes, position} = parse(`<ng-template ng¦If></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.TextAttribute);
   });
@@ -162,8 +162,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template bound attribute key', () => {
     const {errors, nodes, position} = parse(`<ng-template [ng¦If]="foo"></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.BoundAttribute);
   });
@@ -171,8 +171,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template bound attribute value', () => {
     const {errors, nodes, position} = parse(`<ng-template [ngIf]="f¦oo"></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
   });
@@ -180,8 +180,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template bound attribute key in two-way binding', () => {
     const {errors, nodes, position} = parse(`<ng-template [(f¦oo)]="bar"></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.BoundAttribute);
     expect((node as t.BoundAttribute).name).toBe('foo');
@@ -190,8 +190,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template bound attribute value in two-way binding', () => {
     const {errors, nodes, position} = parse(`<ng-template [(foo)]="b¦ar"></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
     expect((node as e.PropertyRead).name).toBe('bar');
@@ -200,8 +200,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template bound event key', () => {
     const {errors, nodes, position} = parse(`<ng-template (cl¦ick)="foo()"></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.BoundEvent);
   });
@@ -209,16 +209,16 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template bound event value', () => {
     const {errors, nodes, position} = parse(`<ng-template (click)="f¦oo()"></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(node).toBeInstanceOf(e.MethodCall);
   });
 
   it('should locate template attribute key', () => {
     const {errors, nodes, position} = parse(`<ng-template i¦d="foo"></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.TextAttribute);
   });
@@ -226,8 +226,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template attribute value', () => {
     const {errors, nodes, position} = parse(`<ng-template id="f¦oo"></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     // TODO: Note that we do not have the ability to detect the RHS (yet)
     expect(node).toBeInstanceOf(t.TextAttribute);
@@ -236,8 +236,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template reference key via the # notation', () => {
     const {errors, nodes, position} = parse(`<ng-template #f¦oo></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Reference);
     expect((node as t.Reference).name).toBe('foo');
@@ -246,8 +246,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template reference key via the ref- notation', () => {
     const {errors, nodes, position} = parse(`<ng-template ref-fo¦o></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Reference);
     expect((node as t.Reference).name).toBe('foo');
@@ -256,8 +256,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template reference value via the # notation', () => {
     const {errors, nodes, position} = parse(`<ng-template #foo="export¦As"></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Reference);
     expect((node as t.Reference).value).toBe('exportAs');
@@ -267,8 +267,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template reference value via the ref- notation', () => {
     const {errors, nodes, position} = parse(`<ng-template ref-foo="export¦As"></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Reference);
     expect((node as t.Reference).value).toBe('exportAs');
@@ -278,8 +278,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template variable key', () => {
     const {errors, nodes, position} = parse(`<ng-template let-f¦oo="bar"></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Variable);
   });
@@ -287,8 +287,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template variable value', () => {
     const {errors, nodes, position} = parse(`<ng-template let-foo="b¦ar"></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Variable);
   });
@@ -296,8 +296,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate template children', () => {
     const {errors, nodes, position} = parse(`<ng-template><d¦iv></div></ng-template>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Element);
   });
@@ -305,8 +305,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate ng-content', () => {
     const {errors, nodes, position} = parse(`<ng-co¦ntent></ng-content>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Content);
   });
@@ -314,8 +314,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate ng-content attribute key', () => {
     const {errors, nodes, position} = parse('<ng-content cla¦ss="red"></ng-content>');
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.TextAttribute);
   });
@@ -323,8 +323,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate ng-content attribute value', () => {
     const {errors, nodes, position} = parse('<ng-content class="r¦ed"></ng-content>');
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     // TODO: Note that we do not have the ability to detect the RHS (yet)
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.TextAttribute);
@@ -333,8 +333,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should not locate implicit receiver', () => {
     const {errors, nodes, position} = parse(`<div [foo]="¦bar"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
   });
@@ -342,8 +342,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate bound attribute key in two-way binding', () => {
     const {errors, nodes, position} = parse(`<cmp [(f¦oo)]="bar"></cmp>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.BoundAttribute);
     expect((node as t.BoundAttribute).name).toBe('foo');
@@ -352,8 +352,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate bound attribute value in two-way binding', () => {
     const {errors, nodes, position} = parse(`<cmp [(foo)]="b¦ar"></cmp>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
     expect((node as e.PropertyRead).name).toBe('bar');
@@ -362,8 +362,8 @@ describe('getTargetAtPosition for template AST', () => {
   it('should locate switch value in ICUs', () => {
     const {errors, nodes, position} = parse(`<span i18n>{sw¦itch, plural, other {text}}"></span>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
     expect((node as e.PropertyRead).name).toBe('switch');
@@ -373,8 +373,8 @@ describe('getTargetAtPosition for template AST', () => {
     const {errors, nodes, position} = parse(
         `<span i18n>{expr, plural, other { {ne¦sted, plural, =1 { {{nestedInterpolation}} }} }}"></span>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
     expect((node as e.PropertyRead).name).toBe('nested');
@@ -384,8 +384,8 @@ describe('getTargetAtPosition for template AST', () => {
     const {errors, nodes, position} =
         parse(`<span i18n>{expr, plural, other { {{ i¦nterpolation }} }}"></span>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
     expect((node as e.PropertyRead).name).toBe('interpolation');
@@ -395,8 +395,8 @@ describe('getTargetAtPosition for template AST', () => {
     const {errors, nodes, position} = parse(
         `<span i18n>{expr, plural, other { {nested, plural, =1 { {{n¦estedInterpolation}} }} }}"></span>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
     expect((node as e.PropertyRead).name).toBe('nestedInterpolation');
@@ -407,8 +407,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should not locate implicit receiver', () => {
     const {errors, nodes, position} = parse(`{{ ¦title }}`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
     expect((node as e.PropertyRead).name).toBe('title');
@@ -417,8 +417,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate property read', () => {
     const {errors, nodes, position} = parse(`{{ ti¦tle }}`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
     expect((node as e.PropertyRead).name).toBe('title');
@@ -427,8 +427,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate safe property read', () => {
     const {errors, nodes, position} = parse(`{{ foo?¦.bar }}`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.SafePropertyRead);
     expect((node as e.SafePropertyRead).name).toBe('bar');
@@ -437,8 +437,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate keyed read', () => {
     const {errors, nodes, position} = parse(`{{ foo['bar']¦ }}`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.KeyedRead);
   });
@@ -446,8 +446,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate property write', () => {
     const {errors, nodes, position} = parse(`<div (foo)="b¦ar=$event"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyWrite);
   });
@@ -455,8 +455,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate keyed write', () => {
     const {errors, nodes, position} = parse(`<div (foo)="bar['baz']¦=$event"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.KeyedWrite);
   });
@@ -464,8 +464,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate binary', () => {
     const {errors, nodes, position} = parse(`{{ 1 +¦ 2 }}`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.Binary);
   });
@@ -473,8 +473,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate binding pipe with an identifier', () => {
     const {errors, nodes, position} = parse(`{{ title | p¦ }}`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.BindingPipe);
   });
@@ -485,8 +485,8 @@ describe('getTargetAtPosition for expression AST', () => {
     expect(errors![0].toString())
         .toContain(
             'Unexpected end of input, expected identifier or keyword at the end of the expression');
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     // TODO: We want this to be a BindingPipe.
     expect(node).toBeInstanceOf(e.Interpolation);
@@ -498,7 +498,7 @@ describe('getTargetAtPosition for expression AST', () => {
          // parser throws an error. This case is important for autocomplete.
          // const {errors, nodes, position} = parse(`{{ title | ¦ }}`);
          // expect(errors).toBe(null);
-         // const {nodeInContext} = findNodeAtPosition(nodes, position)!;
+         // const {context} = findNodeAtPosition(nodes, position)!;
          // expect(isExpressionNode(node!)).toBe(true);
          // expect(node).toBeInstanceOf(e.BindingPipe);
      });
@@ -507,8 +507,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate method call', () => {
     const {errors, nodes, position} = parse(`{{ title.toString(¦) }}`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.MethodCall);
   });
@@ -516,8 +516,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate safe method call', () => {
     const {errors, nodes, position} = parse(`{{ title?.toString(¦) }}`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.SafeMethodCall);
   });
@@ -525,8 +525,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate literal primitive in interpolation', () => {
     const {errors, nodes, position} = parse(`{{ title.indexOf('t¦') }}`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.LiteralPrimitive);
     expect((node as e.LiteralPrimitive).value).toBe('t');
@@ -535,8 +535,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate literal primitive in binding', () => {
     const {errors, nodes, position} = parse(`<div [id]="'t¦'"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.LiteralPrimitive);
     expect((node as e.LiteralPrimitive).value).toBe('t');
@@ -545,8 +545,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate empty expression', () => {
     const {errors, nodes, position} = parse(`<div [id]="¦"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.EmptyExpr);
   });
@@ -554,8 +554,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate literal array', () => {
     const {errors, nodes, position} = parse(`{{ [1, 2,¦ 3] }}`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.LiteralArray);
   });
@@ -563,8 +563,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate literal map', () => {
     const {errors, nodes, position} = parse(`{{ { hello:¦ "world" } }}`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.LiteralMap);
   });
@@ -572,8 +572,8 @@ describe('getTargetAtPosition for expression AST', () => {
   it('should locate conditional', () => {
     const {errors, nodes, position} = parse(`{{ cond ?¦ true : false }}`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.Conditional);
   });
@@ -583,8 +583,8 @@ describe('findNodeAtPosition for microsyntax expression', () => {
   it('should locate template key', () => {
     const {errors, nodes, position} = parse(`<div *ng¦If="foo"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.BoundAttribute);
   });
@@ -592,8 +592,8 @@ describe('findNodeAtPosition for microsyntax expression', () => {
   it('should locate template value', () => {
     const {errors, nodes, position} = parse(`<div *ngIf="f¦oo"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
   });
@@ -601,8 +601,8 @@ describe('findNodeAtPosition for microsyntax expression', () => {
   it('should locate property read next to variable in structural directive syntax', () => {
     const {errors, nodes, position} = parse(`<div *ngIf="fo¦o as bar"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
   });
@@ -612,8 +612,8 @@ describe('findNodeAtPosition for microsyntax expression', () => {
     // ngFor is a text attribute because the desugared form is
     // <ng-template ngFor let-item [ngForOf]="items">
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBeTrue();
     expect(node).toBeInstanceOf(t.TextAttribute);
     expect((node as t.TextAttribute).name).toBe('ngFor');
@@ -629,8 +629,8 @@ describe('findNodeAtPosition for microsyntax expression', () => {
   it('should locate let variable', () => {
     const {errors, nodes, position} = parse(`<div *ngFor="let i¦tem of items"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Variable);
     expect((node as t.Variable).name).toBe('item');
@@ -639,8 +639,8 @@ describe('findNodeAtPosition for microsyntax expression', () => {
   it('should locate bound attribute key', () => {
     const {errors, nodes, position} = parse(`<div *ngFor="let item o¦f items"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.BoundAttribute);
     expect((node as t.BoundAttribute).name).toBe('ngForOf');
@@ -649,8 +649,8 @@ describe('findNodeAtPosition for microsyntax expression', () => {
   it('should locate bound attribute key when cursor is at the start', () => {
     const {errors, nodes, position} = parse(`<div *ngFor="let item ¦of items"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const node = nodeInContext.node;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const node = (context as SingleNodeTarget).node;
     expect(isTemplateNode(node)).toBe(true);
     expect(node).toBeInstanceOf(t.BoundAttribute);
     expect((node as t.BoundAttribute).name).toBe('ngForOf');
@@ -660,8 +660,8 @@ describe('findNodeAtPosition for microsyntax expression', () => {
     const {errors, nodes, position} =
         parse(`<div *ngFor="let item of items; trac¦kBy: trackByFn"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.BoundAttribute);
     expect((node as t.BoundAttribute).name).toBe('ngForTrackBy');
@@ -674,8 +674,8 @@ describe('findNodeAtPosition for microsyntax expression', () => {
     const {errors, nodes, position} =
         parse(`<div *ngFor="let item o¦f items; trackBy: trackByFn"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.BoundAttribute);
     expect((node as t.BoundAttribute).name).toBe('ngForOf');
@@ -684,8 +684,8 @@ describe('findNodeAtPosition for microsyntax expression', () => {
   it('should locate bound attribute value', () => {
     const {errors, nodes, position} = parse(`<div *ngFor="let item of it¦ems"></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
     expect((node as e.PropertyRead).name).toBe('items');
@@ -694,12 +694,12 @@ describe('findNodeAtPosition for microsyntax expression', () => {
   it('should locate template children', () => {
     const {errors, nodes, position} = parse(`<di¦v *ngIf></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext, template: context} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context, template} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Element);
     expect((node as t.Element).name).toBe('div');
-    expect(context).toBeInstanceOf(t.Template);
+    expect(template).toBeInstanceOf(t.Template);
   });
 
   it('should locate property read of variable declared within template', () => {
@@ -708,8 +708,8 @@ describe('findNodeAtPosition for microsyntax expression', () => {
         {{ i¦ }}
       </div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isExpressionNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(e.PropertyRead);
   });
@@ -717,8 +717,8 @@ describe('findNodeAtPosition for microsyntax expression', () => {
   it('should locate LHS of variable declaration', () => {
     const {errors, nodes, position} = parse(`<div *ngFor="let item of items; let i¦=index">`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Variable);
     // TODO: Currently there is no way to distinguish LHS from RHS
@@ -728,8 +728,8 @@ describe('findNodeAtPosition for microsyntax expression', () => {
   it('should locate RHS of variable declaration', () => {
     const {errors, nodes, position} = parse(`<div *ngFor="let item of items; let i=in¦dex">`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    const {node} = nodeInContext;
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(t.Variable);
     // TODO: Currently there is no way to distinguish LHS from RHS
@@ -739,16 +739,16 @@ describe('findNodeAtPosition for microsyntax expression', () => {
   it('should locate an element in its tag context', () => {
     const {errors, nodes, position} = parse(`<div¦ attr></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    expect(nodeInContext.kind).toBe(TargetNodeKind.ElementInTagContext);
-    expect(nodeInContext.node).toBeInstanceOf(t.Element);
+    const {context} = getTargetAtPosition(nodes, position)!;
+    expect(context.kind).toBe(TargetNodeKind.ElementInTagContext);
+    expect((context as SingleNodeTarget).node).toBeInstanceOf(t.Element);
   });
 
   it('should locate an element in its body context', () => {
     const {errors, nodes, position} = parse(`<div ¦ attr></div>`);
     expect(errors).toBe(null);
-    const {nodeInContext} = getTargetAtPosition(nodes, position)!;
-    expect(nodeInContext.kind).toBe(TargetNodeKind.ElementInBodyContext);
-    expect(nodeInContext.node).toBeInstanceOf(t.Element);
+    const {context} = getTargetAtPosition(nodes, position)!;
+    expect(context.kind).toBe(TargetNodeKind.ElementInBodyContext);
+    expect((context as SingleNodeTarget).node).toBeInstanceOf(t.Element);
   });
 });

--- a/packages/language-service/ivy/utils.ts
+++ b/packages/language-service/ivy/utils.ts
@@ -54,6 +54,16 @@ export function isTemplateNodeWithKeyAndValue(node: t.Node|e.AST): node is NodeW
   return isTemplateNode(node) && node.hasOwnProperty('keySpan');
 }
 
+export function isWithinKey(position: number, node: NodeWithKeyAndValue): boolean {
+  let {keySpan, valueSpan} = node;
+  if (valueSpan === undefined && node instanceof TmplAstBoundEvent) {
+    valueSpan = node.handlerSpan;
+  }
+  const isWithinKeyValue =
+      isWithin(position, keySpan) || !!(valueSpan && isWithin(position, valueSpan));
+  return isWithinKeyValue;
+}
+
 export function isWithinKeyValue(position: number, node: NodeWithKeyAndValue): boolean {
   let {keySpan, valueSpan} = node;
   if (valueSpan === undefined && node instanceof TmplAstBoundEvent) {


### PR DESCRIPTION
This PR adjusts various pieces of the Ivy native LS implementation to account for two-way bindings (aka banana in a box syntax). 

Each commit has a very targeted goal to make it easier to review incrementally. 