### PR TITLE
feat(core): support fakeAsync.wrap() functionality across multiple test cases.

### DIFF
--- a/aio/content/examples/testing/src/app/app.module.ts
+++ b/aio/content/examples/testing/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { HeroService } from './model/hero.service';
 import { UserService } from './model/user.service';
 import { TwainComponent } from './twain/twain.component';
 import { TwainService } from './twain/twain.service';
+import { MockTokenService, AuthService } from './model/auth.service';
 import { WelcomeComponent } from './welcome/welcome.component';
 
 import { DashboardModule } from './dashboard/dashboard.module';
@@ -18,6 +19,7 @@ import { SharedModule } from './shared/shared.module';
 
 import { HttpClientInMemoryWebApiModule } from 'angular-in-memory-web-api';
 import { InMemoryDataService } from './in-memory-data.service';
+import { AuthComponent } from './auth/auth.component';
 
 @NgModule({
   imports: [
@@ -37,7 +39,9 @@ import { InMemoryDataService } from './in-memory-data.service';
   providers: [
     HeroService,
     TwainService,
-    UserService
+    UserService,
+    MockTokenService,
+    AuthService
   ],
   declarations: [
     AppComponent,
@@ -45,6 +49,7 @@ import { InMemoryDataService } from './in-memory-data.service';
     BannerComponent,
     TwainComponent,
     WelcomeComponent,
+    AuthComponent
   ],
   bootstrap: [ AppComponent ]
 })

--- a/aio/content/examples/testing/src/app/auth/auth.component.spec.ts
+++ b/aio/content/examples/testing/src/app/auth/auth.component.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { AuthService, MockTokenService } from '../model/auth.service';
+
+import { AuthComponent } from './auth.component';
+
+let fixture: ComponentFixture<AuthComponent>;
+
+// #docregion wrap
+describe('AuthComponent', () => {
+  // Wrap `fakeAsync()` to add `beforeEach()` and `afterEach()` hooks.
+  // In the `beforeEach()` hook, creating the fixture and call `detectChanges()`
+  // to render for the first time.
+  // In the `afterEach()` hook, destroy the fixture to clear the async timer.
+  // Both `beforeEach()` and `afterEach()` runs in the same `fakeAsync()` scope
+  // with the test body `it()`.
+
+  const fakeAsyncWithFixture = fakeAsync.wrap({
+    beforeEach: () => {
+      const tokenService = new MockTokenService();
+      const authService = new AuthService(tokenService);
+      fixture = TestBed.configureTestingModule({
+        declarations: [ AuthComponent ],
+        providers: [{provide: AuthService, useValue: authService}],
+      }).createComponent(AuthComponent);
+      fixture.componentInstance.user = 'user1';
+      fixture.detectChanges();
+    },
+    afterEach: () => fixture.destroy()
+  });
+
+  it('shouldWork1 should work correctly', fakeAsyncWithFixture(() => {
+    fixture.componentInstance.doSomeWork1();
+    tick();
+    expect(fixture.componentInstance.result).toBe(undefined);
+    tick(1000);
+    expect(fixture.componentInstance.result).toEqual('work1 done after auth with token user1 token');
+  }));
+
+  it('shouldWork2 should work correctly', fakeAsyncWithFixture(() => {
+    fixture.componentInstance.doSomeWork2();
+    tick();
+    expect(fixture.componentInstance.result).toBe(undefined);
+    tick(1000);
+    expect(fixture.componentInstance.result).toEqual('work2 done after auth with token user1 token');
+  }));
+
+  describe('increase with token', () => {
+    const fakeAsyncNested = fakeAsyncWithFixture.wrap({
+      beforeEach: () => {
+        fixture.componentInstance.reset();
+      },
+      afterEach: () => {
+        fixture.componentInstance.stop();
+        fixture.componentInstance.reset();
+      }
+    });
+
+    it('start should increase the counter with token', fakeAsyncNested(() => {
+      expect(fixture.componentInstance.token).toBe(undefined);
+      fixture.componentInstance.start();
+      tick(1200);
+      expect(fixture.componentInstance.token).toBe('user1 token');
+      expect(fixture.componentInstance.counter).toBe(2);
+    }));
+  });
+  // #enddocregion wrap
+});

--- a/aio/content/examples/testing/src/app/auth/auth.component.ts
+++ b/aio/content/examples/testing/src/app/auth/auth.component.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+// #docregion
+import { Component, OnDestroy } from '@angular/core';
+import { filter } from 'rxjs/operators';
+import { AuthService } from '../model/auth.service';
+
+@Component({
+  template: `
+    <input value="{{user}}" (change)="user = $event.target.value"/>
+    <button (click)="doSomeWork1()">do some work 1</button>
+    <button (click)="doSomeWork2()">do some work 2</button>
+    {{result}}
+  `
+})
+export class AuthComponent implements OnDestroy {
+  user: string;
+  result: string;
+  token: string;
+  counter: number;
+  counterInterval = -1;
+
+  constructor(private authService: AuthService) {}
+
+  ngOnDestroy() {
+    this.authService.logout(this.user);
+    this.token = '';
+  }
+
+  doSomeWork1() {
+    this.authService.userToken$.pipe(filter(token => !!token)).subscribe(t => {
+      this.token = t;
+      this.result = `work1 done after auth with token ${t}`;
+    });
+    this.authService.auth(this.user);
+  }
+
+  doSomeWork2() {
+    this.authService.userToken$.pipe(filter(token => !!token)).subscribe(t => {
+      this.token = t;
+      this.result = `work2 done after auth with token ${t}`;
+    });
+    this.authService.auth(this.user);
+  }
+
+  start() {
+    this.authService.userToken$.pipe(filter(token => !!token)).subscribe(t => {
+      this.token = t;
+      this.counterInterval = setInterval(() => {
+        this.counter ++;
+      }, 100);
+    });
+    this.authService.auth(this.user);
+  }
+
+  stop() {
+    if (this.counterInterval !== -1) {
+      clearInterval(this.counterInterval);
+    }
+  }
+
+  reset() {
+    this.counter = 0;
+    this.counterInterval = -1;
+  }
+}

--- a/aio/content/examples/testing/src/app/model/auth.service.ts
+++ b/aio/content/examples/testing/src/app/model/auth.service.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable()
+export class MockTokenService {
+  // Simulate get auth token from some remote service.
+  async getToken(user: string): Promise<string> {
+    return new Promise(res => {
+      setTimeout(() => res(`${user} token`));
+    });
+  }
+}
+
+@Injectable()
+export class AuthService {
+  userToken$ = new BehaviorSubject('');
+  tokenInterval;
+
+  constructor(private tokenService: MockTokenService) {}
+
+  // Simulate refresh token with setInterval
+  auth(user: string) {
+    this.tokenInterval = setInterval(async () => {
+      const token = await this.tokenService.getToken(user);
+      this.userToken$.next(token);
+    }, 1000);
+  }
+
+  logout(user: string) {
+    // Clear the setInterval to finish the refresh token process.
+    clearInterval(this.tokenInterval);
+    this.userToken$.next(undefined);
+  }
+}

--- a/goldens/public-api/core/testing/testing.md
+++ b/goldens/public-api/core/testing/testing.md
@@ -57,7 +57,16 @@ export const ComponentFixtureNoNgZone: InjectionToken<boolean[]>;
 export function discardPeriodicTasks(): void;
 
 // @public
-export function fakeAsync(fn: Function): (...args: any[]) => any;
+export interface FakeAsync {
+    (fn: Function): (...args: any[]) => any;
+    wrap(hooks: {
+        beforeEach?: () => void;
+        afterEach?: () => void;
+    }): FakeAsync;
+}
+
+// @public
+export const fakeAsync: FakeAsync;
 
 // @public
 export function flush(maxTurns?: number): number;

--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -48,7 +48,10 @@ export function resetFakeAsyncZone(): void {
  *
  * @publicApi
  */
-export function fakeAsync(fn: Function): (...args: any[]) => any {
+export function fakeAsync(fn: Function): {
+  (fn: Function): (...args: any[]) => any;
+  wrap: (hooks: {beforeEach?: (() => void); afterEach?: (() => void)}) => typeof fakeAsync
+} {
   if (fakeAsyncTestModule) {
     return fakeAsyncTestModule.fakeAsync(fn);
   }

--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -1699,4 +1699,107 @@ const {fakeAsync, tick, discardPeriodicTasks, flush, flushMicrotasks} = fakeAsyn
       expect(state).toEqual('works');
     });
   });
