### PR TITLE
fix(compiler): improved support for `:host-context()` selectors

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -314,7 +314,7 @@ export class ShadowCss {
 
       // The context selectors now must be combined with each other to capture all the possible
       // selectors that `:host-context` can match.
-      return combineHostContextSelectors(_polyfillHostNoCombinator, contextSelectors, selectorText);
+      return combineHostContextSelectors(contextSelectors, selectorText);
     });
   }
 
@@ -682,8 +682,10 @@ function escapeBlocks(
  * @param contextSelectors an array of context selectors that will be combined.
  * @param otherSelectors the rest of the selectors that are not context selectors.
  */
-function combineHostContextSelectors(
-    hostMarker: string, contextSelectors: string[], otherSelectors: string): string {
+function combineHostContextSelectors(contextSelectors: string[], otherSelectors: string): string {
+  const hostMarker = _polyfillHostNoCombinator;
+  const otherSelectorsHasHost = _polyfillHostRe.test(otherSelectors);
+
   // If there are no context selectors then just output a host marker
   if (contextSelectors.length === 0) {
     return hostMarker + otherSelectors;
@@ -706,6 +708,9 @@ function combineHostContextSelectors(
   // Finally connect the selector to the `hostMarker`s: either acting directly on the host
   // (A<hostMarker>) or as an ancestor (A <hostMarker>).
   return combined
-      .map(s => `${s}${hostMarker}${otherSelectors}, ${s} ${hostMarker}${otherSelectors}`)
+      .map(
+          s => otherSelectorsHasHost ?
+              `${s}${otherSelectors}` :
+              `${s}${hostMarker}${otherSelectors}, ${s} ${hostMarker}${otherSelectors}`)
       .join(',');
 }

--- a/packages/compiler/test/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css_spec.ts
@@ -145,6 +145,10 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
             .toEqual('ul[a-host] > .z[contenta], li[a-host] > .z[contenta] {}');
       });
 
+      it('should handle compound class selectors', () => {
+        expect(s(':host(.a.b) {}', 'contenta', 'a-host')).toEqual('.a.b[a-host] {}');
+      });
+
       it('should handle multiple class selectors', () => {
         expect(s(':host(.x,.y) {}', 'contenta', 'a-host')).toEqual('.x[a-host], .y[a-host] {}');
         expect(s(':host(.x,.y) > .z {}', 'contenta', 'a-host'))
@@ -207,6 +211,52 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
             .toEqual('[a="b"][a-host], [a="b"] [a-host] {}');
         expect(s(':host-context([a=b]) {}', 'contenta', 'a-host'))
             .toEqual('[a=b][a-host], [a="b"] [a-host] {}');
+      });
+
+      it('should handle multiple :host-context() selectors', () => {
+        expect(s(':host-context(.one):host-context(.two) {}', 'contenta', 'a-host'))
+            .toEqual(
+                '.one.two[a-host], ' +    // `one` and `two` both on the host
+                '.one.two [a-host], ' +   // `one` and `two` are both on the same ancestor
+                '.one .two[a-host], ' +   // `one` is an ancestor and `two` is on the host
+                '.one .two [a-host], ' +  // `one` and `two` are both ancestors (in that order)
+                '.two .one[a-host], ' +   // `two` is an ancestor and `one` is on the host
+                '.two .one [a-host]' +    // `two` and `one` are both ancestors (in that order)
+                ' {}');
+
+        expect(s(':host-context(.X):host-context(.Y):host-context(.Z) {}', 'contenta', 'a-host')
+                   .replace(/ \{\}$/, '')
+                   .split(/\,\s+/))
+            .toEqual([
+              '.X.Y.Z[a-host]',
+              '.X.Y.Z [a-host]',
+              '.X.Y .Z[a-host]',
+              '.X.Y .Z [a-host]',
+              '.X.Z .Y[a-host]',
+              '.X.Z .Y [a-host]',
+              '.X .Y.Z[a-host]',
+              '.X .Y.Z [a-host]',
+              '.X .Y .Z[a-host]',
+              '.X .Y .Z [a-host]',
+              '.X .Z .Y[a-host]',
+              '.X .Z .Y [a-host]',
+              '.Y.Z .X[a-host]',
+              '.Y.Z .X [a-host]',
+              '.Y .Z .X[a-host]',
+              '.Y .Z .X [a-host]',
+              '.Z .Y .X[a-host]',
+              '.Z .Y .X [a-host]',
+            ]);
+      });
+
+      // This test is checking backward compatibility.
+      // It is not clear what the behaviour should be for a `:host-context` with no selectors.
+      // Arguably it is actually an error that should be reported.
+      it('should handle :host-context with no ancestor selectors', () => {
+        expect(s('.outer :host-context .inner {}', 'contenta', 'a-host'))
+            .toEqual('.outer [a-host] .inner[contenta] {}');
+        expect(s('.outer :host-context() .inner {}', 'contenta', 'a-host'))
+            .toEqual('.outer [a-host] .inner[contenta] {}');
       });
     });
 

--- a/packages/compiler/test/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css_spec.ts
@@ -260,6 +260,21 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
       });
     });
 
+    describe((':host-context and :host combination selector'), () => {
+      it('should handle selectors on the same element', () => {
+        expect(s(':host-context(div):host(.x) > .y {}', 'contenta', 'a-host'))
+            .toEqual('div.x[a-host] > .y[contenta] {}');
+      });
+
+      it('should handle selectors on different elements', () => {
+        expect(s(':host-context(div) :host(.x) > .y {}', 'contenta', 'a-host'))
+            .toEqual('div .x[a-host] > .y[contenta] {}');
+
+        expect(s(':host-context(div) > :host(.x) > .y {}', 'contenta', 'a-host'))
+            .toEqual('div > .x[a-host] > .y[contenta] {}');
+      });
+    });
+
     it('should support polyfill-next-selector', () => {
       let css = s('polyfill-next-selector {content: \'x > y\'} z {}', 'contenta');
       expect(css).toEqual('x[contenta] > y[contenta]{}');


### PR DESCRIPTION
Two commits that fix problems with emulated shadow dom handling of `:host-context`.

Fixes #19199
Fixes #14349
