### PR TITLE
fix(http): emit error on XMLHttpRequest abort event

### DIFF
--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -311,6 +311,7 @@ export class HttpXhrBackend implements HttpBackend {
       xhr.addEventListener('load', onLoad);
       xhr.addEventListener('error', onError);
       xhr.addEventListener('timeout', onError);
+      xhr.addEventListener('abort', onError);
 
       // Progress events are only enabled if requested.
       if (req.reportProgress) {
@@ -332,6 +333,7 @@ export class HttpXhrBackend implements HttpBackend {
       return () => {
         // On a cancellation, remove all registered event listeners.
         xhr.removeEventListener('error', onError);
+        xhr.removeEventListener('abort', onError);
         xhr.removeEventListener('load', onLoad);
         xhr.removeEventListener('timeout', onError);
         if (req.reportProgress) {

--- a/packages/common/http/test/xhr_mock.ts
+++ b/packages/common/http/test/xhr_mock.ts
@@ -55,6 +55,7 @@ export class MockXMLHttpRequest {
   listeners: {
     error?: (event: ErrorEvent) => void,
     timeout?: (event: ErrorEvent) => void,
+    abort?: () => void,
     load?: () => void,
     progress?: (event: ProgressEvent) => void,
     uploadProgress?: (event: ProgressEvent) => void,
@@ -71,12 +72,13 @@ export class MockXMLHttpRequest {
     this.body = body;
   }
 
-  addEventListener(event: 'error'|'timeout'|'load'|'progress'|'uploadProgress', handler: Function):
-      void {
+  addEventListener(
+      event: 'error'|'timeout'|'load'|'progress'|'uploadProgress'|'abort',
+      handler: Function): void {
     this.listeners[event] = handler as any;
   }
 
-  removeEventListener(event: 'error'|'timeout'|'load'|'progress'|'uploadProgress'): void {
+  removeEventListener(event: 'error'|'timeout'|'load'|'progress'|'uploadProgress'|'abort'): void {
     delete this.listeners[event];
   }
 
@@ -134,6 +136,12 @@ export class MockXMLHttpRequest {
   mockTimeoutEvent(error: any): void {
     if (this.listeners.timeout) {
       this.listeners.timeout(error);
+    }
+  }
+
+  mockAbortEvent(): void {
+    if (this.listeners.abort) {
+      this.listeners.abort();
     }
   }
 

--- a/packages/common/http/test/xhr_spec.ts
+++ b/packages/common/http/test/xhr_spec.ts
@@ -169,6 +169,13 @@ const XSSI_PREFIX = ')]}\'\n';
       factory.mock.abort = abort;
       factory.mock.mockFlush(200, 'OK', 'Done');
     });
+    it('emits an error when browser cancels a request', done => {
+      backend.handle(TEST_POST).subscribe(undefined, (err: HttpErrorResponse) => {
+        expect(err instanceof HttpErrorResponse).toBe(true);
+        done();
+      });
+      factory.mock.mockAbortEvent();
+    });
     describe('progress events', () => {
       it('are emitted for download progress', done => {
         backend.handle(TEST_POST.clone({reportProgress: true}))


### PR DESCRIPTION
Fixes #22324

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #22324 

Before this change, when Google Chrome cancels a XMLHttpRequest, an Observable of the response never finishes. This happens, for example, when you put your computer to sleep or just press Ctrl+S to save the browser page.

## What is the new behavior?

After this commit, if request is canceled or aborted an appropriate Observable will be completed with an error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I was thinking about a new HttpEventType that tracks the abort event, but it seems to me that if forces beyond your control have decided your request is no longer going to continue, it looks more like an error.

I couldn't find a way to reproduce this bug with JSONP. It appears JSONP request is not aborted.