### PR TITLE
refactor: `_ng_content` and `_ng_host` are now shorter valid attributes

### DIFF
--- a/aio/content/guide/view-encapsulation.md
+++ b/aio/content/guide/view-encapsulation.md
@@ -44,10 +44,10 @@ encapsulation enabled, each DOM element has some extra attributes
 attached to it:
 
 <code-example format="">
-  &lt;hero-details _nghost-pmm-5>
-    &lt;h2 _ngcontent-pmm-5>Mister Fantastic&lt;/h2>
-    &lt;hero-team _ngcontent-pmm-5 _nghost-pmm-6>
-      &lt;h3 _ngcontent-pmm-6>Team&lt;/h3>
+  &lt;hero-details data-nghpmm-5>
+    &lt;h2 data-ngcpmm-5>Mister Fantastic&lt;/h2>
+    &lt;hero-team data-ngcpmm-5 data-nghpmm-6>
+      &lt;h3 data-ngcpmm-6>Team&lt;/h3>
     &lt;/hero-team>
   &lt;/hero-detail>
 
@@ -56,8 +56,8 @@ attached to it:
 There are two kinds of generated attributes:
 
 * An element that would be a shadow DOM host in native encapsulation has a
-  generated `_nghost` attribute. This is typically the case for component host elements.
-* An element within a component's view has a `_ngcontent` attribute
+  generated `data-ngh...` attribute. This is typically the case for component host elements.
+* An element within a component's view has a `data-ngc...` attribute
 that identifies to which host's emulated shadow DOM this element belongs.
 
 The exact values of these attributes aren't important. They are automatically
@@ -65,17 +65,17 @@ generated and you should never refer to them in application code. But they are t
 by the generated component styles, which are in the `<head>` section of the DOM:
 
 <code-example format="">
