### PR TITLE
docs: fix instructions for setting up `ProductDetailsComponent` in `start-routing.md`

### DIFF
--- a/aio/content/examples/getting-started-v0/src/app/app.component.css
+++ b/aio/content/examples/getting-started-v0/src/app/app.component.css
@@ -1,3 +1,1 @@
-p {
-  font-family: Lato;
-}
+

--- a/aio/content/examples/getting-started-v0/src/app/app.component.ts
+++ b/aio/content/examples/getting-started-v0/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: [ './app.component.css' ]
+  styleUrls: ['./app.component.css']
 })
-export class AppComponent  {}
+export class AppComponent {
+}

--- a/aio/content/examples/getting-started-v0/src/app/app.module.ts
+++ b/aio/content/examples/getting-started-v0/src/app/app.module.ts
@@ -20,6 +20,8 @@ import { ProductListComponent } from './product-list/product-list.component';
     TopBarComponent,
     ProductListComponent
   ],
-  bootstrap: [ AppComponent ]
+  bootstrap: [
+    AppComponent
+  ]
 })
 export class AppModule { }

--- a/aio/content/examples/getting-started-v0/src/app/products.ts
+++ b/aio/content/examples/getting-started-v0/src/app/products.ts
@@ -1,15 +1,18 @@
 export const products = [
   {
+    id: 1,
     name: 'Phone XL',
     price: 799,
     description: 'A large phone with one of the best screens'
   },
   {
+    id: 2,
     name: 'Phone Mini',
     price: 699,
     description: 'A great phone with one of the best cameras'
   },
   {
+    id: 3,
     name: 'Phone Standard',
     price: 299,
     description: ''

--- a/aio/content/examples/getting-started-v0/src/app/top-bar/top-bar.component.ts
+++ b/aio/content/examples/getting-started-v0/src/app/top-bar/top-bar.component.ts
@@ -1,15 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-top-bar',
   templateUrl: './top-bar.component.html',
   styleUrls: ['./top-bar.component.css']
 })
-export class TopBarComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
+export class TopBarComponent {
 
 }

--- a/aio/content/examples/getting-started-v0/src/main.ts
+++ b/aio/content/examples/getting-started-v0/src/main.ts
@@ -1,11 +1,12 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { environment } from './environments/environment';
 
 import { AppModule } from './app/app.module';
+import { environment } from './environments/environment';
 
 if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule);
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/aio/content/examples/getting-started/src/app/product-details/product-details.component.1.ts
+++ b/aio/content/examples/getting-started/src/app/product-details/product-details.component.1.ts
@@ -24,11 +24,11 @@ export class ProductDetailsComponent implements OnInit {
   // #docregion get-product
   ngOnInit() {
     // First get the product id from the current route.
-    const productIdFromRoute = this.route.snapshot.paramMap.get('productId');
+    const routeParams = this.route.snapshot.paramMap;
+    const productIdFromRoute = Number(routeParams.get('productId'));
+
     // Find the product that correspond with the id provided in route.
-    this.product = products.find(product => {
-      return product.id === Number(productIdFromRoute);
-    });
+    this.product = products.find(product => product.id === productIdFromRoute);
   }
   // #enddocregion get-product
   // #docregion product-prop

--- a/aio/content/examples/getting-started/src/app/product-details/product-details.component.1.ts
+++ b/aio/content/examples/getting-started/src/app/product-details/product-details.component.1.ts
@@ -11,7 +11,7 @@ import { products } from '../products';
   templateUrl: './product-details.component.html',
   styleUrls: ['./product-details.component.css']
 })
-// #docregion props-methods, add-to-cart, product-prop
+// #docregion props-methods, product-prop
 export class ProductDetailsComponent implements OnInit {
   product;
   // #enddocregion product-prop
@@ -29,9 +29,9 @@ export class ProductDetailsComponent implements OnInit {
     this.product = products.find(product => {
       return product.id === Number(productIdFromRoute);
     });
-  // #docregion product-prop
   }
-  // #enddocregion product-prop
   // #enddocregion get-product
+  // #docregion product-prop
+  /* ... */
   // #docregion props-methods
 }

--- a/aio/content/examples/getting-started/src/app/product-details/product-details.component.ts
+++ b/aio/content/examples/getting-started/src/app/product-details/product-details.component.ts
@@ -13,9 +13,9 @@ import { CartService } from '../cart.service';
   templateUrl: './product-details.component.html',
   styleUrls: ['./product-details.component.css']
 })
