### PR TITLE
WIP(core): Allow Trusted Types values to bypass sanitization

### DIFF
--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -11,7 +11,7 @@ import {SANITIZER} from '../render3/interfaces/view';
 import {getLView} from '../render3/state';
 import {renderStringify} from '../render3/util/stringify_utils';
 import {TrustedHTML, TrustedScript, TrustedScriptURL} from '../util/security/trusted_type_defs';
-import {trustedHTMLFromString, trustedScriptURLFromString} from '../util/security/trusted_types';
+import {isTrustedHTML, isTrustedScript, isTrustedScriptURL, trustedHTMLFromString, trustedScriptURLFromString} from '../util/security/trusted_types';
 import {trustedHTMLFromStringBypass, trustedScriptFromStringBypass, trustedScriptURLFromStringBypass} from '../util/security/trusted_types_bypass';
 
 import {allowSanitizationBypassAndThrow, BypassType, unwrapSafeValue} from './bypass';
@@ -38,6 +38,11 @@ import {_sanitizeUrl as _sanitizeUrl} from './url_sanitizer';
  * @codeGenApi
  */
 export function ɵɵsanitizeHtml(unsafeHtml: any): TrustedHTML|string {
+  if (isTrustedHTML(unsafeHtml)) {
+    // Value has been blessed by a Trusted Types policy, and thus does not need
+    // sanitization.
+    return unsafeHtml;
+  }
   const sanitizer = getSanitizer();
   if (sanitizer) {
     return trustedHTMLFromStringBypass(sanitizer.sanitize(SecurityContext.HTML, unsafeHtml) || '');
@@ -109,6 +114,11 @@ export function ɵɵsanitizeUrl(unsafeUrl: any): string {
  * @codeGenApi
  */
 export function ɵɵsanitizeResourceUrl(unsafeResourceUrl: any): TrustedScriptURL|string {
+  if (isTrustedScriptURL(unsafeResourceUrl)) {
+    // Value has been blessed by a Trusted Types policy, and thus does not need
+    // sanitization.
+    return unsafeResourceUrl;
+  }
   const sanitizer = getSanitizer();
   if (sanitizer) {
     return trustedScriptURLFromStringBypass(
@@ -133,6 +143,11 @@ export function ɵɵsanitizeResourceUrl(unsafeResourceUrl: any): TrustedScriptUR
  * @codeGenApi
  */
 export function ɵɵsanitizeScript(unsafeScript: any): TrustedScript|string {
+  if (isTrustedScript(unsafeScript)) {
+    // Value has been blessed by a Trusted Types policy, and thus does not need
+    // sanitization.
+    return unsafeScript;
+  }
   const sanitizer = getSanitizer();
   if (sanitizer) {
     return trustedScriptFromStringBypass(

--- a/packages/core/src/util/security/trusted_type_defs.ts
+++ b/packages/core/src/util/security/trusted_type_defs.ts
@@ -41,6 +41,9 @@ export declare interface TrustedTypePolicyFactory {
     createScript?: (input: string) => string,
     createScriptURL?: (input: string) => string,
   }): TrustedTypePolicy;
+  isHTML(value: unknown): value is TrustedHTML;
+  isScript(value: unknown): value is TrustedScript;
+  isScriptURL(value: unknown): value is TrustedScriptURL;
   getAttributeType(tagName: string, attribute: string): string|null;
 }
 

--- a/packages/core/src/util/security/trusted_types.ts
+++ b/packages/core/src/util/security/trusted_types.ts
@@ -132,3 +132,25 @@ export function newTrustedFunctionForDev(...args: string[]): Function {
   // the implementation of this function can be simplified to:
   // return new Function(...args.map(a => trustedScriptFromString(a)));
 }
+
+/**
+ * Returns true if `value` is a TrustedHTML.
+ */
+export function isTrustedHTML(value: unknown): value is TrustedHTML {
+  return global.trustedTypes && (global.trustedTypes as TrustedTypePolicyFactory).isHTML(value);
+}
+
+/**
+ * Returns true if `value` is a TrustedScript.
+ */
+export function isTrustedScript(value: unknown): value is TrustedScript {
+  return global.trustedTypes && (global.trustedTypes as TrustedTypePolicyFactory).isScript(value);
+}
+
+/**
+ * Returns true if `value` is a TrustedScriptURL.
+ */
+export function isTrustedScriptURL(value: unknown): value is TrustedScriptURL {
+  return global.trustedTypes &&
+      (global.trustedTypes as TrustedTypePolicyFactory).isScriptURL(value);
+}


### PR DESCRIPTION
Trusted Types values can be considered safe to inject directly into DOM
sinks, as they can only be produced from Trusted Types security
policies.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [X] Other... Please describe: Security


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
