### PR TITLE
fix(router): handle Object.keys router error in Edge

### DIFF
--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -20,12 +20,10 @@ export function shallowEqualArrays(a: any[], b: any[]): boolean {
 }
 
 export function shallowEqual(a: Params, b: Params): boolean {
-  // Casting Object.keys return values to include `undefined` as there are some cases
-  // in IE 11 where this can happen. Cannot provide a test because the behavior only
-  // exists in certain circumstances in IE 11, therefore doing this cast ensures the
-  // logic is correct for when this edge case is hit.
-  const k1 = Object.keys(a) as string[] | undefined;
-  const k2 = Object.keys(b) as string[] | undefined;
+  // While `undefined` should never be possible, it would sometimes be the case in IE 11
+  // and pre-chromium Edge. The check below accounts for this edge case.
+  const k1 = a ? Object.keys(a) : undefined;
+  const k2 = b ? Object.keys(b) : undefined;
   if (!k1 || !k2 || k1.length != k2.length) {
     return false;
   }


### PR DESCRIPTION
For the Google Cloud Console within Google we observed errors in the
shallowEqual function for users in IE and Edge. I made this patch within
Google and observed that the errors went away so I am upstreaming this
change into Angular.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
An error would be thrown in Edge when navigating using shallowEqual

Issue Number: #40090


## What is the new behavior?
No error is thrown

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
