### PR TITLE
build(zone.js): do not error when build `zone.js` on Windows

### DIFF
--- a/scripts/build/zone-js-builder.js
+++ b/scripts/build/zone-js-builder.js
@@ -35,7 +35,7 @@ function buildZoneJsPackage(destPath) {
   console.info(`${scriptPath}:`);
   console.info('  Building zone.js npm package');
   console.info('##############################');
-  exec(`${bazelCmd} run //packages/zone.js:npm_package.pack`);
+  exec(`${bazelCmd} build //packages/zone.js:npm_package`);
 
   // Create the output directory.
   const absDestPath = resolve(baseDir, destPath);
@@ -45,6 +45,12 @@ function buildZoneJsPackage(destPath) {
   // scripts/tests.
   const buildOutputDir = `${bazelBin}/packages/zone.js/npm_package`;
   const distTargetDir = `${absDestPath}/zone.js`;
+
+  // Also create an archive so we can test the package itself.
+  // Currently, the `npm_package.pack` rule does not work on Windows, so run `npm pack` directly.
+  //
+  // TODO: Switch to `npm_package.pack`, once we upgrade to `bazelbuild/rules_nodejs` >=2.3.0.
+  exec(`npm pack ${buildOutputDir}`, false, {cwd: baseDir});
 
   console.info(`# Copy npm_package artifacts to ${distTargetDir}`);
   rm('-rf', distTargetDir);


### PR DESCRIPTION
In older versions of `bazelbuild/rules_nodejs`, the `npm_package.pack` rule does not work on Windows. This has been fixed in
bazelbuild/rules_nodejs#2257, but the fix is not available before [version 2.3.0][1].

Currently, we use version 2.2.0 (see [WORKSPACE][2]). In order to allow the `zone-js-builder.js` script to work on Windows, this commit switches to using `npm pack` directly, intead of relying on `npm_package.pack`.

For reference, the version of `bazelbuild/rules_nodejs` was updated to 2.3.2 in PR #39636, but this was later reverted due to CI flakes (4e6d69cc85c824faf8e55bbc474cc070aceb2950).

[1]: https://github.com/bazelbuild/rules_nodejs/releases/tag/2.3.0
[2]: https://github.com/angular/angular/blob/fc64fa8e1af9e0bbab40d1b441743744a40c5581/WORKSPACE#L12
