### PR TITLE
feat(language-service): add command for getting components for a temp…

### DIFF
--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -33,10 +33,13 @@ export type GetTcbResponse = {
   selections: ts.TextSpan[],
 }|undefined;
 
+export type GetComponentLocationsForTemplateResponse = ts.DocumentSpan[];
+
 /**
  * `NgLanguageService` describes an instance of an Angular language service,
  * whose API surface is a strict superset of TypeScript's language service.
  */
 export interface NgLanguageService extends ts.LanguageService {
   getTcb(fileName: string, position: number): GetTcbResponse;
+  getComponentLocationsForTemplate(fileName: string): GetComponentLocationsForTemplateResponse;
 }

--- a/packages/language-service/ivy/ts_plugin.ts
+++ b/packages/language-service/ivy/ts_plugin.ts
@@ -7,7 +7,9 @@
  */
 
 import * as ts from 'typescript/lib/tsserverlibrary';
-import {GetTcbResponse, NgLanguageService} from '../api';
+
+import {GetComponentLocationsForTemplateResponse, GetTcbResponse, NgLanguageService} from '../api';
+
 import {LanguageService} from './language_service';
 
 export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
@@ -132,6 +134,14 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     return ngLS.getTcb(fileName, position);
   }
 
+  /**
+   * Given an external template, finds the associated components that use it as a `templateUrl`.
+   */
+  function getComponentLocationsForTemplate(fileName: string):
+      GetComponentLocationsForTemplateResponse {
+    return ngLS.getComponentLocationsForTemplate(fileName);
+  }
+
   return {
     ...tsLS,
     getSemanticDiagnostics,
@@ -146,6 +156,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     getCompletionEntrySymbol,
     getTcb,
     getCompilerOptionsDiagnostics,
+    getComponentLocationsForTemplate,
   };
 }
 

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -141,6 +141,11 @@ export function create(info: tss.server.PluginCreateInfo): NgLanguageService {
     return undefined;
   }
 
+  function getComponentLocationsForTemplate(fileName: string) {
+    // Not implemented in VE Language Service
+    return [];
+  }
+
   return {
     // First clone the original TS language service
     ...tsLS,
@@ -154,5 +159,6 @@ export function create(info: tss.server.PluginCreateInfo): NgLanguageService {
     getReferencesAtPosition,
     findRenameLocations,
     getTcb,
+    getComponentLocationsForTemplate,
   };
 }


### PR DESCRIPTION
…late file

This commit adds a feature to the Angular Language Service that enables
getting the locations for components that use a template file. 

Part of https://github.com/angular/vscode-ng-language-service/issues/1081
