### PR TITLE
fix(compiler-cli): ngcc - remove outdated link

### DIFF
--- a/packages/compiler-cli/ngcc/src/locking/sync_locker.ts
+++ b/packages/compiler-cli/ngcc/src/locking/sync_locker.ts
@@ -54,8 +54,7 @@ export class SyncLocker {
     const pid = this.lockFile.read();
     throw new Error(
         `ngcc is already running at process with id ${pid}.\n` +
-        `If you are running multiple builds in parallel then you should pre-process your node_modules via the command line ngcc tool before starting the builds;\n` +
-        `See https://v9.angular.io/guide/ivy#speeding-up-ngcc-compilation.\n` +
+        `If you are running multiple builds in parallel then you might try pre-processing your node_modules via the command line ngcc tool before starting the builds.\n` +
         `(If you are sure no ngcc process is running then you should delete the lock-file at ${
             this.lockFile.path}.)`);
   }

--- a/packages/compiler-cli/ngcc/test/locking/sync_locker_spec.ts
+++ b/packages/compiler-cli/ngcc/test/locking/sync_locker_spec.ts
@@ -58,8 +58,7 @@ runInEachFileSystem(() => {
         expect(() => locker.lock(() => {}))
             .toThrowError(
                 `ngcc is already running at process with id 188.\n` +
-                `If you are running multiple builds in parallel then you should pre-process your node_modules via the command line ngcc tool before starting the builds;\n` +
-                `See https://v9.angular.io/guide/ivy#speeding-up-ngcc-compilation.\n` +
+                `If you are running multiple builds in parallel then you might try pre-processing your node_modules via the command line ngcc tool before starting the builds.\n` +
                 `(If you are sure no ngcc process is running then you should delete the lock-file at ${
                     lockFile.path}.)`);
       });


### PR DESCRIPTION
The link to the "speeding-up-ngcc-compilation" URL does not exist,
it was removed shortly after it was added, but the link in the ngcc
error message was not updated.

Fixes #39837
