### PR TITLE
refactor(core): use RuntimeError to throw "provider not found" error

### DIFF
--- a/packages/core/src/di/inject_switch.ts
+++ b/packages/core/src/di/inject_switch.ts
@@ -7,6 +7,7 @@
  */
 
 import {AbstractType, Type} from '../interface/type';
+import {throwProviderNotFoundError} from '../render3/errors_di';
 import {assertNotEqual} from '../util/assert';
 import {stringify} from '../util/stringify';
 import {InjectionToken} from './injection_token';
@@ -62,7 +63,7 @@ export function injectRootLimpMode<T>(
   }
   if (flags & InjectFlags.Optional) return null;
   if (notFoundValue !== undefined) return notFoundValue;
-  throw new Error(`Injector: NOT_FOUND [${stringify(token)}]`);
+  throwProviderNotFoundError(stringify(token), 'Injector');
 }
 
 

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -48,6 +48,9 @@
     "name": "R3Injector"
   },
   {
+    "name": "RuntimeError"
+  },
+  {
     "name": "ScopedService"
   },
   {


### PR DESCRIPTION
This PR performs a small refactoring to use `RuntimeError` class and corresponding error code (by calling
`throwProviderNotFoundError` which formats the message) to make it more consistent with other places where
similar errors are thrown.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No