### PR TITLE
fix(language-service): LSParseConfigHost.resolve should collapse abs paths

### DIFF
--- a/packages/language-service/ivy/adapters.ts
+++ b/packages/language-service/ivy/adapters.ts
@@ -122,7 +122,7 @@ export class LSParseConfigHost implements ConfigurationHost {
     return p.extname(path);
   }
   resolve(...paths: string[]): AbsoluteFsPath {
-    return this.serverHost.resolvePath(this.join(paths[0], ...paths.slice(1))) as AbsoluteFsPath;
+    return p.resolve(...paths) as AbsoluteFsPath;
   }
   dirname<T extends PathString>(file: T): T {
     return p.dirname(file) as T;

--- a/packages/language-service/ivy/test/adapters_spec.ts
+++ b/packages/language-service/ivy/test/adapters_spec.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript/lib/tsserverlibrary';
+
+import {LSParseConfigHost} from '../adapters';
+
+describe('LSParseConfigHost.resolve()', () => {
+  it('should collapse absolute paths', () => {
+    const p1 = '/foo/bar/baz';
+    const p2 = '/foo/bar/baz/tsconfig.json';
+    const host = new LSParseConfigHost(ts.sys as ts.server.ServerHost);
+    const resolved = host.resolve(p1, p2);
+    expect(resolved).toBe('/foo/bar/baz/tsconfig.json');
+  });
+});


### PR DESCRIPTION
`ts.server.ServerHost.resolvePath()` is different from Angular's
`FileSystem.resolve()` because the signature of the former is

```ts
resolvePath(path: string): string;	// ts.server.ServerHost
```

whereas the signature of the latter is
```ts
resolve(...paths: string[]): AbsoluteFsPath; // FileSystem on compiler-cli
```

The current implementation calls `path.join()` to concatenate all the input
paths and pass the result to `ts.server.ServerHost.resolvePath()`, but doing
so results in filenames like
```
/foo/bar/baz/foo/bar/baz/tsconfig.json
```
if both input paths are absolute.

`ts.server.ServerHost` should not be used to implement the
`resolve()` method expected by Angular's `FileSystem`.
We should use Node's `path.resolve()` instead, which will correctly collapse the absolute paths.

Fix https://github.com/angular/vscode-ng-language-service/issues/1035

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
