### PR TITLE
docs: fix absent documentation for digitsInfo parameter in the API docs

### DIFF
--- a/packages/common/src/i18n/format_number.ts
+++ b/packages/common/src/i18n/format_number.ts
@@ -136,7 +136,7 @@ function formatNumberToLocaleString(
  * @param currencyCode The [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)
  * currency code, such as `USD` for the US dollar and `EUR` for the euro.
  * Used to determine the number of digits in the decimal part.
- * @param digitInfo Decimal representation options, specified by a string in the following format:
+ * @param digitsInfo Decimal representation options, specified by a string in the following format:
  * `{minIntegerDigits}.{minFractionDigits}-{maxFractionDigits}`. See `DecimalPipe` for more details.
  *
  * @returns The formatted currency value.
@@ -177,7 +177,7 @@ export function formatCurrency(
  *
  * @param value The number to format.
  * @param locale A locale code for the locale format rules to use.
- * @param digitInfo Decimal representation options, specified by a string in the following format:
+ * @param digitsInfo Decimal representation options, specified by a string in the following format:
  * `{minIntegerDigits}.{minFractionDigits}-{maxFractionDigits}`. See `DecimalPipe` for more details.
  *
  * @returns The formatted percentage value.
@@ -206,7 +206,7 @@ export function formatPercent(value: number, locale: string, digitsInfo?: string
  *
  * @param value The number to format.
  * @param locale A locale code for the locale format rules to use.
- * @param digitInfo Decimal representation options, specified by a string in the following format:
+ * @param digitsInfo Decimal representation options, specified by a string in the following format:
  * `{minIntegerDigits}.{minFractionDigits}-{maxFractionDigits}`. See `DecimalPipe` for more details.
  *
  * @returns The formatted text string.


### PR DESCRIPTION
Fix absent documentation for digitsInfo parameter in the API docs for the following functions

* `formatCurrency`
* `formatPercent`
* `formatNumber`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Fix absent documentation for digitsInfo parameter in the API docs for the following functions
* https://angular.io/api/common/formatCurrency
* https://angular.io/api/common/formatNumber
* https://angular.io/api/common/formatPercent

## What is the new behavior?
The docs will be present

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No