### PR TITLE
docs(aio): remove `Intl` references

### DIFF
--- a/aio/content/guide/browser-support.md
+++ b/aio/content/guide/browser-support.md
@@ -357,24 +357,6 @@ The following polyfills are used to test the framework itself. They are a good s
 
     <td>
 
-      <a id='intl' href="https://github.com/andyearnshaw/Intl.js">Intl</a>
-
-    </td>
-
-    <td>
-      MIT / Unicode license
-    </td>
-
-    <td>
-      13.5KB
-    </td>
-
-  </tr>
-
-  <tr>
-
-    <td>
-
        <a id='web-animations' href="https://github.com/web-animations/web-animations-js">Web Animations</a>
 
     </td>

--- a/packages/platform-browser/testing/src/browser_util.ts
+++ b/packages/platform-browser/testing/src/browser_util.ts
@@ -59,14 +59,6 @@ export class BrowserDetection {
     return this.isAndroid || this.isIE || this.isIOS7;
   }
 
-  // The Intl API is only natively supported in Chrome, Firefox, IE11 and Edge.
-  // This detector is needed in tests to make the difference between:
-  // 1) IE11/Edge: they have a native Intl API, but with some discrepancies
-  // 2) IE9/IE10: they use the polyfill, and so no discrepancies
-  get supportsNativeIntlApi(): boolean {
-    return !!(<any>global).Intl && (<any>global).Intl !== (<any>global).IntlPolyfill;
-  }
-
   get isChromeDesktop(): boolean {
     return this._ua.indexOf('Chrome') > -1 && this._ua.indexOf('Mobile Safari') == -1 &&
         this._ua.indexOf('Edge') == -1;


### PR DESCRIPTION
Since `Intl` API was dropped to use to improve browser support,
would be nice to remove the reference from `Suggested polyfills` as well.
