### PR TITLE
fix(common): fix currencyCode in CurrencyPipe

### DIFF
--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -253,7 +253,7 @@ export class CurrencyPipe implements PipeTransform {
       display?: 'code'|'symbol'|'symbol-narrow'|string|boolean, digitsInfo?: string,
       locale?: string): string|null;
   transform(
-      value: number|string|null|undefined, currencyCode?: string,
+      value: number|string|null|undefined, currencyCode: string = this._defaultCurrencyCode,
       display: 'code'|'symbol'|'symbol-narrow'|string|boolean = 'symbol', digitsInfo?: string,
       locale?: string): string|null {
     if (!isValue(value)) return null;

--- a/packages/common/test/pipes/number_pipe_spec.ts
+++ b/packages/common/test/pipes/number_pipe_spec.ts
@@ -140,6 +140,11 @@ import {ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
           expect(pipe.transform(5.1234, 'DKK', '', '', 'da')).toEqual('5,12');
         });
 
+        it('should use the injected default currency code if none is provided', () => {
+          const clpPipe = new CurrencyPipe('en-US', 'CLP');
+          expect(clpPipe.transform(1234)).toEqual('CLP1,234');
+        });
+
         it('should support any currency code name', () => {
           // currency code is unknown, default formatting options will be used
           expect(pipe.transform(5.1234, 'unexisting_ISO_code', 'symbol'))


### PR DESCRIPTION
When providing `DEFAULT_CURRENCY_CODE`, it's expected that the `CurrenyPipe` would pass it as `currencyCode` to `formatCurrency` function.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently providing the `DEFAULT_CURRENCY_CODE` changes the symbol that's being displayed but it's not used inside the `formatCurrency` function for getting the `minFrac` ([link to source code](https://github.com/angular/angular/blob/master/packages/common/src/i18n/format_number.ts#L156)), therefore the default value (USD) is being used. So as an example, despite providing `{ provide: DEFAULT_CURRENCY_CODE, useValue: 'IRR' }`, the code `{{ 1000 | currency }}` will result in `1,000.00` but it should be `1,000` based on [this line](https://github.com/angular/angular/blob/69385f7df4/packages/common/src/i18n/currencies.ts#L70)

## What is the new behavior?

With this change, the provided value for `DEFAULT_CURRENCY_CODE` will be passed as `currencyCode` to `formatCurrency` function.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
