### PR TITLE
fix(service-worker): allow checking for updates when constantly polling the server

### DIFF
--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -1026,10 +1026,10 @@ export class Driver implements Debuggable, UpdateSource {
                                 .filter(([clientId, hash]) => hash === brokenHash)
                                 .map(([clientId]) => clientId);
 
-    affectedClients.forEach(async clientId => {
+    await Promise.all(affectedClients.map(async clientId => {
       const client = await this.scope.clients.get(clientId);
       client.postMessage({type: 'UNRECOVERABLE_STATE', reason});
-    });
+    }));
   }
 
   async notifyClientsAboutUpdate(next: AppVersion): Promise<void> {

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -1037,9 +1037,7 @@ export class Driver implements Debuggable, UpdateSource {
 
     const clients = await this.scope.clients.matchAll();
 
-    await clients.reduce(async (previous, client) => {
-      await previous;
-
+    await Promise.all(clients.map(async client => {
       // Firstly, determine which version this client is on.
       const version = this.clientVersionMap.get(client.id);
       if (version === undefined) {
@@ -1062,7 +1060,7 @@ export class Driver implements Debuggable, UpdateSource {
       };
 
       client.postMessage(notice);
-    }, Promise.resolve());
+    }));
   }
 
   async broadcast(msg: Object): Promise<void> {

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -25,7 +25,8 @@ type ClientAssignments = {
   [id: string]: ManifestHash
 };
 
-const IDLE_THRESHOLD = 5000;
+const IDLE_DELAY = 5000;
+const MAX_IDLE_DELAY = 30000;
 
 const SUPPORTED_CONFIG_VERSION = 1;
 
@@ -167,7 +168,7 @@ export class Driver implements Debuggable, UpdateSource {
     this.debugger = new DebugHandler(this, this.adapter);
 
     // The IdleScheduler will execute idle tasks after a given delay.
-    this.idle = new IdleScheduler(this.adapter, IDLE_THRESHOLD, this.debugger);
+    this.idle = new IdleScheduler(this.adapter, IDLE_DELAY, MAX_IDLE_DELAY, this.debugger);
   }
 
   /**

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -720,12 +720,7 @@ export class Driver implements Debuggable, UpdateSource {
   private async deleteAllCaches(): Promise<void> {
     const cacheNames = await this.scope.caches.keys();
     const ownCacheNames =
-        cacheNames
-            // The Chrome debugger is not able to render the syntax properly when the
-            // code contains backticks. This is a known issue in Chrome and they have an
-            // open [issue](https://bugs.chromium.org/p/chromium/issues/detail?id=659515) for that.
-            // As a work-around for the time being, we can use \\ ` at the end of the line.
-            .filter(name => name.startsWith(`${this.adapter.cacheNamePrefix}:`));  // `
+        cacheNames.filter(name => name.startsWith(`${this.adapter.cacheNamePrefix}:`));
 
     await Promise.all(ownCacheNames.map(name => this.scope.caches.delete(name)));
   }

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -722,18 +722,16 @@ export class Driver implements Debuggable, UpdateSource {
   }
 
   private async deleteAllCaches(): Promise<void> {
-    await (await this.scope.caches.keys())
-        // The Chrome debugger is not able to render the syntax properly when the
-        // code contains backticks. This is a known issue in Chrome and they have an
-        // open [issue](https://bugs.chromium.org/p/chromium/issues/detail?id=659515) for that.
-        // As a work-around for the time being, we can use \\ ` at the end of the line.
-        .filter(key => key.startsWith(`${this.adapter.cacheNamePrefix}:`))  // `
-        .reduce(async (previous, key) => {
-          await Promise.all([
-            previous,
-            this.scope.caches.delete(key),
-          ]);
-        }, Promise.resolve());
+    const cacheNames = await this.scope.caches.keys();
+    const ownCacheNames =
+        cacheNames
+            // The Chrome debugger is not able to render the syntax properly when the
+            // code contains backticks. This is a known issue in Chrome and they have an
+            // open [issue](https://bugs.chromium.org/p/chromium/issues/detail?id=659515) for that.
+            // As a work-around for the time being, we can use \\ ` at the end of the line.
+            .filter(name => name.startsWith(`${this.adapter.cacheNamePrefix}:`));  // `
+
+    await Promise.all(ownCacheNames.map(name => this.scope.caches.delete(name)));
   }
 
   /**

--- a/packages/service-worker/worker/test/prefetch_spec.ts
+++ b/packages/service-worker/worker/test/prefetch_spec.ts
@@ -38,7 +38,7 @@ describe('prefetch assets', () => {
   let group: PrefetchAssetGroup;
   let idle: IdleScheduler;
   beforeEach(() => {
-    idle = new IdleScheduler(null!, 3000, {
+    idle = new IdleScheduler(null!, 3000, 30000, {
       log: (v, ctx = '') => console.error(v, ctx),
     });
     group = new PrefetchAssetGroup(


### PR DESCRIPTION
Previously, the SW would wait to become idle before executing scheduled tasks (including checks for newer app versions). It was considered idle when it hadn't received any request for at least 5 seconds. As a result, if the app performed polling (i.e. sent requests to the server) in a shorter than 5 seconds interval, the SW would never detect and update to a newer app version.  
Related issue: #40207

This PR fixes this by adding a max delay to `IdleScheduler` to ensure that no scheduled task will remain pending for longer than the specified max delay.

##
This PR also includes some minor refactorings/improvements. See the individual commits for more details.