### PR TITLE
feat(dev-infra): make ts-api-guardian compatible with rules_nodejs version 3

### DIFF
--- a/tools/ts-api-guardian/BUILD.bazel
+++ b/tools/ts-api-guardian/BUILD.bazel
@@ -39,9 +39,8 @@ pkg_npm(
         "package.json",
     ],
     substitutions = {
-        "@angular//tools/ts-api-guardian:bin": "@npm_ts_api_guardian//:bin",
+        "@angular//tools/ts-api-guardian:bin": "//:node_modules/ts-api-guardian/bin",
         "@angular//tools/ts-api-guardian:lib": "@npm//ts-api-guardian",
-        "angular/tools/ts-api-guardian/": "npm_ts_api_guardian/",
     },
     deps = [
         ":lib",
@@ -103,7 +102,6 @@ jasmine_node_test(
         ":ts-api-guardian",
     ],
 )
-# END-INTERNAL
 
 filegroup(
     name = "bin",
@@ -113,3 +111,5 @@ filegroup(
 
 # Exported to be referenced as entry_point of the nodejs_binary
 exports_files(["bin/ts-api-guardian"])
+
+# END-INTERNAL

--- a/tools/ts-api-guardian/index.bzl
+++ b/tools/ts-api-guardian/index.bzl
@@ -34,7 +34,9 @@ def ts_api_guardian_test(
         # Locally we need to add the TS build target
         # But it will replaced to @npm//ts-api-guardian when publishing
         "@angular//tools/ts-api-guardian:lib",
+        # BEGIN-INTERNAL
         "@angular//tools/ts-api-guardian:bin",
+        # END-INTERNAL
         # The below are required during runtime
         "@npm//chalk",
         "@npm//diff",
@@ -46,6 +48,9 @@ def ts_api_guardian_test(
         # Needed so that node doesn't walk back to the source directory.
         # From there, the relative imports would point to .ts files.
         "--node_options=--preserve-symlinks",
+        # Since version 3, monkey-patch the implementation of require() in NodeJS is opt-in
+        # https://github.com/bazelbuild/rules_nodejs/wiki#--bazel_patch_module_resolver-now-defaults-to-false-2324
+        "--bazel_patch_module_resolver",
     ]
 
     for i in strip_export_pattern:
@@ -62,7 +67,7 @@ def ts_api_guardian_test(
     nodejs_test(
         name = name,
         data = data,
-        entry_point = "@angular//tools/ts-api-guardian:bin/ts-api-guardian",
+        entry_point = Label("@angular//tools/ts-api-guardian:bin/ts-api-guardian"),
         tags = kwargs.pop("tags", []) + ["api_guard"],
         templated_args = args + ["--verify", golden, actual],
         **kwargs
@@ -72,7 +77,7 @@ def ts_api_guardian_test(
         name = name + ".accept",
         testonly = True,
         data = data,
-        entry_point = "@angular//tools/ts-api-guardian:bin/ts-api-guardian",
+        entry_point = Label("@angular//tools/ts-api-guardian:bin/ts-api-guardian"),
         tags = kwargs.pop("tags", []) + ["api_guard"],
         templated_args = args + ["--out", golden, actual],
         **kwargs

--- a/tools/ts-api-guardian/package.json
+++ b/tools/ts-api-guardian/package.json
@@ -4,12 +4,6 @@
   "description": "Guards the API of TypeScript libraries!",
   "main": "lib/main.js",
   "typings": "lib/main.d.ts",
-  "bazelWorkspaces": {
-    "npm_ts_api_guardian": {
-      "version": "0.5.0",
-      "rootPath": "."
-    }
-  },
   "bin": {
     "ts-api-guardian": "./bin/ts-api-guardian"
   },


### PR DESCRIPTION

Changes include:
- Remove `bazelWorkspaces` as this is no longer supported due to a single version policy https://github.com/bazelbuild/rules_nodejs/pull/783 and `install_bazel_dependencies` has been removed.
- Enable `bazel_patch_module_resolver` since monkey-patch the implementation of `require()` in NodeJS is opt-in

More info about the changes can be found here: https://github.com/bazelbuild/rules_nodejs/wiki#migrating-to-30

Blocking: https://github.com/angular/angular-cli/pull/19716
