### PR TITLE
refactor(localize): avoid computing source-maps in extraction unnecesarily

### DIFF
--- a/packages/localize/src/tools/src/extract/extraction.ts
+++ b/packages/localize/src/tools/src/extract/extraction.ts
@@ -58,9 +58,9 @@ export class MessageExtractor {
         code: false,
         ast: false
       });
-    }
-    if (this.useSourceMaps) {
-      this.updateSourceLocations(filename, sourceCode, messages);
+      if (this.useSourceMaps && messages.length > 0) {
+        this.updateSourceLocations(filename, sourceCode, messages);
+      }
     }
     return messages;
   }


### PR DESCRIPTION
Previously we were calling `updateSourceLocations()` as part of
`extractMessages()` for every file that was passed in, regardless of
whether any `$localize` tagged strings were to be found in the file.

This was very wasteful because it is non-trivial to compute the flattened
source-map for files if it is not needed.
