### PR TITLE
refactor(compiler-cli): `FileSystem` interface break up

### DIFF
--- a/packages/compiler-cli/linker/babel/src/linker_plugin_options.ts
+++ b/packages/compiler-cli/linker/babel/src/linker_plugin_options.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {LinkerOptions} from '../..';
-import {FileSystem} from '../../../src/ngtsc/file_system';
+import {ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {Logger} from '../../../src/ngtsc/logging';
 
 export interface LinkerPluginOptions extends Partial<LinkerOptions> {
   /**
    * File-system, used to load up the input source-map and content.
    */
-  fileSystem: FileSystem;
+  fileSystem: ReadonlyFileSystem;
 
   /**
    * Logger used by the linker.

--- a/packages/compiler-cli/linker/src/file_linker/linker_environment.ts
+++ b/packages/compiler-cli/linker/src/file_linker/linker_environment.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {FileSystem} from '../../../src/ngtsc/file_system';
+import {ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {Logger} from '../../../src/ngtsc/logging';
 import {SourceFileLoader} from '../../../src/ngtsc/sourcemaps';
 import {AstFactory} from '../../../src/ngtsc/translator';
@@ -20,11 +20,12 @@ export class LinkerEnvironment<TStatement, TExpression> {
       this.options.sourceMapping ? new SourceFileLoader(this.fileSystem, this.logger, {}) : null;
 
   private constructor(
-      readonly fileSystem: FileSystem, readonly logger: Logger, readonly host: AstHost<TExpression>,
-      readonly factory: AstFactory<TStatement, TExpression>, readonly options: LinkerOptions) {}
+      readonly fileSystem: ReadonlyFileSystem, readonly logger: Logger,
+      readonly host: AstHost<TExpression>, readonly factory: AstFactory<TStatement, TExpression>,
+      readonly options: LinkerOptions) {}
 
   static create<TStatement, TExpression>(
-      fileSystem: FileSystem, logger: Logger, host: AstHost<TExpression>,
+      fileSystem: ReadonlyFileSystem, logger: Logger, host: AstHost<TExpression>,
       factory: AstFactory<TStatement, TExpression>,
       options: Partial<LinkerOptions>): LinkerEnvironment<TStatement, TExpression> {
     return new LinkerEnvironment(fileSystem, logger, host, factory, {

--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -12,7 +12,7 @@ import {ParsedConfiguration} from '../../..';
 import {ComponentDecoratorHandler, DirectiveDecoratorHandler, InjectableDecoratorHandler, NgModuleDecoratorHandler, PipeDecoratorHandler, ReferencesRegistry, ResourceLoader} from '../../../src/ngtsc/annotations';
 import {CycleAnalyzer, ImportGraph} from '../../../src/ngtsc/cycles';
 import {isFatalDiagnosticError} from '../../../src/ngtsc/diagnostics';
-import {absoluteFrom, absoluteFromSourceFile, dirname, FileSystem, LogicalFileSystem, resolve} from '../../../src/ngtsc/file_system';
+import {absoluteFromSourceFile, LogicalFileSystem, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {AbsoluteModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, NOOP_DEFAULT_IMPORT_RECORDER, PrivateExportAliasingHost, Reexport, ReferenceEmitter} from '../../../src/ngtsc/imports';
 import {CompoundMetadataReader, CompoundMetadataRegistry, DtsMetadataReader, InjectableClassRegistry, LocalMetadataRegistry, ResourceRegistry} from '../../../src/ngtsc/metadata';
 import {PartialEvaluator} from '../../../src/ngtsc/partial_evaluator';
@@ -36,16 +36,16 @@ import {isWithinPackage, NOOP_DEPENDENCY_TRACKER} from './util';
  * Simple class that resolves and loads files directly from the filesystem.
  */
 class NgccResourceLoader implements ResourceLoader {
-  constructor(private fs: FileSystem) {}
+  constructor(private fs: ReadonlyFileSystem) {}
   canPreload = false;
   preload(): undefined|Promise<void> {
     throw new Error('Not implemented.');
   }
   load(url: string): string {
-    return this.fs.readFile(resolve(url));
+    return this.fs.readFile(this.fs.resolve(url));
   }
   resolve(url: string, containingFile: string): string {
-    return resolve(dirname(absoluteFrom(containingFile)), url);
+    return this.fs.resolve(this.fs.dirname(containingFile), url);
   }
 }
 
@@ -139,7 +139,7 @@ export class DecorationAnalyzer {
   ];
 
   constructor(
-      private fs: FileSystem, private bundle: EntryPointBundle,
+      private fs: ReadonlyFileSystem, private bundle: EntryPointBundle,
       private reflectionHost: NgccReflectionHost, private referencesRegistry: ReferencesRegistry,
       private diagnosticHandler: (error: ts.Diagnostic) => void = () => {},
       private tsConfig: ParsedConfiguration|null = null) {}

--- a/packages/compiler-cli/ngcc/src/command_line_options.ts
+++ b/packages/compiler-cli/ngcc/src/command_line_options.ts
@@ -8,7 +8,7 @@
  */
 import * as yargs from 'yargs';
 
-import {resolve, setFileSystem, NodeJSFileSystem} from '../../src/ngtsc/file_system';
+import {setFileSystem, NodeJSFileSystem} from '../../src/ngtsc/file_system';
 import {ConsoleLogger, LogLevel} from '../../src/ngtsc/logging';
 import {NgccOptions} from './ngcc_options';
 
@@ -115,9 +115,10 @@ export function parseCommandLineOptions(args: string[]): NgccOptions {
     process.exit(1);
   }
 
-  setFileSystem(new NodeJSFileSystem());
+  const fs = new NodeJSFileSystem();
+  setFileSystem(fs);
 
-  const baseSourcePath = resolve(options.s || './node_modules');
+  const baseSourcePath = fs.resolve(options.s || './node_modules');
   const propertiesToConsider = options.p;
   const targetEntryPointPath = options.t;
   const compileAllFormats = !options['first-only'];

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_host.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem, PathSegment} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, PathSegment, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {EntryPoint} from '../packages/entry_point';
 import {resolveFileWithPostfixes} from '../utils';
 
@@ -32,7 +32,7 @@ export function createDependencyInfo(): DependencyInfo {
 }
 
 export abstract class DependencyHostBase implements DependencyHost {
-  constructor(protected fs: FileSystem, protected moduleResolver: ModuleResolver) {}
+  constructor(protected fs: ReadonlyFileSystem, protected moduleResolver: ModuleResolver) {}
 
   /**
    * Find all the dependencies for the entry-point at the given path.

--- a/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dependency_resolver.ts
@@ -8,7 +8,7 @@
 
 import {DepGraph} from 'dependency-graph';
 
-import {AbsoluteFsPath, FileSystem, resolve} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {Logger} from '../../../src/ngtsc/logging';
 import {NgccConfiguration} from '../packages/configuration';
 import {EntryPoint, EntryPointFormat, getEntryPointFormat, SUPPORTED_FORMAT_PROPERTIES} from '../packages/entry_point';
@@ -84,7 +84,7 @@ export interface SortedEntryPointsInfo extends DependencyDiagnostics {
  */
 export class DependencyResolver {
   constructor(
-      private fs: FileSystem, private logger: Logger, private config: NgccConfiguration,
+      private fs: ReadonlyFileSystem, private logger: Logger, private config: NgccConfiguration,
       private hosts: Partial<Record<EntryPointFormat, DependencyHost>>,
       private typingsHost: DependencyHost) {}
   /**
@@ -212,7 +212,7 @@ export class DependencyResolver {
       const format = getEntryPointFormat(this.fs, entryPoint, property);
       if (format === undefined) continue;
 
-      return {format, path: resolve(entryPoint.path, formatPath)};
+      return {format, path: this.fs.resolve(entryPoint.path, formatPath)};
     }
 
     throw new Error(

--- a/packages/compiler-cli/ngcc/src/dependencies/dts_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/dts_dependency_host.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {PathMappings} from '../path_mappings';
 import {EsmDependencyHost} from './esm_dependency_host';
 import {ModuleResolver} from './module_resolver';
@@ -14,7 +14,7 @@ import {ModuleResolver} from './module_resolver';
  * Helper functions for computing dependencies via typings files.
  */
 export class DtsDependencyHost extends EsmDependencyHost {
-  constructor(fs: FileSystem, pathMappings?: PathMappings) {
+  constructor(fs: ReadonlyFileSystem, pathMappings?: PathMappings) {
     super(
         fs, new ModuleResolver(fs, pathMappings, ['', '.d.ts', '/index.d.ts', '.js', '/index.js']),
         false);

--- a/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/esm_dependency_host.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
-import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {DependencyHostBase} from './dependency_host';
 import {ModuleResolver} from './module_resolver';
 
@@ -15,7 +15,8 @@ import {ModuleResolver} from './module_resolver';
  */
 export class EsmDependencyHost extends DependencyHostBase {
   constructor(
-      fs: FileSystem, moduleResolver: ModuleResolver, private scanImportExpressions = true) {
+      fs: ReadonlyFileSystem, moduleResolver: ModuleResolver,
+      private scanImportExpressions = true) {
     super(fs, moduleResolver);
   }
   // By skipping trivia here we don't have to account for it in the processing below

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/entry_point_collector.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/entry_point_collector.ts
@@ -5,9 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem, PathSegment} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, PathSegment, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {Logger} from '../../../src/ngtsc/logging';
-
 import {EntryPointWithDependencies} from '../dependencies/dependency_host';
 import {DependencyResolver} from '../dependencies/dependency_resolver';
 import {NgccConfiguration} from '../packages/configuration';
@@ -20,7 +19,7 @@ import {NGCC_DIRECTORY} from '../writing/new_entry_point_file_writer';
  */
 export class EntryPointCollector {
   constructor(
-      private fs: FileSystem, private config: NgccConfiguration, private logger: Logger,
+      private fs: ReadonlyFileSystem, private config: NgccConfiguration, private logger: Logger,
       private resolver: DependencyResolver) {}
 
   /**

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/program_based_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/program_based_entry_point_finder.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {Logger} from '../../../src/ngtsc/logging';
 import {ParsedConfiguration} from '../../../src/perform_compile';
 
@@ -32,12 +32,13 @@ export class ProgramBasedEntryPointFinder extends TracingEntryPointFinder {
   private entryPointsWithDependencies: Map<AbsoluteFsPath, EntryPointWithDependencies>|null = null;
 
   constructor(
-      fs: FileSystem, config: NgccConfiguration, logger: Logger, resolver: DependencyResolver,
-      private entryPointCollector: EntryPointCollector,
+      fs: ReadonlyFileSystem, config: NgccConfiguration, logger: Logger,
+      resolver: DependencyResolver, private entryPointCollector: EntryPointCollector,
       private entryPointManifest: EntryPointManifest, basePath: AbsoluteFsPath,
       private tsConfig: ParsedConfiguration, projectPath: AbsoluteFsPath) {
     super(
-        fs, config, logger, resolver, basePath, getPathMappingsFromTsConfig(tsConfig, projectPath));
+        fs, config, logger, resolver, basePath,
+        getPathMappingsFromTsConfig(fs, tsConfig, projectPath));
   }
 
   /**

--- a/packages/compiler-cli/ngcc/src/entry_point_finder/tracing_entry_point_finder.ts
+++ b/packages/compiler-cli/ngcc/src/entry_point_finder/tracing_entry_point_finder.ts
@@ -5,9 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, PathManipulation, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {Logger} from '../../../src/ngtsc/logging';
-
 import {EntryPointWithDependencies} from '../dependencies/dependency_host';
 import {DependencyResolver, SortedEntryPointsInfo} from '../dependencies/dependency_resolver';
 import {NgccConfiguration} from '../packages/configuration';
@@ -36,9 +35,9 @@ export abstract class TracingEntryPointFinder implements EntryPointFinder {
   private basePaths: AbsoluteFsPath[]|null = null;
 
   constructor(
-      protected fs: FileSystem, protected config: NgccConfiguration, protected logger: Logger,
-      protected resolver: DependencyResolver, protected basePath: AbsoluteFsPath,
-      protected pathMappings: PathMappings|undefined) {}
+      protected fs: ReadonlyFileSystem, protected config: NgccConfiguration,
+      protected logger: Logger, protected resolver: DependencyResolver,
+      protected basePath: AbsoluteFsPath, protected pathMappings: PathMappings|undefined) {}
 
   /**
    * Search for Angular package entry-points.

--- a/packages/compiler-cli/ngcc/src/execution/cluster/executor.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/executor.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {FileSystem} from '../../../../src/ngtsc/file_system';
+import {PathManipulation} from '../../../../src/ngtsc/file_system';
 import {Logger} from '../../../../src/ngtsc/logging';
 import {AsyncLocker} from '../../locking/async_locker';
 import {FileWriter} from '../../writing/file_writer';
@@ -21,7 +21,7 @@ import {ClusterMaster} from './master';
  */
 export class ClusterExecutor implements Executor {
   constructor(
-      private workerCount: number, private fileSystem: FileSystem, private logger: Logger,
+      private workerCount: number, private fileSystem: PathManipulation, private logger: Logger,
       private fileWriter: FileWriter, private pkgJsonUpdater: PackageJsonUpdater,
       private lockFile: AsyncLocker,
       private createTaskCompletedCallback: CreateTaskCompletedCallback) {}

--- a/packages/compiler-cli/ngcc/src/execution/cluster/master.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/master.ts
@@ -10,7 +10,7 @@
 
 import * as cluster from 'cluster';
 
-import {AbsoluteFsPath, FileSystem} from '../../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, PathManipulation} from '../../../../src/ngtsc/file_system';
 import {Logger} from '../../../../src/ngtsc/logging';
 import {FileWriter} from '../../writing/file_writer';
 import {PackageJsonUpdater} from '../../writing/package_json_updater';
@@ -35,7 +35,7 @@ export class ClusterMaster {
   private remainingRespawnAttempts = 3;
 
   constructor(
-      private maxWorkerCount: number, private fileSystem: FileSystem, private logger: Logger,
+      private maxWorkerCount: number, private fileSystem: PathManipulation, private logger: Logger,
       private fileWriter: FileWriter, private pkgJsonUpdater: PackageJsonUpdater,
       analyzeEntryPoints: AnalyzeEntryPointsFn,
       createTaskCompletedCallback: CreateTaskCompletedCallback) {

--- a/packages/compiler-cli/ngcc/src/execution/tasks/completion.ts
+++ b/packages/compiler-cli/ngcc/src/execution/tasks/completion.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {FileSystem, resolve} from '../../../../src/ngtsc/file_system';
+import {PathManipulation, ReadonlyFileSystem} from '../../../../src/ngtsc/file_system';
 import {Logger} from '../../../../src/ngtsc/logging';
 import {markAsProcessed} from '../../packages/build_marker';
 import {getEntryPointFormat, PackageJsonFormatProperties} from '../../packages/entry_point';
@@ -46,11 +46,11 @@ export function composeTaskCompletedCallbacks(
  *
  * @param pkgJsonUpdater The service used to update the package.json
  */
-export function createMarkAsProcessedHandler(pkgJsonUpdater: PackageJsonUpdater):
-    TaskCompletedHandler {
+export function createMarkAsProcessedHandler(
+    fs: PathManipulation, pkgJsonUpdater: PackageJsonUpdater): TaskCompletedHandler {
   return (task: Task): void => {
     const {entryPoint, formatPropertiesToMarkAsProcessed, processDts} = task;
-    const packageJsonPath = resolve(entryPoint.path, 'package.json');
+    const packageJsonPath = fs.resolve(entryPoint.path, 'package.json');
     const propsToMarkAsProcessed: PackageJsonFormatProperties[] =
         [...formatPropertiesToMarkAsProcessed];
     if (processDts) {
@@ -64,7 +64,7 @@ export function createMarkAsProcessedHandler(pkgJsonUpdater: PackageJsonUpdater)
 /**
  * Create a handler that will throw an error.
  */
-export function createThrowErrorHandler(fs: FileSystem): TaskCompletedHandler {
+export function createThrowErrorHandler(fs: ReadonlyFileSystem): TaskCompletedHandler {
   return (task: Task, message: string|null): void => {
     const format = getEntryPointFormat(fs, task.entryPoint, task.formatProperty);
     throw new Error(
@@ -78,7 +78,7 @@ export function createThrowErrorHandler(fs: FileSystem): TaskCompletedHandler {
  * Create a handler that logs an error and marks the task as failed.
  */
 export function createLogErrorHandler(
-    logger: Logger, fs: FileSystem, taskQueue: TaskQueue): TaskCompletedHandler {
+    logger: Logger, fs: ReadonlyFileSystem, taskQueue: TaskQueue): TaskCompletedHandler {
   return (task: Task, message: string|null): void => {
     taskQueue.markAsFailed(task);
     const format = getEntryPointFormat(fs, task.entryPoint, task.formatProperty);

--- a/packages/compiler-cli/ngcc/src/locking/lock_file.ts
+++ b/packages/compiler-cli/ngcc/src/locking/lock_file.ts
@@ -5,9 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, PathManipulation} from '../../../src/ngtsc/file_system';
 
-export function getLockFilePath(fs: FileSystem) {
+export function getLockFilePath(fs: PathManipulation) {
   return fs.resolve(require.resolve('@angular/compiler-cli/ngcc'), '../__ngcc_lock_file__');
 }
 

--- a/packages/compiler-cli/ngcc/src/ngcc_options.ts
+++ b/packages/compiler-cli/ngcc/src/ngcc_options.ts
@@ -7,7 +7,7 @@
  */
 import * as os from 'os';
 
-import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem} from '../../src/ngtsc/file_system';
+import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, PathManipulation} from '../../src/ngtsc/file_system';
 import {ConsoleLogger, Logger, LogLevel} from '../../src/ngtsc/logging';
 import {ParsedConfiguration, readConfiguration} from '../../src/perform_compile';
 
@@ -175,7 +175,7 @@ export function getSharedSetup(options: NgccOptions): SharedSetup&RequiredNgccOp
     compileAllFormats = true,
     createNewEntryPointFormats = false,
     logger = new ConsoleLogger(LogLevel.info),
-    pathMappings = getPathMappingsFromTsConfig(tsConfig, projectPath),
+    pathMappings = getPathMappingsFromTsConfig(fileSystem, tsConfig, projectPath),
     async = false,
     errorOnFailedEntryPoint = false,
     enableI18nLegacyMessageIdFormat = true,
@@ -239,7 +239,7 @@ export function clearTsConfigCache() {
 }
 
 function checkForSolutionStyleTsConfig(
-    fileSystem: FileSystem, logger: Logger, projectPath: AbsoluteFsPath,
+    fileSystem: PathManipulation, logger: Logger, projectPath: AbsoluteFsPath,
     tsConfigPath: string|null|undefined, tsConfig: ParsedConfiguration|null): void {
   if (tsConfigPath !== null && !tsConfigPath && tsConfig !== null &&
       tsConfig.rootNames.length === 0 && tsConfig.projectReferences !== undefined &&

--- a/packages/compiler-cli/ngcc/src/packages/entry_point.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point.ts
@@ -5,11 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {relative} from 'canonical-path';
-import {basename} from 'path';
 import * as ts from 'typescript';
 
-import {AbsoluteFsPath, FileSystem, join, resolve} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, PathManipulation, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {Logger} from '../../../src/ngtsc/logging';
 import {parseStatementForUmdModule} from '../host/umd_host';
 import {resolveFileWithPostfixes} from '../utils';
@@ -130,10 +128,10 @@ export type GetEntryPointResult =
  *   entry-point.
  */
 export function getEntryPointInfo(
-    fs: FileSystem, config: NgccConfiguration, logger: Logger, packagePath: AbsoluteFsPath,
+    fs: ReadonlyFileSystem, config: NgccConfiguration, logger: Logger, packagePath: AbsoluteFsPath,
     entryPointPath: AbsoluteFsPath): GetEntryPointResult {
-  const packagePackageJsonPath = resolve(packagePath, 'package.json');
-  const entryPointPackageJsonPath = resolve(entryPointPath, 'package.json');
+  const packagePackageJsonPath = fs.resolve(packagePath, 'package.json');
+  const entryPointPackageJsonPath = fs.resolve(entryPointPath, 'package.json');
   const loadedPackagePackageJson = loadPackageJson(fs, packagePackageJsonPath);
   const loadedEntryPointPackageJson = (packagePackageJsonPath === entryPointPackageJsonPath) ?
       loadedPackagePackageJson :
@@ -163,7 +161,7 @@ export function getEntryPointInfo(
     return IGNORED_ENTRY_POINT;
   } else {
     entryPointPackageJson = mergeConfigAndPackageJson(
-        loadedEntryPointPackageJson, entryPointConfig, packagePath, entryPointPath);
+        fs, loadedEntryPointPackageJson, entryPointConfig, packagePath, entryPointPath);
   }
 
   const typings = entryPointPackageJson.typings || entryPointPackageJson.types ||
@@ -176,7 +174,8 @@ export function getEntryPointInfo(
   // An entry-point is assumed to be compiled by Angular if there is either:
   // * a `metadata.json` file next to the typings entry-point
   // * a custom config for this entry-point
-  const metadataPath = resolve(entryPointPath, typings.replace(/\.d\.ts$/, '') + '.metadata.json');
+  const metadataPath =
+      fs.resolve(entryPointPath, typings.replace(/\.d\.ts$/, '') + '.metadata.json');
   const compiledByAngular = entryPointConfig !== undefined || fs.exists(metadataPath);
 
   const entryPointInfo: EntryPoint = {
@@ -185,7 +184,7 @@ export function getEntryPointInfo(
     packageName,
     packagePath,
     packageJson: entryPointPackageJson,
-    typings: resolve(entryPointPath, typings),
+    typings: fs.resolve(entryPointPath, typings),
     compiledByAngular,
     ignoreMissingDependencies:
         entryPointConfig !== undefined ? !!entryPointConfig.ignoreMissingDependencies : false,
@@ -208,8 +207,8 @@ export function isEntryPoint(result: GetEntryPointResult): result is EntryPoint 
  * @returns An entry-point format or `undefined` if none match the given property.
  */
 export function getEntryPointFormat(
-    fs: FileSystem, entryPoint: EntryPoint, property: EntryPointJsonProperty): EntryPointFormat|
-    undefined {
+    fs: ReadonlyFileSystem, entryPoint: EntryPoint,
+    property: EntryPointJsonProperty): EntryPointFormat|undefined {
   switch (property) {
     case 'fesm2015':
       return 'esm2015';
@@ -226,13 +225,13 @@ export function getEntryPointFormat(
       if (typeof browserFile !== 'string') {
         return undefined;
       }
-      return sniffModuleFormat(fs, join(entryPoint.path, browserFile));
+      return sniffModuleFormat(fs, fs.join(entryPoint.path, browserFile));
     case 'main':
       const mainFile = entryPoint.packageJson['main'];
       if (mainFile === undefined) {
         return undefined;
       }
-      return sniffModuleFormat(fs, join(entryPoint.path, mainFile));
+      return sniffModuleFormat(fs, fs.join(entryPoint.path, mainFile));
     case 'module':
       const moduleFilePath = entryPoint.packageJson['module'];
       // As of version 10, the `module` property in `package.json` should point to
@@ -254,8 +253,8 @@ export function getEntryPointFormat(
  * @param packageJsonPath the absolute path to the `package.json` file.
  * @returns JSON from the `package.json` file if it is valid, `null` otherwise.
  */
-function loadPackageJson(fs: FileSystem, packageJsonPath: AbsoluteFsPath): EntryPointPackageJson|
-    null {
+function loadPackageJson(
+    fs: ReadonlyFileSystem, packageJsonPath: AbsoluteFsPath): EntryPointPackageJson|null {
   try {
     return JSON.parse(fs.readFile(packageJsonPath));
   } catch {
@@ -263,8 +262,8 @@ function loadPackageJson(fs: FileSystem, packageJsonPath: AbsoluteFsPath): Entry
   }
 }
 
-function sniffModuleFormat(fs: FileSystem, sourceFilePath: AbsoluteFsPath): EntryPointFormat|
-    undefined {
+function sniffModuleFormat(
+    fs: ReadonlyFileSystem, sourceFilePath: AbsoluteFsPath): EntryPointFormat|undefined {
   const resolvedPath = resolveFileWithPostfixes(fs, sourceFilePath, ['', '.js', '/index.js']);
   if (resolvedPath === null) {
     return undefined;
@@ -285,18 +284,19 @@ function sniffModuleFormat(fs: FileSystem, sourceFilePath: AbsoluteFsPath): Entr
 }
 
 function mergeConfigAndPackageJson(
-    entryPointPackageJson: EntryPointPackageJson|null, entryPointConfig: NgccEntryPointConfig,
-    packagePath: AbsoluteFsPath, entryPointPath: AbsoluteFsPath): EntryPointPackageJson {
+    fs: PathManipulation, entryPointPackageJson: EntryPointPackageJson|null,
+    entryPointConfig: NgccEntryPointConfig, packagePath: AbsoluteFsPath,
+    entryPointPath: AbsoluteFsPath): EntryPointPackageJson {
   if (entryPointPackageJson !== null) {
     return {...entryPointPackageJson, ...entryPointConfig.override};
   } else {
-    const name = `${basename(packagePath)}/${relative(packagePath, entryPointPath)}`;
+    const name = `${fs.basename(packagePath)}/${fs.relative(packagePath, entryPointPath)}`;
     return {name, ...entryPointConfig.override};
   }
 }
 
 function guessTypingsFromPackageJson(
-    fs: FileSystem, entryPointPath: AbsoluteFsPath,
+    fs: ReadonlyFileSystem, entryPointPath: AbsoluteFsPath,
     entryPointPackageJson: EntryPointPackageJson): AbsoluteFsPath|null {
   for (const prop of SUPPORTED_FORMAT_PROPERTIES) {
     const field = entryPointPackageJson[prop];
@@ -305,7 +305,7 @@ function guessTypingsFromPackageJson(
       continue;
     }
     const relativeTypingsPath = field.replace(/\.js$/, '.d.ts');
-    const typingsPath = resolve(entryPointPath, relativeTypingsPath);
+    const typingsPath = fs.resolve(entryPointPath, relativeTypingsPath);
     if (fs.exists(typingsPath)) {
       return typingsPath;
     }
@@ -321,14 +321,15 @@ function guessTypingsFromPackageJson(
  * - The version is read off of the `version` property of the package's `package.json` file (if
  *   available).
  *
- * @param fs The `FileSystem` instance to use for parsing `packagePath` (if needed).
+ * @param fs The file-system to use for processing `packagePath`.
  * @param packagePath the absolute path to the package.
  * @param packagePackageJson the parsed `package.json` of the package (if available).
  * @param entryPointPackageJson the parsed `package.json` of an entry-point (if available).
  * @returns the computed name and version of the package.
  */
 function getPackageNameAndVersion(
-    fs: FileSystem, packagePath: AbsoluteFsPath, packagePackageJson: EntryPointPackageJson|null,
+    fs: PathManipulation, packagePath: AbsoluteFsPath,
+    packagePackageJson: EntryPointPackageJson|null,
     entryPointPackageJson: EntryPointPackageJson|
     null): {packageName: string, packageVersion: string|null} {
   let packageName: string;

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_bundle.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
-import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, FileSystem, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {PathMappings} from '../path_mappings';
 import {BundleProgram, makeBundleProgram} from './bundle_program';
 import {EntryPoint, EntryPointFormat} from './entry_point';
@@ -86,7 +86,7 @@ export function makeEntryPointBundle(
 }
 
 function computePotentialDtsFilesFromJsFiles(
-    fs: FileSystem, srcProgram: ts.Program, formatPath: AbsoluteFsPath,
+    fs: ReadonlyFileSystem, srcProgram: ts.Program, formatPath: AbsoluteFsPath,
     typingsPath: AbsoluteFsPath) {
   const formatRoot = fs.dirname(formatPath);
   const typingsRoot = fs.dirname(typingsPath);

--- a/packages/compiler-cli/ngcc/src/packages/source_file_cache.ts
+++ b/packages/compiler-cli/ngcc/src/packages/source_file_cache.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
-import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 
 /**
  * A cache that holds on to source files that can be shared for processing all entry-points in a
@@ -29,7 +29,7 @@ import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
 export class SharedFileCache {
   private sfCache = new Map<AbsoluteFsPath, ts.SourceFile>();
 
-  constructor(private fs: FileSystem) {}
+  constructor(private fs: ReadonlyFileSystem) {}
 
   /**
    * Loads a `ts.SourceFile` if the provided `fileName` is deemed appropriate to be cached. To
@@ -95,7 +95,7 @@ const DEFAULT_LIB_PATTERN = ['node_modules', 'typescript', 'lib', /^lib\..+\.d\.
  * @param absPath The path for which to determine if it corresponds with a default library file.
  * @param fs The filesystem to use for inspecting the path.
  */
-export function isDefaultLibrary(absPath: AbsoluteFsPath, fs: FileSystem): boolean {
+export function isDefaultLibrary(absPath: AbsoluteFsPath, fs: ReadonlyFileSystem): boolean {
   return isFile(absPath, DEFAULT_LIB_PATTERN, fs);
 }
 
@@ -109,7 +109,7 @@ const ANGULAR_DTS_PATTERN = ['node_modules', '@angular', /./, /\.d\.ts$/];
  * @param absPath The path for which to determine if it corresponds with an @angular .d.ts file.
  * @param fs The filesystem to use for inspecting the path.
  */
-export function isAngularDts(absPath: AbsoluteFsPath, fs: FileSystem): boolean {
+export function isAngularDts(absPath: AbsoluteFsPath, fs: ReadonlyFileSystem): boolean {
   return isFile(absPath, ANGULAR_DTS_PATTERN, fs);
 }
 
@@ -122,7 +122,7 @@ export function isAngularDts(absPath: AbsoluteFsPath, fs: FileSystem): boolean {
  * @param fs The filesystem to use for inspecting the path.
  */
 function isFile(
-    path: AbsoluteFsPath, segments: ReadonlyArray<string|RegExp>, fs: FileSystem): boolean {
+    path: AbsoluteFsPath, segments: ReadonlyArray<string|RegExp>, fs: ReadonlyFileSystem): boolean {
   for (let i = segments.length - 1; i >= 0; i--) {
     const pattern = segments[i];
     const segment = fs.basename(path);
@@ -147,7 +147,7 @@ function isFile(
 export class EntryPointFileCache {
   private readonly sfCache = new Map<AbsoluteFsPath, ts.SourceFile>();
 
-  constructor(private fs: FileSystem, private sharedFileCache: SharedFileCache) {}
+  constructor(private fs: ReadonlyFileSystem, private sharedFileCache: SharedFileCache) {}
 
   /**
    * Returns and caches a parsed `ts.SourceFile` for the provided `fileName`. If the `fileName` is
@@ -178,7 +178,7 @@ export class EntryPointFileCache {
   }
 }
 
-function readFile(absPath: AbsoluteFsPath, fs: FileSystem): string|undefined {
+function readFile(absPath: AbsoluteFsPath, fs: ReadonlyFileSystem): string|undefined {
   if (!fs.exists(absPath) || !fs.stat(absPath).isFile()) {
     return undefined;
   }
@@ -190,7 +190,7 @@ function readFile(absPath: AbsoluteFsPath, fs: FileSystem): string|undefined {
  *
  * @param fs The filesystem to use for path operations.
  */
-export function createModuleResolutionCache(fs: FileSystem): ts.ModuleResolutionCache {
+export function createModuleResolutionCache(fs: ReadonlyFileSystem): ts.ModuleResolutionCache {
   return ts.createModuleResolutionCache(fs.pwd(), fileName => {
     return fs.isCaseSensitive() ? fileName : fileName.toLowerCase();
   });

--- a/packages/compiler-cli/ngcc/src/path_mappings.ts
+++ b/packages/compiler-cli/ngcc/src/path_mappings.ts
@@ -5,9 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, resolve} from '../../src/ngtsc/file_system';
+import {AbsoluteFsPath, PathManipulation} from '../../src/ngtsc/file_system';
 import {ParsedConfiguration} from '../../src/perform_compile';
-
 
 export type PathMappings = {
   baseUrl: string,
@@ -18,11 +17,12 @@ export type PathMappings = {
  * If `pathMappings` is not provided directly, then try getting it from `tsConfig`, if available.
  */
 export function getPathMappingsFromTsConfig(
-    tsConfig: ParsedConfiguration|null, projectPath: AbsoluteFsPath): PathMappings|undefined {
+    fs: PathManipulation, tsConfig: ParsedConfiguration|null,
+    projectPath: AbsoluteFsPath): PathMappings|undefined {
   if (tsConfig !== null && tsConfig.options.baseUrl !== undefined &&
       tsConfig.options.paths !== undefined) {
     return {
-      baseUrl: resolve(projectPath, tsConfig.options.baseUrl),
+      baseUrl: fs.resolve(projectPath, tsConfig.options.baseUrl),
       paths: tsConfig.options.paths,
     };
   }

--- a/packages/compiler-cli/ngcc/src/rendering/commonjs_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/commonjs_rendering_formatter.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {dirname, relative} from 'canonical-path';
+import {PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import MagicString from 'magic-string';
 import * as ts from 'typescript';
 
@@ -24,8 +24,8 @@ import {stripExtension} from './utils';
  * wrapper function for AMD, CommonJS and global module formats.
  */
 export class CommonJsRenderingFormatter extends Esm5RenderingFormatter {
-  constructor(protected commonJsHost: NgccReflectionHost, isCore: boolean) {
-    super(commonJsHost, isCore);
+  constructor(fs: PathManipulation, protected commonJsHost: NgccReflectionHost, isCore: boolean) {
+    super(fs, commonJsHost, isCore);
   }
 
   /**
@@ -51,7 +51,7 @@ export class CommonJsRenderingFormatter extends Esm5RenderingFormatter {
       importManager: ImportManager, file: ts.SourceFile): void {
     exports.forEach(e => {
       const basePath = stripExtension(e.from);
-      const relativePath = './' + relative(dirname(entryPointBasePath), basePath);
+      const relativePath = './' + this.fs.relative(this.fs.dirname(entryPointBasePath), basePath);
       const namedImport = entryPointBasePath !== basePath ?
           importManager.generateNamedImport(relativePath, e.identifier) :
           {symbol: e.identifier, moduleImport: null};

--- a/packages/compiler-cli/ngcc/src/rendering/dts_renderer.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/dts_renderer.ts
@@ -8,7 +8,7 @@
 import MagicString from 'magic-string';
 import * as ts from 'typescript';
 
-import {FileSystem} from '../../../src/ngtsc/file_system';
+import {ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {Reexport} from '../../../src/ngtsc/imports';
 import {Logger} from '../../../src/ngtsc/logging';
 import {CompileResult} from '../../../src/ngtsc/transform';
@@ -56,8 +56,8 @@ export interface DtsClassInfo {
  */
 export class DtsRenderer {
   constructor(
-      private dtsFormatter: RenderingFormatter, private fs: FileSystem, private logger: Logger,
-      private host: NgccReflectionHost, private bundle: EntryPointBundle) {}
+      private dtsFormatter: RenderingFormatter, private fs: ReadonlyFileSystem,
+      private logger: Logger, private host: NgccReflectionHost, private bundle: EntryPointBundle) {}
 
   renderProgram(
       decorationAnalyses: DecorationAnalyses,

--- a/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
@@ -9,7 +9,7 @@ import {Statement} from '@angular/compiler';
 import MagicString from 'magic-string';
 import * as ts from 'typescript';
 
-import {absoluteFromSourceFile, AbsoluteFsPath, dirname, relative, toRelativeImport} from '../../../src/ngtsc/file_system';
+import {absoluteFromSourceFile, AbsoluteFsPath, PathManipulation, toRelativeImport} from '../../../src/ngtsc/file_system';
 import {Reexport} from '../../../src/ngtsc/imports';
 import {Import, ImportManager, translateStatement} from '../../../src/ngtsc/translator';
 import {isDtsPath} from '../../../src/ngtsc/util/src/typescript';
@@ -28,7 +28,9 @@ import {stripExtension} from './utils';
 export class EsmRenderingFormatter implements RenderingFormatter {
   protected printer = ts.createPrinter({newLine: ts.NewLineKind.LineFeed});
 
-  constructor(protected host: NgccReflectionHost, protected isCore: boolean) {}
+  constructor(
+      protected fs: PathManipulation, protected host: NgccReflectionHost,
+      protected isCore: boolean) {}
 
   /**
    *  Add the imports at the top of the file, after any imports that are already there.
@@ -57,7 +59,7 @@ export class EsmRenderingFormatter implements RenderingFormatter {
 
       if (from) {
         const basePath = stripExtension(from);
-        const relativePath = relative(dirname(entryPointBasePath), basePath);
+        const relativePath = this.fs.relative(this.fs.dirname(entryPointBasePath), basePath);
         const relativeImport = toRelativeImport(relativePath);
         exportFrom = entryPointBasePath !== basePath ? ` from '${relativeImport}'` : '';
       }
@@ -198,7 +200,7 @@ export class EsmRenderingFormatter implements RenderingFormatter {
       const ngModuleName = info.ngModule.node.name.text;
       const declarationFile = absoluteFromSourceFile(info.declaration.getSourceFile());
       const ngModuleFile = absoluteFromSourceFile(info.ngModule.node.getSourceFile());
-      const relativePath = relative(dirname(declarationFile), ngModuleFile);
+      const relativePath = this.fs.relative(this.fs.dirname(declarationFile), ngModuleFile);
       const relativeImport = toRelativeImport(relativePath);
       const importPath = info.ngModule.ownedByModuleGuess ||
           (declarationFile !== ngModuleFile ? stripExtension(relativeImport) : null);

--- a/packages/compiler-cli/ngcc/src/rendering/renderer.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/renderer.ts
@@ -9,7 +9,7 @@ import {ConstantPool, Expression, jsDocComment, LeadingComment, Statement, Wrapp
 import MagicString from 'magic-string';
 import * as ts from 'typescript';
 
-import {FileSystem} from '../../../src/ngtsc/file_system';
+import {ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {Logger} from '../../../src/ngtsc/logging';
 import {ImportManager} from '../../../src/ngtsc/translator';
 import {ParsedConfiguration} from '../../../src/perform_compile';
@@ -33,7 +33,7 @@ import {FileToWrite, getImportRewriter, stripExtension} from './utils';
 export class Renderer {
   constructor(
       private host: NgccReflectionHost, private srcFormatter: RenderingFormatter,
-      private fs: FileSystem, private logger: Logger, private bundle: EntryPointBundle,
+      private fs: ReadonlyFileSystem, private logger: Logger, private bundle: EntryPointBundle,
       private tsConfig: ParsedConfiguration|null = null) {}
 
   renderProgram(

--- a/packages/compiler-cli/ngcc/src/rendering/source_maps.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/source_maps.ts
@@ -9,7 +9,7 @@ import {fromObject, generateMapFileComment, SourceMapConverter} from 'convert-so
 import MagicString from 'magic-string';
 import * as ts from 'typescript';
 
-import {absoluteFrom, absoluteFromSourceFile, basename, FileSystem} from '../../../src/ngtsc/file_system';
+import {absoluteFrom, absoluteFromSourceFile, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {Logger} from '../../../src/ngtsc/logging';
 import {RawSourceMap, SourceFileLoader} from '../../../src/ngtsc/sourcemaps';
 
@@ -26,7 +26,7 @@ export interface SourceMapInfo {
  * with an appropriate source-map comment pointing to the merged source-map.
  */
 export function renderSourceAndMap(
-    logger: Logger, fs: FileSystem, sourceFile: ts.SourceFile,
+    logger: Logger, fs: ReadonlyFileSystem, sourceFile: ts.SourceFile,
     generatedMagicString: MagicString): FileToWrite[] {
   const generatedPath = absoluteFromSourceFile(sourceFile);
   const generatedMapPath = absoluteFrom(`${generatedPath}.map`);
@@ -55,7 +55,7 @@ export function renderSourceAndMap(
         {path: generatedPath, contents: `${generatedFile.contents}\n${mergedMap.toComment()}`}
       ];
     } else {
-      const sourceMapComment = generateMapFileComment(`${basename(generatedPath)}.map`);
+      const sourceMapComment = generateMapFileComment(`${fs.basename(generatedPath)}.map`);
       return [
         {path: generatedPath, contents: `${generatedFile.contents}\n${sourceMapComment}`},
         {path: generatedMapPath, contents: mergedMap.toJSON()}

--- a/packages/compiler-cli/ngcc/src/rendering/umd_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/umd_rendering_formatter.ts
@@ -5,10 +5,10 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {dirname, relative} from 'canonical-path';
 import MagicString from 'magic-string';
 import * as ts from 'typescript';
 
+import {PathManipulation} from '../../../src/ngtsc/file_system';
 import {Reexport} from '../../../src/ngtsc/imports';
 import {Import, ImportManager} from '../../../src/ngtsc/translator';
 import {ExportInfo} from '../analysis/private_declarations_analyzer';
@@ -26,8 +26,8 @@ type AmdConditional = ts.ConditionalExpression&{whenTrue: ts.CallExpression};
  * wrapper function for AMD, CommonJS and global module formats.
  */
 export class UmdRenderingFormatter extends Esm5RenderingFormatter {
-  constructor(protected umdHost: UmdReflectionHost, isCore: boolean) {
-    super(umdHost, isCore);
+  constructor(fs: PathManipulation, protected umdHost: UmdReflectionHost, isCore: boolean) {
+    super(fs, umdHost, isCore);
   }
 
   /**
@@ -87,7 +87,7 @@ export class UmdRenderingFormatter extends Esm5RenderingFormatter {
         lastStatement ? lastStatement.getEnd() : factoryFunction.body.getEnd() - 1;
     exports.forEach(e => {
       const basePath = stripExtension(e.from);
-      const relativePath = './' + relative(dirname(entryPointBasePath), basePath);
+      const relativePath = './' + this.fs.relative(this.fs.dirname(entryPointBasePath), basePath);
       const namedImport = entryPointBasePath !== basePath ?
           importManager.generateNamedImport(relativePath, e.identifier) :
           {symbol: e.identifier, moduleImport: null};

--- a/packages/compiler-cli/ngcc/src/utils.ts
+++ b/packages/compiler-cli/ngcc/src/utils.ts
@@ -7,7 +7,7 @@
  */
 import * as ts from 'typescript';
 
-import {absoluteFrom, AbsoluteFsPath, FileSystem, isRooted} from '../../src/ngtsc/file_system';
+import {absoluteFrom, AbsoluteFsPath, isRooted, ReadonlyFileSystem} from '../../src/ngtsc/file_system';
 import {DeclarationNode, KnownDeclaration} from '../../src/ngtsc/reflection';
 
 /**
@@ -122,7 +122,7 @@ export class FactoryMap<K, V> {
  * @returns An absolute path to the first matching existing file, or `null` if none exist.
  */
 export function resolveFileWithPostfixes(
-    fs: FileSystem, path: AbsoluteFsPath, postFixes: string[]): AbsoluteFsPath|null {
+    fs: ReadonlyFileSystem, path: AbsoluteFsPath, postFixes: string[]): AbsoluteFsPath|null {
   for (const postFix of postFixes) {
     const testPath = absoluteFrom(path + postFix);
     if (fs.exists(testPath) && fs.stat(testPath).isFile()) {

--- a/packages/compiler-cli/ngcc/src/writing/cleaning/package_cleaner.ts
+++ b/packages/compiler-cli/ngcc/src/writing/cleaning/package_cleaner.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem} from '../../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, FileSystem, ReadonlyFileSystem} from '../../../../src/ngtsc/file_system';
 import {needsCleaning} from '../../packages/build_marker';
 import {EntryPoint} from '../../packages/entry_point';
 
@@ -16,7 +16,7 @@ import {isLocalDirectory} from './utils';
  * A class that can clean ngcc artifacts from a directory.
  */
 export class PackageCleaner {
-  constructor(private fs: FileSystem, private cleaners: CleaningStrategy[]) {}
+  constructor(private fs: ReadonlyFileSystem, private cleaners: CleaningStrategy[]) {}
 
   /**
    * Recurse through the file-system cleaning files and directories as determined by the configured

--- a/packages/compiler-cli/ngcc/src/writing/cleaning/utils.ts
+++ b/packages/compiler-cli/ngcc/src/writing/cleaning/utils.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem} from '../../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, ReadonlyFileSystem} from '../../../../src/ngtsc/file_system';
 
 /**
  * Returns true if the given `path` is a directory (not a symlink) and actually exists.
@@ -13,7 +13,7 @@ import {AbsoluteFsPath, FileSystem} from '../../../../src/ngtsc/file_system';
  * @param fs the current filesystem
  * @param path the path to check
  */
-export function isLocalDirectory(fs: FileSystem, path: AbsoluteFsPath): boolean {
+export function isLocalDirectory(fs: ReadonlyFileSystem, path: AbsoluteFsPath): boolean {
   if (fs.exists(path)) {
     const stat = fs.lstat(path);
     return stat.isDirectory();

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/directory_walker_entry_point_finder_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, relative} from '../../../src/ngtsc/file_system';
+import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
 import {loadTestFiles} from '../../../src/ngtsc/testing';
@@ -114,7 +114,7 @@ runInEachFileSystem(() => {
         loadTestFiles(createPackage(basePath, 'some-package'));
         spyOn(config, 'getPackageConfig')
             .and.returnValue(
-                new ProcessedNgccPackageConfig(_Abs('/project/node_modules/some-package'), {
+                new ProcessedNgccPackageConfig(fs, _Abs('/project/node_modules/some-package'), {
                   entryPoints: {
                     '.': {ignore: true},
                   },
@@ -137,7 +137,7 @@ runInEachFileSystem(() => {
         ]);
         spyOn(config, 'getPackageConfig')
             .and.returnValue(
-                new ProcessedNgccPackageConfig(_Abs('/project/node_modules/some-package'), {
+                new ProcessedNgccPackageConfig(fs, _Abs('/project/node_modules/some-package'), {
                   entryPoints: {
                     './sub-entry-point-1': {ignore: true},
                   },
@@ -457,7 +457,7 @@ runInEachFileSystem(() => {
       function dumpEntryPointPaths(
           basePath: AbsoluteFsPath, entryPoints: EntryPoint[]): [string, string][] {
         return entryPoints.map(
-            x => [relative(basePath, x.packagePath), relative(basePath, x.path)]);
+            x => [fs.relative(basePath, x.packagePath), fs.relative(basePath, x.path)]);
       }
     });
   });

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/program_based_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/program_based_entry_point_finder_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, relative} from '../../../src/ngtsc/file_system';
+import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
 import {loadTestFiles} from '../../../src/ngtsc/testing';
@@ -231,7 +231,7 @@ runInEachFileSystem(() => {
       function dumpEntryPointPaths(
           basePath: AbsoluteFsPath, entryPoints: EntryPoint[]): [string, string][] {
         return entryPoints.map(
-            x => [relative(basePath, x.packagePath), relative(basePath, x.path)]);
+            x => [fs.relative(basePath, x.packagePath), fs.relative(basePath, x.path)]);
       }
     });
   });

--- a/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
+++ b/packages/compiler-cli/ngcc/test/entry_point_finder/targeted_entry_point_finder_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, relative} from '../../../src/ngtsc/file_system';
+import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
 import {loadTestFiles} from '../../../src/ngtsc/testing';
@@ -118,7 +118,7 @@ runInEachFileSystem(() => {
         loadTestFiles(createPackage(basePath, 'some-package'));
         spyOn(config, 'getPackageConfig')
             .and.returnValue(
-                new ProcessedNgccPackageConfig(_Abs('/project/node_modules/some-package'), {
+                new ProcessedNgccPackageConfig(fs, _Abs('/project/node_modules/some-package'), {
                   entryPoints: {
                     '.': {ignore: true},
                   },
@@ -383,7 +383,7 @@ runInEachFileSystem(() => {
       function dumpEntryPointPaths(
           basePath: AbsoluteFsPath, entryPoints: EntryPoint[]): [string, string][] {
         return entryPoints.map(
-            x => [relative(basePath, x.packagePath), relative(basePath, x.path)]);
+            x => [fs.relative(basePath, x.packagePath), fs.relative(basePath, x.path)]);
       }
     });
 
@@ -419,7 +419,7 @@ runInEachFileSystem(() => {
         loadTestFiles(createPackage(basePath, 'some-package'));
         spyOn(config, 'getPackageConfig')
             .and.returnValue(
-                new ProcessedNgccPackageConfig(_Abs('/project/node_modules/some-package'), {
+                new ProcessedNgccPackageConfig(fs, _Abs('/project/node_modules/some-package'), {
                   entryPoints: {
                     '.': {ignore: true},
                   },

--- a/packages/compiler-cli/ngcc/test/helpers/mock_lock_file.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/mock_lock_file.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {FileSystem} from '../../../src/ngtsc/file_system';
+import {PathManipulation} from '../../../src/ngtsc/file_system';
 import {LockFile} from '../../src/locking/lock_file';
 
 /**
@@ -13,7 +13,7 @@ import {LockFile} from '../../src/locking/lock_file';
  */
 export class MockLockFile implements LockFile {
   constructor(
-      fs: FileSystem, private log: string[] = [], public path = fs.resolve('/lockfile'),
+      fs: PathManipulation, private log: string[] = [], public path = fs.resolve('/lockfile'),
       private pid = '1234') {}
   write() {
     this.log.push('write()');

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -10,7 +10,7 @@
 import {readFileSync} from 'fs';
 import * as os from 'os';
 
-import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, join} from '../../../src/ngtsc/file_system';
+import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem} from '../../../src/ngtsc/file_system';
 import {Folder, MockFileSystem, runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
 import {loadStandardTestFiles, loadTestFiles} from '../../../src/ngtsc/testing';
@@ -1017,7 +1017,7 @@ runInEachFileSystem(() => {
 
     function markPropertiesAsProcessed(packagePath: string, properties: EntryPointJsonProperty[]) {
       const basePath = _('/node_modules');
-      const targetPackageJsonPath = join(basePath, packagePath, 'package.json');
+      const targetPackageJsonPath = fs.join(basePath, packagePath, 'package.json');
       const targetPackage = loadPackage(packagePath);
       markAsProcessed(
           pkgJsonUpdater, targetPackage, targetPackageJsonPath, ['typings', ...properties]);

--- a/packages/compiler-cli/ngcc/test/packages/configuration_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/configuration_spec.ts
@@ -7,7 +7,7 @@
  */
 import {createHash} from 'crypto';
 
-import {absoluteFrom, FileSystem, getFileSystem} from '../../../src/ngtsc/file_system';
+import {absoluteFrom, getFileSystem, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadTestFiles} from '../../../src/ngtsc/testing';
 import {DEFAULT_NGCC_CONFIG, NgccConfiguration, ProcessLockingConfiguration} from '../../src/packages/configuration';
@@ -15,7 +15,7 @@ import {DEFAULT_NGCC_CONFIG, NgccConfiguration, ProcessLockingConfiguration} fro
 
 runInEachFileSystem(() => {
   let _Abs: typeof absoluteFrom;
-  let fs: FileSystem;
+  let fs: ReadonlyFileSystem;
 
   beforeEach(() => {
     _Abs = absoluteFrom;

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_manifest_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_manifest_spec.ts
@@ -225,7 +225,7 @@ runInEachFileSystem(() => {
 
         spyOn(config, 'getPackageConfig')
             .and.returnValue(
-                new ProcessedNgccPackageConfig(_Abs('/project/node_modules/some_package'), {
+                new ProcessedNgccPackageConfig(fs, _Abs('/project/node_modules/some_package'), {
                   entryPoints: {
                     './ignored_entry_point': {ignore: true},
                   },

--- a/packages/compiler-cli/ngcc/test/rendering/commonjs_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/commonjs_rendering_formatter_spec.ts
@@ -157,7 +157,7 @@ exports.D = D;
           new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();
       const switchMarkerAnalyses = new SwitchMarkerAnalyzer(host, bundle.entryPoint.packagePath)
                                        .analyzeProgram(bundle.src.program);
-      const renderer = new CommonJsRenderingFormatter(host, false);
+      const renderer = new CommonJsRenderingFormatter(fs, host, false);
       const importManager = new ImportManager(new NoopImportRewriter(), 'i');
       return {
         host,

--- a/packages/compiler-cli/ngcc/test/rendering/esm5_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm5_rendering_formatter_spec.ts
@@ -34,7 +34,7 @@ function setup(file: {name: AbsoluteFsPath, contents: string}) {
       new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();
   const switchMarkerAnalyses = new SwitchMarkerAnalyzer(host, bundle.entryPoint.packagePath)
                                    .analyzeProgram(bundle.src.program);
-  const renderer = new Esm5RenderingFormatter(host, false);
+  const renderer = new Esm5RenderingFormatter(fs, host, false);
   const importManager = new ImportManager(new NoopImportRewriter(), IMPORT_PREFIX);
   return {
     host,

--- a/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
@@ -40,7 +40,7 @@ function setup(files: TestFile[], dtsFiles?: TestFile[]) {
       new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();
   const switchMarkerAnalyses = new SwitchMarkerAnalyzer(host, bundle.entryPoint.packagePath)
                                    .analyzeProgram(bundle.src.program);
-  const renderer = new EsmRenderingFormatter(host, false);
+  const renderer = new EsmRenderingFormatter(fs, host, false);
   const importManager = new ImportManager(new NoopImportRewriter(), IMPORT_PREFIX);
   return {
     host,

--- a/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
@@ -34,7 +34,7 @@ function setup(file: TestFile) {
       new DecorationAnalyzer(fs, bundle, host, referencesRegistry).analyzeProgram();
   const switchMarkerAnalyses =
       new SwitchMarkerAnalyzer(host, bundle.entryPoint.packagePath).analyzeProgram(src.program);
-  const renderer = new UmdRenderingFormatter(host, false);
+  const renderer = new UmdRenderingFormatter(fs, host, false);
   const importManager = new ImportManager(new NoopImportRewriter(), 'i');
   return {
     decorationAnalyses,

--- a/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {absoluteFrom, FileSystem, getFileSystem, join} from '../../../src/ngtsc/file_system';
+import {absoluteFrom, FileSystem, getFileSystem} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
 import {loadTestFiles} from '../../../src/ngtsc/testing';
@@ -578,7 +578,7 @@ runInEachFileSystem(() => {
 
       it('should revert changes to `package.json`', () => {
         const entryPoint = esm5bundle.entryPoint;
-        const packageJsonPath = join(entryPoint.packagePath, 'package.json');
+        const packageJsonPath = fs.join(entryPoint.packagePath, 'package.json');
 
         fileWriter.writeBundle(
             esm5bundle,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -10,8 +10,8 @@ import {compileComponentFromMetadata, compileDeclareComponentFromMetadata, Const
 import * as ts from 'typescript';
 
 import {CycleAnalyzer} from '../../cycles';
-import {ErrorCode, FatalDiagnosticError, ngErrorCode} from '../../diagnostics';
-import {absoluteFrom, relative, resolve} from '../../file_system';
+import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
+import {absoluteFrom, relative} from '../../file_system';
 import {DefaultImportRecorder, ModuleResolver, Reference, ReferenceEmitter} from '../../imports';
 import {DependencyTracker} from '../../incremental/api';
 import {IndexingContext} from '../../indexer';
@@ -21,7 +21,6 @@ import {ClassDeclaration, DeclarationNode, Decorator, ReflectionHost, reflectObj
 import {ComponentScopeReader, LocalModuleScopeRegistry, TypeCheckScopeRegistry} from '../../scope';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerFlags, HandlerPrecedence, ResolveResult} from '../../transform';
 import {TemplateSourceMapping, TypeCheckContext} from '../../typecheck/api';
-import {getTemplateId, makeTemplateDiagnostic} from '../../typecheck/diagnostics';
 import {tsSourceMapBug29300Fixed} from '../../util/src/ts_source_map_bug_29300';
 import {SubsetOfKeys} from '../../util/src/typescript';
 

--- a/packages/compiler-cli/src/ngtsc/cycles/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/cycles/test/util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as ts from 'typescript';
-import {FileSystem} from '../../file_system';
+import {PathManipulation} from '../../file_system';
 import {TestFile} from '../../file_system/testing';
 import {makeProgram} from '../../testing';
 
@@ -31,7 +31,7 @@ import {makeProgram} from '../../testing';
  *
  * represents a program where a.ts exports from b.ts and imports from c.ts.
  */
-export function makeProgramFromGraph(fs: FileSystem, graph: string): {
+export function makeProgramFromGraph(fs: PathManipulation, graph: string): {
   program: ts.Program,
   host: ts.CompilerHost,
   options: ts.CompilerOptions,

--- a/packages/compiler-cli/src/ngtsc/file_system/README.md
+++ b/packages/compiler-cli/src/ngtsc/file_system/README.md
@@ -3,7 +3,15 @@
 To improve cross platform support, all file access (and path manipulation)
 is now done through a well known interface (`FileSystem`).
 
-For testing a number of `MockFileSystem` implementations are supplied.
+Note that `FileSystem` extends `ReadonlyFileSystem`, which itself extends
+`PathManipulation`.
+If you are using a file-system object you should only ask for the type that supports
+all the methods that you require.
+For example, if you have a function (`foo()`) that only needs to resolve paths then
+it should only require `PathManipulation`: `foo(fs: PathManipulation)`.
+This allows the caller to avoid implementing unneeded functionality.
+
+For testing, a number of `MockFileSystem` implementations are supplied.
 These provide an in-memory file-system which emulates operating systems
 like OS/X, Unix and Windows.
 
@@ -15,6 +23,11 @@ has been initialized before using any of these helper methods.
 To prevent this happening accidentally the current file system always starts out
 as an instance of `InvalidFileSystem`, which will throw an error if any of its
 methods are called.
+
+Generally it is safer to explicitly pass file-system objects to constructors or
+free-standing functions if possible. This avoids confusing bugs where the
+global file-system has not been set-up correctly before calling functions that
+expect there to be a file-system configured globally.
 
 You can set the current file-system by calling `setFileSystem()`.
 During testing you can call the helper function `initMockFileSystem(os)`

--- a/packages/compiler-cli/src/ngtsc/file_system/index.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/index.ts
@@ -9,5 +9,5 @@ export {NgtscCompilerHost} from './src/compiler_host';
 export {absoluteFrom, absoluteFromSourceFile, basename, dirname, getFileSystem, isLocalRelativePath, isRoot, isRooted, join, relative, relativeFrom, resolve, setFileSystem, toRelativeImport} from './src/helpers';
 export {LogicalFileSystem, LogicalProjectPath} from './src/logical';
 export {NodeJSFileSystem} from './src/node_js_file_system';
-export {AbsoluteFsPath, FileStats, FileSystem, PathSegment, PathString} from './src/types';
+export {AbsoluteFsPath, FileStats, FileSystem, PathManipulation, PathSegment, PathString, ReadonlyFileSystem} from './src/types';
 export {getSourceFileOrError} from './src/util';

--- a/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
@@ -9,73 +9,17 @@
 import * as fs from 'fs';
 import * as fsExtra from 'fs-extra';
 import * as p from 'path';
-import {absoluteFrom} from './helpers';
-import {AbsoluteFsPath, FileStats, FileSystem, PathSegment, PathString} from './types';
+import {AbsoluteFsPath, FileStats, FileSystem, PathManipulation, PathSegment, PathString, ReadonlyFileSystem} from './types';
 
 /**
- * A wrapper around the Node.js file-system (i.e the `fs` package).
+ * A wrapper around the Node.js file-system that supports path manipulation.
  */
-export class NodeJSFileSystem implements FileSystem {
-  private _caseSensitive: boolean|undefined = undefined;
-  exists(path: AbsoluteFsPath): boolean {
-    return fs.existsSync(path);
-  }
-  readFile(path: AbsoluteFsPath): string {
-    return fs.readFileSync(path, 'utf8');
-  }
-  readFileBuffer(path: AbsoluteFsPath): Uint8Array {
-    return fs.readFileSync(path);
-  }
-  writeFile(path: AbsoluteFsPath, data: string|Uint8Array, exclusive: boolean = false): void {
-    fs.writeFileSync(path, data, exclusive ? {flag: 'wx'} : undefined);
-  }
-  removeFile(path: AbsoluteFsPath): void {
-    fs.unlinkSync(path);
-  }
-  symlink(target: AbsoluteFsPath, path: AbsoluteFsPath): void {
-    fs.symlinkSync(target, path);
-  }
-  readdir(path: AbsoluteFsPath): PathSegment[] {
-    return fs.readdirSync(path) as PathSegment[];
-  }
-  lstat(path: AbsoluteFsPath): FileStats {
-    return fs.lstatSync(path);
-  }
-  stat(path: AbsoluteFsPath): FileStats {
-    return fs.statSync(path);
-  }
+export class NodeJSPathManipulation implements PathManipulation {
   pwd(): AbsoluteFsPath {
     return this.normalize(process.cwd()) as AbsoluteFsPath;
   }
   chdir(dir: AbsoluteFsPath): void {
     process.chdir(dir);
-  }
-  copyFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void {
-    fs.copyFileSync(from, to);
-  }
-  moveFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void {
-    fs.renameSync(from, to);
-  }
-  ensureDir(path: AbsoluteFsPath): void {
-    const parents: AbsoluteFsPath[] = [];
-    while (!this.isRoot(path) && !this.exists(path)) {
-      parents.push(path);
-      path = this.dirname(path);
-    }
-    while (parents.length) {
-      this.safeMkdir(parents.pop()!);
-    }
-  }
-  removeDeep(path: AbsoluteFsPath): void {
-    fsExtra.removeSync(path);
-  }
-  isCaseSensitive(): boolean {
-    if (this._caseSensitive === undefined) {
-      // Note the use of the real file-system is intentional:
-      // `this.exists()` relies upon `isCaseSensitive()` so that would cause an infinite recursion.
-      this._caseSensitive = !fs.existsSync(togglePathCase(__filename));
-    }
-    return this._caseSensitive;
   }
   resolve(...paths: string[]): AbsoluteFsPath {
     return this.normalize(p.resolve(...paths)) as AbsoluteFsPath;
@@ -102,15 +46,82 @@ export class NodeJSFileSystem implements FileSystem {
   extname(path: AbsoluteFsPath|PathSegment): string {
     return p.extname(path);
   }
+  normalize<T extends string>(path: T): T {
+    // Convert backslashes to forward slashes
+    return path.replace(/\\/g, '/') as T;
+  }
+}
+
+/**
+ * A wrapper around the Node.js file-system that supports readonly operations and path manipulation.
+ */
+export class NodeJSReadonlyFileSystem extends NodeJSPathManipulation implements ReadonlyFileSystem {
+  private _caseSensitive: boolean|undefined = undefined;
+  isCaseSensitive(): boolean {
+    if (this._caseSensitive === undefined) {
+      // Note the use of the real file-system is intentional:
+      // `this.exists()` relies upon `isCaseSensitive()` so that would cause an infinite recursion.
+      this._caseSensitive = !fs.existsSync(this.normalize(toggleCase(__filename)));
+    }
+    return this._caseSensitive;
+  }
+  exists(path: AbsoluteFsPath): boolean {
+    return fs.existsSync(path);
+  }
+  readFile(path: AbsoluteFsPath): string {
+    return fs.readFileSync(path, 'utf8');
+  }
+  readFileBuffer(path: AbsoluteFsPath): Uint8Array {
+    return fs.readFileSync(path);
+  }
+  readdir(path: AbsoluteFsPath): PathSegment[] {
+    return fs.readdirSync(path) as PathSegment[];
+  }
+  lstat(path: AbsoluteFsPath): FileStats {
+    return fs.lstatSync(path);
+  }
+  stat(path: AbsoluteFsPath): FileStats {
+    return fs.statSync(path);
+  }
   realpath(path: AbsoluteFsPath): AbsoluteFsPath {
     return this.resolve(fs.realpathSync(path));
   }
   getDefaultLibLocation(): AbsoluteFsPath {
     return this.resolve(require.resolve('typescript'), '..');
   }
-  normalize<T extends string>(path: T): T {
-    // Convert backslashes to forward slashes
-    return path.replace(/\\/g, '/') as T;
+}
+
+/**
+ * A wrapper around the Node.js file-system (i.e. the `fs` package).
+ */
+export class NodeJSFileSystem extends NodeJSReadonlyFileSystem implements FileSystem {
+  writeFile(path: AbsoluteFsPath, data: string|Uint8Array, exclusive: boolean = false): void {
+    fs.writeFileSync(path, data, exclusive ? {flag: 'wx'} : undefined);
+  }
+  removeFile(path: AbsoluteFsPath): void {
+    fs.unlinkSync(path);
+  }
+  symlink(target: AbsoluteFsPath, path: AbsoluteFsPath): void {
+    fs.symlinkSync(target, path);
+  }
+  copyFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void {
+    fs.copyFileSync(from, to);
+  }
+  moveFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void {
+    fs.renameSync(from, to);
+  }
+  ensureDir(path: AbsoluteFsPath): void {
+    const parents: AbsoluteFsPath[] = [];
+    while (!this.isRoot(path) && !this.exists(path)) {
+      parents.push(path);
+      path = this.dirname(path);
+    }
+    while (parents.length) {
+      this.safeMkdir(parents.pop()!);
+    }
+  }
+  removeDeep(path: AbsoluteFsPath): void {
+    fsExtra.removeSync(path);
   }
 
   private safeMkdir(path: AbsoluteFsPath): void {
@@ -127,9 +138,8 @@ export class NodeJSFileSystem implements FileSystem {
 }
 
 /**
- * Toggle the case of each character in a file path.
+ * Toggle the case of each character in a string.
  */
-function togglePathCase(str: string): AbsoluteFsPath {
-  return absoluteFrom(
-      str.replace(/\w/g, ch => ch.toUpperCase() === ch ? ch.toLowerCase() : ch.toUpperCase()));
+function toggleCase(str: string): string {
+  return str.replace(/\w/g, ch => ch.toUpperCase() === ch ? ch.toLowerCase() : ch.toUpperCase());
 }

--- a/packages/compiler-cli/src/ngtsc/file_system/src/types.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/types.ts
@@ -29,33 +29,14 @@ export type AbsoluteFsPath = BrandedPath<'AbsoluteFsPath'>;
 export type PathSegment = BrandedPath<'PathSegment'>;
 
 /**
- * A basic interface to abstract the underlying file-system.
- *
- * This makes it easier to provide mock file-systems in unit tests,
- * but also to create clever file-systems that have features such as caching.
+ * An abstraction over the path manipulation aspects of a file-system.
  */
-export interface FileSystem {
-  exists(path: AbsoluteFsPath): boolean;
-  readFile(path: AbsoluteFsPath): string;
-  readFileBuffer(path: AbsoluteFsPath): Uint8Array;
-  writeFile(path: AbsoluteFsPath, data: string|Uint8Array, exclusive?: boolean): void;
-  removeFile(path: AbsoluteFsPath): void;
-  symlink(target: AbsoluteFsPath, path: AbsoluteFsPath): void;
-  readdir(path: AbsoluteFsPath): PathSegment[];
-  lstat(path: AbsoluteFsPath): FileStats;
-  stat(path: AbsoluteFsPath): FileStats;
-  pwd(): AbsoluteFsPath;
-  chdir(path: AbsoluteFsPath): void;
+export interface PathManipulation {
   extname(path: AbsoluteFsPath|PathSegment): string;
-  copyFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void;
-  moveFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void;
-  ensureDir(path: AbsoluteFsPath): void;
-  removeDeep(path: AbsoluteFsPath): void;
-  isCaseSensitive(): boolean;
   isRoot(path: AbsoluteFsPath): boolean;
   isRooted(path: string): boolean;
-  resolve(...paths: string[]): AbsoluteFsPath;
   dirname<T extends PathString>(file: T): T;
+  extname(path: AbsoluteFsPath|PathSegment): string;
   join<T extends PathString>(basePath: T, ...paths: string[]): T;
   /**
    * Compute the relative path between `from` and `to`.
@@ -66,9 +47,41 @@ export interface FileSystem {
    */
   relative<T extends PathString>(from: T, to: T): PathSegment|AbsoluteFsPath;
   basename(filePath: string, extension?: string): PathSegment;
+  normalize<T extends PathString>(path: T): T;
+  resolve(...paths: string[]): AbsoluteFsPath;
+  pwd(): AbsoluteFsPath;
+  chdir(path: AbsoluteFsPath): void;
+}
+
+/**
+ * An abstraction over the read-only aspects of a file-system.
+ */
+export interface ReadonlyFileSystem extends PathManipulation {
+  isCaseSensitive(): boolean;
+  exists(path: AbsoluteFsPath): boolean;
+  readFile(path: AbsoluteFsPath): string;
+  readFileBuffer(path: AbsoluteFsPath): Uint8Array;
+  readdir(path: AbsoluteFsPath): PathSegment[];
+  lstat(path: AbsoluteFsPath): FileStats;
+  stat(path: AbsoluteFsPath): FileStats;
   realpath(filePath: AbsoluteFsPath): AbsoluteFsPath;
   getDefaultLibLocation(): AbsoluteFsPath;
-  normalize<T extends PathString>(path: T): T;
+}
+
+/**
+ * A basic interface to abstract the underlying file-system.
+ *
+ * This makes it easier to provide mock file-systems in unit tests,
+ * but also to create clever file-systems that have features such as caching.
+ */
+export interface FileSystem extends ReadonlyFileSystem {
+  writeFile(path: AbsoluteFsPath, data: string|Uint8Array, exclusive?: boolean): void;
+  removeFile(path: AbsoluteFsPath): void;
+  symlink(target: AbsoluteFsPath, path: AbsoluteFsPath): void;
+  copyFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void;
+  moveFile(from: AbsoluteFsPath, to: AbsoluteFsPath): void;
+  ensureDir(path: AbsoluteFsPath): void;
+  removeDeep(path: AbsoluteFsPath): void;
 }
 
 export type PathString = string|AbsoluteFsPath|PathSegment;

--- a/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file.ts
+++ b/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file.ts
@@ -8,7 +8,7 @@
 import {removeComments, removeMapFileComments} from 'convert-source-map';
 import {decode, encode, SourceMapMappings, SourceMapSegment} from 'sourcemap-codec';
 
-import {AbsoluteFsPath, FileSystem} from '../../file_system';
+import {AbsoluteFsPath, PathManipulation} from '../../file_system';
 
 import {RawSourceMap} from './raw_source_map';
 import {compareSegments, offsetSegment, SegmentMarker} from './segment_marker';
@@ -39,7 +39,7 @@ export class SourceFile {
       readonly inline: boolean,
       /** Any source files referenced by the raw source map associated with this source file. */
       readonly sources: (SourceFile|null)[],
-      private fs: FileSystem,
+      private fs: PathManipulation,
   ) {
     this.contents = removeSourceMapComments(contents);
     this.startOfLinePositions = computeStartOfLinePositions(this.contents);

--- a/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file_loader.ts
+++ b/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file_loader.ts
@@ -7,7 +7,7 @@
  */
 import {commentRegex, fromComment, mapFileCommentRegex} from 'convert-source-map';
 
-import {AbsoluteFsPath, FileSystem} from '../../file_system';
+import {AbsoluteFsPath, ReadonlyFileSystem} from '../../file_system';
 import {Logger} from '../../logging';
 
 import {RawSourceMap} from './raw_source_map';
@@ -28,7 +28,7 @@ export class SourceFileLoader {
   private currentPaths: AbsoluteFsPath[] = [];
 
   constructor(
-      private fs: FileSystem, private logger: Logger,
+      private fs: ReadonlyFileSystem, private logger: Logger,
       /** A map of URL schemes to base paths. The scheme name should be lowercase. */
       private schemeMap: Record<string, AbsoluteFsPath>) {}
 

--- a/packages/compiler-cli/src/ngtsc/sourcemaps/test/source_file_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/sourcemaps/test/source_file_spec.ts
@@ -7,7 +7,7 @@
  */
 import {encode} from 'sourcemap-codec';
 
-import {absoluteFrom, FileSystem, getFileSystem} from '../../file_system';
+import {absoluteFrom, getFileSystem, PathManipulation} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {RawSourceMap} from '../src/raw_source_map';
 import {SegmentMarker} from '../src/segment_marker';
@@ -15,7 +15,7 @@ import {computeStartOfLinePositions, ensureOriginalSegmentLinks, extractOriginal
 
 runInEachFileSystem(() => {
   describe('SourceFile and utilities', () => {
-    let fs: FileSystem;
+    let fs: PathManipulation;
     let _: typeof absoluteFrom;
 
     beforeEach(() => {

--- a/packages/compiler-cli/src/ngtsc/testing/src/mock_file_loading.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/src/mock_file_loading.ts
@@ -109,6 +109,11 @@ function loadAngularFolder(): Folder {
 
 /**
  * Load real files from the real file-system into a mock file-system.
+ *
+ * Note that this function contains a mix of `FileSystem` calls and NodeJS `fs` calls.
+ * This is because the function is a bridge between the "real" file-system (via `fs`) and the "mock"
+ * file-system (via `FileSystem`).
+ *
  * @param fs the file-system where the directory is to be loaded.
  * @param directoryPath the path to the directory we want to load.
  * @param mockPath the path within the mock file-system where the directory is to be loaded.

--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -9,7 +9,7 @@
 import {isSyntaxError, Position} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, relative, resolve} from '../src/ngtsc/file_system';
+import {absoluteFrom, AbsoluteFsPath, getFileSystem, ReadonlyFileSystem, relative, resolve} from '../src/ngtsc/file_system';
 
 import {replaceTsWithNgInErrors} from './ngtsc/diagnostics';
 import * as api from './transformers/api';
@@ -109,10 +109,8 @@ export function formatDiagnostics(
 }
 
 /** Used to read configuration files. */
-// TODO(ayazhafiz): split FileSystem into a ReadonlyFileSystem and make this a
-// subset of that.
-export type ConfigurationHost =
-    Pick<FileSystem, 'readFile'|'exists'|'lstat'|'resolve'|'join'|'dirname'|'extname'|'pwd'>;
+export type ConfigurationHost = Pick<
+    ReadonlyFileSystem, 'readFile'|'exists'|'lstat'|'resolve'|'join'|'dirname'|'extname'|'pwd'>;
 
 export interface ParsedConfiguration {
   project: string;

--- a/packages/compiler-cli/test/compliance/test_helpers/check_expectations.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/check_expectations.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {FileSystem} from '../../../src/ngtsc/file_system';
+import {ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 
 import {getBuildOutputDirectory, getRootDirectory} from './compile_test';
 import {verifyUniqueFactory} from './di_checks';
@@ -33,7 +33,7 @@ const EXTRA_CHECK_FUNCTIONS: Record<string, ExtraCheckFunction> = {
  * @param expectedFiles The list of expected-generated pairs to compare.
  */
 export function checkExpectations(
-    fs: FileSystem, testPath: string, failureMessage: string, expectedFiles: ExpectedFile[],
+    fs: ReadonlyFileSystem, testPath: string, failureMessage: string, expectedFiles: ExpectedFile[],
     extraChecks: ExtraCheck[]): void {
   const builtDirectory = getBuildOutputDirectory(fs);
   for (const expectedFile of expectedFiles) {

--- a/packages/compiler-cli/test/compliance/test_helpers/compile_test.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/compile_test.ts
@@ -7,7 +7,7 @@
  */
 import * as ts from 'typescript';
 
-import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, FileSystem, PathManipulation, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {initMockFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadStandardTestFiles, loadTestDirectory, NgtscTestCompilerHost} from '../../../src/ngtsc/testing';
 import {Diagnostics, performCompilation} from '../../../src/perform_compile';
@@ -65,7 +65,7 @@ export function compileTest(
  *
  * @param fs the mock file-system where the compilation is happening.
  */
-export function getRootDirectory(fs: FileSystem): AbsoluteFsPath {
+export function getRootDirectory(fs: PathManipulation): AbsoluteFsPath {
   return fs.resolve('/');
 }
 
@@ -75,7 +75,7 @@ export function getRootDirectory(fs: FileSystem): AbsoluteFsPath {
  *
  * @param fs the mock file-system where the compilation is happening.
  */
-export function getBuildOutputDirectory(fs: FileSystem): AbsoluteFsPath {
+export function getBuildOutputDirectory(fs: PathManipulation): AbsoluteFsPath {
   return fs.resolve('/built');
 }
 
@@ -129,7 +129,7 @@ function getOptions(
  * This allows us to simulate, more reliably, files that have `\r\n` line-endings.
  * (See `test_cases/r3_view_compiler_i18n/line_ending_normalization/template.html`.)
  */
-function monkeyPatchReadFile(fs: FileSystem): void {
+function monkeyPatchReadFile(fs: ReadonlyFileSystem): void {
   const originalReadFile = fs.readFile;
   fs.readFile = (path: AbsoluteFsPath): string => {
     const file = originalReadFile.call(fs, path);

--- a/packages/compiler-cli/test/compliance/test_helpers/get_compliance_tests.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/get_compliance_tests.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem, NodeJSFileSystem, PathSegment} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, NodeJSFileSystem, PathSegment, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 
 const fs = new NodeJSFileSystem();
 const basePath = fs.resolve(__dirname, '../test_cases');
@@ -55,7 +55,7 @@ export function* getComplianceTests(testConfigPath: string): Generator<Complianc
 }
 
 function loadTestCasesFile(
-    fs: FileSystem, testCasesPath: AbsoluteFsPath, basePath: AbsoluteFsPath): any {
+    fs: ReadonlyFileSystem, testCasesPath: AbsoluteFsPath, basePath: AbsoluteFsPath): any {
   try {
     return JSON.parse(fs.readFile(testCasesPath));
   } catch (e) {

--- a/packages/compiler-cli/test/compliance/test_helpers/sourcemap_helpers.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/sourcemap_helpers.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem} from '../../../src/ngtsc/file_system';
+import {AbsoluteFsPath, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {ConsoleLogger, LogLevel} from '../../../src/ngtsc/logging';
 import {SourceFileLoader} from '../../../src/ngtsc/sourcemaps';
 
@@ -33,8 +33,8 @@ import {SourceFileLoader} from '../../../src/ngtsc/sourcemaps';
  * @returns The content of the expected source file, stripped of the mapping information.
  */
 export function checkMappings(
-    fs: FileSystem, generated: string, generatedPath: AbsoluteFsPath, expectedSource: string,
-    expectedPath: AbsoluteFsPath): string {
+    fs: ReadonlyFileSystem, generated: string, generatedPath: AbsoluteFsPath,
+    expectedSource: string, expectedPath: AbsoluteFsPath): string {
   const actualMappings = getMappedSegments(fs, generatedPath, generated);
 
   const {expected, mappings} = extractMappings(fs, expectedSource);
@@ -77,7 +77,7 @@ interface SegmentMapping {
  * @param expected The content of the expected file containing source-map information.
  */
 function extractMappings(
-    fs: FileSystem, expected: string): {expected: string, mappings: SegmentMapping[]} {
+    fs: ReadonlyFileSystem, expected: string): {expected: string, mappings: SegmentMapping[]} {
   const mappings: SegmentMapping[] = [];
   // capture and remove source mapping info
   expected = expected.replace(
@@ -113,7 +113,8 @@ function unescape(str: string): string {
  *     empty array is returned if there is no source-map file found.
  */
 function getMappedSegments(
-    fs: FileSystem, generatedPath: AbsoluteFsPath, generatedContents: string): SegmentMapping[] {
+    fs: ReadonlyFileSystem, generatedPath: AbsoluteFsPath,
+    generatedContents: string): SegmentMapping[] {
   const logger = new ConsoleLogger(LogLevel.debug);
   const loader = new SourceFileLoader(fs, logger, {});
   const generatedFile = loader.loadSourceFile(generatedPath, generatedContents);

--- a/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, resolve} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, getFileSystem, PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {AbsoluteSourceSpan, IdentifierKind, IndexedComponent, TopLevelIdentifier} from '@angular/compiler-cli/src/ngtsc/indexer';
 import {ParseSourceFile} from '@angular/compiler/src/compiler';
@@ -14,6 +14,7 @@ import {NgtscTestEnvironment} from './env';
 
 runInEachFileSystem(() => {
   describe('ngtsc component indexing', () => {
+    let fs: PathManipulation;
     let env!: NgtscTestEnvironment;
     let testSourceFile: AbsoluteFsPath;
     let testTemplateFile: AbsoluteFsPath;
@@ -21,8 +22,9 @@ runInEachFileSystem(() => {
     beforeEach(() => {
       env = NgtscTestEnvironment.setup();
       env.tsconfig();
-      testSourceFile = resolve(env.basePath, 'test.ts');
-      testTemplateFile = resolve(env.basePath, 'test.html');
+      fs = getFileSystem();
+      testSourceFile = fs.resolve(env.basePath, 'test.ts');
+      testTemplateFile = fs.resolve(env.basePath, 'test.html');
     });
 
     describe('indexing metadata', () => {

--- a/packages/localize/src/tools/src/extract/duplicates.ts
+++ b/packages/localize/src/tools/src/extract/duplicates.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵMessageId, ɵParsedMessage} from '@angular/localize';
 
 import {DiagnosticHandlingStrategy, Diagnostics} from '../diagnostics';
@@ -17,7 +17,7 @@ import {serializeLocationPosition} from '../source_file_utils';
  * object (as necessary).
  */
 export function checkDuplicateMessages(
-    fs: FileSystem, messages: ɵParsedMessage[],
+    fs: PathManipulation, messages: ɵParsedMessage[],
     duplicateMessageHandling: DiagnosticHandlingStrategy, basePath: AbsoluteFsPath): Diagnostics {
   const diagnostics = new Diagnostics();
   if (duplicateMessageHandling === 'ignore') return diagnostics;
@@ -47,7 +47,7 @@ export function checkDuplicateMessages(
  * Serialize the given `message` object into a string.
  */
 function serializeMessage(
-    fs: FileSystem, basePath: AbsoluteFsPath, message: ɵParsedMessage): string {
+    fs: PathManipulation, basePath: AbsoluteFsPath, message: ɵParsedMessage): string {
   if (message.location === undefined) {
     return `   - "${message.text}"`;
   } else {

--- a/packages/localize/src/tools/src/extract/extraction.ts
+++ b/packages/localize/src/tools/src/extract/extraction.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, ReadonlyFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {Logger} from '@angular/compiler-cli/src/ngtsc/logging';
 import {SourceFile, SourceFileLoader} from '@angular/compiler-cli/src/ngtsc/sourcemaps';
 import {ɵParsedMessage, ɵSourceLocation} from '@angular/localize';
@@ -33,7 +33,7 @@ export class MessageExtractor {
   private loader: SourceFileLoader;
 
   constructor(
-      private fs: FileSystem, private logger: Logger,
+      private fs: ReadonlyFileSystem, private logger: Logger,
       {basePath, useSourceMaps = true, localizeName = '$localize'}: ExtractionOptions) {
     this.basePath = basePath;
     this.useSourceMaps = useSourceMaps;

--- a/packages/localize/src/tools/src/extract/main.ts
+++ b/packages/localize/src/tools/src/extract/main.ts
@@ -6,7 +6,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {setFileSystem, NodeJSFileSystem, AbsoluteFsPath, FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {setFileSystem, NodeJSFileSystem, AbsoluteFsPath, FileSystem, PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ConsoleLogger, Logger, LogLevel} from '@angular/compiler-cli/src/ngtsc/logging';
 import {ɵParsedMessage} from '@angular/localize';
 import * as glob from 'glob';
@@ -214,7 +214,7 @@ export function extractTranslations({
 
 export function getSerializer(
     format: string, sourceLocale: string, rootPath: AbsoluteFsPath, useLegacyIds: boolean,
-    formatOptions: FormatOptions = {}, fs: FileSystem): TranslationSerializer {
+    formatOptions: FormatOptions = {}, fs: PathManipulation): TranslationSerializer {
   switch (format) {
     case 'xlf':
     case 'xlif':

--- a/packages/localize/src/tools/src/extract/source_files/es2015_extract_plugin.ts
+++ b/packages/localize/src/tools/src/extract/source_files/es2015_extract_plugin.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedMessage, ɵparseMessage} from '@angular/localize';
 import {NodePath, PluginObj} from '@babel/core';
 import {TaggedTemplateExpression} from '@babel/types';
@@ -13,7 +13,7 @@ import {TaggedTemplateExpression} from '@babel/types';
 import {getLocation, isGlobalIdentifier, isNamedIdentifier, unwrapExpressionsFromTemplateLiteral, unwrapMessagePartsFromTemplateLiteral} from '../../source_file_utils';
 
 export function makeEs2015ExtractPlugin(
-    fs: FileSystem, messages: ɵParsedMessage[], localizeName = '$localize'): PluginObj {
+    fs: PathManipulation, messages: ɵParsedMessage[], localizeName = '$localize'): PluginObj {
   return {
     visitor: {
       TaggedTemplateExpression(path: NodePath<TaggedTemplateExpression>) {

--- a/packages/localize/src/tools/src/extract/source_files/es5_extract_plugin.ts
+++ b/packages/localize/src/tools/src/extract/source_files/es5_extract_plugin.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedMessage, ɵparseMessage} from '@angular/localize';
 import {NodePath, PluginObj} from '@babel/core';
 import {CallExpression} from '@babel/types';
@@ -13,7 +13,7 @@ import {CallExpression} from '@babel/types';
 import {getLocation, isGlobalIdentifier, isNamedIdentifier, unwrapMessagePartsFromLocalizeCall, unwrapSubstitutionsFromLocalizeCall} from '../../source_file_utils';
 
 export function makeEs5ExtractPlugin(
-    fs: FileSystem, messages: ɵParsedMessage[], localizeName = '$localize'): PluginObj {
+    fs: PathManipulation, messages: ɵParsedMessage[], localizeName = '$localize'): PluginObj {
   return {
     visitor: {
       CallExpression(callPath: NodePath<CallExpression>) {

--- a/packages/localize/src/tools/src/extract/translation_files/arb_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/arb_translation_serializer.ts
@@ -5,9 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedMessage, ɵSourceLocation} from '@angular/localize';
-import {ArbJsonObject, ArbLocation, ArbMetadata} from '../../translate/translation_files/translation_parsers/arb_translation_parser';
 import {TranslationSerializer} from './translation_serializer';
 import {consolidateMessages, hasLocation} from './utils';
 
@@ -45,7 +44,8 @@ import {consolidateMessages, hasLocation} from './utils';
  */
 export class ArbTranslationSerializer implements TranslationSerializer {
   constructor(
-      private sourceLocale: string, private basePath: AbsoluteFsPath, private fs: FileSystem) {}
+      private sourceLocale: string, private basePath: AbsoluteFsPath,
+      private fs: PathManipulation) {}
 
   serialize(messages: ɵParsedMessage[]): string {
     const messageGroups = consolidateMessages(messages, message => getMessageId(message));

--- a/packages/localize/src/tools/src/extract/translation_files/xliff1_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/xliff1_translation_serializer.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, getFileSystem, PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedMessage, ɵSourceLocation} from '@angular/localize';
 
 import {FormatOptions, validateOptions} from './format_options';
@@ -29,7 +29,7 @@ const LEGACY_XLIFF_MESSAGE_LENGTH = 40;
 export class Xliff1TranslationSerializer implements TranslationSerializer {
   constructor(
       private sourceLocale: string, private basePath: AbsoluteFsPath, private useLegacyIds: boolean,
-      private formatOptions: FormatOptions = {}, private fs: FileSystem = getFileSystem()) {
+      private formatOptions: FormatOptions = {}, private fs: PathManipulation = getFileSystem()) {
     validateOptions('Xliff1TranslationSerializer', [['xml:space', ['preserve']]], formatOptions);
   }
 

--- a/packages/localize/src/tools/src/extract/translation_files/xliff2_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/xliff2_translation_serializer.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, getFileSystem, PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedMessage, ɵSourceLocation} from '@angular/localize';
 
 import {FormatOptions, validateOptions} from './format_options';
@@ -29,7 +29,7 @@ export class Xliff2TranslationSerializer implements TranslationSerializer {
   private currentPlaceholderId = 0;
   constructor(
       private sourceLocale: string, private basePath: AbsoluteFsPath, private useLegacyIds: boolean,
-      private formatOptions: FormatOptions = {}, private fs: FileSystem = getFileSystem()) {
+      private formatOptions: FormatOptions = {}, private fs: PathManipulation = getFileSystem()) {
     validateOptions('Xliff1TranslationSerializer', [['xml:space', ['preserve']]], formatOptions);
   }
 

--- a/packages/localize/src/tools/src/extract/translation_files/xmb_translation_serializer.ts
+++ b/packages/localize/src/tools/src/extract/translation_files/xmb_translation_serializer.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, getFileSystem, PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedMessage, ɵSourceLocation} from '@angular/localize';
 
 import {extractIcuPlaceholders} from './icu_parsing';
@@ -24,7 +24,7 @@ import {XmlFile} from './xml_file';
 export class XmbTranslationSerializer implements TranslationSerializer {
   constructor(
       private basePath: AbsoluteFsPath, private useLegacyIds: boolean,
-      private fs: FileSystem = getFileSystem()) {}
+      private fs: PathManipulation = getFileSystem()) {}
 
   serialize(messages: ɵParsedMessage[]): string {
     const messageGroups = consolidateMessages(messages, message => this.getMessageId(message));

--- a/packages/localize/src/tools/src/source_file_utils.ts
+++ b/packages/localize/src/tools/src/source_file_utils.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, getFileSystem, PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵisMissingTranslationError, ɵmakeTemplateObject, ɵParsedTranslation, ɵSourceLocation, ɵtranslate} from '@angular/localize';
 import {NodePath} from '@babel/traverse';
 import * as t from '@babel/types';
@@ -74,7 +74,7 @@ export function buildLocalizeReplacement(
  */
 export function unwrapMessagePartsFromLocalizeCall(
     call: NodePath<t.CallExpression>,
-    fs: FileSystem = getFileSystem(),
+    fs: PathManipulation = getFileSystem(),
     ): [TemplateStringsArray, (ɵSourceLocation | undefined)[]] {
   let cooked = call.get('arguments')[0];
 
@@ -160,7 +160,7 @@ export function unwrapMessagePartsFromLocalizeCall(
  */
 export function unwrapSubstitutionsFromLocalizeCall(
     call: NodePath<t.CallExpression>,
-    fs: FileSystem = getFileSystem()): [t.Expression[], (ɵSourceLocation | undefined)[]] {
+    fs: PathManipulation = getFileSystem()): [t.Expression[], (ɵSourceLocation | undefined)[]] {
   const expressions = call.get('arguments').splice(1);
   if (!isArrayOfExpressions(expressions)) {
     const badExpression = expressions.find(expression => !expression.isExpression())!;
@@ -182,8 +182,8 @@ export function unwrapSubstitutionsFromLocalizeCall(
  * @publicApi used by CLI
  */
 export function unwrapMessagePartsFromTemplateLiteral(
-    elements: NodePath<t.TemplateElement>[],
-    fs: FileSystem = getFileSystem()): [TemplateStringsArray, (ɵSourceLocation | undefined)[]] {
+    elements: NodePath<t.TemplateElement>[], fs: PathManipulation = getFileSystem()):
+    [TemplateStringsArray, (ɵSourceLocation | undefined)[]] {
   const cooked = elements.map(q => {
     if (q.node.value.cooked === undefined) {
       throw new BabelParseError(
@@ -207,7 +207,7 @@ export function unwrapMessagePartsFromTemplateLiteral(
  */
 export function unwrapExpressionsFromTemplateLiteral(
     quasi: NodePath<t.TemplateLiteral>,
-    fs: FileSystem = getFileSystem()): [t.Expression[], (ɵSourceLocation | undefined)[]] {
+    fs: PathManipulation = getFileSystem()): [t.Expression[], (ɵSourceLocation | undefined)[]] {
   return [quasi.node.expressions, quasi.get('expressions').map(e => getLocation(fs, e))];
 }
 
@@ -235,7 +235,7 @@ export function wrapInParensIfNecessary(expression: t.Expression): t.Expression 
  */
 export function unwrapStringLiteralArray(
     array: NodePath<t.Expression>,
-    fs: FileSystem = getFileSystem()): [string[], (ɵSourceLocation | undefined)[]] {
+    fs: PathManipulation = getFileSystem()): [string[], (ɵSourceLocation | undefined)[]] {
   if (!isStringLiteralArray(array.node)) {
     throw new BabelParseError(
         array.node, 'Unexpected messageParts for `$localize` (expected an array of strings).');
@@ -400,7 +400,7 @@ export function buildCodeFrameError(path: NodePath, e: BabelParseError): string 
 }
 
 export function getLocation(
-    fs: FileSystem, startPath: NodePath, endPath?: NodePath): ɵSourceLocation|undefined {
+    fs: PathManipulation, startPath: NodePath, endPath?: NodePath): ɵSourceLocation|undefined {
   const startLocation = startPath.node.loc;
   const file = getFileFromPath(fs, startPath);
   if (!startLocation || !file) {
@@ -425,7 +425,7 @@ export function serializeLocationPosition(location: ɵSourceLocation): string {
   return `${location.start.line + 1}${endLineString}`;
 }
 
-function getFileFromPath(fs: FileSystem, path: NodePath|undefined): AbsoluteFsPath|null {
+function getFileFromPath(fs: PathManipulation, path: NodePath|undefined): AbsoluteFsPath|null {
   const opts = path?.hub.file.opts;
   return opts?.filename ?
       fs.resolve(opts.generatorOpts.sourceRoot ?? opts.cwd, fs.relative(opts.cwd, opts.filename)) :

--- a/packages/localize/src/tools/src/translate/source_files/es2015_translate_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/es2015_translate_plugin.ts
@@ -5,13 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {getFileSystem, PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedTranslation} from '@angular/localize';
 import {NodePath, PluginObj} from '@babel/core';
 import {TaggedTemplateExpression} from '@babel/types';
 
 import {Diagnostics} from '../../diagnostics';
-
 import {buildCodeFrameError, buildLocalizeReplacement, isBabelParseError, isLocalize, translate, TranslatePluginOptions, unwrapMessagePartsFromTemplateLiteral} from '../../source_file_utils';
 
 /**
@@ -23,7 +22,7 @@ import {buildCodeFrameError, buildLocalizeReplacement, isBabelParseError, isLoca
 export function makeEs2015TranslatePlugin(
     diagnostics: Diagnostics, translations: Record<string, ɵParsedTranslation>,
     {missingTranslation = 'error', localizeName = '$localize'}: TranslatePluginOptions = {},
-    fs: FileSystem = getFileSystem()): PluginObj {
+    fs: PathManipulation = getFileSystem()): PluginObj {
   return {
     visitor: {
       TaggedTemplateExpression(path: NodePath<TaggedTemplateExpression>) {

--- a/packages/localize/src/tools/src/translate/source_files/es5_translate_plugin.ts
+++ b/packages/localize/src/tools/src/translate/source_files/es5_translate_plugin.ts
@@ -5,13 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {getFileSystem, PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵParsedTranslation} from '@angular/localize';
 import {NodePath, PluginObj} from '@babel/core';
 import {CallExpression} from '@babel/types';
 
 import {Diagnostics} from '../../diagnostics';
-
 import {buildCodeFrameError, buildLocalizeReplacement, isBabelParseError, isLocalize, translate, TranslatePluginOptions, unwrapMessagePartsFromLocalizeCall, unwrapSubstitutionsFromLocalizeCall} from '../../source_file_utils';
 
 /**
@@ -23,7 +22,7 @@ import {buildCodeFrameError, buildLocalizeReplacement, isBabelParseError, isLoca
 export function makeEs5TranslatePlugin(
     diagnostics: Diagnostics, translations: Record<string, ɵParsedTranslation>,
     {missingTranslation = 'error', localizeName = '$localize'}: TranslatePluginOptions = {},
-    fs: FileSystem = getFileSystem()): PluginObj {
+    fs: PathManipulation = getFileSystem()): PluginObj {
   return {
     visitor: {
       CallExpression(callPath: NodePath<CallExpression>) {

--- a/packages/localize/src/tools/src/translate/translation_files/translation_loader.ts
+++ b/packages/localize/src/tools/src/translate/translation_files/translation_loader.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, ReadonlyFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {DiagnosticHandlingStrategy, Diagnostics} from '../../diagnostics';
 import {TranslationBundle} from '../translator';
 
@@ -16,7 +16,7 @@ import {ParseAnalysis, TranslationParser} from './translation_parsers/translatio
  */
 export class TranslationLoader {
   constructor(
-      private fs: FileSystem, private translationParsers: TranslationParser<any>[],
+      private fs: ReadonlyFileSystem, private translationParsers: TranslationParser<any>[],
       private duplicateTranslation: DiagnosticHandlingStrategy,
       /** @deprecated */ private diagnostics?: Diagnostics) {}
 

--- a/packages/localize/src/tools/src/translate/translator.ts
+++ b/packages/localize/src/tools/src/translate/translator.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AbsoluteFsPath, FileSystem, PathSegment} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {AbsoluteFsPath, PathSegment, ReadonlyFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {ɵMessageId, ɵParsedTranslation} from '@angular/localize';
 
 import {Diagnostics} from '../diagnostics';
@@ -64,7 +64,7 @@ export interface TranslationHandler {
  */
 export class Translator {
   constructor(
-      private fs: FileSystem, private resourceHandlers: TranslationHandler[],
+      private fs: ReadonlyFileSystem, private resourceHandlers: TranslationHandler[],
       private diagnostics: Diagnostics) {}
 
   translateFiles(

--- a/packages/localize/src/tools/test/extract/translation_files/arb_translation_serializer_spec.ts
+++ b/packages/localize/src/tools/test/extract/translation_files/arb_translation_serializer_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {absoluteFrom, FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {absoluteFrom, getFileSystem, PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {ɵParsedMessage} from '@angular/localize';
 
@@ -14,7 +14,7 @@ import {ArbTranslationSerializer} from '../../../src/extract/translation_files/a
 import {location, mockMessage} from './mock_message';
 
 runInEachFileSystem(() => {
-  let fs: FileSystem;
+  let fs: PathManipulation;
   describe('ArbTranslationSerializer', () => {
     beforeEach(() => {
       fs = getFileSystem();

--- a/packages/localize/src/tools/test/extract/translation_files/xmb_translation_serializer_spec.ts
+++ b/packages/localize/src/tools/test/extract/translation_files/xmb_translation_serializer_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {absoluteFrom, FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {absoluteFrom, getFileSystem, PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {ɵParsedMessage, ɵSourceLocation} from '@angular/localize';
 
@@ -14,7 +14,7 @@ import {XmbTranslationSerializer} from '../../../src/extract/translation_files/x
 import {location, mockMessage} from './mock_message';
 
 runInEachFileSystem(() => {
-  let fs: FileSystem;
+  let fs: PathManipulation;
   beforeEach(() => fs = getFileSystem());
   describe('XmbTranslationSerializer', () => {
     [false, true].forEach(useLegacyIds => {

--- a/packages/localize/src/tools/test/source_file_utils_spec.ts
+++ b/packages/localize/src/tools/test/source_file_utils_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {absoluteFrom, FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
+import {absoluteFrom, getFileSystem, PathManipulation} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {ɵmakeTemplateObject} from '@angular/localize';
 import {NodePath, TransformOptions, transformSync} from '@babel/core';
@@ -16,7 +16,7 @@ import {Expression, Identifier, TaggedTemplateExpression, ExpressionStatement, C
 import {isGlobalIdentifier, isNamedIdentifier, isStringLiteralArray, isArrayOfExpressions, unwrapStringLiteralArray, unwrapMessagePartsFromLocalizeCall, wrapInParensIfNecessary, buildLocalizeReplacement, unwrapSubstitutionsFromLocalizeCall, unwrapMessagePartsFromTemplateLiteral, getLocation} from '../src/source_file_utils';
 
 runInEachFileSystem(() => {
-  let fs: FileSystem;
+  let fs: PathManipulation;
   beforeEach(() => fs = getFileSystem());
   describe('utils', () => {
     describe('isNamedIdentifier()', () => {

--- a/packages/localize/src/tools/test/translate/source_files/es2015_translate_plugin_spec.ts
+++ b/packages/localize/src/tools/test/translate/source_files/es2015_translate_plugin_spec.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {ɵcomputeMsgId, ɵparseTranslation} from '@angular/localize';
 import {ɵParsedTranslation} from '@angular/localize/private';
@@ -16,8 +15,6 @@ import {TranslatePluginOptions} from '../../../src/source_file_utils';
 import {makeEs2015TranslatePlugin} from '../../../src/translate/source_files/es2015_translate_plugin';
 
 runInEachFileSystem(() => {
-  let fs: FileSystem;
-  beforeEach(() => fs = getFileSystem());
   describe('makeEs2015Plugin', () => {
     describe('(no translations)', () => {
       it('should transform `$localize` tags with binary expression', () => {

--- a/packages/localize/src/tools/test/translate/source_files/es5_translate_plugin_spec.ts
+++ b/packages/localize/src/tools/test/translate/source_files/es5_translate_plugin_spec.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {FileSystem, getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {ɵcomputeMsgId, ɵparseTranslation} from '@angular/localize';
 import {ɵParsedTranslation} from '@angular/localize/private';
@@ -16,8 +15,6 @@ import {TranslatePluginOptions} from '../../../src/source_file_utils';
 import {makeEs5TranslatePlugin} from '../../../src/translate/source_files/es5_translate_plugin';
 
 runInEachFileSystem(() => {
-  let fs: FileSystem;
-  beforeEach(() => fs = getFileSystem());
   describe('makeEs5Plugin', () => {
     describe('(no translations)', () => {
       it('should transform `$localize` calls with binary expression', () => {


### PR DESCRIPTION
This interface now extends `ReadonlyFileSystem` which in turn
extends `PathManipulation`. This means consumers of these
interfaces can be more specific about what is needed, and so
providers do not need to implement unnecessary methods.