### PR TITLE
docs: add Angular Global Summit to event pages

### DIFF
--- a/aio/content/marketing/events.json
+++ b/aio/content/marketing/events.json
@@ -1,5 +1,14 @@
 [
   {
+    "name": "Angular Global Summit",
+    "location": "Online",
+    "linkUrl": "https://angular.geekle.us/",
+    "date": {
+      "start": "2021-04-13",
+      "end": "2021-04-14"
+    }
+  },
+  {
     "name": "ng-china",
     "location": "Online",
     "linkUrl": "https://ng-china.org/",


### PR DESCRIPTION
Adding [Angular Global Summit](https://angular.geekle.us/) to event pages, per @mgechev
