### PR TITLE
fix(docs-infra): several style fixes for angular.io

### DIFF
--- a/aio/src/app/custom-elements/code/code-example.component.spec.ts
+++ b/aio/src/app/custom-elements/code/code-example.component.spec.ts
@@ -36,6 +36,10 @@ describe('CodeExampleComponent', () => {
     expect(codeExampleComponent.aioCode.code.trim()).toBe(`const foo = "bar";`);
   });
 
+  it('should clean-up the projected code snippet once captured', () => {
+    expect(codeExampleComponent.content.nativeElement.innerHTML).toBe('');
+  });
+
   it('should change aio-code classes based on header presence', () => {
     expect(codeExampleComponent.header).toBe('Great Example');
     expect(fixture.nativeElement.querySelector('header')).toBeTruthy();

--- a/aio/src/app/custom-elements/code/code-example.component.ts
+++ b/aio/src/app/custom-elements/code/code-example.component.ts
@@ -79,11 +79,13 @@ export class CodeExampleComponent implements AfterViewInit {
 
   @HostBinding('class.avoidFile') isAvoid = false;
 
-  @ViewChild('content', { static: true }) content: ElementRef;
+  @ViewChild('content', { static: true }) content: ElementRef<HTMLDivElement>;
 
   @ViewChild(CodeComponent, { static: true }) aioCode: CodeComponent;
 
   ngAfterViewInit() {
-    this.aioCode.code = this.content.nativeElement.innerHTML;
+    const contentElem = this.content.nativeElement;
+    this.aioCode.code = contentElem.innerHTML;
+    contentElem.innerHTML = '';  // Remove DOM nodes that are no longer needed.
   }
 }

--- a/aio/src/app/custom-elements/code/code-tabs.component.spec.ts
+++ b/aio/src/app/custom-elements/code/code-tabs.component.spec.ts
@@ -70,6 +70,10 @@ describe('CodeTabsComponent', () => {
     const codeContent = fixture.nativeElement.querySelector('aio-code').textContent;
     expect(codeContent.indexOf('Code example 1') !== -1).toBeTruthy();
   });
+
+  it('should clean-up the projected tabs content once captured', () => {
+    expect(codeTabsComponent.content.nativeElement.innerHTML).toBe('');
+  });
 });
 
 @Component({

--- a/aio/src/app/custom-elements/code/code-tabs.component.ts
+++ b/aio/src/app/custom-elements/code/code-tabs.component.ts
@@ -55,7 +55,9 @@ export class CodeTabsComponent implements OnInit, AfterViewInit {
 
   ngOnInit() {
     this.tabs = [];
-    const codeExamples = Array.from(this.content.nativeElement.querySelectorAll('code-pane'));
+    const contentElem = this.content.nativeElement;
+    const codeExamples = Array.from(contentElem.querySelectorAll('code-pane'));
+    contentElem.innerHTML = '';  // Remove DOM nodes that are no longer needed.
 
     for (const tabContent of codeExamples) {
       this.tabs.push(this.getTabInfo(tabContent));

--- a/aio/src/styles/1-layouts/_sidenav.scss
+++ b/aio/src/styles/1-layouts/_sidenav.scss
@@ -28,7 +28,7 @@ mat-sidenav-container.sidenav-container {
     background-color: $superlightgray;
     border-right: 1px solid $lightgray;
 
-    &.collapsed {
+    @media (max-width: 599px) {
       top: 56px;
     }
 

--- a/aio/src/styles/2-modules/_code.scss
+++ b/aio/src/styles/2-modules/_code.scss
@@ -109,13 +109,17 @@ aio-code {
       ol.linenums {
         margin: 0;
         font-family: $main-font;
-        color: #B3B6B7;
+        color: lighten($mediumgray, 25%);
 
         li {
           margin: 0;
           font-family: $code-font;
           font-size: 90%;
           @include line-height(24);
+
+          &::marker {
+            color: lighten($mediumgray, 25%);
+          }
         }
       }
 

--- a/aio/src/styles/2-modules/_contributor.scss
+++ b/aio/src/styles/2-modules/_contributor.scss
@@ -57,6 +57,7 @@ aio-contributor {
 
     .info-item {
       color: $white;
+      display: flex;
       @include font-size(14);
       font-weight: 500;
       margin: 8px;

--- a/aio/src/styles/2-modules/_notification.scss
+++ b/aio/src/styles/2-modules/_notification.scss
@@ -69,6 +69,14 @@ aio-notification {
 // Here are all the hacks to make the content and sidebars the right height
 // when the notification is visible
 .aio-notification-show {
+  .toc-container {
+    top: 76px + $notificationHeight;
+  }
+
+  .search-results {
+    padding-top: $notificationHeight;
+  }
+
   mat-sidenav-container.sidenav-container {
     .sidenav-content {
       padding-top: 80px + $notificationHeight;
@@ -83,17 +91,11 @@ aio-notification {
     }
   }
 
-  .toc-container {
-    top: 76px + $notificationHeight;
-  }
-
-  .search-results {
-    padding-top: $notificationHeight;
-  }
-
   &.page-home, &.page-resources, &.page-events, &.page-features, &.page-presskit, &.page-contribute  {
-    .sidenav-content {
-      padding-top: $notificationHeight;
+    mat-sidenav-container.sidenav-container {
+      .sidenav-content {
+        padding-top: $notificationHeight;
+      }
     }
   }
 }

--- a/aio/src/styles/2-modules/_notification.scss
+++ b/aio/src/styles/2-modules/_notification.scss
@@ -88,7 +88,7 @@ aio-notification {
   }
 
   .search-results {
-    padding-top: 68px + $notificationHeight;
+    padding-top: $notificationHeight;
   }
 
   &.page-home, &.page-resources, &.page-events, &.page-features, &.page-presskit, &.page-contribute  {

--- a/aio/src/styles/2-modules/_search-results.scss
+++ b/aio/src/styles/2-modules/_search-results.scss
@@ -41,8 +41,11 @@ aio-search-results {
 
         .search-result-item {
           @include font-size(14);
+          @include line-height(24);
           color: $lightgray;
+          display: inline-block;
           font-weight: normal;
+          padding: 0.6rem 0;
 
           &a {
             text-decoration: none;

--- a/aio/src/styles/2-modules/_toc.scss
+++ b/aio/src/styles/2-modules/_toc.scss
@@ -1,3 +1,20 @@
+$tocItemLineHeight: 24;
+$tocItemTopPadding: 9;
+$tocMarkerRailSize: 1;
+$tocMarkerSize: 6;
+
+@mixin tocMarker($color) {
+  background: $color;
+  border-radius: 50%;
+  content: '';
+  height: #{$tocMarkerSize}px;
+  left: -#{($tocMarkerSize - $tocMarkerRailSize) / 2}px;
+  position: absolute;
+  top: calc(#{$tocItemTopPadding}px + #{$tocItemLineHeight / 2}px - #{$tocMarkerSize / 2}px);
+  top: calc(#{$tocItemTopPadding}px + #{$tocItemLineHeight / 2 / 10}rem - #{$tocMarkerSize / 2}px);
+  width: #{$tocMarkerSize}px;
+}
+
 .toc-container {
   width: 18%;
   position: fixed;
@@ -106,7 +123,8 @@ aio-toc {
 
       li {
         box-sizing: border-box;
-        padding: 9px 0 9px 12px;
+        @include line-height($tocItemLineHeight);
+        padding: #{$tocItemTopPadding}px 0 #{$tocItemTopPadding}px 12px;
         position: relative;
         transition: all 0.3s ease-in-out;
 
@@ -128,7 +146,7 @@ aio-toc {
           color: lighten($darkgray, 10);
           overflow: visible;
           @include font-size(14);
-          @include line-height(24);
+          line-height: inherit;
           display: table-cell;
         }
 
@@ -142,24 +160,17 @@ aio-toc {
           * {
             color: $blue;
             font-weight: 500;
+          }
 
-            &:before {
-              content: '';
-              border-radius: 50%;
-              left: -3px;
-              top: 14px;
-              background: $blue;
-              position: absolute;
-              width: 6px;
-              height: 6px;
-            }
+          a:before {
+            @include tocMarker($blue);
           }
         }
       }
 
       &:not(.embedded) li {
         &:before {
-          border-left: 1px solid $lightgray;
+          border-left: #{$tocMarkerRailSize}px solid $lightgray;
           bottom: 0;
           content: '';
           left: 0;
@@ -168,22 +179,19 @@ aio-toc {
         }
 
         &:first-child:before {
-          top: 15px;
+          top: calc(#{$tocItemTopPadding}px + #{$tocItemLineHeight / 2}px - #{$tocMarkerSize / 2}px);
+          top: calc(#{$tocItemTopPadding}px + #{$tocItemLineHeight / 2 / 10}rem - #{$tocMarkerSize / 2}px);
         }
 
         &:last-child:before {
-          bottom: calc(100% - 15px);
+          bottom: calc(100% - (#{$tocItemTopPadding}px + #{$tocItemLineHeight / 2}px + #{$tocMarkerSize / 2}px));
+          bottom: calc(100% - (#{$tocItemTopPadding}px + #{$tocItemLineHeight / 2 / 10}rem + #{$tocMarkerSize / 2}px));
         }
 
-        &:not(.active):hover a:before {
-          content: '';
-          border-radius: 50%;
-          left: -3px;
-          top: 14px;
-          background: $lightgray;
-          position: absolute;
-          width: 6px;
-          height: 6px;
+        &:not(.active):hover {
+          a:before {
+            @include tocMarker($lightgray);
+          }
         }
       }
     }

--- a/aio/src/styles/2-modules/_toc.scss
+++ b/aio/src/styles/2-modules/_toc.scss
@@ -106,7 +106,7 @@ aio-toc {
 
       li {
         box-sizing: border-box;
-        padding: 7px 0 7px 12px;
+        padding: 9px 0 9px 12px;
         position: relative;
         transition: all 0.3s ease-in-out;
 
@@ -128,7 +128,7 @@ aio-toc {
           color: lighten($darkgray, 10);
           overflow: visible;
           @include font-size(14);
-          @include line-height(28);
+          @include line-height(24);
           display: table-cell;
         }
 

--- a/aio/src/styles/_print.scss
+++ b/aio/src/styles/_print.scss
@@ -18,7 +18,7 @@
         page-break-after: avoid;
     }
 
-    ul, ol, img, code-example, table, tr, .alert, .feature {
+    ul, ol, img, code-example, table, tr, .alert, .feature, .lightbox {
         page-break-inside: avoid;
     }
 


### PR DESCRIPTION
Several style fixes for angular.io:

<details>
  <summary><b>fix(docs-infra): clear unneeded DOM nodes in `CodeExample/TabsComponent`</b> <i>(click to expand)</i></summary><br />

  Both `CodeExampleComponent` and `CodeTabsComponent` components receive some code via content projection, glab the projected content and pass it through to a `CodeComponent` instance for formatting and displaying.

  Previously, the projected content was kept in the DOM (hidden). This unnecessarily increased the number of DOM nodes.

  This commit fixes this by clearing the projected DOM nodes once their content has been captured.

</details>

---
<details>
  <summary><b>fix(docs-infra): fix vertical alignment of contributor info items</b> <i>(click to expand)</i></summary><br />

  This commit fixes the vertical alignment of info items (i.e. links to bio, Twitter, website) in the contributor list.

  _**Before:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/106926453-ca407f80-6719-11eb-9580-8614cc4f4907.png" alt="contributor alignment before" height="250" />
  </p>

  _**After:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/106926469-cd3b7000-6719-11eb-8ba8-c8ae01996c02.png" alt="contributor alignment after" height="250" />
  </p>

</details>

---
<details>
  <summary><b>fix(docs-infra): dim line-numbers in code examples</b> <i>(click to expand)</i></summary><br />

  This commit ensures that the line-numbers in code examples appear "dimmed" to make it clearer that they are not part of the actual code.

  Based on the CSS rules, it seems that the intention was to make it so, but the color was incorrectly set on the `<ol>` elements instead of targeting `li::marker`.

  _**Before:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/106937191-23aeab80-6726-11eb-9178-bdc067fa3d09.png" alt="line-numbers before" height="250" />
  </p>

  _**After:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/106937184-227d7e80-6726-11eb-81d1-f709537b6a56.png" alt="line-numbers after" height="250" />
  </p>

</details>

---
<details>
  <summary><b>fix(docs-infra): fix search results top padding when a notification is visible</b> <i>(click to expand)</i></summary><br />

  Previously, when a notification was visible at the top of the page, the search results pane had more top padding than necessary.

  This commit fixes it by removing the extra padding.

  _**Before:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/106938103-3aa1cd80-6727-11eb-96f5-f607bde314be.png" alt="search-results after" height="250" />
  </p>

  _**After:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/106938100-3970a080-6727-11eb-8ae8-4e7a33af1daf.png" alt="search-results before" height="250" />
  </p>

</details>

---
<details>
  <summary><b>fix(docs-infra): avoid page-breaks inside an image when printing</b> <i>(click to expand)</i></summary><br />

  Previously, when printing, a page-break could be inserted inside an image (contained in a `.lightbox` element).

  This commit ensures no page-breaks are inserted inside `.lightbox` elements (which contain images).

  _**Before:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/106939709-48f0e900-6729-11eb-912c-e5cd0cb40897.png" alt="print-page-break before" height="250" />
  </p>

  _**After:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/106939707-48585280-6729-11eb-8d5f-a12312f32056.png" alt="print-page-break after" height="250" />
  </p>

</details>

---
<details>
  <summary><b>fix(docs-infra): improve line-spacing between search results (esp. for wrapped lines)</b> <i>(click to expand)</i></summary><br />

  Previously, the line-spacing between different search result itemswas the same as that between wrapped lines of the same result. This made it diffucult to distinguish the different results.

  This commit fixes it by reducing the line-spacing between wrapped lines of the same result item and keeping a larger line-spacing between different results.

  _**Before:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/107229685-ca48c400-6a26-11eb-8161-0c0768b10a2d.png" alt="search-results before" height="250" />
  </p>

  _**After:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/107229691-ccab1e00-6a26-11eb-9594-d4c37d0d72b2.png" alt="search-results after" height="250" />
  </p>

</details>

---
<details>
  <summary><b>fix(docs-infra): fix sidenav top position on narrow screens</b> <i>(click to expand)</i></summary><br />

  On larger screens the top-bar has a height of 64px. On screens smaller than 600px, the top-bar has a height of 56px. As a result, the sidenav should have a top position of 56px on screens smaller than 600px and 64px on other screens.

  Previously, the style setting the top position to 56px was tied to the presense of the `.collapsed` class, which depends on whether the sidenav is docked or not. The change from docked to collapsed sidenav, however, happens at 992px. As a result, e sidenav had an incorrect top possition (56px instead of 64px) on screens between 600px and 991px.

  This commit fixes this by ensuring the change of the top position for the sidenav happens at 600px.

</details>

---
<details>
  <summary><b>fix(docs-infra): improve line-spacing between TOC items (esp. for wrapped lines)</b> <i>cClick to expand)</i></summary><br />

  Previously, the line-spacing between different TOC items was almost the same as that between wrapped lines of the same item. This made it more diffucult to distinguish the different items.

  This commit fixes this by reducing the line-spacing between wrapped lines of the same item and keeping a larger line-spacing between different items.

  _**Before:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/107255272-ccb81780-6a40-11eb-9612-4e7b2058417d.png" alt="toc line-spacing before" height="250" />
  </p>

  _**After:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/107255280-cd50ae00-6a40-11eb-8f60-9ce8fba10e12.png" alt="toc line-spacing after" height="250" />
  </p>

</details>

---
<details>
  <summary><b>fix(docs-infra): fix placement of TOC hover/active markers (dots)</b> <i>(click to expand)</i></summary><br />

  This commit fixes the placement of the TOC hover/active markers (dots) so that they are horizontally in the middle of the marker "rail" and vertically in the middle of the first item line.

  This commit also refactor the `_toc.scss` to be more DRY (wrt ot styling the TOC markers/marker rail) and uses Sass variables and mixins to ensure that the styling is kept up-to-date wrt to future typography changes to TOC items.

  _**Before:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/107270751-03e3f400-6a54-11eb-9d77-5b0a3cfb1c2b.png" alt="toc marker before" height="250" />
  </p>

  _**After:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/107270758-047c8a80-6a54-11eb-82c0-98b832c109a3.png" alt="toc marker after" height="250" />
  </p>

</details>

---
<details>
  <summary><b>fix(docs-infra): fix top padding of main content when a notification is visible</b> <i>(click to expand)</i></summary><br />

  This commit fixes the top padding of the main content on the homepage and other pages when a notification is visible at the top of the page.
  The problem was particularly obvious on the homepage (see images below).

  _**Before:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/107394349-74e2e480-6b04-11eb-8853-71a153cdc459.png" alt="homepage top-right before" height="250" />
  </p>

  _**After:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/107394336-71e7f400-6b04-11eb-9ef0-ff82f6f27875.png" alt="homepage top-right after" height="250" />
  </p>

</details>
