### PR TITLE
fix(router): Remove usage of `Object.values` to avoid the need for a …

### DIFF
--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -114,8 +114,8 @@ export class ActivateRoutes {
     const contexts = context && route.value.component ? context.children : parentContexts;
     const children: {[outletName: string]: TreeNode<ActivatedRoute>} = nodeChildrenAsMap(route);
 
-    for (const child of Object.values(children)) {
-      this.deactivateRouteAndItsChildren(child, contexts);
+    for (const childOutlet of Object.keys(children)) {
+      this.deactivateRouteAndItsChildren(children[childOutlet], contexts);
     }
 
     if (context && context.outlet) {


### PR DESCRIPTION
…polyfill

`Object.values` is not supported in IE11 without a polyfill. The quickest,
most straightfoward fix for this is to simply use `Object.keys` instead.
We may want to consider including the polyfill in the CLI in the future
or just wait until IE11 support is dropped before using
`Object.values`.

Fixes #40372