+
+  describe('fakeAsync with hooks', () => {
+    const {fakeAsync, tick} = (Zone as any)[Zone.__symbol__('fakeAsyncTest')];
+    function mockAuth(name: string, callback: Function) {
+      let idx = 0;
+      const timerId = setInterval(() => {
+        callback(`${idx++} ${name} verified`);
+      }, 100);
+      return () => {
+        clearInterval(timerId);
+      };
+    }
+    class App {
+      cleanup: Function|null = null;
+      authToken: string|null = null;
+      data: string|null = null;
+      counter = 0;
+      constructor(public name: string) {}
+
+      doSomeWork1() {
+        this.cleanup = mockAuth(this.name, (token: string) => {
+          this.authToken = token;
+          this.data = this.authToken + ' work1 done';
+        });
+      }
+
+      doSomeWork2() {
+        this.cleanup = mockAuth(this.name, (token: string) => {
+          this.authToken = token;
+          this.data = this.authToken + ' work2 done';
+        });
+      }
+
+      increase() {
+        this.counter++;
+      }
+
+      reset() {
+        this.counter = 0;
+      }
+
+      destroy() {
+        this.cleanup && this.cleanup();
+      }
+    }
+
+    describe('should invoke hook bound with fakeAsync', () => {
+      let app: App|null;
+      let logs: string[] = [];
+      const fakeAsyncWithHook = fakeAsync.wrap({
+        beforeEach: () => {
+          app = new App('test');
+          logs = [];
+          logs.push('beforeEach');
+        },
+        afterEach: () => {
+          logs.push('afterEach');
+          const tokenBefore = app!.authToken;
+          app!.destroy();
+          tick(100);
+          const tokenAfter = app!.authToken;
+          expect(tokenAfter).toEqual(tokenBefore);
+          app = null;
+          if (logs.length === 4) {
+            expect(logs).toEqual(
+                ['beforeEach', 'beforeEach nested', 'afterEach nested', 'afterEach']);
+          } else {
+            expect(logs).toEqual(['beforeEach', 'afterEach']);
+          }
+        }
+      });
+
+      it('test App doSomeWork1', fakeAsyncWithHook(() => {
+           app!.doSomeWork1();
+           tick(100);
+           expect(app!.data).toContain('test verified work1 done');
+         }));
+
+      it('test App doSomeWork2', fakeAsyncWithHook(() => {
+           app!.doSomeWork2();
+           tick(100);
+           expect(app!.data).toContain('test verified work2 done');
+         }));
+
+      describe('should invoke nested hook bound with fakeAsync', () => {
+        const fakeAsyncWithHookNested = fakeAsyncWithHook.wrap({
+          beforeEach: () => {
+            logs.push('beforeEach nested');
+            app!.reset();
+          },
+          afterEach: () => {
+            logs.push('afterEach nested');
+            expect(logs).toEqual(['beforeEach', 'beforeEach nested', 'afterEach nested']);
+          }
+        });
+
+        it('increase should increase the counter', fakeAsyncWithHookNested(() => {
+             app!.increase();
+             expect(app!.counter).toBe(1);
+           }));
+      });
+    });
+  });
 }


