### PR TITLE
fix(common) keep location pathname if useHash=true

### DIFF
--- a/packages/common/src/location/platform_location.ts
+++ b/packages/common/src/location/platform_location.ts
@@ -155,9 +155,19 @@ export class BrowserPlatformLocation extends PlatformLocation {
     this.location.pathname = newPath;
   }
 
+  private prefixWithPathnameIfHashAndNotRootFolder(url: string): string {
+    if (url.startsWith('#')) {
+      const pathname = this.location.pathname;
+      if (pathname !== '/') {
+        return pathname + url;
+      }
+    }
+    return url;
+  }
+
   pushState(state: any, title: string, url: string): void {
     if (supportsState()) {
-      this._history.pushState(state, title, url);
+      this._history.pushState(state, title, this.prefixWithPathnameIfHashAndNotRootFolder(url));
     } else {
       this.location.hash = url;
     }
@@ -165,7 +175,7 @@ export class BrowserPlatformLocation extends PlatformLocation {
 
   replaceState(state: any, title: string, url: string): void {
     if (supportsState()) {
-      this._history.replaceState(state, title, url);
+      this._history.replaceState(state, title, this.prefixWithPathnameIfHashAndNotRootFolder(url));
     } else {
       this.location.hash = url;
     }


### PR DESCRIPTION
I am trying to run an angular application from a subfolder with HashLocationStrategy

For example, the site is http://app.example.com and the applications would be like 
- http://app.example.com/foo/
- http://app.example.com/bar/

What happens currently - the application is loaded and then it removes pathname part from the browser address bar. 

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently after opening http://app.example.com/foo/ the browser location becomes http://app.example.com/#/first

Issue Number: N/A

## What is the new behavior?
The browser location should stay as http://app.example.com/foo/#/first

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
