### PR TITLE
docs: fix missing code line from tutorial example

### DIFF
--- a/aio/content/examples/toh-pt4/src/app/hero.service.ts
+++ b/aio/content/examples/toh-pt4/src/app/hero.service.ts
@@ -25,8 +25,8 @@ export class HeroService {
 
   // #docregion getHeroes, getHeroes-1
   getHeroes(): Observable<Hero[]> {
-    // #enddocregion getHeroes-1
     const heroes = of(HEROES);
+    // #enddocregion getHeroes-1
     this.messageService.add('HeroService: fetched heroes');
     // #docregion getHeroes-1
     return heroes;


### PR DESCRIPTION
In #40419 we move the code that creates the `heroes` object
above the code that updates the message service. But this moved
that line of code outside of the docregion that is displayed in
the tutorial ealier on, making it non-sensical.

This commit ensures that this line of code is now rendered in the
tutorial be moving it within the correct docregion.

Closes #40788