### PR TITLE
fix(zone.js): fesm2015 bundle should also be strict module.

### DIFF
--- a/packages/zone.js/rollup-es5.config.js
+++ b/packages/zone.js/rollup-es5.config.js
@@ -14,7 +14,16 @@ if (bazel_stamp_file) {
   }
 }
 
-const banner = `/**
+// Add 'use strict' to the bundle, https://github.com/angular/angular/pull/40456
+// When rollup build esm bundle of zone.js, there will be no 'use strict'
+// since all esm bundles are `strict`, but when webpack load the esm bundle,
+// because zone.js is a module without export and import, webpack is unable
+// to determine the bundle is `esm` module or not, so it doesn't add the 'use strict'
+// which webpack does to all other `esm` modules which has export or import.
+// And it causes issues such as https://github.com/angular/angular/issues/40215
+// `this` should be `undefined` but is assigned with `Window` instead.
+const banner = `'use strict';
+/**
 * @license Angular v${version}
 * (c) 2010-2020 Google LLC. https://angular.io/
 * License: MIT

--- a/packages/zone.js/rollup-es5.config.js
+++ b/packages/zone.js/rollup-es5.config.js
@@ -24,9 +24,9 @@ if (bazel_stamp_file) {
 // `this` should be `undefined` but is assigned with `Window` instead.
 const banner = `'use strict';
 /**
-* @license Angular v${version}
-* (c) 2010-2020 Google LLC. https://angular.io/
-* License: MIT
+ * @license Angular v${version}
+ * (c) 2010-2020 Google LLC. https://angular.io/
+ * License: MIT
 */`;
 
 module.exports = {

--- a/packages/zone.js/rollup-es5_global-es2015.config.js
+++ b/packages/zone.js/rollup-es5_global-es2015.config.js
@@ -14,7 +14,16 @@ if (bazel_stamp_file) {
   }
 }
 
-const banner = `/**
+// Add 'use strict' to the bundle, https://github.com/angular/angular/pull/40456
+// When rollup build esm bundle of zone.js, there will be no 'use strict'
+// since all esm bundles are `strict`, but when webpack load the esm bundle,
+// because zone.js is a module without export and import, webpack is unable
+// to determine the bundle is `esm` module or not, so it doesn't add the 'use strict'
+// which webpack does to all other `esm` modules which has export or import.
+// And it causes issues such as https://github.com/angular/angular/issues/40215
+// `this` should be `undefined` but is assigned with `Window` instead.
+const banner = `'use strict';
+/**
 * @license Angular v${version}
 * (c) 2010-2020 Google LLC. https://angular.io/
 * License: MIT

--- a/packages/zone.js/rollup-es5_global-es2015.config.js
+++ b/packages/zone.js/rollup-es5_global-es2015.config.js
@@ -24,9 +24,9 @@ if (bazel_stamp_file) {
 // `this` should be `undefined` but is assigned with `Window` instead.
 const banner = `'use strict';
 /**
-* @license Angular v${version}
-* (c) 2010-2020 Google LLC. https://angular.io/
-* License: MIT
+ * @license Angular v${version}
+ * (c) 2010-2020 Google LLC. https://angular.io/
+ * License: MIT
 */`;
 
 module.exports = {

--- a/packages/zone.js/test/npm_package/npm_package.spec.ts
+++ b/packages/zone.js/test/npm_package/npm_package.spec.ts
@@ -86,6 +86,12 @@ describe('Zone.js npm_package', () => {
           expect(shx.cat('zone.umd.js')).not.toContain('sourceMappingURL');
         });
       });
+
+      it('zone.js(es5) should contain use strict', () => {
+        checkInSubFolder('./bundles', () => {
+          expect(shx.cat('zone.umd.js')).toMatch(/^\s*'use strict';/);
+        });
+      });
     });
 
     describe('es2015', () => {
@@ -97,6 +103,11 @@ describe('Zone.js npm_package', () => {
       it('zone.js(es2015) should not contain source map comment', () => {
         checkInSubFolder('./fesm2015', () => {
           expect(shx.cat('zone.js')).not.toContain('sourceMappingURL');
+        });
+      });
+      it('zone.js(es2015) should contain use strict', () => {
+        checkInSubFolder('./fesm2015', () => {
+          expect(shx.cat('zone.js')).toMatch(/^\s*'use strict';/);
         });
       });
     });


### PR DESCRIPTION
Close #40215

`fesm2015/zone.js` is built to `esm` bundle with rollup, so the 'use strict';
statement is not generated in the bundle, even we put the 'use strict' in the src code,
rollup removes the code in the final bundle.

So if we load the `fesm2015/zone.js` as a module, such as `ng serve`, in the index.html

```
<script src="polyfills.js" type="module"></script>
```

Everything works fine, since polyfills.js is loaded as `module`, so it is always `strict`.

But in `ng test`, webpack concat the `zone.js` and loaded into the karma html. For other app and
 test code, they are still `strict` since they are `module` because they have `export/import`
statement, but `zone.js` is a bundle without `export`, it is a `side effect` bundle, so after
 loaded by webpack, it becomes non-strict. Which causes some issues, such as #40215,
the root cause is the `this` context should be `undefined` but treated as `Window` in `non-strict` mode.

```
Object.prototype.toString.apply(undefined);
// should be [object undefined], but it is [object Window] in non-strict mode.
```

So this commit always add `'use strict';` statement at the beginning of the zone.js es2015 bundle.