### PR TITLE
test(localize): fix integration test failures on windows

### DIFF
--- a/packages/localize/src/tools/src/translate/output_path.ts
+++ b/packages/localize/src/tools/src/translate/output_path.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AbsoluteFsPath} from '@angular/compiler-cli/src/ngtsc/file_system';
-import {join} from 'path';
+import {posix} from 'path';
 
 /**
  * A function that will return an absolute path to where a file is to be written, given a locale and
@@ -25,6 +25,7 @@ export interface OutputPathFn {
  */
 export function getOutputPathFn(outputFolder: AbsoluteFsPath): OutputPathFn {
   const [pre, post] = outputFolder.split('{{LOCALE}}');
-  return post === undefined ? (_locale, relativePath) => join(pre, relativePath) :
-                              (locale, relativePath) => join(pre + locale + post, relativePath);
+  return post === undefined ?
+      (_locale, relativePath) => posix.join(pre, relativePath) :
+      (locale, relativePath) => posix.join(pre + locale + post, relativePath);
 }

--- a/packages/localize/src/tools/test/extract/extractor_spec.ts
+++ b/packages/localize/src/tools/test/extract/extractor_spec.ts
@@ -40,19 +40,19 @@ runInEachFileSystem(() => {
           {
             start: {line: 0, column: 10},
             end: {line: 0, column: 32},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: ':meaning|description:a',
           },
           {
             start: {line: 0, column: 36},
             end: {line: 0, column: 37},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: 'b',
           },
           {
             start: {line: 0, column: 41},
             end: {line: 0, column: 42},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: 'c',
           }
         ],
@@ -63,13 +63,13 @@ runInEachFileSystem(() => {
           PH: {
             start: {line: 0, column: 34},
             end: {line: 0, column: 35},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: '1'
           },
           PH_1: {
             start: {line: 0, column: 39},
             end: {line: 0, column: 40},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: '2'
           }
         },
@@ -77,7 +77,7 @@ runInEachFileSystem(() => {
         location: {
           start: {line: 0, column: 9},
           end: {line: 0, column: 43},
-          file,
+          file: jasmine.stringMatching(/relative\/path\.js$/),
           text: '`:meaning|description:a${1}b${2}c`',
         },
       });
@@ -92,19 +92,19 @@ runInEachFileSystem(() => {
           {
             start: {line: 1, column: 69},
             end: {line: 1, column: 72},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: '"a"',
           },
           {
             start: {line: 1, column: 74},
             end: {line: 1, column: 97},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: '":custom-placeholder:b"',
           },
           {
             start: {line: 1, column: 99},
             end: {line: 1, column: 102},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: '"c"',
           }
         ],
@@ -115,13 +115,13 @@ runInEachFileSystem(() => {
           'custom-placeholder': {
             start: {line: 1, column: 106},
             end: {line: 1, column: 107},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: '1'
           },
           PH_1: {
             start: {line: 1, column: 109},
             end: {line: 1, column: 110},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: '2'
           }
         },
@@ -129,7 +129,7 @@ runInEachFileSystem(() => {
         location: {
           start: {line: 1, column: 10},
           end: {line: 1, column: 107},
-          file,
+          file: jasmine.stringMatching(/relative\/path\.js$/),
           text:
               '__makeTemplateObject(["a", ":custom-placeholder:b", "c"], ["a", ":custom-placeholder:b", "c"])',
         },
@@ -148,13 +148,13 @@ runInEachFileSystem(() => {
           PH: {
             start: {line: 2, column: 26},
             end: {line: 2, column: 27},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: '1'
           },
           PH_1: {
             start: {line: 2, column: 31},
             end: {line: 2, column: 32},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: '2'
           }
         },
@@ -162,19 +162,19 @@ runInEachFileSystem(() => {
           {
             start: {line: 2, column: 10},
             end: {line: 2, column: 24},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: ':@@custom-id:a'
           },
           {
             start: {line: 2, column: 28},
             end: {line: 2, column: 29},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: 'b'
           },
           {
             start: {line: 2, column: 33},
             end: {line: 2, column: 34},
-            file: absoluteFrom('/root/path/relative/path.js'),
+            file: jasmine.stringMatching(/relative\/path\.js$/),
             text: 'c'
           }
         ],
@@ -182,7 +182,7 @@ runInEachFileSystem(() => {
         location: {
           start: {line: 2, column: 9},
           end: {line: 2, column: 35},
-          file,
+          file: jasmine.stringMatching(/relative\/path\.js$/),
           text: '`:@@custom-id:a${1}b${2}c`'
         },
       });

--- a/packages/localize/src/tools/test/extract/integration/main_spec.ts
+++ b/packages/localize/src/tools/test/extract/integration/main_spec.ts
@@ -103,14 +103,14 @@ runInEachFileSystem(() => {
             duplicateMessageHandling: 'ignore',
             fileSystem: fs,
           });
-          expect(fs.readFile(outputPath)).toEqual([
+          expect(fs.readFile(outputPath).split('\n')).toEqual([
             '{',
             '  "@@locale": "en-GB",',
             '  "3291030485717846467": "Hello, {$PH}!",',
             '  "@3291030485717846467": {',
             '    "x-locations": [',
             '      {',
-            '        "file": "test_files/test.js",',
+            jasmine.stringMatching(/"file": ".*test\.js",/),
             '        "start": { "line": "1", "column": "23" },',
             '        "end": { "line": "1", "column": "40" }',
             '      }',
@@ -120,7 +120,7 @@ runInEachFileSystem(() => {
             '  "@8669027859022295761": {',
             '    "x-locations": [',
             '      {',
-            '        "file": "test_files/test.js",',
+            jasmine.stringMatching(/"file": ".*test\.js",/),
             '        "start": { "line": "2", "column": "22" },',
             '        "end": { "line": "2", "column": "80" }',
             '      }',
@@ -130,7 +130,7 @@ runInEachFileSystem(() => {
             '  "@custom-id": {',
             '    "x-locations": [',
             '      {',
-            '        "file": "test_files/test.js",',
+            jasmine.stringMatching(/"file": ".*test\.js",/),
             '        "start": { "line": "3", "column": "29" },',
             '        "end": { "line": "3", "column": "61" }',
             '      }',
@@ -140,7 +140,7 @@ runInEachFileSystem(() => {
             '  "@273296103957933077": {',
             '    "x-locations": [',
             '      {',
-            '        "file": "test_files/test.js",',
+            jasmine.stringMatching(/"file": ".*test\.js",/),
             '        "start": { "line": "5", "column": "13" },',
             '        "end": { "line": "5", "column": "96" }',
             '      }',
@@ -150,7 +150,7 @@ runInEachFileSystem(() => {
             '  "@custom-id-2": {',
             '    "x-locations": [',
             '      {',
-            '        "file": "test_files/test.js",',
+            jasmine.stringMatching(/"file": ".*test\.js",/),
             '        "start": { "line": "7", "column": "13" },',
             '        "end": { "line": "7", "column": "117" }',
             '      }',
@@ -160,14 +160,14 @@ runInEachFileSystem(() => {
             '  "@2932901491976224757": {',
             '    "x-locations": [',
             '      {',
-            '        "file": "test_files/test.js",',
+            jasmine.stringMatching(/"file": ".*test\.js",/),
             '        "start": { "line": "8", "column": "26" },',
             '        "end": { "line": "9", "column": "93" }',
             '      }',
             '    ]',
             '  }',
             '}',
-          ].join('\n'));
+          ]);
         });
 
         it('should extract translations from source code, and write as xmb format', () => {
@@ -183,7 +183,7 @@ runInEachFileSystem(() => {
             duplicateMessageHandling: 'ignore',
             fileSystem: fs,
           });
-          expect(fs.readFile(outputPath)).toEqual([
+          expect(fs.readFile(outputPath).split('\n')).toEqual([
             `<?xml version="1.0" encoding="UTF-8" ?>`,
             `<!DOCTYPE messagebundle [`,
             `<!ELEMENT messagebundle (msg)*>`,
@@ -207,18 +207,24 @@ runInEachFileSystem(() => {
             `<!ELEMENT ex (#PCDATA)>`,
             `]>`,
             `<messagebundle>`,
-            `  <msg id="3291030485717846467"><source>test_files/test.js:1</source>Hello, <ph name="PH"/>!</msg>`,
-            `  <msg id="8669027859022295761"><source>test_files/test.js:2</source>try<ph name="PH"/>me</msg>`,
-            `  <msg id="custom-id"><source>test_files/test.js:3</source>Custom id message</msg>`,
-            `  <msg id="${
+            jasmine.stringMatching(
+                /<msg id="3291030485717846467"><source>.*test\.js:1<\/source>Hello, <ph name="PH"\/>!<\/msg>/),
+            jasmine.stringMatching(
+                /<msg id="8669027859022295761"><source>.*test\.js:2<\/source>try<ph name="PH"\/>me<\/msg>/),
+            jasmine.stringMatching(
+                /<msg id="custom-id"><source>.*test\.js:3<\/source>Custom id message<\/msg>/),
+            jasmine.stringMatching(new RegExp(`  <msg id="${
                 useLegacyIds ?
                     '12345678901234567890' :
-                    '273296103957933077'}"><source>test_files/test.js:5</source>Legacy id message</msg>`,
-            `  <msg id="custom-id-2"><source>test_files/test.js:7</source>Custom and legacy message</msg>`,
-            `  <msg id="2932901491976224757"><source>test_files/test.js:8,10</source>pre<ph name="START_TAG_SPAN"/>` +
-                `inner-pre<ph name="START_BOLD_TEXT"/>bold<ph name="CLOSE_BOLD_TEXT"/>inner-post<ph name="CLOSE_TAG_SPAN"/>post</msg>`,
-            `</messagebundle>\n`,
-          ].join('\n'));
+                    '273296103957933077'}"><source>.*test\\.js:5<\\/source>Legacy id message<\\/msg>`)),
+            jasmine.stringMatching(
+                /<msg id="custom-id-2"><source>.*test\.js:7<\/source>Custom and legacy message<\/msg>/),
+            jasmine.stringMatching(new RegExp(
+                `<msg id="2932901491976224757"><source>.*test.js:8,10<\\/source>pre<ph name="START_TAG_SPAN"\\/>` +
+                `inner-pre<ph name="START_BOLD_TEXT"\\/>bold<ph name="CLOSE_BOLD_TEXT"\\/>inner-post<ph name="CLOSE_TAG_SPAN"\\/>post</msg>`)),
+            `</messagebundle>`,
+            ''
+          ]);
         });
 
         for (const formatOptions of [{}, {'xml:space': 'preserve'}] as FormatOptions[]) {
@@ -238,7 +244,7 @@ runInEachFileSystem(() => {
                  formatOptions,
                  fileSystem: fs,
                });
-               expect(fs.readFile(outputPath)).toEqual([
+               expect(fs.readFile(outputPath).split('\n')).toEqual([
                  `<?xml version="1.0" encoding="UTF-8" ?>`,
                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
                  `  <file source-language="en-CA" datatype="plaintext" original="ng2.template"${
@@ -247,21 +253,21 @@ runInEachFileSystem(() => {
                  `      <trans-unit id="3291030485717846467" datatype="html">`,
                  `        <source>Hello, <x id="PH" equiv-text="name"/>!</source>`,
                  `        <context-group purpose="location">`,
-                 `          <context context-type="sourcefile">test_files/test.js</context>`,
+                 jasmine.stringMatching(/<context context-type="sourcefile">.*test\.js<\/context>/),
                  `          <context context-type="linenumber">2</context>`,
                  `        </context-group>`,
                  `      </trans-unit>`,
                  `      <trans-unit id="8669027859022295761" datatype="html">`,
                  `        <source>try<x id="PH" equiv-text="40 + 2"/>me</source>`,
                  `        <context-group purpose="location">`,
-                 `          <context context-type="sourcefile">test_files/test.js</context>`,
+                 jasmine.stringMatching(/<context context-type="sourcefile">.*test\.js<\/context>/),
                  `          <context context-type="linenumber">3</context>`,
                  `        </context-group>`,
                  `      </trans-unit>`,
                  `      <trans-unit id="custom-id" datatype="html">`,
                  `        <source>Custom id message</source>`,
                  `        <context-group purpose="location">`,
-                 `          <context context-type="sourcefile">test_files/test.js</context>`,
+                 jasmine.stringMatching(/<context context-type="sourcefile">.*test\.js<\/context>/),
                  `          <context context-type="linenumber">4</context>`,
                  `        </context-group>`,
                  `      </trans-unit>`,
@@ -270,14 +276,14 @@ runInEachFileSystem(() => {
                                     '273296103957933077'}" datatype="html">`,
                  `        <source>Legacy id message</source>`,
                  `        <context-group purpose="location">`,
-                 `          <context context-type="sourcefile">test_files/test.js</context>`,
+                 jasmine.stringMatching(/<context context-type="sourcefile">.*test\.js<\/context>/),
                  `          <context context-type="linenumber">6</context>`,
                  `        </context-group>`,
                  `      </trans-unit>`,
                  `      <trans-unit id="custom-id-2" datatype="html">`,
                  `        <source>Custom and legacy message</source>`,
                  `        <context-group purpose="location">`,
-                 `          <context context-type="sourcefile">test_files/test.js</context>`,
+                 jasmine.stringMatching(/<context context-type="sourcefile">.*test\.js<\/context>/),
                  `          <context context-type="linenumber">8</context>`,
                  `        </context-group>`,
                  `      </trans-unit>`,
@@ -286,14 +292,15 @@ runInEachFileSystem(() => {
                      `inner-pre<x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&apos;&lt;b&gt;&apos;"/>bold<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&apos;&lt;/b&gt;&apos;"/>` +
                      `inner-post<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&apos;&lt;/span&gt;&apos;"/>post</source>`,
                  `        <context-group purpose="location">`,
-                 `          <context context-type="sourcefile">test_files/test.js</context>`,
+                 jasmine.stringMatching(/<context context-type="sourcefile">.*test\.js<\/context>/),
                  `          <context context-type="linenumber">9,10</context>`,
                  `        </context-group>`,
                  `      </trans-unit>`,
                  `    </body>`,
                  `  </file>`,
-                 `</xliff>\n`,
-               ].join('\n'));
+                 `</xliff>`,
+                 ''
+               ]);
              });
 
           it('should extract translations from source code, and write as XLIFF 2 format', () => {
@@ -310,13 +317,13 @@ runInEachFileSystem(() => {
               formatOptions,
               fileSystem: fs,
             });
-            expect(fs.readFile(outputPath)).toEqual([
+            expect(fs.readFile(outputPath).split('\n')).toEqual([
               `<?xml version="1.0" encoding="UTF-8" ?>`,
               `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-AU">`,
               `  <file id="ngi18n" original="ng.template"${toAttributes(formatOptions)}>`,
               `    <unit id="3291030485717846467">`,
               `      <notes>`,
-              `        <note category="location">test_files/test.js:2</note>`,
+              jasmine.stringMatching(/<note category="location">.*test\.js:2<\/note>/),
               `      </notes>`,
               `      <segment>`,
               `        <source>Hello, <ph id="0" equiv="PH" disp="name"/>!</source>`,
@@ -324,7 +331,7 @@ runInEachFileSystem(() => {
               `    </unit>`,
               `    <unit id="8669027859022295761">`,
               `      <notes>`,
-              `        <note category="location">test_files/test.js:3</note>`,
+              jasmine.stringMatching(/<note category="location">.*test\.js:3<\/note>/),
               `      </notes>`,
               `      <segment>`,
               `        <source>try<ph id="0" equiv="PH" disp="40 + 2"/>me</source>`,
@@ -332,7 +339,7 @@ runInEachFileSystem(() => {
               `    </unit>`,
               `    <unit id="custom-id">`,
               `      <notes>`,
-              `        <note category="location">test_files/test.js:4</note>`,
+              jasmine.stringMatching(/<note category="location">.*test\.js:4<\/note>/),
               `      </notes>`,
               `      <segment>`,
               `        <source>Custom id message</source>`,
@@ -340,7 +347,7 @@ runInEachFileSystem(() => {
               `    </unit>`,
               `    <unit id="${useLegacyIds ? '12345678901234567890' : '273296103957933077'}">`,
               `      <notes>`,
-              `        <note category="location">test_files/test.js:6</note>`,
+              jasmine.stringMatching(/<note category="location">.*test\.js:6<\/note>/),
               `      </notes>`,
               `      <segment>`,
               `        <source>Legacy id message</source>`,
@@ -348,7 +355,7 @@ runInEachFileSystem(() => {
               `    </unit>`,
               `    <unit id="custom-id-2">`,
               `      <notes>`,
-              `        <note category="location">test_files/test.js:8</note>`,
+              jasmine.stringMatching(/<note category="location">.*test\.js:8<\/note>/),
               `      </notes>`,
               `      <segment>`,
               `        <source>Custom and legacy message</source>`,
@@ -356,7 +363,7 @@ runInEachFileSystem(() => {
               `    </unit>`,
               `    <unit id="2932901491976224757">`,
               `      <notes>`,
-              `        <note category="location">test_files/test.js:9,10</note>`,
+              jasmine.stringMatching(/<note category="location">.*test\.js:9,10<\/note>/),
               `      </notes>`,
               `      <segment>`,
               `        <source>pre<pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN" type="other" dispStart="&apos;&lt;span&gt;&apos;" dispEnd="&apos;&lt;/span&gt;&apos;">` +
@@ -365,8 +372,9 @@ runInEachFileSystem(() => {
               `      </segment>`,
               `    </unit>`,
               `  </file>`,
-              `</xliff>\n`,
-            ].join('\n'));
+              `</xliff>`,
+              ''
+            ]);
           });
         }
       });
@@ -430,12 +438,12 @@ runInEachFileSystem(() => {
                  duplicateMessageHandling: 'error',
                  fileSystem: fs,
                }))
-            .toThrowError(
+            .toThrowError(new RegExp(
                 `Failed to extract messages\n` +
                 `ERRORS:\n` +
                 ` - Duplicate messages with id "message-2":\n` +
-                `   - "message contents" : test_files/duplicate.js:6\n` +
-                `   - "different message contents" : test_files/duplicate.js:7`);
+                `   - "message contents" : .*duplicate.js:6\n` +
+                `   - "different message contents" : .*duplicate.js:7`));
         expect(fs.exists(outputPath)).toBe(false);
       });
 
@@ -452,13 +460,12 @@ runInEachFileSystem(() => {
           duplicateMessageHandling: 'warning',
           fileSystem: fs,
         });
-        expect(logger.logs.warn).toEqual([
-          ['Messages extracted with warnings\n' +
-           `WARNINGS:\n` +
-           ` - Duplicate messages with id "message-2":\n` +
-           `   - "message contents" : test_files/duplicate.js:6\n` +
-           `   - "different message contents" : test_files/duplicate.js:7`]
-        ]);
+        expect(logger.logs.warn).toEqual([[jasmine.stringMatching(new RegExp(
+            'Messages extracted with warnings\n' +
+            `WARNINGS:\n` +
+            ` - Duplicate messages with id "message-2":\n` +
+            `   - "message contents" : .*duplicate.js:6\n` +
+            `   - "different message contents" : .*duplicate.js:7`))]]);
         expect(fs.readFile(outputPath)).toEqual([
           `{`,
           `  "locale": "en-GB",`,

--- a/packages/localize/src/tools/test/extract/integration/test_files/BUILD.bazel
+++ b/packages/localize/src/tools/test/extract/integration/test_files/BUILD.bazel
@@ -1,6 +1,7 @@
 package(default_visibility = ["//packages/localize/src/tools/test/extract/integration:__pkg__"])
 
 load("@npm//typescript:index.bzl", "tsc")
+load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin")
 
 tsc(
     name = "compile_es5",
@@ -44,7 +45,8 @@ tsc(
     data = glob(["src/*.ts"]),
 )
 
-filegroup(
+# Use copy_to_bin since filegroup doesn't seem to work on Windows.
+copy_to_bin(
     name = "test_files",
     srcs = glob([
         "**/*.js",

--- a/packages/localize/src/tools/test/extract/source_files/es5_extract_plugin_spec.ts
+++ b/packages/localize/src/tools/test/extract/source_files/es5_extract_plugin_spec.ts
@@ -18,9 +18,18 @@ runInEachFileSystem(() => {
     it('should error with code-frame information if the first argument to `$localize` is not an array',
        () => {
          const input = '$localize(null, [])';
-         expect(() => transformCode(input))
-             .toThrowError(
-                 'Cannot create property \'message\' on string \'/app/dist/test.js: Unexpected messageParts for `$localize` (expected an array of strings).\n' +
+         let errorMessage: string|undefined;
+
+         try {
+           transformCode(input);
+         } catch (e) {
+           errorMessage = e.message;
+         }
+
+         expect(errorMessage).toMatch(/^Cannot create property 'message' on string '.*test\.js/);
+         expect(errorMessage)
+             .toContain(
+                 'Unexpected messageParts for `$localize` (expected an array of strings).\n' +
                  '> 1 | $localize(null, [])\n' +
                  '    |           ^^^^\'');
        });

--- a/packages/localize/src/tools/test/source_file_utils_spec.ts
+++ b/packages/localize/src/tools/test/source_file_utils_spec.ts
@@ -85,19 +85,19 @@ runInEachFileSystem(() => {
              {
                start: {line: 0, column: 11},
                end: {line: 0, column: 14},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'a'`,
              },
              {
                start: {line: 0, column: 16},
                end: {line: 0, column: 21},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'b\\t'`,
              },
              {
                start: {line: 0, column: 23},
                end: {line: 0, column: 26},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'c'`,
              },
            ]);
@@ -114,19 +114,19 @@ runInEachFileSystem(() => {
              {
                start: {line: 0, column: 51},
                end: {line: 0, column: 54},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'a'`,
              },
              {
                start: {line: 0, column: 56},
                end: {line: 0, column: 62},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'b\\\\t'`,
              },
              {
                start: {line: 0, column: 64},
                end: {line: 0, column: 67},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'c'`,
              },
            ]);
@@ -143,19 +143,19 @@ runInEachFileSystem(() => {
              {
                start: {line: 0, column: 65},
                end: {line: 0, column: 68},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'a'`,
              },
              {
                start: {line: 0, column: 70},
                end: {line: 0, column: 76},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'b\\\\t'`,
              },
              {
                start: {line: 0, column: 78},
                end: {line: 0, column: 81},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'c'`,
              },
            ]);
@@ -173,19 +173,19 @@ runInEachFileSystem(() => {
              {
                start: {line: 2, column: 105},
                end: {line: 2, column: 108},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'a'`,
              },
              {
                start: {line: 2, column: 110},
                end: {line: 2, column: 116},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'b\\\\t'`,
              },
              {
                start: {line: 2, column: 118},
                end: {line: 2, column: 121},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'c'`,
              },
            ]);
@@ -212,19 +212,19 @@ runInEachFileSystem(() => {
              {
                start: {line: 4, column: 21},
                end: {line: 4, column: 24},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `"a"`,
              },
              {
                start: {line: 4, column: 25},
                end: {line: 4, column: 29},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `"b\t"`,
              },
              {
                start: {line: 4, column: 30},
                end: {line: 4, column: 33},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `"c"`,
              },
            ]);
@@ -245,19 +245,19 @@ runInEachFileSystem(() => {
              {
                start: {line: 2, column: 61},
                end: {line: 2, column: 64},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'a'`,
              },
              {
                start: {line: 2, column: 66},
                end: {line: 2, column: 72},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'b\\\\t'`,
              },
              {
                start: {line: 2, column: 74},
                end: {line: 2, column: 77},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: `'c'`,
              },
            ]);
@@ -289,13 +289,13 @@ runInEachFileSystem(() => {
              {
                start: {line: 0, column: 28},
                end: {line: 0, column: 29},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: '1'
              },
              {
                start: {line: 0, column: 31},
                end: {line: 0, column: 32},
-               file: absoluteFrom('/test/file.js'),
+               file: jasmine.stringMatching(/test\/file\.js/),
                text: '2'
              },
            ]);
@@ -310,13 +310,13 @@ runInEachFileSystem(() => {
           {
             start: {line: 0, column: 66},
             end: {line: 0, column: 67},
-            file: absoluteFrom('/test/file.js'),
+            file: jasmine.stringMatching(/test\/file\.js/),
             text: '1'
           },
           {
             start: {line: 0, column: 69},
             end: {line: 0, column: 70},
-            file: absoluteFrom('/test/file.js'),
+            file: jasmine.stringMatching(/test\/file\.js/),
             text: '2'
           },
         ]);
@@ -355,19 +355,19 @@ runInEachFileSystem(() => {
           {
             start: {line: 0, column: 1},
             end: {line: 0, column: 4},
-            file: absoluteFrom('/test/file.js'),
+            file: jasmine.stringMatching(/test\/file\.js/),
             text: `'a'`,
           },
           {
             start: {line: 0, column: 6},
             end: {line: 0, column: 9},
-            file: absoluteFrom('/test/file.js'),
+            file: jasmine.stringMatching(/test\/file\.js/),
             text: `'b'`,
           },
           {
             start: {line: 0, column: 11},
             end: {line: 0, column: 14},
-            file: absoluteFrom('/test/file.js'),
+            file: jasmine.stringMatching(/test\/file\.js/),
             text: `'c'`,
           },
         ]);
@@ -422,7 +422,7 @@ runInEachFileSystem(() => {
         expect(location.start.constructor.name).toEqual('Object');
         expect(location.end).toEqual({line: 0, column: 29});
         expect(location.end?.constructor.name).toEqual('Object');
-        expect(location.file).toEqual(absoluteFrom('/root/src/test.js'));
+        expect(location.file).toMatch(/src\/test\.js/);
       });
 
       it('should return `undefined` if the NodePath has no filename', () => {

--- a/packages/localize/src/tools/test/translate/source_files/es5_translate_plugin_spec.ts
+++ b/packages/localize/src/tools/test/translate/source_files/es5_translate_plugin_spec.ts
@@ -140,9 +140,10 @@ runInEachFileSystem(() => {
            const diagnostics = new Diagnostics();
            transformCode(input, {}, {}, diagnostics);
            expect(diagnostics.hasErrors).toBe(true);
-           expect(diagnostics.messages[0]).toEqual({
-             type: 'error',
-             message: '/app/dist/test.js: `$localize` called without any arguments.\n' +
+           expect(diagnostics.messages[0].type).toBe('error');
+           expect(parseDiagnosticMessage(diagnostics.messages[0].message)).toEqual({
+             path: jasmine.stringMatching(/test\.js$/),
+             message: '`$localize` called without any arguments.\n' +
                  '> 1 | $localize()\n' +
                  '    | ^^^^^^^^^^^',
            });
@@ -154,10 +155,10 @@ runInEachFileSystem(() => {
            const diagnostics = new Diagnostics();
            transformCode(input, {}, {}, diagnostics);
            expect(diagnostics.hasErrors).toBe(true);
-           expect(diagnostics.messages[0]).toEqual({
-             type: 'error',
-             message:
-                 '/app/dist/test.js: Unexpected argument to `$localize` (expected an array).\n' +
+           expect(diagnostics.messages[0].type).toBe('error');
+           expect(parseDiagnosticMessage(diagnostics.messages[0].message)).toEqual({
+             path: jasmine.stringMatching(/test\.js$/),
+             message: 'Unexpected argument to `$localize` (expected an array).\n' +
                  '> 1 | $localize(...x)\n' +
                  '    |           ^^^^',
            });
@@ -169,10 +170,10 @@ runInEachFileSystem(() => {
            const diagnostics = new Diagnostics();
            transformCode(input, {}, {}, diagnostics);
            expect(diagnostics.hasErrors).toBe(true);
-           expect(diagnostics.messages[0]).toEqual({
-             type: 'error',
-             message:
-                 '/app/dist/test.js: Unexpected messageParts for `$localize` (expected an array of strings).\n' +
+           expect(diagnostics.messages[0].type).toBe('error');
+           expect(parseDiagnosticMessage(diagnostics.messages[0].message)).toEqual({
+             path: jasmine.stringMatching(/test\.js$/),
+             message: 'Unexpected messageParts for `$localize` (expected an array of strings).\n' +
                  '> 1 | $localize(null, [])\n' +
                  '    |           ^^^^',
            });
@@ -184,10 +185,11 @@ runInEachFileSystem(() => {
            const diagnostics = new Diagnostics();
            transformCode(input, {}, {}, diagnostics);
            expect(diagnostics.hasErrors).toBe(true);
-           expect(diagnostics.messages[0]).toEqual({
-             type: 'error',
+           expect(diagnostics.messages[0].type).toBe('error');
+           expect(parseDiagnosticMessage(diagnostics.messages[0].message)).toEqual({
+             path: jasmine.stringMatching(/test\.js$/),
              message:
-                 '/app/dist/test.js: Unexpected `raw` argument to the "makeTemplateObject()" function (expected an expression).\n' +
+                 'Unexpected `raw` argument to the "makeTemplateObject()" function (expected an expression).\n' +
                  '> 1 | $localize(__makeTemplateObject([], ...[]))\n' +
                  '    |                                    ^^^^^',
            });
@@ -199,10 +201,11 @@ runInEachFileSystem(() => {
            const diagnostics = new Diagnostics();
            transformCode(input, {}, {}, diagnostics);
            expect(diagnostics.hasErrors).toBe(true);
-           expect(diagnostics.messages[0]).toEqual({
-             type: 'error',
+           expect(diagnostics.messages[0].type).toBe('error');
+           expect(parseDiagnosticMessage(diagnostics.messages[0].message)).toEqual({
+             path: jasmine.stringMatching(/test\.js$/),
              message:
-                 '/app/dist/test.js: Unexpected `cooked` argument to the "makeTemplateObject()" function (expected an expression).\n' +
+                 'Unexpected `cooked` argument to the "makeTemplateObject()" function (expected an expression).\n' +
                  '> 1 | $localize(__makeTemplateObject(...[], []))\n' +
                  '    |                                ^^^^^',
            });
@@ -214,10 +217,10 @@ runInEachFileSystem(() => {
            const diagnostics = new Diagnostics();
            transformCode(input, {}, {}, diagnostics);
            expect(diagnostics.hasErrors).toBe(true);
-           expect(diagnostics.messages[0]).toEqual({
-             type: 'error',
-             message:
-                 '/app/dist/test.js: Unexpected messageParts for `$localize` (expected an array of strings).\n' +
+           expect(diagnostics.messages[0].type).toBe('error');
+           expect(parseDiagnosticMessage(diagnostics.messages[0].message)).toEqual({
+             path: jasmine.stringMatching(/test\.js$/),
+             message: 'Unexpected messageParts for `$localize` (expected an array of strings).\n' +
                  '> 1 | $localize(__makeTemplateObject(["a", 12, "b"], ["a", "12", "b"]))\n' +
                  '    |                                ^^^^^^^^^^^^^^',
            });
@@ -229,10 +232,10 @@ runInEachFileSystem(() => {
            const diagnostics = new Diagnostics();
            transformCode(input, {}, {}, diagnostics);
            expect(diagnostics.hasErrors).toBe(true);
-           expect(diagnostics.messages[0]).toEqual({
-             type: 'error',
-             message:
-                 '/app/dist/test.js: Unexpected messageParts for `$localize` (expected an array of strings).\n' +
+           expect(diagnostics.messages[0].type).toBe('error');
+           expect(parseDiagnosticMessage(diagnostics.messages[0].message)).toEqual({
+             path: jasmine.stringMatching(/test\.js$/),
+             message: 'Unexpected messageParts for `$localize` (expected an array of strings).\n' +
                  '> 1 | $localize(__makeTemplateObject(["a", "12", "b"], ["a", 12, "b"]))\n' +
                  '    |                                                  ^^^^^^^^^^^^^^',
            });
@@ -244,10 +247,11 @@ runInEachFileSystem(() => {
            const diagnostics = new Diagnostics();
            transformCode(input, {}, {}, diagnostics);
            expect(diagnostics.hasErrors).toBe(true);
-           expect(diagnostics.messages[0]).toEqual({
-             type: 'error',
+           expect(diagnostics.messages[0].type).toBe('error');
+           expect(parseDiagnosticMessage(diagnostics.messages[0].message)).toEqual({
+             path: jasmine.stringMatching(/test\.js$/),
              message:
-                 '/app/dist/test.js: Invalid substitutions for `$localize` (expected all substitution arguments to be expressions).\n' +
+                 'Invalid substitutions for `$localize` (expected all substitution arguments to be expressions).\n' +
                  '> 1 | $localize(__makeTemplateObject(["a", "b"], ["a", "b"]), ...[])\n' +
                  '    |                                                         ^^^^^',
            });
@@ -365,5 +369,14 @@ runInEachFileSystem(() => {
              plugins: [makeEs5TranslatePlugin(diagnostics, translations, pluginOptions)],
              filename: '/app/dist/test.js'
            })!.code!;
+  }
+
+  function parseDiagnosticMessage(message: string) {
+    const separator = ': ';
+    const separatorIndex = message.indexOf(': ');
+    return {
+      path: message.slice(0, separatorIndex),
+      message: message.slice(separatorIndex + separator.length)
+    };
   }
 });


### PR DESCRIPTION
Resolves the following issues which prevented the `localize` integration tests from passing on a Windows machine:
* The `file_group` that's supposed to copy some files into the testing directory wasn't working on Windows. I've changed it to use `copy_to_bin` instead.
* A bunch of tests were failing, because they were assuming that the machine they were being run on is Unix based. I've reworked them to use regexes which should work against all platforms.