### PR TITLE
fix(dev-infra): update npm package subsitutions to reflect no longer having an imported workspace

### DIFF
--- a/dev-infra/BUILD.bazel
+++ b/dev-infra/BUILD.bazel
@@ -48,7 +48,7 @@ pkg_npm(
     substitutions = {
         # angular/angular should not consume it's own packages, so we use
         # substitutions to replace these in the published version of dev-infra.
-        "//dev-infra/": "@npm_angular_dev_infra_private//",
+        "//dev-infra/": "@npm//@angular/dev-infra-private/",
         "//packages/benchpress": "@npm//@angular/benchpress",
         "//packages/bazel": "@npm//@angular/bazel",
         "//packages/zone.js/bundles:zone.umd.js": "@npm//:node_modules/zone.js/dist/zone.js",

--- a/dev-infra/tmpl-package.json
+++ b/dev-infra/tmpl-package.json
@@ -53,11 +53,5 @@
     "ts-node": {
       "optional": true
     }
-  },
-  "bazelWorkspaces": {
-    "npm_angular_dev_infra_private": {
-      "version": "0.0.0-PLACEHOLDER",
-      "rootPath": "."
-    }
   }
 }


### PR DESCRIPTION
Update replacements of the `//dev-infra/` piece of bazel path segments to reference the `@npm//`
workspace rather than creating its own workspace.
