### PR TITLE
Router/common: Refactors and fixes the BrowserViewportScroller's scrolling behavior

### DIFF
--- a/packages/common/src/viewport_scroller.ts
+++ b/packages/common/src/viewport_scroller.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ErrorHandler, ɵɵdefineInjectable, ɵɵinject} from '@angular/core';
+import {ɵɵdefineInjectable, ɵɵinject} from '@angular/core';
 
 import {DOCUMENT} from './dom_tokens';
 
@@ -24,7 +24,7 @@ export abstract class ViewportScroller {
   static ɵprov = ɵɵdefineInjectable({
     token: ViewportScroller,
     providedIn: 'root',
-    factory: () => new BrowserViewportScroller(ɵɵinject(DOCUMENT), window, ɵɵinject(ErrorHandler))
+    factory: () => new BrowserViewportScroller(ɵɵinject(DOCUMENT), window)
   });
 
   /**
@@ -67,7 +67,7 @@ export abstract class ViewportScroller {
 export class BrowserViewportScroller implements ViewportScroller {
   private offset: () => [number, number] = () => [0, 0];
 
-  constructor(private document: any, private window: any, private errorHandler: ErrorHandler) {}
+  constructor(private document: any, private window: any) {}
 
   /**
    * Configures the top offset used when scrolling to an anchor.

--- a/packages/common/test/viewport_scroller_spec.ts
+++ b/packages/common/test/viewport_scroller_spec.ts
@@ -10,19 +10,17 @@ import {describe, expect, it} from '@angular/core/testing/src/testing_internal';
 import {BrowserViewportScroller, ViewportScroller} from '../src/viewport_scroller';
 
 describe('BrowserViewportScroller', () => {
-  let scroller: ViewportScroller;
-  let documentSpy: any;
-  let windowSpy: any;
-
-  beforeEach(() => {
-    windowSpy =
-        jasmine.createSpyObj('window', ['history', 'scrollTo', 'pageXOffset', 'pageYOffset']);
-    windowSpy.history.scrollRestoration = 'auto';
-    documentSpy = jasmine.createSpyObj('document', ['getElementById', 'getElementsByName']);
-    scroller = new BrowserViewportScroller(documentSpy, windowSpy);
-  });
-
   describe('setHistoryScrollRestoration', () => {
+    let scroller: ViewportScroller;
+    let windowSpy: any;
+
+    beforeEach(() => {
+      windowSpy =
+          jasmine.createSpyObj('window', ['history', 'scrollTo', 'pageXOffset', 'pageYOffset']);
+      windowSpy.history.scrollRestoration = 'auto';
+      scroller = new BrowserViewportScroller(document, windowSpy);
+    });
+
     function createNonWritableScrollRestoration() {
       Object.defineProperty(windowSpy.history, 'scrollRestoration', {
         value: 'auto',
@@ -43,34 +41,47 @@ describe('BrowserViewportScroller', () => {
   });
 
   describe('scrollToAnchor', () => {
+    // Testing scroll behavior does not make sense outside a browser
+    if (isNode) return;
     const anchor = 'anchor';
-    const el = document.createElement('a');
+    let tallItem: HTMLDivElement;
+    let el: HTMLAnchorElement;
+    let scroller: BrowserViewportScroller;
 
-    it('should only call getElementById when an element is found by id', () => {
-      documentSpy.getElementById.and.returnValue(el);
-      spyOn<any>(scroller, 'scrollToElement');
-      scroller.scrollToAnchor(anchor);
-      expect(documentSpy.getElementById).toHaveBeenCalledWith(anchor);
-      expect(documentSpy.getElementsByName).not.toHaveBeenCalled();
-      expect((scroller as any).scrollToElement).toHaveBeenCalledWith(el);
+    beforeEach(() => {
+      scroller = new BrowserViewportScroller(document, window);
+      scroller.scrollToPosition([0, 0]);
+
+      tallItem = document.createElement('div');
+      tallItem.style.height = '3000px';
+      document.body.appendChild(tallItem);
+
+      el = document.createElement('a');
+      el.innerText = 'some link';
+      el.href = '#';
+      document.body.appendChild(el);
     });
 
-    it('should call getElementById and getElementsByName when an element is found by name', () => {
-      documentSpy.getElementsByName.and.returnValue([el]);
-      spyOn<any>(scroller, 'scrollToElement');
-      scroller.scrollToAnchor(anchor);
-      expect(documentSpy.getElementById).toHaveBeenCalledWith(anchor);
-      expect(documentSpy.getElementsByName).toHaveBeenCalledWith(anchor);
-      expect((scroller as any).scrollToElement).toHaveBeenCalledWith(el);
+    afterEach(() => {
+      document.body.removeChild(tallItem);
+      document.body.removeChild(el);
     });
 
-    it('should not call scrollToElement when an element is not found by its id or its name', () => {
-      documentSpy.getElementsByName.and.returnValue([]);
-      spyOn<any>(scroller, 'scrollToElement');
+    it('should scroll when element with matching id is found', () => {
+      el.id = anchor;
       scroller.scrollToAnchor(anchor);
-      expect(documentSpy.getElementById).toHaveBeenCalledWith(anchor);
-      expect(documentSpy.getElementsByName).toHaveBeenCalledWith(anchor);
-      expect((scroller as any).scrollToElement).not.toHaveBeenCalled();
+      expect(scroller.getScrollPosition()[1]).not.toEqual(0);
+    });
+
+    it('should scroll when anchor with matching name is found', () => {
+      el.name = anchor;
+      scroller.scrollToAnchor(anchor);
+      expect(scroller.getScrollPosition()[1]).not.toEqual(0);
+    });
+
+    it('should not scroll when no matching element is found', () => {
+      scroller.scrollToAnchor(anchor);
+      expect(scroller.getScrollPosition()[1]).toEqual(0);
     });
   });
 });

--- a/packages/common/test/viewport_scroller_spec.ts
+++ b/packages/common/test/viewport_scroller_spec.ts
@@ -19,7 +19,7 @@ describe('BrowserViewportScroller', () => {
         jasmine.createSpyObj('window', ['history', 'scrollTo', 'pageXOffset', 'pageYOffset']);
     windowSpy.history.scrollRestoration = 'auto';
     documentSpy = jasmine.createSpyObj('document', ['getElementById', 'getElementsByName']);
-    scroller = new BrowserViewportScroller(documentSpy, windowSpy, null!);
+    scroller = new BrowserViewportScroller(documentSpy, windowSpy);
   });
 
   describe('setHistoryScrollRestoration', () => {


### PR DESCRIPTION
Refactors and fixes the `BrowserViewportScroller`'s scrolling behavior.

Commit 1:
The `BrowserViewportScroller` injects but does not use the `ErrorHandler`.
This commit removes the `ErrorHandler` from the constructor.

Commit 2:
The current tests in the router scroller are
[change-detector tests](https://testing.googleblog.com/2015/01/testing-on-toilet-change-detector-tests.html)
and do not ensure the correct behavior of the scroller.
This commit updates the tests to assert actual scrolling behavior of the
browser.

Commit 3:
According to the [spec](https://html.spec.whatwg.org/#scroll-to-fragid),
we should attempt to set the browser focus after scrolling to a
fragment. Note that this change does not exactly follow the robust steps
outlined in the spec by finding a fallback target if the original is not
focusable. Instead, we simply attempt to focus the element by calling
`focus` on it, which will do nothing if the element is not focusable.

fixes #30067