### PR TITLE
fix(router): activate route should run in the angular zone

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -388,6 +388,7 @@ export class Router {
   private configLoader: RouterConfigLoader;
   private ngModule: NgModuleRef<any>;
   private console: Console;
+  private ngZone: NgZone;
   private isNgZoneEnabled: boolean = false;
 
   /**
@@ -490,8 +491,8 @@ export class Router {
 
     this.ngModule = injector.get(NgModuleRef);
     this.console = injector.get(Console);
-    const ngZone = injector.get(NgZone);
-    this.isNgZoneEnabled = ngZone instanceof NgZone && NgZone.isInAngularZone();
+    this.ngZone = injector.get(NgZone);
+    this.isNgZoneEnabled = this.ngZone instanceof NgZone && NgZone.isInAngularZone();
 
     this.resetConfig(config);
     this.currentUrlTree = createEmptyUrlTree();
@@ -794,7 +795,7 @@ export class Router {
                      }),
 
                      activateRoutes(
-                         this.rootContexts, this.routeReuseStrategy,
+                         this.rootContexts, this.routeReuseStrategy, this.ngZone,
                          (evt: Event) => this.triggerEvent(evt)),
 
                      tap({


### PR DESCRIPTION
Close #37223

When router activate a new route, it renders the component template and registers
the event listeners, all should happen in the angular zone. But in some case, the
operation can happen outside of the angular zone, for example, in the issue #37223,
a canActivate guard is outside of the angular zone and cause all the following
operations (including activation) outside of the angular zone, and finally the
component event listners are all outside of the angular zone and does not trigger
change detection automatically.

This commit check when `activate` happens, if it is currently inside of the angular zone,
we call the logic of activate(), otherwise, we run the `activate()` in `ngZone.run()`.