-  [_nghost-pmm-5] {
+  [data-nghpmm-5] {
     display: block;
     border: 1px solid black;
   }
 
-  h3[_ngcontent-pmm-6] {
+  h3[data-ngcpmm-6] {
     background-color: white;
     border: 1px solid #777;
   }
 </code-example>
 
 These styles are post-processed so that each selector is augmented
-with `_nghost` or `_ngcontent` attribute selectors.
+with `data-ngh...` or `data-ngc...` attribute selectors.
 These extra selectors enable the scoping rules described in this page.

--- a/aio/content/marketing/test.html
+++ b/aio/content/marketing/test.html
@@ -48,7 +48,7 @@
 &lt;hero-details <em>nghost-pmm-5&gt;
   &lt;h2 </em>ngcontent-pmm-5&gt;Bah Dah Bing&lt;/h2&gt;
   &lt;hero-team <em>ngcontent-pmm-5 </em>nghost-pmm-6&gt;
-    &lt;h3 _ngcontent-pmm-6&gt;Headless Team&lt;/h3&gt;
+    &lt;h3 data-ngcpmm-6&gt;Headless Team&lt;/h3&gt;
   &lt;/hero-team&gt;
 &lt;/hero-details&gt;
 </code-example>
@@ -58,7 +58,7 @@
 &lt;hero-details <em>nghost-pmm-5&gt;
   &lt;h2 </em>ngcontent-pmm-5&gt;Mister Fantastic&lt;/h2&gt;
   &lt;hero-team <em>ngcontent-pmm-5 </em>nghost-pmm-6&gt;
-    &lt;h3 _ngcontent-pmm-6&gt;Headless Team&lt;/h3&gt;
+    &lt;h3 data-ngcpmm-6&gt;Headless Team&lt;/h3&gt;
   &lt;/hero-team&gt;
 &lt;/hero-details&gt;
 </code-example>
@@ -68,7 +68,7 @@
   &lt;hero-details <em>nghost-pmm-5&gt;
     &lt;h2 </em>ngcontent-pmm-5&gt;Mister Fantastic&lt;/h2&gt;
     &lt;hero-team <em>ngcontent-pmm-5 </em>nghost-pmm-6&gt;
-      &lt;h3 _ngcontent-pmm-6&gt;Winning Team&lt;/h3&gt;
+      &lt;h3 data-ngcpmm-6&gt;Winning Team&lt;/h3&gt;
     &lt;/hero-team&gt;
   &lt;/hero-details&gt;
 </code-example>
@@ -78,7 +78,7 @@
   &lt;hero-details <em>nghost-pmm-5&gt;
     &lt;h2 </em>ngcontent-pmm-5&gt;Mister Fantastic&lt;/h2&gt;
     &lt;hero-team <em>ngcontent-pmm-5 </em>nghost-pmm-6&gt;
-      &lt;h3 _ngcontent-pmm-6&gt;Losing Team&lt;/h3&gt;
+      &lt;h3 data-ngcpmm-6&gt;Losing Team&lt;/h3&gt;
     &lt;/hero-team&gt;
   &lt;/hero-details&gt;
 </code-example>

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 140871,
+        "main-es2015": 140356,
         "polyfills-es2015": 36964
       }
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/encapsulation_default.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/encapsulation_default.js
@@ -1,1 +1,1 @@
-styles: ["div.foo[_ngcontent-%COMP%] { color: red; }", "[_nghost-%COMP%]   p[_ngcontent-%COMP%]:nth-child(even) { --webkit-transition: 1s linear all; }"]
+styles: ["div.foo[data-ngc%COMP%] { color: red; }", "[data-ngh%COMP%]   p[data-ngc%COMP%]:nth-child(even) { --webkit-transition: 1s linear all; }"]

--- a/packages/compiler-cli/test/compliance_old/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance_old/r3_view_compiler_styling_spec.ts
@@ -40,7 +40,7 @@ describe('compiler compliance: styling', () => {
          };
 
          const template =
-             'styles: ["div.foo[_ngcontent-%COMP%] { color: red; }", "[_nghost-%COMP%]   p[_ngcontent-%COMP%]:nth-child(even) { --webkit-transition: 1s linear all; }"]';
+             'styles: ["div.foo[data-ngc%COMP%] { color: red; }", "[data-ngh%COMP%]   p[data-ngc%COMP%]:nth-child(even) { --webkit-transition: 1s linear all; }"]';
          const result = compile(files, angularFiles);
          expectEmit(result.source, template, 'Incorrect template');
        });

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -7047,7 +7047,7 @@ export const Foo = Foo__PRE_R3__;
         const jsContents = env.getContents('test.js');
         expect(jsContents)
             .toContain(
-                'styles: ["h2[_ngcontent-%COMP%] {width: 10px}", "h1[_ngcontent-%COMP%] {font-size: larger}"]');
+                'styles: ["h2[data-ngc%COMP%] {width: 10px}", "h1[data-ngc%COMP%] {font-size: larger}"]');
       });
 
       it('should process inline <link> tags', () => {
@@ -7064,7 +7064,7 @@ export const Foo = Foo__PRE_R3__;
 
         env.driveMain();
         const jsContents = env.getContents('test.js');
-        expect(jsContents).toContain('styles: ["h1[_ngcontent-%COMP%] {font-size: larger}"]');
+        expect(jsContents).toContain('styles: ["h1[data-ngc%COMP%] {font-size: larger}"]');
       });
 
       it('should share same styles declared in different components in the same file', () => {
@@ -7075,7 +7075,7 @@ export const Foo = Foo__PRE_R3__;
             selector: 'comp-a',
             template: 'Comp A',
             styles: [
-              'span { font-size: larger; }',
+              'span { font-size:larger; }',
               'div { background: url(/some-very-very-long-path.png); }',
               'img { background: url(/a/some-very-very-long-path.png); }'
             ]
@@ -7086,7 +7086,7 @@ export const Foo = Foo__PRE_R3__;
             selector: 'comp-b',
             template: 'Comp B',
             styles: [
-              'span { font-size: larger; }',
+              'span { font-size:larger; }',
               'div { background: url(/some-very-very-long-path.png); }',
               'img { background: url(/b/some-very-very-long-path.png); }'
             ]
@@ -7101,7 +7101,7 @@ export const Foo = Foo__PRE_R3__;
         // separate var.
         expect(jsContents)
             .toContain(
-                '_c0 = "div[_ngcontent-%COMP%] { background: url(/some-very-very-long-path.png); }";');
+                '_c0 = "div[data-ngc%COMP%] { background: url(/some-very-very-long-path.png); }";');
 
         expect(jsContents)
             .toContain(
@@ -7109,13 +7109,13 @@ export const Foo = Foo__PRE_R3__;
                 // This style is present in both components, but was not extracted into
                 // a separate var since it doesn't reach length threshold (50 chars) in
                 // `ConstantPool`.
-                '"span[_ngcontent-%COMP%] { font-size: larger; }", ' +
+                '"span[data-ngc%COMP%] { font-size:larger; }", ' +
                 // Style that is present in both components, but reaches length
                 // threshold - extracted to a separate var.
                 '_c0, ' +
                 // Style that is unique to this component, but that reaches length
                 // threshold - remains a string in the `styles` array.
-                '"img[_ngcontent-%COMP%] { background: url(/a/some-very-very-long-path.png); }"]');
+                '"img[data-ngc%COMP%] { background: url(/a/some-very-very-long-path.png); }"]');
 
         expect(jsContents)
             .toContain(
@@ -7123,13 +7123,13 @@ export const Foo = Foo__PRE_R3__;
                 // This style is present in both components, but was not extracted into
                 // a separate var since it doesn't reach length threshold (50 chars) in
                 // `ConstantPool`.
-                '"span[_ngcontent-%COMP%] { font-size: larger; }", ' +
+                '"span[data-ngc%COMP%] { font-size:larger; }", ' +
                 // Style that is present in both components, but reaches length
                 // threshold - extracted to a separate var.
                 '_c0, ' +
                 // Style that is unique to this component, but that reaches length
                 // threshold - remains a string in the `styles` array.
-                '"img[_ngcontent-%COMP%] { background: url(/b/some-very-very-long-path.png); }"]');
+                '"img[data-ngc%COMP%] { background: url(/b/some-very-very-long-path.png); }"]');
       });
 
       it('large strings are wrapped in a function for Closure', () => {
@@ -7170,7 +7170,7 @@ export const Foo = Foo__PRE_R3__;
         expect(jsContents)
             .toContain(
                 '_c0 = function () {' +
-                ' return "div[_ngcontent-%COMP%] {' +
+                ' return "div[data-ngc%COMP%] {' +
                 ' background: url(/some-very-very-long-path.png);' +
                 ' }";' +
                 ' };');
@@ -7179,7 +7179,7 @@ export const Foo = Foo__PRE_R3__;
             .toContain(
                 'styles: [' +
                 // Check styles for component A.
-                '"div[_ngcontent-%COMP%] { background: url(/a.png); }", ' +
+                '"div[data-ngc%COMP%] { background: url(/a.png); }", ' +
                 // Large string should be called from function definition.
                 '_c0()]');
 
@@ -7187,7 +7187,7 @@ export const Foo = Foo__PRE_R3__;
             .toContain(
                 'styles: [' +
                 // Check styles for component B.
-                '"div[_ngcontent-%COMP%] { background: url(/b.png); }", ' +
+                '"div[data-ngc%COMP%] { background: url(/b.png); }", ' +
                 // Large string should be called from function definition.
                 '_c0()]');
       });

