### PR TITLE
fix(router): activate components within Angular zone

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -389,6 +389,7 @@ export class Router {
   private configLoader: RouterConfigLoader;
   private ngModule: NgModuleRef<any>;
   private console: Console;
+  private ngZone: NgZone;
   private isNgZoneEnabled: boolean = false;
 
   /**
@@ -491,8 +492,8 @@ export class Router {
 
     this.ngModule = injector.get(NgModuleRef);
     this.console = injector.get(Console);
-    const ngZone = injector.get(NgZone);
-    this.isNgZoneEnabled = ngZone instanceof NgZone && NgZone.isInAngularZone();
+    this.ngZone = injector.get(NgZone);
+    this.isNgZoneEnabled = this.ngZone instanceof NgZone && NgZone.isInAngularZone();
 
     this.resetConfig(config);
     this.currentUrlTree = createEmptyUrlTree();
@@ -795,7 +796,7 @@ export class Router {
                      }),
 
                      activateRoutes(
-                         this.rootContexts, this.routeReuseStrategy,
+                         this.ngZone, this.rootContexts, this.routeReuseStrategy,
                          (evt: Event) => this.triggerEvent(evt)),
 
                      tap({


### PR DESCRIPTION
In the new behavior components are explicitly activated within Angular zone.
Since if some guard or resolver leaves Angular zone, then component will be
activated outside Angular zone. Therefore change detection will be broken,
because event listeners will be added outside Angular zone and will not
trigger change detection.

Closes #37223

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
## What is the current behavior?
Issue Number: #37223


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No