### PR TITLE
fix(core): memory leak if view container host view is destroyed while view ref is not

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -112,45 +112,6 @@
     "packages/core/src/change_detection/change_detection.ts",
     "packages/core/src/change_detection/change_detector_ref.ts",
     "packages/core/src/render3/view_ref.ts",
-    "packages/core/src/linker/view_container_ref.ts",
-    "packages/core/src/linker/component_factory.ts"
-  ],
-  [
-    "packages/core/src/change_detection/change_detection.ts",
-    "packages/core/src/change_detection/change_detector_ref.ts",
-    "packages/core/src/render3/view_ref.ts",
-    "packages/core/src/linker/view_container_ref.ts",
-    "packages/core/src/linker/ng_module_factory.ts",
-    "packages/core/src/linker/component_factory_resolver.ts",
-    "packages/core/src/linker/component_factory.ts"
-  ],
-  [
-    "packages/core/src/change_detection/change_detection.ts",
-    "packages/core/src/change_detection/change_detector_ref.ts",
-    "packages/core/src/render3/view_ref.ts",
-    "packages/core/src/linker/view_container_ref.ts",
-    "packages/core/src/linker/template_ref.ts",
-    "packages/core/src/render3/instructions/shared.ts",
-    "packages/core/src/error_handler.ts",
-    "packages/core/src/errors.ts",
-    "packages/core/src/view/types.ts",
-    "packages/core/src/linker/component_factory.ts"
-  ],
-  [
-    "packages/core/src/change_detection/change_detection.ts",
-    "packages/core/src/change_detection/change_detector_ref.ts",
-    "packages/core/src/render3/view_ref.ts",
-    "packages/core/src/linker/view_container_ref.ts",
-    "packages/core/src/render3/instructions/shared.ts",
-    "packages/core/src/error_handler.ts",
-    "packages/core/src/errors.ts",
-    "packages/core/src/view/types.ts",
-    "packages/core/src/linker/component_factory.ts"
-  ],
-  [
-    "packages/core/src/change_detection/change_detection.ts",
-    "packages/core/src/change_detection/change_detector_ref.ts",
-    "packages/core/src/render3/view_ref.ts",
     "packages/core/src/render3/instructions/shared.ts",
     "packages/core/src/error_handler.ts",
     "packages/core/src/errors.ts",
@@ -164,8 +125,6 @@
   [
     "packages/core/src/change_detection/change_detector_ref.ts",
     "packages/core/src/render3/view_ref.ts",
-    "packages/core/src/linker/view_container_ref.ts",
-    "packages/core/src/linker/template_ref.ts",
     "packages/core/src/linker/view_ref.ts"
   ],
   [
@@ -206,17 +165,27 @@
     "packages/core/src/view/types.ts"
   ],
   [
+    "packages/core/src/error_handler.ts",
+    "packages/core/src/errors.ts",
+    "packages/core/src/view/types.ts",
+    "packages/core/src/linker/template_ref.ts",
+    "packages/core/src/render3/instructions/shared.ts"
+  ],
+  [
+    "packages/core/src/error_handler.ts",
+    "packages/core/src/errors.ts",
+    "packages/core/src/view/types.ts",
+    "packages/core/src/linker/view_container_ref.ts",
+    "packages/core/src/render3/instructions/shared.ts"
+  ],
+  [
     "packages/core/src/linker/component_factory_resolver.ts",
+    "packages/core/src/linker/component_factory.ts",
     "packages/core/src/linker/ng_module_factory.ts"
   ],
   [
-    "packages/core/src/linker/template_ref.ts",
-    "packages/core/src/render3/view_ref.ts",
-    "packages/core/src/linker/view_container_ref.ts"
-  ],
-  [
-    "packages/core/src/linker/view_container_ref.ts",
-    "packages/core/src/render3/view_ref.ts"
+    "packages/core/src/linker/component_factory_resolver.ts",
+    "packages/core/src/linker/ng_module_factory.ts"
   ],
   [
     "packages/core/src/metadata/directives.ts",

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -307,7 +307,7 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
       addViewToContainer(tView, lContainer[T_HOST], renderer, lView, parentRNode, beforeNode);
     }
 
-    (viewRef as R3ViewRef<any>).attachToViewContainerRef(this);
+    (viewRef as R3ViewRef<any>).attachToViewContainerRef();
     addToArray(getOrCreateViewRefs(lContainer), adjustedIdx, viewRef);
 
     return viewRef;

--- a/packages/core/test/acceptance/view_ref_spec.ts
+++ b/packages/core/test/acceptance/view_ref_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, ChangeDetectorRef, Component, ComponentFactoryResolver, ComponentRef, ElementRef, Injector, NgModule} from '@angular/core';
+import {ApplicationRef, ChangeDetectorRef, Component, ComponentFactoryResolver, ComponentRef, ElementRef, EmbeddedViewRef, Injector, NgModule, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
 import {InternalViewRef} from '@angular/core/src/linker/view_ref';
 import {TestBed} from '@angular/core/testing';
 
@@ -71,5 +71,81 @@ describe('ViewRef', () => {
     fixture.destroy();
 
     expect(called).toBe(true);
+  });
+
+  it('should remove view ref from view container when destroyed', () => {
+    @Component({template: ''})
+    class DynamicComponent {
+      constructor(public viewContainerRef: ViewContainerRef) {}
+    }
+
+    @Component({template: `<ng-template>Hello</ng-template>`})
+    class App {
+      @ViewChild(TemplateRef) templateRef!: TemplateRef<any>;
+      componentRef!: ComponentRef<DynamicComponent>;
+      viewRef!: EmbeddedViewRef<any>;
+      constructor(
+          private _viewContainerRef: ViewContainerRef,
+          private _componentFactoryResolver: ComponentFactoryResolver) {}
+
+      create() {
+        const factory = this._componentFactoryResolver.resolveComponentFactory(DynamicComponent);
+        this.viewRef = this.templateRef.createEmbeddedView(null);
+        this.componentRef = this._viewContainerRef.createComponent(factory);
+        this.componentRef.instance.viewContainerRef.insert(this.viewRef);
+      }
+    }
+
+    @NgModule({declarations: [App, DynamicComponent], entryComponents: [DynamicComponent]})
+    class MyTestModule {
+    }
+
+    TestBed.configureTestingModule({imports: [MyTestModule]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    fixture.componentInstance.create();
+    const viewContainerRef = fixture.componentInstance.componentRef.instance.viewContainerRef;
+
+    expect(viewContainerRef.length).toBe(1);
+    fixture.componentInstance.viewRef.destroy();
+    expect(viewContainerRef.length).toBe(0);
+  });
+
+  it('should mark a ViewRef as destroyed when the host view is destroyed', () => {
+    @Component({template: ''})
+    class DynamicComponent {
+      constructor(public viewContainerRef: ViewContainerRef) {}
+    }
+
+    @Component({template: `<ng-template>Hello</ng-template>`})
+    class App {
+      @ViewChild(TemplateRef) templateRef!: TemplateRef<any>;
+      componentRef!: ComponentRef<DynamicComponent>;
+      viewRef!: EmbeddedViewRef<any>;
+      constructor(
+          private _viewContainerRef: ViewContainerRef,
+          private _componentFactoryResolver: ComponentFactoryResolver) {}
+
+      create() {
+        const factory = this._componentFactoryResolver.resolveComponentFactory(DynamicComponent);
+        this.viewRef = this.templateRef.createEmbeddedView(null);
+        this.componentRef = this._viewContainerRef.createComponent(factory);
+        this.componentRef.instance.viewContainerRef.insert(this.viewRef);
+      }
+    }
+
+    @NgModule({declarations: [App, DynamicComponent], entryComponents: [DynamicComponent]})
+    class MyTestModule {
+    }
+
+    TestBed.configureTestingModule({imports: [MyTestModule]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    fixture.componentInstance.create();
+    const {componentRef, viewRef} = fixture.componentInstance;
+
+    expect(viewRef.destroyed).toBe(false);
+    componentRef.hostView.destroy();
+    expect(viewRef.destroyed).toBe(true);
   });
 });


### PR DESCRIPTION
When we attach a `ViewRef` to a `ViewContainerRef`, we save a reference to the container onto the `ViewRef` so that we can remove it when the ref is destroyed. The problem is that if the container's `hostView` is destroyed first, the `ViewRef` has no way of knowing that it should stop referencing the container.

These changes remove the leak by not saving a reference at all. Instead, when a `ViewRef` is destroyed, we clean it up through the `LContainer` directly. We don't need to worry about the case where the container is destroyed before the view, because containers automatically clean up all of their views upon destruction.

Fixes #38648.