-// #docregion props-methods, get-product, inject-cart-service, add-to-cart
+// #docregion props-methods, inject-cart-service, add-to-cart
 export class ProductDetailsComponent implements OnInit {
-// #enddocregion add-to-cart, get-product, inject-cart-service
+// #enddocregion add-to-cart, inject-cart-service
   product;
 
 // #docregion inject-cart-service
@@ -27,7 +27,6 @@ export class ProductDetailsComponent implements OnInit {
   ) { }
 // #enddocregion inject-cart-service
 
-// #docregion get-product
   ngOnInit() {
 // #enddocregion props-methods
     // First get the product id from the current route.
@@ -39,11 +38,11 @@ export class ProductDetailsComponent implements OnInit {
 // #docregion props-methods
   }
 
-// #enddocregion props-methods, get-product
+// #enddocregion props-methods
 // #docregion add-to-cart
   addToCart(product) {
     this.cartService.addToCart(product);
     window.alert('Your product has been added to the cart!');
   }
-// #docregion props-methods, get-product, inject-cart-service
+// #docregion props-methods, inject-cart-service
 }

--- a/aio/content/examples/getting-started/src/app/product-details/product-details.component.ts
+++ b/aio/content/examples/getting-started/src/app/product-details/product-details.component.ts
@@ -30,11 +30,11 @@ export class ProductDetailsComponent implements OnInit {
   ngOnInit() {
 // #enddocregion props-methods
     // First get the product id from the current route.
-    const productIdFromRoute = this.route.snapshot.paramMap.get('productId');
+    const routeParams = this.route.snapshot.paramMap;
+    const productIdFromRoute = Number(routeParams.get('productId'));
+
     // Find the product that correspond with the id provided in route.
-    this.product = products.find(product => {
-      return product.id === Number(productIdFromRoute);
-    });
+    this.product = products.find(product => product.id === productIdFromRoute);
 // #docregion props-methods
   }
 

--- a/aio/content/examples/getting-started/src/app/product-list/product-list.component.html
+++ b/aio/content/examples/getting-started/src/app/product-list/product-list.component.html
@@ -8,19 +8,21 @@
       {{ product.name }}
     </a>
   </h3>
-<!-- #enddocregion router-link -->  
+
+  <!-- #enddocregion router-link -->
   <p *ngIf="product.description">
     Description: {{ product.description }}
   </p>
-  
+
   <button (click)="share()">
     Share
   </button>
-  
+
   <app-product-alerts
     [product]="product"
     (notify)="onNotify()">
   </app-product-alerts>
-<!-- #docregion router-link -->
+  <!-- #docregion router-link -->
+
 </div>
 <!-- #enddocregion router-link -->

--- a/aio/content/start/start-routing.md
+++ b/aio/content/start/start-routing.md
@@ -28,9 +28,6 @@ This section shows you how to define a route to show individual product details.
 
 1. Open `product-list.component.html`.
 
-1. Update the `*ngFor` directive to read as follows.
-    This statement instructs Angular to iterate over the items in the `products` array and assigns each index in the array to the `productId` variable when iterating over the list.
-
 1. Modify the product name anchor to include a `routerLink` with the `product.id` as a parameter.
 
     <code-example header="src/app/product-list/product-list.component.html" path="getting-started/src/app/product-list/product-list.component.html" region="router-link">
@@ -79,12 +76,15 @@ In this section, you'll use the Angular Router to combine the `products` data an
     By injecting `ActivatedRoute`, you are configuring the component to use a service.
     The [Managing Data](start/start-data "Try it: Managing Data") step covers services in more detail.
 
-1. In the `ngOnInit()` method, subscribe to route parameters and fetch the product based on the `productId`.
+1. In the `ngOnInit()` method, extract the `productId` from the route parameters and find the corresponding product in the `products` array.
 
     <code-example path="getting-started/src/app/product-details/product-details.component.1.ts" header="src/app/product-details/product-details.component.ts" region="get-product">
     </code-example>
 
-    The route parameters correspond to the path variables you define in the route. The URL that matches the route provides the `productId`. Angular uses the `productId` to display the details for each unique product.
+    The route parameters correspond to the path variables you define in the route.
+    To access the route parameters, we use `route.snapshot`, which is the `ActivatedRouteSnapshot` that contains information about the active route at that particular moment in time.
+    The URL that matches the route provides the `productId` .
+    Angular uses the `productId` to display the details for each unique product.
 
 1. Update the `ProductDetailsComponent` template to display product details with an `*ngIf`.
     If a product exists, the `<div>` renders with a name, price, and description.


### PR DESCRIPTION
PR #34934 switched the `getting-started` docs example from using the index of a product in the `products` array to using the product's ID property for indentifiying each product in the `ProductDetailsComponent` component. However, some necessary changes in the example code and the `start-routing.md` guide were missed in #34934, resulting in broken instructions for the readers (see #40189).

This PR is essentially a follow-up to #34934, making the remaining changes in the example code and the guide instructions.

Fixes #40189.

##
This PR also includes some refactorings and clean-ups for the `getting-started`/`getting-started-v0` docs examples. See individual commits for more details.