### PR TITLE
feat(forms): make form controls strictly typed

### DIFF
--- a/aio/tests/e2e/src/api-pages.e2e-spec.ts
+++ b/aio/tests/e2e/src/api-pages.e2e-spec.ts
@@ -58,7 +58,7 @@ describe('Api pages', () => {
   });
 
   it('should not show a "Properties" section if there are only internal properties', async () => {
-    await page.navigateTo('api/forms/FormControl');
+    await page.navigateTo('api/core/Component');
     expect(await page.getSection('instance-properties').isPresent()).toBe(false);
   });
 

--- a/goldens/public-api/forms/forms.d.ts.orig
+++ b/goldens/public-api/forms/forms.d.ts.orig
@@ -428,12 +428,16 @@ export declare class MinLengthValidator implements Validator, OnChanges {
     validate(control: AbstractControl): ValidationErrors | null;
 }
 
+<<<<<<< master
 export declare class MinValidator extends AbstractValidatorDirective implements OnChanges {
     min: string | number;
     ngOnChanges(changes: SimpleChanges): void;
 }
 
+export declare const NG_ASYNC_VALIDATORS: InjectionToken<(Function | Validator)[]>;
+=======
 export declare const NG_ASYNC_VALIDATORS: InjectionToken<(Function | Validator<any>)[]>;
+>>>>>>> fixup! feat(forms): add typing to form controls
 
 export declare const NG_VALIDATORS: InjectionToken<(Function | Validator<any>)[]>;
 

