### PR TITLE
fix(core): support sanitizing uncontained `<tr>` and `<td>` elements

### DIFF
--- a/packages/core/src/sanitization/inert_body.ts
+++ b/packages/core/src/sanitization/inert_body.ts
@@ -42,7 +42,7 @@ class DOMParserHelper implements InertBodyHelper {
     html = '<body><remove></remove>' + html;
     try {
       const body = new window.DOMParser()
-                       .parseFromString(trustedHTMLFromString(html) as string, 'text/html')
+                       .parseFromString(trustedHTMLFromString(html) as string, 'application/xml')
                        .body as HTMLBodyElement;
       if (body === null) {
         // In some browsers (e.g. Mozilla/5.0 iPad AppleWebKit Mobile) the `body` property only
@@ -142,7 +142,7 @@ class InertDocumentHelper implements InertBodyHelper {
 export function isDOMParserAvailable() {
   try {
     return !!new window.DOMParser().parseFromString(
-        trustedHTMLFromString('') as string, 'text/html');
+        trustedHTMLFromString('') as string, 'application/xml');
   } catch {
     return false;
   }

--- a/packages/core/test/sanitization/html_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/html_sanitizer_spec.ts
@@ -89,6 +89,11 @@ function sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): string {
       expect(logMsgs).toEqual([]);
     });
 
+    it('supports table rows and cells without a containing table element', () => {
+      expect(sanitizeHtml(defaultDoc, '<tr><td>Hello {{ world }}!</td></tr>'))
+          .toEqual('<tr><td>Hello {{ world }}!</td></tr>');
+    });
+
     it('does not warn when just re-encoding text', () => {
       expect(sanitizeHtml(defaultDoc, '<p>Hellö Wörld</p>'))
           .toEqual('<p>Hell&#246; W&#246;rld</p>');


### PR DESCRIPTION
Previously, `<tr>` or `<td>`elements that were not containing within a
`<table>` element were stripped from the string by the HTML sanitizer.

Fixes #35387

**Given the security sensitive nature of this code, this is only a tentative fix that needs thorough review**

It appears that we parsing in "XML" mode still has the same result as in HTML mode, while being more relaxed about the semantic of what elements can contain others. Importantly, dangerous stuff still appears to be stripped away.