### PR TITLE
Hero fetching now before sending the message

### DIFF
--- a/aio/content/examples/toh-pt4/src/app/hero.service.ts
+++ b/aio/content/examples/toh-pt4/src/app/hero.service.ts
@@ -26,10 +26,10 @@ export class HeroService {
   // #docregion getHeroes, getHeroes-1
   getHeroes(): Observable<Hero[]> {
     // #enddocregion getHeroes-1
-    // TODO: send the message _after_ fetching the heroes
+    const heroes = of(HEROES);
     this.messageService.add('HeroService: fetched heroes');
     // #docregion getHeroes-1
-    return of(HEROES);
+    return heroes;
   }
   // #enddocregion getHeroes, getHeroes-1
 }


### PR DESCRIPTION
There was an todo for sending the message after the heroes were fetched.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the tour of heroes in part 4 is an todo.

Issue Number: N/A


## What is the new behavior?
In the same place is now no todo instead it uses the intended behaviour.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
