### PR TITLE
build: update to @bazel/bazelisk@1.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
   "// 2": "devDependencies are not used under Bazel. Many can be removed after test.sh is deleted.",
   "devDependencies": {
     "@angular/cli": "11.0.0-rc.1",
-    "@bazel/bazelisk": "^1.4.0",
+    "@bazel/bazelisk": "^1.7.3",
     "@bazel/buildifier": "^0.29.0",
     "@bazel/ibazel": "^0.12.3",
     "@octokit/graphql": "^4.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1938,10 +1938,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@bazel/bazelisk@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@bazel/bazelisk/-/bazelisk-1.4.0.tgz#401d7b89b8d89dd579d1e16cc24cd4d9281a4fbb"
-  integrity sha512-VNI/jF7baQiBy4x+u8gmSDsFehqaAuzMyLuCj0j6/aZCZSw2OssytJVj73m8sFYbXgj67D8iYEQ0gbuoafDk6w==
+"@bazel/bazelisk@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@bazel/bazelisk/-/bazelisk-1.7.3.tgz#51d99286326e15434ce10c54c1ee598c4ab1f694"
+  integrity sha512-A+QLZvKifKnbFawH5aaCnooPx0Ia5JS3S8SckKB034GVB3BjtUTCwjaxzxG3ARQ6Jq1vDcQwWgF2bjT9FjrdDg==
 
 "@bazel/buildifier-darwin_x64@0.29.0":
   version "0.29.0"


### PR DESCRIPTION
Update to the latest version of bazelisk as part of preperation for supporting
new Macs with M1 chips.

Addresses https://github.com/angular/angular/issues/40498
