### PR TITLE
fix(core): prevent Ivy TestBed from exposing non-tree-shakable providers in module injector

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -29,6 +29,7 @@ export {
   NG_INJ_DEF as ɵNG_INJ_DEF,
   NG_PROV_DEF as ɵNG_PROV_DEF,
 } from './di/interface/defs';
+export {compileInjectable as ɵcompileInjectable} from './di/jit/injectable';
 export {CREATE_ATTRIBUTE_DECORATOR__POST_R3__ as ɵCREATE_ATTRIBUTE_DECORATOR__POST_R3__} from './di/metadata_attr';
 export {createInjector as ɵcreateInjector} from './di/r3_injector';
 export {
@@ -76,6 +77,7 @@ export {
   NG_COMP_DEF as ɵNG_COMP_DEF,
   NG_DIR_DEF as ɵNG_DIR_DEF,
   NG_ELEMENT_ID as ɵNG_ELEMENT_ID,
+  NG_FACTORY_DEF as ɵNG_FACTORY_DEF,
   NG_MOD_DEF as ɵNG_MOD_DEF,
   NG_PIPE_DEF as ɵNG_PIPE_DEF,
 } from './render3/fields';

--- a/packages/core/src/di/jit/injectable.ts
+++ b/packages/core/src/di/jit/injectable.ts
@@ -24,12 +24,14 @@ import {convertDependencies, reflectDependencies} from './util';
  * Compile an Angular injectable according to its `Injectable` metadata, and patch the resulting
  * injectable def (`ɵprov`) onto the injectable type.
  */
-export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
+export function compileInjectable(
+    type: Type<any>, srcMeta?: Injectable, forceCompile?: boolean): void {
   let ngInjectableDef: any = null;
   let ngFactoryDef: any = null;
 
-  // if NG_PROV_DEF is already defined on this class then don't overwrite it
-  if (!type.hasOwnProperty(NG_PROV_DEF)) {
+  // If NG_PROV_DEF is already defined on this class then don't overwrite it,
+  // unless it's specifically requested to recompile this injectable.
+  if (!type.hasOwnProperty(NG_PROV_DEF) || !!forceCompile) {
     Object.defineProperty(type, NG_PROV_DEF, {
       get: () => {
         if (ngInjectableDef === null) {
@@ -39,11 +41,14 @@ export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
         }
         return ngInjectableDef;
       },
+      // Make the property configurable in dev mode to allow overriding in tests.
+      configurable: true
     });
   }
 
-  // if NG_FACTORY_DEF is already defined on this class then don't overwrite it
-  if (!type.hasOwnProperty(NG_FACTORY_DEF)) {
+  // If NG_FACTORY_DEF is already defined on this class then don't overwrite it,
+  // unless it's specifically requested to recompile this injectable.
+  if (!type.hasOwnProperty(NG_FACTORY_DEF) || !!forceCompile) {
     Object.defineProperty(type, NG_FACTORY_DEF, {
       get: () => {
         if (ngFactoryDef === null) {
@@ -61,6 +66,7 @@ export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
         return ngFactoryDef;
       },
       // Leave this configurable so that the factories from directives or pipes can take precedence.
+      // This is also needed in dev mode to allow overriding in tests.
       configurable: true
     });
   }

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -290,6 +290,88 @@ describe('TestBed', () => {
     expect(hello.nativeElement).toHaveText('Hello injected World a second time!');
   });
 
+  it('should not expose overridden non-tree-shakable provider in module injector', () => {
+    @Injectable()
+    class MyService {
+      public name = 'MyService';
+    }
+
+    class FakeService {
+      name = 'FakeService';
+    }
+
+    @Component({
+      selector: 'my-comp',
+      template: '...',
+      providers: [MyService],
+    })
+    class MyComponent {
+      constructor(public myService: MyService) {}
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [MyComponent],
+    });
+
+    TestBed.overrideProvider(MyService, {
+      useFactory: () => new FakeService(),
+    });
+
+    const fixture = TestBed.createComponent(MyComponent);
+    fixture.detectChanges();
+
+    const NOT_FOUND = Symbol('NOT_FOUND');
+    const service = TestBed.inject(MyService, NOT_FOUND as any);
+
+    // Since provider was exposed on the component level only (thus only NodeInjector should have
+    // it), we do not expect to see it in ModuleInjector.
+    expect(service).toBe(NOT_FOUND);
+  });
+
+  it('should override tree-shakable providers', () => {
+    function useFactory(name: string) {
+      class FakeService {
+        name = name;
+      };
+      return {
+        useFactory: () => new FakeService(),
+      };
+    }
+
+    @Injectable({providedIn: 'root'})
+    class RootProvider {
+      name = 'root';
+    }
+    TestBed.overrideProvider(RootProvider, useFactory('overridden (root) - initial'));
+    // Add second override to verify that it invalidates the first one.
+    TestBed.overrideProvider(RootProvider, useFactory('overridden (root)'));
+
+    @Injectable({providedIn: 'platform'})
+    class PlatformProvider {
+      name = 'platform';
+    }
+    TestBed.overrideProvider(PlatformProvider, useFactory('overridden (platform) - initial'));
+    // Add second override to verify that it invalidates the first one.
+    TestBed.overrideProvider(PlatformProvider, useFactory('overridden (platform)'));
+
+    @Injectable({providedIn: 'any'})
+    class AnyProvider {
+      name = 'any';
+    }
+    TestBed.overrideProvider(AnyProvider, useFactory('overridden (any) - initial'));
+    // Add second override to verify that it invalidates the first one.
+    TestBed.overrideProvider(AnyProvider, useFactory('overridden (any)'));
+
+    const rootProvider = TestBed.inject(RootProvider);
+    expect(rootProvider.name).toBe('overridden (root)');
+
+    const platformProvider = TestBed.inject(PlatformProvider);
+    expect(platformProvider.name).toBe('overridden (platform)');
+
+    const anyProvider = TestBed.inject(AnyProvider);
+    expect(anyProvider.name).toBe('overridden (any)');
+  });
+
   it('should not call ngOnDestroy for a service that was overridden', () => {
     SimpleService.ngOnDestroyCalls = 0;
 
@@ -1241,7 +1323,7 @@ describe('TestBed', () => {
   onlyInIvy('VE injects undefined when provider does not have useValue or useFactory')
       .describe('overrides provider', () => {
         it('with empty provider object', () => {
-          @Injectable()
+          @Injectable({providedIn: 'root'})
           class Service {
           }
           TestBed.overrideProvider(Service, {});


### PR DESCRIPTION
Currently all provider overrides (added using `TestBed.overrideProvider` calls) are exposed in the root NgModule
created in TestBed as a root scope module. This approach makes overridden providers accessible by module injector
even though they are not defined at that level (or not defined in app structure at all). This TestBed behavior may
lead to incorrect assertions in tests, thus making dev setup and behavior different from the prod one. This logic was
initially implemented to better support tree-shakable providers (that may not be referenced by any NgModules).

This commit updates TestBed logic to avoid exposing overridden providers in module injector and instead:
- accumulate overrides in internal set and apply overrides as needed for Components/Directives/NgModules instances
- for tree-shakable providers TestBed uses an approach similar to Directives/Components: current compiled defs
(`ɵprov` and `ɵfac`) are preserved and provider is being recompiled with overridden values. At the end of a test,
original defs are restored.

Fixes #39080.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No, but if some tests relied on incorrect behavior, these tests may start to fail now.