### PR TITLE
build(docs-infra): upgrade cli command docs sources to 73ab73f51

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -23,7 +23,7 @@
     "build-local-with-viewengine": "yarn ~~build",
     "prebuild-local-with-viewengine-ci": "node scripts/switch-to-viewengine && yarn setup-local-ci",
     "build-local-with-viewengine-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js e1bcfba66",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 73ab73f51",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#11.1.x](https://github.com/angular/angular/tree/11.1.x) from [cli-builds#11.1.x](https://github.com/angular/cli-builds/tree/11.1.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/e1bcfba66...73ab73f51):

**Modified**
- help/build.json
- help/serve.json