### PR TITLE
feat(zone.js): Provide auto fakeAsync() functionality

### DIFF
--- a/aio/content/examples/testing/src/app/demo/async-helper.spec.ts
+++ b/aio/content/examples/testing/src/app/demo/async-helper.spec.ts
@@ -1,5 +1,5 @@
 // tslint:disable-next-line:no-unused-variable
-import { fakeAsync, tick, waitForAsync } from '@angular/core/testing';
+import { fakeAsync, tick, waitForAsync, enableAutoFakeAsync, disableAutoFakeAsync } from '@angular/core/testing';
 import { interval, of } from 'rxjs';
 import { delay, take } from 'rxjs/operators';
 
@@ -174,6 +174,26 @@ describe('Angular async helper', () => {
     });
   });
   // #enddocregion fake-async-test-clock
+
+  // #docregion auto-fake-async
+  describe('use jasmine.clock()', () => {
+    beforeAll(() => {
+      enableAutoFakeAsync();
+    });
+    afterAll(() => {
+      disableAutoFakeAsync();
+    });
+    it('should auto enter fakeAsync', () => {
+      // is in fakeAsync now, don't need to call fakeAsync(testFn)
+      let called = false;
+      setTimeout(() => {
+        called = true;
+      }, 100);
+      tick(100);
+      expect(called).toBe(true);
+    });
+  });
+  // #enddocregion auto-fake-async
 
   describe('test jsonp', () => {
     function jsonp(url: string, callback: () => void) {

--- a/aio/content/guide/testing-components-scenarios.md
+++ b/aio/content/guide/testing-components-scenarios.md
@@ -461,6 +461,17 @@ import 'zone.js/dist/zone-testing';
   region="fake-async-test-clock">
 </code-example>
 
+#### Automatically become fakeAsync() test
+
+When using `jasmine.clock()`, the test case becomes `fakeAsync()` automatically, the same
+functionality can be also achieved by using `enableAutoFakeAsync()` and `disableAutoFakeAsync()` API.  Angular automatically runs tests that are run after
+`enableAutoFakeAsync()` is called inside a `fakeAsync()` method until `disableAutoFakeAsync()` is called. `fakeAsync()` is not needed and throws an error if nested.
+
+<code-example
+  path="testing/src/app/demo/async-helper.spec.ts"
+  region="auto-fake-async">
+</code-example>
+
 #### Using the RxJS scheduler inside fakeAsync()
 
 You can also use RxJS scheduler in `fakeAsync()` just like using `setTimeout()` or `setInterval()`, but you need to import `zone.js/dist/zone-patch-rxjs-fake-async` to patch RxJS scheduler.

--- a/packages/core/test/fake_async_spec.ts
+++ b/packages/core/test/fake_async_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, tick} from '@angular/core/testing';
+import {disableAutoFakeAsync, discardPeriodicTasks, enableAutoFakeAsync, fakeAsync, flush, flushMicrotasks, tick} from '@angular/core/testing';
 import {beforeEach, describe, inject, it, Log} from '@angular/core/testing/src/testing_internal';
 import {EventManager} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -430,6 +430,26 @@ const ProxyZoneSpec: {assertPresent: () => void} = (Zone as any)['ProxyZoneSpec'
         });
       }))();
       expect(state).toEqual('works');
+    });
+  });
+
+  describe('Auto fakeAsync()', () => {
+    let FakeAsyncTestZoneSpec = (Zone as any)['FakeAsyncTestZoneSpec'];
+    beforeAll(() => enableAutoFakeAsync());
+    afterAll(() => disableAutoFakeAsync());
+
+    it('should auto go into FakeAsyncTestZone', () => {
+      expect(Zone.current.get('FakeAsyncTestZoneSpec') instanceof FakeAsyncTestZoneSpec).toBe(true);
+    });
+
+    it('should auto become fakeAsync() test', () => {
+      let t = 0;
+      setTimeout(() => {
+        t = t + 1;
+      }, 100);
+      expect(t).toBe(0);
+      tick(100);
+      expect(t).toBe(1);
     });
   });
 }

--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -152,3 +152,40 @@ export function flushMicrotasks(): void {
   }
   throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);
 }
+
+/**
+ * Enable automatically go into the `fakeAsync()` test.
+ *
+ * describe('Auto go into fakeAsync()', () => {
+ *   beforeAll(() => enableAutoFakeAsync());
+ *   beforeAll(() => disableAutoFakeAsync());
+ *
+ *   it('test1 in fakeAsync()', () => { // don't need to call fakeAsync() here
+ *     let counter = 0;
+ *     setTimeout(() => counter ++, 100);
+ *     tick(100);
+ *     expect(counter).toBe(1);
+ *   });
+ * });
+ *
+ * @publicApi
+ */
+export function enableAutoFakeAsync(): void {
+  if (fakeAsyncTestModule) {
+    return fakeAsyncTestModule.enableAutoFakeAsync();
+  }
+  throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);
+}
+
+/**
+ * Disable automatically go into the `fakeAsync()` test.
+ * This is the default behavior.
+ *
+ * @publicApi
+ */
+export function disableAutoFakeAsync(): void {
+  if (fakeAsyncTestModule) {
+    return fakeAsyncTestModule.disableAutoFakeAsync();
+  }
+  throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);
+}