--- a/packages/examples/forms/ts/formBuilder/form_builder_example.ts
+++ b/packages/examples/forms/ts/formBuilder/form_builder_example.ts
@@ -31,9 +31,9 @@ export class FormBuilderComp {
   form: FormGroup;
 
   constructor(@Inject(FormBuilder) fb: FormBuilder) {
-    this.form = fb.group(
+    this.form = fb.group<any>(
         {
-          name: fb.group({
+          name: fb.group<any>({
             first: ['Nancy', Validators.minLength(2)],
             last: 'Drew',
           }),

--- a/packages/examples/forms/ts/nestedFormGroup/nested_form_group_example.ts
+++ b/packages/examples/forms/ts/nestedFormGroup/nested_form_group_example.ts
@@ -31,8 +31,8 @@ import {FormControl, FormGroup, Validators} from '@angular/forms';
 export class NestedFormGroupComp {
   form = new FormGroup({
     name: new FormGroup({
-      first: new FormControl('Nancy', Validators.minLength(2)),
-      last: new FormControl('Drew', Validators.required)
+      first: new FormControl<string>('Nancy', Validators.minLength(2)),
+      last: new FormControl<string>('Drew', Validators.required)
     }),
     email: new FormControl()
   });

--- a/packages/examples/forms/ts/simpleFormControl/simple_form_control_example.ts
+++ b/packages/examples/forms/ts/simpleFormControl/simple_form_control_example.ts
@@ -22,7 +22,7 @@ import {FormControl, Validators} from '@angular/forms';
   `,
 })
 export class SimpleFormControl {
-  control: FormControl = new FormControl('value', Validators.minLength(2));
+  control: FormControl = new FormControl<string>('value', Validators.minLength(2));
 
   setValue() {
     this.control.setValue('new value');

--- a/packages/examples/forms/ts/simpleFormGroup/simple_form_group_example.ts
+++ b/packages/examples/forms/ts/simpleFormGroup/simple_form_group_example.ts
@@ -27,7 +27,7 @@ import {FormControl, FormGroup, Validators} from '@angular/forms';
 })
 export class SimpleFormGroup {
   form = new FormGroup({
-    first: new FormControl('Nancy', Validators.minLength(2)),
+    first: new FormControl<string>('Nancy', Validators.minLength(2)),
     last: new FormControl('Drew'),
   });
 

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -9,7 +9,7 @@
 import {Directive, forwardRef, Input, OnChanges, SimpleChanges, StaticProvider} from '@angular/core';
 import {Observable} from 'rxjs';
 
-import {AbstractControl} from '../model';
+import {AbstractControl, FormControl} from '../model';
 import {NG_VALIDATORS, Validators} from '../validators';
 
 
@@ -48,7 +48,7 @@ export type ValidationErrors = {
  *
  * @publicApi
  */
-export interface Validator {
+export interface Validator<T extends AbstractControl = any> {
   /**
    * @description
    * Method that performs synchronous validation against the provided control.
@@ -58,7 +58,7 @@ export interface Validator {
    * @returns A map of validation errors if validation fails,
    * otherwise null.
    */
-  validate(control: AbstractControl): ValidationErrors|null;
+  validate(control: T): ValidationErrors|null;
 
   /**
    * @description
@@ -280,7 +280,7 @@ export class MinValidator extends AbstractValidatorDirective implements OnChange
  *
  * @publicApi
  */
-export interface AsyncValidator extends Validator {
+export interface AsyncValidator<T extends AbstractControl = any> extends Validator<T> {
   /**
    * @description
    * Method that performs async validation against the provided control.
@@ -290,8 +290,7 @@ export interface AsyncValidator extends Validator {
    * @returns A promise or observable that resolves a map of validation errors
    * if validation fails, otherwise null.
    */
-  validate(control: AbstractControl):
-      Promise<ValidationErrors|null>|Observable<ValidationErrors|null>;
+  validate(control: T): Promise<ValidationErrors|null>|Observable<ValidationErrors|null>;
 }
 
 /**
@@ -410,7 +409,7 @@ export class CheckboxRequiredValidator extends RequiredValidator {
    * Returns the validation result if enabled, otherwise null.
    * @nodoc
    */
-  validate(control: AbstractControl): ValidationErrors|null {
+  validate(control: FormControl<boolean>): ValidationErrors|null {
     return this.required ? Validators.requiredTrue(control) : null;
   }
 }
@@ -471,7 +470,7 @@ export class EmailValidator implements Validator {
    * Returns the validation result if enabled, otherwise null.
    * @nodoc
    */
-  validate(control: AbstractControl): ValidationErrors|null {
+  validate(control: FormControl<string>): ValidationErrors|null {
     return this._enabled ? Validators.email(control) : null;
   }
 
@@ -491,8 +490,8 @@ export class EmailValidator implements Validator {
  *
  * @publicApi
  */
-export interface ValidatorFn {
-  (control: AbstractControl): ValidationErrors|null;
+export interface ValidatorFn<T extends AbstractControl = any> {
+  (control: T): ValidationErrors|null;
 }
 
 /**
@@ -502,8 +501,8 @@ export interface ValidatorFn {
  *
  * @publicApi
  */
-export interface AsyncValidatorFn {
-  (control: AbstractControl): Promise<ValidationErrors|null>|Observable<ValidationErrors|null>;
+export interface AsyncValidatorFn<T extends AbstractControl = any> {
+  (control: T): Promise<ValidationErrors|null>|Observable<ValidationErrors|null>;
 }
 
 /**

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -9,7 +9,7 @@
 import {Injectable} from '@angular/core';
 
 import {AsyncValidatorFn, ValidatorFn} from './directives/validators';
-import {AbstractControl, AbstractControlOptions, FormSection, FormArray, FormControl, FormControlState, FormGroup, FormHooks} from './model';
+import {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormControlState, FormGroup, FormHooks, FormSection} from './model';
 
 function isAbstractControlOptions<T extends AbstractControl>(
     options: AbstractControlOptions<T>|{[key: string]: any}): options is AbstractControlOptions<T> {
@@ -151,8 +151,8 @@ export class FormBuilder {
    * submit')
    */
   section<T extends {[key: string]: AbstractControl | FormControlConfig<any>}>(
-      controlsConfig: T,
-      options?: AbstractControlOptions<FormSection<ConfigToForm<T>>>|null): FormSection<ConfigToForm<T>>;
+      controlsConfig: T, options?: AbstractControlOptions<FormSection<ConfigToForm<T>>>|null):
+      FormSection<ConfigToForm<T>>;
   /**
    * @description
    * Construct a new `FormSection` instance.
@@ -161,10 +161,11 @@ export class FormBuilder {
    * Use the `FormBuilder#section` overload with `AbstractControlOptions` instead.
    * Note that `AbstractControlOptions` expects `validators` and `asyncValidators` to be valid
    * validators. If you have custom validators, make sure their validation function parameter is
-   * `AbstractControl` and not a sub-class, such as `FormSection`. These functions will be called with
-   * an object of type `AbstractControl` and that cannot be automatically downcast to a subclass, so
-   * TypeScript sees this as an error. For example, change the `(section: FormSection) =>
-   * ValidationErrors|null` signature to be `(section: AbstractControl) => ValidationErrors|null`.
+   * `AbstractControl` and not a sub-class, such as `FormSection`. These functions will be called
+   * with an object of type `AbstractControl` and that cannot be automatically downcast to a
+   * subclass, so TypeScript sees this as an error. For example, change the `(section: FormSection)
+   * => ValidationErrors|null` signature to be `(section: AbstractControl) =>
+   * ValidationErrors|null`.
    *
    * @param controlsConfig A collection of child controls. The key for each child is the name
    * under which it is registered.
@@ -178,7 +179,7 @@ export class FormBuilder {
    */
   section<T extends {[key: string]: AbstractControl | FormControlConfig<any>}>(
       controlsConfig: T, options: {[key: string]: any}): FormSection<ConfigToForm<T>>;
-      section(
+  section(
       controlsConfig: {[key: string]: any},
       options: AbstractControlOptions<FormSection<any>>|{[key: string]: any}|null = null) {
     return new FormSection(this._reduceControls(controlsConfig), this._normalizeOptions(options));
@@ -286,7 +287,9 @@ export class FormBuilder {
 
   /** @internal */
   _createControl<T extends AbstractControl>(controlConfig: T): T;
+  /** @internal */
   _createControl<T>(controlConfig: FormControlConfig<T>): FormControl<T>;
+  /** @internal */
   _createControl<T>(controlConfig: AbstractControl|FormControlConfig<T>) {
     if (controlConfig instanceof FormControl || controlConfig instanceof FormGroup ||
         controlConfig instanceof FormArray || controlConfig instanceof FormSection) {

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -45,7 +45,7 @@ export {SelectMultipleControlValueAccessor} from './directives/select_multiple_c
 export {ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {FormBuilder} from './form_builder';
-export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormGroup} from './model';
+export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormGroup, FormSection} from './model';
 export {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from './validators';
 export {VERSION} from './version';
 

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -138,7 +138,7 @@ function isOptionsObj<T extends AbstractControl>(
       typeof validatorOrOpts === 'object';
 }
 
-export type FormControlState<T> = [T|null|{value: T | null, disabled: boolean}][0];
+export type FormControlState<T> = [T | null | {value: T | null, disabled: boolean}][0];
 
 export type StateType<T> =
     T extends FormArray<infer U>? StateType<U>[] : T extends FormControl<infer V>?
@@ -756,27 +756,33 @@ export abstract class AbstractControl {
   protected _getComposedValidator(): ValidatorFn|null {
     return this._composedValidatorFn;
   }
+  /** @internal */
   protected _setComposedValidator(validatorFn: ValidatorFn|null) {
     this._rawValidators = this._composedValidatorFn = validatorFn;
   }
 
+  /** @internal */
   protected _getComposedAsyncValidator(): AsyncValidatorFn|null {
     return this._composedAsyncValidatorFn;
   }
+  /** @internal */
   protected _setComposedAsyncValidator(asyncValidatorFn: AsyncValidatorFn|null) {
     this._rawAsyncValidators = this._composedAsyncValidatorFn = asyncValidatorFn;
   }
 
+  /** @internal */
   protected _setValidators(newValidator: ValidatorFn|ValidatorFn[]|null): void {
     this._rawValidators = newValidator;
     this._composedValidatorFn = coerceToValidator(newValidator);
   }
 
+  /** @internal */
   protected _setAsyncValidators(newValidator: AsyncValidatorFn|AsyncValidatorFn[]|null): void {
     this._rawAsyncValidators = newValidator;
     this._composedAsyncValidatorFn = coerceToAsyncValidator(newValidator);
   }
 
+  /** @internal */
   _updateTreeValidity(opts: {emitEvent?: boolean} = {emitEvent: true}) {
     this._forEachChild((ctrl: AbstractControl) => ctrl._updateTreeValidity(opts));
     this.updateValueAndValidity({onlySelf: true, emitEvent: opts.emitEvent});
@@ -1322,7 +1328,8 @@ export class FormControl<T = any> extends AbstractControl {
    * When false, no events are emitted.
    *
    */
-  reset(formState: FormControlState<T> = null, options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+  reset(formState: FormControlState<T> = null, options: {onlySelf?: boolean,
+                                                         emitEvent?: boolean} = {}): void {
     this._applyFormState(formState);
     this.markAsPristine(options);
     this.markAsUntouched(options);
@@ -2491,7 +2498,8 @@ export class FormArray<T extends AbstractControl = any> extends AbstractControl 
  *
  * @publicApi
  */
-export class FormSection<T extends {[K in keyof T]: AbstractControl} = any> extends AbstractControl {
+export class FormSection<T extends {[K in keyof T]: AbstractControl} = any> extends
+    AbstractControl {
   /**
    * * For an enabled `FormSection`, the values of enabled controls as an object
    * with a key-value pair for each member of the form.
@@ -2515,8 +2523,8 @@ export class FormSection<T extends {[K in keyof T]: AbstractControl} = any> exte
    */
   constructor(
       public controls: T,
-      validatorOrOpts?: ValidatorFn<FormSection<T>>|ValidatorFn<FormSection<T>>[]|AbstractControlOptions<FormSection<T>>|
-      null,
+      validatorOrOpts?: ValidatorFn<FormSection<T>>|ValidatorFn<FormSection<T>>[]|
+      AbstractControlOptions<FormSection<T>>|null,
       asyncValidator?: AsyncValidatorFn<FormSection<T>>|AsyncValidatorFn<FormSection<T>>[]|null) {
     super(pickValidators(validatorOrOpts), pickAsyncValidators(asyncValidator, validatorOrOpts));
     this._initObservables();
@@ -2568,7 +2576,8 @@ export class FormSection<T extends {[K in keyof T]: AbstractControl} = any> exte
    * `updateValueAndValidity()` for the new validation to take effect.
    *
    */
-  setValidators(newValidator: ValidatorFn<FormSection<T>>|ValidatorFn<FormSection<T>>[]|null): void {
+  setValidators(newValidator: ValidatorFn<FormSection<T>>|ValidatorFn<FormSection<T>>[]|
+                null): void {
     this._setValidators(newValidator);
   }
 
@@ -2580,8 +2589,8 @@ export class FormSection<T extends {[K in keyof T]: AbstractControl} = any> exte
    * `updateValueAndValidity()` for the new validation to take effect.
    *
    */
-  setAsyncValidators(newValidator: AsyncValidatorFn<FormSection<T>>|AsyncValidatorFn<FormSection<T>>[]|
-                     null): void {
+  setAsyncValidators(newValidator: AsyncValidatorFn<FormSection<T>>|
+                     AsyncValidatorFn<FormSection<T>>[]|null): void {
     this._setAsyncValidators(newValidator);
   }
 

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -131,7 +131,8 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static min(min: number): ValidatorFn<FormControl<number>|FormControl<string>|FormControl<number|string>> {
+  static min(min: number):
+      ValidatorFn<FormControl<number>|FormControl<string>|FormControl<number|string>> {
     return (control): ValidationErrors|null => {
       if (isEmptyInputValue(control.value) || isEmptyInputValue(min)) {
         return null;  // don't validate empty values to allow optional controls
@@ -165,7 +166,8 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static max(max: number): ValidatorFn<FormControl<number>|FormControl<string>|FormControl<number|string>> {
+  static max(max: number):
+      ValidatorFn<FormControl<number>|FormControl<string>|FormControl<number|string>> {
     return (control): ValidationErrors|null => {
       if (isEmptyInputValue(control.value) || isEmptyInputValue(max)) {
         return null;  // don't validate empty values to allow optional controls
@@ -299,7 +301,8 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static minLength(minLength: number): ValidatorFn<FormControl<string>|FormControl<any[]>|FormArray<any>> {
+  static minLength(minLength: number):
+      ValidatorFn<FormControl<string>|FormControl<any[]>|FormArray<any>> {
     return (control): ValidationErrors|null => {
       if (isEmptyInputValue(control.value) || !hasValidLength(control.value)) {
         // don't validate empty values to allow optional controls
@@ -340,7 +343,8 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static maxLength(maxLength: number): ValidatorFn<FormControl<string>|FormControl<any[]>|FormArray<any>> {
+  static maxLength(maxLength: number):
+      ValidatorFn<FormControl<string>|FormControl<any[]>|FormArray<any>> {
     return (control): ValidationErrors|null => {
       return hasValidLength(control.value) && control.value!.length > maxLength ?
           {'maxlength': {'requiredLength': maxLength, 'actualLength': control.value!.length}} :

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -16,14 +16,14 @@ import {asyncValidator} from './util';
 (function() {
 describe('FormArray', () => {
   describe('adding/removing', () => {
-    let a: FormArray;
-    let c1: FormControl, c2: FormControl, c3: FormControl;
+    let a: FormArray<any>;
+    let c1: FormControl<any>, c2: FormControl<any>, c3: FormControl<any>;
 
     beforeEach(() => {
-      a = new FormArray([]);
-      c1 = new FormControl(1);
-      c2 = new FormControl(2);
-      c3 = new FormControl(3);
+      a = new FormArray<any>([]);
+      c1 = new FormControl<any>(1);
+      c2 = new FormControl<any>(2);
+      c3 = new FormControl<any>(3);
     });
 
     it('should support pushing', () => {
@@ -68,26 +68,26 @@ describe('FormArray', () => {
 
   describe('value', () => {
     it('should be the reduced value of the child controls', () => {
-      const a = new FormArray([new FormControl(1), new FormControl(2)]);
+      const a = new FormArray<any>([new FormControl<any>(1), new FormControl<any>(2)]);
       expect(a.value).toEqual([1, 2]);
     });
 
     it('should be an empty array when there are no child controls', () => {
-      const a = new FormArray([]);
+      const a = new FormArray<any>([]);
       expect(a.value).toEqual([]);
     });
   });
 
   describe('getRawValue()', () => {
-    let a: FormArray;
+    let a: FormArray<any>;
 
     it('should work with nested form groups/arrays', () => {
-      a = new FormArray([
-        new FormGroup({'c2': new FormControl('v2'), 'c3': new FormControl('v3')}),
-        new FormArray([new FormControl('v4'), new FormControl('v5')])
+      a = new FormArray<any>([
+        new FormGroup<any>({'c2': new FormControl<any>('v2'), 'c3': new FormControl<any>('v3')}),
+        new FormArray<any>([new FormControl<any>('v4'), new FormControl<any>('v5')])
       ]);
       a.at(0).get('c3')!.disable();
-      (a.at(1) as FormArray).at(1).disable();
+      (a.at(1) as FormArray<any>).at(1).disable();
 
       expect(a.getRawValue()).toEqual([{'c2': 'v2', 'c3': 'v3'}, ['v4', 'v5']]);
     });
@@ -95,34 +95,35 @@ describe('FormArray', () => {
 
   describe('markAllAsTouched', () => {
     it('should mark all descendants as touched', () => {
-      const formArray: FormArray = new FormArray([
-        new FormControl('v1'), new FormControl('v2'), new FormGroup({'c1': new FormControl('v1')}),
-        new FormArray([new FormGroup({'c2': new FormControl('v2')})])
+      const formArray: FormArray<any> = new FormArray<any>([
+        new FormControl<any>('v1'), new FormControl<any>('v2'),
+        new FormGroup<any>({'c1': new FormControl<any>('v1')}),
+        new FormArray<any>([new FormGroup<any>({'c2': new FormControl<any>('v2')})])
       ]);
 
       expect(formArray.touched).toBe(false);
 
-      const control1 = formArray.at(0) as FormControl;
+      const control1 = formArray.at(0) as FormControl<any>;
 
       expect(control1.touched).toBe(false);
 
-      const group1 = formArray.at(2) as FormGroup;
+      const group1 = formArray.at(2) as FormGroup<any>;
 
       expect(group1.touched).toBe(false);
 
-      const group1Control1 = group1.get('c1') as FormControl;
+      const group1Control1 = group1.get('c1') as FormControl<any>;
 
       expect(group1Control1.touched).toBe(false);
 
-      const innerFormArray = formArray.at(3) as FormArray;
+      const innerFormArray = formArray.at(3) as FormArray<any>;
 
       expect(innerFormArray.touched).toBe(false);
 
-      const innerFormArrayGroup = innerFormArray.at(0) as FormGroup;
+      const innerFormArrayGroup = innerFormArray.at(0) as FormGroup<any>;
 
       expect(innerFormArrayGroup.touched).toBe(false);
 
-      const innerFormArrayGroupControl1 = innerFormArrayGroup.get('c2') as FormControl;
+      const innerFormArrayGroupControl1 = innerFormArrayGroup.get('c2') as FormControl<any>;
 
       expect(innerFormArrayGroupControl1.touched).toBe(false);
 
@@ -145,12 +146,12 @@ describe('FormArray', () => {
   });
 
   describe('setValue', () => {
-    let c: FormControl, c2: FormControl, a: FormArray;
+    let c: FormControl<any>, c2: FormControl<any>, a: FormArray<any>;
 
     beforeEach(() => {
-      c = new FormControl('');
-      c2 = new FormControl('');
-      a = new FormArray([c, c2]);
+      c = new FormControl<any>('');
+      c2 = new FormControl<any>('');
+      a = new FormArray<any>([c, c2]);
     });
 
     it('should set its own value', () => {
@@ -181,13 +182,13 @@ describe('FormArray', () => {
     });
 
     it('should set parent values', () => {
-      const form = new FormGroup({'parent': a});
+      const form = new FormGroup<any>({'parent': a});
       a.setValue(['one', 'two']);
       expect(form.value).toEqual({'parent': ['one', 'two']});
     });
 
     it('should not update the parent explicitly specified', () => {
-      const form = new FormGroup({'parent': a});
+      const form = new FormGroup<any>({'parent': a});
       a.setValue(['one', 'two'], {onlySelf: true});
 
       expect(form.value).toEqual({parent: ['', '']});
@@ -211,17 +212,17 @@ describe('FormArray', () => {
     });
 
     it('should throw if no controls are set yet', () => {
-      const empty = new FormArray([]);
+      const empty = new FormArray<any>([]);
       expect(() => empty.setValue(['one']))
           .toThrowError(new RegExp(`no form controls registered with this array`));
     });
 
     describe('setValue() events', () => {
-      let form: FormGroup;
+      let form: FormGroup<any>;
       let logger: any[];
 
       beforeEach(() => {
-        form = new FormGroup({'parent': a});
+        form = new FormGroup<any>({'parent': a});
         logger = [];
       });
 
@@ -266,13 +267,13 @@ describe('FormArray', () => {
   });
 
   describe('patchValue', () => {
-    let c: FormControl, c2: FormControl, a: FormArray, a2: FormArray;
+    let c: FormControl<any>, c2: FormControl<any>, a: FormArray<any>, a2: FormArray<any>;
 
     beforeEach(() => {
-      c = new FormControl('');
-      c2 = new FormControl('');
-      a = new FormArray([c, c2]);
-      a2 = new FormArray([a]);
+      c = new FormControl<any>('');
+      c2 = new FormControl<any>('');
+      a = new FormArray<any>([c, c2]);
+      a2 = new FormArray<any>([a]);
     });
 
     it('should set its own value', () => {
@@ -303,13 +304,13 @@ describe('FormArray', () => {
     });
 
     it('should set parent values', () => {
-      const form = new FormGroup({'parent': a});
+      const form = new FormGroup<any>({'parent': a});
       a.patchValue(['one', 'two']);
       expect(form.value).toEqual({'parent': ['one', 'two']});
     });
 
     it('should not update the parent explicitly specified', () => {
-      const form = new FormGroup({'parent': a});
+      const form = new FormGroup<any>({'parent': a});
       a.patchValue(['one', 'two'], {onlySelf: true});
 
       expect(form.value).toEqual({parent: ['', '']});
@@ -341,11 +342,11 @@ describe('FormArray', () => {
     });
 
     describe('patchValue() events', () => {
-      let form: FormGroup;
+      let form: FormGroup<any>;
       let logger: any[];
 
       beforeEach(() => {
-        form = new FormGroup({'parent': a});
+        form = new FormGroup<any>({'parent': a});
         logger = [];
       });
 
@@ -373,7 +374,8 @@ describe('FormArray', () => {
          () => {
            const logEvent = () => logger.push('valueChanges event');
 
-           const [formArrayControl1, formArrayControl2] = (a2.controls as FormArray[])[0].controls;
+           const [formArrayControl1, formArrayControl2] =
+               (a2.controls as FormArray<any>[])[0].controls;
 
            formArrayControl1.valueChanges.subscribe(logEvent);
            formArrayControl2.valueChanges.subscribe(logEvent);
@@ -417,12 +419,12 @@ describe('FormArray', () => {
   });
 
   describe('reset()', () => {
-    let c: FormControl, c2: FormControl, a: FormArray;
+    let c: FormControl<any>, c2: FormControl<any>, a: FormArray<any>;
 
     beforeEach(() => {
-      c = new FormControl('initial value');
-      c2 = new FormControl('');
-      a = new FormArray([c, c2]);
+      c = new FormControl<any>('initial value');
+      c2 = new FormControl<any>('');
+      a = new FormArray<any>([c, c2]);
     });
 
     it('should set its own value if value passed', () => {
@@ -433,7 +435,7 @@ describe('FormArray', () => {
     });
 
     it('should not update the parent when explicitly specified', () => {
-      const form = new FormGroup({'a': a});
+      const form = new FormGroup<any>({'a': a});
       a.reset(['one', 'two'], {onlySelf: true});
 
       expect(form.value).toEqual({a: ['initial value', '']});
@@ -470,7 +472,7 @@ describe('FormArray', () => {
     });
 
     it('should set the value of its parent if value passed', () => {
-      const form = new FormGroup({'a': a});
+      const form = new FormGroup<any>({'a': a});
       a.setValue(['new value', 'new value']);
 
       a.reset(['initial value', '']);
@@ -478,7 +480,7 @@ describe('FormArray', () => {
     });
 
     it('should clear the value of its parent if no value passed', () => {
-      const form = new FormGroup({'a': a});
+      const form = new FormGroup<any>({'a': a});
       a.setValue(['new value', 'new value']);
 
       a.reset();
@@ -505,8 +507,8 @@ describe('FormArray', () => {
     });
 
     it('should mark the parent as pristine if all siblings pristine', () => {
-      const c3 = new FormControl('');
-      const form = new FormGroup({'a': a, 'c3': c3});
+      const c3 = new FormControl<any>('');
+      const form = new FormGroup<any>({'a': a, 'c3': c3});
 
       a.markAsDirty();
       expect(form.pristine).toBe(false);
@@ -516,8 +518,8 @@ describe('FormArray', () => {
     });
 
     it('should not mark the parent pristine if any dirty siblings', () => {
-      const c3 = new FormControl('');
-      const form = new FormGroup({'a': a, 'c3': c3});
+      const c3 = new FormControl<any>('');
+      const form = new FormGroup<any>({'a': a, 'c3': c3});
 
       a.markAsDirty();
       c3.markAsDirty();
@@ -547,8 +549,8 @@ describe('FormArray', () => {
     });
 
     it('should mark the parent untouched if all siblings untouched', () => {
-      const c3 = new FormControl('');
-      const form = new FormGroup({'a': a, 'c3': c3});
+      const c3 = new FormControl<any>('');
+      const form = new FormGroup<any>({'a': a, 'c3': c3});
 
       a.markAsTouched();
       expect(form.untouched).toBe(false);
@@ -558,8 +560,8 @@ describe('FormArray', () => {
     });
 
     it('should not mark the parent untouched if any touched siblings', () => {
-      const c3 = new FormControl('');
-      const form = new FormGroup({'a': a, 'c3': c3});
+      const c3 = new FormControl<any>('');
+      const form = new FormGroup<any>({'a': a, 'c3': c3});
 
       a.markAsTouched();
       c3.markAsTouched();
@@ -586,11 +588,11 @@ describe('FormArray', () => {
 
 
     describe('reset() events', () => {
-      let form: FormGroup, c3: FormControl, logger: any[];
+      let form: FormGroup<any>, c3: FormControl<any>, logger: any[];
 
       beforeEach(() => {
-        c3 = new FormControl('');
-        form = new FormGroup({'a': a, 'c3': c3});
+        c3 = new FormControl<any>('');
+        form = new FormGroup<any>({'a': a, 'c3': c3});
         logger = [];
       });
 
@@ -658,11 +660,11 @@ describe('FormArray', () => {
 
   describe('errors', () => {
     it('should run the validator when the value changes', () => {
-      const simpleValidator = (c: FormArray) =>
+      const simpleValidator = (c: FormArray<any>) =>
           c.controls[0].value != 'correct' ? {'broken': true} : null;
 
-      const c = new FormControl(null);
-      const g = new FormArray([c], simpleValidator as ValidatorFn);
+      const c = new FormControl<any>(null);
+      const g = new FormArray<any>([c], simpleValidator as ValidatorFn);
 
       c.setValue('correct');
 
@@ -678,12 +680,12 @@ describe('FormArray', () => {
 
 
   describe('dirty', () => {
-    let c: FormControl;
-    let a: FormArray;
+    let c: FormControl<any>;
+    let a: FormArray<any>;
 
     beforeEach(() => {
-      c = new FormControl('value');
-      a = new FormArray([c]);
+      c = new FormControl<any>('value');
+      a = new FormArray<any>([c]);
     });
 
     it('should be false after creating a control', () => {
@@ -698,12 +700,12 @@ describe('FormArray', () => {
   });
 
   describe('touched', () => {
-    let c: FormControl;
-    let a: FormArray;
+    let c: FormControl<any>;
+    let a: FormArray<any>;
 
     beforeEach(() => {
-      c = new FormControl('value');
-      a = new FormArray([c]);
+      c = new FormControl<any>('value');
+      a = new FormArray<any>([c]);
     });
 
     it('should be false after creating a control', () => {
@@ -719,12 +721,12 @@ describe('FormArray', () => {
 
 
   describe('pending', () => {
-    let c: FormControl;
-    let a: FormArray;
+    let c: FormControl<any>;
+    let a: FormArray<any>;
 
     beforeEach(() => {
-      c = new FormControl('value');
-      a = new FormArray([c]);
+      c = new FormControl<any>('value');
+      a = new FormArray<any>([c]);
     });
 
     it('should be false after creating a control', () => {
@@ -777,13 +779,13 @@ describe('FormArray', () => {
   });
 
   describe('valueChanges', () => {
-    let a: FormArray;
+    let a: FormArray<any>;
     let c1: any /** TODO #9100 */, c2: any /** TODO #9100 */;
 
     beforeEach(() => {
-      c1 = new FormControl('old1');
-      c2 = new FormControl('old2');
-      a = new FormArray([c1, c2]);
+      c1 = new FormControl<any>('old1');
+      c2 = new FormControl<any>('old2');
+      a = new FormArray<any>([c1, c2]);
     });
 
     it('should fire an event after the value has been updated',
@@ -848,24 +850,24 @@ describe('FormArray', () => {
 
   describe('get', () => {
     it('should return null when path is null', () => {
-      const g = new FormGroup({});
+      const g = new FormGroup<any>({});
       expect(g.get(null!)).toEqual(null);
     });
 
     it('should return null when path is empty', () => {
-      const g = new FormGroup({});
+      const g = new FormGroup<any>({});
       expect(g.get([])).toEqual(null);
     });
 
     it('should return null when path is invalid', () => {
-      const g = new FormGroup({});
+      const g = new FormGroup<any>({});
       expect(g.get('invalid')).toEqual(null);
     });
 
     it('should return a child of a control group', () => {
-      const g = new FormGroup({
-        'one': new FormControl('111'),
-        'nested': new FormGroup({'two': new FormControl('222')})
+      const g = new FormGroup<any>({
+        'one': new FormControl<any>('111'),
+        'nested': new FormGroup<any>({'two': new FormControl<any>('222')})
       });
 
       expect(g.get(['one'])!.value).toEqual('111');
@@ -875,7 +877,7 @@ describe('FormArray', () => {
     });
 
     it('should return an element of an array', () => {
-      const g = new FormGroup({'array': new FormArray([new FormControl('111')])});
+      const g = new FormGroup<any>({'array': new FormArray<any>([new FormControl<any>('111')])});
 
       expect(g.get(['array', 0])!.value).toEqual('111');
     });
@@ -891,7 +893,7 @@ describe('FormArray', () => {
     }
 
     it('should set a single validator', () => {
-      const a = new FormArray([new FormControl()], simpleValidator);
+      const a = new FormArray<any>([new FormControl<any>()], simpleValidator);
       expect(a.valid).toBe(false);
       expect(a.errors).toEqual({'broken': true});
 
@@ -900,7 +902,7 @@ describe('FormArray', () => {
     });
 
     it('should set a single validator from options obj', () => {
-      const a = new FormArray([new FormControl()], {validators: simpleValidator});
+      const a = new FormArray<any>([new FormControl<any>()], {validators: simpleValidator});
       expect(a.valid).toBe(false);
       expect(a.errors).toEqual({'broken': true});
 
@@ -909,7 +911,8 @@ describe('FormArray', () => {
     });
 
     it('should set multiple validators from an array', () => {
-      const a = new FormArray([new FormControl()], [simpleValidator, arrayRequiredValidator]);
+      const a =
+          new FormArray<any>([new FormControl<any>()], [simpleValidator, arrayRequiredValidator]);
       expect(a.valid).toBe(false);
       expect(a.errors).toEqual({'required': true, 'broken': true});
 
@@ -922,8 +925,8 @@ describe('FormArray', () => {
     });
 
     it('should set multiple validators from options obj', () => {
-      const a = new FormArray(
-          [new FormControl()], {validators: [simpleValidator, arrayRequiredValidator]});
+      const a = new FormArray<any>(
+          [new FormControl<any>()], {validators: [simpleValidator, arrayRequiredValidator]});
       expect(a.valid).toBe(false);
       expect(a.errors).toEqual({'required': true, 'broken': true});
 
@@ -934,6 +937,13 @@ describe('FormArray', () => {
       a.setValue(['correct']);
       expect(a.valid).toBe(true);
     });
+
+    it('should compile with properly typed validator', () => {
+      const validatorFn = (control: FormArray<FormControl<string>>) => null;
+      const a = new FormArray([new FormControl('test')], {validators: validatorFn });
+
+      expect(a.valid).toBe(true);
+    });
   });
 
   describe('asyncValidator', () => {
@@ -942,8 +952,8 @@ describe('FormArray', () => {
     }
 
     it('should run the async validator', fakeAsync(() => {
-         const c = new FormControl('value');
-         const g = new FormArray([c], null!, asyncValidator('expected'));
+         const c = new FormControl<any>('value');
+         const g = new FormArray<any>([c], null!, asyncValidator('expected'));
 
          expect(g.pending).toEqual(true);
 
@@ -954,8 +964,8 @@ describe('FormArray', () => {
        }));
 
     it('should set a single async validator from options obj', fakeAsync(() => {
-         const g = new FormArray(
-             [new FormControl('value')], {asyncValidators: asyncValidator('expected')});
+         const g = new FormArray<any>(
+             [new FormControl<any>('value')], {asyncValidators: asyncValidator('expected')});
 
          expect(g.pending).toEqual(true);
 
@@ -966,8 +976,8 @@ describe('FormArray', () => {
        }));
 
     it('should set multiple async validators from an array', fakeAsync(() => {
-         const g = new FormArray(
-             [new FormControl('value')], null!,
+         const g = new FormArray<any>(
+             [new FormControl<any>('value')], null!,
              [asyncValidator('expected'), otherObservableValidator]);
 
          expect(g.pending).toEqual(true);
@@ -979,8 +989,8 @@ describe('FormArray', () => {
        }));
 
     it('should set multiple async validators from options obj', fakeAsync(() => {
-         const g = new FormArray(
-             [new FormControl('value')],
+         const g = new FormArray<any>(
+             [new FormControl<any>('value')],
              {asyncValidators: [asyncValidator('expected'), otherObservableValidator]});
 
          expect(g.pending).toEqual(true);
@@ -993,14 +1003,14 @@ describe('FormArray', () => {
   });
 
   describe('disable() & enable()', () => {
-    let a: FormArray;
-    let c: FormControl;
-    let c2: FormControl;
+    let a: FormArray<any>;
+    let c: FormControl<any>;
+    let c2: FormControl<any>;
 
     beforeEach(() => {
-      c = new FormControl(null);
-      c2 = new FormControl(null);
-      a = new FormArray([c, c2]);
+      c = new FormControl<any>(null);
+      c2 = new FormControl<any>(null);
+      a = new FormArray<any>([c, c2]);
     });
 
     it('should mark the array as disabled', () => {
@@ -1040,9 +1050,9 @@ describe('FormArray', () => {
     });
 
     it('should ignore disabled controls in validation', () => {
-      const g = new FormGroup({
-        nested: new FormArray([new FormControl(null, Validators.required)]),
-        two: new FormControl('two')
+      const g = new FormGroup<any>({
+        nested: new FormArray<any>([new FormControl<any>(null, Validators.required)]),
+        two: new FormControl<any>('two')
       });
       expect(g.valid).toBe(false);
 
@@ -1054,8 +1064,10 @@ describe('FormArray', () => {
     });
 
     it('should ignore disabled controls when serializing value', () => {
-      const g = new FormGroup(
-          {nested: new FormArray([new FormControl('one')]), two: new FormControl('two')});
+      const g = new FormGroup<any>({
+        nested: new FormArray<any>([new FormControl<any>('one')]),
+        two: new FormControl<any>('two')
+      });
       expect(g.value).toEqual({'nested': ['one'], 'two': 'two'});
 
       g.get('nested')!.disable();
@@ -1066,7 +1078,7 @@ describe('FormArray', () => {
     });
 
     it('should ignore disabled controls when determining dirtiness', () => {
-      const g = new FormGroup({nested: a, two: new FormControl('two')});
+      const g = new FormGroup<any>({nested: a, two: new FormControl<any>('two')});
       g.get(['nested', 0])!.markAsDirty();
       expect(g.dirty).toBe(true);
 
@@ -1079,7 +1091,7 @@ describe('FormArray', () => {
     });
 
     it('should ignore disabled controls when determining touched state', () => {
-      const g = new FormGroup({nested: a, two: new FormControl('two')});
+      const g = new FormGroup<any>({nested: a, two: new FormControl<any>('two')});
       g.get(['nested', 0])!.markAsTouched();
       expect(g.touched).toBe(true);
 
@@ -1092,7 +1104,7 @@ describe('FormArray', () => {
     });
 
     it('should keep empty, disabled arrays disabled when updating validity', () => {
-      const arr = new FormArray([]);
+      const arr = new FormArray<any>([]);
       expect(arr.status).toEqual('VALID');
 
       arr.disable();
@@ -1101,15 +1113,15 @@ describe('FormArray', () => {
       arr.updateValueAndValidity();
       expect(arr.status).toEqual('DISABLED');
 
-      arr.push(new FormControl({value: '', disabled: true}));
+      arr.push(new FormControl<any>({value: '', disabled: true}));
       expect(arr.status).toEqual('DISABLED');
 
-      arr.push(new FormControl());
+      arr.push(new FormControl<any>());
       expect(arr.status).toEqual('VALID');
     });
 
     it('should re-enable empty, disabled arrays', () => {
-      const arr = new FormArray([]);
+      const arr = new FormArray<any>([]);
       arr.disable();
       expect(arr.status).toEqual('DISABLED');
 
@@ -1119,7 +1131,7 @@ describe('FormArray', () => {
 
     it('should not run validators on disabled controls', () => {
       const validator = jasmine.createSpy('validator');
-      const arr = new FormArray([new FormControl()], validator);
+      const arr = new FormArray<any>([new FormControl<any>()], validator);
       expect(validator.calls.count()).toEqual(1);
 
       arr.disable();
@@ -1134,7 +1146,7 @@ describe('FormArray', () => {
 
     describe('disabled errors', () => {
       it('should clear out array errors when disabled', () => {
-        const arr = new FormArray([new FormControl()], () => ({'expected': true}));
+        const arr = new FormArray<any>([new FormControl<any>()], () => ({'expected': true}));
         expect(arr.errors).toEqual({'expected': true});
 
         arr.disable();
@@ -1145,16 +1157,17 @@ describe('FormArray', () => {
       });
 
       it('should re-populate array errors when enabled from a child', () => {
-        const arr = new FormArray([new FormControl()], () => ({'expected': true}));
+        const arr = new FormArray<any>([new FormControl<any>()], () => ({'expected': true}));
         arr.disable();
         expect(arr.errors).toEqual(null);
 
-        arr.push(new FormControl());
+        arr.push(new FormControl<any>());
         expect(arr.errors).toEqual({'expected': true});
       });
 
       it('should clear out async array errors when disabled', fakeAsync(() => {
-           const arr = new FormArray([new FormControl()], null!, asyncValidator('expected'));
+           const arr =
+               new FormArray<any>([new FormControl<any>()], null!, asyncValidator('expected'));
            tick();
            expect(arr.errors).toEqual({'async': true});
 
@@ -1167,14 +1180,15 @@ describe('FormArray', () => {
          }));
 
       it('should re-populate async array errors when enabled from a child', fakeAsync(() => {
-           const arr = new FormArray([new FormControl()], null!, asyncValidator('expected'));
+           const arr =
+               new FormArray<any>([new FormControl<any>()], null!, asyncValidator('expected'));
            tick();
            expect(arr.errors).toEqual({'async': true});
 
            arr.disable();
            expect(arr.errors).toEqual(null);
 
-           arr.push(new FormControl());
+           arr.push(new FormControl<any>());
            tick();
            expect(arr.errors).toEqual({'async': true});
          }));
@@ -1182,15 +1196,15 @@ describe('FormArray', () => {
 
     describe('disabled events', () => {
       let logger: string[];
-      let c: FormControl;
-      let a: FormArray;
-      let form: FormGroup;
+      let c: FormControl<any>;
+      let a: FormArray<any>;
+      let form: FormGroup<any>;
 
       beforeEach(() => {
         logger = [];
-        c = new FormControl('', Validators.required);
-        a = new FormArray([c]);
-        form = new FormGroup({a: a});
+        c = new FormControl<any>('', Validators.required);
+        a = new FormArray<any>([c]);
+        form = new FormGroup<any>({a: a});
       });
 
       it('should emit value change events in the right order', () => {
@@ -1235,16 +1249,16 @@ describe('FormArray', () => {
     });
 
     describe('setControl()', () => {
-      let c: FormControl;
-      let a: FormArray;
+      let c: FormControl<any>;
+      let a: FormArray<any>;
 
       beforeEach(() => {
-        c = new FormControl('one');
-        a = new FormArray([c]);
+        c = new FormControl<any>('one');
+        a = new FormArray<any>([c]);
       });
 
       it('should replace existing control with new control', () => {
-        const c2 = new FormControl('new!', Validators.minLength(10));
+        const c2 = new FormControl<any>('new!', Validators.minLength(10));
         a.setControl(0, c2);
 
         expect(a.controls[0]).toEqual(c2);
@@ -1253,7 +1267,7 @@ describe('FormArray', () => {
       });
 
       it('should add control if control did not exist before', () => {
-        const c2 = new FormControl('new!', Validators.minLength(10));
+        const c2 = new FormControl<any>('new!', Validators.minLength(10));
         a.setControl(1, c2);
 
         expect(a.controls[1]).toEqual(c2);
@@ -1269,7 +1283,7 @@ describe('FormArray', () => {
 
       it('should only emit value change event once', () => {
         const logger: string[] = [];
-        const c2 = new FormControl('new!');
+        const c2 = new FormControl<any>('new!');
         a.valueChanges.subscribe(() => logger.push('change!'));
         a.setControl(0, c2);
         expect(logger).toEqual(['change!']);

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -940,7 +940,7 @@ describe('FormArray', () => {
 
     it('should compile with properly typed validator', () => {
       const validatorFn = (control: FormArray<FormControl<string>>) => null;
-      const a = new FormArray([new FormControl('test')], {validators: validatorFn });
+      const a = new FormArray([new FormControl('test')], {validators: validatorFn});
 
       expect(a.valid).toBe(true);
     });

--- a/packages/forms/test/form_builder_spec.ts
+++ b/packages/forms/test/form_builder_spec.ts
@@ -92,11 +92,17 @@ describe('Form Builder', () => {
     expect(g.asyncValidator).toBe(asyncValidator);
   });
 
+  it('should create groups with children of different types when generic type is `any`', () => {
+    const g = b.group<any>({one: 'value', two: b.array<any>(['other value'])});
+
+    expect(g.value).toEqual({one: 'value', two: ['other value']});
+  });
+
   it('should create control arrays', () => {
     const c = b.control('three');
     const e = b.control(null);
     const f = b.control(undefined);
-    const a = b.array(
+    const a = b.array<any>(
         ['one', ['two', syncValidator], c, b.array(['four']), e, f], syncValidator, asyncValidator);
 
     expect(a.value).toEqual(['one', 'two', 'three', ['four'], null, null]);

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -24,13 +24,13 @@ function syncValidator(_: any /** TODO #9100 */): any /** TODO #9100 */ {
 
 describe('FormControl', () => {
   it('should default the value to null', () => {
-    const c = new FormControl();
+    const c = new FormControl<any>();
     expect(c.value).toBe(null);
   });
 
   describe('markAllAsTouched', () => {
     it('should mark only the control itself as touched', () => {
-      const control = new FormControl('');
+      const control = new FormControl<any>('');
       expect(control.touched).toBe(false);
       control.markAllAsTouched();
       expect(control.touched).toBe(true);
@@ -39,7 +39,7 @@ describe('FormControl', () => {
 
   describe('boxed values', () => {
     it('should support valid boxed values on creation', () => {
-      const c = new FormControl({value: 'some val', disabled: true}, null!, null!);
+      const c = new FormControl<any>({value: 'some val', disabled: true}, null!, null!);
       expect(c.disabled).toBe(true);
       expect(c.value).toBe('some val');
       expect(c.status).toBe('DISABLED');
@@ -47,26 +47,26 @@ describe('FormControl', () => {
 
     it('should not treat objects as boxed values when `disabled` field is present, but `value` is missing',
        () => {
-         const c = new FormControl({disabled: true});
+         const c = new FormControl<any>({disabled: true});
          expect(c.value).toEqual({disabled: true});
          expect(c.disabled).toBe(false);
        });
 
     it('should honor boxed value with disabled control when validating', () => {
-      const c = new FormControl({value: '', disabled: true}, Validators.required);
+      const c = new FormControl<any>({value: '', disabled: true}, Validators.required);
       expect(c.disabled).toBe(true);
       expect(c.valid).toBe(false);
       expect(c.status).toBe('DISABLED');
     });
 
     it('should not treat objects as boxed values if they have more than two props', () => {
-      const c = new FormControl({value: '', disabled: true, test: 'test'}, null!, null!);
+      const c = new FormControl<any>({value: '', disabled: true, test: 'test'}, null!, null!);
       expect(c.value).toEqual({value: '', disabled: true, test: 'test'});
       expect(c.disabled).toBe(false);
     });
 
     it('should not treat objects as boxed values if disabled is missing', () => {
-      const c = new FormControl({value: '', test: 'test'}, null!, null!);
+      const c = new FormControl<any>({value: '', test: 'test'}, null!, null!);
       expect(c.value).toEqual({value: '', test: 'test'});
       expect(c.disabled).toBe(false);
     });
@@ -74,40 +74,41 @@ describe('FormControl', () => {
 
   describe('updateOn', () => {
     it('should default to on change', () => {
-      const c = new FormControl('');
+      const c = new FormControl<any>('');
       expect(c.updateOn).toEqual('change');
     });
 
     it('should default to on change with an options obj', () => {
-      const c = new FormControl('', {validators: Validators.required});
+      const c = new FormControl<any>('', {validators: Validators.required});
       expect(c.updateOn).toEqual('change');
     });
 
     it('should set updateOn when updating on blur', () => {
-      const c = new FormControl('', {updateOn: 'blur'});
+      const c = new FormControl<any>('', {updateOn: 'blur'});
       expect(c.updateOn).toEqual('blur');
     });
 
     describe('in groups and arrays', () => {
       it('should default to group updateOn when not set in control', () => {
-        const g =
-            new FormGroup({one: new FormControl(), two: new FormControl()}, {updateOn: 'blur'});
+        const g = new FormGroup<any>(
+            {one: new FormControl<any>(), two: new FormControl<any>()}, {updateOn: 'blur'});
 
         expect(g.get('one')!.updateOn).toEqual('blur');
         expect(g.get('two')!.updateOn).toEqual('blur');
       });
 
       it('should default to array updateOn when not set in control', () => {
-        const a = new FormArray([new FormControl(), new FormControl()], {updateOn: 'blur'});
+        const a =
+            new FormArray([new FormControl<any>(), new FormControl<any>()], {updateOn: 'blur'});
 
         expect(a.get([0])!.updateOn).toEqual('blur');
         expect(a.get([1])!.updateOn).toEqual('blur');
       });
 
       it('should set updateOn with nested groups', () => {
-        const g = new FormGroup(
+        const g = new FormGroup<any>(
             {
-              group: new FormGroup({one: new FormControl(), two: new FormControl()}),
+              group: new FormGroup<any>({one: new FormControl<any>(), two: new FormControl<any>()}),
             },
             {updateOn: 'blur'});
 
@@ -117,9 +118,9 @@ describe('FormControl', () => {
       });
 
       it('should set updateOn with nested arrays', () => {
-        const g = new FormGroup(
+        const g = new FormGroup<any>(
             {
-              arr: new FormArray([new FormControl(), new FormControl()]),
+              arr: new FormArray([new FormControl<any>(), new FormControl<any>()]),
             },
             {updateOn: 'blur'});
 
@@ -129,8 +130,8 @@ describe('FormControl', () => {
       });
 
       it('should allow control updateOn to override group updateOn', () => {
-        const g = new FormGroup(
-            {one: new FormControl('', {updateOn: 'change'}), two: new FormControl()},
+        const g = new FormGroup<any>(
+            {one: new FormControl<any>('', {updateOn: 'change'}), two: new FormControl<any>()},
             {updateOn: 'blur'});
 
         expect(g.get('one')!.updateOn).toEqual('change');
@@ -138,12 +139,12 @@ describe('FormControl', () => {
       });
 
       it('should set updateOn with complex setup', () => {
-        const g = new FormGroup({
-          group: new FormGroup(
-              {one: new FormControl('', {updateOn: 'change'}), two: new FormControl()},
+        const g = new FormGroup<any>({
+          group: new FormGroup<any>(
+              {one: new FormControl<any>('', {updateOn: 'change'}), two: new FormControl<any>()},
               {updateOn: 'blur'}),
-          groupTwo: new FormGroup({one: new FormControl()}, {updateOn: 'submit'}),
-          three: new FormControl()
+          groupTwo: new FormGroup<any>({one: new FormControl<any>()}, {updateOn: 'submit'}),
+          three: new FormControl<any>()
         });
 
         expect(g.get('group.one')!.updateOn).toEqual('change');
@@ -156,18 +157,18 @@ describe('FormControl', () => {
 
   describe('validator', () => {
     it('should run validator with the initial value', () => {
-      const c = new FormControl('value', Validators.required);
+      const c = new FormControl<any>('value', Validators.required);
       expect(c.valid).toEqual(true);
     });
 
     it('should rerun the validator when the value changes', () => {
-      const c = new FormControl('value', Validators.required);
+      const c = new FormControl<any>('value', Validators.required);
       c.setValue(null);
       expect(c.valid).toEqual(false);
     });
 
     it('should support arrays of validator functions if passed', () => {
-      const c = new FormControl('value', [Validators.required, Validators.minLength(3)]);
+      const c = new FormControl<any>('value', [Validators.required, Validators.minLength(3)]);
       c.setValue('a');
       expect(c.valid).toEqual(false);
 
@@ -176,7 +177,7 @@ describe('FormControl', () => {
     });
 
     it('should support single validator from options obj', () => {
-      const c = new FormControl(null, {validators: Validators.required});
+      const c = new FormControl<any>(null, {validators: Validators.required});
       expect(c.valid).toEqual(false);
       expect(c.errors).toEqual({required: true});
 
@@ -185,7 +186,8 @@ describe('FormControl', () => {
     });
 
     it('should support multiple validators from options obj', () => {
-      const c = new FormControl(null, {validators: [Validators.required, Validators.minLength(3)]});
+      const c =
+          new FormControl<any>(null, {validators: [Validators.required, Validators.minLength(3)]});
       expect(c.valid).toEqual(false);
       expect(c.errors).toEqual({required: true});
 
@@ -198,22 +200,22 @@ describe('FormControl', () => {
     });
 
     it('should support a null validators value', () => {
-      const c = new FormControl(null, {validators: null});
+      const c = new FormControl<any>(null, {validators: null});
       expect(c.valid).toEqual(true);
     });
 
     it('should support an empty options obj', () => {
-      const c = new FormControl(null, {});
+      const c = new FormControl<any>(null, {});
       expect(c.valid).toEqual(true);
     });
 
     it('should return errors', () => {
-      const c = new FormControl(null, Validators.required);
+      const c = new FormControl<any>(null, Validators.required);
       expect(c.errors).toEqual({'required': true});
     });
 
     it('should set single validator', () => {
-      const c = new FormControl(null);
+      const c = new FormControl<any>(null);
       expect(c.valid).toEqual(true);
 
       c.setValidators(Validators.required);
@@ -226,7 +228,7 @@ describe('FormControl', () => {
     });
 
     it('should set multiple validators from array', () => {
-      const c = new FormControl('');
+      const c = new FormControl<any>('');
       expect(c.valid).toEqual(true);
 
       c.setValidators([Validators.minLength(5), Validators.required]);
@@ -242,7 +244,7 @@ describe('FormControl', () => {
     });
 
     it('should override validators using `setValidators` function', () => {
-      const c = new FormControl('');
+      const c = new FormControl<any>('');
       expect(c.valid).toEqual(true);
 
       c.setValidators([Validators.minLength(5), Validators.required]);
@@ -267,7 +269,7 @@ describe('FormControl', () => {
     });
 
     it('should override validators by setting `control.validator` field value', () => {
-      const c = new FormControl('');
+      const c = new FormControl<any>('');
       expect(c.valid).toEqual(true);
 
       // Define new set of validators, overriding previously applied ones.
@@ -293,7 +295,7 @@ describe('FormControl', () => {
     });
 
     it('should clear validators', () => {
-      const c = new FormControl('', Validators.required);
+      const c = new FormControl<any>('', Validators.required);
       expect(c.valid).toEqual(false);
 
       c.clearValidators();
@@ -304,7 +306,7 @@ describe('FormControl', () => {
     });
 
     it('should add after clearing', () => {
-      const c = new FormControl('', Validators.required);
+      const c = new FormControl<any>('', Validators.required);
       expect(c.valid).toEqual(false);
 
       c.clearValidators();
@@ -317,7 +319,7 @@ describe('FormControl', () => {
 
   describe('asyncValidator', () => {
     it('should run validator with the initial value', fakeAsync(() => {
-         const c = new FormControl('value', null!, asyncValidator('expected'));
+         const c = new FormControl<any>('value', null!, asyncValidator('expected'));
          tick();
 
          expect(c.valid).toEqual(false);
@@ -325,7 +327,7 @@ describe('FormControl', () => {
        }));
 
     it('should support validators returning observables', fakeAsync(() => {
-         const c = new FormControl('value', null!, asyncValidatorReturningObservable);
+         const c = new FormControl<any>('value', null!, asyncValidatorReturningObservable);
          tick();
 
          expect(c.valid).toEqual(false);
@@ -333,7 +335,7 @@ describe('FormControl', () => {
        }));
 
     it('should rerun the validator when the value changes', fakeAsync(() => {
-         const c = new FormControl('value', null!, asyncValidator('expected'));
+         const c = new FormControl<any>('value', null!, asyncValidator('expected'));
 
          c.setValue('expected');
          tick();
@@ -342,7 +344,7 @@ describe('FormControl', () => {
        }));
 
     it('should run the async validator only when the sync validator passes', fakeAsync(() => {
-         const c = new FormControl('', Validators.required, asyncValidator('expected'));
+         const c = new FormControl<any>('', Validators.required, asyncValidator('expected'));
          tick();
 
          expect(c.errors).toEqual({'required': true});
@@ -354,7 +356,7 @@ describe('FormControl', () => {
        }));
 
     it('should mark the control as pending while running the async validation', fakeAsync(() => {
-         const c = new FormControl('', null!, asyncValidator('expected'));
+         const c = new FormControl<any>('', null!, asyncValidator('expected'));
 
          expect(c.pending).toEqual(true);
 
@@ -364,8 +366,8 @@ describe('FormControl', () => {
        }));
 
     it('should only use the latest async validation run', fakeAsync(() => {
-         const c =
-             new FormControl('', null!, asyncValidator('expected', {'long': 200, 'expected': 100}));
+         const c = new FormControl<any>(
+             '', null!, asyncValidator('expected', {'long': 200, 'expected': 100}));
 
          c.setValue('long');
          c.setValue('expected');
@@ -376,8 +378,8 @@ describe('FormControl', () => {
        }));
 
     it('should support arrays of async validator functions if passed', fakeAsync(() => {
-         const c =
-             new FormControl('value', null!, [asyncValidator('expected'), otherAsyncValidator]);
+         const c = new FormControl<any>(
+             'value', null!, [asyncValidator('expected'), otherAsyncValidator]);
          tick();
 
          expect(c.errors).toEqual({'async': true, 'other': true});
@@ -385,7 +387,7 @@ describe('FormControl', () => {
 
 
     it('should support a single async validator from options obj', fakeAsync(() => {
-         const c = new FormControl('value', {asyncValidators: asyncValidator('expected')});
+         const c = new FormControl<any>('value', {asyncValidators: asyncValidator('expected')});
          expect(c.pending).toEqual(true);
          tick();
 
@@ -394,7 +396,7 @@ describe('FormControl', () => {
        }));
 
     it('should support multiple async validators from options obj', fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'value', {asyncValidators: [asyncValidator('expected'), otherAsyncValidator]});
          expect(c.pending).toEqual(true);
          tick();
@@ -404,7 +406,7 @@ describe('FormControl', () => {
        }));
 
     it('should support a mix of validators from options obj', fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              '', {validators: Validators.required, asyncValidators: asyncValidator('expected')});
          tick();
          expect(c.errors).toEqual({required: true});
@@ -418,7 +420,7 @@ describe('FormControl', () => {
        }));
 
     it('should add single async validator', fakeAsync(() => {
-         const c = new FormControl('value', null!);
+         const c = new FormControl<any>('value', null!);
 
          c.setAsyncValidators(asyncValidator('expected'));
          expect(c.asyncValidator).not.toEqual(null);
@@ -430,7 +432,7 @@ describe('FormControl', () => {
        }));
 
     it('should add async validator from array', fakeAsync(() => {
-         const c = new FormControl('value', null!);
+         const c = new FormControl<any>('value', null!);
 
          c.setAsyncValidators([asyncValidator('expected')]);
          expect(c.asyncValidator).not.toEqual(null);
@@ -442,7 +444,7 @@ describe('FormControl', () => {
        }));
 
     it('should override validators using `setAsyncValidators` function', fakeAsync(() => {
-         const c = new FormControl('');
+         const c = new FormControl<any>('');
          expect(c.valid).toEqual(true);
 
          c.setAsyncValidators([asyncValidator('expected')]);
@@ -469,7 +471,7 @@ describe('FormControl', () => {
 
     it('should override validators by setting `control.asyncValidator` field value',
        fakeAsync(() => {
-         const c = new FormControl('');
+         const c = new FormControl<any>('');
          expect(c.valid).toEqual(true);
 
          c.asyncValidator = Validators.composeAsync([asyncValidator('expected')]);
@@ -495,7 +497,7 @@ describe('FormControl', () => {
        }));
 
     it('should clear async validators', fakeAsync(() => {
-         const c = new FormControl('value', [asyncValidator('expected'), otherAsyncValidator]);
+         const c = new FormControl<any>('value', [asyncValidator('expected'), otherAsyncValidator]);
 
          c.clearValidators();
 
@@ -504,7 +506,7 @@ describe('FormControl', () => {
 
     it('should not change validity state if control is disabled while async validating',
        fakeAsync(() => {
-         const c = new FormControl('value', [asyncValidator('expected')]);
+         const c = new FormControl<any>('value', [asyncValidator('expected')]);
          c.disable();
          tick();
          expect(c.status).toEqual('DISABLED');
@@ -513,12 +515,12 @@ describe('FormControl', () => {
 
   describe('dirty', () => {
     it('should be false after creating a control', () => {
-      const c = new FormControl('value');
+      const c = new FormControl<any>('value');
       expect(c.dirty).toEqual(false);
     });
 
     it('should be true after changing the value of the control', () => {
-      const c = new FormControl('value');
+      const c = new FormControl<any>('value');
       c.markAsDirty();
       expect(c.dirty).toEqual(true);
     });
@@ -526,22 +528,22 @@ describe('FormControl', () => {
 
   describe('touched', () => {
     it('should be false after creating a control', () => {
-      const c = new FormControl('value');
+      const c = new FormControl<any>('value');
       expect(c.touched).toEqual(false);
     });
 
     it('should be true after markAsTouched runs', () => {
-      const c = new FormControl('value');
+      const c = new FormControl<any>('value');
       c.markAsTouched();
       expect(c.touched).toEqual(true);
     });
   });
 
   describe('setValue', () => {
-    let g: FormGroup, c: FormControl;
+    let g: FormGroup<any>, c: FormControl<any>;
     beforeEach(() => {
-      c = new FormControl('oldValue');
-      g = new FormGroup({'one': c});
+      c = new FormControl<any>('oldValue');
+      g = new FormGroup<any>({'one': c});
     });
 
     it('should set the value of the control', () => {
@@ -596,7 +598,7 @@ describe('FormControl', () => {
        }));
 
     it('should work on a disabled control', () => {
-      g.addControl('two', new FormControl('two'));
+      g.addControl('two', new FormControl<any>('two'));
       c.disable();
       c.setValue('new value');
       expect(c.value).toEqual('new value');
@@ -605,10 +607,10 @@ describe('FormControl', () => {
   });
 
   describe('patchValue', () => {
-    let g: FormGroup, c: FormControl;
+    let g: FormGroup<any>, c: FormControl<any>;
     beforeEach(() => {
-      c = new FormControl('oldValue');
-      g = new FormGroup({'one': c});
+      c = new FormControl<any>('oldValue');
+      g = new FormGroup<any>({'one': c});
     });
 
     it('should set the value of the control', () => {
@@ -664,7 +666,7 @@ describe('FormControl', () => {
        }));
 
     it('should patch value on a disabled control', () => {
-      g.addControl('two', new FormControl('two'));
+      g.addControl('two', new FormControl<any>('two'));
       c.disable();
 
       c.patchValue('new value');
@@ -674,10 +676,10 @@ describe('FormControl', () => {
   });
 
   describe('reset()', () => {
-    let c: FormControl;
+    let c: FormControl<any>;
 
     beforeEach(() => {
-      c = new FormControl('initial value');
+      c = new FormControl<any>('initial value');
     });
 
     it('should reset to a specific value if passed', () => {
@@ -689,7 +691,7 @@ describe('FormControl', () => {
     });
 
     it('should not set the parent when explicitly specified', () => {
-      const g = new FormGroup({'one': c});
+      const g = new FormGroup<any>({'one': c});
       c.patchValue('newValue', {onlySelf: true});
       expect(g.value).toEqual({'one': 'initial value'});
     });
@@ -711,7 +713,7 @@ describe('FormControl', () => {
     });
 
     it('should update the value of any parent controls with passed value', () => {
-      const g = new FormGroup({'one': c});
+      const g = new FormGroup<any>({'one': c});
       c.setValue('new value');
       expect(g.value).toEqual({'one': 'new value'});
 
@@ -720,7 +722,7 @@ describe('FormControl', () => {
     });
 
     it('should update the value of any parent controls with null value', () => {
-      const g = new FormGroup({'one': c});
+      const g = new FormGroup<any>({'one': c});
       c.setValue('new value');
       expect(g.value).toEqual({'one': 'new value'});
 
@@ -737,7 +739,7 @@ describe('FormControl', () => {
     });
 
     it('should set the parent pristine state if all pristine', () => {
-      const g = new FormGroup({'one': c});
+      const g = new FormGroup<any>({'one': c});
       c.markAsDirty();
       expect(g.pristine).toBe(false);
 
@@ -746,8 +748,8 @@ describe('FormControl', () => {
     });
 
     it('should not set the parent pristine state if it has other dirty controls', () => {
-      const c2 = new FormControl('two');
-      const g = new FormGroup({'one': c, 'two': c2});
+      const c2 = new FormControl<any>('two');
+      const g = new FormGroup<any>({'one': c, 'two': c2});
       c.markAsDirty();
       c2.markAsDirty();
 
@@ -764,7 +766,7 @@ describe('FormControl', () => {
     });
 
     it('should set the parent untouched state if all untouched', () => {
-      const g = new FormGroup({'one': c});
+      const g = new FormGroup<any>({'one': c});
       c.markAsTouched();
       expect(g.untouched).toBe(false);
 
@@ -773,8 +775,8 @@ describe('FormControl', () => {
     });
 
     it('should not set the parent untouched state if other touched controls', () => {
-      const c2 = new FormControl('two');
-      const g = new FormGroup({'one': c, 'two': c2});
+      const c2 = new FormControl<any>('two');
+      const g = new FormGroup<any>({'one': c, 'two': c2});
       c.markAsTouched();
       c2.markAsTouched();
 
@@ -797,11 +799,11 @@ describe('FormControl', () => {
     });
 
     describe('reset() events', () => {
-      let g: FormGroup, c2: FormControl, logger: any[];
+      let g: FormGroup<any>, c2: FormControl<any>, logger: any[];
 
       beforeEach(() => {
-        c2 = new FormControl('two');
-        g = new FormGroup({'one': c, 'two': c2});
+        c2 = new FormControl<any>('two');
+        g = new FormGroup<any>({'one': c, 'two': c2});
         logger = [];
       });
 
@@ -851,10 +853,10 @@ describe('FormControl', () => {
   });
 
   describe('valueChanges & statusChanges', () => {
-    let c: FormControl;
+    let c: FormControl<any>;
 
     beforeEach(() => {
-      c = new FormControl('old', Validators.required);
+      c = new FormControl<any>('old', Validators.required);
     });
 
     it('should fire an event after the value has been updated',
@@ -882,7 +884,7 @@ describe('FormControl', () => {
        }));
 
     it('should fire an event after the status has been updated to pending', fakeAsync(() => {
-         const c = new FormControl('old', Validators.required, asyncValidator('expected'));
+         const c = new FormControl<any>('old', Validators.required, asyncValidator('expected'));
 
          const log: any[] /** TODO #9100 */ = [];
          c.valueChanges.subscribe({next: (value: any) => log.push(`value: '${value}'`)});
@@ -936,7 +938,7 @@ describe('FormControl', () => {
 
   describe('setErrors', () => {
     it('should set errors on a control', () => {
-      const c = new FormControl('someValue');
+      const c = new FormControl<any>('someValue');
 
       c.setErrors({'someError': true});
 
@@ -945,7 +947,7 @@ describe('FormControl', () => {
     });
 
     it('should reset the errors and validity when the value changes', () => {
-      const c = new FormControl('someValue', Validators.required);
+      const c = new FormControl<any>('someValue', Validators.required);
 
       c.setErrors({'someError': true});
       c.setValue('');
@@ -954,8 +956,8 @@ describe('FormControl', () => {
     });
 
     it('should update the parent group\'s validity', () => {
-      const c = new FormControl('someValue');
-      const g = new FormGroup({'one': c});
+      const c = new FormControl<any>('someValue');
+      const g = new FormGroup<any>({'one': c});
 
       expect(g.valid).toEqual(true);
 
@@ -965,8 +967,8 @@ describe('FormControl', () => {
     });
 
     it('should not reset parent\'s errors', () => {
-      const c = new FormControl('someValue');
-      const g = new FormGroup({'one': c});
+      const c = new FormControl<any>('someValue');
+      const g = new FormGroup<any>({'one': c});
 
       g.setErrors({'someGroupError': true});
       c.setErrors({'someError': true});
@@ -975,8 +977,8 @@ describe('FormControl', () => {
     });
 
     it('should reset errors when updating a value', () => {
-      const c = new FormControl('oldValue');
-      const g = new FormGroup({'one': c});
+      const c = new FormControl<any>('oldValue');
+      const g = new FormGroup<any>({'one': c});
 
       g.setErrors({'someGroupError': true});
       c.setErrors({'someError': true});
@@ -990,7 +992,7 @@ describe('FormControl', () => {
 
   describe('disable() & enable()', () => {
     it('should mark the control as disabled', () => {
-      const c = new FormControl(null);
+      const c = new FormControl<any>(null);
       expect(c.disabled).toBe(false);
       expect(c.valid).toBe(true);
 
@@ -1004,7 +1006,7 @@ describe('FormControl', () => {
     });
 
     it('should set the control status as disabled', () => {
-      const c = new FormControl(null);
+      const c = new FormControl<any>(null);
       expect(c.status).toEqual('VALID');
 
       c.disable();
@@ -1015,7 +1017,7 @@ describe('FormControl', () => {
     });
 
     it('should retain the original value when disabled', () => {
-      const c = new FormControl('some value');
+      const c = new FormControl<any>('some value');
       expect(c.value).toEqual('some value');
 
       c.disable();
@@ -1026,8 +1028,8 @@ describe('FormControl', () => {
     });
 
     it('should keep the disabled control in the group, but return false for contains()', () => {
-      const c = new FormControl('');
-      const g = new FormGroup({'one': c});
+      const c = new FormControl<any>('');
+      const g = new FormGroup<any>({'one': c});
 
       expect(g.get('one')).toBeDefined();
       expect(g.contains('one')).toBe(true);
@@ -1038,9 +1040,9 @@ describe('FormControl', () => {
     });
 
     it('should mark the parent group disabled if all controls are disabled', () => {
-      const c = new FormControl();
-      const c2 = new FormControl();
-      const g = new FormGroup({'one': c, 'two': c2});
+      const c = new FormControl<any>();
+      const c2 = new FormControl<any>();
+      const g = new FormGroup<any>({'one': c, 'two': c2});
       expect(g.enabled).toBe(true);
 
       c.disable();
@@ -1054,9 +1056,9 @@ describe('FormControl', () => {
     });
 
     it('should update the parent group value when child control status changes', () => {
-      const c = new FormControl('one');
-      const c2 = new FormControl('two');
-      const g = new FormGroup({'one': c, 'two': c2});
+      const c = new FormControl<any>('one');
+      const c2 = new FormControl<any>('two');
+      const g = new FormGroup<any>({'one': c, 'two': c2});
       expect(g.value).toEqual({'one': 'one', 'two': 'two'});
 
       c.disable();
@@ -1070,8 +1072,8 @@ describe('FormControl', () => {
     });
 
     it('should mark the parent array disabled if all controls are disabled', () => {
-      const c = new FormControl();
-      const c2 = new FormControl();
+      const c = new FormControl<any>();
+      const c2 = new FormControl<any>();
       const a = new FormArray([c, c2]);
       expect(a.enabled).toBe(true);
 
@@ -1086,8 +1088,8 @@ describe('FormControl', () => {
     });
 
     it('should update the parent array value when child control status changes', () => {
-      const c = new FormControl('one');
-      const c2 = new FormControl('two');
+      const c = new FormControl<any>('one');
+      const c2 = new FormControl<any>('two');
       const a = new FormArray([c, c2]);
       expect(a.value).toEqual(['one', 'two']);
 
@@ -1102,8 +1104,8 @@ describe('FormControl', () => {
     });
 
     it('should ignore disabled array controls when determining dirtiness', () => {
-      const c = new FormControl('one');
-      const c2 = new FormControl('two');
+      const c = new FormControl<any>('one');
+      const c2 = new FormControl<any>('two');
       const a = new FormArray([c, c2]);
       c.markAsDirty();
       expect(a.dirty).toBe(true);
@@ -1117,8 +1119,8 @@ describe('FormControl', () => {
     });
 
     it('should not make a dirty array not dirty when disabling controls', () => {
-      const c = new FormControl('one');
-      const c2 = new FormControl('two');
+      const c = new FormControl<any>('one');
+      const c2 = new FormControl<any>('two');
       const a = new FormArray([c, c2]);
 
       a.markAsDirty();
@@ -1133,9 +1135,9 @@ describe('FormControl', () => {
     });
 
     it('should ignore disabled controls in validation', () => {
-      const c = new FormControl(null, Validators.required);
-      const c2 = new FormControl(null);
-      const g = new FormGroup({one: c, two: c2});
+      const c = new FormControl<any>(null, Validators.required);
+      const c2 = new FormControl<any>(null);
+      const g = new FormGroup<any>({one: c, two: c2});
       expect(g.valid).toBe(false);
 
       c.disable();
@@ -1146,9 +1148,9 @@ describe('FormControl', () => {
     });
 
     it('should ignore disabled controls when serializing value in a group', () => {
-      const c = new FormControl('one');
-      const c2 = new FormControl('two');
-      const g = new FormGroup({one: c, two: c2});
+      const c = new FormControl<any>('one');
+      const c2 = new FormControl<any>('two');
+      const g = new FormGroup<any>({one: c, two: c2});
       expect(g.value).toEqual({one: 'one', two: 'two'});
 
       c.disable();
@@ -1159,8 +1161,8 @@ describe('FormControl', () => {
     });
 
     it('should ignore disabled controls when serializing value in an array', () => {
-      const c = new FormControl('one');
-      const c2 = new FormControl('two');
+      const c = new FormControl<any>('one');
+      const c2 = new FormControl<any>('two');
       const a = new FormArray([c, c2]);
       expect(a.value).toEqual(['one', 'two']);
 
@@ -1172,9 +1174,9 @@ describe('FormControl', () => {
     });
 
     it('should ignore disabled controls when determining dirtiness', () => {
-      const c = new FormControl('one');
-      const c2 = new FormControl('two');
-      const g = new FormGroup({one: c, two: c2});
+      const c = new FormControl<any>('one');
+      const c2 = new FormControl<any>('two');
+      const g = new FormGroup<any>({one: c, two: c2});
       c.markAsDirty();
       expect(g.dirty).toBe(true);
 
@@ -1187,9 +1189,9 @@ describe('FormControl', () => {
     });
 
     it('should not make a dirty group not dirty when disabling controls', () => {
-      const c = new FormControl('one');
-      const c2 = new FormControl('two');
-      const g = new FormGroup({one: c, two: c2});
+      const c = new FormControl<any>('one');
+      const c2 = new FormControl<any>('two');
+      const g = new FormGroup<any>({one: c, two: c2});
 
       g.markAsDirty();
       expect(g.dirty).toBe(true);
@@ -1203,9 +1205,9 @@ describe('FormControl', () => {
     });
 
     it('should ignore disabled controls when determining touched state', () => {
-      const c = new FormControl('one');
-      const c2 = new FormControl('two');
-      const g = new FormGroup({one: c, two: c2});
+      const c = new FormControl<any>('one');
+      const c2 = new FormControl<any>('two');
+      const g = new FormGroup<any>({one: c, two: c2});
       c.markAsTouched();
       expect(g.touched).toBe(true);
 
@@ -1219,7 +1221,7 @@ describe('FormControl', () => {
 
     it('should not run validators on disabled controls', () => {
       const validator = jasmine.createSpy('validator');
-      const c = new FormControl('', validator);
+      const c = new FormControl<any>('', validator);
       expect(validator.calls.count()).toEqual(1);
 
       c.disable();
@@ -1234,7 +1236,7 @@ describe('FormControl', () => {
 
     describe('disabled errors', () => {
       it('should clear out the errors when disabled', () => {
-        const c = new FormControl('', Validators.required);
+        const c = new FormControl<any>('', Validators.required);
         expect(c.errors).toEqual({required: true});
 
         c.disable();
@@ -1245,7 +1247,7 @@ describe('FormControl', () => {
       });
 
       it('should clear out async errors when disabled', fakeAsync(() => {
-           const c = new FormControl('', null!, asyncValidator('expected'));
+           const c = new FormControl<any>('', null!, asyncValidator('expected'));
            tick();
            expect(c.errors).toEqual({'async': true});
 
@@ -1260,13 +1262,13 @@ describe('FormControl', () => {
 
     describe('disabled events', () => {
       let logger: string[];
-      let c: FormControl;
-      let g: FormGroup;
+      let c: FormControl<any>;
+      let g: FormGroup<any>;
 
       beforeEach(() => {
         logger = [];
-        c = new FormControl('', Validators.required);
-        g = new FormGroup({one: c});
+        c = new FormControl<any>('', Validators.required);
+        g = new FormGroup<any>({one: c});
       });
 
       it('should emit a statusChange event when disabled status changes', () => {
@@ -1288,7 +1290,7 @@ describe('FormControl', () => {
       });
 
       it('should throw when sync validator passed into async validator param', () => {
-        const fn = () => new FormControl('', syncValidator, syncValidator);
+        const fn = () => new FormControl<any>('', syncValidator, syncValidator);
         // test for the specific error since without the error check it would still throw an error
         // but
         // not a meaningful one
@@ -1317,10 +1319,10 @@ describe('FormControl', () => {
     });
   });
   describe('pending', () => {
-    let c: FormControl;
+    let c: FormControl<any>;
 
     beforeEach(() => {
-      c = new FormControl('value');
+      c = new FormControl<any>('value');
     });
 
     it('should be false after creating a control', () => {

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -26,39 +26,41 @@ function otherObservableValidator() {
 describe('FormGroup', () => {
   describe('value', () => {
     it('should be the reduced value of the child controls', () => {
-      const g = new FormGroup({'one': new FormControl('111'), 'two': new FormControl('222')});
+      const g = new FormGroup<any>(
+          {'one': new FormControl<any>('111'), 'two': new FormControl<any>('222')});
       expect(g.value).toEqual({'one': '111', 'two': '222'});
     });
 
     it('should be empty when there are no child controls', () => {
-      const g = new FormGroup({});
+      const g = new FormGroup<any>({});
       expect(g.value).toEqual({});
     });
 
     it('should support nested groups', () => {
-      const g = new FormGroup({
-        'one': new FormControl('111'),
-        'nested': new FormGroup({'two': new FormControl('222')})
+      const g = new FormGroup<any>({
+        'one': new FormControl<any>('111'),
+        'nested': new FormGroup<any>({'two': new FormControl<any>('222')})
       });
       expect(g.value).toEqual({'one': '111', 'nested': {'two': '222'}});
 
-      (<FormControl>(g.get('nested.two'))).setValue('333');
+      (<FormControl<any>>(g.get('nested.two'))).setValue('333');
 
       expect(g.value).toEqual({'one': '111', 'nested': {'two': '333'}});
     });
   });
 
   describe('getRawValue', () => {
-    let fg: FormGroup;
+    let fg: FormGroup<any>;
 
     it('should work with nested form groups/arrays', () => {
-      fg = new FormGroup({
-        'c1': new FormControl('v1'),
-        'group': new FormGroup({'c2': new FormControl('v2'), 'c3': new FormControl('v3')}),
-        'array': new FormArray([new FormControl('v4'), new FormControl('v5')])
+      fg = new FormGroup<any>({
+        'c1': new FormControl<any>('v1'),
+        'group': new FormGroup<any>(
+            {'c2': new FormControl<any>('v2'), 'c3': new FormControl<any>('v3')}),
+        'array': new FormArray<any>([new FormControl<any>('v4'), new FormControl<any>('v5')])
       });
       fg.get('group')!.get('c3')!.disable();
-      (fg.get('array') as FormArray).at(1).disable();
+      (fg.get('array') as FormArray<any>).at(1).disable();
 
       expect(fg.getRawValue())
           .toEqual({'c1': 'v1', 'group': {'c2': 'v2', 'c3': 'v3'}, 'array': ['v4', 'v5']});
@@ -67,25 +69,27 @@ describe('FormGroup', () => {
 
   describe('markAllAsTouched', () => {
     it('should mark all descendants as touched', () => {
-      const formGroup: FormGroup = new FormGroup({
-        'c1': new FormControl('v1'),
-        'group': new FormGroup({'c2': new FormControl('v2'), 'c3': new FormControl('v3')}),
-        'array': new FormArray([
-          new FormControl('v4'), new FormControl('v5'), new FormGroup({'c4': new FormControl('v4')})
+      const formGroup: FormGroup<any> = new FormGroup<any>({
+        'c1': new FormControl<any>('v1'),
+        'group': new FormGroup<any>(
+            {'c2': new FormControl<any>('v2'), 'c3': new FormControl<any>('v3')}),
+        'array': new FormArray<any>([
+          new FormControl<any>('v4'), new FormControl<any>('v5'),
+          new FormGroup<any>({'c4': new FormControl<any>('v4')})
         ])
       });
 
       expect(formGroup.touched).toBe(false);
 
-      const control1 = formGroup.get('c1') as FormControl;
+      const control1 = formGroup.get('c1') as FormControl<any>;
 
       expect(control1.touched).toBe(false);
 
-      const innerGroup = formGroup.get('group') as FormGroup;
+      const innerGroup = formGroup.get('group') as FormGroup<any>;
 
       expect(innerGroup.touched).toBe(false);
 
-      const innerGroupFirstChildCtrl = innerGroup.get('c2') as FormControl;
+      const innerGroupFirstChildCtrl = innerGroup.get('c2') as FormControl<any>;
 
       expect(innerGroupFirstChildCtrl.touched).toBe(false);
 
@@ -99,27 +103,27 @@ describe('FormGroup', () => {
 
       expect(innerGroupFirstChildCtrl.touched).toBe(true);
 
-      const innerGroupSecondChildCtrl = innerGroup.get('c3') as FormControl;
+      const innerGroupSecondChildCtrl = innerGroup.get('c3') as FormControl<any>;
 
       expect(innerGroupSecondChildCtrl.touched).toBe(true);
 
-      const array = formGroup.get('array') as FormArray;
+      const array = formGroup.get('array') as FormArray<any>;
 
       expect(array.touched).toBe(true);
 
-      const arrayFirstChildCtrl = array.at(0) as FormControl;
+      const arrayFirstChildCtrl = array.at(0) as FormControl<any>;
 
       expect(arrayFirstChildCtrl.touched).toBe(true);
 
-      const arraySecondChildCtrl = array.at(1) as FormControl;
+      const arraySecondChildCtrl = array.at(1) as FormControl<any>;
 
       expect(arraySecondChildCtrl.touched).toBe(true);
 
-      const arrayFirstChildGroup = array.at(2) as FormGroup;
+      const arrayFirstChildGroup = array.at(2) as FormGroup<any>;
 
       expect(arrayFirstChildGroup.touched).toBe(true);
 
-      const arrayFirstChildGroupFirstChildCtrl = arrayFirstChildGroup.get('c4') as FormControl;
+      const arrayFirstChildGroupFirstChildCtrl = arrayFirstChildGroup.get('c4') as FormControl<any>;
 
       expect(arrayFirstChildGroupFirstChildCtrl.touched).toBe(true);
     });
@@ -127,19 +131,21 @@ describe('FormGroup', () => {
 
   describe('adding and removing controls', () => {
     it('should update value and validity when control is added', () => {
-      const g = new FormGroup({'one': new FormControl('1')});
+      const g = new FormGroup<any>({'one': new FormControl<any>('1')});
       expect(g.value).toEqual({'one': '1'});
       expect(g.valid).toBe(true);
 
-      g.addControl('two', new FormControl('2', Validators.minLength(10)));
+      g.addControl('two', new FormControl<any>('2', Validators.minLength(10)));
 
       expect(g.value).toEqual({'one': '1', 'two': '2'});
       expect(g.valid).toBe(false);
     });
 
     it('should update value and validity when control is removed', () => {
-      const g = new FormGroup(
-          {'one': new FormControl('1'), 'two': new FormControl('2', Validators.minLength(10))});
+      const g = new FormGroup<any>({
+        'one': new FormControl<any>('1'),
+        'two': new FormControl<any>('2', Validators.minLength(10))
+      });
       expect(g.value).toEqual({'one': '1', 'two': '2'});
       expect(g.valid).toBe(false);
 
@@ -151,11 +157,11 @@ describe('FormGroup', () => {
   });
 
   describe('dirty', () => {
-    let c: FormControl, g: FormGroup;
+    let c: FormControl<any>, g: FormGroup<any>;
 
     beforeEach(() => {
-      c = new FormControl('value');
-      g = new FormGroup({'one': c});
+      c = new FormControl<any>('value');
+      g = new FormGroup<any>({'one': c});
     });
 
     it('should be false after creating a control', () => {
@@ -171,11 +177,11 @@ describe('FormGroup', () => {
 
 
   describe('touched', () => {
-    let c: FormControl, g: FormGroup;
+    let c: FormControl<any>, g: FormGroup<any>;
 
     beforeEach(() => {
-      c = new FormControl('value');
-      g = new FormGroup({'one': c});
+      c = new FormControl<any>('value');
+      g = new FormGroup<any>({'one': c});
     });
 
     it('should be false after creating a control', () => {
@@ -190,12 +196,12 @@ describe('FormGroup', () => {
   });
 
   describe('setValue', () => {
-    let c: FormControl, c2: FormControl, g: FormGroup;
+    let c: FormControl<any>, c2: FormControl<any>, g: FormGroup<any>;
 
     beforeEach(() => {
-      c = new FormControl('');
-      c2 = new FormControl('');
-      g = new FormGroup({'one': c, 'two': c2});
+      c = new FormControl<any>('');
+      c2 = new FormControl<any>('');
+      g = new FormGroup<any>({'one': c, 'two': c2});
     });
 
     it('should set its own value', () => {
@@ -227,13 +233,13 @@ describe('FormGroup', () => {
     });
 
     it('should set parent values', () => {
-      const form = new FormGroup({'parent': g});
+      const form = new FormGroup<any>({'parent': g});
       g.setValue({'one': 'one', 'two': 'two'});
       expect(form.value).toEqual({'parent': {'one': 'one', 'two': 'two'}});
     });
 
     it('should not update the parent when explicitly specified', () => {
-      const form = new FormGroup({'parent': g});
+      const form = new FormGroup<any>({'parent': g});
       g.setValue({'one': 'one', 'two': 'two'}, {onlySelf: true});
 
       expect(form.value).toEqual({parent: {'one': '', 'two': ''}});
@@ -258,18 +264,18 @@ describe('FormGroup', () => {
     });
 
     it('should throw if no controls are set yet', () => {
-      const empty = new FormGroup({});
+      const empty = new FormGroup<any>({});
       expect(() => empty.setValue({
         'one': 'one'
       })).toThrowError(new RegExp(`no form controls registered with this group`));
     });
 
     describe('setValue() events', () => {
-      let form: FormGroup;
+      let form: FormGroup<any>;
       let logger: any[];
 
       beforeEach(() => {
-        form = new FormGroup({'parent': g});
+        form = new FormGroup<any>({'parent': g});
         logger = [];
       });
 
@@ -311,15 +317,15 @@ describe('FormGroup', () => {
   });
 
   describe('patchValue', () => {
-    let c: FormControl, c2: FormControl, g: FormGroup, g2: FormGroup;
+    let c: FormControl<any>, c2: FormControl<any>, g: FormGroup<any>, g2: FormGroup<any>;
 
     beforeEach(() => {
-      c = new FormControl('');
-      c2 = new FormControl('');
-      g = new FormGroup({'one': c, 'two': c2});
-      g2 = new FormGroup({
-        'array': new FormArray([new FormControl(1), new FormControl(2)]),
-        'group': new FormGroup({'one': new FormControl(3)}),
+      c = new FormControl<any>('');
+      c2 = new FormControl<any>('');
+      g = new FormGroup<any>({'one': c, 'two': c2});
+      g2 = new FormGroup<any>({
+        'array': new FormArray<any>([new FormControl<any>(1), new FormControl<any>(2)]),
+        'group': new FormGroup<any>({'one': new FormControl<any>(3)}),
       });
     });
 
@@ -351,13 +357,13 @@ describe('FormGroup', () => {
     });
 
     it('should set parent values', () => {
-      const form = new FormGroup({'parent': g});
+      const form = new FormGroup<any>({'parent': g});
       g.patchValue({'one': 'one', 'two': 'two'});
       expect(form.value).toEqual({'parent': {'one': 'one', 'two': 'two'}});
     });
 
     it('should not update the parent when explicitly specified', () => {
-      const form = new FormGroup({'parent': g});
+      const form = new FormGroup<any>({'parent': g});
       g.patchValue({'one': 'one', 'two': 'two'}, {onlySelf: true});
 
       expect(form.value).toEqual({parent: {'one': '', 'two': ''}});
@@ -395,11 +401,11 @@ describe('FormGroup', () => {
     });
 
     describe('patchValue() events', () => {
-      let form: FormGroup;
+      let form: FormGroup<any>;
       let logger: any[];
 
       beforeEach(() => {
-        form = new FormGroup({'parent': g});
+        form = new FormGroup<any>({'parent': g});
         logger = [];
       });
 
@@ -427,8 +433,9 @@ describe('FormGroup', () => {
          () => {
            const logEvent = () => logger.push('valueChanges event');
 
-           const [formArrayControl1, formArrayControl2] = (g2.controls.array as FormArray).controls;
-           const formGroupControl = (g2.controls.group as FormGroup).controls.one;
+           const [formArrayControl1, formArrayControl2] =
+               (g2.controls.array as FormArray<any>).controls;
+           const formGroupControl = (g2.controls.group as FormGroup<any>).controls.one;
 
            formArrayControl1.valueChanges.subscribe(logEvent);
            formArrayControl2.valueChanges.subscribe(logEvent);
@@ -472,12 +479,12 @@ describe('FormGroup', () => {
   });
 
   describe('reset()', () => {
-    let c: FormControl, c2: FormControl, g: FormGroup;
+    let c: FormControl<any>, c2: FormControl<any>, g: FormGroup<any>;
 
     beforeEach(() => {
-      c = new FormControl('initial value');
-      c2 = new FormControl('');
-      g = new FormGroup({'one': c, 'two': c2});
+      c = new FormControl<any>('initial value');
+      c2 = new FormControl<any>('');
+      g = new FormGroup<any>({'one': c, 'two': c2});
     });
 
     it('should set its own value if value passed', () => {
@@ -518,7 +525,7 @@ describe('FormGroup', () => {
     });
 
     it('should set the value of its parent if value passed', () => {
-      const form = new FormGroup({'g': g});
+      const form = new FormGroup<any>({'g': g});
       g.setValue({'one': 'new value', 'two': 'new value'});
 
       g.reset({'one': 'initial value', 'two': ''});
@@ -526,7 +533,7 @@ describe('FormGroup', () => {
     });
 
     it('should clear the value of its parent if no value passed', () => {
-      const form = new FormGroup({'g': g});
+      const form = new FormGroup<any>({'g': g});
       g.setValue({'one': 'new value', 'two': 'new value'});
 
       g.reset();
@@ -534,7 +541,7 @@ describe('FormGroup', () => {
     });
 
     it('should not update the parent when explicitly specified', () => {
-      const form = new FormGroup({'g': g});
+      const form = new FormGroup<any>({'g': g});
       g.reset({'one': 'new value', 'two': 'new value'}, {onlySelf: true});
 
       expect(form.value).toEqual({g: {'one': 'initial value', 'two': ''}});
@@ -560,8 +567,8 @@ describe('FormGroup', () => {
     });
 
     it('should mark the parent as pristine if all siblings pristine', () => {
-      const c3 = new FormControl('');
-      const form = new FormGroup({'g': g, 'c3': c3});
+      const c3 = new FormControl<any>('');
+      const form = new FormGroup<any>({'g': g, 'c3': c3});
 
       g.markAsDirty();
       expect(form.pristine).toBe(false);
@@ -571,8 +578,8 @@ describe('FormGroup', () => {
     });
 
     it('should not mark the parent pristine if any dirty siblings', () => {
-      const c3 = new FormControl('');
-      const form = new FormGroup({'g': g, 'c3': c3});
+      const c3 = new FormControl<any>('');
+      const form = new FormGroup<any>({'g': g, 'c3': c3});
 
       g.markAsDirty();
       c3.markAsDirty();
@@ -602,8 +609,8 @@ describe('FormGroup', () => {
     });
 
     it('should mark the parent untouched if all siblings untouched', () => {
-      const c3 = new FormControl('');
-      const form = new FormGroup({'g': g, 'c3': c3});
+      const c3 = new FormControl<any>('');
+      const form = new FormGroup<any>({'g': g, 'c3': c3});
 
       g.markAsTouched();
       expect(form.untouched).toBe(false);
@@ -613,8 +620,8 @@ describe('FormGroup', () => {
     });
 
     it('should not mark the parent untouched if any touched siblings', () => {
-      const c3 = new FormControl('');
-      const form = new FormGroup({'g': g, 'c3': c3});
+      const c3 = new FormControl<any>('');
+      const form = new FormGroup<any>({'g': g, 'c3': c3});
 
       g.markAsTouched();
       c3.markAsTouched();
@@ -640,11 +647,11 @@ describe('FormGroup', () => {
     });
 
     describe('reset() events', () => {
-      let form: FormGroup, c3: FormControl, logger: any[];
+      let form: FormGroup<any>, c3: FormControl<any>, logger: any[];
 
       beforeEach(() => {
-        c3 = new FormControl('');
-        form = new FormGroup({'g': g, 'c3': c3});
+        c3 = new FormControl<any>('');
+        form = new FormGroup<any>({'g': g, 'c3': c3});
         logger = [];
       });
 
@@ -716,12 +723,12 @@ describe('FormGroup', () => {
   });
 
   describe('contains', () => {
-    let group: FormGroup;
+    let group: FormGroup<any>;
 
     beforeEach(() => {
-      group = new FormGroup({
-        'required': new FormControl('requiredValue'),
-        'optional': new FormControl({value: 'disabled value', disabled: true})
+      group = new FormGroup<any>({
+        'required': new FormControl<any>('requiredValue'),
+        'optional': new FormControl<any>({value: 'disabled value', disabled: true})
       });
     });
 
@@ -743,18 +750,18 @@ describe('FormGroup', () => {
 
     it('should support controls with dots in their name', () => {
       expect(group.contains('some.name')).toBe(false);
-      group.addControl('some.name', new FormControl());
+      group.addControl('some.name', new FormControl<any>());
 
       expect(group.contains('some.name')).toBe(true);
     });
   });
 
   describe('retrieve', () => {
-    let group: FormGroup;
+    let group: FormGroup<any>;
 
     beforeEach(() => {
-      group = new FormGroup({
-        'required': new FormControl('requiredValue'),
+      group = new FormGroup<any>({
+        'required': new FormControl<any>('requiredValue'),
       });
     });
 
@@ -764,12 +771,12 @@ describe('FormGroup', () => {
   });
 
   describe('statusChanges', () => {
-    let control: FormControl;
-    let group: FormGroup;
+    let control: FormControl<any>;
+    let group: FormGroup<any>;
 
     beforeEach(waitForAsync(() => {
-      control = new FormControl('', asyncValidatorReturningObservable);
-      group = new FormGroup({'one': control});
+      control = new FormControl<any>('', asyncValidatorReturningObservable);
+      group = new FormGroup<any>({'one': control});
     }));
 
 
@@ -792,40 +799,40 @@ describe('FormGroup', () => {
 
   describe('getError', () => {
     it('should return the error when it is present', () => {
-      const c = new FormControl('', Validators.required);
-      const g = new FormGroup({'one': c});
+      const c = new FormControl<any>('', Validators.required);
+      const g = new FormGroup<any>({'one': c});
       expect(c.getError('required')).toEqual(true);
       expect(g.getError('required', ['one'])).toEqual(true);
     });
 
     it('should return null otherwise', () => {
-      const c = new FormControl('not empty', Validators.required);
-      const g = new FormGroup({'one': c});
+      const c = new FormControl<any>('not empty', Validators.required);
+      const g = new FormGroup<any>({'one': c});
       expect(c.getError('invalid')).toEqual(null);
       expect(g.getError('required', ['one'])).toEqual(null);
       expect(g.getError('required', ['invalid'])).toEqual(null);
     });
 
     it('should be able to traverse group with single string', () => {
-      const c = new FormControl('', Validators.required);
-      const g = new FormGroup({'one': c});
+      const c = new FormControl<any>('', Validators.required);
+      const g = new FormGroup<any>({'one': c});
       expect(c.getError('required')).toEqual(true);
       expect(g.getError('required', 'one')).toEqual(true);
     });
 
     it('should be able to traverse group with string delimited by dots', () => {
-      const c = new FormControl('', Validators.required);
-      const g2 = new FormGroup({'two': c});
-      const g1 = new FormGroup({'one': g2});
+      const c = new FormControl<any>('', Validators.required);
+      const g2 = new FormGroup<any>({'two': c});
+      const g1 = new FormGroup<any>({'one': g2});
       expect(c.getError('required')).toEqual(true);
       expect(g1.getError('required', 'one.two')).toEqual(true);
     });
 
     it('should traverse group with form array using string and numbers', () => {
-      const c = new FormControl('', Validators.required);
-      const g2 = new FormGroup({'two': c});
-      const a = new FormArray([g2]);
-      const g1 = new FormGroup({'one': a});
+      const c = new FormControl<any>('', Validators.required);
+      const g2 = new FormGroup<any>({'two': c});
+      const a = new FormArray<any>([g2]);
+      const g1 = new FormGroup<any>({'one': a});
       expect(c.getError('required')).toEqual(true);
       expect(g1.getError('required', ['one', 0, 'two'])).toEqual(true);
     });
@@ -833,39 +840,39 @@ describe('FormGroup', () => {
 
   describe('hasError', () => {
     it('should return true when it is present', () => {
-      const c = new FormControl('', Validators.required);
-      const g = new FormGroup({'one': c});
+      const c = new FormControl<any>('', Validators.required);
+      const g = new FormGroup<any>({'one': c});
       expect(c.hasError('required')).toEqual(true);
       expect(g.hasError('required', ['one'])).toEqual(true);
     });
 
     it('should return false otherwise', () => {
-      const c = new FormControl('not empty', Validators.required);
-      const g = new FormGroup({'one': c});
+      const c = new FormControl<any>('not empty', Validators.required);
+      const g = new FormGroup<any>({'one': c});
       expect(c.hasError('invalid')).toEqual(false);
       expect(g.hasError('required', ['one'])).toEqual(false);
       expect(g.hasError('required', ['invalid'])).toEqual(false);
     });
 
     it('should be able to traverse group with single string', () => {
-      const c = new FormControl('', Validators.required);
-      const g = new FormGroup({'one': c});
+      const c = new FormControl<any>('', Validators.required);
+      const g = new FormGroup<any>({'one': c});
       expect(c.hasError('required')).toEqual(true);
       expect(g.hasError('required', 'one')).toEqual(true);
     });
 
     it('should be able to traverse group with string delimited by dots', () => {
-      const c = new FormControl('', Validators.required);
-      const g2 = new FormGroup({'two': c});
-      const g1 = new FormGroup({'one': g2});
+      const c = new FormControl<any>('', Validators.required);
+      const g2 = new FormGroup<any>({'two': c});
+      const g1 = new FormGroup<any>({'one': g2});
       expect(c.hasError('required')).toEqual(true);
       expect(g1.hasError('required', 'one.two')).toEqual(true);
     });
     it('should traverse group with form array using string and numbers', () => {
-      const c = new FormControl('', Validators.required);
-      const g2 = new FormGroup({'two': c});
-      const a = new FormArray([g2]);
-      const g1 = new FormGroup({'one': a});
+      const c = new FormControl<any>('', Validators.required);
+      const g2 = new FormGroup<any>({'two': c});
+      const a = new FormArray<any>([g2]);
+      const g1 = new FormGroup<any>({'one': a});
       expect(c.getError('required')).toEqual(true);
       expect(g1.getError('required', ['one', 0, 'two'])).toEqual(true);
     });
@@ -878,8 +885,8 @@ describe('FormGroup', () => {
     }
 
     it('should run a single validator when the value changes', () => {
-      const c = new FormControl(null);
-      const g = new FormGroup({'one': c}, simpleValidator);
+      const c = new FormControl<any>(null);
+      const g = new FormGroup<any>({'one': c}, simpleValidator);
 
       c.setValue('correct');
 
@@ -893,7 +900,8 @@ describe('FormGroup', () => {
     });
 
     it('should support multiple validators from array', () => {
-      const g = new FormGroup({one: new FormControl()}, [simpleValidator, containsValidator]);
+      const g =
+          new FormGroup<any>({one: new FormControl<any>()}, [simpleValidator, containsValidator]);
       expect(g.valid).toEqual(false);
       expect(g.errors).toEqual({missing: true, broken: true});
 
@@ -906,7 +914,7 @@ describe('FormGroup', () => {
     });
 
     it('should set single validator from options obj', () => {
-      const g = new FormGroup({one: new FormControl()}, {validators: simpleValidator});
+      const g = new FormGroup<any>({one: new FormControl<any>()}, {validators: simpleValidator});
       expect(g.valid).toEqual(false);
       expect(g.errors).toEqual({broken: true});
 
@@ -915,8 +923,8 @@ describe('FormGroup', () => {
     });
 
     it('should set multiple validators from options obj', () => {
-      const g = new FormGroup(
-          {one: new FormControl()}, {validators: [simpleValidator, containsValidator]});
+      const g = new FormGroup<any>(
+          {one: new FormControl<any>()}, {validators: [simpleValidator, containsValidator]});
       expect(g.valid).toEqual(false);
       expect(g.errors).toEqual({missing: true, broken: true});
 
@@ -931,8 +939,8 @@ describe('FormGroup', () => {
 
   describe('asyncValidator', () => {
     it('should run the async validator', fakeAsync(() => {
-         const c = new FormControl('value');
-         const g = new FormGroup({'one': c}, null!, asyncValidator('expected'));
+         const c = new FormControl<any>('value');
+         const g = new FormGroup<any>({'one': c}, null!, asyncValidator('expected'));
 
          expect(g.pending).toEqual(true);
 
@@ -943,8 +951,8 @@ describe('FormGroup', () => {
        }));
 
     it('should set multiple async validators from array', fakeAsync(() => {
-         const g = new FormGroup(
-             {'one': new FormControl('value')}, null!,
+         const g = new FormGroup<any>(
+             {'one': new FormControl<any>('value')}, null!,
              [asyncValidator('expected'), otherObservableValidator]);
          expect(g.pending).toEqual(true);
 
@@ -954,8 +962,8 @@ describe('FormGroup', () => {
        }));
 
     it('should set single async validator from options obj', fakeAsync(() => {
-         const g = new FormGroup(
-             {'one': new FormControl('value')}, {asyncValidators: asyncValidator('expected')});
+         const g = new FormGroup<any>(
+             {'one': new FormControl<any>('value')}, {asyncValidators: asyncValidator('expected')});
          expect(g.pending).toEqual(true);
 
          tick();
@@ -964,8 +972,8 @@ describe('FormGroup', () => {
        }));
 
     it('should set multiple async validators from options obj', fakeAsync(() => {
-         const g = new FormGroup(
-             {'one': new FormControl('value')},
+         const g = new FormGroup<any>(
+             {'one': new FormControl<any>('value')},
              {asyncValidators: [asyncValidator('expected'), otherObservableValidator]});
          expect(g.pending).toEqual(true);
 
@@ -975,8 +983,8 @@ describe('FormGroup', () => {
        }));
 
     it('should set the parent group\'s status to pending', fakeAsync(() => {
-         const c = new FormControl('value', null!, asyncValidator('expected'));
-         const g = new FormGroup({'one': c});
+         const c = new FormControl<any>('value', null!, asyncValidator('expected'));
+         const g = new FormGroup<any>({'one': c});
 
          expect(g.pending).toEqual(true);
 
@@ -986,8 +994,8 @@ describe('FormGroup', () => {
        }));
 
     it('should run the parent group\'s async validator when children are pending', fakeAsync(() => {
-         const c = new FormControl('value', null!, asyncValidator('expected'));
-         const g = new FormGroup({'one': c}, null!, asyncValidator('expected'));
+         const c = new FormControl<any>('value', null!, asyncValidator('expected'));
+         const g = new FormGroup<any>({'one': c}, null!, asyncValidator('expected'));
 
          tick(1);
 
@@ -995,11 +1003,11 @@ describe('FormGroup', () => {
          expect(g.get('one')!.errors).toEqual({'async': true});
        }));
 
-    it('should handle successful async FormGroup resolving synchronously before a successful async child validator',
+    it('should handle successful async FormGroup<any> resolving synchronously before a successful async child validator',
        fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 1, shouldFail: false}));
-         const g = new FormGroup(
+         const g = new FormGroup<any>(
              {'one': c}, null!, simpleAsyncValidator({timeout: 0, shouldFail: false}));
 
          // Initially, the form control validation is pending, and the form group own validation has
@@ -1018,11 +1026,11 @@ describe('FormGroup', () => {
          ]);
        }));
 
-    it('should handle successful async FormGroup resolving after a synchronously and successfully resolving child validator',
+    it('should handle successful async FormGroup<any> resolving after a synchronously and successfully resolving child validator',
        fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 0, shouldFail: false}));
-         const g = new FormGroup(
+         const g = new FormGroup<any>(
              {'one': c}, null!, simpleAsyncValidator({timeout: 1, shouldFail: false}));
 
          // Initially, form control validator has synchronously resolved. However, g has its own
@@ -1041,11 +1049,11 @@ describe('FormGroup', () => {
          ]);
        }));
 
-    it('should handle successful async FormGroup and child control validators resolving synchronously',
+    it('should handle successful async FormGroup<any> and child control validators resolving synchronously',
        fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 0, shouldFail: false}));
-         const g = new FormGroup(
+         const g = new FormGroup<any>(
              {'one': c}, null!, simpleAsyncValidator({timeout: 0, shouldFail: false}));
 
          // Both form control and form group successful async validators have resolved synchronously
@@ -1055,14 +1063,15 @@ describe('FormGroup', () => {
          ]);
        }));
 
-    it('should handle failing async FormGroup and failing child control validators resolving synchronously',
+    it('should handle failing async FormGroup<any> and failing child control validators resolving synchronously',
        fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 0, shouldFail: true}));
-         const g =
-             new FormGroup({'one': c}, null!, simpleAsyncValidator({timeout: 0, shouldFail: true}));
+         const g = new FormGroup<any>(
+             {'one': c}, null!, simpleAsyncValidator({timeout: 0, shouldFail: true}));
 
-         // FormControl async validator has executed and failed synchronously with the default error
+         // FormControl<any> async validator has executed and failed synchronously with the default
+         // error
          // `{async: true}`. Next, the form group status is calculated. Since one of its children is
          // failing, the form group itself is marked `INVALID`. And its asynchronous validation is
          // not even triggered. Therefore, we end up with form group that is `INVALID` but whose
@@ -1074,12 +1083,12 @@ describe('FormGroup', () => {
          ]);
        }));
 
-    it('should handle failing async FormGroup and successful child control validators resolving synchronously',
+    it('should handle failing async FormGroup<any> and successful child control validators resolving synchronously',
        fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 0, shouldFail: false}));
-         const g =
-             new FormGroup({'one': c}, null!, simpleAsyncValidator({timeout: 0, shouldFail: true}));
+         const g = new FormGroup<any>(
+             {'one': c}, null!, simpleAsyncValidator({timeout: 0, shouldFail: true}));
 
          expect(currentStateOf([g, g.get('one')!])).toEqual([
            {errors: {async: true}, pending: false, status: 'INVALID'},  // Group
@@ -1087,18 +1096,18 @@ describe('FormGroup', () => {
          ]);
        }));
 
-    it('should handle failing async FormArray and successful children validators resolving synchronously',
+    it('should handle failing async FormArray<any> and successful children validators resolving synchronously',
        fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 0, shouldFail: false}));
-         const g = new FormGroup(
+         const g = new FormGroup<any>(
              {'one': c}, null!, simpleAsyncValidator({timeout: 0, shouldFail: false}));
 
-         const c2 =
-             new FormControl('fcVal', null!, simpleAsyncValidator({timeout: 0, shouldFail: false}));
+         const c2 = new FormControl<any>(
+             'fcVal', null!, simpleAsyncValidator({timeout: 0, shouldFail: false}));
 
-         const a =
-             new FormArray([g, c2], null!, simpleAsyncValidator({timeout: 0, shouldFail: true}));
+         const a = new FormArray<any>(
+             [g, c2], null!, simpleAsyncValidator({timeout: 0, shouldFail: true}));
 
          expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
            {errors: {async: true}, pending: false, status: 'INVALID'},  // Array
@@ -1107,12 +1116,12 @@ describe('FormGroup', () => {
          ]);
        }));
 
-    it('should handle failing FormGroup validator resolving after successful child validator',
+    it('should handle failing FormGroup<any> validator resolving after successful child validator',
        fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 1, shouldFail: false}));
-         const g =
-             new FormGroup({'one': c}, null!, simpleAsyncValidator({timeout: 2, shouldFail: true}));
+         const g = new FormGroup<any>(
+             {'one': c}, null!, simpleAsyncValidator({timeout: 2, shouldFail: true}));
 
          // Initially, the form group and nested control are in pending state
          expect(currentStateOf([g, g.get('one')!])).toEqual([
@@ -1137,15 +1146,16 @@ describe('FormGroup', () => {
          ]);
        }));
 
-    it('should handle failing FormArray validator resolving after successful child validator',
+    it('should handle failing FormArray<any> validator resolving after successful child validator',
        fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 1, shouldFail: false}));
-         const a = new FormArray([c], null!, simpleAsyncValidator({timeout: 2, shouldFail: true}));
+         const a =
+             new FormArray<any>([c], null!, simpleAsyncValidator({timeout: 2, shouldFail: true}));
 
          // Initially, the form array and nested control are in pending state
          expect(currentStateOf([a, a.at(0)!])).toEqual([
-           {errors: null, pending: true, status: 'PENDING'},  // FormArray
+           {errors: null, pending: true, status: 'PENDING'},  // FormArray<any>
            {errors: null, pending: true, status: 'PENDING'},  // Control
          ]);
 
@@ -1153,7 +1163,7 @@ describe('FormGroup', () => {
 
          // After 1ms, only form control validation has resolved
          expect(currentStateOf([a, a.at(0)!])).toEqual([
-           {errors: null, pending: true, status: 'PENDING'},  // FormArray
+           {errors: null, pending: true, status: 'PENDING'},  // FormArray<any>
            {errors: null, pending: false, status: 'VALID'},   // Control
          ]);
 
@@ -1161,16 +1171,16 @@ describe('FormGroup', () => {
 
          // After 1ms, the form array validation fails
          expect(currentStateOf([a, a.at(0)!])).toEqual([
-           {errors: {async: true}, pending: false, status: 'INVALID'},  // FormArray
+           {errors: {async: true}, pending: false, status: 'INVALID'},  // FormArray<any>
            {errors: null, pending: false, status: 'VALID'},             // Control
          ]);
        }));
 
-    it('should handle successful FormGroup validator resolving after successful child validator',
+    it('should handle successful FormGroup<any> validator resolving after successful child validator',
        fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 1, shouldFail: false}));
-         const g = new FormGroup(
+         const g = new FormGroup<any>(
              {'one': c}, null!, simpleAsyncValidator({timeout: 2, shouldFail: false}));
 
          // Initially, the form group and nested control are in pending state
@@ -1196,22 +1206,22 @@ describe('FormGroup', () => {
          ]);
        }));
 
-    it('should handle successful FormArray validator resolving after successful child validators',
+    it('should handle successful FormArray<any> validator resolving after successful child validators',
        fakeAsync(() => {
-         const c1 = new FormControl(
+         const c1 = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 1, shouldFail: false}));
-         const g = new FormGroup(
+         const g = new FormGroup<any>(
              {'one': c1}, null!, simpleAsyncValidator({timeout: 2, shouldFail: false}));
-         const c2 =
-             new FormControl('fcVal', null!, simpleAsyncValidator({timeout: 3, shouldFail: false}));
+         const c2 = new FormControl<any>(
+             'fcVal', null!, simpleAsyncValidator({timeout: 3, shouldFail: false}));
 
-         const a =
-             new FormArray([g, c2], null!, simpleAsyncValidator({timeout: 4, shouldFail: false}));
+         const a = new FormArray<any>(
+             [g, c2], null!, simpleAsyncValidator({timeout: 4, shouldFail: false}));
 
          // Initially, the form array and the tested form group and form control c2 are in pending
          // state
          expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
-           {errors: null, pending: true, status: 'PENDING'},  // FormArray
+           {errors: null, pending: true, status: 'PENDING'},  // FormArray<any>
            {errors: null, pending: true, status: 'PENDING'},  // g
            {errors: null, pending: true, status: 'PENDING'},  // c2
          ]);
@@ -1220,7 +1230,7 @@ describe('FormGroup', () => {
 
          // After 2ms, g validation has resolved
          expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
-           {errors: null, pending: true, status: 'PENDING'},  // FormArray
+           {errors: null, pending: true, status: 'PENDING'},  // FormArray<any>
            {errors: null, pending: false, status: 'VALID'},   // g
            {errors: null, pending: true, status: 'PENDING'},  // c2
          ]);
@@ -1229,37 +1239,37 @@ describe('FormGroup', () => {
 
          // After 1ms, c2 validation has resolved
          expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
-           {errors: null, pending: true, status: 'PENDING'},  // FormArray
+           {errors: null, pending: true, status: 'PENDING'},  // FormArray<any>
            {errors: null, pending: false, status: 'VALID'},   // g
            {errors: null, pending: false, status: 'VALID'},   // c2
          ]);
 
          tick(1);
 
-         // After 1ms, FormArray own validation has resolved
+         // After 1ms, FormArray<any> own validation has resolved
          expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
-           {errors: null, pending: false, status: 'VALID'},  // FormArray
+           {errors: null, pending: false, status: 'VALID'},  // FormArray<any>
            {errors: null, pending: false, status: 'VALID'},  // g
            {errors: null, pending: false, status: 'VALID'},  // c2
          ]);
        }));
 
-    it('should handle failing FormArray validator resolving after successful child validators',
+    it('should handle failing FormArray<any> validator resolving after successful child validators',
        fakeAsync(() => {
-         const c1 = new FormControl(
+         const c1 = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 1, shouldFail: false}));
-         const g = new FormGroup(
+         const g = new FormGroup<any>(
              {'one': c1}, null!, simpleAsyncValidator({timeout: 2, shouldFail: false}));
-         const c2 =
-             new FormControl('fcVal', null!, simpleAsyncValidator({timeout: 3, shouldFail: false}));
+         const c2 = new FormControl<any>(
+             'fcVal', null!, simpleAsyncValidator({timeout: 3, shouldFail: false}));
 
-         const a =
-             new FormArray([g, c2], null!, simpleAsyncValidator({timeout: 4, shouldFail: true}));
+         const a = new FormArray<any>(
+             [g, c2], null!, simpleAsyncValidator({timeout: 4, shouldFail: true}));
 
          // Initially, the form array and the tested form group and form control c2 are in pending
          // state
          expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
-           {errors: null, pending: true, status: 'PENDING'},  // FormArray
+           {errors: null, pending: true, status: 'PENDING'},  // FormArray<any>
            {errors: null, pending: true, status: 'PENDING'},  // g
            {errors: null, pending: true, status: 'PENDING'},  // c2
          ]);
@@ -1268,7 +1278,7 @@ describe('FormGroup', () => {
 
          // After 2ms, g validation has resolved
          expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
-           {errors: null, pending: true, status: 'PENDING'},  // FormArray
+           {errors: null, pending: true, status: 'PENDING'},  // FormArray<any>
            {errors: null, pending: false, status: 'VALID'},   // g
            {errors: null, pending: true, status: 'PENDING'},  // c2
          ]);
@@ -1277,26 +1287,26 @@ describe('FormGroup', () => {
 
          // After 1ms, c2 validation has resolved
          expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
-           {errors: null, pending: true, status: 'PENDING'},  // FormArray
+           {errors: null, pending: true, status: 'PENDING'},  // FormArray<any>
            {errors: null, pending: false, status: 'VALID'},   // g
            {errors: null, pending: false, status: 'VALID'},   // c2
          ]);
 
          tick(1);
 
-         // After 1ms, FormArray own validation has failed
+         // After 1ms, FormArray<any> own validation has failed
          expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
-           {errors: {async: true}, pending: false, status: 'INVALID'},  // FormArray
+           {errors: {async: true}, pending: false, status: 'INVALID'},  // FormArray<any>
            {errors: null, pending: false, status: 'VALID'},             // g
            {errors: null, pending: false, status: 'VALID'},             // c2
          ]);
        }));
 
-    it('should handle multiple successful FormGroup validators resolving after successful child validator',
+    it('should handle multiple successful FormGroup<any> validators resolving after successful child validator',
        fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 1, shouldFail: false}));
-         const g = new FormGroup({'one': c}, null!, [
+         const g = new FormGroup<any>({'one': c}, null!, [
            simpleAsyncValidator({timeout: 2, shouldFail: false}),
            simpleAsyncValidator({timeout: 3, shouldFail: false})
          ]);
@@ -1332,11 +1342,11 @@ describe('FormGroup', () => {
          ]);
        }));
 
-    it('should handle multiple FormGroup validators (success then failure) resolving after successful child validator',
+    it('should handle multiple FormGroup<any> validators (success then failure) resolving after successful child validator',
        fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 1, shouldFail: false}));
-         const g = new FormGroup({'one': c}, null!, [
+         const g = new FormGroup<any>({'one': c}, null!, [
            simpleAsyncValidator({timeout: 2, shouldFail: false}),
            simpleAsyncValidator({timeout: 3, shouldFail: true})
          ]);
@@ -1373,11 +1383,11 @@ describe('FormGroup', () => {
        }));
 
 
-    it('should handle multiple FormGroup validators (failure then success) resolving after successful child validator',
+    it('should handle multiple FormGroup<any> validators (failure then success) resolving after successful child validator',
        fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 1, shouldFail: false}));
-         const g = new FormGroup({'one': c}, null!, [
+         const g = new FormGroup<any>({'one': c}, null!, [
            simpleAsyncValidator({timeout: 2, shouldFail: true}),
            simpleAsyncValidator({timeout: 3, shouldFail: false})
          ]);
@@ -1399,8 +1409,8 @@ describe('FormGroup', () => {
 
          tick(1);
 
-         // All async validators are composed into one function. So, after 2ms, the FormGroup g is
-         // still in pending state without errors
+         // All async validators are composed into one function. So, after 2ms, the FormGroup<any> g
+         // is still in pending state without errors
          expect(currentStateOf([g, g.get('one')!])).toEqual([
            {errors: null, pending: true, status: 'PENDING'},  // Group
            {errors: null, pending: false, status: 'VALID'},   // Control
@@ -1417,19 +1427,19 @@ describe('FormGroup', () => {
 
 
     it('should handle async validators in nested form groups / arrays', fakeAsync(() => {
-         const c1 = new FormControl(
+         const c1 = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 1, shouldFail: false}));
 
-         const g1 = new FormGroup(
+         const g1 = new FormGroup<any>(
              {'one': c1}, null!, simpleAsyncValidator({timeout: 2, shouldFail: true}));
 
-         const c2 =
-             new FormControl('fcVal', null!, simpleAsyncValidator({timeout: 3, shouldFail: false}));
+         const c2 = new FormControl<any>(
+             'fcVal', null!, simpleAsyncValidator({timeout: 3, shouldFail: false}));
 
          const g2 =
-             new FormArray([c2], null!, simpleAsyncValidator({timeout: 4, shouldFail: false}));
+             new FormArray<any>([c2], null!, simpleAsyncValidator({timeout: 4, shouldFail: false}));
 
-         const g = new FormGroup(
+         const g = new FormGroup<any>(
              {'g1': g1, 'g2': g2}, null!, simpleAsyncValidator({timeout: 5, shouldFail: false}));
 
          // Initially, the form group and nested control are in pending state
@@ -1468,12 +1478,12 @@ describe('FormGroup', () => {
          ]);
        }));
 
-    it('should handle failing FormGroup validator resolving before successful child validator',
+    it('should handle failing FormGroup<any> validator resolving before successful child validator',
        fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 2, shouldFail: false}));
-         const g =
-             new FormGroup({'one': c}, null!, simpleAsyncValidator({timeout: 1, shouldFail: true}));
+         const g = new FormGroup<any>(
+             {'one': c}, null!, simpleAsyncValidator({timeout: 1, shouldFail: true}));
 
          // Initially, the form group and nested control are in pending state
          expect(currentStateOf([g, g.get('one')!])).toEqual([
@@ -1498,15 +1508,16 @@ describe('FormGroup', () => {
          ]);
        }));
 
-    it('should handle failing FormArray validator resolving before successful child validator',
+    it('should handle failing FormArray<any> validator resolving before successful child validator',
        fakeAsync(() => {
-         const c = new FormControl(
+         const c = new FormControl<any>(
              'fcValue', null!, simpleAsyncValidator({timeout: 2, shouldFail: false}));
-         const a = new FormArray([c], null!, simpleAsyncValidator({timeout: 1, shouldFail: true}));
+         const a =
+             new FormArray<any>([c], null!, simpleAsyncValidator({timeout: 1, shouldFail: true}));
 
          // Initially, the form array and nested control are in pending state
          expect(currentStateOf([a, a.at(0)!])).toEqual([
-           {errors: null, pending: true, status: 'PENDING'},  // FormArray
+           {errors: null, pending: true, status: 'PENDING'},  // FormArray<any>
            {errors: null, pending: true, status: 'PENDING'},  // Control
          ]);
 
@@ -1514,7 +1525,7 @@ describe('FormGroup', () => {
 
          // After 1ms, form array validation fails
          expect(currentStateOf([a, a.at(0)!])).toEqual([
-           {errors: {async: true}, pending: false, status: 'INVALID'},  // FormArray
+           {errors: {async: true}, pending: false, status: 'INVALID'},  // FormArray<any>
            {errors: null, pending: true, status: 'PENDING'},            // Control
          ]);
 
@@ -1522,7 +1533,7 @@ describe('FormGroup', () => {
 
          // After 1ms, child validation resolves
          expect(currentStateOf([a, a.at(0)!])).toEqual([
-           {errors: {async: true}, pending: false, status: 'INVALID'},  // FormArray
+           {errors: {async: true}, pending: false, status: 'INVALID'},  // FormArray<any>
            {errors: null, pending: false, status: 'VALID'},             // Control
          ]);
        }));
@@ -1530,7 +1541,7 @@ describe('FormGroup', () => {
 
   describe('disable() & enable()', () => {
     it('should mark the group as disabled', () => {
-      const g = new FormGroup({'one': new FormControl(null)});
+      const g = new FormGroup<any>({'one': new FormControl<any>(null)});
       expect(g.disabled).toBe(false);
       expect(g.valid).toBe(true);
 
@@ -1544,7 +1555,7 @@ describe('FormGroup', () => {
     });
 
     it('should set the group status as disabled', () => {
-      const g = new FormGroup({'one': new FormControl(null)});
+      const g = new FormGroup<any>({'one': new FormControl<any>(null)});
       expect(g.status).toEqual('VALID');
 
       g.disable();
@@ -1555,9 +1566,9 @@ describe('FormGroup', () => {
     });
 
     it('should mark children of the group as disabled', () => {
-      const c1 = new FormControl(null);
-      const c2 = new FormControl(null);
-      const g = new FormGroup({'one': c1, 'two': c2});
+      const c1 = new FormControl<any>(null);
+      const c2 = new FormControl<any>(null);
+      const g = new FormGroup<any>({'one': c1, 'two': c2});
       expect(c1.disabled).toBe(false);
       expect(c2.disabled).toBe(false);
 
@@ -1571,9 +1582,9 @@ describe('FormGroup', () => {
     });
 
     it('should ignore disabled controls in validation', () => {
-      const g = new FormGroup({
-        nested: new FormGroup({one: new FormControl(null, Validators.required)}),
-        two: new FormControl('two')
+      const g = new FormGroup<any>({
+        nested: new FormGroup<any>({one: new FormControl<any>(null, Validators.required)}),
+        two: new FormControl<any>('two')
       });
       expect(g.valid).toBe(false);
 
@@ -1585,8 +1596,10 @@ describe('FormGroup', () => {
     });
 
     it('should ignore disabled controls when serializing value', () => {
-      const g = new FormGroup(
-          {nested: new FormGroup({one: new FormControl('one')}), two: new FormControl('two')});
+      const g = new FormGroup<any>({
+        nested: new FormGroup<any>({one: new FormControl<any>('one')}),
+        two: new FormControl<any>('two')
+      });
       expect(g.value).toEqual({'nested': {'one': 'one'}, 'two': 'two'});
 
       g.get('nested')!.disable();
@@ -1597,8 +1610,10 @@ describe('FormGroup', () => {
     });
 
     it('should update its value when disabled with disabled children', () => {
-      const g = new FormGroup(
-          {nested: new FormGroup({one: new FormControl('one'), two: new FormControl('two')})});
+      const g = new FormGroup<any>({
+        nested:
+            new FormGroup<any>({one: new FormControl<any>('one'), two: new FormControl<any>('two')})
+      });
 
       g.get('nested.two')!.disable();
       expect(g.value).toEqual({nested: {one: 'one'}});
@@ -1611,8 +1626,10 @@ describe('FormGroup', () => {
     });
 
     it('should update its value when enabled with disabled children', () => {
-      const g = new FormGroup(
-          {nested: new FormGroup({one: new FormControl('one'), two: new FormControl('two')})});
+      const g = new FormGroup<any>({
+        nested:
+            new FormGroup<any>({one: new FormControl<any>('one'), two: new FormControl<any>('two')})
+      });
 
       g.get('nested.two')!.disable();
       expect(g.value).toEqual({nested: {one: 'one'}});
@@ -1622,8 +1639,10 @@ describe('FormGroup', () => {
     });
 
     it('should ignore disabled controls when determining dirtiness', () => {
-      const g = new FormGroup(
-          {nested: new FormGroup({one: new FormControl('one')}), two: new FormControl('two')});
+      const g = new FormGroup<any>({
+        nested: new FormGroup<any>({one: new FormControl<any>('one')}),
+        two: new FormControl<any>('two')
+      });
       g.get('nested.one')!.markAsDirty();
       expect(g.dirty).toBe(true);
 
@@ -1636,8 +1655,10 @@ describe('FormGroup', () => {
     });
 
     it('should ignore disabled controls when determining touched state', () => {
-      const g = new FormGroup(
-          {nested: new FormGroup({one: new FormControl('one')}), two: new FormControl('two')});
+      const g = new FormGroup<any>({
+        nested: new FormGroup<any>({one: new FormControl<any>('one')}),
+        two: new FormControl<any>('two')
+      });
       g.get('nested.one')!.markAsTouched();
       expect(g.touched).toBe(true);
 
@@ -1650,7 +1671,7 @@ describe('FormGroup', () => {
     });
 
     it('should keep empty, disabled groups disabled when updating validity', () => {
-      const group = new FormGroup({});
+      const group = new FormGroup<any>({});
       expect(group.status).toEqual('VALID');
 
       group.disable();
@@ -1659,15 +1680,15 @@ describe('FormGroup', () => {
       group.updateValueAndValidity();
       expect(group.status).toEqual('DISABLED');
 
-      group.addControl('one', new FormControl({value: '', disabled: true}));
+      group.addControl('one', new FormControl<any>({value: '', disabled: true}));
       expect(group.status).toEqual('DISABLED');
 
-      group.addControl('two', new FormControl());
+      group.addControl('two', new FormControl<any>());
       expect(group.status).toEqual('VALID');
     });
 
     it('should re-enable empty, disabled groups', () => {
-      const group = new FormGroup({});
+      const group = new FormGroup<any>({});
       group.disable();
       expect(group.status).toEqual('DISABLED');
 
@@ -1677,7 +1698,7 @@ describe('FormGroup', () => {
 
     it('should not run validators on disabled controls', () => {
       const validator = jasmine.createSpy('validator');
-      const g = new FormGroup({'one': new FormControl()}, validator);
+      const g = new FormGroup<any>({'one': new FormControl<any>()}, validator);
       expect(validator.calls.count()).toEqual(1);
 
       g.disable();
@@ -1692,7 +1713,7 @@ describe('FormGroup', () => {
 
     describe('disabled errors', () => {
       it('should clear out group errors when disabled', () => {
-        const g = new FormGroup({'one': new FormControl()}, () => ({'expected': true}));
+        const g = new FormGroup<any>({'one': new FormControl<any>()}, () => ({'expected': true}));
         expect(g.errors).toEqual({'expected': true});
 
         g.disable();
@@ -1703,16 +1724,17 @@ describe('FormGroup', () => {
       });
 
       it('should re-populate group errors when enabled from a child', () => {
-        const g = new FormGroup({'one': new FormControl()}, () => ({'expected': true}));
+        const g = new FormGroup<any>({'one': new FormControl<any>()}, () => ({'expected': true}));
         g.disable();
         expect(g.errors).toEqual(null);
 
-        g.addControl('two', new FormControl());
+        g.addControl('two', new FormControl<any>());
         expect(g.errors).toEqual({'expected': true});
       });
 
       it('should clear out async group errors when disabled', fakeAsync(() => {
-           const g = new FormGroup({'one': new FormControl()}, null!, asyncValidator('expected'));
+           const g = new FormGroup<any>(
+               {'one': new FormControl<any>()}, null!, asyncValidator('expected'));
            tick();
            expect(g.errors).toEqual({'async': true});
 
@@ -1725,14 +1747,15 @@ describe('FormGroup', () => {
          }));
 
       it('should re-populate async group errors when enabled from a child', fakeAsync(() => {
-           const g = new FormGroup({'one': new FormControl()}, null!, asyncValidator('expected'));
+           const g = new FormGroup<any>(
+               {'one': new FormControl<any>()}, null!, asyncValidator('expected'));
            tick();
            expect(g.errors).toEqual({'async': true});
 
            g.disable();
            expect(g.errors).toEqual(null);
 
-           g.addControl('two', new FormControl());
+           g.addControl('two', new FormControl<any>());
            tick();
            expect(g.errors).toEqual({'async': true});
          }));
@@ -1740,15 +1763,15 @@ describe('FormGroup', () => {
 
     describe('disabled events', () => {
       let logger: string[];
-      let c: FormControl;
-      let g: FormGroup;
-      let form: FormGroup;
+      let c: FormControl<any>;
+      let g: FormGroup<any>;
+      let form: FormGroup<any>;
 
       beforeEach(() => {
         logger = [];
-        c = new FormControl('', Validators.required);
-        g = new FormGroup({one: c});
-        form = new FormGroup({g: g});
+        c = new FormControl<any>('', Validators.required);
+        g = new FormGroup<any>({one: c});
+        form = new FormGroup<any>({g: g});
       });
 
       it('should emit value change events in the right order', () => {
@@ -1794,16 +1817,16 @@ describe('FormGroup', () => {
   });
 
   describe('updateTreeValidity()', () => {
-    let c: FormControl, c2: FormControl, c3: FormControl;
-    let nested: FormGroup, form: FormGroup;
+    let c: FormControl<any>, c2: FormControl<any>, c3: FormControl<any>;
+    let nested: FormGroup<any>, form: FormGroup<any>;
     let logger: string[];
 
     beforeEach(() => {
-      c = new FormControl('one');
-      c2 = new FormControl('two');
-      c3 = new FormControl('three');
-      nested = new FormGroup({one: c, two: c2});
-      form = new FormGroup({nested: nested, three: c3});
+      c = new FormControl<any>('one');
+      c2 = new FormControl<any>('two');
+      c3 = new FormControl<any>('three');
+      nested = new FormGroup<any>({one: c, two: c2});
+      form = new FormGroup<any>({nested: nested, three: c3});
       logger = [];
 
       c.statusChanges.subscribe(() => logger.push('one'));
@@ -1825,16 +1848,16 @@ describe('FormGroup', () => {
   });
 
   describe('setControl()', () => {
-    let c: FormControl;
-    let g: FormGroup;
+    let c: FormControl<any>;
+    let g: FormGroup<any>;
 
     beforeEach(() => {
-      c = new FormControl('one');
-      g = new FormGroup({one: c});
+      c = new FormControl<any>('one');
+      g = new FormGroup<any>({one: c});
     });
 
     it('should replace existing control with new control', () => {
-      const c2 = new FormControl('new!', Validators.minLength(10));
+      const c2 = new FormControl<any>('new!', Validators.minLength(10));
       g.setControl('one', c2);
 
       expect(g.controls['one']).toEqual(c2);
@@ -1843,7 +1866,7 @@ describe('FormGroup', () => {
     });
 
     it('should add control if control did not exist before', () => {
-      const c2 = new FormControl('new!', Validators.minLength(10));
+      const c2 = new FormControl<any>('new!', Validators.minLength(10));
       g.setControl('two', c2);
 
       expect(g.controls['two']).toEqual(c2);
@@ -1859,7 +1882,7 @@ describe('FormGroup', () => {
 
     it('should only emit value change event once', () => {
       const logger: string[] = [];
-      const c2 = new FormControl('new!');
+      const c2 = new FormControl<any>('new!');
       g.valueChanges.subscribe(() => logger.push('change!'));
       g.setControl('one', c2);
       expect(logger).toEqual(['change!']);
@@ -1878,7 +1901,7 @@ describe('FormGroup', () => {
          fakeAsync(() => {
            const logs: string[] = [];
            const c =
-               new FormControl('', null, simpleAsyncValidator({timeout: 0, shouldFail: true}));
+               new FormControl<any>('', null, simpleAsyncValidator({timeout: 0, shouldFail: true}));
 
            attachEventsLogger(c, logs);
 
@@ -1904,7 +1927,7 @@ describe('FormGroup', () => {
       it('should run the async validator on stand alone controls and set status to `VALID`',
          fakeAsync(() => {
            const logs: string[] = [];
-           const c = new FormControl('', null, asyncValidator('new!'));
+           const c = new FormControl<any>('', null, asyncValidator('new!'));
 
            attachEventsLogger(c, logs);
 
@@ -1928,7 +1951,7 @@ describe('FormGroup', () => {
          fakeAsync(() => {
            const logs: string[] = [];
            const c =
-               new FormControl('', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
+               new FormControl<any>('', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
 
            attachEventsLogger(c, logs);
 
@@ -1951,7 +1974,7 @@ describe('FormGroup', () => {
       it('should run setValue before the initial async validator and set status to `VALID`',
          fakeAsync(() => {
            const logs: string[] = [];
-           const c = new FormControl('', null, asyncValidator('new!'));
+           const c = new FormControl<any>('', null, asyncValidator('new!'));
 
            attachEventsLogger(c, logs);
 
@@ -1975,7 +1998,7 @@ describe('FormGroup', () => {
          fakeAsync(() => {
            const logs: string[] = [];
            const c =
-               new FormControl('', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
+               new FormControl<any>('', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
 
            attachEventsLogger(c, logs);
 
@@ -1998,7 +2021,7 @@ describe('FormGroup', () => {
       it('should cancel initial run of the async validator and not emit anything', fakeAsync(() => {
            const logger: string[] = [];
            const c =
-               new FormControl('', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
+               new FormControl<any>('', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
 
            attachEventsLogger(c, logger);
 
@@ -2016,7 +2039,7 @@ describe('FormGroup', () => {
       it('should run the sync validator on stand alone controls and set status to `INVALID`',
          fakeAsync(() => {
            const logs: string[] = [];
-           const c = new FormControl('new!', Validators.required);
+           const c = new FormControl<any>('new!', Validators.required);
 
            attachEventsLogger(c, logs);
 
@@ -2037,7 +2060,7 @@ describe('FormGroup', () => {
       it('should run the sync validator on stand alone controls and set status to `VALID`',
          fakeAsync(() => {
            const logs: string[] = [];
-           const c = new FormControl('', Validators.required);
+           const c = new FormControl<any>('', Validators.required);
 
            attachEventsLogger(c, logs);
 
@@ -2057,11 +2080,11 @@ describe('FormGroup', () => {
     });
 
     describe('combination of multiple form controls', () => {
-      it('should run the async validator on the FormControl added to the FormGroup and set status to `VALID`',
+      it('should run the async validator on the FormControl<any> added to the FormGroup<any> and set status to `VALID`',
          fakeAsync(() => {
            const logs: string[] = [];
-           const c1 = new FormControl('one');
-           const g1 = new FormGroup({'one': c1});
+           const c1 = new FormControl<any>('one');
+           const g1 = new FormGroup<any>({'one': c1});
 
            // Initial state of the controls
            expect(currentStateOf([c1, g1])).toEqual([
@@ -2071,7 +2094,7 @@ describe('FormGroup', () => {
 
            attachEventsLogger(g1, logs, 'g1');
 
-           const c2 = new FormControl('new!', null, asyncValidator('new!'));
+           const c2 = new FormControl<any>('new!', null, asyncValidator('new!'));
 
            attachEventsLogger(c2, logs, 'c2');
 
@@ -2100,11 +2123,11 @@ describe('FormGroup', () => {
            ]);
          }));
 
-      it('should run the async validator on the FormControl added to the FormGroup and set status to `INVALID`',
+      it('should run the async validator on the FormControl<any> added to the FormGroup<any> and set status to `INVALID`',
          fakeAsync(() => {
            const logs: string[] = [];
-           const c1 = new FormControl('one');
-           const g1 = new FormGroup({'one': c1});
+           const c1 = new FormControl<any>('one');
+           const g1 = new FormGroup<any>({'one': c1});
 
            // Initial state of the controls
            expect(currentStateOf([c1, g1])).toEqual([
@@ -2114,8 +2137,8 @@ describe('FormGroup', () => {
 
            attachEventsLogger(g1, logs, 'g1');
 
-           const c2 =
-               new FormControl('new!', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
+           const c2 = new FormControl<any>(
+               'new!', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
 
            attachEventsLogger(c2, logs, 'c2');
 
@@ -2145,11 +2168,11 @@ describe('FormGroup', () => {
            ]);
          }));
 
-      it('should run the async validator at `FormControl` and `FormGroup` level and set status to `INVALID`',
+      it('should run the async validator at `FormControl<any>` and `FormGroup<any>` level and set status to `INVALID`',
          fakeAsync(() => {
            const logs: string[] = [];
-           const c1 = new FormControl('one');
-           const g1 = new FormGroup(
+           const c1 = new FormControl<any>('one');
+           const g1 = new FormGroup<any>(
                {'one': c1}, null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
 
            // Initial state of the controls
@@ -2160,8 +2183,8 @@ describe('FormGroup', () => {
 
            attachEventsLogger(g1, logs, 'g1');
 
-           const c2 =
-               new FormControl('new!', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
+           const c2 = new FormControl<any>(
+               'new!', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
 
            attachEventsLogger(c2, logs, 'c2');
 
@@ -2192,14 +2215,14 @@ describe('FormGroup', () => {
            ]);
          }));
 
-      it('should run the async validator on a `FormArray` and a `FormControl` and status to `INVALID`',
+      it('should run the async validator on a `FormArray<any>` and a `FormControl<any>` and status to `INVALID`',
          fakeAsync(() => {
            const logs: string[] = [];
-           const c1 = new FormControl('one');
-           const g1 = new FormGroup(
+           const c1 = new FormControl<any>('one');
+           const g1 = new FormGroup<any>(
                {'one': c1}, null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
-           const fa =
-               new FormArray([g1], null!, simpleAsyncValidator({timeout: 1, shouldFail: true}));
+           const fa = new FormArray<any>(
+               [g1], null!, simpleAsyncValidator({timeout: 1, shouldFail: true}));
 
            attachEventsLogger(g1, logs, 'g1');
 
@@ -2207,13 +2230,13 @@ describe('FormGroup', () => {
            expect(currentStateOf([c1, g1, fa])).toEqual([
              {errors: null, pending: false, status: 'VALID'},   // Control 1
              {errors: null, pending: true, status: 'PENDING'},  // Group
-             {errors: null, pending: true, status: 'PENDING'},  // FormArray
+             {errors: null, pending: true, status: 'PENDING'},  // FormArray<any>
            ]);
 
            attachEventsLogger(fa, logs, 'fa');
 
-           const c2 =
-               new FormControl('new!', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
+           const c2 = new FormControl<any>(
+               'new!', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
 
            attachEventsLogger(c2, logs, 'c2');
 
@@ -2231,20 +2254,21 @@ describe('FormGroup', () => {
            expect(logs).toEqual([
              'value (g1): {"one":"new!"}',    // g1's call to `setControl` triggered value update
              'status (g1): PENDING',          // g1's call to `setControl` triggered status update
-             'value (fa): [{"one":"new!"}]',  // g1 update triggers the `FormArray` value update
-             'status (fa): PENDING',          // g1 update triggers the `FormArray` status update
-             'status (c2): INVALID',          // async validator run after `setControl` call
-             'status (g1): PENDING',          // async validator run after `setControl` call
-             'status (fa): PENDING',          // async validator run after `setControl` call
-             'status (g1): INVALID',          // g1 validator completed with the `INVALID` status
-             'status (fa): PENDING',          // fa validator still running
-             'status (fa): INVALID'           // fa validator completed with the `INVALID` status
+             'value (fa): [{"one":"new!"}]',  // g1 update triggers the `FormArray<any>` value
+                                              // update
+             'status (fa): PENDING',  // g1 update triggers the `FormArray<any>` status update
+             'status (c2): INVALID',  // async validator run after `setControl` call
+             'status (g1): PENDING',  // async validator run after `setControl` call
+             'status (fa): PENDING',  // async validator run after `setControl` call
+             'status (g1): INVALID',  // g1 validator completed with the `INVALID` status
+             'status (fa): PENDING',  // fa validator still running
+             'status (fa): INVALID'   // fa validator completed with the `INVALID` status
            ]);
 
            // Final state of all controls
            expect(currentStateOf([g1, fa, c2])).toEqual([
              {errors: {async: true}, pending: false, status: 'INVALID'},  // Group
-             {errors: {async: true}, pending: false, status: 'INVALID'},  // FormArray
+             {errors: {async: true}, pending: false, status: 'INVALID'},  // FormArray<any>
              {errors: {async: true}, pending: false, status: 'INVALID'},  // Control 2
            ]);
          }));
@@ -2252,12 +2276,12 @@ describe('FormGroup', () => {
   });
 
   describe('pending', () => {
-    let c: FormControl;
-    let g: FormGroup;
+    let c: FormControl<any>;
+    let g: FormGroup<any>;
 
     beforeEach(() => {
-      c = new FormControl('value');
-      g = new FormGroup({'one': c});
+      c = new FormControl<any>('value');
+      g = new FormGroup<any>({'one': c});
     });
 
     it('should be false after creating a control', () => {

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -262,8 +262,9 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
       it('should strip named controls that are not found', () => {
         const fixture = initTest(NestedFormGroupComp, LoginIsEmptyValidator);
-        const form = new FormGroup({
-          'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')})
+        const form = new FormGroup<any>({
+          'signin':
+              new FormGroup<any>({'login': new FormControl(''), 'password': new FormControl('')})
         });
         fixture.componentInstance.form = form;
         fixture.detectChanges();
@@ -1092,8 +1093,8 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
         it('should set initial value and validity on init', () => {
           const fixture = initTest(FormControlComp);
-          const control =
-              new FormControl('Nancy', {validators: Validators.maxLength(3), updateOn: 'blur'});
+          const control = new FormControl<string>(
+              'Nancy', {validators: Validators.maxLength(3), updateOn: 'blur'});
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
@@ -1935,7 +1936,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
     describe('validations', () => {
       it('required validator should validate checkbox', () => {
         const fixture = initTest(FormControlCheckboxRequiredValidator);
-        const control = new FormControl(false, Validators.requiredTrue);
+        const control = new FormControl<boolean>(false, Validators.requiredTrue);
         fixture.componentInstance.control = control;
         fixture.detectChanges();
 

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -42,11 +42,11 @@ describe('Validators', () => {
     });
 
     it('should not error on null', () => {
-      expect(Validators.min(2)(new FormControl(null))).toBeNull();
+      expect(Validators.min(2)(new FormControl<any>(null))).toBeNull();
     });
 
     it('should not error on undefined', () => {
-      expect(Validators.min(2)(new FormControl(undefined))).toBeNull();
+      expect(Validators.min(2)(new FormControl<any>(undefined))).toBeNull();
     });
 
     it('should return null if NaN after parsing', () => {
@@ -94,11 +94,11 @@ describe('Validators', () => {
     });
 
     it('should not error on null', () => {
-      expect(Validators.max(2)(new FormControl(null))).toBeNull();
+      expect(Validators.max(2)(new FormControl<any>(null))).toBeNull();
     });
 
     it('should not error on undefined', () => {
-      expect(Validators.max(2)(new FormControl(undefined))).toBeNull();
+      expect(Validators.max(2)(new FormControl<any>(undefined))).toBeNull();
     });
 
     it('should return null if NaN after parsing', () => {
@@ -171,10 +171,10 @@ describe('Validators', () => {
 
   describe('requiredTrue', () => {
     it('should error on false',
-       () => expect(Validators.requiredTrue(new FormControl(false))).toEqual({'required': true}));
+       () => expect(Validators.requiredTrue(new FormControl<boolean>(false))).toEqual({'required': true}));
 
     it('should not error on true',
-       () => expect(Validators.requiredTrue(new FormControl(true))).toBeNull());
+       () => expect(Validators.requiredTrue(new FormControl<boolean>(true))).toBeNull());
   });
 
   describe('email', () => {
@@ -182,7 +182,7 @@ describe('Validators', () => {
        () => expect(Validators.email(new FormControl(''))).toBeNull());
 
     it('should not error on null',
-       () => expect(Validators.email(new FormControl(null))).toBeNull());
+       () => expect(Validators.email(new FormControl<string>(null))).toBeNull());
 
     it('should error on invalid email',
        () => expect(Validators.email(new FormControl('some text'))).toEqual({'email': true}));
@@ -197,11 +197,11 @@ describe('Validators', () => {
     });
 
     it('should not error on null', () => {
-      expect(Validators.minLength(2)(new FormControl(null))).toBeNull();
+      expect(Validators.minLength(2)(new FormControl<string>(null))).toBeNull();
     });
 
     it('should not error on undefined', () => {
-      expect(Validators.minLength(2)(new FormControl(undefined))).toBeNull();
+      expect(Validators.minLength(2)(new FormControl<string>(undefined))).toBeNull();
     });
 
     it('should not error on valid strings', () => {
@@ -227,23 +227,23 @@ describe('Validators', () => {
     });
 
     it('should always return null with numeric values', () => {
-      expect(Validators.minLength(1)(new FormControl(0))).toBeNull();
-      expect(Validators.minLength(1)(new FormControl(1))).toBeNull();
-      expect(Validators.minLength(1)(new FormControl(-1))).toBeNull();
-      expect(Validators.minLength(1)(new FormControl(+1))).toBeNull();
+      expect(Validators.minLength(1)(new FormControl<any>(0))).toBeNull();
+      expect(Validators.minLength(1)(new FormControl<any>(1))).toBeNull();
+      expect(Validators.minLength(1)(new FormControl<any>(-1))).toBeNull();
+      expect(Validators.minLength(1)(new FormControl<any>(+1))).toBeNull();
     });
 
     it('should trigger validation for an object that contains numeric length property', () => {
       const value = {length: 5, someValue: [1, 2, 3, 4, 5]};
-      expect(Validators.minLength(1)(new FormControl(value))).toBeNull();
-      expect(Validators.minLength(10)(new FormControl(value))).toEqual({
+      expect(Validators.minLength(1)(new FormControl<any>(value))).toBeNull();
+      expect(Validators.minLength(10)(new FormControl<any>(value))).toEqual({
         'minlength': {'requiredLength': 10, 'actualLength': 5}
       });
     });
 
     it('should return null when passing a boolean', () => {
-      expect(Validators.minLength(1)(new FormControl(true))).toBeNull();
-      expect(Validators.minLength(1)(new FormControl(false))).toBeNull();
+      expect(Validators.minLength(1)(new FormControl<any>(true))).toBeNull();
+      expect(Validators.minLength(1)(new FormControl<any>(false))).toBeNull();
     });
   });
 
@@ -253,11 +253,11 @@ describe('Validators', () => {
     });
 
     it('should not error on null', () => {
-      expect(Validators.maxLength(2)(new FormControl(null))).toBeNull();
+      expect(Validators.maxLength(2)(new FormControl<any>(null))).toBeNull();
     });
 
     it('should not error on undefined', () => {
-      expect(Validators.maxLength(2)(new FormControl(undefined))).toBeNull();
+      expect(Validators.maxLength(2)(new FormControl<any>(undefined))).toBeNull();
     });
 
     it('should not error on valid strings', () => {
@@ -283,23 +283,23 @@ describe('Validators', () => {
     });
 
     it('should always return null with numeric values', () => {
-      expect(Validators.maxLength(1)(new FormControl(0))).toBeNull();
-      expect(Validators.maxLength(1)(new FormControl(1))).toBeNull();
-      expect(Validators.maxLength(1)(new FormControl(-1))).toBeNull();
-      expect(Validators.maxLength(1)(new FormControl(+1))).toBeNull();
+      expect(Validators.maxLength(1)(new FormControl<any>(0))).toBeNull();
+      expect(Validators.maxLength(1)(new FormControl<any>(1))).toBeNull();
+      expect(Validators.maxLength(1)(new FormControl<any>(-1))).toBeNull();
+      expect(Validators.maxLength(1)(new FormControl<any>(+1))).toBeNull();
     });
 
     it('should trigger validation for an object that contains numeric length property', () => {
       const value = {length: 5, someValue: [1, 2, 3, 4, 5]};
-      expect(Validators.maxLength(10)(new FormControl(value))).toBeNull();
-      expect(Validators.maxLength(1)(new FormControl(value))).toEqual({
+      expect(Validators.maxLength(10)(new FormControl<any>(value))).toBeNull();
+      expect(Validators.maxLength(1)(new FormControl<any>(value))).toEqual({
         'maxlength': {'requiredLength': 1, 'actualLength': 5}
       });
     });
 
     it('should return null when passing a boolean', () => {
-      expect(Validators.maxLength(1)(new FormControl(true))).toBeNull();
-      expect(Validators.maxLength(1)(new FormControl(false))).toBeNull();
+      expect(Validators.maxLength(1)(new FormControl<any>(true))).toBeNull();
+      expect(Validators.maxLength(1)(new FormControl<any>(false))).toBeNull();
     });
   });
 
@@ -309,15 +309,15 @@ describe('Validators', () => {
     });
 
     it('should not error on null', () => {
-      expect(Validators.pattern('[a-zA-Z ]+')(new FormControl(null))).toBeNull();
+      expect(Validators.pattern('[a-zA-Z ]+')(new FormControl<any>(null))).toBeNull();
     });
 
     it('should not error on undefined', () => {
-      expect(Validators.pattern('[a-zA-Z ]+')(new FormControl(undefined))).toBeNull();
+      expect(Validators.pattern('[a-zA-Z ]+')(new FormControl<any>(undefined))).toBeNull();
     });
 
     it('should not error on null value and "null" pattern', () => {
-      expect(Validators.pattern('null')(new FormControl(null))).toBeNull();
+      expect(Validators.pattern('null')(new FormControl<any>(null))).toBeNull();
     });
 
     it('should not error on valid strings',
@@ -413,7 +413,7 @@ describe('Validators', () => {
          }));
 
       it('should normalize and evaluate async validator-directives correctly', fakeAsync(() => {
-           const normalizedValidators = normalizeValidators<AsyncValidatorFn>(
+           const normalizedValidators = normalizeValidators<any, AsyncValidatorFn>(
                [new AsyncValidatorDirective('expected', {'one': true})]);
            const validatorFn = Validators.composeAsync(normalizedValidators)!;
 
@@ -476,7 +476,7 @@ describe('Validators', () => {
       });
 
       it('should normalize and evaluate async validator-directives correctly', () => {
-        const normalizedValidators = normalizeValidators<AsyncValidatorFn>(
+        const normalizedValidators = normalizeValidators<any, AsyncValidatorFn>(
             [new AsyncValidatorDirective('expected', {'one': true})]);
         const validatorFn = Validators.composeAsync(normalizedValidators)!;
 

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -171,7 +171,9 @@ describe('Validators', () => {
 
   describe('requiredTrue', () => {
     it('should error on false',
-       () => expect(Validators.requiredTrue(new FormControl<boolean>(false))).toEqual({'required': true}));
+       () => expect(Validators.requiredTrue(new FormControl<boolean>(false))).toEqual({
+         'required': true
+       }));
 
     it('should not error on true',
        () => expect(Validators.requiredTrue(new FormControl<boolean>(true))).toBeNull());


### PR DESCRIPTION
Closes #13721

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Feature


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #13721 


## What is the new behavior?

Type information is now available on all form controls and validators.


There is an additional control called `FormSection` which is very similar to `FormGroup` except that controls cannot be added or removed at runtime, so it can contain different types of control and still have strong type information. I have not implemented an equivalent for `FormArray`, but this could be done if there is a use case (perhaps call it `FormTuple`?).

Types should for the most part be inferred automatically by typescript when constructing the control (or using the `FormBuilder`).

Examples:
```typescript
const c = new FormControl('test');
// types:
// c: FormControl<string>
// c.value: string | null
// c.valueChanges: Observable<string | null>

const a = new FormArray([
  new FormControl('value'),
  new FormControl('other value')
]);
// types:
// a: FormArray<FormControl<string>>
// a.value: (string | null)[]

const a2 = new FormArray([
  new FormControl('value'),
  new FormControl(5)
]);
// types:
// a2: FormArray<FormControl<string> | FormControl<number>>
// a2.value: (string | number | null)[]

const a3 = new FormArray<FormControl<string>>([
  new FormControl('value'),
  new FormControl(5)
// Error: Type 'FormControl<number>' is not assignable to type 'FormControl<string>'
]);

const g = new FormGroup({
  one: new FormControl('value'),
  two: new FormControl(10)
});
// types:
// g: FormGroup<FormControl<string> | FormControl<number>>
// g.value: { [key: string]: string | number | null }

const s = new FormSection({
  name: new FormControl<string>(),
  details: new FormSection({
    size: new FormControl<'small' | 'medium' | 'large'>(),
    weight: new FormControl<number>()
  }),
  locations: new FormGroup({
    usa: new FormSection({
      cost: new FormControl<number>(),
      count: new FormControl<number>()
    }),
    japan: new FormSection({
      cost: new FormControl<number>(),
      count: new FormControl<number>()
    })
  })
});
// types:
// s.controls.details.controls.size.value: 'small' | 'medium' | 'large' | null
// s.controls.locations.controls['usa'].controls.cost: FormControl<number>
// s.value.locations['japan'].cost: number | null
```

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

All places where a `FormControl`, `FormArray`, or `FormGroup` are constructed must be replaced with `FormControl<any>`, `FormArray<any>` or `FormGroup<any>` respectively to ensure that existing code will not cause typescript errors, .e.g:

```typescript
const g = new FormGroup({
  foo: new FormControl('test')
});
g.addControl('bar', new FormControl(5));
// Error: Argument of type 'FormControl<number>' is not assignable to parameter of type 'FormControl<string>'

const c = new FormControl({foo: 10});
c.setValue({foo:15, bar: 1});
// Error: Argument of type '{ foo: number; bar: number; }' is not assignable to parameter of type '{ foo: number; }'
```

Alternatively, the controls in this PR could be renamed to something else (e.g. `TypedFormControl`) and then have `FormControl` be an alias for `TypedFormControl<any>`, in which case this PR would not introduce a breaking change.

## Other information
