### PR TITLE
fix(zone.js): fix typo in zone_externs

### DIFF
--- a/packages/zone.js/lib/closure/zone_externs.js
+++ b/packages/zone.js/lib/closure/zone_externs.js
@@ -420,7 +420,7 @@ Task.prototype.zone;
  * @type {number}
  */
 Task.prototype.runCount;
-Task.prototype.cancelSchduleRequest = function() {};
+Task.prototype.cancelScheduleRequest = function() {};
 
 /**
  * @interface


### PR DESCRIPTION
This change fixes a typo in zone.js externs definition and avoids Closure
compiler renaming Task.cancelScheduleRequest() unexpectedly.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There are two scripts loaded in the browser:
* lib.js: Containing zone.js, compiled with Closure, added zonejs_externs
* app.js: Main app, containing a line "zone.cancelScheduleRequest()"

When app.js runs, getting error "zone.Xlb is not a function", because Closure renames cancelScheduleRequest().

Issue Number: N/A


## What is the new behavior?
app.js loads without throwing this error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
