### PR TITLE
build(zone.js): use `npm_package.pack` to build the Zone.js package

### DIFF
--- a/scripts/build/zone-js-builder.js
+++ b/scripts/build/zone-js-builder.js
@@ -35,7 +35,7 @@ function buildZoneJsPackage(destPath) {
   console.info(`${scriptPath}:`);
   console.info('  Building zone.js npm package');
   console.info('##############################');
-  exec(`${bazelCmd} build //packages/zone.js:npm_package`);
+  exec(`${bazelCmd} run //packages/zone.js:npm_package.pack`);
 
   // Create the output directory.
   const absDestPath = resolve(baseDir, destPath);
@@ -45,12 +45,6 @@ function buildZoneJsPackage(destPath) {
   // scripts/tests.
   const buildOutputDir = `${bazelBin}/packages/zone.js/npm_package`;
   const distTargetDir = `${absDestPath}/zone.js`;
-
-  // Also create an archive so we can test the package itself.
-  // Currently, the `npm_package.pack` rule does not work on Windows, so run `npm pack` directly.
-  //
-  // TODO: Switch to `npm_package.pack`, once we upgrade to `bazelbuild/rules_nodejs` >=2.3.0.
-  exec(`npm pack ${buildOutputDir}`, false, {cwd: baseDir});
 
   console.info(`# Copy npm_package artifacts to ${distTargetDir}`);
   rm('-rf', distTargetDir);


### PR DESCRIPTION
Previously, we could not use `npm_package.pack` for building the Zone.js package due to a bug in Windows. This bug has been fixed in version 2.3.0 of `bazelbuild/rules_nodejs`.

Now that we have updated `bazelbuild/rules_nodejs` to version 2.3.3 (in #40581) we can replace `npm pack` with `npm_package.pack`.
