### PR TITLE
refactor(core): make error messages in ApplicationRef class tree-shakable

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3033,
-        "main-es2015": 447894,
+        "main-es2015": 447322,
         "polyfills-es2015": 52493
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3153,
-        "main-es2015": 432647,
+        "main-es2015": 432024,
         "polyfills-es2015": 52493
       }
     }

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 140871,
+        "main-es2015": 139849,
         "polyfills-es2015": 36964
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 146680,
+        "main-es2015": 145812,
         "polyfills-es2015": 36964
       }
     }
@@ -30,7 +30,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 137236,
+        "main-es2015": 136484,
         "polyfills-es2015": 37641
       }
     }
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2285,
-        "main-es2015": 241843,
+        "main-es2015": 241138,
         "polyfills-es2015": 36709,
         "5-es2015": 745
       }
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2289,
-        "main-es2015": 217591,
+        "main-es2015": 216923,
         "polyfills-es2015": 36723,
         "5-es2015": 781
       }

--- a/packages/core/src/render3/error_code.ts
+++ b/packages/core/src/render3/error_code.ts
@@ -28,6 +28,15 @@ export const enum RuntimeErrorCode {
   UNKNOWN_BINDING = '303',
   UNKNOWN_ELEMENT = '304',
 
+  // Bootstrap Errors
+  MULTIPLE_PLATFORMS_NOT_ALLOWED = '400',
+  BOOTSTRAP_DECLARATION_MISSING = '401',
+  ERROR_HANDLER_MISSING = '402',
+  PLATFORM_MISSING = '403',
+  RECURSIVE_TICK_CALL = '404',
+  PLATFORM_ALREADY_DESTROYED = '405',
+  ASYNC_INITIALIZERS_NOT_COMPLETED = '406',
+
   // Styling Errors
 
   // Declarations Errors
@@ -38,7 +47,7 @@ export const enum RuntimeErrorCode {
 }
 
 export class RuntimeError extends Error {
-  constructor(public code: RuntimeErrorCode, message: string) {
+  constructor(public code: RuntimeErrorCode, message?: string) {
     super(formatRuntimeError(code, message));
   }
 }
@@ -57,10 +66,11 @@ export const RUNTIME_ERRORS_WITH_GUIDES = new Set([
 /* tslint:enable:no-toplevel-property-access */
 
 /** Called to format a runtime error */
-export function formatRuntimeError(code: RuntimeErrorCode, message: string): string {
-  const fullCode = code ? `NG0${code}: ` : '';
+export function formatRuntimeError(code: RuntimeErrorCode, message?: string): string {
+  const fullCode = code ? `NG0${code}` : '';
 
-  let errorMessage = `${fullCode}${message}`;
+  // If the message is not provided (or it's an empty string), just output the error code.
+  let errorMessage = message ? `${fullCode}: ${message}` : fullCode;
 
   // Some runtime errors are still thrown without `ngDevMode` (for example
   // `throwProviderNotFoundError`), so we add `ngDevMode` check here to avoid pulling

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -170,7 +170,7 @@ class SomeComponent {
         appRef.attachView(fixture.componentRef.hostView);
         appRef.tick();
         expect(fixture.componentInstance.reenterErr.message)
-            .toBe('ApplicationRef.tick is called recursively');
+            .toBe('NG0404: ApplicationRef.tick is called recursively');
       });
 
       describe('APP_BOOTSTRAP_LISTENER', () => {
@@ -208,7 +208,8 @@ class SomeComponent {
                  createRootEl();
                  expect(() => ref.bootstrap(SomeComponent))
                      .toThrowError(
-                         'Cannot bootstrap as there are still asynchronous initializers running. Bootstrap components in the `ngDoBootstrap` method of the root module.');
+                         'NG0406: Cannot bootstrap as there are still asynchronous initializers running. ' +
+                         'Bootstrap components in the `ngDoBootstrap` method of the root module.');
                })));
       });
     });
@@ -277,7 +278,8 @@ class SomeComponent {
            return defaultPlatform.bootstrapModule(EmptyModule)
                .then(() => fail('expecting error'), (error) => {
                  expect(error.message)
-                     .toEqual('No ErrorHandler. Is platform module (BrowserModule) included?');
+                     .toEqual(
+                         'NG0402: No ErrorHandler. Is platform module (BrowserModule) included?');
                });
          }));
 
@@ -303,8 +305,9 @@ class SomeComponent {
          waitForAsync(() => {
            defaultPlatform.bootstrapModule(createModule({ngDoBootstrap: false}))
                .then(() => expect(false).toBe(true), (e) => {
-                 const expectedErrMsg =
-                     `The module MyModule was bootstrapped, but it does not declare "@NgModule.bootstrap" components nor a "ngDoBootstrap" method. Please define one of these.`;
+                 const expectedErrMsg = `NG0401: The module MyModule was bootstrapped, ` +
+                     `but it does not declare "@NgModule.bootstrap" components nor a "ngDoBootstrap" method. ` +
+                     `Please define one of these.`;
                  expect(e.message).toEqual(expectedErrMsg);
                  expect(mockConsole.res[0].join('#')).toEqual('ERROR#Error: ' + expectedErrMsg);
                });


### PR DESCRIPTION
Currently ApplicationRef class contains some error messages that are relatively long. This PR makes use of
`ngDevMode` Ivy flag to make them tree-shakable in production bundles. There is no difference in behavior (all
errors are thrown) and the only change is that in prod only the error code would be present in error message.


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No