### PR TITLE
feat(docs-infra): use Record type instead of key-value

### DIFF
--- a/aio/content/examples/form-validation/src/app/shared/forbidden-name.directive.ts
+++ b/aio/content/examples/form-validation/src/app/shared/forbidden-name.directive.ts
@@ -1,6 +1,6 @@
 // #docregion
-import { Directive, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { AbstractControl, NG_VALIDATORS, Validator, ValidatorFn, Validators } from '@angular/forms';
+import { Directive, Input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator, ValidatorFn } from '@angular/forms';
 
 // #docregion custom-validator
 /** A hero's name can't match the given regular expression */
@@ -22,7 +22,7 @@ export function forbiddenNameValidator(nameRe: RegExp): ValidatorFn {
 export class ForbiddenValidatorDirective implements Validator {
   @Input('appForbiddenName') forbiddenName: string;
 
-  validate(control: AbstractControl): {[key: string]: any} | null {
+  validate(control: AbstractControl): ValidationErrors | null {
     return this.forbiddenName ? forbiddenNameValidator(new RegExp(this.forbiddenName, 'i'))(control)
                               : null;
   }

--- a/aio/content/guide/attribute-binding.md
+++ b/aio/content/guide/attribute-binding.md
@@ -150,7 +150,7 @@ The following table summarizes class binding syntax.
     <td><code>"my-class-1 my-class-2 my-class-3"</code></td>
   </tr>
   <tr>
-    <td><code>{[key: string]: boolean | undefined | null}</code></td>
+    <td><code>Record&lt;string, boolean | undefined | null&gt;</code></td>
     <td><code>{foo: true, bar: false}</code></td>
   </tr>
   <tr>
@@ -248,7 +248,7 @@ The following table summarizes style binding syntax.
     <td><code>"width: 100px; height: 100px"</code></td>
   </tr>
   <tr>
-    <td><code>{[key: string]: string | undefined | null}</code></td>
+    <td><code>Record&lt;string, string | undefined | null&gt;</code></td>
     <td><code>{width: '100px', height: '100px'}</code></td>
   </tr>
 </table>


### PR DESCRIPTION
use Record type instead of key-value

Closes #39804

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

**I did not change key-value types in https://github.com/angular/angular/blob/master/aio/content/guide/http.md as the key is named in those examples and as @petebacondarwin said here https://github.com/angular/angular/issues/39804#issuecomment-761562660 Record type prevents key naming**