### PR TITLE
fix(forms): error if control is removed as a result of another one being reset

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1691,7 +1691,8 @@ export class FormGroup extends AbstractControl {
   /** @internal */
   _forEachChild(cb: (v: any, k: string) => void): void {
     Object.keys(this.controls).forEach(key => {
-      // Controls can change while the loop is running so we
+      // The list of controls can change (for ex. controls might be removed) while the loop
+      // is running (as a result of invoking Forms API in `valueChanges` subscription), so we
       // have to null check before invoking the callback.
       const control = this.controls[key];
       control && cb(control, key);

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1690,7 +1690,12 @@ export class FormGroup extends AbstractControl {
 
   /** @internal */
   _forEachChild(cb: (v: any, k: string) => void): void {
-    Object.keys(this.controls).forEach(k => cb(this.controls[k], k));
+    Object.keys(this.controls).forEach(key => {
+      // Controls can change while the loop is running so we
+      // have to null check before invoking the callback.
+      const control = this.controls[key];
+      control && cb(control, key);
+    });
   }
 
   /** @internal */


### PR DESCRIPTION
When a form is reset, it goes through `_forEachChild` to call `reset` on each of its children. The problem is that if a control is removed while the loop is running (e.g. by a subscription), the form will throw an error, because it built up the list of available controls before the loop started.

These changes fix the issue by adding a null check before invoking the callback.

Fixes #33401.