### PR TITLE
    feat(core): drop support for zone.js 0.10.x     

### DIFF
--- a/aio/content/examples/http/src/main-specs.ts
+++ b/aio/content/examples/http/src/main-specs.ts
@@ -6,7 +6,7 @@ declare var jasmine;
 
 import './polyfills';
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 
 import { getTestBed } from '@angular/core/testing';
 import {

--- a/aio/content/examples/testing/src/app/demo/async-helper.spec.ts
+++ b/aio/content/examples/testing/src/app/demo/async-helper.spec.ts
@@ -131,7 +131,7 @@ describe('Angular async helper', () => {
 
     // #docregion fake-async-test-rxjs
     it('should get Date diff correctly in fakeAsync with rxjs scheduler', fakeAsync(() => {
-         // need to add `import 'zone.js/dist/zone-patch-rxjs-fake-async'
+         // need to add `import 'zone.js/plugins/zone-patch-rxjs-fake-async'
          // to patch rxjs scheduler
          let result = null;
          of('hello').pipe(delay(1000)).subscribe(v => {
@@ -156,7 +156,7 @@ describe('Angular async helper', () => {
   // #docregion fake-async-test-clock
   describe('use jasmine.clock()', () => {
     // need to config __zone_symbol__fakeAsyncPatchLock flag
-    // before loading zone.js/dist/zone-testing
+    // before loading zone.js/testing
     beforeEach(() => {
       jasmine.clock().install();
     });
@@ -180,7 +180,7 @@ describe('Angular async helper', () => {
       // do a jsonp call which is not zone aware
     }
     // need to config __zone_symbol__supportWaitUnResolvedChainedPromise flag
-    // before loading zone.js/dist/zone-testing
+    // before loading zone.js/testing
     it('should wait until promise.then is called', waitForAsync(() => {
          let finished = false;
          new Promise((res, rej) => {

--- a/aio/content/examples/testing/src/app/shared/canvas.component.ts
+++ b/aio/content/examples/testing/src/app/shared/canvas.component.ts
@@ -3,7 +3,7 @@
 // Import patch to make async `HTMLCanvasElement` methods (such as `.toBlob()`) Zone.js-aware.
 // Either import in `polyfills.ts` (if used in more than one places in the app) or in the component
 // file using `HTMLCanvasElement` (if it is only used in a single file).
-import 'zone.js/dist/zone-patch-canvas';
+import 'zone.js/plugins/zone-patch-canvas';
 // #enddocregion import-canvas-patch
 // #docregion main
 import { Component, AfterViewInit, ViewChild, ElementRef } from '@angular/core';

--- a/aio/content/examples/testing/src/main-specs.ts
+++ b/aio/content/examples/testing/src/main-specs.ts
@@ -6,7 +6,7 @@ declare var jasmine;
 
 import './polyfills';
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 
 import { getTestBed } from '@angular/core/testing';
 import {

--- a/aio/content/examples/universal/server.ts
+++ b/aio/content/examples/universal/server.ts
@@ -1,4 +1,4 @@
-import 'zone.js/dist/zone-node';
+import 'zone.js/node';
 
 import { ngExpressEngine } from '@nguniversal/express-engine';
 import * as express from 'express';

--- a/aio/content/guide/ivy.md
+++ b/aio/content/guide/ivy.md
@@ -142,7 +142,7 @@ The following example shows how you modify the `server.ts` file to provide the `
 * Set `bootstrap: AppServerModuleNgFactory` in the `ngExpressEngine` call.
 
 <code-example language="typescript" header="server.ts">
-import 'zone.js/dist/zone-node';
+import 'zone.js/node';
 
 import { ngExpressEngine } from '@nguniversal/express-engine';
 import * as express from 'express';

--- a/aio/content/guide/testing-components-scenarios.md
+++ b/aio/content/guide/testing-components-scenarios.md
@@ -371,7 +371,7 @@ value becomes available. The test must become _asynchronous_.
 
 #### Async test with _fakeAsync()_
 
-To use `fakeAsync()` functionality, you must import `zone.js/dist/zone-testing` in your test setup file.
+To use `fakeAsync()` functionality, you must import `zone.js/testing` in your test setup file.
 If you created your project with the Angular CLI, `zone-testing` is already imported in `src/test.ts`.
 
 The following test confirms the expected behavior when the service returns an `ErrorObservable`.
@@ -453,7 +453,7 @@ If you use the Angular CLI, configure this flag in `src/test.ts`.
 
 ```
 (window as any)['__zone_symbol__fakeAsyncPatchLock'] = true;
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 ```
 
 <code-example
@@ -463,7 +463,7 @@ import 'zone.js/dist/zone-testing';
 
 #### Using the RxJS scheduler inside fakeAsync()
 
-You can also use RxJS scheduler in `fakeAsync()` just like using `setTimeout()` or `setInterval()`, but you need to import `zone.js/dist/zone-patch-rxjs-fake-async` to patch RxJS scheduler.
+You can also use RxJS scheduler in `fakeAsync()` just like using `setTimeout()` or `setInterval()`, but you need to import `zone.js/plugins/zone-patch-rxjs-fake-async` to patch RxJS scheduler.
 <code-example
   path="testing/src/app/demo/async-helper.spec.ts"
   region="fake-async-test-rxjs">
@@ -583,7 +583,7 @@ Then you can assert that the quote element displays the expected text.
 
 #### Async test with _waitForAsync()_
 
-To use `waitForAsync()` functionality, you must import `zone.js/dist/zone-testing` in your test setup file.
+To use `waitForAsync()` functionality, you must import `zone.js/testing` in your test setup file.
 If you created your project with the Angular CLI, `zone-testing` is already imported in `src/test.ts`.
 
 <div class="alert is-helpful">

--- a/aio/content/guide/upgrade-setup.md
+++ b/aio/content/guide/upgrade-setup.md
@@ -308,7 +308,7 @@ So when IE is refreshed (manually or automatically by `ng serve`), sometimes the
 
 ## Appendix: Test using `fakeAsync()/waitForAsync()`
 
-If you use the `fakeAsync()/waitForAsync()` helper function to run unit tests (for details, read the [Testing guide](guide/testing-components-scenarios#fake-async)), you need to import `zone.js/dist/zone-testing` in your test setup file.
+If you use the `fakeAsync()/waitForAsync()` helper function to run unit tests (for details, read the [Testing guide](guide/testing-components-scenarios#fake-async)), you need to import `zone.js/testing` in your test setup file.
 
 <div class="alert is-important">
 If you create project with `Angular/CLI`, it is already imported in `src/test.ts`.
@@ -317,12 +317,12 @@ If you create project with `Angular/CLI`, it is already imported in `src/test.ts
 And in the earlier versions of `Angular`, the following files were imported or added in your html file:
 
 ```
-import 'zone.js/dist/long-stack-trace-zone';
-import 'zone.js/dist/proxy';
-import 'zone.js/dist/sync-test';
-import 'zone.js/dist/jasmine-patch';
-import 'zone.js/dist/async-test';
-import 'zone.js/dist/fake-async-test';
+import 'zone.js/plugins/long-stack-trace-zone';
+import 'zone.js/plugins/proxy';
+import 'zone.js/plugins/sync-test';
+import 'zone.js/plugins/jasmine-patch';
+import 'zone.js/plugins/async-test';
+import 'zone.js/plugins/fake-async-test';
 ```
 
 You can still load those files separately, but the order is important, you must import `proxy` before `sync-test`, `async-test`, `fake-async-test` and `jasmine-patch`. And you also need to import `sync-test` before `jasmine-patch`, so it is recommended to just import `zone-testing` instead of loading those separated files.

--- a/aio/content/guide/user-input.md
+++ b/aio/content/guide/user-input.md
@@ -323,7 +323,7 @@ Angular also supports passive event listeners. For example, you can use the foll
 
 ```
 import './zone-flags';
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js';  // Included with Angular CLI.
 ```
 
 After those steps, if you add event listeners for the `scroll` event, the listeners will be `passive`.

--- a/aio/content/guide/zone.md
+++ b/aio/content/guide/zone.md
@@ -352,7 +352,7 @@ If you are using the Angular CLI, this step is done automatically, and you will 
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js';  // Included with Angular CLI.
 ```
 
 Before importing the  `zone.js` package, you can set the following configurations:
@@ -380,7 +380,7 @@ Next, import `zone-flags` before you import `zone.js` in the `polyfills.ts`:
  * Zone JS is required by default for Angular.
  */
 import `./zone-flags`;
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js';  // Included with Angular CLI.
 ```
 
 For more information about what you can configure, see the [Zone.js](https://github.com/angular/angular/tree/master/packages/zone.js) documentation.
@@ -406,7 +406,7 @@ To remove Zone.js, make the following changes.
   /***************************************************************************************************
    * Zone JS is required by default for Angular itself.
    */
-  // import 'zone.js/dist/zone';  // Included with Angular CLI.
+  // import 'zone.js';  // Included with Angular CLI.
   ```
 
 2. Bootstrap Angular with the `noop` zone in `src/main.ts`:

--- a/aio/package.json
+++ b/aio/package.json
@@ -103,7 +103,7 @@
     "@webcomponents/custom-elements": "1.2.1",
     "rxjs": "^6.5.3",
     "tslib": "^2.0.0",
-    "zone.js": "~0.11.3"
+    "zone.js": "~0.11.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "0.1100.1",

--- a/aio/src/polyfills.ts
+++ b/aio/src/polyfills.ts
@@ -55,7 +55,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js';  // Included with Angular CLI.
 
 
 /***************************************************************************************************

--- a/aio/src/test.ts
+++ b/aio/src/test.ts
@@ -1,6 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
     BrowserDynamicTestingModule,

--- a/aio/tools/examples/shared/boilerplate/cli-ajs/package.json
+++ b/aio/tools/examples/shared/boilerplate/cli-ajs/package.json
@@ -26,7 +26,7 @@
     "angular-route": "1.8.0",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
-    "zone.js": "~0.10.3"
+    "zone.js": "~0.11.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1100.2",

--- a/aio/tools/examples/shared/boilerplate/cli/package.json
+++ b/aio/tools/examples/shared/boilerplate/cli/package.json
@@ -24,7 +24,7 @@
     "angular-in-memory-web-api": "~0.11.0",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
-    "zone.js": "~0.10.3"
+    "zone.js": "~0.11.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1100.2",

--- a/aio/tools/examples/shared/boilerplate/cli/src/environments/environment.ts
+++ b/aio/tools/examples/shared/boilerplate/cli/src/environments/environment.ts
@@ -13,4 +13,4 @@ export const environment = {
  * This import should be commented out in production mode because it will have a negative impact
  * on performance if an error is thrown.
  */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.
+// import 'zone.js/plugins/zone-error';  // Included with Angular CLI.

--- a/aio/tools/examples/shared/boilerplate/cli/src/polyfills.ts
+++ b/aio/tools/examples/shared/boilerplate/cli/src/polyfills.ts
@@ -57,7 +57,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone'; // Included with Angular CLI.
+import 'zone.js'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/aio/tools/examples/shared/boilerplate/cli/src/test.ts
+++ b/aio/tools/examples/shared/boilerplate/cli/src/test.ts
@@ -1,6 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/aio/tools/examples/shared/boilerplate/elements/package.json
+++ b/aio/tools/examples/shared/boilerplate/elements/package.json
@@ -26,7 +26,7 @@
     "angular-in-memory-web-api": "~0.11.0",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
-    "zone.js": "~0.10.3"
+    "zone.js": "~0.11.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1100.2",

--- a/aio/tools/examples/shared/boilerplate/elements/src/polyfills.ts
+++ b/aio/tools/examples/shared/boilerplate/elements/src/polyfills.ts
@@ -57,7 +57,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone'; // Included with Angular CLI.
+import 'zone.js'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/aio/tools/examples/shared/boilerplate/i18n/package.json
+++ b/aio/tools/examples/shared/boilerplate/i18n/package.json
@@ -28,7 +28,7 @@
     "angular-in-memory-web-api": "~0.11.0",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
-    "zone.js": "~0.10.3"
+    "zone.js": "~0.11.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1100.2",

--- a/aio/tools/examples/shared/boilerplate/i18n/src/polyfills.ts
+++ b/aio/tools/examples/shared/boilerplate/i18n/src/polyfills.ts
@@ -61,7 +61,7 @@ import '@angular/localize/init';
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone'; // Included with Angular CLI.
+import 'zone.js'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/aio/tools/examples/shared/boilerplate/service-worker/package.json
+++ b/aio/tools/examples/shared/boilerplate/service-worker/package.json
@@ -25,7 +25,7 @@
     "angular-in-memory-web-api": "~0.11.0",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
-    "zone.js": "~0.10.3"
+    "zone.js": "~0.11.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1100.2",

--- a/aio/tools/examples/shared/boilerplate/systemjs/package.json
+++ b/aio/tools/examples/shared/boilerplate/systemjs/package.json
@@ -39,7 +39,7 @@
     "core-js": "^2.5.4",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
-    "zone.js": "~0.10.3"
+    "zone.js": "~0.11.4"
   },
   "devDependencies": {
     "@angular/compiler-cli": "~11.0.1",

--- a/aio/tools/examples/shared/boilerplate/universal/package.json
+++ b/aio/tools/examples/shared/boilerplate/universal/package.json
@@ -31,7 +31,7 @@
     "express": "^4.15.2",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
-    "zone.js": "~0.10.3"
+    "zone.js": "~0.11.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1100.2",

--- a/aio/tools/examples/shared/package.json
+++ b/aio/tools/examples/shared/package.json
@@ -44,7 +44,7 @@
     "rxjs": "~6.6.0",
     "systemjs": "0.19.39",
     "tslib": "^2.0.0",
-    "zone.js": "~0.10.3"
+    "zone.js": "~0.11.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1100.2",

--- a/aio/tools/examples/shared/yarn.lock
+++ b/aio/tools/examples/shared/yarn.lock
@@ -12663,3 +12663,10 @@ zone.js@~0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.10.3.tgz#3e5e4da03c607c9dcd92e37dd35687a14a140c16"
   integrity sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==
+
+zone.js@~0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.11.4.tgz#0f70dcf6aba80f698af5735cbb257969396e8025"
+  integrity sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==
+  dependencies:
+    tslib "^2.0.0"

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -14704,9 +14704,9 @@ zone.js@~0.10.3:
   resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.10.3.tgz#3e5e4da03c607c9dcd92e37dd35687a14a140c16"
   integrity sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==
 
-zone.js@~0.11.3:
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.11.3.tgz#255a6313174731cc014d63233ef04fd9858da375"
-  integrity sha512-Y4hTHoh4VcxU5BDGAqEoOnOiyT254w6CiHtpQxAJUSMZPyVgdbKf+5R7Mwz6xsPhMIeBXk5rTopRZDpjssTCUg==
+zone.js@~0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.11.4.tgz#0f70dcf6aba80f698af5735cbb257969396e8025"
+  integrity sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==
   dependencies:
     tslib "^2.0.0"

--- a/dev-infra/BUILD.bazel
+++ b/dev-infra/BUILD.bazel
@@ -51,7 +51,7 @@ pkg_npm(
         "//dev-infra/": "@npm//@angular/dev-infra-private/",
         "//packages/benchpress": "@npm//@angular/benchpress",
         "//packages/bazel": "@npm//@angular/bazel",
-        "//packages/zone.js/bundles:zone.umd.js": "@npm//:node_modules/zone.js/dist/zone.js",
+        "//packages/zone.js/bundles:zone.umd.js": "@npm//zone.js",
         "//packages/core": "@npm//@angular/core",
         "//packages/platform-browser": "@npm//@angular/platform-browser",
 

--- a/integration/cli-hello-world-ivy-compat/src/environments/environment.ts
+++ b/integration/cli-hello-world-ivy-compat/src/environments/environment.ts
@@ -13,4 +13,4 @@ export const environment = {
  * This import should be commented out in production mode because it will have a negative impact
  * on performance if an error is thrown.
  */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.
+// import 'zone.js/plugins/zone-error';  // Included with Angular CLI.

--- a/integration/cli-hello-world-ivy-compat/src/polyfills.ts
+++ b/integration/cli-hello-world-ivy-compat/src/polyfills.ts
@@ -55,7 +55,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js';  // Included with Angular CLI.
 
 
 /***************************************************************************************************

--- a/integration/cli-hello-world-ivy-compat/src/test.ts
+++ b/integration/cli-hello-world-ivy-compat/src/test.ts
@@ -1,6 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/integration/cli-hello-world-ivy-i18n/src/environments/environment.ts
+++ b/integration/cli-hello-world-ivy-i18n/src/environments/environment.ts
@@ -13,4 +13,4 @@ export const environment = {
  * This import should be commented out in production mode because it will have a negative impact
  * on performance if an error is thrown.
  */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.
+// import 'zone.js/plugins/zone-error';  // Included with Angular CLI.

--- a/integration/cli-hello-world-ivy-i18n/src/polyfills.ts
+++ b/integration/cli-hello-world-ivy-i18n/src/polyfills.ts
@@ -55,7 +55,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone'; // Included with Angular CLI.
+import 'zone.js'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * Load `$localize` onto the global scope - used if i18n tags appear in Angular templates.

--- a/integration/cli-hello-world-ivy-i18n/src/test.ts
+++ b/integration/cli-hello-world-ivy-i18n/src/test.ts
@@ -1,6 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/integration/cli-hello-world-ivy-minimal/src/polyfills.ts
+++ b/integration/cli-hello-world-ivy-minimal/src/polyfills.ts
@@ -55,7 +55,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js';  // Included with Angular CLI.
 
 
 /***************************************************************************************************

--- a/integration/cli-hello-world-ivy-minimal/src/test.ts
+++ b/integration/cli-hello-world-ivy-minimal/src/test.ts
@@ -1,6 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/integration/cli-hello-world-lazy-rollup/src/environments/environment.ts
+++ b/integration/cli-hello-world-lazy-rollup/src/environments/environment.ts
@@ -13,4 +13,4 @@ export const environment = {
  * This import should be commented out in production mode because it will have a negative impact
  * on performance if an error is thrown.
  */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.
+// import 'zone.js/plugins/zone-error';  // Included with Angular CLI.

--- a/integration/cli-hello-world-lazy-rollup/src/polyfills.ts
+++ b/integration/cli-hello-world-lazy-rollup/src/polyfills.ts
@@ -55,7 +55,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js';  // Included with Angular CLI.
 
 
 /***************************************************************************************************

--- a/integration/cli-hello-world-lazy-rollup/src/test.ts
+++ b/integration/cli-hello-world-lazy-rollup/src/test.ts
@@ -1,6 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/integration/cli-hello-world-lazy/src/environments/environment.ts
+++ b/integration/cli-hello-world-lazy/src/environments/environment.ts
@@ -13,4 +13,4 @@ export const environment = {
  * This import should be commented out in production mode because it will have a negative impact
  * on performance if an error is thrown.
  */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.
+// import 'zone.js/plugins/zone-error';  // Included with Angular CLI.

--- a/integration/cli-hello-world-lazy/src/polyfills.ts
+++ b/integration/cli-hello-world-lazy/src/polyfills.ts
@@ -55,7 +55,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js';  // Included with Angular CLI.
 
 
 /***************************************************************************************************

--- a/integration/cli-hello-world-lazy/src/test.ts
+++ b/integration/cli-hello-world-lazy/src/test.ts
@@ -1,6 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/integration/cli-hello-world/src/environments/environment.ts
+++ b/integration/cli-hello-world/src/environments/environment.ts
@@ -13,4 +13,4 @@ export const environment = {
  * This import should be commented out in production mode because it will have a negative impact
  * on performance if an error is thrown.
  */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.
+// import 'zone.js/plugins/zone-error';  // Included with Angular CLI.

--- a/integration/cli-hello-world/src/polyfills.ts
+++ b/integration/cli-hello-world/src/polyfills.ts
@@ -55,7 +55,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js';  // Included with Angular CLI.
 
 
 /***************************************************************************************************

--- a/integration/cli-hello-world/src/test.ts
+++ b/integration/cli-hello-world/src/test.ts
@@ -1,6 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/integration/injectable-def/src/main.ts
+++ b/integration/injectable-def/src/main.ts
@@ -1,4 +1,4 @@
-import 'zone.js/dist/zone-node';
+import 'zone.js/node';
 
 import {enableProdMode} from '@angular/core';
 import {renderModuleFactory} from '@angular/platform-server';

--- a/integration/ivy-i18n/src/environments/environment.ts
+++ b/integration/ivy-i18n/src/environments/environment.ts
@@ -13,4 +13,4 @@ export const environment = {
  * This import should be commented out in production mode because it will have a negative impact
  * on performance if an error is thrown.
  */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.
+// import 'zone.js/plugins/zone-error';  // Included with Angular CLI.

--- a/integration/ivy-i18n/src/polyfills-runtime.ts
+++ b/integration/ivy-i18n/src/polyfills-runtime.ts
@@ -57,7 +57,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone'; // Included with Angular CLI.
+import 'zone.js'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * Load `$localize` onto the global scope - used if i18n tags appear in Angular templates.

--- a/integration/ivy-i18n/src/polyfills.ts
+++ b/integration/ivy-i18n/src/polyfills.ts
@@ -55,7 +55,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone'; // Included with Angular CLI.
+import 'zone.js'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * Load `$localize` onto the global scope - used if i18n tags appear in Angular templates.

--- a/integration/ivy-i18n/src/test.ts
+++ b/integration/ivy-i18n/src/test.ts
@@ -1,6 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/integration/ng_update_migrations/src/environments/environment.ts
+++ b/integration/ng_update_migrations/src/environments/environment.ts
@@ -13,4 +13,4 @@ export const environment = {
  * This import should be commented out in production mode because it will have a negative impact
  * on performance if an error is thrown.
  */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.
+// import 'zone.js/plugins/zone-error';  // Included with Angular CLI.

--- a/integration/ng_update_migrations/src/polyfills.ts
+++ b/integration/ng_update_migrations/src/polyfills.ts
@@ -55,7 +55,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js';  // Included with Angular CLI.
 
 
 /***************************************************************************************************

--- a/integration/ng_update_migrations/src/test.ts
+++ b/integration/ng_update_migrations/src/test.ts
@@ -1,6 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/integration/trusted-types/src/environments/environment.ts
+++ b/integration/trusted-types/src/environments/environment.ts
@@ -13,4 +13,4 @@ export const environment = {
  * This import should be commented out in production mode because it will have a negative impact
  * on performance if an error is thrown.
  */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.
+// import 'zone.js/plugins/zone-error';  // Included with Angular CLI.

--- a/integration/trusted-types/src/polyfills.ts
+++ b/integration/trusted-types/src/polyfills.ts
@@ -55,7 +55,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js';  // Included with Angular CLI.
 
 
 /***************************************************************************************************

--- a/integration/trusted-types/src/test.ts
+++ b/integration/trusted-types/src/test.ts
@@ -1,6 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/packages/compiler-cli/integrationtest/test/init.ts
+++ b/packages/compiler-cli/integrationtest/test/init.ts
@@ -8,8 +8,8 @@
 
 // import zone.js from npm here because integration test will load zone.js
 // from built npm_package instead of source
-import 'zone.js/dist/zone-node';
-import 'zone.js/dist/zone-testing';
+import 'zone.js/node';
+import 'zone.js/testing';
 // Only needed to satisfy the check in core/src/util/decorators.ts
 // TODO(alexeagle): maybe remove that check?
 require('reflect-metadata');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
   },
   "peerDependencies": {
     "rxjs": "^6.5.3",
-    "zone.js": "^0.10.2 || ^0.11.3"
+    "zone.js": "~0.11.4"
   },
   "repository": {
     "type": "git",

--- a/packages/core/src/testability/testability.ts
+++ b/packages/core/src/testability/testability.ts
@@ -199,7 +199,7 @@ export class Testability implements PublicTestability {
     if (updateCb && !this.taskTrackingZone) {
       throw new Error(
           'Task tracking zone is required when passing an update callback to ' +
-          'whenStable(). Is "zone.js/dist/task-tracking.js" loaded?');
+          'whenStable(). Is "zone.js/plugins/task-tracking" loaded?');
     }
     // These arguments are 'Function' above to keep the public API simple.
     this.addCallback(doneCb as DoneCallback, timeout, updateCb as UpdateCallback);

--- a/packages/core/testing/src/async.ts
+++ b/packages/core/testing/src/async.ts
@@ -28,7 +28,7 @@ export function waitForAsync(fn: Function): (done: any) => any {
     return function() {
       return Promise.reject(
           'Zone is needed for the waitForAsync() test helper but could not be found. ' +
-          'Please make sure that your environment includes zone.js/dist/zone.js');
+          'Please make sure that your environment includes zone.js');
     };
   }
   const asyncTest = _Zone && _Zone[_Zone.__symbol__('asyncTest')];
@@ -38,7 +38,7 @@ export function waitForAsync(fn: Function): (done: any) => any {
   return function() {
     return Promise.reject(
         'zone-testing.js is needed for the async() test helper but could not be found. ' +
-        'Please make sure that your environment includes zone.js/dist/zone-testing.js');
+        'Please make sure that your environment includes zone.js/testing');
   };
 }
 

--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -10,7 +10,7 @@ const fakeAsyncTestModule = _Zone && _Zone[_Zone.__symbol__('fakeAsyncTest')];
 
 const fakeAsyncTestModuleNotLoadedErrorMessage =
     `zone-testing.js is needed for the fakeAsync() test helper but could not be found.
-        Please make sure that your environment includes zone.js/dist/zone-testing.js`;
+        Please make sure that your environment includes zone.js/testing`;
 
 /**
  * Clears out the shared fake async zone for a test.

--- a/packages/localize/schematics/ng-add/index_spec.ts
+++ b/packages/localize/schematics/ng-add/index_spec.ts
@@ -22,7 +22,7 @@ describe('ng-add schematic', () => {
       `/***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';`;
+import 'zone.js';`;
   const mainServerContent = `import { enableProdMode } from '@angular/core';
 import { environment } from './environments/environment';
 if (environment.production) {

--- a/packages/zone.js/MODULE.md
+++ b/packages/zone.js/MODULE.md
@@ -85,12 +85,12 @@ you can do like this.
       }
     ];
   </script>
-  <script src="../dist/zone.js"></script>
+  <script src="../bundles/zone.umd.js"></script>
 ```
 
 - Error
 
-By default, `zone.js/dist/zone-error` will not be loaded for performance concern.
+By default, `zone.js/plugins/zone-error` will not be loaded for performance concern.
 This package will provide following functionality.
 
   1. Error inherit: handle `extend Error` issue.
@@ -125,13 +125,13 @@ This package will provide following functionality.
   The second feature will slow down the `Error` performance, so `zone.js` provide a flag to let you be able to control the behavior.
   The flag is `__Zone_Error_ZoneJsInternalStackFrames_policy`. And the available options is:
 
-    1. default: this is the default one, if you load `zone.js/dist/zone-error` without
+    1. default: this is the default one, if you load `zone.js/plugins/zone-error` without
      setting the flag, `default` will be used, and `ZoneJsInternalStackFrames` will be available
      when `new Error()`, you can get a `error.stack`  which is `zone stack free`. But this
      will slow down `new Error()` a little bit.
 
     2. disable: this will disable `ZoneJsInternalStackFrames` feature, and if you load
-     `zone.js/dist/zone-error`, you will only get a `wrapped Error` which can handle
+     `zone.js/plugins/zone-error`, you will only get a `wrapped Error` which can handle
       `Error inherit` issue.
 
     3. lazy: this is a feature to let you be able to get `ZoneJsInternalStackFrames` feature,

--- a/packages/zone.js/MODULE.md
+++ b/packages/zone.js/MODULE.md
@@ -13,7 +13,7 @@ before loading zone.js.
     __Zone_disable_blocking = true; // Zone will not patch alert/prompt/confirm
     __Zone_disable_PromiseRejectionEvent = true; // Zone will not patch PromiseRejectionEventHandler
   </script>
-  <script src="../dist/zone.js"></script>
+  <script src="../bundles/zone.umd.js"></script>
 ```
 
 Below is the full list of currently supported modules.

--- a/packages/zone.js/NON-STANDARD-APIS.md
+++ b/packages/zone.js/NON-STANDARD-APIS.md
@@ -14,7 +14,6 @@ But there are still a lot of non-standard APIs that are not patched by default, 
 * webcomponents
 
 Usage:
-
 ```
 <script src="webcomponents-lite.js"></script>
 <script src="node_modules/zone.js/bundles/zone.umd.js"></script>
@@ -45,8 +44,8 @@ Angular Usage:
 in polyfills.ts, import the `zone-bluebird` package.
 
 ```
-import 'zone.js/dist/zone'; // Included with Angular CLI.
-import 'zone.js/dist/zone-bluebird';
+import 'zone.js'; // Included with Angular CLI.
+import 'zone.js/plugins/zone-bluebird';
 ```
 
 in main.ts, patch bluebird.
@@ -67,7 +66,7 @@ Node Sample Usage:
 ```
 require('zone.js');
 const Bluebird = require('bluebird');
-require('zone.js/dist/zone-bluebird');
+require('zone.js/plugins/zone-bluebird');
 Zone[Zone['__symbol__']('bluebird')](Bluebird);
 Zone.current.fork({
   name: 'bluebird'
@@ -178,7 +177,7 @@ is patched, so each asynchronous call will run in the correct zone.
 For example, in an Angular application, you can load this patch in your `app.module.ts`.
 
 ```
-import 'zone.js/dist/zone-patch-rxjs';
+import 'zone.js/plugins/zone-patch-rxjs';
 ```
 
 * electron
@@ -194,9 +193,9 @@ In electron, we patched the following APIs with `zone.js`
 add following line into `polyfill.ts` after loading zone-mix.
 
 ```
-//import 'zone.js/dist/zone'; // originally added by angular-cli, comment it out
-import 'zone.js/dist/zone-mix'; // add zone-mix to patch both Browser and Nodejs
-import 'zone.js/dist/zone-patch-electron'; // add zone-patch-electron to patch Electron native API
+//import 'zone.js'; // originally added by angular-cli, comment it out
+import 'zone.js/mix'; // add zone-mix to patch both Browser and Nodejs
+import 'zone.js/plugins/zone-patch-electron'; // add zone-patch-electron to patch Electron native API
 ```
 
 there is a sampel repo [zone-electron](https://github.com/JiaLiPassion/zone-electron).
@@ -207,8 +206,8 @@ user need to patch `io` themselves just like following code.
 
 ```javascript
     <script src="socket.io-client/dist/socket.io.js"></script>
-    <script src="zone.js/dist/zone.js"></script>
-    <script src="zone.js/dist/zone-patch-socket-io.js"></script>
+    <script src="zone.js/bundles/zone.umd.js"></script>
+    <script src="zone.js/bundles/zone-patch-socket-io.js"></script>
     <script>
       // patch io here
       Zone[Zone.__symbol__('socketio')](io);
@@ -229,7 +228,7 @@ there is a sampel repo [zone-jsonp](https://github.com/JiaLiPassion/test-zone-js
 sample usage is:
 
 ```javascript
-import 'zone.js/dist/zone-patch-jsonp';
+import 'zone.js/plugins/zone-patch-jsonp';
 Zone['__zone_symbol__jsonp']({
   jsonp: getJSONP,
   sendFuncName: 'send',
@@ -243,8 +242,8 @@ Currently only `Chrome 64` native support this feature.
 you can add the following line into `polyfill.ts` after loading `zone.js`.
 
 ```
-import 'zone.js/dist/zone';
-import 'zone.js/dist/zone-patch-resize-observer';
+import 'zone.js';
+import 'zone.js/plugins/zone-patch-resize-observer';
 ```
 
 there is a sample repo [zone-resize-observer](https://github.com/JiaLiPassion/zone-resize-observer) here

--- a/packages/zone.js/NON-STANDARD-APIS.md
+++ b/packages/zone.js/NON-STANDARD-APIS.md
@@ -17,8 +17,8 @@ Usage:
 
 ```
 <script src="webcomponents-lite.js"></script>
-<script src="node_modules/zone.js/dist/zone.js"></script>
-<script src="node_modules/zone.js/dist/webapis-shadydom.js"></script>
+<script src="node_modules/zone.js/bundles/zone.umd.js"></script>
+<script src="node_modules/zone.js/bundles/webapis-shadydom.umd.js"></script>
 ```
 
 ## Currently supported non standard node APIs

--- a/packages/zone.js/lib/zone-spec/async-test.ts
+++ b/packages/zone.js/lib/zone-spec/async-test.ts
@@ -194,7 +194,7 @@ Zone.__load_patch('asynctest', (global: any, Zone: ZoneType, api: _ZonePrivate) 
     if (AsyncTestZoneSpec === undefined) {
       throw new Error(
           'AsyncTestZoneSpec is needed for the async() test helper but could not be found. ' +
-          'Please make sure that your environment includes zone.js/dist/async-test.js');
+          'Please make sure that your environment includes zone.js/plugins/async-test');
     }
     const ProxyZoneSpec = (Zone as any)['ProxyZoneSpec'] as {
       get(): {setDelegate(spec: ZoneSpec): void; getDelegate(): ZoneSpec;};
@@ -203,7 +203,7 @@ Zone.__load_patch('asynctest', (global: any, Zone: ZoneType, api: _ZonePrivate) 
     if (!ProxyZoneSpec) {
       throw new Error(
           'ProxyZoneSpec is needed for the async() test helper but could not be found. ' +
-          'Please make sure that your environment includes zone.js/dist/proxy.js');
+          'Please make sure that your environment includes zone.js/plugins/proxy');
     }
     const proxyZoneSpec = ProxyZoneSpec.get();
     ProxyZoneSpec.assertPresent();

--- a/packages/zone.js/lib/zone-spec/fake-async-test.ts
+++ b/packages/zone.js/lib/zone-spec/fake-async-test.ts
@@ -756,7 +756,7 @@ Zone.__load_patch('fakeasync', (global: any, Zone: ZoneType, api: _ZonePrivate) 
       if (!ProxyZoneSpec) {
         throw new Error(
             'ProxyZoneSpec is needed for the async() test helper but could not be found. ' +
-            'Please make sure that your environment includes zone.js/dist/proxy.js');
+            'Please make sure that your environment includes zone.js/plugins/proxy');
       }
       const proxyZoneSpec = ProxyZoneSpec.assertPresent();
       if (Zone.current.get('FakeAsyncTestZoneSpec')) {

--- a/scripts/release/post-check-next
+++ b/scripts/release/post-check-next
@@ -7,7 +7,7 @@
 mkdir tmp
 cd tmp
 npm init -y
-npm install typescript@~3.8.3 rxjs@^6.5.3 zone.js@~0.11.3 @bazel/typescript@^1.0.0 rollup@^1.20.0 rollup-plugin-commonjs@^9.0.0 rollup-plugin-node-resolve@^4.2.0 rollup-plugin-sourcemaps@0.4.0 @angular/{animations,bazel,common,compiler,compiler-cli,core,elements,forms,language-service,localize,platform-browser,platform-browser-dynamic,platform-server,router,service-worker,upgrade}@next --save
+npm install typescript@~3.8.3 rxjs@^6.5.3 zone.js@~0.11.4 @bazel/typescript@^1.0.0 rollup@^1.20.0 rollup-plugin-commonjs@^9.0.0 rollup-plugin-node-resolve@^4.2.0 rollup-plugin-sourcemaps@0.4.0 @angular/{animations,bazel,common,compiler,compiler-cli,core,elements,forms,language-service,localize,platform-browser,platform-browser-dynamic,platform-server,router,service-worker,upgrade}@next --save
 cd ..
 rm -rf tmp
 


### PR DESCRIPTION
With this change we drop support for zone.js 0.10.x.
This is needed because in version 12 the CLI will only work with `~0.11.4`. See angular/angular-cli#20034.

BREAKING CHANGE:

Minimum supported `zone.js` version is `0.11.4`