### PR TITLE
docs: clarify a possible error case

### DIFF
--- a/aio/content/tutorial/toh-pt3.md
+++ b/aio/content/tutorial/toh-pt3.md
@@ -81,6 +81,12 @@ That's the only change you should make to the `HeroDetailComponent` class.
 There are no more properties. There's no presentation logic.
 This component simply receives a hero object through its `hero` property and displays it.
 
+You may get this error: `Property 'contact' has no initializer and is not definitely assigned in the constructor.ts(2564)`.
+It is likely that you use a version of Typescript >= 2.7. To resolve this, simply put an exclamation mark after the variable name like this:
+  ```ts
+  @Input() hero!: Hero;
+  ```
+
 ## Show the `HeroDetailComponent`
 
 The `HeroesComponent` is still a master/detail view.

--- a/aio/content/tutorial/toh-pt3.md
+++ b/aio/content/tutorial/toh-pt3.md
@@ -81,7 +81,7 @@ That's the only change you should make to the `HeroDetailComponent` class.
 There are no more properties. There's no presentation logic.
 This component simply receives a hero object through its `hero` property and displays it.
 
-You may get this error: `Property 'contact' has no initializer and is not definitely assigned in the constructor.ts(2564)`.
+You may get this error: `Property 'hero' has no initializer and is not definitely assigned in the constructor.ts(2564)`.
 It is likely that you use a version of Typescript >= 2.7. To resolve this, simply put an exclamation mark after the variable name like this:
   ```ts
   @Input() hero!: Hero;

--- a/aio/content/tutorial/toh-pt3.md
+++ b/aio/content/tutorial/toh-pt3.md
@@ -86,6 +86,8 @@ It is likely that you use a version of Typescript >= 2.7. To resolve this, simpl
   ```ts
   @Input() hero!: Hero;
   ```
+More information [here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#strict-class-initialization).
+
 
 ## Show the `HeroDetailComponent`
 


### PR DESCRIPTION
If we use a Typescript version >= 2.7, we get an error: 
> Property 'hero' has no initializer and is not definitely assigned in the constructor.ts(2564)

We need to inform the user of a possible solution. This is what I described.

Another solution would be to set `"strictPropertyInitialization": false` in `tsconfig.json`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

