### PR TITLE
fix(forms): use parent when retrieving control in `FormControlName` directive

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -72,13 +72,6 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
 
   /**
    * @description
-   * Tracks the `FormControl` instance bound to the directive.
-   */
-  // TODO(issue/24571): remove '!'.
-  readonly control!: FormControl;
-
-  /**
-   * @description
    * Tracks the name of the `FormControl` bound to the directive. The name corresponds
    * to a key in the parent `FormGroup` or `FormArray`.
    * Accepts a name as a string or a number.
@@ -173,6 +166,14 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
 
   /**
    * @description
+   * Tracks the `FormControl` instance bound to the directive.
+   */
+  get control(): FormControl|null {
+    return (this.name != null && this.formDirective?.getControl(this)) || null;
+  }
+
+  /**
+   * @description
    * Returns an array that represents the path from the top-level form to this control.
    * Each index is the string name of the control on that level.
    */
@@ -204,8 +205,8 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
 
   private _setUpControl() {
     this._checkParentType();
-    (this as {control: FormControl}).control = this.formDirective.addControl(this);
-    if (this.control.disabled && this.valueAccessor!.setDisabledState) {
+    const control = this.formDirective.addControl(this);
+    if (control.disabled && this.valueAccessor!.setDisabledState) {
       this.valueAccessor!.setDisabledState!(true);
     }
     this._added = true;

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -168,8 +168,8 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
    * @description
    * Tracks the `FormControl` instance bound to the directive.
    */
-  get control(): FormControl|null {
-    return (this.name != null && this.formDirective?.getControl(this)) || null;
+  get control(): FormControl {
+    return this.formDirective?.getControl(this);
   }
 
   /**

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -657,7 +657,6 @@ class CustomValidatorDirective implements Validator {
         parent.form = new FormGroup({'name': formModel});
         controlNameDir = new FormControlName(parent, [], [], [defaultAccessor], null);
         controlNameDir.name = 'name';
-        (controlNameDir as {control: FormControl}).control = formModel;
       });
 
       it('should reexport control properties', () => {


### PR DESCRIPTION
NOTE: this is **EXPERIMENTAL** and **TEST-ONLY** PR.

This commit updates the `FormControlName` directive logic to use parent to retrieve a control currently associated
with a given directive instance.

Related issue: #35330.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
