### PR TITLE
fix(http): ignore question mark when params are parsed

### DIFF
--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -73,9 +73,9 @@ export class HttpUrlEncodingCodec implements HttpParameterCodec {
 function paramParser(rawParams: string, codec: HttpParameterCodec): Map<string, string[]> {
   const map = new Map<string, string[]>();
   if (rawParams.length > 0) {
-    // The `window.location.search` can be used while creating an instance of the `HttpParams` class (e.g.
-    // `new HttpParams({ fromString: window.location.search })`). The `window.location.search` may start with
-    // the `?` char, so we strip it if it's present.
+    // The `window.location.search` can be used while creating an instance of the `HttpParams` class
+    // (e.g. `new HttpParams({ fromString: window.location.search })`). The `window.location.search`
+    // may start with the `?` char, so we strip it if it's present.
     const params: string[] = rawParams.replace(/^\?/, '').split('&');
     params.forEach((param: string) => {
       const eqIdx = param.indexOf('=');

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -73,7 +73,10 @@ export class HttpUrlEncodingCodec implements HttpParameterCodec {
 function paramParser(rawParams: string, codec: HttpParameterCodec): Map<string, string[]> {
   const map = new Map<string, string[]>();
   if (rawParams.length > 0) {
-    const params: string[] = rawParams.split('&');
+    // The `window.location.search` can be used while creating an instance of the `HttpParams` class (e.g.
+    // `new HttpParams({ fromString: window.location.search })`). The `window.location.search` may start with
+    // the `?` char, so we strip it if it's present.
+    const params: string[] = rawParams.replace(/^\?/, '').split('&');
     params.forEach((param: string) => {
       const eqIdx = param.indexOf('=');
       const [key, val]: string[] = eqIdx == -1 ?

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -21,6 +21,19 @@ import {HttpParams} from '@angular/common/http/src/params';
         expect(body.getAll('a')).toEqual(['b']);
         expect(body.getAll('c')).toEqual(['d', 'e']);
       });
+
+      it('should ignore question mark in a url', () => {
+        const body = new HttpParams({fromString: '?a=b&c=d&c=e'});
+        expect(body.getAll('a')).toEqual(['b']);
+        expect(body.getAll('c')).toEqual(['d', 'e']);
+      });
+
+      it('should only remove question mark at the beginning of the params', () => {
+        const body = new HttpParams({fromString: '?a=b&c=d&?e=f'});
+        expect(body.getAll('a')).toEqual(['b']);
+        expect(body.getAll('c')).toEqual(['d']);
+        expect(body.getAll('?e')).toEqual(['f']);
+      });
     });
 
     describe('lazy mutation', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes #28722

When the HTTP params are parsed it will not ignore the question mark params when this is in the string.

## What is the new behavior?

With this change we will replace/remove the `?` so that we won't have the problem as described in the issue.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
