### PR TITLE
feat(docs-infra): add dark mode to documentation web site

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -32,6 +32,7 @@
         <mat-icon svgIcon="logos:github"></mat-icon>
       </a>
     </div>
+    <theme-picker></theme-picker>
   </mat-toolbar-row>
 </mat-toolbar>
 

--- a/aio/src/app/shared/shared.module.ts
+++ b/aio/src/app/shared/shared.module.ts
@@ -2,18 +2,27 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SearchResultsComponent } from './search-results/search-results.component';
 import { SelectComponent } from './select/select.component';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { ThemePickerComponent } from './theme-picker/theme-picker.component';
+import { ThemeStorageService } from './theme-picker/theme-storage/theme-storage.service';
 
 @NgModule({
   imports: [
-    CommonModule
+    CommonModule,
+    MatButtonModule,
+    MatIconModule
   ],
   exports: [
     SearchResultsComponent,
-    SelectComponent
+    SelectComponent,
+    ThemePickerComponent
   ],
   declarations: [
     SearchResultsComponent,
-    SelectComponent
-  ]
+    SelectComponent,
+    ThemePickerComponent
+  ],
+  providers: [ThemeStorageService]
 })
 export class SharedModule {}

--- a/aio/src/app/shared/theme-picker/theme-picker.component.html
+++ b/aio/src/app/shared/theme-picker/theme-picker.component.html
@@ -1,0 +1,3 @@
+<button mat-icon-button aria-label="Theme switcher button" (click)="currentTheme.name === 'night-theme' ? selectTheme('ng-io-theme') : selectTheme('night-theme')">
+  <mat-icon>{{currentTheme.name === 'night-theme' ? themes[0].icon : themes[1].icon}}</mat-icon>
+</button>

--- a/aio/src/app/shared/theme-picker/theme-picker.component.spec.ts
+++ b/aio/src/app/shared/theme-picker/theme-picker.component.spec.ts
@@ -1,0 +1,24 @@
+import {async, TestBed} from '@angular/core/testing';
+import { ThemePickerComponent } from './theme-picker.component';
+import { ThemeStorageService } from './theme-storage/theme-storage.service';
+
+
+describe('ThemePicker', () => {
+  let themeStorageService: any;
+
+  beforeEach(async(() => {
+    themeStorageService = jasmine.createSpyObj('themeStorageService', ['getStoredThemeName', 'storeTheme']);
+    TestBed.configureTestingModule({
+      declarations: [ThemePickerComponent],
+      providers: [ { provide: ThemeStorageService, useValue: themeStorageService } ]
+    }).compileComponents();
+  }));
+
+  it('should install theme based on name', () => {
+    const fixture = TestBed.createComponent(ThemePickerComponent);
+    const component = fixture.componentInstance;
+    const name = 'night-theme';
+    component.selectTheme(name);
+    expect(themeStorageService.storeTheme).toHaveBeenCalledWith(component.themes[1]);
+  });
+});

--- a/aio/src/app/shared/theme-picker/theme-picker.component.ts
+++ b/aio/src/app/shared/theme-picker/theme-picker.component.ts
@@ -1,0 +1,53 @@
+import {
+    ChangeDetectionStrategy,
+    Component,
+    ViewEncapsulation,
+  } from '@angular/core';
+  import {DocsSiteTheme, ThemeStorageService} from './theme-storage/theme-storage.service';
+
+@Component({
+  selector: 'theme-picker',
+  templateUrl: 'theme-picker.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None
+})
+export class ThemePickerComponent {
+  readonly themes: DocsSiteTheme[] = [
+    {
+      primary: '#1976d2',
+      accent: '#e91e63',
+      displayName: 'Light Theme',
+      name: 'ng-io-theme',
+      icon: 'light_mode'
+    },
+    {
+      primary: '#00796b',
+      accent: '#80cbc4',
+      displayName: 'Night Theme',
+      name: 'night-theme',
+      isDark: true,
+      icon: 'dark_mode'
+    },
+  ];
+
+  readonly defaultTheme: DocsSiteTheme = this.themes[0];
+  currentTheme: DocsSiteTheme = this.themes[0];
+
+  constructor(private themeStorageService: ThemeStorageService) {
+    const themeName = this.themeStorageService.getStoredThemeName();
+    if (themeName) {
+      this.selectTheme(themeName);
+    }
+  }
+
+  selectTheme(themeName: string) {
+    const theme = this.themes.find(currentTheme => currentTheme.name === themeName);
+    this.currentTheme = theme || this.defaultTheme;
+    if (this.currentTheme.name === this.defaultTheme.name) {
+      document.body.classList.value = '';
+    } else {
+      document.body.classList.value = this.currentTheme.name;
+    }
+    this.themeStorageService.storeTheme(this.currentTheme);
+  }
+}

