### PR TITLE
ci: Add docs label to guide/example changes on aio

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1222,17 +1222,18 @@ groups:
         - mgechev
 
   # =========================================================
-  #  Docs: All
+  #  Docs: Guides
   #
   # Ensures the `comp: docs` label is applied to aio doc changes
   # =========================================================
-  docs-all:
+  docs-guides:
     type: optional
     conditions:
       - >
         contains_any_globs(files, [
           'aio/content/guide/**',
-          'aio/content/examples/**'
+          'aio/content/examples/**',
+          'aio/content/images/guide/**'
           ])
     labels:
       pending: "comp: docs"

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1221,6 +1221,23 @@ groups:
         - IgorMinar
         - mgechev
 
+  # =========================================================
+  #  Docs: All
+  #
+  # Ensures the `comp: docs` label is applied to aio doc changes
+  # =========================================================
+  docs-all:
+    type: optional
+    conditions:
+      - >
+        contains_any_globs(files, [
+          'aio/content/guide/**',
+          'aio/content/examples/**'
+          ])
+    labels:
+      pending: "comp: docs"
+      approved: "comp: docs"
+      rejected: "comp: docs"
 
   # =========================================================
   #  Docs-infra


### PR DESCRIPTION
The current configuration does not capture all possibilities for the docs label.
This change adds a group which applies the docs label for anything any changes
to aio guides or examples.
