### PR TITLE
fix(dev-infra): fix substitution string for component_benchmark

### DIFF
--- a/dev-infra/BUILD.bazel
+++ b/dev-infra/BUILD.bazel
@@ -58,7 +58,7 @@ pkg_npm(
         # This substitution is particularly verbose because we need to make sure
         # that only things available via Angular Bazel are imported from
         # tools/defaults.bzl.
-        "load(\"//tools:defaults.bzl\", \"ng_module\")": "load(\"@npm//@angular/bazel:index.bzl\", \"ng_module\")",
+        "load\\(\"//tools:defaults.bzl\", \"ng_module\"\\)": "load(\"@npm//@angular/bazel:index.bzl\", \"ng_module\")",
     },
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
Correct the substitution made to import `ng_module` from `@angular/bazel`,
rather than local to the repository.