--- a/aio/src/app/shared/theme-picker/theme-storage/theme-storage.service.spec.ts
+++ b/aio/src/app/shared/theme-picker/theme-storage/theme-storage.service.spec.ts
@@ -1,0 +1,46 @@
+import {DocsSiteTheme, ThemeStorageService} from './theme-storage.service';
+
+
+const testStorageKey = ThemeStorageService.storageKey;
+const testTheme: DocsSiteTheme = {
+  primary: '#000000',
+  accent: '#ffffff',
+  name: 'test-theme',
+  icon: 'test-icon'
+};
+
+describe('ThemeStorage Service', () => {
+  const service = new ThemeStorageService();
+  const getCurrTheme = () => window.localStorage.getItem(testStorageKey);
+  const secondTestTheme = {
+    primary: '#666666',
+    accent: '#333333',
+    name: 'other-test-theme',
+    icon: 'other-test-icon'
+  };
+
+  beforeEach(() => {
+    window.localStorage[testStorageKey] = testTheme.name;
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('should set the current theme name', () => {
+    expect(getCurrTheme()).toEqual(testTheme.name);
+    service.storeTheme(secondTestTheme);
+    expect(getCurrTheme()).toEqual(secondTestTheme.name);
+  });
+
+  it('should get the current theme name', () => {
+    const theme = service.getStoredThemeName();
+    expect(theme).toEqual(testTheme.name);
+  });
+
+  it('should clear the stored theme data', () => {
+    expect(getCurrTheme()).not.toBeNull();
+    service.clearStorage();
+    expect(getCurrTheme()).toBeNull();
+  });
+});

--- a/aio/src/app/shared/theme-picker/theme-storage/theme-storage.service.ts
+++ b/aio/src/app/shared/theme-picker/theme-storage/theme-storage.service.ts
@@ -1,0 +1,37 @@
+import {Injectable} from '@angular/core';
+
+export interface DocsSiteTheme {
+  name: string;
+  displayName?: string;
+  accent: string;
+  primary: string;
+  isDark?: boolean;
+  icon: string;
+  isDefault?: boolean;
+}
+
+
+@Injectable()
+export class ThemeStorageService {
+  static storageKey = 'docs-theme-storage-current-name';
+
+  storeTheme(theme: DocsSiteTheme) {
+    try {
+      window.localStorage[ThemeStorageService.storageKey] = theme.name;
+    } catch { }
+  }
+
+  getStoredThemeName(): string | null {
+    try {
+      return window.localStorage[ThemeStorageService.storageKey] || null;
+    } catch {
+      return null;
+    }
+  }
+
+  clearStorage() {
+    try {
+      window.localStorage.removeItem(ThemeStorageService.storageKey);
+    } catch { }
+  }
+}

--- a/aio/src/styles/_custom-styles.scss
+++ b/aio/src/styles/_custom-styles.scss
@@ -1,7 +1,6 @@
 @mixin custom-styles($theme) {
     $theme-primary: map-get($theme, primary);
     $theme-accent: map-get($theme, accent);
-    $theme-warn: map-get($theme, warn);
     $theme-background: map-get($theme, background);
     $theme-foreground: map-get($theme, foreground);
 
@@ -11,7 +10,6 @@
     $theme-accent-color: mat-color($theme-accent);
     $theme-accent-lighter-color: mat-color($theme-accent, lighter);
     $theme-accent-darker-color: mat-color($theme-accent, darker);
-    $theme-warn-color: mat-color($theme-warn);
     $theme-background-color: mat-color($theme-background, background);
     $theme-app-bar-color: mat-color($theme-background, app-bar);
     $theme-card-color: mat-color($theme-background, card);
@@ -22,6 +20,9 @@
     $theme-hover-background-color: mat-color($theme-background, hover);
     $theme-selected-button-color: mat-color($theme-background, selected-button);
 
+    $warn-color: #DD0031;
+    $important-color: #FF9800;
+    $helpful-color: #1976D2;
     $angular-logo-lighter-color: #dd0031;
     $angular-logo-darker-color: #c3002f;
     $syntax-default-color: #ffffff;
@@ -29,12 +30,13 @@
     $syntax-comment-color: #8b949e;
     $syntax-string-color: #a0e99d;
     $syntax-type-color: #79c0ff;
+    $syntax-background-color: #0d1117;
 
     background-color: $theme-background-color;
     color: $theme-foreground-color;
 
     .mat-tab-body {
-        background-color: #0d1117;
+        background-color: $syntax-background-color;
     }
 
     .mat-tab-group.mat-primary .mat-ink-bar, .mat-tab-nav-bar.mat-primary .mat-ink-bar{
@@ -350,6 +352,7 @@
 
     table {
         background-color: $theme-background-color;
+        border: 1px solid $theme-divider-color;
 
         thead > {
             tr > th {
@@ -390,18 +393,18 @@
 
     code-example {
         &:not(.no-box) {
-            background-color: #0d1117;
+            background-color: $syntax-background-color;
             color: $theme-foreground-color;
             border-color: rgba($theme-foreground-secondary-color, 0.2);
         }
 
         header {
-            background-color: $theme-app-bar-color;
+            background-color: $theme-primary-color;
         }
 
         &.avoid header, &.avoidFile header {
-            border: 2px solid $theme-warn-color;
-            background: $theme-warn-color;
+            border: 2px solid $warn-color;
+            background: $warn-color;
         }
     }
 
@@ -409,7 +412,7 @@
     code-example.avoidFile,
     code-tabs.avoid mat-tab-body,
     code-tabs.avoidFile mat-tab-body {
-        border: 0.5px solid $theme-warn-color;
+        border: 0.5px solid $warn-color;
     }
 
     .copy-button {
@@ -454,9 +457,19 @@
         color: $syntax-comment-color;
     }
 
+    // src/styles/2-modules/_cli-pages.scss
+
+    .cli-name .kwd {
+        color: $syntax-default-color;
+    }
+
     // src/styles/2-modules/_api-pages.scss
 
     .api-body table {
+        tr {
+            border-bottom: 1px solid $theme-divider-color;
+        }
+
         th {
             font-weight: normal;
         }
@@ -477,6 +490,59 @@
                 }
             }
         }
+    }
+
+    // src/styles/2-modules/_api-list.scss
+
+    .docs-content .api-list {
+        li {
+            a {
+                color: $theme-foreground-color;
+
+                &:hover {
+                    background-color: $theme-hover-background-color;
+                    color: $theme-accent-color;
+                }
+            }
+        }
+    }
+
+    // src/styles/2-modules/_callout.scss
+
+    .is-critical {
+        &.alert, &.callout {
+            background-color: $theme-hover-background-color;
+        }
+
+        &.callout {
+            border: 1px solid $warn-color !important;
+        }
+    }
+
+    .is-important {
+        &.alert, &.callout {
+            background-color: $theme-hover-background-color;
+        }
+
+        &.callout {
+            border: 1px solid $important-color !important;
+        }
+    }
+
+    .is-helpful {
+        &.alert, &.callout {
+            background-color: $theme-hover-background-color;
+        }
+
+        &.callout {
+            border: 1px solid $helpful-color !important;
+        }
+    }
+
+    // src/styles/2-modules/_contributor.scss
+
+    aio-contributor {
+        background-color: $theme-card-color;
     }
 
     .github-links .material-icons:hover {

--- a/aio/src/styles/_custom-styles.scss
+++ b/aio/src/styles/_custom-styles.scss
@@ -22,6 +22,14 @@
     $theme-hover-background-color: mat-color($theme-background, hover);
     $theme-selected-button-color: mat-color($theme-background, selected-button);
 
+    $angular-logo-lighter-color: #dd0031;
+    $angular-logo-darker-color: #c3002f;
+    $syntax-default-color: #ffffff;
+    $syntax-keyword-color: #ff7b72;
+    $syntax-comment-color: #8b949e;
+    $syntax-string-color: #a0e99d;
+    $syntax-type-color: #79c0ff;
+
     background-color: $theme-background-color;
     color: $theme-foreground-color;
 
@@ -79,28 +87,47 @@
 
     // src/styles/2-modules/_toc.scss
 
-    .toc-inner ul.toc-list li {
-        &.active a {
-            color: $theme-accent-color;
+    .toc-inner {
+        ul.toc-list li {
+            &.active a {
+                color: $theme-accent-color;
 
-            &:before {
-                background-color: $theme-accent-color;
+                &:before {
+                    background-color: $theme-accent-color;
+                }
+            }
+
+            &:hover a {
+                color: $theme-accent-color;
+            }
+
+            a {
+                color: $theme-foreground-color;
+            }
+
+            &.active * {
+                color: $theme-accent-color;
+
+                &:before {
+                    background: $theme-accent-color;
+                }
             }
         }
 
-        &:hover a {
-            color: $theme-accent-color;
+        .toc-heading.secondary:hover {
+            color: $theme-accent-lighter-color;
         }
 
-        a {
-            color: $theme-foreground-color;
-        }
-
-        &.active * {
+        button.toc-more-items, button.toc-heading {
             color: $theme-accent-color;
 
-            &:before {
-                background: $theme-accent-color;
+            &.embedded:focus {
+                color: $theme-accent-color;
+                background-color: transparent;
+            }
+
+            &:hover {
+                color: $theme-accent-lighter-color;
             }
         }
     }
@@ -246,11 +273,11 @@
     // src/styles/1-layouts/_marketing-layout.scss
 
     .button.hero-cta {
-        background-color: #dd0031;
+        background-color: $angular-logo-darker-color;
         color: $theme-foreground-color;
 
         &:hover {
-            background-color: #c3002f;
+            background-color: $angular-logo-lighter-color;
             color: $theme-foreground-color;
         }
     }
@@ -400,45 +427,60 @@
     }
 
     .kwd, .tag {
-        color: #ff7b72;
+        color: $syntax-keyword-color;
     }
 
     .pln {
-        color: #fff;
+        color: $syntax-default-color;
     }
 
     .pun, .opn, .clo {
-        color: #8b949e;
+        color: $syntax-comment-color;
     }
 
     .typ, .atn {
-        color: #79c0ff;
+        color: $syntax-type-color;
     }
 
     .lit {
-        color: #fff;
+        color: $syntax-keyword-color;
     }
 
     .str, .atv {
-        color: #a0e99d;
+        color: $syntax-string-color;
     }
 
     .com {
-        color: #8b949e;
+        color: $syntax-comment-color;
     }
 
     // src/styles/2-modules/_api-pages.scss
 
-    .api-body table th {
-        font-weight: normal;
-    }
+    .api-body table {
+        th {
+            font-weight: normal;
+        }
 
-    .github-links {
-        .material-icons {
-            &:hover {
-                background-color: $theme-hover-background-color;
+        &.method-table, &.option-table, &.list-table {
+            .with-github-links .github-links {
+                .material-icons {
+                    &:hover {
+                        background-color: $theme-hover-background-color;
+                    }
+                }
+
+                a {
+                    color: $theme-accent-color;
+                    .material-icons:hover {
+                        color: $theme-accent-lighter-color;
+                    }
+                }
             }
         }
+    }
+
+    .github-links .material-icons:hover {
+        background-color: $theme-hover-background-color;
     }
 
     // src/styles/2-modules/_filetree.scss

--- a/aio/src/styles/_custom-styles.scss
+++ b/aio/src/styles/_custom-styles.scss
@@ -116,6 +116,10 @@
             }
         }
 
+        ul.toc-list:not(.embedded) li:not(.active):hover a:before {
+            background-color: $theme-accent-color;
+        }
+
         .toc-heading.secondary:hover {
             color: $theme-accent-lighter-color;
         }
@@ -353,6 +357,7 @@
     table {
         background-color: $theme-background-color;
         border: 1px solid $theme-divider-color;
+        @include mat-elevation(4);
 
         thead > {
             tr > th {
@@ -449,6 +454,10 @@
         color: $syntax-keyword-color;
     }
 
+    .dec, .var {
+        color: $syntax-keyword-color;
+    }
+
     .str, .atv {
         color: $syntax-string-color;
     }
@@ -464,6 +473,13 @@
     }
 
     // src/styles/2-modules/_api-pages.scss
+
+    .api-body {
+        .from-constructor, .read-only-property, .write-only-property {
+            background-color: $theme-foreground-color;
+            color: $theme-background-color;
+        }
+    }
 
     .api-body table {
         tr {
@@ -490,6 +506,26 @@
                 }
             }
         }
+    }
+
+    // src/styles/2-modules/_search-results.scss
+
+    aio-search-results.embedded .search-results .search-area .search-section-header,
+    aio-search-results.embedded .search-results .search-area .search-result-item,
+    aio-search-results .search-results .search-area ul .search-result-item {
+        color: $theme-foreground-color;
+    }
+
+    aio-search-results.embedded .search-results .search-area .search-result-item,
+    aio-search-results .search-results .search-area ul .search-result-item {
+        &:hover {
+            color: $theme-accent-color;
+        }
+    }
+
+    aio-search-results .search-results .search-area ul.priority-pages .search-result-item {
+        font-weight: normal;
+        text-decoration: underline;
     }
 
     // src/styles/2-modules/_api-list.scss

--- a/aio/src/styles/_custom-styles.scss
+++ b/aio/src/styles/_custom-styles.scss
@@ -1,0 +1,454 @@
+@mixin custom-styles($theme) {
+    $theme-primary: map-get($theme, primary);
+    $theme-accent: map-get($theme, accent);
+    $theme-warn: map-get($theme, warn);
+    $theme-background: map-get($theme, background);
+    $theme-foreground: map-get($theme, foreground);
+
+    $theme-primary-color: mat-color($theme-primary);
+    $theme-primary-lighter-color: mat-color($theme-primary, lighter);
+    $theme-primary-darker-color: mat-color($theme-primary, darker);
+    $theme-accent-color: mat-color($theme-accent);
+    $theme-accent-lighter-color: mat-color($theme-accent, lighter);
+    $theme-accent-darker-color: mat-color($theme-accent, darker);
+    $theme-warn-color: mat-color($theme-warn);
+    $theme-background-color: mat-color($theme-background, background);
+    $theme-app-bar-color: mat-color($theme-background, app-bar);
+    $theme-card-color: mat-color($theme-background, card);
+    $theme-foreground-color: mat-color($theme-foreground, text);
+    $theme-divider-color: mat-color($theme-foreground, divider);
+    $theme-foreground-secondary-color: mat-color($theme-foreground, secondary-text);
+    $theme-dialog-background-color: mat-color($theme-background, dialog);
+    $theme-hover-background-color: mat-color($theme-background, hover);
+    $theme-selected-button-color: mat-color($theme-background, selected-button);
+
+    background-color: $theme-background-color;
+    color: $theme-foreground-color;
+
+    .mat-tab-body {
+        background-color: #0d1117;
+    }
+
+    .mat-tab-group.mat-primary .mat-ink-bar, .mat-tab-nav-bar.mat-primary .mat-ink-bar{
+        background-color: $theme-accent-lighter-color;
+    }
+
+    .mat-tab-label {
+        color: $theme-foreground-color;
+        opacity: 1;
+    }
+
+    .mat-tab-list .mat-tab-labels .mat-tab-label-active {
+        color: $theme-accent-lighter-color;
+    }
+
+    // src/styles/1-layouts/_layout-global.scss
+
+    .content {
+        background-color: $theme-background-color;
+        color: $theme-foreground-color;
+    }
+
+    // src/styles/1-layouts/_sidenav.scss
+
+    .heading {
+        color: $theme-foreground-color;
+    }
+
+    // src/styles/1-layouts/_marketing-layout.scss
+
+    .text-headline {
+        color: $theme-foreground-color;
+    }
+
+    // src/styles/1-layouts/_footer.scss
+
+    footer {
+        background-color: $theme-primary-color;
+    }
+
+    // src/styles/1-layouts/_sidenav.scss
+
+    mat-sidenav-container.sidenav-container.mat-drawer-container.mat-sidenav-container, mat-sidenav-container .sidenav-content {
+        background-color: $theme-background-color;
+    }
+
+    mat-sidenav.mat-sidenav.sidenav {
+        background-color: $theme-dialog-background-color;
+    }
+
+    // src/styles/2-modules/_toc.scss
+
+    .toc-inner ul.toc-list li {
+        &.active a {
+            color: $theme-accent-color;
+
+            &:before {
+                background-color: $theme-accent-color;
+            }
+        }
+
+        &:hover a {
+            color: $theme-accent-color;
+        }
+
+        a {
+            color: $theme-foreground-color;
+        }
+
+        &.active * {
+            color: $theme-accent-color;
+
+            &:before {
+                background: $theme-accent-color;
+            }
+        }
+    }
+
+    // src/styles/1-layouts/_sidenav.scss
+
+    .vertical-menu-item {
+        color: $theme-foreground-color;
+
+        &:hover {
+            background-color: $theme-hover-background-color;
+            color: $theme-accent-lighter-color;
+            text-shadow: 0 0 0px;
+        }
+
+        &.selected {
+            background-color: $theme-dialog-background-color;
+            color: $theme-accent-lighter-color;
+        }
+
+        &:focus {
+            color: $theme-accent-lighter-color;
+            outline-width: 0px;
+            text-shadow: 0 0 0px;
+        }
+
+        &:focus, :not(&:selected) {
+            background-color: $theme-hover-background-color;
+            color: $theme-foreground-color;
+        }
+    }
+
+    .sidenav-content {
+        a {
+            color: $theme-accent-color;
+            &:hover {
+                color: $theme-accent-lighter-color;
+            }
+        }
+    }
+
+    // src/styles/2-modules/_select-menu.scss
+
+    .form-select-button {
+        background-color: $theme-card-color;
+        color: $theme-accent-color;
+        border-width: 0px;
+    }
+
+    .form-select-dropdown {
+        background-color: $theme-card-color;
+
+        li {
+            &:hover {
+                background-color: $theme-hover-background-color;
+                color: $theme-accent-color;
+            }
+
+            &.selected {
+                background-color: $theme-card-color;
+                color: $theme-accent-color;
+            }
+        }
+    }
+
+    // src/styles/2-modules/_images.scss
+
+    .content {
+        .lightbox {
+            background-color: $theme-card-color;
+            border-color: rgba($theme-foreground-secondary-color, 0.2);
+
+            img {
+                padding: 4px;
+            }
+        }
+    }
+
+    // src/styles/1-layouts/_marketing-layout.scss
+
+    .background-sky {
+        background-color: $theme-primary-color;
+        background: linear-gradient(145deg, $theme-primary-darker-color, $theme-primary-color, $theme-primary-lighter-color);
+    }
+
+    .marketing-banner {
+        background-color: $theme-primary-color;
+
+        .banner-headline {
+            color: $theme-foreground-color;
+        }
+    }
+
+    .home-row .card {
+        background-color: $theme-card-color;
+
+        .card-text-container p {
+            color: $theme-foreground-color;
+        }
+    }
+
+    // src/styles/2-modules/_card.scss
+
+    .card-container {
+        .docs-card {
+            background-color: $theme-card-color;
+            color: $theme-foreground-color;
+
+            &:hover {
+                section {
+                    color: $theme-accent-color;
+                }
+
+                p {
+                    color: $theme-foreground-color;
+                }
+
+                .card-footer {
+                    color: $theme-accent-color;
+                }
+
+            }
+
+            section {
+                color: $theme-foreground-color;
+            }
+
+            p {
+                color: $theme-foreground-color;
+            }
+
+            .card-footer {
+                color: $theme-foreground-secondary-color;
+                border-top-color: $theme-divider-color;
+            }
+        }
+    }
+
+    .card-section {
+        background-color: $theme-card-color;
+    }
+
+    // src/styles/1-layouts/_marketing-layout.scss
+
+    .button.hero-cta {
+        background-color: #dd0031;
+        color: $theme-foreground-color;
+
+        &:hover {
+            background-color: #c3002f;
+            color: $theme-foreground-color;
+        }
+    }
+
+    .announcement-bar .button {
+        background-color: $theme-primary-color;
+        color: $theme-foreground-color;
+    }
+
+    // src/styles/2-modules/_contributor.scss
+
+    .group-buttons {
+        a {
+            &.selected {
+                background-color: $theme-primary-color;
+                color: $theme-foreground-color;
+            }
+        }
+    }
+
+    // src/styles/2-modules/_buttons.scss
+
+    a.filter-button {
+        &:hover {
+            background-color: $theme-primary-color;
+            color: $theme-foreground-color;
+        }
+    }
+
+    .button.button-blue, a.button.mat-button.button-blue {
+        background-color: transparent;
+        border: 1px solid $theme-accent-color;
+    }
+
+    // src/styles/2-modules/_resources.scss
+
+    aio-resource-list .resource-row-link:hover {
+        border-color: $theme-accent-color;
+        @include mat-elevation(8);
+    }
+
+    aio-resource-list .subcategory-title {
+        background-color: $theme-primary-color;
+        color: $theme-foreground-color;
+    }
+
+    // src/styles/1-layouts/_top-menu.scss
+
+    aio-shell.page-features mat-toolbar.mat-toolbar,
+    aio-shell.page-events mat-toolbar.mat-toolbar,
+    aio-shell.page-resources mat-toolbar.mat-toolbar {
+        @include mat-elevation(6);
+    }
+
+    // src/styles/0-base/_typography.scss
+
+    h1, h2, h3, h4, h5, h6 {
+        color: $theme-foreground-color;
+    }
+
+    p, ol, ul, ol, li, input, a {
+        color: $theme-foreground-color;
+    }
+
+    code {
+        color: $theme-foreground-color;
+    }
+
+    // src/styles/2-modules/_table.scss
+
+    table {
+        background-color: $theme-background-color;
+
+        thead > {
+            tr > th {
+                background-color: $theme-card-color;
+                color: $theme-foreground-color;
+                border-bottom-color: $theme-divider-color;
+            }
+        }
+
+        tbody > {
+            tr > th {
+                background-color: $theme-card-color;
+                font-weight: normal;
+            }
+            tr > th, tr > td {
+                color: $theme-foreground-color;
+                border-right-color: $theme-divider-color;
+                border-bottom-color: $theme-divider-color;
+
+                a {
+                    color: $theme-accent-color;
+
+                    &:hover {
+                        color: $theme-accent-lighter-color;
+                    }
+                }
+            }
+        }
+    }
+
+    // src/styles/2-modules/_code.scss
+
+    code-example.code-shell, code-example[language=sh], code-example[language=bash] {
+        .pnk, .blk, .pln, .otl, .kwd, .typ, .tag, .str, .atv, .atn, .com, .lit, .pun, .dec {
+            color: $theme-foreground-color;
+        }
+    }
+
+    code-example {
+        &:not(.no-box) {
+            background-color: #0d1117;
+            color: $theme-foreground-color;
+            border-color: rgba($theme-foreground-secondary-color, 0.2);
+        }
+
+        header {
+            background-color: $theme-app-bar-color;
+        }
+
+        &.avoid header, &.avoidFile header {
+            border: 2px solid $theme-warn-color;
+            background: $theme-warn-color;
+        }
+    }
+
+    code-example.avoid,
+    code-example.avoidFile,
+    code-tabs.avoid mat-tab-body,
+    code-tabs.avoidFile mat-tab-body {
+        border: 0.5px solid $theme-warn-color;
+    }
+
+    .copy-button {
+        color: $theme-accent-color;
+        &:hover {
+            color: $theme-accent-lighter-color;
+        }
+    }
+
+    .lang-sh .copy-button, .lang-bash .copy-button {
+        color: $theme-accent-color;
+        &:hover {
+            color: $theme-accent-lighter-color;
+        }
+    }
+
+    .kwd, .tag {
+        color: #ff7b72;
+    }
+
+    .pln {
+        color: #fff;
+    }
+
+    .pun, .opn, .clo {
+        color: #8b949e;
+    }
+
+    .typ, .atn {
+        color: #79c0ff;
+    }
+
+    .lit {
+        color: #fff;
+    }
+
+    .str, .atv {
+        color: #a0e99d;
+    }
+
+    .com {
+        color: #8b949e;
+    }
+
+    // src/styles/2-modules/_api-pages.scss
+
+    .api-body table th {
+        font-weight: normal;
+    }
+
+    .github-links {
+        .material-icons {
+            &:hover {
+                background-color: $theme-hover-background-color;
+            }
+        }
+    }
+
+    // src/styles/2-modules/_filetree.scss
+
+    .filetree {
+        background: $theme-card-color;
+        border: 4px solid $theme-divider-color;
+
+        .file {
+            color: $theme-foreground-color;
+        }
+    }
+}

--- a/aio/src/styles/ng-io-theme.scss
+++ b/aio/src/styles/ng-io-theme.scss
@@ -17,8 +17,8 @@ $ng-io-warn:    mat-palette($mat-red);
 // Create the theme object (a Sass map containing all of the palettes).
 $ng-io-theme: mat-light-theme($ng-io-primary, $ng-io-accent, $ng-io-warn);
 
-$night-primary: mat-palette($mat-teal, 700, 600, 800);
-$night-accent:  mat-palette($mat-teal, 200, 100, 300);
+$night-primary: mat-palette($mat-blue, 800, 700, 900);
+$night-accent:  mat-palette($mat-blue, 300, 200, 400);
 
 $night-theme: mat-dark-theme($night-primary, $night-accent);
 

--- a/aio/src/styles/ng-io-theme.scss
+++ b/aio/src/styles/ng-io-theme.scss
@@ -17,7 +17,21 @@ $ng-io-warn:    mat-palette($mat-red);
 // Create the theme object (a Sass map containing all of the palettes).
 $ng-io-theme: mat-light-theme($ng-io-primary, $ng-io-accent, $ng-io-warn);
 
+$night-primary: mat-palette($mat-teal, 700, 600, 800);
+$night-accent:  mat-palette($mat-teal, 200, 100, 300);
+
+$night-theme: mat-dark-theme($night-primary, $night-accent);
+
 // Include theme styles for core and each component used in your app.
 // Alternatively, you can import and @include the theme mixins for each component
 // that you are using.
 @include angular-material-theme($ng-io-theme);
+
+@import 'custom-styles';
+
+@media not print {
+    .night-theme {
+        @include angular-material-color($night-theme);
+        @include custom-styles($night-theme);
+    }
+}


### PR DESCRIPTION
Add dark mode to angular.io web site to make it easier to read

Add a button to the top right of the web site to toggle dark mode
Save user selected theme using local storage
Use theme picker component source code from angular material with some modifications

Do not run dark mode when printing is enabled

Modify the current styles spead accross many files by placing the relevant styles into one file for dark mode

Closes #40102

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Web site currently has no dark mode

Issue Number: #40102


## What is the new behavior?
Adds dark mode and ability to toggle it

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Please try it out as well locally to see if there's something missing.
![image](https://user-images.githubusercontent.com/5408993/103059832-31441380-4574-11eb-95d2-9fba79360fd4.png)
