### PR TITLE
docs: fix misleading step in getting started routing

### DIFF
--- a/aio/content/start/start-routing.md
+++ b/aio/content/start/start-routing.md
@@ -28,10 +28,8 @@ This section shows you how to define a route to show individual product details.
 
 1. Open `product-list.component.html`.
 
-1. Update the `*ngFor` directive to read as follows.
-    This statement instructs Angular to iterate over the items in the `products` array and assigns each index in the array to the `productId` variable when iterating over the list.
-
 1. Modify the product name anchor to include a `routerLink` with the `product.id` as a parameter.
+    This modification assigns each index in the array to the `productId` variable when iterating over the list.
 
     <code-example header="src/app/product-list/product-list.component.html" path="getting-started/src/app/product-list/product-list.component.html" region="router-link">
     </code-example>


### PR DESCRIPTION
The [getting started routing step #4](https://angular.io/start/start-routing#associate-a-url-path-with-a-component) about updating the `*ngFor` is misleading because the user doesn't actually update it specifically, rather the update is made to the anchor tag, within the `*ngFor`. There is no change from the first step of the tutorial to the `*ngFor`. "As follows" is not followed by a code sample, instead the code sample is in the next step, which is confusing. This PR removes the reference to the `*ngFor` and moves the explanation into the next step, where it is more appropriate. The change goes from:

```
<div *ngFor="let product of products">
  <h3> <a [title]="product.name + ' details'">{{ product.name }}</a></h3>
</div>

```

to

```
<div *ngFor="let product of products">
  <h3> <a [title]="product.name + ' details'" [routerLink]="['/products', product.id]">{{ product.name }}</a></h3>
</div>
```

You don't edit `<div *ngFor="let product of products">` so there is no code snippet to pull for it.

Fixes https://github.com/angular/angular/issues/40280
