### PR TITLE
docs: fix `SpyDirective` in `lifecycle-hooks` docs example to use one ID per instance

### DIFF
--- a/aio/content/examples/lifecycle-hooks/src/app/app.component.html
+++ b/aio/content/examples/lifecycle-hooks/src/app/app.component.html
@@ -1,11 +1,11 @@
 <a id="top"></a>
 <h1>Component Lifecycle Hooks</h1>
 <a href="#hooks">Peek-a-boo: (most) lifecycle hooks</a><br>
+<a href="#spy">Spy: directive with OnInit & OnDestroy</a><br>
 <a href="#onchanges">OnChanges</a><br>
 <a href="#docheck">DoCheck</a><br>
 <a href="#after-view">AfterViewInit & AfterViewChecked</a><br>
 <a href="#after-content">AfterContentInit & AfterContentChecked</a><br>
-<a href="#spy">Spy: directive with OnInit & OnDestroy</a><br>
 <a href="#counter">Counter: OnChanges + Spy directive</a><br>
 
 <a id="hooks"></a>

--- a/aio/content/examples/lifecycle-hooks/src/app/spy.directive.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/spy.directive.ts
@@ -10,15 +10,16 @@ let nextId = 1;
 // Usage: <div appSpy>...</div>
 @Directive({selector: '[appSpy]'})
 export class SpyDirective implements OnInit, OnDestroy {
+  private id = nextId++;
 
   constructor(private logger: LoggerService) { }
 
   ngOnInit() {
-    this.logger.log(`Spy #${nextId++} onInit`);
+    this.logger.log(`Spy #${this.id} onInit`);
   }
 
   ngOnDestroy() {
-    this.logger.log(`Spy #${nextId++} onDestroy`);
+    this.logger.log(`Spy #${this.id} onDestroy`);
   }
 }
 // #enddocregion spy-directive

--- a/aio/content/examples/lifecycle-hooks/src/app/spy.directive.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/spy.directive.ts
@@ -3,9 +3,9 @@ import { Directive, OnInit, OnDestroy } from '@angular/core';
 
 import { LoggerService } from './logger.service';
 
+// #docregion spy-directive
 let nextId = 1;
 
-// #docregion spy-directive
 // Spy on any element to which it is applied.
 // Usage: <div appSpy>...</div>
 @Directive({selector: '[appSpy]'})
@@ -13,12 +13,12 @@ export class SpyDirective implements OnInit, OnDestroy {
 
   constructor(private logger: LoggerService) { }
 
-  ngOnInit()    { this.logIt(`onInit`); }
+  ngOnInit() {
+    this.logger.log(`Spy #${nextId++} onInit`);
+  }
 
-  ngOnDestroy() { this.logIt(`onDestroy`); }
-
-  private logIt(msg: string) {
-    this.logger.log(`Spy #${nextId++} ${msg}`);
+  ngOnDestroy() {
+    this.logger.log(`Spy #${nextId++} onDestroy`);
   }
 }
 // #enddocregion spy-directive


### PR DESCRIPTION
Previously, the `SpyDirective` in the `lifecycle-hooks` docs example would use a different ID when logging `onInit` and when logging `onDestroy` for the same instance, making it impossible to associate the two calls. This was not helpful and came in constrast with how the directive was described in the corresponding guide and shown in the accompanying `spy-directive.gif` image.

This PR fixes the logic of the `SpyDirective` class to use the same ID for all log operations of an instance.

Partially addresses #40193.

##
This PR also slightly refactors the `lifecycle-hooks` docs example to be a little easier to follow. See individual commits for details.