### PR TITLE
fix(core): ensure that the type `T` of `EventEmitter<T>` can be inferred

### DIFF
--- a/goldens/public-api/core/core.d.ts
+++ b/goldens/public-api/core/core.d.ts
@@ -314,7 +314,8 @@ export declare class ErrorHandler {
 export declare interface EventEmitter<T> extends Subject<T> {
     new (isAsync?: boolean): EventEmitter<T>;
     emit(value?: T): void;
-    subscribe(generatorOrNext?: any, error?: any, complete?: any): Subscription;
+    subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
+    subscribe(observerOrNext?: any, error?: any, complete?: any): Subscription;
 }
 
 export declare const EventEmitter: {

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -129,6 +129,16 @@ import {SpyChangeDetectorRef} from '../spies';
       });
     });
 
+    describe('Subscribable', () => {
+      it('should infer the type from the subscribable', () => {
+        const ref = new SpyChangeDetectorRef() as any;
+        const pipe = new AsyncPipe(ref);
+        const emitter = new EventEmitter<{name: 'T'}>();
+        // The following line will fail to compile if the type cannot be inferred.
+        const name = pipe.transform(emitter)?.name;
+      });
+    });
+
     describe('Promise', () => {
       const message = {};
       let pipe: AsyncPipe;

--- a/packages/compiler-cli/src/ngtsc/testing/fake_core/index.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/fake_core/index.ts
@@ -90,7 +90,10 @@ export const CUSTOM_ELEMENTS_SCHEMA: any = false;
 export const NO_ERRORS_SCHEMA: any = false;
 
 export class EventEmitter<T> {
-  subscribe(generatorOrNext?: any, error?: any, complete?: any): unknown {
+  subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void):
+      unknown;
+  subscribe(observerOrNext?: any, error?: any, complete?: any): unknown;
+  subscribe(observerOrNext?: any, error?: any, complete?: any): unknown {
     return null;
   }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -97,7 +97,8 @@ export function angularCoreDts(): TestFile {
     }
 
     export declare class EventEmitter<T> {
-      subscribe(generatorOrNext?: any, error?: any, complete?: any): unknown;
+      subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): unknown;
+      subscribe(observerOrNext?: any, error?: any, complete?: any): unknown;
     }
 
     export declare type NgIterable<T> = Array<T> | Iterable<T>;


### PR DESCRIPTION
The `AsyncPipe.transform<T>(emitter)` method must infer the `T`
type from the `emitter` parameter. Since we changed the `AsyncPipe`
to expect a `Subscribable<T>` rather than `Observable<T>` the
`EventEmitter.subscribe()` method needs to have a tighter signature.
Otherwise TypeScript struggles to infer the type and ends up making
it `unknown`.

Fixes #40637
