### PR TITLE
build(docs-infra): upgrade cli command docs sources to e1bcfba66

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -23,7 +23,7 @@
     "build-local-with-viewengine": "yarn ~~build",
     "prebuild-local-with-viewengine-ci": "node scripts/switch-to-viewengine && yarn setup-local-ci",
     "build-local-with-viewengine-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 4cefc7dc1",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js e1bcfba66",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#master](https://github.com/angular/angular/tree/master) from [cli-builds#master](https://github.com/angular/cli-builds/tree/master).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/4cefc7dc1...e1bcfba66):

**Modified**
- help/extract-i18n.json
- help/test.json

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/e41d0dd01...e1bcfba66) since PR #40355:

**Modified**
- help/extract-i18n.json

##
Closes #40355