### PR TITLE
ci: add new group to approve contributor list changes

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -209,6 +209,7 @@ groups:
          - pkozlowski-opensource   # Pawel Kozlowski
          - Splaktar                # Michael Prentice
          - StephenFluin            # Stephen Fluin
+         - twerske                 # Emma Twersky
 
   # =========================================================
   #  Framework: Animations
@@ -877,6 +878,25 @@ groups:
 
 
   # =========================================================
+  #  Docs: Contributors
+  # =========================================================
+  docs-contributors:
+    <<: *defaults
+    conditions:
+      - *can-be-global-approved
+      - *can-be-global-docs-approved
+      - >
+        contains_any_globs(files, [
+          'aio/content/marketing/contributors.json',
+          'aio/content/images/bios/**',
+          ])
+    reviewers:
+      users:
+        - mgechev
+        - twerske
+
+
+  # =========================================================
   #  Docs: Gettings Started & Tutorial
   # =========================================================
   docs-getting-started-and-tutorial:
@@ -918,10 +938,9 @@ groups:
       - *can-be-global-approved
       - *can-be-global-docs-approved
       - >
-        contains_any_globs(files, [
+        contains_any_globs(files.exclude("aio/content/marketing/contributors.json"), [
           'aio/content/guide/roadmap.md',
           'aio/content/marketing/**',
-          'aio/content/images/bios/**',
           'aio/content/images/marketing/**',
           'aio/content/file-not-found.md',
           'aio/content/license.md',


### PR DESCRIPTION
This commit adds a new `docs-contributors` group (with Emma and Minko as members) which will be used as reviewers
for PRs that update the list of contributors.

// cc @twerske @mgechev 

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No