### PR TITLE
fix(router): stop emitting to event observable on destroy

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -377,6 +377,7 @@ export class Router {
   private navigations: Observable<NavigationTransition>;
   private lastSuccessfulNavigation: Navigation|null = null;
   private currentNavigation: Navigation|null = null;
+  private disposed = false;
 
   private locationSubscription?: SubscriptionLike;
   /**
@@ -1043,10 +1044,12 @@ export class Router {
 
   /** Disposes of the router. */
   dispose(): void {
+    this.transitions.complete();
     if (this.locationSubscription) {
       this.locationSubscription.unsubscribe();
       this.locationSubscription = undefined;
     }
+    this.disposed = true;
   }
 
   /**
@@ -1251,6 +1254,9 @@ export class Router {
       rawUrl: UrlTree, source: NavigationTrigger, restoredState: RestoredState|null,
       extras: NavigationExtras,
       priorPromise?: {resolve: any, reject: any, promise: Promise<boolean>}): Promise<boolean> {
+    if (this.disposed) {
+      return Promise.resolve(false);
+    }
     // * Imperative navigations (router.navigate) might trigger additional navigations to the same
     //   URL via a popstate event and the locationChangeListener. We should skip these duplicate
     //   navs. Duplicates may also be triggered by attempts to sync AngularJS and Angular router

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -4504,6 +4504,52 @@ describe('Integration', () => {
 
          expect(navigateSpy.calls.mostRecent().args[1]!.queryParams);
        })));
+
+
+    it('should stop emitting events after the router is destroyed',
+       fakeAsync(inject([Router], (router: Router) => {
+         const fixture = createRoot(router, RootCmp);
+         router.resetConfig([{path: 'user/:name', component: UserCmp}]);
+
+         let events = 0;
+         const subscription = router.events.subscribe(() => events++);
+
+         router.navigateByUrl('/user/frodo');
+         advance(fixture);
+         expect(events).toBeGreaterThan(0);
+
+         const previousCount = events;
+         router.dispose();
+         router.navigateByUrl('/user/bilbo');
+         advance(fixture);
+
+         expect(events).toBe(previousCount);
+         subscription.unsubscribe();
+       })));
+
+    it('should resolve navigation promise with false after the router is destroyed',
+       fakeAsync(inject([Router], (router: Router) => {
+         const fixture = createRoot(router, RootCmp);
+         let result = null as boolean | null;
+         const callback = (r: boolean) => result = r;
+         router.resetConfig([{path: 'user/:name', component: UserCmp}]);
+
+         router.navigateByUrl('/user/frodo').then(callback);
+         advance(fixture);
+         expect(result).toBe(true);
+         result = null as boolean | null;
+
+         router.dispose();
+
+         router.navigateByUrl('/user/bilbo').then(callback);
+         advance(fixture);
+         expect(result).toBe(false);
+         result = null as boolean | null;
+
+         router.navigate(['/user/bilbo']).then(callback);
+         advance(fixture);
+         expect(result).toBe(false);
+       })));
   });
 
   describe('routerLinkActive', () => {


### PR DESCRIPTION
No longer emits to `Router.events` after the router has been destroyed. Also  returns a resolved promise to the navigation methods.

Fixes #40502.