### PR TITLE
ci: add pete to the fw-http group

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -479,6 +479,7 @@ groups:
       users:
         - alxhub
         - IgorMinar
+        - petebacondarwin
 
 
   # =========================================================


### PR DESCRIPTION
This allows @petebacondarwin to approve PRs for the
`@angular/common/http` package.
