### PR TITLE
fix(router): allow question mark characters in query parameters values

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -436,7 +436,7 @@ function matchQueryParams(str: string): string {
   return match ? match[0] : '';
 }
 
-const QUERY_PARAM_VALUE_RE = /^[^?&#]+/;
+const QUERY_PARAM_VALUE_RE = /^[^&#]+/;
 // Return the value of the query param at the start of the string or an empty string
 function matchUrlQueryParamValue(str: string): string {
   const match = str.match(QUERY_PARAM_VALUE_RE);

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -25,6 +25,16 @@ describe('UrlTree', () => {
         'k/(a;b)': 'c',
       });
     });
+
+    it('should parse query parameters containing question marks', () => {
+      const tree = serializer.parse('/path/to/search?q1=something?&q2=something%3F&q3=?something&q4=%3Fsomething');
+      expect(tree.queryParams).toEqual({
+        'q1': 'something?',
+        'q2': 'something?',
+        'q3': '?something',
+        'q4': '?something',
+      });
+    });
   });
 
   describe('containsTree', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
If Router navigation happens using a URL that contains a question mark as a value of one of the query parameters, the `UrlParser` will remove it from the query. E.g. `/path/to/search?q=somethingWith?` will be `/path/to/search?q=somethingWith`.
This might be an issue for Applications that need to provide search functionality through URL especially if the search terms (for book titles for example) can contain special characters like a question mark.

## What is the new behavior?
This PR fixes this issue by removing the `?` from the regular expression used in `matchUrlQueryParamValue`. At this stage, the first `?` for query query params is already removed, thus it is no problem to include it in query params values.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
