### PR TITLE
refactor(common): add generic type to async pipe

### DIFF
--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -11,15 +11,16 @@ import {Subscribable, Unsubscribable} from 'rxjs';
 
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
-interface SubscriptionStrategy<T> {
-  createSubscription(async: Subscribable<T>|Promise<T>, updateLatestValue: (value: T) => void):
-      Unsubscribable|Promise<void>;
-  dispose(subscription: Unsubscribable|Promise<void>): void;
-  onDestroy(subscription: Unsubscribable|Promise<void>): void;
+interface SubscriptionStrategy {
+  createSubscription(
+      async: Subscribable<Object>|Promise<Object>,
+      updateLatestValue: (value: Object) => void): Unsubscribable|Promise<void>;
+  dispose(subscription: Unsubscribable|Promise<any>): void;
+  onDestroy(subscription: Unsubscribable|Promise<any>): void;
 }
 
-class SubscribableStrategy<T> implements SubscriptionStrategy<T> {
-  createSubscription(async: Subscribable<T>, updateLatestValue: (value: T) => void):
+class SubscribableStrategy implements SubscriptionStrategy {
+  createSubscription(async: Subscribable<Object>, updateLatestValue: (value: Object) => void):
       Unsubscribable {
     return async.subscribe({
       next: updateLatestValue,
@@ -38,16 +39,17 @@ class SubscribableStrategy<T> implements SubscriptionStrategy<T> {
   }
 }
 
-class PromiseStrategy<T> implements SubscriptionStrategy<T> {
-  createSubscription(async: Promise<T>, updateLatestValue: (v: T) => void): Promise<void> {
+class PromiseStrategy implements SubscriptionStrategy {
+  createSubscription(async: Promise<Object>, updateLatestValue: (v: Object) => void):
+      Promise<void> {
     return async.then(updateLatestValue, e => {
       throw e;
     });
   }
 
-  dispose(subscription: Promise<any>): void {}
+  dispose(subscription: Promise<Object>): void {}
 
-  onDestroy(subscription: Promise<any>): void {}
+  onDestroy(subscription: Promise<Object>): void {}
 }
 
 const _promiseStrategy = new PromiseStrategy();
@@ -81,12 +83,12 @@ const _subscribableStrategy = new SubscribableStrategy();
  * @publicApi
  */
 @Pipe({name: 'async', pure: false})
-export class AsyncPipe<T> implements OnDestroy, PipeTransform {
-  private _latestValue: T|null = null;
+export class AsyncPipe implements OnDestroy, PipeTransform {
+  private _latestValue: any = null;
 
-  private _subscription: Unsubscribable|Promise<void>|null = null;
-  private _obj: Subscribable<T>|Promise<T>|EventEmitter<T>|null = null;
-  private _strategy: SubscriptionStrategy<T> = null!;
+  private _subscription: Unsubscribable|Promise<any>|null = null;
+  private _obj: Subscribable<any>|Promise<any>|EventEmitter<any>|null = null;
+  private _strategy: SubscriptionStrategy = null!;
 
   constructor(private _ref: ChangeDetectorRef) {}
 
@@ -96,10 +98,10 @@ export class AsyncPipe<T> implements OnDestroy, PipeTransform {
     }
   }
 
-  transform(obj: Subscribable<T>|Promise<T>): T|null;
-  transform(obj: null|undefined): null;
-  transform(obj: Subscribable<T>|Promise<T>|null|undefined): T|null;
-  transform(obj: Subscribable<T>|Promise<T>|null|undefined): T|null {
+  transform<T>(obj: Subscribable<T>|Promise<T>): T|null;
+  transform<T>(obj: null|undefined): null;
+  transform<T>(obj: Subscribable<T>|Promise<T>|null|undefined): T|null;
+  transform<T>(obj: Subscribable<T>|Promise<T>|null|undefined): T|null {
     if (!this._obj) {
       if (obj) {
         this._subscribe(obj);
@@ -115,14 +117,14 @@ export class AsyncPipe<T> implements OnDestroy, PipeTransform {
     return this._latestValue;
   }
 
-  private _subscribe(obj: Subscribable<T>|Promise<T>|EventEmitter<T>): void {
+  private _subscribe(obj: Subscribable<any>|Promise<any>|EventEmitter<any>): void {
     this._obj = obj;
     this._strategy = this._selectStrategy(obj);
-    this._subscription =
-        this._strategy.createSubscription(obj, (value) => this._updateLatestValue(obj, value));
+    this._subscription = this._strategy.createSubscription(
+        obj, (value: Object) => this._updateLatestValue(obj, value));
   }
 
-  private _selectStrategy(obj: Subscribable<T>|Promise<T>|EventEmitter<T>): any {
+  private _selectStrategy(obj: Subscribable<any>|Promise<any>|EventEmitter<any>): any {
     if (ɵisPromise(obj)) {
       return _promiseStrategy;
     }
@@ -141,7 +143,7 @@ export class AsyncPipe<T> implements OnDestroy, PipeTransform {
     this._obj = null;
   }
 
-  private _updateLatestValue(async: Subscribable<T>|Promise<T>|EventEmitter<T>, value: T): void {
+  private _updateLatestValue(async: any, value: Object): void {
     if (async === this._obj) {
       this._latestValue = value;
       this._ref.markForCheck();

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -32,7 +32,7 @@ import {SpyChangeDetectorRef} from '../spies';
 
       let emitter: EventEmitter<any>;
       let subscribable: Subscribable<any>;
-      let pipe: AsyncPipe<any>;
+      let pipe: AsyncPipe;
       let ref: any;
       const message = {};
 
@@ -129,9 +129,19 @@ import {SpyChangeDetectorRef} from '../spies';
       });
     });
 
+    describe('Subscribable', () => {
+      it('should infer the type from the subscribable', () => {
+        const ref = new SpyChangeDetectorRef() as any;
+        const pipe = new AsyncPipe(ref);
+        const emitter = new EventEmitter<{name: 'T'}>();
+        // The following line will fail to compile if the type cannot be inferred.
+        const name = pipe.transform(emitter)?.name;
+      });
+    });
+
     describe('Promise', () => {
       const message = {};
-      let pipe: AsyncPipe<any>;
+      let pipe: AsyncPipe;
       let resolve: (result: any) => void;
       let reject: (error: any) => void;
       let promise: Promise<any>;

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -32,7 +32,7 @@ import {SpyChangeDetectorRef} from '../spies';
 
       let emitter: EventEmitter<any>;
       let subscribable: Subscribable<any>;
-      let pipe: AsyncPipe;
+      let pipe: AsyncPipe<any>;
       let ref: any;
       const message = {};
 
@@ -129,19 +129,9 @@ import {SpyChangeDetectorRef} from '../spies';
       });
     });
 
-    describe('Subscribable', () => {
-      it('should infer the type from the subscribable', () => {
-        const ref = new SpyChangeDetectorRef() as any;
-        const pipe = new AsyncPipe(ref);
-        const emitter = new EventEmitter<{name: 'T'}>();
-        // The following line will fail to compile if the type cannot be inferred.
-        const name = pipe.transform(emitter)?.name;
-      });
-    });
-
     describe('Promise', () => {
       const message = {};
-      let pipe: AsyncPipe;
+      let pipe: AsyncPipe<any>;
       let resolve: (result: any) => void;
       let reject: (error: any) => void;
       let promise: Promise<any>;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
Type improvements

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

At first glance, the `SubscriptionStrategy` types were not obvious to me. Since `updateLatestValue` is always a function, I think it's better to show this explicitly. More than that now we can't return anything from `transform` or assign anything to `_latestValue`.


## What is the new behavior?
No breaking change, only types.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No