### PR TITLE
fix(docs-infra): correctly handle entry-points with no public exports

### DIFF
--- a/aio/tools/transforms/angular-api-package/processors/processPackages.js
+++ b/aio/tools/transforms/angular-api-package/processors/processPackages.js
@@ -18,6 +18,7 @@ module.exports = function processPackages(collectPackageContentDocsProcessor) {
           // Partition the exports into groups by type
           if (doc.exports) {
             const publicExports = doc.exports.filter(doc => !doc.privateExport);
+            doc.hasPublicExports = publicExports.length > 0;
             doc.ngmodules = publicExports.filter(doc => doc.docType === 'ngmodule').sort(byId);
             doc.classes = publicExports.filter(doc => doc.docType === 'class').sort(byId);
             doc.decorators = publicExports.filter(doc => doc.docType === 'decorator').sort(byId);
@@ -26,7 +27,7 @@ module.exports = function processPackages(collectPackageContentDocsProcessor) {
             doc.directives = publicExports.filter(doc => doc.docType === 'directive').sort(byId);
             doc.pipes = publicExports.filter(doc => doc.docType === 'pipe').sort(byId);
             doc.types = publicExports.filter(doc => doc.docType === 'type-alias' || doc.docType === 'const').sort(byId);
-            if (publicExports.every(doc => !!doc.deprecated)) {
+            if (doc.hasPublicExports && publicExports.every(doc => !!doc.deprecated)) {
               doc.deprecated = 'all exports of this entry point are deprecated.';
             }
           }

--- a/aio/tools/transforms/angular-api-package/processors/processPackages.spec.js
+++ b/aio/tools/transforms/angular-api-package/processors/processPackages.spec.js
@@ -163,6 +163,47 @@ describe('processPackages processor', () => {
     ]);
   });
 
+  it('should compute whether the entry point has public exports', () => {
+    const docs = [
+      {
+        fileInfo: { filePath: 'some/package-1/index' },
+        docType: 'module',
+        id: 'package-1',
+        exports: [
+          { docType: 'class', id: 'class-1' },
+        ]
+      },
+      {
+        fileInfo: { filePath: 'some/package-1/sub-1index' },
+        docType: 'module',
+        id: 'package-1/sub-1',
+        exports: [],
+      },
+      {
+        fileInfo: { filePath: 'some/package-2/index' },
+        docType: 'module',
+        id: 'package-2',
+        exports: [],
+      },
+      {
+        fileInfo: { filePath: 'some/package-1/sub-1index' },
+        docType: 'module',
+        id: 'package-1/sub-1',
+        exports: [
+          { docType: 'const', id: 'const-2' },
+          { docType: 'enum', id: 'enum-3' },
+        ],
+      },
+    ];
+    const processor = processorFactory({ packageContentFiles: {} });
+    processor.$process(docs);
+
+    expect(docs[0].hasPublicExports).toBeTrue();
+    expect(docs[1].hasPublicExports).toBeFalse();
+    expect(docs[2].hasPublicExports).toBeFalse();
+    expect(docs[3].hasPublicExports).toBeTrue();
+  });
+
   it('should compute the deprecated status of each entry point', () => {
     const docs = [
       {
@@ -199,6 +240,12 @@ describe('processPackages processor', () => {
           { docType: 'class', id: 'class-6' },
         ]
       },
+      {
+        fileInfo: { filePath: 'some/package-4/index' },
+        docType: 'module',
+        id: 'package-4',
+        exports: []
+      },
     ];
     const processor = processorFactory({ packageContentFiles: {} });
     processor.$process(docs);
@@ -207,6 +254,7 @@ describe('processPackages processor', () => {
     expect(docs[1].deprecated).toBeTruthy();
     expect(docs[2].deprecated).toBeUndefined();
     expect(docs[3].deprecated).toBeUndefined();
+    expect(docs[4].deprecated).toBeUndefined();
   });
 
   it('should compute the deprecated status of packages', () => {

--- a/aio/tools/transforms/templates/api/package.template.html
+++ b/aio/tools/transforms/templates/api/package.template.html
@@ -43,6 +43,9 @@
   {% endif %}
 
   <h2>{% if doc.isPrimaryPackage %}Primary entry{% else %}Entry{% endif %} point exports</h2>
+  {% if not doc.hasPublicExports %}
+    <p><i>No public exports.</i></p>
+  {% endif %}
   {% include "includes/deprecation.html" %}
   {$ listItems(doc.ngmodules, 'NgModules') $}
   {$ listItems(doc.classes, 'Classes') $}


### PR DESCRIPTION
Previously, if an entry-point had no public exports (such as the `@angular/platform-server/shims` introduced in #40559, which is a side-effect-ful entry-point), it was incorrectly marked as having all its exports deprecated (which marks the entry-point as deprecated as well).

This commit fixes this by ensuring that an entry-point is not marked as having all its exports deprecated if it has no public exports.
