### PR TITLE
refactor(language-service): do not mutate the original template node …

### DIFF
--- a/packages/language-service/ivy/references.ts
+++ b/packages/language-service/ivy/references.ts
@@ -87,7 +87,7 @@ export class ReferencesAndRenameBuilder {
       canRename: true,
       displayName: text,
       fullDisplayName: text,
-      triggerSpan: toTextSpan(span),
+      triggerSpan: span,
     };
   }
 
@@ -409,19 +409,19 @@ export class ReferencesAndRenameBuilder {
   }
 }
 
-function getRenameTextAndSpanAtPosition(node: TmplAstNode|AST, position: number):
-    {text: string, span: ParseSourceSpan|AbsoluteSourceSpan}|null {
+function getRenameTextAndSpanAtPosition(
+    node: TmplAstNode|AST, position: number): {text: string, span: ts.TextSpan}|null {
   if (node instanceof TmplAstBoundAttribute || node instanceof TmplAstTextAttribute ||
       node instanceof TmplAstBoundEvent) {
     if (node.keySpan === undefined) {
       return null;
     }
-    return {text: node.name, span: node.keySpan};
+    return {text: node.name, span: toTextSpan(node.keySpan)};
   } else if (node instanceof TmplAstVariable || node instanceof TmplAstReference) {
     if (isWithin(position, node.keySpan)) {
-      return {text: node.keySpan.toString(), span: node.keySpan};
+      return {text: node.keySpan.toString(), span: toTextSpan(node.keySpan)};
     } else if (node.valueSpan && isWithin(position, node.valueSpan)) {
-      return {text: node.valueSpan.toString(), span: node.valueSpan};
+      return {text: node.valueSpan.toString(), span: toTextSpan(node.valueSpan)};
     }
   }
 
@@ -431,14 +431,14 @@ function getRenameTextAndSpanAtPosition(node: TmplAstNode|AST, position: number)
   }
   if (node instanceof PropertyRead || node instanceof MethodCall || node instanceof PropertyWrite ||
       node instanceof SafePropertyRead || node instanceof SafeMethodCall) {
-    return {text: node.name, span: node.nameSpan};
+    return {text: node.name, span: toTextSpan(node.nameSpan)};
   } else if (node instanceof LiteralPrimitive) {
-    const span = node.span;
+    const span = toTextSpan(node.sourceSpan);
     const text = node.value;
     if (typeof text === 'string') {
       // The span of a string literal includes the quotes but they should be removed for renaming.
       span.start += 1;
-      span.end -= 1;
+      span.length -= 2;
     }
     return {text, span};
   }

--- a/packages/language-service/ivy/test/references_spec.ts
+++ b/packages/language-service/ivy/test/references_spec.ts
@@ -1415,7 +1415,15 @@ describe('find references and rename locations', () => {
       expect(result.canRename).toEqual(true);
       expect(result.displayName).toEqual('myProp');
       expect(result.kind).toEqual('property');
-      expect(result.triggerSpan.length).toEqual('myProp'.length);
+      expect(text.substring(
+                 result.triggerSpan.start, result.triggerSpan.start + result.triggerSpan.length))
+          .toBe('myProp');
+      // re-queries also work
+      const {triggerSpan, displayName} =
+          env.ngLS.getRenameInfo(_('/my-comp.ts'), cursor) as ts.RenameInfoSuccess;
+      expect(displayName).toEqual('myProp');
+      expect(text.substring(triggerSpan.start, triggerSpan.start + triggerSpan.length))
+          .toBe('myProp');
     });
 
     it('gets rename info when cursor is on a directive input in a template', () => {


### PR DESCRIPTION
…span

Rather than mutating the span on the template when renaming literal strings,
this commit updates the logic to mutate the `TextSpan` equivalent that
is used by the Language Service.
