### PR TITLE
docs: add `style` commit type back to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,7 +251,7 @@ Any line of the commit message cannot be longer than 100 characters.
   │                          upgrade|zone.js|packaging|changelog|dev-infra|docs-infra|migrations|
   │                          ngcc|ve
   │
-  └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|test
+  └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|style|test
 ```
 
 The `<type>` and `<summary>` fields are mandatory, the `(<scope>)` field is optional.
@@ -268,6 +268,7 @@ Must be one of the following:
 * **fix**: A bug fix
 * **perf**: A code change that improves performance
 * **refactor**: A code change that neither fixes a bug nor adds a feature
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
 * **test**: Adding missing tests or correcting existing tests
 
 
@@ -312,7 +313,7 @@ There are currently a few exceptions to the "use package name" rule:
 
 * `ve`: used for changes specific to ViewEngine (legacy compiler/renderer).
 
-* none/empty string: useful for `test` and `refactor` changes that are done across all packages (e.g. `test: add missing unit tests`) and for docs changes that are not related to a specific package (e.g. `docs: fix typo in tutorial`).
+* none/empty string: useful for `style`, `test` and `refactor` changes that are done across all packages (e.g. `style: add missing semicolons`, `test: add missing unit tests`) and for docs changes that are not related to a specific package (e.g. `docs: fix typo in tutorial`).
 
 
 ##### Summary

--- a/dev-infra/commit-message/config.ts
+++ b/dev-infra/commit-message/config.ts
@@ -87,6 +87,11 @@ export const COMMIT_TYPES: {[key: string]: CommitType} = {
     description: 'A release point in the repository',
     scope: ScopeRequirement.Forbidden,
   },
+  style: {
+    name: 'style',
+    description: 'Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)',
+    scope: ScopeRequirement.Required,
+  },
   test: {
     name: 'test',
     description: 'Improvements or corrections made to the project\'s test suite',

--- a/dev-infra/commit-message/validate.spec.ts
+++ b/dev-infra/commit-message/validate.spec.ts
@@ -48,6 +48,7 @@ describe('validate-commit-message.js', () => {
     it('should be valid', () => {
       expectValidationResult(validateCommitMessage('feat(packaging): something'), VALID);
       expectValidationResult(validateCommitMessage('fix(packaging): something'), VALID);
+      expectValidationResult(validateCommitMessage('style: add missing semicolons'), VALID);
       expectValidationResult(validateCommitMessage('fixup! fix(packaging): something'), VALID);
       expectValidationResult(validateCommitMessage('squash! fix(packaging): something'), VALID);
       expectValidationResult(validateCommitMessage('Revert: "fix(packaging): something"'), VALID);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

I see no reason to remove the `style` commit type in PR #38639 and #39357. The `style` commit type is useful when we have commits that introduce for example, whitespace changes, minor lint error fixes, etc.. `refactor` doesn't seem to fit these use cases as we are not changing the structure of a function etc.

## What is the new behavior?

Re-introduce `style` commit type back to `CONTRIBUTING.md`, and add `style` into `dev-infra/commit-message/config.ts`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