--- a/packages/compiler/src/style_compiler.ts
+++ b/packages/compiler/src/style_compiler.ts
@@ -14,8 +14,8 @@ import {UrlResolver} from './url_resolver';
 import {OutputContext} from './util';
 
 const COMPONENT_VARIABLE = '%COMP%';
-export const HOST_ATTR = `_nghost-${COMPONENT_VARIABLE}`;
-export const CONTENT_ATTR = `_ngcontent-${COMPONENT_VARIABLE}`;
+export const HOST_ATTR = `data-ngh${COMPONENT_VARIABLE}`;
+export const CONTENT_ATTR = `data-ngc${COMPONENT_VARIABLE}`;
 
 export class StylesCompileDependency {
   constructor(

--- a/packages/core/test/acceptance/bootstrap_spec.ts
+++ b/packages/core/test/acceptance/bootstrap_spec.ts
@@ -72,7 +72,7 @@ describe('bootstrap', () => {
          const TestModule = createComponentAndModule();
 
          const ngModuleRef = await platformBrowserDynamic().bootstrapModule(TestModule);
-         expect(document.body.innerHTML).toContain('<span _ngcontent-');
+         expect(document.body.innerHTML).toContain('<span data-ngc');
          ngModuleRef.destroy();
        }));
 
@@ -83,7 +83,7 @@ describe('bootstrap', () => {
          const ngModuleRef = await platformBrowserDynamic().bootstrapModule(
              TestModule, {defaultEncapsulation: ViewEncapsulation.None});
          expect(document.body.innerHTML).toContain('<span>');
-         expect(document.body.innerHTML).not.toContain('_ngcontent-');
+         expect(document.body.innerHTML).not.toContain('data-ngc');
          ngModuleRef.destroy();
        }));
 
