### PR TITLE
docs(router): Clearly document how to retrieve all params in the router tree

### DIFF
--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -298,7 +298,25 @@ export class ActivatedRouteSnapshot {
   constructor(
       /** The URL segments matched by this route */
       public url: UrlSegment[],
-      /** The matrix parameters scoped to this route */
+      /**
+       *  The matrix parameters scoped to this route.
+       *
+       *  You can compute all params (or data) in the router state or to get params outside
+       *  of an activated component by traversing the `RouterState` tree as in the following
+       *  example:
+       *  ```
+       *  collectRouteParams(router: Router) {
+       *    let params = {};
+       *    let stack: ActivatedRouteSnapshot[] = [router.routerState.snapshot.root];
+       *    while (stack.length > 0) {
+       *      const route = stack.pop()!;
+       *      params = {...params, ...route.params};
+       *      stack.push(...route.children);
+       *    }
+       *    return params;
+       *  }
+       *  ```
+       */
       public params: Params,
       /** The query parameters shared by all the routes */
       public queryParams: Params,


### PR DESCRIPTION

This commit documents how to add a helper function which combines all the params
in the router state tree into a single object. It provides a starting point for
developers to reference if they require a more fine-tuned approach.

Fixes #11023