### PR TITLE
fix(core): address Trusted Types bug in Chrome 83

### DIFF
--- a/packages/core/src/util/security/trusted_types.ts
+++ b/packages/core/src/util/security/trusted_types.ts
@@ -111,7 +111,7 @@ export function newTrustedFunctionForDev(...args: string[]): Function {
   // below, where the Chromium bug is also referenced:
   // https://github.com/w3c/webappsec-trusted-types/wiki/Trusted-Types-for-function-constructor
   const fnArgs = args.slice(0, -1).join(',');
-  const fnBody = args.pop()!.toString();
+  const fnBody = args[args.length - 1];
   const body = `(function anonymous(${fnArgs}
 ) { ${fnBody}
 })`;
@@ -120,6 +120,13 @@ export function newTrustedFunctionForDev(...args: string[]): Function {
   // being stripped out of JS binaries even if not used. The global['eval']
   // indirection fixes that.
   const fn = global['eval'](trustedScriptFromString(body) as string) as Function;
+  if (fn.bind === undefined) {
+    // Workaround for a browser bug that only exists in Chrome 83, where passing
+    // a TrustedScript to eval just returns the TrustedScript back without
+    // evaluating it. In that case, fall back to the most straightforward
+    // implementation:
+    return new Function(...args);
+  }
 
   // To completely mimic the behavior of calling "new Function", two more
   // things need to happen:


### PR DESCRIPTION
In Chrome 83 passing a TrustedScript to eval just returns the
TrustedScript back without evaluating it, causing the
newTrustedFunctionFor{Dev,JIT} functions to fail. This is a browser bug
that has been fixed in Chrome 84, and only affects Angular applications
running with JIT (which includes unit tests).

As a temporary workaround for users still on Chrome 83, detect when this
occurs in the newTrustedFunctionFor* functions and fall back to the
straightforward, non-Trusted Types compatible implementation. The only
combination that is left affected consists of Angular applications
running with JIT, that have explicitly configured Trusted Types in
enforcement mode, with users that are still on Chrome 83.

Also correct docstring for newTrustedFunctionForJIT.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/40507

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
