### PR TITLE
refactor(animations): remove unused utils function

### DIFF
--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -9,7 +9,7 @@ import {AnimationOptions, ɵStyleData} from '@angular/animations';
 
 import {AnimationDriver} from '../render/animation_driver';
 import {getOrSetAsInMap} from '../render/shared';
-import {copyObj, interpolateParams, iteratorToArray, mergeAnimationOptions} from '../util';
+import {copyObj, interpolateParams, iteratorToArray} from '../util';
 
 import {StyleAst, TransitionAst} from './animation_ast';
 import {buildAnimationTimelines} from './animation_timeline_builder';

--- a/packages/animations/browser/src/util.ts
+++ b/packages/animations/browser/src/util.ts
@@ -252,23 +252,6 @@ export function iteratorToArray(iterator: any): any[] {
   return arr;
 }
 
-export function mergeAnimationOptions(
-    source: AnimationOptions, destination: AnimationOptions): AnimationOptions {
-  if (source.params) {
-    const p0 = source.params;
-    if (!destination.params) {
-      destination.params = {};
-    }
-    const p1 = destination.params;
-    Object.keys(p0).forEach(param => {
-      if (!p1.hasOwnProperty(param)) {
-        p1[param] = p0[param];
-      }
-    });
-  }
-  return destination;
-}
-
 const DASH_CASE_REGEXP = /-+([a-z0-9])/g;
 export function dashCaseToCamelCase(input: string): string {
   return input.replace(DASH_CASE_REGEXP, (...m: any[]) => m[1].toUpperCase());


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The `mergeAnimationOptions` function is no longer used since 05472cb21be17d9f3ae526ea1a4d6ceb4cad5da7

## What is the new behavior?

Removes the unused function

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
