### PR TITLE
build(docs-infra): add a link to `usage notes` from description

### DIFF
--- a/aio/tools/transforms/templates/api/includes/description.html
+++ b/aio/tools/transforms/templates/api/includes/description.html
@@ -2,5 +2,7 @@
 <section class="description">
   <h2>Description</h2>
   {$ doc.description | trimBlankLines | marked $}
+  {% if doc.usageNotes %}<p>Further information available in the <a href="#usage-notes">Usage Notes</a>...</p>{%
+  endif %}
 </section>
 {% endif %}


### PR DESCRIPTION
The Usage Notes section is often at the bottom of a long page of content
which can make it difficult to discover. This commit add a link to the
description block if there is a Usage Notes section. This link should help
the reader to discover that there is more information available further
down the doc.

This is basically a marginal fix, which the longer term fix should be to
think about what content goes in which sections and how they should
be laid out on the page.

See #40753

<img width="577" alt="Screenshot 2021-02-13 at 16 30 04" src="https://user-images.githubusercontent.com/15655/107855190-cb0f9a80-6e18-11eb-892e-9bff73f7bd25.png">
