### PR TITLE
docs: remove unnecessary `<hr />` tags in Getting Started sections

### DIFF
--- a/aio/content/start/index.md
+++ b/aio/content/start/index.md
@@ -263,8 +263,6 @@ The `ProductAlertsComponent` needs to emit an event when the user clicks **Notif
 
 For more information on communication between components, see [Component Interaction](guide/component-interaction "Component interaction").
 
-<hr />
-
 {@a whats-next}
 
 ## What's next

--- a/aio/content/start/start-data.md
+++ b/aio/content/start/start-data.md
@@ -281,8 +281,6 @@ This section guides you through modifying the `ShippingComponent` to retrieve sh
       <img src='generated/images/guide/start/shipping-prices.png' alt="Display shipping prices">
     </div>
 
-<hr />
-
 ## What's next
 
 You now have a store application with a product catalog, a shopping cart, and you can  look up shipping prices.

--- a/aio/content/start/start-deployment.md
+++ b/aio/content/start/start-deployment.md
@@ -67,8 +67,6 @@ A best practice is to run your project locally before you deploy it. To run your
     Because these files are static, you can host them on any web server capable of serving files; such as `Node.js`, Java, .NET, or any backend such as [Firebase](https://firebase.google.com/docs/hosting), [Google Cloud](https://cloud.google.com/solutions/web-hosting), or [App Engine](https://cloud.google.com/appengine/docs/standard/python/getting-started/hosting-a-static-website).
     For more information, see [Building & Serving](guide/build "Building and Serving Angular Apps") and [Deployment](guide/deployment "Deployment guide").
 
-<hr />
-
 ## What's next
 
 In this tutorial, you've laid the foundation to explore the Angular world in areas such as mobile development, UX/UI development, and server-side rendering.

--- a/aio/content/start/start-forms.md
+++ b/aio/content/start/start-forms.md
@@ -66,8 +66,6 @@ After putting a few items in the cart, users can review their items, enter their
 
 To confirm submission, open the console to see an object containing the name and address you submitted.
 
-<hr />
-
 ## What's next
 
 You have a complete online store application with a product catalog, a shopping cart, and a checkout function.

--- a/aio/content/start/start-routing.md
+++ b/aio/content/start/start-routing.md
@@ -104,8 +104,6 @@ When users click on a name in the product list, the router navigates them to the
 
 For more information about the Angular Router, see [Routing & Navigation](guide/router "Routing & Navigation guide").
 
-<hr />
-
 ## What's next
 
 You have configured your application so you can view product details, each with a distinct URL.


### PR DESCRIPTION

After the docs UI was redesigned, `h2` tags got a border top. `border-top: 1px solid #dbdbdb;`;
In the sections of the Getting Started guide in order to separate `What's next` from the above content an `<hr />` tag was used, which now becomes unnecessary.

This pull request removes unnecessary `<hr />` tags.


## PR Type
What kind of change does this PR introduce?

- [x] angular.io application / infrastructure changes


## What is the current behavior?
Two separator lines
![image](https://user-images.githubusercontent.com/25394362/106762697-609b7500-6636-11eb-877c-5f9fdc77c69d.png)

## What is the new behavior?
1 separator line
![image](https://user-images.githubusercontent.com/25394362/106762818-7dd04380-6636-11eb-9fad-c40e997506dd.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

