### PR TITLE
docs: Fix typo in Trusted Types documentation

### DIFF
--- a/aio/content/guide/security.md
+++ b/aio/content/guide/security.md
@@ -199,7 +199,7 @@ You should configure the HTTP headers for Trusted Types in the following locatio
 The following is an example of a header specifically configured for Trusted Types and Angular:
 
 <code-example language="html">
-Content-Security-Policy: trusted-types angular; required-trusted-types-for 'script';
+Content-Security-Policy: trusted-types angular; require-trusted-types-for 'script';
 </code-example>
 
 The following is an example of a header specifically configured for Trusted Types and Angular applications that use any of the methods in Angular's [DomSanitizer](api/platform-browser/DomSanitizer) that bypasses security.


### PR DESCRIPTION
Remove an extraneous 'd' from the Trusted Types header.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:
