### PR TITLE
test(core): update test expectation to account for IE11 anonymous function names

### DIFF
--- a/packages/core/test/render3/jit/declare_component_spec.ts
+++ b/packages/core/test/render3/jit/declare_component_spec.ts
@@ -19,7 +19,8 @@ describe('component declaration jit compilation', () => {
 
     expectComponentDef(def, {
       template: functionContaining([
-        /element[^(]*\(0,'div'\)/,
+        // NOTE: the `anonymous` match is to support IE11, as functions don't have a name there.
+        /(?:element|anonymous)[^(]*\(0,'div'\)/,
       ]),
     });
   });


### PR DESCRIPTION
The "monitoring" workflow has been failing since #40127 was merged,
due to a Saucelabs test failure in Internet Explorer 11. The issue is
with the test's expectation which does not account for Ivy instruction
invocations to use "anonymous" instead of the instruction's function
name. This commit changes the test expectation to also accept
"anonymous", which was already the case for similar expectations.

---

[Failing workflow run for reference](https://app.circleci.com/pipelines/github/angular/angular/26719/workflows/83f00245-fbe4-4aa0-8cca-b859d562623c/jobs/891410)