### PR TITLE
feat(router): Add more find-tuned control in `routerLinkActiveOptions`

### DIFF
--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -158,6 +158,13 @@ export declare class GuardsCheckStart extends RouterEvent {
 
 export declare type InitialNavigation = 'disabled' | 'enabled' | 'enabledBlocking' | 'enabledNonBlocking';
 
+export declare interface IsActiveMatchOptions {
+    fragment: 'exact' | 'ignored';
+    matrixParams: 'exact' | 'subset' | 'ignored';
+    paths: 'exact' | 'subset';
+    queryParams: 'exact' | 'subset' | 'ignored';
+}
+
 export declare type LoadChildren = LoadChildrenCallback | DeprecatedLoadChildren;
 
 export declare type LoadChildrenCallback = () => Type<any> | NgModuleFactory<any> | Observable<Type<any>> | Promise<NgModuleFactory<any> | Type<any> | any>;
@@ -345,7 +352,8 @@ export declare class Router {
     dispose(): void;
     getCurrentNavigation(): Navigation | null;
     initialNavigation(): void;
-    isActive(url: string | UrlTree, exact: boolean): boolean;
+    /** @deprecated */ isActive(url: string | UrlTree, exact: boolean): boolean;
+    isActive(url: string | UrlTree, matchOptions: IsActiveMatchOptions): boolean;
     navigate(commands: any[], extras?: NavigationExtras): Promise<boolean>;
     navigateByUrl(url: string | UrlTree, extras?: NavigationBehaviorOptions): Promise<boolean>;
     ngOnDestroy(): void;
@@ -400,7 +408,7 @@ export declare class RouterLinkActive implements OnChanges, OnDestroy, AfterCont
     set routerLinkActive(data: string[] | string);
     routerLinkActiveOptions: {
         exact: boolean;
-    };
+    } | IsActiveMatchOptions;
     constructor(router: Router, element: ElementRef, renderer: Renderer2, cdr: ChangeDetectorRef, link?: RouterLink | undefined, linkWithHref?: RouterLinkWithHref | undefined);
     ngAfterContentInit(): void;
     ngOnChanges(changes: SimpleChanges): void;

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2285,
-        "main-es2015": 241843,
+        "main-es2015": 242531,
         "polyfills-es2015": 36709,
         "5-es2015": 745
       }
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 217591,
+        "main-es2015": 218317,
         "polyfills-es2015": 36723,
         "5-es2015": 781
       }

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1200,6 +1200,9 @@
     "name": "equalPath"
   },
   {
+    "name": "exactMatchOptions"
+  },
+  {
     "name": "executeCheckHooks"
   },
   {
@@ -1659,6 +1662,9 @@
     "name": "materializeViewResults"
   },
   {
+    "name": "matrixParamsMatch"
+  },
+  {
     "name": "maybeUnwrapFn"
   },
   {
@@ -1750,6 +1756,12 @@
   },
   {
     "name": "optionsReducer"
+  },
+  {
+    "name": "paramCompareMap"
+  },
+  {
+    "name": "pathCompareMap"
   },
   {
     "name": "pipeFromArray"
@@ -1945,6 +1957,9 @@
   },
   {
     "name": "subscribeToResult"
+  },
+  {
+    "name": "subsetMatchOptions"
   },
   {
     "name": "supportsState"

--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -12,6 +12,7 @@ import {mergeAll} from 'rxjs/operators';
 
 import {Event, NavigationEnd} from '../events';
 import {Router} from '../router';
+import {IsActiveMatchOptions} from '../url_tree';
 
 import {RouterLink, RouterLinkWithHref} from './router_link';
 
@@ -89,7 +90,15 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
   private linkInputChangesSubscription?: Subscription;
   public readonly isActive: boolean = false;
 
-  @Input() routerLinkActiveOptions: {exact: boolean} = {exact: false};
+  /**
+   * Options to configure how to determine if the router link is active.
+   *
+   * These options are passed to the `Router.isActive()` function.
+   *
+   * @see Router.isActive
+   */
+  @Input() routerLinkActiveOptions: {exact: boolean}|IsActiveMatchOptions = {exact: false};
+
 
   constructor(
       private router: Router, private element: ElementRef, private renderer: Renderer2,
@@ -159,8 +168,11 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
   }
 
   private isLinkActive(router: Router): (link: (RouterLink|RouterLinkWithHref)) => boolean {
-    return (link: RouterLink|RouterLinkWithHref) =>
-               router.isActive(link.urlTree, this.routerLinkActiveOptions.exact);
+    const options = 'paths' in this.routerLinkActiveOptions ?
+        this.routerLinkActiveOptions :
+        // While the types should disallow `undefined` here, it's possible without strict inputs
+        (this.routerLinkActiveOptions.exact || false);
+    return (link: RouterLink|RouterLinkWithHref) => router.isActive(link.urlTree, options);
   }
 
   private hasActiveLinks(): boolean {

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -22,7 +22,7 @@ export {NoPreloading, PreloadAllModules, PreloadingStrategy, RouterPreloader} fr
 export {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot} from './router_state';
 export {convertToParamMap, ParamMap, Params, PRIMARY_OUTLET} from './shared';
 export {UrlHandlingStrategy} from './url_handling_strategy';
-export {DefaultUrlSerializer, UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
+export {DefaultUrlSerializer, IsActiveMatchOptions, UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
 export {VERSION} from './version';
 
 export * from './private_export';

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {exactMatchOptions, subsetMatchOptions} from '../src/router';
 import {containsTree, DefaultUrlSerializer} from '../src/url_tree';
 
 describe('UrlTree', () => {
@@ -33,80 +34,80 @@ describe('UrlTree', () => {
         const url = '/one/(one//left:three)(right:four)';
         const t1 = serializer.parse(url);
         const t2 = serializer.parse(url);
-        expect(containsTree(t1, t2, true)).toBe(true);
-        expect(containsTree(t2, t1, true)).toBe(true);
+        expect(containsTree(t1, t2, exactMatchOptions)).toBe(true);
+        expect(containsTree(t2, t1, exactMatchOptions)).toBe(true);
       });
 
       it('should return true when queryParams are the same', () => {
         const t1 = serializer.parse('/one/two?test=1&page=5');
         const t2 = serializer.parse('/one/two?test=1&page=5');
-        expect(containsTree(t1, t2, true)).toBe(true);
+        expect(containsTree(t1, t2, exactMatchOptions)).toBe(true);
       });
 
       it('should return true when queryParams are the same but with diffrent order', () => {
         const t1 = serializer.parse('/one/two?test=1&page=5');
         const t2 = serializer.parse('/one/two?page=5&test=1');
-        expect(containsTree(t1, t2, true)).toBe(true);
+        expect(containsTree(t1, t2, exactMatchOptions)).toBe(true);
       });
 
       it('should return true when queryParams contains array params that are the same', () => {
         const t1 = serializer.parse('/one/two?test=a&test=b&pages=5&pages=6');
         const t2 = serializer.parse('/one/two?test=a&test=b&pages=5&pages=6');
-        expect(containsTree(t1, t2, true)).toBe(true);
+        expect(containsTree(t1, t2, exactMatchOptions)).toBe(true);
       });
 
       it('should return false when queryParams contains array params but are not the same', () => {
         const t1 = serializer.parse('/one/two?test=a&test=b&pages=5&pages=6');
         const t2 = serializer.parse('/one/two?test=a&test=b&pages=5&pages=7');
-        expect(containsTree(t1, t2, false)).toBe(false);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(false);
       });
 
       it('should return false when queryParams are not the same', () => {
         const t1 = serializer.parse('/one/two?test=1&page=5');
         const t2 = serializer.parse('/one/two?test=1');
-        expect(containsTree(t1, t2, true)).toBe(false);
+        expect(containsTree(t1, t2, exactMatchOptions)).toBe(false);
       });
 
       it('should return false when queryParams are not the same', () => {
         const t1 = serializer.parse('/one/two?test=4&test=4&test=2');
         const t2 = serializer.parse('/one/two?test=4&test=3&test=2');
-        expect(containsTree(t1, t2, false)).toBe(false);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(false);
       });
 
       it('should return true when queryParams are the same in different order', () => {
         const t1 = serializer.parse('/one/two?test=4&test=3&test=2');
         const t2 = serializer.parse('/one/two?test=2&test=3&test=4');
-        expect(containsTree(t1, t2, false)).toBe(true);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(true);
       });
 
       it('should return true when queryParams are the same in different order', () => {
         const t1 = serializer.parse('/one/two?test=4&test=4&test=1');
         const t2 = serializer.parse('/one/two?test=1&test=4&test=4');
-        expect(containsTree(t1, t2, false)).toBe(true);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(true);
       });
 
       it('should return false when containee is missing queryParams', () => {
         const t1 = serializer.parse('/one/two?page=5');
         const t2 = serializer.parse('/one/two');
-        expect(containsTree(t1, t2, true)).toBe(false);
+        expect(containsTree(t1, t2, exactMatchOptions)).toBe(false);
       });
 
       it('should return false when paths are not the same', () => {
         const t1 = serializer.parse('/one/two(right:three)');
         const t2 = serializer.parse('/one/two2(right:three)');
-        expect(containsTree(t1, t2, true)).toBe(false);
+        expect(containsTree(t1, t2, exactMatchOptions)).toBe(false);
       });
 
       it('should return false when container has an extra child', () => {
         const t1 = serializer.parse('/one/two(right:three)');
         const t2 = serializer.parse('/one/two');
-        expect(containsTree(t1, t2, true)).toBe(false);
+        expect(containsTree(t1, t2, exactMatchOptions)).toBe(false);
       });
 
       it('should return false when containee has an extra child', () => {
         const t1 = serializer.parse('/one/two');
         const t2 = serializer.parse('/one/two(right:three)');
-        expect(containsTree(t1, t2, true)).toBe(false);
+        expect(containsTree(t1, t2, exactMatchOptions)).toBe(false);
       });
     });
 
@@ -114,85 +115,183 @@ describe('UrlTree', () => {
       it('should return true when containee is missing a segment', () => {
         const t1 = serializer.parse('/one/(two//left:three)(right:four)');
         const t2 = serializer.parse('/one/(two//left:three)');
-        expect(containsTree(t1, t2, false)).toBe(true);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(true);
       });
 
       it('should return true when containee is missing some paths', () => {
         const t1 = serializer.parse('/one/two/three');
         const t2 = serializer.parse('/one/two');
-        expect(containsTree(t1, t2, false)).toBe(true);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(true);
       });
 
       it('should return true container has its paths split into multiple segments', () => {
         const t1 = serializer.parse('/one/(two//left:three)');
         const t2 = serializer.parse('/one/two');
-        expect(containsTree(t1, t2, false)).toBe(true);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(true);
       });
 
       it('should return false when containee has extra segments', () => {
         const t1 = serializer.parse('/one/two');
         const t2 = serializer.parse('/one/(two//left:three)');
-        expect(containsTree(t1, t2, false)).toBe(false);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(false);
       });
 
       it('should return false containee has segments that the container does not have', () => {
         const t1 = serializer.parse('/one/(two//left:three)');
         const t2 = serializer.parse('/one/(two//right:four)');
-        expect(containsTree(t1, t2, false)).toBe(false);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(false);
       });
 
       it('should return false when containee has extra paths', () => {
         const t1 = serializer.parse('/one');
         const t2 = serializer.parse('/one/two');
-        expect(containsTree(t1, t2, false)).toBe(false);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(false);
       });
 
       it('should return true when queryParams are the same', () => {
         const t1 = serializer.parse('/one/two?test=1&page=5');
         const t2 = serializer.parse('/one/two?test=1&page=5');
-        expect(containsTree(t1, t2, false)).toBe(true);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(true);
       });
 
       it('should return true when container contains containees queryParams', () => {
         const t1 = serializer.parse('/one/two?test=1&u=5');
         const t2 = serializer.parse('/one/two?u=5');
-        expect(containsTree(t1, t2, false)).toBe(true);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(true);
       });
 
       it('should return true when containee does not have queryParams', () => {
         const t1 = serializer.parse('/one/two?page=5');
         const t2 = serializer.parse('/one/two');
-        expect(containsTree(t1, t2, false)).toBe(true);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(true);
       });
 
       it('should return false when containee has but container does not have queryParams', () => {
         const t1 = serializer.parse('/one/two');
         const t2 = serializer.parse('/one/two?page=1');
-        expect(containsTree(t1, t2, false)).toBe(false);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(false);
       });
 
       it('should return true when container has array params but containee does not have', () => {
         const t1 = serializer.parse('/one/two?test=a&test=b&pages=5&pages=6');
         const t2 = serializer.parse('/one/two?test=a&test=b');
-        expect(containsTree(t1, t2, false)).toBe(true);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(true);
       });
 
       it('should return false when containee has array params but container does not have', () => {
         const t1 = serializer.parse('/one/two?test=a&test=b');
         const t2 = serializer.parse('/one/two?test=a&test=b&pages=5&pages=6');
-        expect(containsTree(t1, t2, false)).toBe(false);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(false);
       });
 
       it('should return false when containee has different queryParams', () => {
         const t1 = serializer.parse('/one/two?page=5');
         const t2 = serializer.parse('/one/two?test=1');
-        expect(containsTree(t1, t2, false)).toBe(false);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(false);
       });
 
       it('should return false when containee has more queryParams than container', () => {
         const t1 = serializer.parse('/one/two?page=5');
         const t2 = serializer.parse('/one/two?page=5&test=1');
-        expect(containsTree(t1, t2, false)).toBe(false);
+        expect(containsTree(t1, t2, subsetMatchOptions)).toBe(false);
+      });
+    });
+
+    describe('ignored query params', () => {
+      it('should return true when queryParams differ but are ignored', () => {
+        const t1 = serializer.parse('/?test=1&page=2');
+        const t2 = serializer.parse('/?test=3&page=4&x=y');
+        expect(containsTree(t1, t2, {...exactMatchOptions, queryParams: 'ignored'})).toBe(true);
+      });
+    });
+
+    describe('fragment', () => {
+      it('should return false when fragments differ but options require exact match', () => {
+        const t1 = serializer.parse('/#fragment1');
+        const t2 = serializer.parse('/#fragment2');
+        expect(containsTree(t1, t2, {...exactMatchOptions, fragment: 'exact'})).toBe(false);
+      });
+
+      it('should return true when fragments differ but options ignore the fragment', () => {
+        const t1 = serializer.parse('/#fragment1');
+        const t2 = serializer.parse('/#fragment2');
+        expect(containsTree(t1, t2, {...exactMatchOptions, fragment: 'ignored'})).toBe(true);
+      });
+    });
+
+    describe('matrix params', () => {
+      describe('ignored', () => {
+        it('returns true when matrix params differ but are ignored', () => {
+          const t1 = serializer.parse('/a;id=15;foo=foo');
+          const t2 = serializer.parse('/a;abc=123');
+          expect(containsTree(t1, t2, {...exactMatchOptions, matrixParams: 'ignored'})).toBe(true);
+        });
+      });
+
+      describe('exact match', () => {
+        const matrixParams = 'exact';
+
+        it('returns true when matrix params match', () => {
+          const t1 = serializer.parse('/a;id=15;foo=foo');
+          const t2 = serializer.parse('/a;id=15;foo=foo');
+          expect(containsTree(t1, t2, {...exactMatchOptions, matrixParams})).toBe(true);
+        });
+
+        it('returns false when matrix params differ', () => {
+          const t1 = serializer.parse('/a;id=15;foo=foo');
+          const t2 = serializer.parse('/a;abc=123');
+          expect(containsTree(t1, t2, {...exactMatchOptions, matrixParams})).toBe(false);
+        });
+
+        it('returns true when matrix params match on the subset of the matched url tree', () => {
+          const t1 = serializer.parse('/a;id=15;foo=bar/c');
+          const t2 = serializer.parse('/a;id=15;foo=bar');
+          expect(containsTree(t1, t2, {...subsetMatchOptions, matrixParams})).toBe(true);
+        });
+
+        it('should return true when matrix params match on subset of urlTree match ' +
+               'with container paths split into multiple segments',
+           () => {
+             const t1 = serializer.parse('/one;a=1/(two;b=2//left:three)');
+             const t2 = serializer.parse('/one;a=1/two;b=2');
+             expect(containsTree(t1, t2, {...subsetMatchOptions, matrixParams})).toBe(true);
+           });
+      });
+
+      describe('subset match', () => {
+        const matrixParams = 'subset';
+
+        it('returns true when matrix params match', () => {
+          const t1 = serializer.parse('/a;id=15;foo=foo');
+          const t2 = serializer.parse('/a;id=15;foo=foo');
+          expect(containsTree(t1, t2, {...exactMatchOptions, matrixParams})).toBe(true);
+        });
+
+        it('returns true when container has extra matrix params', () => {
+          const t1 = serializer.parse('/a;id=15;foo=foo');
+          const t2 = serializer.parse('/a;id=15');
+          expect(containsTree(t1, t2, {...exactMatchOptions, matrixParams})).toBe(true);
+        });
+
+        it('returns false when matrix params differ', () => {
+          const t1 = serializer.parse('/a;id=15;foo=foo');
+          const t2 = serializer.parse('/a;abc=123');
+          expect(containsTree(t1, t2, {...exactMatchOptions, matrixParams})).toBe(false);
+        });
+
+        it('returns true when matrix params match on the subset of the matched url tree', () => {
+          const t1 = serializer.parse('/a;id=15;foo=bar/c');
+          const t2 = serializer.parse('/a;id=15;foo=bar');
+          expect(containsTree(t1, t2, {...subsetMatchOptions, matrixParams})).toBe(true);
+        });
+
+        it('should return true when matrix params match on subset of urlTree match ' +
+               'with container paths split into multiple segments',
+           () => {
+             const t1 = serializer.parse('/one;a=1/(two;b=2//left:three)');
+             const t2 = serializer.parse('/one;a=1/two');
+             expect(containsTree(t1, t2, {...subsetMatchOptions, matrixParams})).toBe(true);
+           });
       });
     });
   });


### PR DESCRIPTION
This commit adds more configurability to the `Router#isActive` method
and `RouterLinkActive#routerLinkActiveOptions`.
It allows tuning individual match options for query params and the url
tree, which were either both partial or both exact matches in the past.
Additionally, it also allows matching against the fragment and matrix
parameters.

fixes #13205

BREAKING CHANGE:
The type of the `RouterLinkActive.routerLinkActiveOptions` input was
expanded to allow more fine-tuned control. Code that previously read
this property may need to be updated to account for the new type.


Additional note on the breaking change: 
I found no places where `routerLinkActiveOptions` was read in g3. So while the type change is _technically_ breaking, it's possible that nobody will be affected.