### PR DESCRIPTION
Close #40387

Enable global `fakeAsync()` feature by introducing hooks functions.
`fakeAsync.wrap({beforeEach?: () => void, afterEach?: () => void)`;

# Motivation

Consider the similar function from `jest.useFakeTimers()`, we can write test cases like this.

```
describe('test', () => {
   beforeAll(() => {
     jest.useFakeTimers();   
   });

   afterAll(() => {
     jest.clearAllTimers();
     jest.useRealTimers();
   });

   test('async test1', () => {
      setInterval(() => {}, 100);
      jest.advanceTimersByTime(100);
      expect(...);
   });

    test('async test2', () => {
      setInterval(() => {}, 200);
      jest.advanceTimersByTime(200);
      expect(...);
   });
});
```

So with `jest.useFakeTimers()`, all the following tests are automatically using the fake timers, and the developers can write the common `init`, `cleanup` logic in `beforeEach()/afterEach()`. 

But with `fakeAsync()`, we can not do the same thing for now.

For example, we have a Component like this.

```
@component({...})
export class AppComponent {
  timerId: number;
  ngOnInit() {
    this.timerId = setTimeout(() => {});
  }

  ngOnDestroy() {
    clearTimeout(this.timerId);
  }
}

And for now, we need to write test
like this.

describe('AppComponent test', () => {
  let fixture: ComponentFixture<AppComponent>;
  beforeEach(() => {
    ...
    fixture = TestBed.createComponent(AppComponent);
  });

  it('test case1', fakeAsync(() => {
    fixture.detectChanges();
    // do some test with fixture
    fixture.destroy();
  }));

  it('test case2', fakeAsync(() => {
    fixture.detectChanges();
    // do some test with fixture
    fixture.destroy();
  }));
});
```

