### PR TITLE
docs: fix schematics' package name for `ng generate` sub-commands

### DIFF
--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -76,9 +76,9 @@ The following top-level configuration properties are available for each project,
 ## Generation schematics
 
 Angular generation [schematics](guide/glossary#schematic) are instructions for modifying a project by adding files or modifying existing files.
-Individual schematics for the default Angular CLI `ng generate` sub-commands are collected in the package `@angular`.
+Individual schematics for the default Angular CLI `ng generate` sub-commands are collected in the package `@schematics/angular`.
 Specify the schematic name for a subcommand in the format `schematic-package:schematic-name`;
-for example, the schematic for generating a component is `@angular:component`.
+for example, the schematic for generating a component is `@schematics/angular:component`.
 
 The JSON schemas for the default schematics used by the CLI to generate projects and parts of projects are collected in the package [`@schematics/angular`](https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/application/schema.json).
 The schema describes the options available to the CLI for each of the `ng generate` sub-commands, as shown in the `--help` output.


### PR DESCRIPTION
The [Generation schematics chapther](https://angular.io/guide/workspace-config#generation-schematics) states

> Individual schematics for the default Angular CLI ng generate sub-commands are collected in the package @angular. Specify the schematic name for a subcommand in the format schematic-package:schematic-name; for example, the schematic for generating a component is @angular:component.

Using @angular:component as a schematic's name resuts in an error. See a description in the _What is the current behavior?_ section

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Executing `ng generate @angular:component` prints an error  
`An unhandled exception occurred: Collection "@angular" cannot be resolved.`


## What is the new behavior?
There's no the error


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No