### PR TITLE
fix(core): support sanitizing uncontained `<tr>` and `<td>` elements

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3033,
-        "main-es2015": 447766,
+        "main-es2015": 447751,
         "polyfills-es2015": 52343
       }
     }
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3033,
-        "main-es2015": 447894,
+        "main-es2015": 447989,
         "polyfills-es2015": 52493
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3153,
-        "main-es2015": 432647,
+        "main-es2015": 432600,
         "polyfills-es2015": 52493
       }
     }

--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -9,7 +9,7 @@ import '../../util/ng_dev_mode';
 import '../../util/ng_i18n_closure_mode';
 
 import {getTemplateContent, SRCSET_ATTRS, URI_ATTRS, VALID_ATTRS, VALID_ELEMENTS} from '../../sanitization/html_sanitizer';
-import {getInertBodyHelper} from '../../sanitization/inert_body';
+import {getInertElementHelper} from '../../sanitization/inert_body';
 import {_sanitizeUrl, sanitizeSrcset} from '../../sanitization/url_sanitizer';
 import {assertDefined, assertEqual, assertGreaterThanOrEqual, assertOneOf, assertString} from '../../util/assert';
 import {CharCode} from '../../util/char_code';
@@ -557,10 +557,10 @@ export function parseIcuCase(
   tIcu.remove.push(remove);
   tIcu.update.push(update);
 
-  const inertBodyHelper = getInertBodyHelper(getDocument());
-  const inertBodyElement = inertBodyHelper.getInertBodyElement(unsafeCaseHtml);
-  ngDevMode && assertDefined(inertBodyElement, 'Unable to generate inert body element');
-  const inertRootNode = getTemplateContent(inertBodyElement!) as Element || inertBodyElement;
+  const inertElementHelper = getInertElementHelper(getDocument());
+  const inertElement = inertElementHelper.getInertElement(unsafeCaseHtml);
+  ngDevMode && assertDefined(inertElement, 'Unable to generate inert element.');
+  const inertRootNode = getTemplateContent(inertElement!) as Element || inertElement;
   if (inertRootNode) {
     return walkIcuTree(
         tView, tIcu, lView, updateOpCodes, create, remove, update, inertRootNode, parentIdx,

--- a/packages/core/src/sanitization/inert_body.ts
+++ b/packages/core/src/sanitization/inert_body.ts
@@ -15,26 +15,26 @@ import {trustedHTMLFromString} from '../util/security/trusted_types';
  * Default: DOMParser strategy
  * Fallback: InertDocument strategy
  */
-export function getInertBodyHelper(defaultDoc: Document): InertBodyHelper {
+export function getInertElementHelper(defaultDoc: Document): InertElementHelper {
   const inertDocumentHelper = new InertDocumentHelper(defaultDoc);
   return isDOMParserAvailable() ? new DOMParserHelper(inertDocumentHelper) : inertDocumentHelper;
 }
 
-export interface InertBodyHelper {
+export interface InertElementHelper {
   /**
    * Get an inert DOM element containing DOM created from the dirty HTML string provided.
    */
-  getInertBodyElement: (html: string) => HTMLElement | null;
+  getInertElement: (html: string) => HTMLElement | null;
 }
 
 /**
- * Uses DOMParser to create and fill an inert body element.
+ * Uses DOMParser to create and fill an inert element.
  * This is the default strategy used in browsers that support it.
  */
-class DOMParserHelper implements InertBodyHelper {
-  constructor(private inertDocumentHelper: InertBodyHelper) {}
+class DOMParserHelper implements InertElementHelper {
+  constructor(private inertDocumentHelper: InertElementHelper) {}
 
-  getInertBodyElement(html: string): HTMLElement|null {
+  getInertElement(html: string): HTMLElement|null {
     // We add these extra elements to ensure that the rest of the content is parsed as expected
     // e.g. leading whitespace is maintained and tags like `<meta>` do not get hoisted to the
     // `<head>` tag. Note that the `<body>` tag is closed implicitly to prevent unclosed tags
@@ -48,7 +48,7 @@ class DOMParserHelper implements InertBodyHelper {
         // In some browsers (e.g. Mozilla/5.0 iPad AppleWebKit Mobile) the `body` property only
         // becomes available in the following tick of the JS engine. In that case we fall back to
         // the `inertDocumentHelper` instead.
-        return this.inertDocumentHelper.getInertBodyElement(html);
+        return this.inertDocumentHelper.getInertElement(html);
       }
       body.removeChild(body.firstChild!);
       return body;
@@ -63,7 +63,7 @@ class DOMParserHelper implements InertBodyHelper {
  * `createHtmlDocument` to create and fill an inert DOM element.
  * This is the fallback strategy if the browser does not support DOMParser.
  */
-class InertDocumentHelper implements InertBodyHelper {
+class InertDocumentHelper implements InertElementHelper {
   private inertDocument: Document;
 
   constructor(private defaultDoc: Document) {
@@ -79,7 +79,7 @@ class InertDocumentHelper implements InertBodyHelper {
     }
   }
 
-  getInertBodyElement(html: string): HTMLElement|null {
+  getInertElement(html: string): HTMLElement|null {
     // Prefer using <template> element if supported.
     const templateEl = this.inertDocument.createElement('template');
     if ('content' in templateEl) {


### PR DESCRIPTION
Previously, `<tr>` or `<td>`elements that were not containing within a
`<table>` element were stripped from the string by the HTML sanitizer.

Fixes #35387

---

This PR looks more complicated than it really is. First of all there is a simple rename refactoring in the first commit The second commit contains the actual fix. It looks busy but here is the overview.

Previously the inert element was worked out like this:

- If DOMParser strategy is available use that; if it fails mid-computation fall back to the inert body strategy.
- In the inert body strategy
  - first try putting the content into a `<template>` element; if that works use it
  - otherwise fallback on putting the content into a special `<body>` element attached to an inert document.

The problem is that neither the DOMParser nor the inert document body will accept HTML fragments, such as an unwrapped `<tr>` element. This PR just moves the order around a bit. Now the inert element is worked out as:

- First try putting the content into a `<template>` element; if that works use it
- If DOMParser strategy is available use that; if it fails mid-computation fall back to the inert body strategy.
- Fallback on putting the content into a special `<body>` element attached to an inert document.

Note that what has happened is that the priority of the `<template>` element as the container for the inert content has increased ahead of the other two strategies.

**We need to review this from a security perspective to ensure that putting `<template>` strategy first does not open up any attack vectors for all the browsers that we support.**

@koto it would be great if you could take a view.