### PR TITLE
fix(router): Remove usage of `Object.entiries` to avoid the need for a polyfill

### DIFF
--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -502,7 +502,8 @@ function mergeTrivialChildren(s: UrlSegmentGroup): UrlSegmentGroup {
  */
 function squashSegmentGroup(segmentGroup: UrlSegmentGroup): UrlSegmentGroup {
   const newChildren = {} as any;
-  for (const [childOutlet, child] of Object.entries(segmentGroup.children)) {
+  for (const childOutlet of Object.keys(segmentGroup.children)) {
+    const child = segmentGroup.children[childOutlet];
     const childCandidate = squashSegmentGroup(child);
     // don't add empty children
     if (childCandidate.segments.length > 0 || childCandidate.hasChildren()) {


### PR DESCRIPTION

`Object.entries` is not supported in IE11 without a polyfill. The quickest,
most straightfoward fix for this is to simply use `Object.keys` instead.
We may want to consider including the polyfill in the CLI in the future
or just wait until IE11 support is dropped before using
`Object.entires`.
