### PR TITLE
fix(compiler): don't report parse error for interpolation inside string in property binding

### DIFF
--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -307,7 +307,9 @@ export class Parser {
 
     for (const charIndex of this._forEachUnquotedChar(input, 0)) {
       if (startIndex === -1) {
-        startIndex = input.indexOf(start, charIndex);
+        if (input.startsWith(start)) {
+          startIndex = charIndex;
+        }
       } else {
         endIndex = this._getInterpolationEndIndex(input, end, charIndex);
         if (endIndex > -1) {

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -316,7 +316,10 @@ describe('parser', () => {
     });
 
     it('should not report interpolation inside a string', () => {
-      expect(parseAction('"{{a()}}"').errors).toEqual([]);
+      expect(parseAction(`"{{a()}}"`).errors).toEqual([]);
+      expect(parseAction(`'{{a()}}'`).errors).toEqual([]);
+      expect(parseAction(`"{{a('\\"')}}"`).errors).toEqual([]);
+      expect(parseAction(`'{{a("\\'")}}'`).errors).toEqual([]);
     });
   });
 
@@ -491,7 +494,10 @@ describe('parser', () => {
     });
 
     it('should not report interpolation inside a string', () => {
-      expect(parseBinding('"{{exp}}"').errors).toEqual([]);
+      expect(parseBinding(`"{{exp}}"`).errors).toEqual([]);
+      expect(parseBinding(`'{{exp}}'`).errors).toEqual([]);
+      expect(parseBinding(`'{{\\"}}'`).errors).toEqual([]);
+      expect(parseBinding(`'{{\\'}}'`).errors).toEqual([]);
     });
 
     it('should parse conditional expression', () => {
@@ -961,7 +967,10 @@ describe('parser', () => {
     });
 
     it('should not report interpolation inside a string', () => {
-      expect(parseSimpleBinding('"{{exp}}"').errors).toEqual([]);
+      expect(parseSimpleBinding(`"{{exp}}"`).errors).toEqual([]);
+      expect(parseSimpleBinding(`'{{exp}}'`).errors).toEqual([]);
+      expect(parseSimpleBinding(`'{{\\"}}'`).errors).toEqual([]);
+      expect(parseSimpleBinding(`'{{\\'}}'`).errors).toEqual([]);
     });
 
     it('should report when encountering field write', () => {

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -314,6 +314,10 @@ describe('parser', () => {
     it('should report when encountering interpolation', () => {
       expectActionError('{{a()}}', 'Got interpolation ({{}}) where expression was expected');
     });
+
+    it('should not report interpolation inside a string', () => {
+      expect(parseAction('"{{a()}}"').errors).toEqual([]);
+    });
   });
 
   describe('parse spans', () => {
@@ -484,6 +488,10 @@ describe('parser', () => {
 
     it('should report when encountering interpolation', () => {
       expectBindingError('{{a.b}}', 'Got interpolation ({{}}) where expression was expected');
+    });
+
+    it('should not report interpolation inside a string', () => {
+      expect(parseBinding('"{{exp}}"').errors).toEqual([]);
     });
 
     it('should parse conditional expression', () => {
@@ -950,6 +958,10 @@ describe('parser', () => {
       expectError(
           validate(parseSimpleBinding('{{exp}}')),
           'Got interpolation ({{}}) where expression was expected');
+    });
+
+    it('should not report interpolation inside a string', () => {
+      expect(parseSimpleBinding('"{{exp}}"').errors).toEqual([]);
     });
 
     it('should report when encountering field write', () => {

--- a/packages/core/test/acceptance/property_binding_spec.ts
+++ b/packages/core/test/acceptance/property_binding_spec.ts
@@ -623,4 +623,15 @@ describe('property bindings', () => {
          fixture.detectChanges();
        }).not.toThrow();
      });
+
+  it('should allow quoted binding syntax inside property binding', () => {
+    @Component({template: `<span [id]="'{{ id }}'"></span>`})
+    class Comp {
+    }
+
+    TestBed.configureTestingModule({declarations: [Comp]});
+    const fixture = TestBed.createComponent(Comp);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('span').id).toBe('{{ id }}');
+  });
 });

--- a/packages/core/test/acceptance/property_binding_spec.ts
+++ b/packages/core/test/acceptance/property_binding_spec.ts
@@ -634,4 +634,15 @@ describe('property bindings', () => {
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('span').id).toBe('{{ id }}');
   });
+
+  it('should allow quoted binding syntax with escaped quotes inside property binding', () => {
+    @Component({template: `<span [id]="'{{ \\' }}'"></span>`})
+    class Comp {
+    }
+
+    TestBed.configureTestingModule({declarations: [Comp]});
+    const fixture = TestBed.createComponent(Comp);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('span').id).toBe('{{ \' }}');
+  });
 });


### PR DESCRIPTION
Currently we check whether a property binding contains an interpolation using a regex so that we can throw an error. The problem is that the regex doesn't account for quotes which means that something like `[prop]="'{{ foo }}'"` will be considered an error, even though it's not actually an interpolation.

These changes build on top of the logic from #39826 to account for interpolation characters inside quotes.

Fixes #39601.