### PR TITLE
build(docs-infra): upgrade cli command docs sources to f67800842

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -23,7 +23,7 @@
     "build-local-with-viewengine": "yarn ~~build",
     "prebuild-local-with-viewengine-ci": "node scripts/switch-to-viewengine && yarn setup-local-ci",
     "build-local-with-viewengine-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 2677dd0a6",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js f67800842",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#11.0.x](https://github.com/angular/angular/tree/11.0.x) from [cli-builds#11.1.x](https://github.com/angular/cli-builds/tree/11.1.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/2677dd0a6...f67800842):

**Modified**
- help/add.json
- help/analytics.json
- help/build.json
- help/config.json
- help/deploy.json
- help/doc.json
- help/e2e.json
- help/generate.json
- help/lint.json
- help/new.json
- help/run.json
- help/serve.json
- help/test.json
- help/update.json

**Renamed**
- help/extract-i18n.json