### PR TITLE
fix(dev-infra): wait for changelog to cherry pick to next branch

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -5885,11 +5885,13 @@ class ReleaseAction {
                 return false;
             }
             // Create a cherry-pick pull request that should be merged by the caretaker.
-            const { url } = yield this.pushChangesToForkAndCreatePullRequest(nextBranch, `changelog-cherry-pick-${newVersion}`, commitMessage, `Cherry-picks the changelog from the "${stagingBranch}" branch to the next ` +
+            const { url, id } = yield this.pushChangesToForkAndCreatePullRequest(nextBranch, `changelog-cherry-pick-${newVersion}`, commitMessage, `Cherry-picks the changelog from the "${stagingBranch}" branch to the next ` +
                 `branch (${nextBranch}).`);
             info(green(`  ✓   Pull request for cherry-picking the changelog into "${nextBranch}" ` +
                 'has been created.'));
             info(yellow(`      Please ask team members to review: ${url}.`));
+            // Wait for the Pull Request to be merged.
+            yield this.waitForPullRequestToBeMerged(id);
             return true;
         });
     }

--- a/dev-infra/release/publish/actions.ts
+++ b/dev-infra/release/publish/actions.ts
@@ -450,7 +450,7 @@ export abstract class ReleaseAction {
     }
 
     // Create a cherry-pick pull request that should be merged by the caretaker.
-    const {url} = await this.pushChangesToForkAndCreatePullRequest(
+    const {url, id} = await this.pushChangesToForkAndCreatePullRequest(
         nextBranch, `changelog-cherry-pick-${newVersion}`, commitMessage,
         `Cherry-picks the changelog from the "${stagingBranch}" branch to the next ` +
             `branch (${nextBranch}).`);
@@ -459,6 +459,10 @@ export abstract class ReleaseAction {
         `  ✓   Pull request for cherry-picking the changelog into "${nextBranch}" ` +
         'has been created.'));
     info(yellow(`      Please ask team members to review: ${url}.`));
+
+    // Wait for the Pull Request to be merged.
+    await this.waitForPullRequestToBeMerged(id);
+
     return true;
   }
 

--- a/dev-infra/release/publish/test/common.spec.ts
+++ b/dev-infra/release/publish/test/common.spec.ts
@@ -93,7 +93,8 @@ describe('common release action logic', () => {
       // it is properly appended. Also expect a pull request to be created in the fork.
       repo.expectChangelogFetch(branchName, fakeReleaseNotes)
           .expectFindForkRequest(fork)
-          .expectPullRequestToBeCreated('master', fork, forkBranchName, 200);
+          .expectPullRequestToBeCreated('master', fork, forkBranchName, 200)
+          .expectPullRequestWait(200);
 
       // Simulate that the fork branch name is available.
       fork.expectBranchRequest(forkBranchName, null);
@@ -119,7 +120,8 @@ describe('common release action logic', () => {
       // it is properly appended. Also expect a pull request to be created in the fork.
       repo.expectChangelogFetch(branchName, customReleaseNotes)
           .expectFindForkRequest(fork)
-          .expectPullRequestToBeCreated('master', fork, forkBranchName, 200);
+          .expectPullRequestToBeCreated('master', fork, forkBranchName, 200)
+          .expectPullRequestWait(200);
 
       // Simulate that the fork branch name is available.
       fork.expectBranchRequest(forkBranchName, null);
@@ -138,7 +140,8 @@ describe('common release action logic', () => {
       // it is properly appended. Also expect a pull request to be created in the fork.
       repo.expectChangelogFetch(branchName, `non analyzable changelog`)
           .expectFindForkRequest(fork)
-          .expectPullRequestToBeCreated('master', fork, forkBranchName, 200);
+          .expectPullRequestToBeCreated('master', fork, forkBranchName, 200)
+          .expectPullRequestWait(200);
 
       // Simulate that the fork branch name is available.
       fork.expectBranchRequest(forkBranchName, null);
@@ -166,7 +169,8 @@ describe('common release action logic', () => {
       // it is properly appended. Also expect a pull request to be created in the fork.
       repo.expectChangelogFetch(branchName, fakeReleaseNotes)
           .expectFindForkRequest(fork)
-          .expectPullRequestToBeCreated('master', fork, forkBranchName, 200);
+          .expectPullRequestToBeCreated('master', fork, forkBranchName, 200)
+          .expectPullRequestWait(200);
 
       // Simulate that the fork branch name is available.
       fork.expectBranchRequest(forkBranchName, null);

--- a/dev-infra/release/publish/test/test-utils.ts
+++ b/dev-infra/release/publish/test/test-utils.ts
@@ -194,7 +194,8 @@ export async function expectStagingAndPublishWithCherryPick(
       .expectTagToBeCreated(expectedTagName, 'STAGING_COMMIT_SHA')
       .expectReleaseToBeCreated(`v${expectedVersion}`, expectedTagName)
       .expectChangelogFetch(expectedBranch, getChangelogForVersion(expectedVersion))
-      .expectPullRequestToBeCreated('master', fork, expectedCherryPickForkBranch, 300);
+      .expectPullRequestToBeCreated('master', fork, expectedCherryPickForkBranch, 300)
+      .expectPullRequestWait(300);
 
   // In the fork, we make the staging and cherry-pick branches appear as
   // non-existent, so that the PRs can be created properly without collisions.


### PR DESCRIPTION
Wait for the cherry-picked changelog to be merged into the next
branch before completing the task.