### PR TITLE
fix(common): parse `YYYY` strings as UTC dates

### DIFF
--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -711,13 +711,6 @@ export function toDate(value: string|number|Date): Date {
   if (typeof value === 'string') {
     value = value.trim();
 
-    const parsedNb = parseFloat(value);
-
-    // any string that only contains numbers, like "1234" but not like "1234hello"
-    if (!isNaN(value as any - parsedNb)) {
-      return new Date(parsedNb);
-    }
-
     if (/^(\d{4}(-\d{1,2}(-\d{1,2})?)?)$/.test(value)) {
       /* For ISO Strings without time the day, month and year must be extracted from the ISO String
       before Date creation to avoid time offset and errors in the new Date.
@@ -728,6 +721,13 @@ export function toDate(value: string|number|Date): Date {
       Note: ISO months are 0 for January, 1 for February, ... */
       const [y, m = 1, d = 1] = value.split('-').map((val: string) => +val);
       return new Date(y, m - 1, d);
+    }
+
+    const parsedNb = parseFloat(value);
+
+    // any string that only contains numbers, like "1234" but not like "1234hello"
+    if (!isNaN(value as any - parsedNb)) {
+      return new Date(parsedNb);
     }
 
     let match: RegExpMatchArray|null;

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -61,7 +61,7 @@ describe('Format date', () => {
   describe('formatDate', () => {
     const isoStringWithoutTime = '2015-01-01';
     const isoStringWithoutTimeOrDate = '2015-01';
-    const isoStringWithoutTimeOrDateOrMonth = '2015-01';
+    const isoStringWithoutTimeOrDateOrMonth = '2015';
     const defaultFormat = 'mediumDate';
     let date: Date;
 


### PR DESCRIPTION
In b6cd38ff055f003f92fff4c3e27d165fb4437057 we fixed the DatePipe so
that when it parsed date strings that looked like `YYYY-MM` it created a UTC
date that was not affected by the local timezone of the JavaScript engine.

This commit does the same for date strings of the form `YYYY`.

(Note that the previous commit, mentioned above, attempted to fix this case
too but the test was not actually checking the correct input string.)

Fixes #33944