### PR TITLE
fix(forms): incorrectly keeping track of ngModel with ngFor inside a form

### DIFF
--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -16,7 +16,7 @@ import {Form} from './form_interface';
 import {NgControl} from './ng_control';
 import {NgModel} from './ng_model';
 import {NgModelGroup} from './ng_model_group';
-import {removeListItem, setUpControl, setUpFormContainer, syncPendingControls} from './shared';
+import {setUpControl, setUpFormContainer, syncPendingControls} from './shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from './validators';
 
 export const formDirectiveProvider: any = {
@@ -104,7 +104,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    */
   public readonly submitted: boolean = false;
 
-  private _directives: NgModel[] = [];
+  private _directives = new Set<NgModel>();
 
   /**
    * @description
@@ -191,7 +191,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
           <FormControl>container.registerControl(dir.name, dir.control);
       setUpControl(dir.control, dir);
       dir.control.updateValueAndValidity({emitEvent: false});
-      this._directives.push(dir);
+      this._directives.add(dir);
     });
   }
 
@@ -217,7 +217,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
       if (container) {
         container.removeControl(dir.name);
       }
-      removeListItem(this._directives, dir);
+      this._directives.delete(dir);
     });
   }
 
@@ -324,8 +324,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
     }
   }
 
-  /** @internal */
-  _findContainer(path: string[]): FormGroup {
+  private _findContainer(path: string[]): FormGroup {
     path.pop();
     return path.length ? <FormGroup>this.form.get(path) : this.form;
   }

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -298,9 +298,9 @@ export function isBuiltInAccessor(valueAccessor: ControlValueAccessor): boolean 
   return Object.getPrototypeOf(valueAccessor.constructor) === BuiltInControlValueAccessor;
 }
 
-export function syncPendingControls(form: FormGroup, directives: NgControl[]): void {
+export function syncPendingControls(form: FormGroup, directives: Set<NgControl>|NgControl[]): void {
   form._syncPendingControls();
-  directives.forEach(dir => {
+  directives.forEach((dir: NgControl) => {
     const control = dir.control as FormControl;
     if (control.updateOn === 'submit' && control._pendingChange) {
       dir.viewToModelUpdate(control._pendingValue);


### PR DESCRIPTION
When an `NgModel` is created within a `form`, it receives an `NgControl` based on its `name`, but the control doesn't get swapped out if the name changes. This can lead to problems if the `NgModel` is part of an `ngFor`, because the name can change based on its position in the list and a new control can be defined with the same name, leading us to having multiple directives pointing to the same control. For example, if we start off with a list like :

```
[0, 1, 2]; -> [NgModel(0), NgModel(1), NgModel(2)]
```

Then we remove the second item:

```
[0, 2]; -> [NgModel(0), NgModel(2)]
```

And finally, if we decide to add an item to the end of the list, we'll already have a control for
index 2, causing the list to look like:

```
[0, 2, 3]; -> [NgModel(0), NgModel(2), NgModel(2)]
```

These changes fix the issue by removing the old control when the `name` of the directive changes.

Fixes #38465.
Fixes #37920.