@@ -97,7 +97,7 @@ describe('bootstrap', () => {
                                multi: true
                              }]).bootstrapModule(TestModule);
          expect(document.body.innerHTML).toContain('<span>');
-         expect(document.body.innerHTML).not.toContain('_ngcontent-');
+         expect(document.body.innerHTML).not.toContain('data-ngc');
          ngModuleRef.destroy();
        }));
 
@@ -107,7 +107,7 @@ describe('bootstrap', () => {
 
          const ngModuleRef = await platformBrowserDynamic().bootstrapModule(
              TestModule, {defaultEncapsulation: ViewEncapsulation.None});
-         expect(document.body.innerHTML).toContain('<span _ngcontent-');
+         expect(document.body.innerHTML).toContain('<span data-ngc');
          ngModuleRef.destroy();
        }));
 
@@ -265,7 +265,7 @@ describe('bootstrap', () => {
                    'Provided value for `defaultEncapsulation` can not be changed once it has been set.');
 
            // The options should not have been changed
-           expect(document.body.innerHTML).not.toContain('_ngcontent-');
+           expect(document.body.innerHTML).not.toContain('data-ngc');
 
            ngModuleRefB.destroy();
          }));

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -175,16 +175,16 @@ describe('component', () => {
       fixture.detectChanges();
       expect(fixture.nativeElement.innerHTML)
           .toMatch(
-              /<encapsulated _nghost-[a-z\-]+(\d+)="">foo<leaf _ngcontent-[a-z\-]+\1=""><span>bar<\/span><\/leaf><\/encapsulated>/);
+              /<encapsulated data-ngh[a-z\-]+(\d+)="">foo<leaf data-ngc[a-z\-]+\1=""><span>bar<\/span><\/leaf><\/encapsulated>/);
     });
 
     it('should encapsulate host', () => {
       const fixture = TestBed.createComponent(EncapsulatedComponent);
       fixture.detectChanges();
       const html = fixture.nativeElement.outerHTML;
-      const match = html.match(/_nghost-([a-z\-]+\d+)/);
+      const match = html.match(/data-ngh([a-z\-]+\d+)/);
       expect(match).toBeDefined();
-      expect(html).toMatch(new RegExp(`<leaf _ngcontent-${match[1]}=""><span>bar</span></leaf>`));
+      expect(html).toMatch(new RegExp(`<leaf data-ngc${match[1]}=""><span>bar</span></leaf>`));
     });
 
     it('should encapsulate host and children with different attributes', () => {
@@ -194,12 +194,12 @@ describe('component', () => {
       const fixture = TestBed.createComponent(EncapsulatedComponent);
       fixture.detectChanges();
       const html = fixture.nativeElement.outerHTML;
-      const match = html.match(/_nghost-([a-z\-]+\d+)/g);
+      const match = html.match(/data-ngh([a-z\-]+\d+)/g);
       expect(match).toBeDefined();
       expect(match.length).toEqual(2);
       expect(html).toMatch(
-          `<leaf ${match[0].replace('_nghost', '_ngcontent')}="" ${match[1]}=""><span ${
-              match[1].replace('_nghost', '_ngcontent')}="">bar</span></leaf></div>`);
+          `<leaf ${match[0].replace('data-ngh', 'data-ngc')}="" ${match[1]}=""><span ${
+              match[1].replace('data-ngh', 'data-ngc')}="">bar</span></leaf></div>`);
     });
   });
 
@@ -429,7 +429,7 @@ describe('component', () => {
     });
   });
 
