### PR TITLE
docs: the token should be associated with LibHeaderComponent

### DIFF
--- a/aio/content/guide/lightweight-injection-tokens.md
+++ b/aio/content/guide/lightweight-injection-tokens.md
@@ -152,7 +152,7 @@ abstract class LibHeaderToken {
 @Component({
   selector: 'lib-header',
   providers: [
-    {provide: LibHeaderToken, useExisting: LibHeader}
+    {provide: LibHeaderToken, useExisting: LibHeaderComponent}
   ]
   ...,
 })


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The lighweight token is associated with the wrong component (`LibHeader`).


## What is the new behavior?

The lighweight token is associated with the right component (`LibHeaderComponent`).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
