### PR TITLE
docs: clarify that fileReplacements only supports compilation sourcefiles.

### DIFF
--- a/aio/content/guide/build.md
+++ b/aio/content/guide/build.md
@@ -98,7 +98,7 @@ export class AppComponent {
 
 ## Configure target-specific file replacements
 
-The main CLI configuration file, `angular.json`, contains a `fileReplacements` section in the configuration for each build target, which allows you to replace any file with a target-specific version of that file.
+The main CLI configuration file, `angular.json`, contains a `fileReplacements` section in the configuration for each build target, which allows you to replace any file in the TypeScript program with a target-specific version of that file.
 This is useful for including target-specific code or variables in a build that targets a specific environment, such as production or staging.
 
 By default no files are replaced.


### PR DESCRIPTION
fileReplacements is intended to only work on compilation source files

Closes https://github.com/angular/angular-cli/issues/19947