-  it('should use a new ngcontent attribute for child elements created w/ Renderer2', () => {
+  it('should use a new data-ngc... attribute for child elements created w/ Renderer2', () => {
     @Component({
       selector: 'app-root',
       template: '<parent-comp></parent-comp>',
@@ -459,7 +459,7 @@ describe('component', () => {
     const secondParentEl: HTMLElement = fixture.nativeElement.querySelector('parent-comp');
     const elementFromRenderer: HTMLElement = fixture.nativeElement.querySelector('p');
     const getNgContentAttr = (element: HTMLElement) => {
-      return Array.from(element.attributes).map(a => a.name).find(a => /ngcontent/.test(a));
+      return Array.from(element.attributes).map(a => a.name).find(a => /data-ngc/.test(a));
     };
 
     const hostNgContentAttr = getNgContentAttr(secondParentEl);

--- a/packages/core/test/bundling/todo_r2/todo_e2e_spec.ts
+++ b/packages/core/test/bundling/todo_r2/todo_e2e_spec.ts
@@ -27,8 +27,7 @@ describe('functional test for todo', () => {
            const toDoAppComponent = (window as any).toDoAppComponent;
            await whenRendered(toDoAppComponent);
 
-           const styleContent =
-               findStyleTextForSelector('.todo-list\\\[_ngcontent-[a-z]+-\\\w+\\\]');
+           const styleContent = findStyleTextForSelector('.todo-list\\\[data-ngc[a-z]+-\\\w+\\\]');
            expect(styleContent).toMatch(/font-weight:\s*bold;/);
            expect(styleContent).toMatch(/color:\s*#d9d9d9;/);
          }));

--- a/packages/core/test/render3/jit/declare_component_spec.ts
+++ b/packages/core/test/render3/jit/declare_component_spec.ts
@@ -262,7 +262,7 @@ describe('component declaration jit compilation', () => {
                 }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
-      styles: ['div[_ngcontent-%COMP%] {}'],
+      styles: ['div[data-ngc%COMP%] {}'],
       encapsulation: ViewEncapsulation.Emulated,
     });
   });

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -1103,7 +1103,7 @@ describe('providers', () => {
          fixture.update();
          expect(fixture.html)
              .toMatch(
-                 /<host-cmp>foo<\/host-cmp><embedded-cmp _nghost-[a-z]+-c(\d+)="">From module injector<\/embedded-cmp>/);
+                 /<host-cmp>foo<\/host-cmp><embedded-cmp data-ngh[a-z]+-c(\d+)="">From module injector<\/embedded-cmp>/);
        });
 
     it('should cross the root view boundary to the parent of the host, thanks to the default root view injector',

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -23,8 +23,8 @@ const COMPONENT_REGEX = /%COMP%/g;
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
 
 export const COMPONENT_VARIABLE = '%COMP%';
-export const HOST_ATTR = `_nghost-${COMPONENT_VARIABLE}`;
-export const CONTENT_ATTR = `_ngcontent-${COMPONENT_VARIABLE}`;
+export const HOST_ATTR = `data-ngh${COMPONENT_VARIABLE}`;
+export const CONTENT_ATTR = `data-ngc${COMPONENT_VARIABLE}`;
 
 export function shimContentAttribute(componentShortId: string): string {
   return CONTENT_ATTR.replace(COMPONENT_REGEX, componentShortId);

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -675,10 +675,10 @@ describe('platform-server integration', () => {
        }));
 
 
-    it('sets a prefix for the _nghost and _ngcontent attributes', waitForAsync(() => {
+    it('sets a prefix for the data-ngh... and data-ngc... attributes', waitForAsync(() => {
          renderModule(ExampleStylesModule, {document: doc}).then(output => {
            expect(output).toMatch(
-               /<html><head><style ng-transition="example-styles">div\[_ngcontent-sc\d+\] {color: blue; } \[_nghost-sc\d+\] { color: red; }<\/style><\/head><body><app _nghost-sc\d+="" ng-version="0.0.0-PLACEHOLDER"><div _ngcontent-sc\d+="">Works!<\/div><\/app><\/body><\/html>/);
+               /<html><head><style ng-transition="example-styles">div\[data-ngcsc\d+\] {color: blue; } \[data-nghsc\d+\] { color: red; }<\/style><\/head><body><app data-nghsc\d+="" ng-version="0.0.0-PLACEHOLDER"><div data-ngcsc\d+="">Works!<\/div><\/app><\/body><\/html>/);
            called = true;
          });
        }));


### PR DESCRIPTION
The Angular compiler will create additional attributes on HTML generated for
emulated shadow DOM CSS encapsulation. These attributes are of the form:

* `_ng_host_<id>` - attached to the host element of each
  component.
* `_ng_content_<id>` - attached to every element within a
  component template.

  where `<id>` is the id of the instance of the component being
  rendered.

These attributes could be shorter and are also not strictly valid HTML
according to the WCAG spec and validators.

This commit changes the names of these attributes to `data-ngh<id>` and
`data-ngc<id>`. The result of this is that attributes are now valid (`data-`
attributes of any name are valid HTML). Also, the host attribute is 1
character shorter, while the content attribute is 4 characters shorter.

Supercedes #37786

Fixes #25355