### PR TITLE
docs: fix issue #40941

### DIFF
--- a/aio/content/examples/toh-pt3/src/app/hero-detail/hero-detail.component.ts
+++ b/aio/content/examples/toh-pt3/src/app/hero-detail/hero-detail.component.ts
@@ -13,7 +13,7 @@ import { Hero } from '../hero';
 })
 export class HeroDetailComponent implements OnInit {
   // #docregion input-hero
-  @Input() hero: Hero;
+  @Input() hero?: Hero;
   // #enddocregion input-hero
 
   constructor() { }


### PR DESCRIPTION
setting the `hero` property as an optional property fixes the compilation error: `Property 'hero' has no initializer and is not definitely assigned in the constructor` when having the ts transpiler set to "strict" mode.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The issue is described in detail here: https://github.com/angular/angular/issues/40941

Issue Number: 40941


## What is the new behavior?
Compiles fine and tutorial works (and is consistent with the previous chapters) even though you set the ts transpiler to "strict".

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
