### PR TITLE
fix(compiler): correct the `KeySpan` for animation events and properties

### DIFF
--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -244,6 +244,10 @@ export class BindingParser {
       targetProps: ParsedProperty[], keySpan?: ParseSourceSpan) {
     if (isAnimationLabel(name)) {
       name = name.substring(1);
+      if (keySpan) {
+        keySpan = moveParseSourceSpan(
+            keySpan, new AbsoluteSourceSpan(keySpan.start.offset + 1, keySpan.end.offset));
+      }
       if (value) {
         this._reportError(
             `Assigning animation triggers via @prop="exp" attributes with an expression is invalid.` +
@@ -274,9 +278,19 @@ export class BindingParser {
     if (name.startsWith(ANIMATE_PROP_PREFIX)) {
       isAnimationProp = true;
       name = name.substring(ANIMATE_PROP_PREFIX.length);
+      if (keySpan) {
+        keySpan = moveParseSourceSpan(
+            keySpan,
+            new AbsoluteSourceSpan(
+                keySpan.start.offset + ANIMATE_PROP_PREFIX.length, keySpan.end.offset));
+      }
     } else if (isAnimationLabel(name)) {
       isAnimationProp = true;
       name = name.substring(1);
+      if (keySpan) {
+        keySpan = moveParseSourceSpan(
+            keySpan, new AbsoluteSourceSpan(keySpan.start.offset + 1, keySpan.end.offset));
+      }
     }
 
     if (isAnimationProp) {
@@ -424,6 +438,10 @@ export class BindingParser {
 
     if (isAnimationLabel(name)) {
       name = name.substr(1);
+      if (keySpan) {
+        keySpan = moveParseSourceSpan(
+            keySpan, new AbsoluteSourceSpan(keySpan.start.offset + 1, keySpan.end.offset));
+      }
       this._parseAnimationEvent(name, expression, sourceSpan, handlerSpan, targetEvents, keySpan);
     } else {
       this._parseRegularEvent(

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -244,7 +244,7 @@ export class BindingParser {
       targetProps: ParsedProperty[], keySpan?: ParseSourceSpan) {
     if (isAnimationLabel(name)) {
       name = name.substring(1);
-      if (keySpan) {
+      if (keySpan !== undefined) {
         keySpan = moveParseSourceSpan(
             keySpan, new AbsoluteSourceSpan(keySpan.start.offset + 1, keySpan.end.offset));
       }
@@ -278,7 +278,7 @@ export class BindingParser {
     if (name.startsWith(ANIMATE_PROP_PREFIX)) {
       isAnimationProp = true;
       name = name.substring(ANIMATE_PROP_PREFIX.length);
-      if (keySpan) {
+      if (keySpan !== undefined) {
         keySpan = moveParseSourceSpan(
             keySpan,
             new AbsoluteSourceSpan(
@@ -287,7 +287,7 @@ export class BindingParser {
     } else if (isAnimationLabel(name)) {
       isAnimationProp = true;
       name = name.substring(1);
-      if (keySpan) {
+      if (keySpan !== undefined) {
         keySpan = moveParseSourceSpan(
             keySpan, new AbsoluteSourceSpan(keySpan.start.offset + 1, keySpan.end.offset));
       }
@@ -438,7 +438,7 @@ export class BindingParser {
 
     if (isAnimationLabel(name)) {
       name = name.substr(1);
-      if (keySpan) {
+      if (keySpan !== undefined) {
         keySpan = moveParseSourceSpan(
             keySpan, new AbsoluteSourceSpan(keySpan.start.offset + 1, keySpan.end.offset));
       }

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -193,6 +193,30 @@ describe('R3 AST source spans', () => {
         ['BoundAttribute', 'data-prop="{{v}}"', 'prop', '{{v}}'],
       ]);
     });
+
+    it('is correct for bound properties via @', () => {
+      expectFromHtml('<div bind-@animation="v"></div>').toEqual([
+        ['Element', '<div bind-@animation="v"></div>', '<div bind-@animation="v">', '</div>'],
+        ['BoundAttribute', 'bind-@animation="v"', 'animation', 'v'],
+      ]);
+    });
+
+    it('is correct for bound properties via animation-', () => {
+      expectFromHtml('<div bind-animate-animationName="v"></div>').toEqual([
+        [
+          'Element', '<div bind-animate-animationName="v"></div>',
+          '<div bind-animate-animationName="v">', '</div>'
+        ],
+        ['BoundAttribute', 'bind-animate-animationName="v"', 'animationName', 'v'],
+      ]);
+    });
+
+    it('is correct for bound properties via @ without value', () => {
+      expectFromHtml('<div @animation></div>').toEqual([
+        ['Element', '<div @animation></div>', '<div @animation>', '</div>'],
+        ['BoundAttribute', '@animation', 'animation', '<empty>'],
+      ]);
+    });
   });
 
   describe('templates', () => {
@@ -399,6 +423,13 @@ describe('R3 AST source spans', () => {
         ['Element', '<div data-bindon-prop="v"></div>', '<div data-bindon-prop="v">', '</div>'],
         ['BoundAttribute', 'data-bindon-prop="v"', 'prop', 'v'],
         ['BoundEvent', 'data-bindon-prop="v"', 'prop', 'v'],
+      ]);
+    });
+
+    it('is correct for bound events via @', () => {
+      expectFromHtml('<div (@name.done)="v"></div>').toEqual([
+        ['Element', '<div (@name.done)="v"></div>', '<div (@name.done)="v">', '</div>'],
+        ['BoundEvent', '(@name.done)="v"', 'name.done', 'v'],
       ]);
     });
   });


### PR DESCRIPTION
Now the `KeySpan` for animation includes `@`, `animate-`,
this PR will correct the position.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
