### PR TITLE
build(docs-infra): upgrade cli command docs sources to ab638724c

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -23,7 +23,7 @@
     "build-local-with-viewengine": "yarn ~~build",
     "prebuild-local-with-viewengine-ci": "node scripts/switch-to-viewengine && yarn setup-local-ci",
     "build-local-with-viewengine-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 829e1bae4",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js ab638724c",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#11.2.x](https://github.com/angular/angular/tree/11.2.x) from [cli-builds#11.2.x](https://github.com/angular/cli-builds/tree/11.2.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/829e1bae4...ab638724c):

**Modified**
- help/build.json
- help/lint.json
- help/new.json
- help/serve.json

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/e98241829...ab638724c) since PR #40719:

**Modified**
- help/lint.json

##
Closes #40719