### PR TITLE
test(compiler-cli): reset i18n message index in compliance test macro

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/icu_logic/html_content.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/icu_logic/html_content.js
@@ -2,7 +2,7 @@ decls: 5,
 vars: 1,
 consts: function() {
   __i18nIcuMsg__('{VAR_SELECT, select, male {male - {START_BOLD_TEXT}male{CLOSE_BOLD_TEXT}} female {female {START_BOLD_TEXT}female{CLOSE_BOLD_TEXT}} other {{START_TAG_DIV}{START_ITALIC_TEXT}other{CLOSE_ITALIC_TEXT}{CLOSE_TAG_DIV}}}', [['VAR_SELECT', String.raw`\uFFFD0\uFFFD`], ['START_BOLD_TEXT', '<b>'], ['CLOSE_BOLD_TEXT', '</b>'], ['START_ITALIC_TEXT', '<i>'], ['CLOSE_ITALIC_TEXT', '</i>'], ['START_TAG_DIV', '<div class=\\"other\\">'], ['CLOSE_TAG_DIV', '</div>'],])
-  __i18nMsg__(' {$icu} {$startBoldText}Other content{$closeBoldText}{$startTagDiv}{$startItalicText}Another content{$closeItalicText}{$closeTagDiv}', [['startBoldText', String.raw`\uFFFD#2\uFFFD`], ['closeBoldText', String.raw`\uFFFD/#2\uFFFD`], ['startTagDiv', String.raw`\uFFFD#3\uFFFD`], ['startItalicText', String.raw`\uFFFD#4\uFFFD`], ['closeItalicText', String.raw`\uFFFD/#4\uFFFD`], ['closeTagDiv', String.raw`\uFFFD/#3\uFFFD`], ['icu', '$I18N_0$']], {})
+  __i18nMsg__(' {$icu} {$startBoldText}Other content{$closeBoldText}{$startTagDiv}{$startItalicText}Another content{$closeItalicText}{$closeTagDiv}', [['startBoldText', String.raw`\uFFFD#2\uFFFD`], ['closeBoldText', String.raw`\uFFFD/#2\uFFFD`], ['startTagDiv', String.raw`\uFFFD#3\uFFFD`], ['startItalicText', String.raw`\uFFFD#4\uFFFD`], ['closeItalicText', String.raw`\uFFFD/#4\uFFFD`], ['closeTagDiv', String.raw`\uFFFD/#3\uFFFD`], ['icu', '$I18N_1$']], {})
   return [
     $i18n_1$,
     [__AttributeMarker.Classes__, "other"]

--- a/packages/compiler-cli/test/compliance/test_helpers/expected_file_macros.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/expected_file_macros.ts
@@ -7,7 +7,7 @@
  */
 import {AttributeMarker, SelectorFlags} from '@angular/compiler/src/core';
 import {QueryFlags} from '@angular/compiler/src/render3/view/compiler';
-import {i18nIcuMsg, i18nMsg, i18nMsgWithPostprocess, Placeholder} from './i18n_helpers';
+import {i18nIcuMsg, i18nMsg, i18nMsgWithPostprocess, Placeholder, resetMessageIndex} from './i18n_helpers';
 
 const EXPECTED_FILE_MACROS: [RegExp, (...args: string[]) => string][] = [
   [
@@ -47,6 +47,8 @@ const EXPECTED_FILE_MACROS: [RegExp, (...args: string[]) => string][] = [
  * @param expectedContent The content to process.
  */
 export function replaceMacros(expectedContent: string): string {
+  resetMessageIndex();
+
   for (const [regex, replacer] of EXPECTED_FILE_MACROS) {
     expectedContent = expectedContent.replace(regex, replacer);
   }

--- a/packages/compiler-cli/test/compliance/test_helpers/i18n_helpers.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/i18n_helpers.ts
@@ -12,6 +12,10 @@
  */
 let msgIndex = 0;
 
+export function resetMessageIndex(): void {
+  msgIndex = 0;
+}
+
 /**
  * Generate a string that represents expected i18n block content for a simple message.
  */


### PR DESCRIPTION
The compliance test runner has various macros that process the
expectation files before actually checking their contents. Among those
macros are i18n helpers, which uses a global message counter to be able
to uniquely identify ICU variables.

Because of the global nature of this message index, it was susceptible
to ordering issues which could result in flaky tests, although it failed
very infrequently.

This commit resets the global message counter before applying the macros.
As a result of this change an expectation file had to be updated; this
is actually a bug fix as said test used to fail if run in isolation (if
`focusTest: true` was set for that particular testcase).