### PR TITLE
fix(localize): ensure extracted messages are serialized in a consistent order

### DIFF
--- a/packages/localize/src/tools/src/extract/translation_files/arb_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/arb_translation_serializer.ts
@@ -48,12 +48,13 @@ export class ArbTranslationSerializer implements TranslationSerializer {
       private sourceLocale: string, private basePath: AbsoluteFsPath, private fs: FileSystem) {}
 
   serialize(messages: ɵParsedMessage[]): string {
-    const messageMap = consolidateMessages(messages, message => message.customId || message.id);
+    const messageGroups = consolidateMessages(messages, message => getMessageId(message));
 
     let output = `{\n  "@@locale": ${JSON.stringify(this.sourceLocale)}`;
 
-    for (const [id, duplicateMessages] of messageMap.entries()) {
+    for (const duplicateMessages of messageGroups) {
       const message = duplicateMessages[0];
+      const id = getMessageId(message);
       output += this.serializeMessage(id, message);
       output += this.serializeMeta(
           id, message.description, duplicateMessages.filter(hasLocation).map(m => m.location));
@@ -97,4 +98,8 @@ export class ArbTranslationSerializer implements TranslationSerializer {
       `      }`,
     ].join('\n');
   }
+}
+
+function getMessageId(message: ɵParsedMessage): string {
+  return message.customId || message.id;
 }

--- a/packages/localize/src/tools/src/extract/translation_files/json_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/json_translation_serializer.ts
@@ -7,6 +7,7 @@
  */
 import {ɵMessageId, ɵParsedMessage, ɵSourceMessage} from '@angular/localize';
 import {TranslationSerializer} from './translation_serializer';
+import {consolidateMessages} from './utils';
 
 
 interface SimpleJsonTranslationFile {
@@ -24,7 +25,7 @@ export class SimpleJsonTranslationSerializer implements TranslationSerializer {
   constructor(private sourceLocale: string) {}
   serialize(messages: ɵParsedMessage[]): string {
     const fileObj: SimpleJsonTranslationFile = {locale: this.sourceLocale, translations: {}};
-    for (const message of messages) {
+    for (const [message] of consolidateMessages(messages, message => message.id)) {
       fileObj.translations[message.id] = message.text;
     }
     return JSON.stringify(fileObj, null, 2);

--- a/packages/localize/src/tools/src/extract/translation_files/utils.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/utils.ts
@@ -8,24 +8,40 @@
 import {ɵMessageId, ɵParsedMessage, ɵSourceLocation} from '@angular/localize';
 
 /**
- * Consolidate an array of messages into a map from message id to an array of messages with that id.
+ * Consolidate messages into groups that have the same id.
+ *
+ * Messages with the same id are grouped together so that we can quickly deduplicate messages when
+ * rendering into translation files.
+ *
+ * To ensure that messages are rendered in a deterministic order:
+ *  - the messages within a group are sorted by location (file path, then start position)
+ *  - the groups are sorted by the location of the first message in the group
  *
  * @param messages the messages to consolidate.
  * @param getMessageId a function that will compute the message id of a message.
+ * @returns an array of message groups, where each group is an array of messages that have the same
+ *     id.
  */
 export function consolidateMessages(
     messages: ɵParsedMessage[],
-    getMessageId: (message: ɵParsedMessage) => string): Map<ɵMessageId, ɵParsedMessage[]> {
-  const consolidateMessages = new Map<ɵMessageId, ɵParsedMessage[]>();
+    getMessageId: (message: ɵParsedMessage) => string): ɵParsedMessage[][] {
+  const messageGroups = new Map<ɵMessageId, ɵParsedMessage[]>();
   for (const message of messages) {
     const id = getMessageId(message);
-    if (!consolidateMessages.has(id)) {
-      consolidateMessages.set(id, [message]);
+    if (!messageGroups.has(id)) {
+      messageGroups.set(id, [message]);
     } else {
-      consolidateMessages.get(id)!.push(message);
+      messageGroups.get(id)!.push(message);
     }
   }
-  return consolidateMessages;
+
+  // Here we sort the messages within a group into location order.
+  // Note that `Array.sort()` will mutate the array in-place.
+  for (const messages of messageGroups.values()) {
+    messages.sort(compareLocations);
+  }
+  // Now we sort the groups by location of the first message in the group.
+  return Array.from(messageGroups.values()).sort((a1, a2) => compareLocations(a1[0], a2[0]));
 }
 
 /**
@@ -34,4 +50,27 @@ export function consolidateMessages(
 export function hasLocation(message: ɵParsedMessage): message is ɵParsedMessage&
     {location: ɵSourceLocation} {
   return message.location !== undefined;
+}
+
+export function compareLocations(
+    {location: location1}: ɵParsedMessage, {location: location2}: ɵParsedMessage): number {
+  if (location1 === location2) {
+    return 0;
+  }
+  if (location1 === undefined) {
+    return -1;
+  }
+  if (location2 === undefined) {
+    return 1;
+  }
+  if (location1.file !== location2.file) {
+    return location1.file < location2.file ? -1 : 1;
+  }
+  if (location1.start.line !== location2.start.line) {
+    return location1.start.line < location2.start.line ? -1 : 1;
+  }
+  if (location1.start.column !== location2.start.column) {
+    return location1.start.column < location2.start.column ? -1 : 1;
+  }
+  return 0;
 }

--- a/packages/localize/src/tools/src/extract/translation_files/xliff1_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/xliff1_translation_serializer.ts
@@ -34,7 +34,7 @@ export class Xliff1TranslationSerializer implements TranslationSerializer {
   }
 
   serialize(messages: ɵParsedMessage[]): string {
-    const messageMap = consolidateMessages(messages, message => this.getMessageId(message));
+    const messageGroups = consolidateMessages(messages, message => this.getMessageId(message));
     const xml = new XmlFile();
     xml.startTag('xliff', {'version': '1.2', 'xmlns': 'urn:oasis:names:tc:xliff:document:1.2'});
     // NOTE: the `original` property is set to the legacy `ng2.template` value for backward
@@ -51,8 +51,9 @@ export class Xliff1TranslationSerializer implements TranslationSerializer {
       ...this.formatOptions,
     });
     xml.startTag('body');
-    for (const [id, duplicateMessages] of messageMap.entries()) {
+    for (const duplicateMessages of messageGroups) {
       const message = duplicateMessages[0];
+      const id = this.getMessageId(message);
 
       xml.startTag('trans-unit', {id, datatype: 'html'});
       xml.startTag('source', {}, {preserveWhitespace: true});

--- a/packages/localize/src/tools/src/extract/translation_files/xliff2_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/xliff2_translation_serializer.ts
@@ -34,7 +34,7 @@ export class Xliff2TranslationSerializer implements TranslationSerializer {
   }
 
   serialize(messages: ɵParsedMessage[]): string {
-    const messageMap = consolidateMessages(messages, message => this.getMessageId(message));
+    const messageGroups = consolidateMessages(messages, message => this.getMessageId(message));
     const xml = new XmlFile();
     xml.startTag('xliff', {
       'version': '2.0',
@@ -49,8 +49,9 @@ export class Xliff2TranslationSerializer implements TranslationSerializer {
     // messages that come from a particular original file, and the translation file parsers may
     // not
     xml.startTag('file', {'id': 'ngi18n', 'original': 'ng.template', ...this.formatOptions});
-    for (const [id, duplicateMessages] of messageMap.entries()) {
+    for (const duplicateMessages of messageGroups) {
       const message = duplicateMessages[0];
+      const id = this.getMessageId(message);
 
       xml.startTag('unit', {id});
       const messagesWithLocations = duplicateMessages.filter(hasLocation);

--- a/packages/localize/src/tools/src/extract/translation_files/xmb_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/xmb_translation_serializer.ts
@@ -10,6 +10,7 @@ import {ɵParsedMessage, ɵSourceLocation} from '@angular/localize';
 
 import {extractIcuPlaceholders} from './icu_parsing';
 import {TranslationSerializer} from './translation_serializer';
+import {consolidateMessages} from './utils';
 import {XmlFile} from './xml_file';
 
 /**
@@ -26,7 +27,7 @@ export class XmbTranslationSerializer implements TranslationSerializer {
       private fs: FileSystem = getFileSystem()) {}
 
   serialize(messages: ɵParsedMessage[]): string {
-    const ids = new Set<string>();
+    const messageGroups = consolidateMessages(messages, message => this.getMessageId(message));
     const xml = new XmlFile();
     xml.rawText(
         `<!DOCTYPE messagebundle [\n` +
@@ -51,13 +52,9 @@ export class XmbTranslationSerializer implements TranslationSerializer {
         `<!ELEMENT ex (#PCDATA)>\n` +
         `]>\n`);
     xml.startTag('messagebundle');
-    for (const message of messages) {
+    for (const duplicateMessages of messageGroups) {
+      const message = duplicateMessages[0];
       const id = this.getMessageId(message);
-      if (ids.has(id)) {
-        // Do not render the same message more than once
-        continue;
-      }
-      ids.add(id);
       xml.startTag(
           'msg', {id, desc: message.description, meaning: message.meaning},
           {preserveWhitespace: true});

--- a/packages/localize/src/tools/test/extract/integration/main_spec.ts
+++ b/packages/localize/src/tools/test/extract/integration/main_spec.ts
@@ -464,7 +464,7 @@ runInEachFileSystem(() => {
           `  "locale": "en-GB",`,
           `  "translations": {`,
           `    "message-1": "message {$PH} contents",`,
-          `    "message-2": "different message contents"`,
+          `    "message-2": "message contents"`,
           `  }`,
           `}`,
         ].join('\n'));
@@ -489,7 +489,7 @@ runInEachFileSystem(() => {
           `  "locale": "en-GB",`,
           `  "translations": {`,
           `    "message-1": "message {$PH} contents",`,
-          `    "message-2": "different message contents"`,
+          `    "message-2": "message contents"`,
           `  }`,
           `}`,
         ].join('\n'));

--- a/packages/localize/src/tools/test/extract/translation_files/mock_message.ts
+++ b/packages/localize/src/tools/test/extract/translation_files/mock_message.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {absoluteFrom} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedMessage} from '@angular/localize';
 import {MessageId, SourceLocation} from '@angular/localize/src/utils';
 
@@ -36,5 +37,15 @@ export function mockMessage(
     text,
     messageParts,
     placeholderNames,
+  };
+}
+
+export function location(
+    file: string, startLine: number, startCol: number, endLine: number,
+    endCol: number): SourceLocation {
+  return {
+    file: absoluteFrom(file),
+    start: {line: startLine, column: startCol},
+    end: {line: endLine, column: endCol}
   };
 }

--- a/packages/localize/src/tools/test/extract/translation_files/xmb_translation_serializer_spec.ts
+++ b/packages/localize/src/tools/test/extract/translation_files/xmb_translation_serializer_spec.ts
@@ -11,7 +11,7 @@ import {ɵParsedMessage, ɵSourceLocation} from '@angular/localize';
 
 import {XmbTranslationSerializer} from '../../../src/extract/translation_files/xmb_translation_serializer';
 
-import {mockMessage} from './mock_message';
+import {location, mockMessage} from './mock_message';
 
 runInEachFileSystem(() => {
   let fs: FileSystem;
@@ -84,6 +84,54 @@ runInEachFileSystem(() => {
           ].join('\n'));
         });
       });
+    });
+  });
+
+  describe('renderFile()', () => {
+    it('should consistently order serialized messages by location', () => {
+      const messages: ɵParsedMessage[] = [
+        mockMessage('1', ['message-1'], [], {location: location('/root/c-1.ts', 5, 10, 5, 12)}),
+        mockMessage('2', ['message-1'], [], {location: location('/root/c-2.ts', 5, 10, 5, 12)}),
+        mockMessage('1', ['message-1'], [], {location: location('/root/b-1.ts', 8, 0, 10, 12)}),
+        mockMessage('2', ['message-1'], [], {location: location('/root/b-2.ts', 8, 0, 10, 12)}),
+        mockMessage('1', ['message-1'], [], {location: location('/root/a-1.ts', 5, 10, 5, 12)}),
+        mockMessage('2', ['message-1'], [], {location: location('/root/a-2.ts', 5, 10, 5, 12)}),
+        mockMessage('1', ['message-1'], [], {location: location('/root/b-1.ts', 5, 10, 5, 12)}),
+        mockMessage('2', ['message-1'], [], {location: location('/root/b-2.ts', 5, 10, 5, 12)}),
+        mockMessage('1', ['message-1'], [], {location: location('/root/b-1.ts', 5, 20, 5, 12)}),
+        mockMessage('2', ['message-1'], [], {location: location('/root/b-2.ts', 5, 20, 5, 12)}),
+      ];
+      const serializer = new XmbTranslationSerializer(absoluteFrom('/root'), false);
+      const output = serializer.serialize(messages);
+      expect(output.split('\n')).toEqual([
+        '<?xml version="1.0" encoding="UTF-8" ?>',
+        '<!DOCTYPE messagebundle [',
+        '<!ELEMENT messagebundle (msg)*>',
+        '<!ATTLIST messagebundle class CDATA #IMPLIED>',
+        '',
+        '<!ELEMENT msg (#PCDATA|ph|source)*>',
+        '<!ATTLIST msg id CDATA #IMPLIED>',
+        '<!ATTLIST msg seq CDATA #IMPLIED>',
+        '<!ATTLIST msg name CDATA #IMPLIED>',
+        '<!ATTLIST msg desc CDATA #IMPLIED>',
+        '<!ATTLIST msg meaning CDATA #IMPLIED>',
+        '<!ATTLIST msg obsolete (obsolete) #IMPLIED>',
+        '<!ATTLIST msg xml:space (default|preserve) "default">',
+        '<!ATTLIST msg is_hidden CDATA #IMPLIED>',
+        '',
+        '<!ELEMENT source (#PCDATA)>',
+        '',
+        '<!ELEMENT ph (#PCDATA|ex)*>',
+        '<!ATTLIST ph name CDATA #REQUIRED>',
+        '',
+        '<!ELEMENT ex (#PCDATA)>',
+        ']>',
+        '<messagebundle>',
+        '  <msg id="1"><source>a-1.ts:5</source>message-1</msg>',
+        '  <msg id="2"><source>a-2.ts:5</source>message-1</msg>',
+        '</messagebundle>',
+        '',
+      ]);
     });
   });
 });


### PR DESCRIPTION
The CLI integration can provide code files in a non-deterministic
order, which led to the extracted translation files having
messages in a non-consistent order between extractions.

This commit fixes this by ensuring that serialized messages
are ordered by their location.

Fixes #39262

