### PR TITLE
ci: Remove language-service from testing group

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -682,7 +682,10 @@ groups:
       - *can-be-global-approved
       - *can-be-global-docs-approved
       - >
-        contains_any_globs(files.exclude('packages/compiler-cli/**'), [
+        contains_any_globs(
+          files.exclude('packages/compiler-cli/**'),
+          files.exclude('packages/language-service/**'),
+          [
           'packages/**/testing/**',
           'aio/content/guide/testing.md',
           'aio/content/guide/test-debugging.md',


### PR DESCRIPTION
Much like the compiler-cli, the language-service package has internal testing
tools that are not intended for external use and do not need fw-testing review.
See #40679.
