### PR TITLE
ci: move "test" job to use 2xlarge resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ jobs:
       # as they require network access for yarn install), this test is running out of memory
       # consistently with the xlarge machine.
       # TODO: switch back to xlarge once integration tests are running on remote-exec
-      resource_class: 2xlarge+
+      resource_class: 2xlarge
     steps:
       - custom_attach_workspace
       - init_environment


### PR DESCRIPTION
Move to use the 2xlarge resource class for the test job. For unknown reasons the 2xlarge+ resource
class does not work for our configuration currently, a ticket has been opened with CircleCI to resolve
the configuration issue.
