### PR TITLE
Log compiler options

### DIFF
--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -32,6 +32,7 @@ export class LanguageService {
   constructor(project: ts.server.Project, private readonly tsLS: ts.LanguageService) {
     this.parseConfigHost = new LSParseConfigHost(project.projectService.host);
     this.options = parseNgCompilerOptions(project, this.parseConfigHost);
+    logCompilerOptions(project, this.options);
     this.strategy = createTypeCheckingProgramStrategy(project);
     this.adapter = new LanguageServiceAdapter(project);
     this.compilerFactory = new CompilerFactory(this.adapter, this.strategy, this.options);
@@ -185,9 +186,16 @@ export class LanguageService {
           project.log(`Config file changed: ${fileName}`);
           if (eventKind === ts.FileWatcherEventKind.Changed) {
             this.options = parseNgCompilerOptions(project, this.parseConfigHost);
+            logCompilerOptions(project, this.options);
           }
         });
   }
+}
+
+function logCompilerOptions(project: ts.server.Project, options: CompilerOptions) {
+  const {logger} = project.projectService;
+  const projectName = project.getProjectName();
+  logger.info(`Angular compiler options for ${projectName}: ` + JSON.stringify(options, null, 2));
 }
 
 function parseNgCompilerOptions(

--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -32,18 +32,6 @@ export class LanguageService {
   constructor(project: ts.server.Project, private readonly tsLS: ts.LanguageService) {
     this.parseConfigHost = new LSParseConfigHost(project.projectService.host);
     this.options = parseNgCompilerOptions(project, this.parseConfigHost);
-
-    // Projects loaded into the Language Service often include test files which are not part of the
-    // app's main compilation unit, and these test files often include inline NgModules that declare
-    // components from the app. These declarations conflict with the main declarations of such
-    // components in the app's NgModules. This conflict is not normally present during regular
-    // compilation because the app and the tests are part of separate compilation units.
-    //
-    // As a temporary mitigation of this problem, we instruct the compiler to ignore classes which
-    // are not exported. In many cases, this ensures the test NgModules are ignored by the compiler
-    // and only the real component declaration is used.
-    this.options.compileNonExportedClasses = false;
-
     this.strategy = createTypeCheckingProgramStrategy(project);
     this.adapter = new LanguageServiceAdapter(project);
     this.compilerFactory = new CompilerFactory(this.adapter, this.strategy, this.options);
@@ -212,6 +200,17 @@ function parseNgCompilerOptions(
   if (errors.length > 0) {
     project.setProjectErrors(errors);
   }
+
+  // Projects loaded into the Language Service often include test files which are not part of the
+  // app's main compilation unit, and these test files often include inline NgModules that declare
+  // components from the app. These declarations conflict with the main declarations of such
+  // components in the app's NgModules. This conflict is not normally present during regular
+  // compilation because the app and the tests are part of separate compilation units.
+  //
+  // As a temporary mitigation of this problem, we instruct the compiler to ignore classes which
+  // are not exported. In many cases, this ensures the test NgModules are ignored by the compiler
+  // and only the real component declaration is used.
+  options.compileNonExportedClasses = false;
 
   return options;
 }


### PR DESCRIPTION
Please see individual commit messages:

1. fix(language-service): reinstate overridden compiler option after change
    
    Currently the language service has to force `compileNonExportedClasses` to
    `true` to handle inline NgModules in tests, regardless of the value in user's
    tsconfig.json.
    
    However, the override is not reinstated after the compiler option changes
    (triggered by a change in tsconfig.json).
    This commit fixes the bug.
1. feat(language-service): log Angular compiler options
    
    This commit records the Angular compiler options in the log file to help
    debugging.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