We need to call `fixture.destroy()` inside each tests, since each it() use
it's own fakeAsync() and we need to clean up the timerId created in that
FakeAsyncZoneSpec. Otherwise the `fakeAsync()` will throw `there are 
still pending timers` error.


# Solution
So in this PR, there are two hooks functions are introduced. 

With the hook functions, we can write case in this way.
   
```
   describe('AppComponent test', () => {
     let fixture: ComponentFixture<AppComponent>;
   
     const fakeAsyncWithFixture = fakeAsync.wrap({
       beforeEach: () => {
         fixture = TestBed.createComponent(AppComponent);
         fixture.detectChanges();
       }
       afterEach: () => fixture.destroy();
     });
   
     it('test case1', fakeAsyncWithFixture(() => {
       // do some test with fixture
     }));
   
     it('test case2', fakeAsyncWithFixture(() => {
       // do some test with fixture
     }));
   });
   
   Also the `wrap()` function support nesting.
   
   describe('AppComponent test', () => {
     let fixture: ComponentFixture<AppComponent>;
   
     const fakeAsyncWithFixture = fakeAsync.wrap({
       beforeEach: () => {
         fixture = TestBed.createComponent(AppComponent);
         fixture.detectChanges();
       }
       afterEach: () => fixture.destroy();
     });
   
     it('test case1', fakeAsyncWithFixture(() => {
       // do some test with fixture
     }));
   
     it('test case2', fakeAsyncWithFixture(() => {
       // do some test with fixture
     }));
   
     describe('AppComponent sub test: auth test', () => {
       const fakeAsyncNested = fakeAsyncWithFeature.wrap({
         beforeEach: () => fixture.componentInstance.login(),
         afterEach: () => fixture.componentInstance.logout();
       });
   
       it('should show user info', () => {
         // do some test with fixture with authenticated user.
       });
     });
   });
```

This feature will be useful when we want to do some global cleanup
in `afterEach()` when the component have some `async` tasks
(especially `setInterval`) running by 3rd party library.