### PR TITLE
fix(compiler): ensure JIT compilation of ɵɵngDeclarePipe() works

### DIFF
--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -54,7 +54,8 @@ export class CompilerFacadeImpl implements CompilerFacade {
       angularCoreEnv: CoreEnvironment, sourceMapUrl: string,
       declaration: R3DeclarePipeFacade): any {
     const meta = convertDeclarePipeFacadeToMetadata(declaration);
-    return compilePipeFromMetadata(meta);
+    const res = compilePipeFromMetadata(meta);
+    return this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, []);
   }
 
   compileInjectable(

--- a/packages/core/test/render3/jit/declare_pipe_spec.ts
+++ b/packages/core/test/render3/jit/declare_pipe_spec.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ɵɵngDeclarePipe} from '@angular/core';
+import {PipeDef} from '../../../src/render3';
+
+describe('Pipe declaration jit compilation', () => {
+  it('should compile a named Pipe declaration', () => {
+    const def = ɵɵngDeclarePipe({type: TestClass, name: 'foo'}) as PipeDef<TestClass>;
+
+    expect(def.type).toBe(TestClass);
+    expect(def.name).toEqual('foo');
+    expect(def.pure).toEqual(true);
+  });
+
+  it('should compile an impure Pipe declaration', () => {
+    const def = ɵɵngDeclarePipe({type: TestClass, name: 'foo', pure: false}) as PipeDef<TestClass>;
+
+    expect(def.type).toBe(TestClass);
+    expect(def.name).toEqual('foo');
+    expect(def.pure).toEqual(false);
+  });
+});
+
+class TestClass {}


### PR DESCRIPTION
Previously the compiler was not evaluating the JIT compilation
of `ɵɵngDeclarePipe()` but there was no test to check it.
