### PR TITLE
docs: update stackblitz code version by fixing name of <live-example>

### DIFF
--- a/aio/content/examples/getting-started-v0/src/app/products.ts
+++ b/aio/content/examples/getting-started-v0/src/app/products.ts
@@ -1,15 +1,18 @@
 export const products = [
   {
+    id: 1,
     name: 'Phone XL',
     price: 799,
     description: 'A large phone with one of the best screens'
   },
   {
+    id: 2,
     name: 'Phone Mini',
     price: 699,
     description: 'A great phone with one of the best cameras'
   },
   {
+    id: 3,
     name: 'Phone Standard',
     price: 299,
     description: ''

--- a/aio/content/start/index.md
+++ b/aio/content/start/index.md
@@ -49,7 +49,7 @@ For more information about components, see [Introduction to Components](guide/ar
 
 ## Create the sample project
 
-To create the sample project, generate the <live-example name="getting-started" noDownload>ready-made sample project in StackBlitz</live-example>.
+To create the sample project, generate the <live-example name="getting-started-v0" noDownload>ready-made sample project in StackBlitz</live-example>.
 To save your work:
 
 1. Log into StackBlitz.

--- a/aio/content/start/index.md
+++ b/aio/content/start/index.md
@@ -49,7 +49,7 @@ For more information about components, see [Introduction to Components](guide/ar
 
 ## Create the sample project
 
-To create the sample project, generate the <live-example name="getting-started-v0" noDownload>ready-made sample project in StackBlitz</live-example>.
+To create the sample project, generate the <live-example name="getting-started" noDownload>ready-made sample project in StackBlitz</live-example>.
 To save your work:
 
 1. Log into StackBlitz.


### PR DESCRIPTION
The previous life example had the name "...-v0". This caused the products.ts in the tutorial to not have an id field.
Later on, during navigation, readers had to deduce that they need to add an id field manually.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #40280 


## What is the new behavior?

The `<live-example>` points to the new `products.ts` file that has `id` for each product.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->