### PR TITLE
build(language-service): depend on compiler packages in npm package

### DIFF
--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -45,8 +45,6 @@ pkg_npm(
     ],
     deps = [
         ":language-service",
-        "//packages/compiler",
-        "//packages/compiler-cli",
         "//packages/language-service/ivy",
         # min bundle is not used at the moment; omit from package to speed up build
         "//packages/language-service/bundles:language-service.js",

--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -45,6 +45,8 @@ pkg_npm(
     ],
     deps = [
         ":language-service",
+        "//packages/compiler",
+        "//packages/compiler-cli",
         "//packages/language-service/ivy",
         # min bundle is not used at the moment; omit from package to speed up build
         "//packages/language-service/bundles:language-service.js",

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -16,5 +16,9 @@
   },
   "publishConfig":{
     "registry":"https://wombat-dressing-room.appspot.com"
+  },
+  "peerDependencies": {
+    "@angular/compiler": "0.0.0-PLACEHOLDER",
+    "@angular/compiler-cli": "0.0.0-PLACEHOLDER"
   }
 }


### PR DESCRIPTION
The language service npm package depends on the compiler and
compiler-cli packages to build correctly when used as a module in
external TS projects. See
https://github.com/angular/vscode-ng-language-service/pull/1008 for an
example.

This did not affect us previously because usages of the language server
package (at least in the VSCode extension) resolved the package
implicitly, and did not depend on it explicitly in a TS build.

## PR Type
What kind of change does this PR introduce?

- [x] Build related changes