### PR TITLE
docs(forms): typo word "property" was missing

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -293,7 +293,7 @@ export class Validators {
    * ```
    *
    * @returns A validator function that returns an error map with the
-   * `minlength` if the validation check fails, otherwise `null`.
+   * `minlength` property if the validation check fails, otherwise `null`.
    *
    * @see `updateValueAndValidity()`
    *


### PR DESCRIPTION
docs:Fix a typo, add the word property in the returns comment of the function minLength for clarity

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No behaviour change, only a documentation change.

Issue Number: N/A


## What is the new behavior?
N/A

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Fix typo : add word "property" in @returns comment for minLength.