### PR TITLE
fix(zone.js): fix rollup config file for update to rules_nodejs@3.1.0

### DIFF
--- a/packages/zone.js/rollup-es5_global-es2015.config.js
+++ b/packages/zone.js/rollup-es5_global-es2015.config.js
@@ -3,9 +3,9 @@ const commonjs = require('rollup-plugin-commonjs');
 
 // Parse the stamp file produced by Bazel from the version control system
 let version = '<unknown>';
-if (bazel_stamp_file) {
+if (bazel_version_file) {
   const versionTag = require('fs')
-                         .readFileSync(bazel_stamp_file, {encoding: 'utf-8'})
+                         .readFileSync(bazel_version_file, {encoding: 'utf-8'})
                          .split('\n')
                          .find(s => s.startsWith('BUILD_SCM_VERSION'));
   // Don't assume BUILD_SCM_VERSION exists


### PR DESCRIPTION
Update to use `bazel_version_file` rather than `bazel_stamp_file`.
