### PR TITLE
fix(language-service): implement realpath to resolve symlinks

### DIFF
--- a/packages/language-service/ivy/adapters.ts
+++ b/packages/language-service/ivy/adapters.ts
@@ -52,6 +52,14 @@ export class LanguageServiceAdapter implements NgCompilerAdapter {
   }
 
   /**
+   * Return the real path of a symlink. This method is required in order to
+   * resolve symlinks in node_modules.
+   */
+  realpath(path: string): string {
+    return this.project.realpath?.(path) ?? path;
+  }
+
+  /**
    * readResource() is an Angular-specific method for reading files that are not
    * managed by the TS compiler host, namely templates and stylesheets.
    * It is a method on ExtendedTsCompilerHost, see


### PR DESCRIPTION
The `LanguageServiceAdapter` must implement `realpath` in order to resolve
symlinks in `node_modules`.

Local libraries are often symlinked in `node_modules` by adding a local
dependency in `package.json`.

Fix https://github.com/angular/vscode-ng-language-service/issues/1083

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