--- a/packages/zone.js/lib/jasmine/jasmine.ts
+++ b/packages/zone.js/lib/jasmine/jasmine.ts
@@ -195,9 +195,10 @@ Zone.__load_patch('jasmine', (global: any, Zone: ZoneType, api: _ZonePrivate) =>
     const testProxyZoneSpec = queueRunner.testProxyZoneSpec!;
     const testProxyZone = queueRunner.testProxyZone!;
     let lastDelegate;
-    if (isClockInstalled && enableAutoFakeAsyncWhenClockPatched) {
+    const fakeAsyncModule = (Zone as any)[Zone.__symbol__('fakeAsyncTest')];
+    if ((isClockInstalled && enableAutoFakeAsyncWhenClockPatched) ||
+        (fakeAsyncModule && fakeAsyncModule.isAutoFakeAsyncEnabled())) {
       // auto run a fakeAsync
-      const fakeAsyncModule = (Zone as any)[Zone.__symbol__('fakeAsyncTest')];
       if (fakeAsyncModule && typeof fakeAsyncModule.fakeAsync === 'function') {
         testBody = fakeAsyncModule.fakeAsync(testBody);
       }

--- a/packages/zone.js/lib/zone-spec/fake-async-test.ts
+++ b/packages/zone.js/lib/zone-spec/fake-async-test.ts
@@ -861,6 +861,30 @@ Zone.__load_patch('fakeasync', (global: any, Zone: ZoneType, api: _ZonePrivate) 
   function flushMicrotasks(): void {
     _getFakeAsyncZoneSpec().flushMicrotasks();
   }
-  (Zone as any)[api.symbol('fakeAsyncTest')] =
-      {resetFakeAsyncZone, flushMicrotasks, discardPeriodicTasks, tick, flush, fakeAsync};
+
+  let autoFakeAsyncEnabled = false;
+
+  function isAutoFakeAsyncEnabled() {
+    return autoFakeAsyncEnabled;
+  }
+
+  function enableAutoFakeAsync() {
+    autoFakeAsyncEnabled = true;
+  }
+
+  function disableAutoFakeAsync() {
+    autoFakeAsyncEnabled = false;
+  }
+
+  (Zone as any)[api.symbol('fakeAsyncTest')] = {
+    resetFakeAsyncZone,
+    flushMicrotasks,
+    discardPeriodicTasks,
+    tick,
+    flush,
+    fakeAsync,
+    isAutoFakeAsyncEnabled,
+    enableAutoFakeAsync,
+    disableAutoFakeAsync
+  };
 }, true);

--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -1270,7 +1270,15 @@ class Log {
 const resolvedPromise = Promise.resolve(null);
 const ProxyZoneSpec: {assertPresent: () => void} = (Zone as any)['ProxyZoneSpec'];
 const fakeAsyncTestModule = (Zone as any)[Zone.__symbol__('fakeAsyncTest')];
-const {fakeAsync, tick, discardPeriodicTasks, flush, flushMicrotasks} = fakeAsyncTestModule;
+const {
+  fakeAsync,
+  tick,
+  discardPeriodicTasks,
+  flush,
+  flushMicrotasks,
+  disableAutoFakeAsync,
+  enableAutoFakeAsync
+} = fakeAsyncTestModule;
 
 {
   describe('fake async', () => {
@@ -1697,6 +1705,26 @@ const {fakeAsync, tick, discardPeriodicTasks, flush, flushMicrotasks} = fakeAsyn
         });
       }))();
       expect(state).toEqual('works');
+    });
+  });
+
+  describe('Auto fakeAsync()', () => {
+    let FakeAsyncTestZoneSpec = (Zone as any)['FakeAsyncTestZoneSpec'];
+    beforeAll(() => enableAutoFakeAsync());
+    afterAll(() => disableAutoFakeAsync());
+
+    it('should auto go into FakeAsyncTestZone', () => {
+      expect(Zone.current.get('FakeAsyncTestZoneSpec') instanceof FakeAsyncTestZoneSpec).toBe(true);
+    });
+
+    it('should auto become fakeAsync() test', () => {
+      let t = 0;
+      setTimeout(() => {
+        t = t + 1;
+      }, 100);
+      expect(t).toBe(0);
+      tick(100);
+      expect(t).toBe(1);
     });
   });
 }


### PR DESCRIPTION
`Zone.js` provides an integration with the `jasmine.clock()`,

```
describe(`Auto fakeAsync() with jasmine.clock()`, () => {
  beforeAll(() => jasmine.clock().install());
  afterAll(() => jasmine.clock().uninstall());
  it('test1', () => { // The test becomes fakeAsync() automatically, don't need to call fakeAsync()
    let t = 0;
    setTimeout(() => {
      t = t + 1;
    }, 100);
    expect(t).toBe(0);
    tick(100);
    expect(t).toBe(1);
  });
});
```

This PR provides two new APIs to make the functionality available not only with `jasmine.clock()`.

```
describe('Auto fakeAsync()', () => {
  beforeAll(() => enableAutoFakeAsync());
  afterAll(() => disableAutoFakeAsync());

  it('should auto become fakeAsync() test', () => {
    let t = 0;
    setTimeout(() => {
      t = t + 1;
    }, 100);
    expect(t).toBe(0);
    tick(100);
    expect(t).toBe(1);
  });
});
```

This PR is also related to https://github.com/angular/angular/pull/40611.