### PR TITLE
refactor(compiler): retrieve variables from context inside nested template listener

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/nested_template_context_many_bindings_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/nested_template_context_many_bindings_template.js
@@ -3,9 +3,9 @@ function MyComponent_div_0_Template(rf, ctx) {
     const $s$ = $r3$.ɵɵgetCurrentView();
     $r3$.ɵɵelementStart(0, "div", 1);
     $r3$.ɵɵlistener("click", function MyComponent_div_0_Template_div_click_0_listener() {
-      $r3$.ɵɵrestoreView($s$);
-      const $d$ = ctx.$implicit;
-      const $i$ = ctx.index;
+      const $sr$ = $r3$.ɵɵrestoreView($s$);
+      const $d$ = $sr$.$implicit;
+      const $i$ = $sr$.index;
       const $comp$ = $r3$.ɵɵnextContext();
       return $comp$._handleClick($d$, $i$);
     });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/nested_template_context_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/nested_template_context_template.js
@@ -3,8 +3,8 @@ function MyComponent_ul_0_li_1_div_1_Template(rf, ctx) {
     const $s$ = $i0$.ɵɵgetCurrentView();
     $i0$.ɵɵelementStart(0, "div", 2);
     $i0$.ɵɵlistener("click", function MyComponent_ul_0_li_1_div_1_Template_div_click_0_listener(){
-      $i0$.ɵɵrestoreView($s$);
-      const $inner$ = ctx.$implicit;
+      const $sr$ = $i0$.ɵɵrestoreView($s$);
+      const $inner$ = $sr$.$implicit;
       const $middle$ = $i0$.ɵɵnextContext().$implicit;
       const $outer$ = $i0$.ɵɵnextContext().$implicit;
       const $myComp$ = $i0$.ɵɵnextContext();

--- a/packages/compiler-cli/test/compliance_old/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance_old/r3_view_compiler_template_spec.ts
@@ -55,8 +55,8 @@ describe('compiler compliance: template', () => {
           const $s$ = $i0$.ɵɵgetCurrentView();
           $i0$.ɵɵelementStart(0, "div", 2);
           $i0$.ɵɵlistener("click", function MyComponent_ul_0_li_1_div_1_Template_div_click_0_listener(){
-            $i0$.ɵɵrestoreView($s$);
-            const $inner$ = ctx.$implicit;
+            const $sr$ = $i0$.ɵɵrestoreView($s$);
+            const $inner$ = $sr$.$implicit;
             const $middle$ = $i0$.ɵɵnextContext().$implicit;
             const $outer$ = $i0$.ɵɵnextContext().$implicit;
             const $myComp$ = $i0$.ɵɵnextContext();
@@ -150,9 +150,9 @@ describe('compiler compliance: template', () => {
             const $s$ = $r3$.ɵɵgetCurrentView();
             $r3$.ɵɵelementStart(0, "div", 1);
             $r3$.ɵɵlistener("click", function MyComponent_div_0_Template_div_click_0_listener() {
-              $r3$.ɵɵrestoreView($s$);
-              const $d$ = ctx.$implicit;
-              const $i$ = ctx.index;
+              const $sr$ = $r3$.ɵɵrestoreView($s$);
+              const $d$ = $sr$.$implicit;
+              const $i$ = $sr$.index;
               const $comp$ = $r3$.ɵɵnextContext();
               return $comp$._handleClick($d$, $i$);
             });

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -45,6 +45,9 @@ export const IMPLICIT_REFERENCE = '$implicit';
 /** Non bindable attribute name **/
 export const NON_BINDABLE_ATTR = 'ngNonBindable';
 
+/** Name for the variable keeping track of the context returned by `ɵɵrestoreView`. */
+export const RESTORED_VIEW_CONTEXT_NAME = 'restoredCtx';
+
 /**
  * Creates an allocator for a temporary variable.
  *

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -284,11 +284,13 @@ export function getTView(): TView {
  * walking the declaration view tree in listeners to get vars from parent views.
  *
  * @param viewToRestore The OpaqueViewState instance to restore.
+ * @returns Context of the restored OpaqueViewState instance.
  *
  * @codeGenApi
  */
-export function ɵɵrestoreView(viewToRestore: OpaqueViewState) {
+export function ɵɵrestoreView<T = any>(viewToRestore: OpaqueViewState): T {
   instructionState.lFrame.contextLView = viewToRestore as any as LView;
+  return (viewToRestore as any as LView)[CONTEXT] as T;
 }
 
 


### PR DESCRIPTION
This is a prerequisite for #40360. Given the following template which has a listener that references a variable from a parent template (`name`):

```
<ng-template let-name="name">
  <button (click)="hello(name)"></button>
</ng-template>
```

We generate code that looks that looks like the following. Note how we access `name` through `ctx`:

```js
function template(rf, ctx) {
  if (rf & 1) {
    const r0 = ɵɵgetCurrentView();
    ɵɵelementStart(0, "button", 2);
    ɵɵlistener("click", function() {
      ɵɵrestoreView(r0);
      const name_r0 = ctx.name; // Note the `ctx.name` access here.
      const ctx_r1 = ɵɵnextContext();
      return ctx_r1.log(name_r0);
    });
    ɵɵelementEnd();
  }
}
```

This works fine at the moment, because the template context object can't be changed after creation. The changes in #40360 allow for the object to be changed, which means that the `ctx` reference inside the listener will be out of date, because it was bound during creation mode.

This PR aims to address the issue by accessing the context inside listeners through the saved view reference. With the new code, the generated code from above will look as follows:

```js
function template(rf, ctx) {
  if (rf & 1) {
    const r0 = ɵɵgetCurrentView();
    ɵɵelementStart(0, "button", 2);
    ɵɵlistener("click", function() {
      const restoredCtx = ɵɵrestoreView(r0);
      const name_r0 = restoredCtx.name;
      const ctx_r1 = ɵɵnextContext();
      return ctx_r1.log(name_r0);
    });
    ɵɵelementEnd();
  }
}
```