### PR TITLE
perf(compiler-cli): detect semantic changes and their effect on an incremental rebuild

### DIFF
--- a/packages/compiler-cli/ngcc/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/BUILD.bazel
@@ -19,6 +19,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/incremental:api",
+        "//packages/compiler-cli/src/ngtsc/incremental/semantic_graph",
         "//packages/compiler-cli/src/ngtsc/logging",
         "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/partial_evaluator",

--- a/packages/compiler-cli/ngcc/src/analysis/ngcc_trait_compiler.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/ngcc_trait_compiler.ts
@@ -8,6 +8,7 @@
 import * as ts from 'typescript';
 
 import {IncrementalBuild} from '../../../src/ngtsc/incremental/api';
+import {SemanticSymbol} from '../../../src/ngtsc/incremental/semantic_graph';
 import {NOOP_PERF_RECORDER} from '../../../src/ngtsc/perf';
 import {ClassDeclaration, Decorator} from '../../../src/ngtsc/reflection';
 import {CompilationMode, DecoratorHandler, DtsTransformRegistry, HandlerFlags, Trait, TraitCompiler} from '../../../src/ngtsc/transform';
@@ -22,11 +23,12 @@ import {isDefined} from '../utils';
  */
 export class NgccTraitCompiler extends TraitCompiler {
   constructor(
-      handlers: DecoratorHandler<unknown, unknown, unknown>[],
+      handlers: DecoratorHandler<unknown, unknown, SemanticSymbol|null, unknown>[],
       private ngccReflector: NgccReflectionHost) {
     super(
         handlers, ngccReflector, NOOP_PERF_RECORDER, new NoIncrementalBuild(),
-        /* compileNonExportedClasses */ true, CompilationMode.FULL, new DtsTransformRegistry());
+        /* compileNonExportedClasses */ true, CompilationMode.FULL, new DtsTransformRegistry(),
+        /* semanticDepGraphUpdater */ null);
   }
 
   get analyzedFiles(): ts.SourceFile[] {
@@ -54,7 +56,7 @@ export class NgccTraitCompiler extends TraitCompiler {
    * @param flags optional bitwise flag to influence the compilation of the decorator.
    */
   injectSyntheticDecorator(clazz: ClassDeclaration, decorator: Decorator, flags?: HandlerFlags):
-      Trait<unknown, unknown, unknown>[] {
+      Trait<unknown, unknown, SemanticSymbol|null, unknown>[] {
     const migratedTraits = this.detectTraits(clazz, [decorator]);
     if (migratedTraits === null) {
       return [];

--- a/packages/compiler-cli/ngcc/src/analysis/util.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/util.ts
@@ -16,8 +16,6 @@ export function isWithinPackage(packagePath: AbsoluteFsPath, filePath: AbsoluteF
 class NoopDependencyTracker implements DependencyTracker {
   addDependency(): void {}
   addResourceDependency(): void {}
-  addTransitiveDependency(): void {}
-  addTransitiveResources(): void {}
   recordDependencyAnalysisFailure(): void {}
 }
 

--- a/packages/compiler-cli/ngcc/test/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/test/BUILD.bazel
@@ -19,6 +19,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/file_system/testing",
         "//packages/compiler-cli/src/ngtsc/imports",
+        "//packages/compiler-cli/src/ngtsc/incremental/semantic_graph",
         "//packages/compiler-cli/src/ngtsc/logging/testing",
         "//packages/compiler-cli/src/ngtsc/partial_evaluator",
         "//packages/compiler-cli/src/ngtsc/reflection",

--- a/packages/compiler-cli/ngcc/test/analysis/ngcc_trait_compiler_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/ngcc_trait_compiler_spec.ts
@@ -9,6 +9,7 @@
 import {ErrorCode, makeDiagnostic, ngErrorCode} from '../../../src/ngtsc/diagnostics';
 import {absoluteFrom} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
+import {SemanticSymbol} from '../../../src/ngtsc/incremental/semantic_graph';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
 import {ClassDeclaration, Decorator, isNamedClassDeclaration} from '../../../src/ngtsc/reflection';
 import {getDeclaration, loadTestFiles} from '../../../src/ngtsc/testing';
@@ -39,7 +40,8 @@ runInEachFileSystem(() => {
     });
 
     function createCompiler({entryPoint, handlers}: {
-      entryPoint: EntryPointBundle; handlers: DecoratorHandler<unknown, unknown, unknown>[]
+      entryPoint: EntryPointBundle;
+      handlers: DecoratorHandler<unknown, unknown, SemanticSymbol|null, unknown>[]
     }) {
       const reflectionHost = new Esm2015ReflectionHost(new MockLogger(), false, entryPoint.src);
       return new NgccTraitCompiler(handlers, reflectionHost);
@@ -295,7 +297,7 @@ runInEachFileSystem(() => {
   });
 });
 
-class TestHandler implements DecoratorHandler<unknown, unknown, unknown> {
+class TestHandler implements DecoratorHandler<unknown, unknown, null, unknown> {
   constructor(readonly name: string, protected log: string[]) {}
 
   precedence = HandlerPrecedence.PRIMARY;
@@ -308,6 +310,10 @@ class TestHandler implements DecoratorHandler<unknown, unknown, unknown> {
   analyze(node: ClassDeclaration): AnalysisOutput<unknown> {
     this.log.push(this.name + ':analyze:' + node.name.text);
     return {};
+  }
+
+  symbol(node: ClassDeclaration, analysis: Readonly<unknown>): null {
+    return null;
   }
 
   compileFull(node: ClassDeclaration): CompileResult|CompileResult[] {

--- a/packages/compiler-cli/ngcc/test/host/util.ts
+++ b/packages/compiler-cli/ngcc/test/host/util.ts
@@ -7,6 +7,8 @@
  */
 import {Trait, TraitState} from '@angular/compiler-cli/src/ngtsc/transform';
 import * as ts from 'typescript';
+
+import {SemanticSymbol} from '../../../src/ngtsc/incremental/semantic_graph';
 import {CtorParameter, TypeValueReferenceKind} from '../../../src/ngtsc/reflection';
 
 /**
@@ -50,7 +52,8 @@ export function expectTypeValueReferencesForParameters(
   });
 }
 
-export function getTraitDiagnostics(trait: Trait<unknown, unknown, unknown>): ts.Diagnostic[]|null {
+export function getTraitDiagnostics(trait: Trait<unknown, unknown, SemanticSymbol|null, unknown>):
+    ts.Diagnostic[]|null {
   if (trait.state === TraitState.Analyzed) {
     return trait.analysisDiagnostics;
   } else if (trait.state === TraitState.Resolved) {

--- a/packages/compiler-cli/src/ngtsc/annotations/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/annotations/BUILD.bazel
@@ -14,6 +14,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/incremental:api",
+        "//packages/compiler-cli/src/ngtsc/incremental/semantic_graph",
         "//packages/compiler-cli/src/ngtsc/indexer",
         "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/partial_evaluator",

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -14,6 +14,7 @@ import {ErrorCode, FatalDiagnosticError, makeDiagnostic, makeRelatedInformation}
 import {absoluteFrom, relative} from '../../file_system';
 import {DefaultImportRecorder, ModuleResolver, Reference, ReferenceEmitter} from '../../imports';
 import {DependencyTracker} from '../../incremental/api';
+import {extractSemanticTypeParameters, isArrayEqual, isReferenceEqual, SemanticDepGraphUpdater, SemanticReference, SemanticSymbol} from '../../incremental/semantic_graph';
 import {IndexingContext} from '../../indexer';
 import {ClassPropertyMapping, ComponentResources, DirectiveMeta, DirectiveTypeCheckMeta, extractDirectiveTypeCheckMeta, InjectableClassRegistry, MetadataReader, MetadataRegistry, Resource, ResourceRegistry} from '../../metadata';
 import {EnumValue, PartialEvaluator, ResolvedValue} from '../../partial_evaluator';
@@ -26,9 +27,10 @@ import {SubsetOfKeys} from '../../util/src/typescript';
 
 import {ResourceLoader} from './api';
 import {createValueHasWrongTypeError, getDirectiveDiagnostics, getProviderDiagnostics} from './diagnostics';
-import {extractDirectiveMetadata, parseFieldArrayValue} from './directive';
+import {DirectiveSymbol, extractDirectiveMetadata, parseFieldArrayValue} from './directive';
 import {compileNgFactoryDefField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
+import {NgModuleSymbol} from './ng_module';
 import {findAngularDecorator, isAngularCoreReference, isExpressionForwardReference, readBaseClass, resolveProvidersRequiringFactory, unwrapExpression, wrapFunctionExpressionsInParens} from './util';
 
 const EMPTY_MAP = new Map<string, Expression>();
@@ -112,10 +114,84 @@ export const enum ResourceTypeForDiagnostics {
 }
 
 /**
+ * Represents an Angular component.
+ */
+export class ComponentSymbol extends DirectiveSymbol {
+  usedDirectives: SemanticReference[] = [];
+  usedPipes: SemanticReference[] = [];
+  isRemotelyScoped = false;
+
+  isEmitAffected(previousSymbol: SemanticSymbol, publicApiAffected: Set<SemanticSymbol>): boolean {
+    if (!(previousSymbol instanceof ComponentSymbol)) {
+      return true;
+    }
+
+    // Create an equality function that considers symbols equal if they represent the same
+    // declaration, but only if the symbol in the current compilation does not have its public API
+    // affected.
+    const isSymbolUnaffected = (current: SemanticReference, previous: SemanticReference) =>
+        isReferenceEqual(current, previous) && !publicApiAffected.has(current.symbol);
+
+    // The emit of a component is affected if either of the following is true:
+    //  1. The component used to be remotely scoped but no longer is, or vice versa.
+    //  2. The list of used directives has changed or any of those directives have had their public
+    //     API changed. If the used directives have been reordered but not otherwise affected then
+    //     the component must still be re-emitted, as this may affect directive instantiation order.
+    //  3. The list of used pipes has changed, or any of those pipes have had their public API
+    //     changed.
+    return this.isRemotelyScoped !== previousSymbol.isRemotelyScoped ||
+        !isArrayEqual(this.usedDirectives, previousSymbol.usedDirectives, isSymbolUnaffected) ||
+        !isArrayEqual(this.usedPipes, previousSymbol.usedPipes, isSymbolUnaffected);
+  }
+
+  isTypeCheckBlockAffected(
+      previousSymbol: SemanticSymbol, typeCheckApiAffected: Set<SemanticSymbol>): boolean {
+    if (!(previousSymbol instanceof ComponentSymbol)) {
+      return true;
+    }
+
+    // To verify that a used directive is not affected we need to verify that its full inheritance
+    // chain is not present in `typeCheckApiAffected`.
+    const isInheritanceChainAffected = (symbol: SemanticSymbol): boolean => {
+      let currentSymbol: SemanticSymbol|null = symbol;
+      while (currentSymbol instanceof DirectiveSymbol) {
+        if (typeCheckApiAffected.has(currentSymbol)) {
+          return true;
+        }
+        currentSymbol = currentSymbol.baseClass;
+      }
+
+      return false;
+    };
+
+    // Create an equality function that considers directives equal if they represent the same
+    // declaration and if the symbol and all symbols it inherits from in the current compilation
+    // do not have their type-check API affected.
+    const isDirectiveUnaffected = (current: SemanticReference, previous: SemanticReference) =>
+        isReferenceEqual(current, previous) && !isInheritanceChainAffected(current.symbol);
+
+    // Create an equality function that considers pipes equal if they represent the same
+    // declaration and if the symbol in the current compilation does not have its type-check
+    // API affected.
+    const isPipeUnaffected = (current: SemanticReference, previous: SemanticReference) =>
+        isReferenceEqual(current, previous) && !typeCheckApiAffected.has(current.symbol);
+
+    // The emit of a type-check block of a component is affected if either of the following is true:
+    //  1. The list of used directives has changed or any of those directives have had their
+    //     type-check API changed.
+    //  2. The list of used pipes has changed, or any of those pipes have had their type-check API
+    //     changed.
+    return !isArrayEqual(
+               this.usedDirectives, previousSymbol.usedDirectives, isDirectiveUnaffected) ||
+        !isArrayEqual(this.usedPipes, previousSymbol.usedPipes, isPipeUnaffected);
+  }
+}
+
+/**
  * `DecoratorHandler` which handles the `@Component` annotation.
  */
 export class ComponentDecoratorHandler implements
-    DecoratorHandler<Decorator, ComponentAnalysisData, ComponentResolutionData> {
+    DecoratorHandler<Decorator, ComponentAnalysisData, ComponentSymbol, ComponentResolutionData> {
   constructor(
       private reflector: ReflectionHost, private evaluator: PartialEvaluator,
       private metaRegistry: MetadataRegistry, private metaReader: MetadataReader,
@@ -131,6 +207,7 @@ export class ComponentDecoratorHandler implements
       private defaultImportRecorder: DefaultImportRecorder,
       private depTracker: DependencyTracker|null,
       private injectableRegistry: InjectableClassRegistry,
+      private semanticDepGraphUpdater: SemanticDepGraphUpdater|null,
       private annotateForClosureCompiler: boolean) {}
 
   private literalCache = new Map<Decorator, ts.ObjectLiteralExpression>();
@@ -397,6 +474,14 @@ export class ComponentDecoratorHandler implements
     return output;
   }
 
+  symbol(node: ClassDeclaration, analysis: Readonly<ComponentAnalysisData>): ComponentSymbol {
+    const typeParameters = extractSemanticTypeParameters(node);
+
+    return new ComponentSymbol(
+        node, analysis.meta.selector, analysis.inputs, analysis.outputs, analysis.meta.exportAs,
+        analysis.typeCheckMeta, typeParameters);
+  }
+
   register(node: ClassDeclaration, analysis: ComponentAnalysisData): void {
     // Register this component's information with the `MetadataRegistry`. This ensures that
     // the information about the component is available during the compile() phase.
@@ -476,8 +561,13 @@ export class ComponentDecoratorHandler implements
         meta.template.sourceMapping, meta.template.file, meta.template.errors);
   }
 
-  resolve(node: ClassDeclaration, analysis: Readonly<ComponentAnalysisData>):
-      ResolveResult<ComponentResolutionData> {
+  resolve(
+      node: ClassDeclaration, analysis: Readonly<ComponentAnalysisData>,
+      symbol: ComponentSymbol): ResolveResult<ComponentResolutionData> {
+    if (this.semanticDepGraphUpdater !== null && analysis.baseClass instanceof Reference) {
+      symbol.baseClass = this.semanticDepGraphUpdater.getSymbol(analysis.baseClass.node);
+    }
+
     if (analysis.isPoisoned && !this.usePoisonedData) {
       return {};
     }
@@ -538,7 +628,7 @@ export class ComponentDecoratorHandler implements
       const bound = binder.bind({template: metadata.template.nodes});
 
       // The BoundTarget knows which directives and pipes matched the template.
-      type UsedDirective = R3UsedDirectiveMetadata&{ref: Reference};
+      type UsedDirective = R3UsedDirectiveMetadata&{ref: Reference<ClassDeclaration>};
       const usedDirectives: UsedDirective[] = bound.getUsedDirectives().map(directive => {
         return {
           ref: directive.ref,
@@ -550,8 +640,7 @@ export class ComponentDecoratorHandler implements
           isComponent: directive.isComponent,
         };
       });
-
-      type UsedPipe = {ref: Reference, pipeName: string, expression: Expression};
+      type UsedPipe = {ref: Reference<ClassDeclaration>, pipeName: string, expression: Expression};
       const usedPipes: UsedPipe[] = [];
       for (const pipeName of bound.getUsedPipes()) {
         if (!pipes.has(pipeName)) {
@@ -563,6 +652,13 @@ export class ComponentDecoratorHandler implements
           pipeName,
           expression: this.refEmitter.emit(pipe, context),
         });
+      }
+      if (this.semanticDepGraphUpdater !== null) {
+        symbol.usedDirectives = usedDirectives.map(
+            dir => this.semanticDepGraphUpdater!.getSemanticReference(dir.ref.node, dir.type));
+        symbol.usedPipes = usedPipes.map(
+            pipe =>
+                this.semanticDepGraphUpdater!.getSemanticReference(pipe.ref.node, pipe.expression));
       }
 
       // Scan through the directives/pipes actually used in the template and check whether any
@@ -582,7 +678,8 @@ export class ComponentDecoratorHandler implements
         }
       }
 
-      if (cyclesFromDirectives.size === 0 && cyclesFromPipes.size === 0) {
+      const cycleDetected = cyclesFromDirectives.size !== 0 || cyclesFromPipes.size !== 0;
+      if (!cycleDetected) {
         // No cycle was detected. Record the imports that need to be created in the cycle detector
         // so that future cyclic import checks consider their production.
         for (const {type} of usedDirectives) {
@@ -613,6 +710,21 @@ export class ComponentDecoratorHandler implements
           // NgModule file will take care of setting the directives for the component.
           this.scopeRegistry.setComponentRemoteScope(
               node, usedDirectives.map(dir => dir.ref), usedPipes.map(pipe => pipe.ref));
+          symbol.isRemotelyScoped = true;
+
+          // If a semantic graph is being tracked, record the fact that this component is remotely
+          // scoped with the declaring NgModule symbol as the NgModule's emit becomes dependent on
+          // the directive/pipe usages of this component.
+          if (this.semanticDepGraphUpdater !== null) {
+            const moduleSymbol = this.semanticDepGraphUpdater.getSymbol(scope.ngModule);
+            if (!(moduleSymbol instanceof NgModuleSymbol)) {
+              throw new Error(
+                  `AssertionError: Expected ${scope.ngModule.name} to be an NgModuleSymbol.`);
+            }
+
+            moduleSymbol.addRemotelyScopedComponent(
+                symbol, symbol.usedDirectives, symbol.usedPipes);
+          }
         } else {
           // We are not able to handle this cycle so throw an error.
           const relatedMessages: ts.DiagnosticRelatedInformation[] = [];

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -11,8 +11,10 @@ import {emitDistinctChangesOnlyDefaultValue} from '@angular/compiler/src/core';
 import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
+import {absoluteFromSourceFile} from '../../file_system';
 import {DefaultImportRecorder, Reference} from '../../imports';
-import {ClassPropertyMapping, DirectiveTypeCheckMeta, InjectableClassRegistry, MetadataReader, MetadataRegistry} from '../../metadata';
+import {areTypeParametersEqual, extractSemanticTypeParameters, isArrayEqual, isSetEqual, isSymbolEqual, SemanticDepGraphUpdater, SemanticSymbol, SemanticTypeParameter} from '../../incremental/semantic_graph';
+import {BindingPropertyName, ClassPropertyMapping, ClassPropertyName, DirectiveTypeCheckMeta, InjectableClassRegistry, MetadataReader, MetadataRegistry, TemplateGuardMeta} from '../../metadata';
 import {extractDirectiveTypeCheckMeta} from '../../metadata/src/util';
 import {DynamicValue, EnumValue, PartialEvaluator} from '../../partial_evaluator';
 import {ClassDeclaration, ClassMember, ClassMemberKind, Decorator, filterToMembersWithDecorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
@@ -46,13 +48,138 @@ export interface DirectiveHandlerData {
   isStructural: boolean;
 }
 
+/**
+ * Represents an Angular directive. Components are represented by `ComponentSymbol`, which inherits
+ * from this symbol.
+ */
+export class DirectiveSymbol extends SemanticSymbol {
+  baseClass: SemanticSymbol|null = null;
+
+  constructor(
+      decl: ClassDeclaration, public readonly selector: string|null,
+      public readonly inputs: ClassPropertyMapping, public readonly outputs: ClassPropertyMapping,
+      public readonly exportAs: string[]|null,
+      public readonly typeCheckMeta: DirectiveTypeCheckMeta,
+      public readonly typeParameters: SemanticTypeParameter[]|null) {
+    super(decl);
+  }
+
+  isPublicApiAffected(previousSymbol: SemanticSymbol): boolean {
+    // Note: since components and directives have exactly the same items contributing to their
+    // public API, it is okay for a directive to change into a component and vice versa without
+    // the API being affected.
+    if (!(previousSymbol instanceof DirectiveSymbol)) {
+      return true;
+    }
+
+    // Directives and components have a public API of:
+    //  1. Their selector.
+    //  2. The binding names of their inputs and outputs; a change in ordering is also considered
+    //     to be a change in public API.
+    //  3. The list of exportAs names and its ordering.
+    return this.selector !== previousSymbol.selector ||
+        !isArrayEqual(this.inputs.propertyNames, previousSymbol.inputs.propertyNames) ||
+        !isArrayEqual(this.outputs.propertyNames, previousSymbol.outputs.propertyNames) ||
+        !isArrayEqual(this.exportAs, previousSymbol.exportAs);
+  }
+
+  isTypeCheckApiAffected(previousSymbol: SemanticSymbol): boolean {
+    // If the public API of the directive has changed, then so has its type-check API.
+    if (this.isPublicApiAffected(previousSymbol)) {
+      return true;
+    }
+
+    if (!(previousSymbol instanceof DirectiveSymbol)) {
+      return true;
+    }
+
+    // The type-check block also depends on the class property names, as writes property bindings
+    // directly into the backing fields.
+    if (!isArrayEqual(
+            Array.from(this.inputs), Array.from(previousSymbol.inputs), isInputMappingEqual) ||
+        !isArrayEqual(
+            Array.from(this.outputs), Array.from(previousSymbol.outputs), isInputMappingEqual)) {
+      return true;
+    }
+
+    // The type parameters of a directive are emitted into the type constructors in the type-check
+    // block of a component, so if the type parameters are not considered equal then consider the
+    // type-check API of this directive to be affected.
+    if (!areTypeParametersEqual(this.typeParameters, previousSymbol.typeParameters)) {
+      return true;
+    }
+
+    // The type-check metadata is used during TCB code generation, so any changes should invalidate
+    // prior type-check files.
+    if (!isTypeCheckMetaEqual(this.typeCheckMeta, previousSymbol.typeCheckMeta)) {
+      return true;
+    }
+
+    // Changing the base class of a directive means that its inputs/outputs etc may have changed,
+    // so the type-check block of components that use this directive needs to be regenerated.
+    if (!isBaseClassEqual(this.baseClass, previousSymbol.baseClass)) {
+      return true;
+    }
+
+    return false;
+  }
+}
+
+function isInputMappingEqual(
+    current: [ClassPropertyName, BindingPropertyName],
+    previous: [ClassPropertyName, BindingPropertyName]): boolean {
+  return current[0] === previous[0] && current[1] === previous[1];
+}
+
+function isTypeCheckMetaEqual(
+    current: DirectiveTypeCheckMeta, previous: DirectiveTypeCheckMeta): boolean {
+  if (current.hasNgTemplateContextGuard !== previous.hasNgTemplateContextGuard) {
+    return false;
+  }
+  if (current.isGeneric !== previous.isGeneric) {
+    // Note: changes in the number of type parameters is also considered in `areTypeParametersEqual`
+    // so this check is technically not needed; it is done anyway for completeness in terms of
+    // whether the `DirectiveTypeCheckMeta` struct itself compares equal or not.
+    return false;
+  }
+  if (!isArrayEqual(current.ngTemplateGuards, previous.ngTemplateGuards, isTemplateGuardEqual)) {
+    return false;
+  }
+  if (!isSetEqual(current.coercedInputFields, previous.coercedInputFields)) {
+    return false;
+  }
+  if (!isSetEqual(current.restrictedInputFields, previous.restrictedInputFields)) {
+    return false;
+  }
+  if (!isSetEqual(current.stringLiteralInputFields, previous.stringLiteralInputFields)) {
+    return false;
+  }
+  if (!isSetEqual(current.undeclaredInputFields, previous.undeclaredInputFields)) {
+    return false;
+  }
+  return true;
+}
+
+function isTemplateGuardEqual(current: TemplateGuardMeta, previous: TemplateGuardMeta): boolean {
+  return current.inputName === previous.inputName && current.type === previous.type;
+}
+
+function isBaseClassEqual(current: SemanticSymbol|null, previous: SemanticSymbol|null): boolean {
+  if (current === null || previous === null) {
+    return current === previous;
+  }
+
+  return isSymbolEqual(current, previous);
+}
+
 export class DirectiveDecoratorHandler implements
-    DecoratorHandler<Decorator|null, DirectiveHandlerData, unknown> {
+    DecoratorHandler<Decorator|null, DirectiveHandlerData, DirectiveSymbol, unknown> {
   constructor(
       private reflector: ReflectionHost, private evaluator: PartialEvaluator,
       private metaRegistry: MetadataRegistry, private scopeRegistry: LocalModuleScopeRegistry,
       private metaReader: MetadataReader, private defaultImportRecorder: DefaultImportRecorder,
       private injectableRegistry: InjectableClassRegistry, private isCore: boolean,
+      private semanticDepGraphUpdater: SemanticDepGraphUpdater|null,
       private annotateForClosureCompiler: boolean,
       private compileUndecoratedClassesWithAngularFeatures: boolean) {}
 
@@ -116,6 +243,14 @@ export class DirectiveDecoratorHandler implements
     };
   }
 
+  symbol(node: ClassDeclaration, analysis: Readonly<DirectiveHandlerData>): DirectiveSymbol {
+    const typeParameters = extractSemanticTypeParameters(node);
+
+    return new DirectiveSymbol(
+        node, analysis.meta.selector, analysis.inputs, analysis.outputs, analysis.meta.exportAs,
+        analysis.typeCheckMeta, typeParameters);
+  }
+
   register(node: ClassDeclaration, analysis: Readonly<DirectiveHandlerData>): void {
     // Register this directive's information with the `MetadataRegistry`. This ensures that
     // the information about the directive is available during the compile() phase.
@@ -138,9 +273,13 @@ export class DirectiveDecoratorHandler implements
     this.injectableRegistry.registerInjectable(node);
   }
 
-  resolve(node: ClassDeclaration, analysis: DirectiveHandlerData): ResolveResult<unknown> {
-    const diagnostics: ts.Diagnostic[] = [];
+  resolve(node: ClassDeclaration, analysis: DirectiveHandlerData, symbol: DirectiveSymbol):
+      ResolveResult<unknown> {
+    if (this.semanticDepGraphUpdater !== null && analysis.baseClass instanceof Reference) {
+      symbol.baseClass = this.semanticDepGraphUpdater.getSymbol(analysis.baseClass.node);
+    }
 
+    const diagnostics: ts.Diagnostic[] = [];
     if (analysis.providersRequiringFactory !== null &&
         analysis.meta.providers instanceof WrappedNodeExpr) {
       const providerDiagnostics = getProviderDiagnostics(

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -30,7 +30,7 @@ export interface InjectableHandlerData {
  * Adapts the `compileIvyInjectable` compiler for `@Injectable` decorators to the Ivy compiler.
  */
 export class InjectableDecoratorHandler implements
-    DecoratorHandler<Decorator, InjectableHandlerData, unknown> {
+    DecoratorHandler<Decorator, InjectableHandlerData, null, unknown> {
   constructor(
       private reflector: ReflectionHost, private defaultImportRecorder: DefaultImportRecorder,
       private isCore: boolean, private strictCtorDeps: boolean,
@@ -81,6 +81,10 @@ export class InjectableDecoratorHandler implements
             decorators.every(current => !isAngularCore(current) || current.name === 'Injectable')
       },
     };
+  }
+
+  symbol(): null {
+    return null;
   }
 
   register(node: ClassDeclaration): void {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -11,9 +11,10 @@ import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError, makeDiagnostic, makeRelatedInformation} from '../../diagnostics';
 import {DefaultImportRecorder, Reference, ReferenceEmitter} from '../../imports';
+import {isArrayEqual, isReferenceEqual, isSymbolEqual, SemanticReference, SemanticSymbol} from '../../incremental/semantic_graph';
 import {InjectableClassRegistry, MetadataReader, MetadataRegistry} from '../../metadata';
 import {PartialEvaluator, ResolvedValue} from '../../partial_evaluator';
-import {ClassDeclaration, DeclarationNode, Decorator, isNamedClassDeclaration, ReflectionHost, reflectObjectLiteral, typeNodeToValueExpr} from '../../reflection';
+import {ClassDeclaration, Decorator, isNamedClassDeclaration, ReflectionHost, reflectObjectLiteral, typeNodeToValueExpr} from '../../reflection';
 import {NgModuleRouteAnalyzer} from '../../routing';
 import {LocalModuleScopeRegistry, ScopeData} from '../../scope';
 import {FactoryTracker} from '../../shims/api';
@@ -45,12 +46,83 @@ export interface NgModuleResolution {
 }
 
 /**
+ * Represents an Angular NgModule.
+ */
+export class NgModuleSymbol extends SemanticSymbol {
+  private remotelyScopedComponents: {
+    component: SemanticSymbol,
+    usedDirectives: SemanticReference[],
+    usedPipes: SemanticReference[]
+  }[] = [];
+
+  isPublicApiAffected(previousSymbol: SemanticSymbol): boolean {
+    if (!(previousSymbol instanceof NgModuleSymbol)) {
+      return true;
+    }
+
+    // NgModules don't have a public API that could affect emit of Angular decorated classes.
+    return false;
+  }
+
+  isEmitAffected(previousSymbol: SemanticSymbol): boolean {
+    if (!(previousSymbol instanceof NgModuleSymbol)) {
+      return true;
+    }
+
+    // compare our remotelyScopedComponents to the previous symbol
+    if (previousSymbol.remotelyScopedComponents.length !== this.remotelyScopedComponents.length) {
+      return true;
+    }
+
+    for (const currEntry of this.remotelyScopedComponents) {
+      const prevEntry = previousSymbol.remotelyScopedComponents.find(prevEntry => {
+        return isSymbolEqual(prevEntry.component, currEntry.component);
+      });
+
+      if (prevEntry === undefined) {
+        // No previous entry was found, which means that this component became remotely scoped and
+        // hence this NgModule needs to be re-emitted.
+        return true;
+      }
+
+      if (!isArrayEqual(currEntry.usedDirectives, prevEntry.usedDirectives, isReferenceEqual)) {
+        // The list of used directives or their order has changed. Since this NgModule emits
+        // references to the list of used directives, it should be re-emitted to update this list.
+        // Note: the NgModule does not have to be re-emitted when any of the directives has had
+        // their public API changed, as the NgModule only emits a reference to the symbol by its
+        // name. Therefore, testing for symbol equality is sufficient.
+        return true;
+      }
+
+      if (!isArrayEqual(currEntry.usedPipes, prevEntry.usedPipes, isReferenceEqual)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  isTypeCheckApiAffected(previousSymbol: SemanticSymbol): boolean {
+    if (!(previousSymbol instanceof NgModuleSymbol)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  addRemotelyScopedComponent(
+      component: SemanticSymbol, usedDirectives: SemanticReference[],
+      usedPipes: SemanticReference[]): void {
+    this.remotelyScopedComponents.push({component, usedDirectives, usedPipes});
+  }
+}
+
+/**
  * Compiles @NgModule annotations to ngModuleDef fields.
  *
  * TODO(alxhub): handle injector side of things as well.
  */
 export class NgModuleDecoratorHandler implements
-    DecoratorHandler<Decorator, NgModuleAnalysis, NgModuleResolution> {
+    DecoratorHandler<Decorator, NgModuleAnalysis, NgModuleSymbol, NgModuleResolution> {
   constructor(
       private reflector: ReflectionHost, private evaluator: PartialEvaluator,
       private metaReader: MetadataReader, private metaRegistry: MetadataRegistry,
@@ -291,6 +363,10 @@ export class NgModuleDecoratorHandler implements
         factorySymbolName: node.name.text,
       },
     };
+  }
+
+  symbol(node: ClassDeclaration): NgModuleSymbol {
+    return new NgModuleSymbol(node);
   }
 
   register(node: ClassDeclaration, analysis: NgModuleAnalysis): void {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -11,13 +11,14 @@ import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
 import {DefaultImportRecorder, Reference} from '../../imports';
+import {SemanticSymbol} from '../../incremental/semantic_graph';
 import {InjectableClassRegistry, MetadataRegistry} from '../../metadata';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
 import {LocalModuleScopeRegistry} from '../../scope';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence, ResolveResult} from '../../transform';
-import {createValueHasWrongTypeError} from './diagnostics';
 
+import {createValueHasWrongTypeError} from './diagnostics';
 import {compileNgFactoryDefField} from './factory';
 import {generateSetClassMetadataCall} from './metadata';
 import {findAngularDecorator, getValidConstructorDependencies, makeDuplicateDeclarationError, unwrapExpression, wrapTypeReference} from './util';
@@ -27,7 +28,29 @@ export interface PipeHandlerData {
   metadataStmt: Statement|null;
 }
 
-export class PipeDecoratorHandler implements DecoratorHandler<Decorator, PipeHandlerData, unknown> {
+/**
+ * Represents an Angular pipe.
+ */
+export class PipeSymbol extends SemanticSymbol {
+  constructor(decl: ClassDeclaration, public readonly name: string) {
+    super(decl);
+  }
+
+  isPublicApiAffected(previousSymbol: SemanticSymbol): boolean {
+    if (!(previousSymbol instanceof PipeSymbol)) {
+      return true;
+    }
+
+    return this.name !== previousSymbol.name;
+  }
+
+  isTypeCheckApiAffected(previousSymbol: SemanticSymbol): boolean {
+    return this.isPublicApiAffected(previousSymbol);
+  }
+}
+
+export class PipeDecoratorHandler implements
+    DecoratorHandler<Decorator, PipeHandlerData, PipeSymbol, unknown> {
   constructor(
       private reflector: ReflectionHost, private evaluator: PartialEvaluator,
       private metaRegistry: MetadataRegistry, private scopeRegistry: LocalModuleScopeRegistry,
@@ -112,6 +135,10 @@ export class PipeDecoratorHandler implements DecoratorHandler<Decorator, PipeHan
             clazz, this.reflector, this.defaultImportRecorder, this.isCore),
       },
     };
+  }
+
+  symbol(node: ClassDeclaration, analysis: Readonly<PipeHandlerData>): PipeSymbol {
+    return new PipeSymbol(node, analysis.meta.name);
   }
 
   register(node: ClassDeclaration, analysis: Readonly<PipeHandlerData>): void {

--- a/packages/compiler-cli/src/ngtsc/annotations/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/BUILD.bazel
@@ -17,6 +17,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/file_system/testing",
         "//packages/compiler-cli/src/ngtsc/imports",
+        "//packages/compiler-cli/src/ngtsc/incremental:api",
         "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/partial_evaluator",
         "//packages/compiler-cli/src/ngtsc/reflection",

--- a/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
@@ -78,6 +78,7 @@ function setup(program: ts.Program, options: ts.CompilerOptions, host: ts.Compil
       NOOP_DEFAULT_IMPORT_RECORDER,
       /* depTracker */ null,
       injectableRegistry,
+      /* semanticDepGraphUpdater */ null,
       /* annotateForClosureCompiler */ false,
   );
   return {reflectionHost, handler};
@@ -247,7 +248,8 @@ runInEachFileSystem(() => {
         return fail('Failed to recognize @Component');
       }
       const {analysis} = handler.analyze(TestCmp, detected.metadata);
-      const resolution = handler.resolve(TestCmp, analysis!);
+      const symbol = handler.symbol(TestCmp, analysis!);
+      const resolution = handler.resolve(TestCmp, analysis!, symbol);
 
       const compileResult =
           handler.compileFull(TestCmp, analysis!, resolution.data!, new ConstantPool());

--- a/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
@@ -169,6 +169,7 @@ runInEachFileSystem(() => {
     const handler = new DirectiveDecoratorHandler(
         reflectionHost, evaluator, scopeRegistry, scopeRegistry, metaReader,
         NOOP_DEFAULT_IMPORT_RECORDER, injectableRegistry, /*isCore*/ false,
+        /*semanticDepGraphUpdater*/ null,
         /*annotateForClosureCompiler*/ false,
         /*detectUndecoratedClassesWithAngularFeatures*/ false);
 

--- a/packages/compiler-cli/src/ngtsc/core/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/core/BUILD.bazel
@@ -19,6 +19,8 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/incremental",
+        "//packages/compiler-cli/src/ngtsc/incremental:api",
+        "//packages/compiler-cli/src/ngtsc/incremental/semantic_graph",
         "//packages/compiler-cli/src/ngtsc/indexer",
         "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/modulewithproviders",

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -16,6 +16,7 @@ import {checkForPrivateExports, ReferenceGraph} from '../../entry_point';
 import {LogicalFileSystem, resolve} from '../../file_system';
 import {AbsoluteModuleStrategy, AliasingHost, AliasStrategy, DefaultImportTracker, ImportRewriter, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, NoopImportRewriter, PrivateExportAliasingHost, R3SymbolsImportRewriter, Reference, ReferenceEmitStrategy, ReferenceEmitter, RelativePathStrategy, UnifiedModulesAliasingHost, UnifiedModulesStrategy} from '../../imports';
 import {IncrementalBuildStrategy, IncrementalDriver} from '../../incremental';
+import {SemanticSymbol} from '../../incremental/semantic_graph';
 import {generateAnalysis, IndexedComponent, IndexingContext} from '../../indexer';
 import {ComponentResources, CompoundMetadataReader, CompoundMetadataRegistry, DtsMetadataReader, InjectableClassRegistry, LocalMetadataRegistry, MetadataReader, ResourceRegistry} from '../../metadata';
 import {ModuleWithProvidersScanner} from '../../modulewithproviders';
@@ -636,8 +637,6 @@ export class NgCompiler {
   private resolveCompilation(traitCompiler: TraitCompiler): void {
     traitCompiler.resolve();
 
-    this.recordNgModuleScopeDependencies();
-
     // At this point, analysis is complete and the compiler can now calculate which files need to
     // be emitted, so do that.
     this.incrementalDriver.recordSuccessfulAnalysis(traitCompiler);
@@ -810,74 +809,6 @@ export class NgCompiler {
     return this.nonTemplateDiagnostics;
   }
 
-  /**
-   * Reifies the inter-dependencies of NgModules and the components within their compilation scopes
-   * into the `IncrementalDriver`'s dependency graph.
-   */
-  private recordNgModuleScopeDependencies() {
-    const recordSpan = this.perfRecorder.start('recordDependencies');
-    const depGraph = this.incrementalDriver.depGraph;
-
-    for (const scope of this.compilation!.scopeRegistry!.getCompilationScopes()) {
-      const file = scope.declaration.getSourceFile();
-      const ngModuleFile = scope.ngModule.getSourceFile();
-
-      // A change to any dependency of the declaration causes the declaration to be invalidated,
-      // which requires the NgModule to be invalidated as well.
-      depGraph.addTransitiveDependency(ngModuleFile, file);
-
-      // A change to the NgModule file should cause the declaration itself to be invalidated.
-      depGraph.addDependency(file, ngModuleFile);
-
-      const meta =
-          this.compilation!.metaReader.getDirectiveMetadata(new Reference(scope.declaration));
-      if (meta !== null && meta.isComponent) {
-        // If a component's template changes, it might have affected the import graph, and thus the
-        // remote scoping feature which is activated in the event of potential import cycles. Thus,
-        // the module depends not only on the transitive dependencies of the component, but on its
-        // resources as well.
-        depGraph.addTransitiveResources(ngModuleFile, file);
-
-        // A change to any directive/pipe in the compilation scope should cause the component to be
-        // invalidated.
-        for (const directive of scope.directives) {
-          // When a directive in scope is updated, the component needs to be recompiled as e.g. a
-          // selector may have changed.
-          depGraph.addTransitiveDependency(file, directive.ref.node.getSourceFile());
-        }
-        for (const pipe of scope.pipes) {
-          // When a pipe in scope is updated, the component needs to be recompiled as e.g. the
-          // pipe's name may have changed.
-          depGraph.addTransitiveDependency(file, pipe.ref.node.getSourceFile());
-        }
-
-        // Components depend on the entire export scope. In addition to transitive dependencies on
-        // all directives/pipes in the export scope, they also depend on every NgModule in the
-        // scope, as changes to a module may add new directives/pipes to the scope.
-        for (const depModule of scope.ngModules) {
-          // There is a correctness issue here. To be correct, this should be a transitive
-          // dependency on the depModule file, since the depModule's exports might change via one of
-          // its dependencies, even if depModule's file itself doesn't change. However, doing this
-          // would also trigger recompilation if a non-exported component or directive changed,
-          // which causes performance issues for rebuilds.
-          //
-          // Given the rebuild issue is an edge case, currently we err on the side of performance
-          // instead of correctness. A correct and performant design would distinguish between
-          // changes to the depModule which affect its export scope and changes which do not, and
-          // only add a dependency for the former. This concept is currently in development.
-          //
-          // TODO(alxhub): fix correctness issue by understanding the semantics of the dependency.
-          depGraph.addDependency(file, depModule.getSourceFile());
-        }
-      } else {
-        // Directives (not components) and pipes only depend on the NgModule which directly declares
-        // them.
-        depGraph.addDependency(file, ngModuleFile);
-      }
-    }
-    this.perfRecorder.stop(recordSpan);
-  }
-
   private scanForMwp(sf: ts.SourceFile): void {
     this.compilation!.mwpScanner.scan(sf, {
       addTypeReplacement: (node: ts.Declaration, type: Type): void => {
@@ -957,6 +888,7 @@ export class NgCompiler {
     const scopeRegistry =
         new LocalModuleScopeRegistry(localMetaReader, depScopeReader, refEmitter, aliasingHost);
     const scopeReader: ComponentScopeReader = scopeRegistry;
+    const semanticDepGraphUpdater = this.incrementalDriver.getSemanticDepGraphUpdater();
     const metaRegistry = new CompoundMetadataRegistry([localMetaRegistry, scopeRegistry]);
     const injectableRegistry = new InjectableClassRegistry(reflector);
 
@@ -998,7 +930,7 @@ export class NgCompiler {
         CycleHandlingStrategy.Error;
 
     // Set up the IvyCompilation, which manages state for the Ivy transformer.
-    const handlers: DecoratorHandler<unknown, unknown, unknown>[] = [
+    const handlers: DecoratorHandler<unknown, unknown, SemanticSymbol|null, unknown>[] = [
       new ComponentDecoratorHandler(
           reflector, evaluator, metaRegistry, metaReader, scopeReader, scopeRegistry,
           typeCheckScopeRegistry, resourceRegistry, isCore, this.resourceManager,
@@ -1007,15 +939,16 @@ export class NgCompiler {
           this.options.enableI18nLegacyMessageIdFormat !== false, this.usePoisonedData,
           this.options.i18nNormalizeLineEndingsInICUs, this.moduleResolver, this.cycleAnalyzer,
           cycleHandlingStrategy, refEmitter, defaultImportTracker, this.incrementalDriver.depGraph,
-          injectableRegistry, this.closureCompilerEnabled),
+          injectableRegistry, semanticDepGraphUpdater, this.closureCompilerEnabled),
+
       // TODO(alxhub): understand why the cast here is necessary (something to do with `null`
       // not being assignable to `unknown` when wrapped in `Readonly`).
       // clang-format off
         new DirectiveDecoratorHandler(
             reflector, evaluator, metaRegistry, scopeRegistry, metaReader,
-            defaultImportTracker, injectableRegistry, isCore, this.closureCompilerEnabled,
-            compileUndecoratedClassesWithAngularFeatures,
-        ) as Readonly<DecoratorHandler<unknown, unknown, unknown>>,
+            defaultImportTracker, injectableRegistry, isCore, semanticDepGraphUpdater,
+          this.closureCompilerEnabled, compileUndecoratedClassesWithAngularFeatures,
+        ) as Readonly<DecoratorHandler<unknown, unknown, SemanticSymbol | null,unknown>>,
       // clang-format on
       // Pipe handler must be before injectable handler in list so pipe factories are printed
       // before injectable factories (so injectable factories can delegate to them)
@@ -1033,7 +966,8 @@ export class NgCompiler {
 
     const traitCompiler = new TraitCompiler(
         handlers, reflector, this.perfRecorder, this.incrementalDriver,
-        this.options.compileNonExportedClasses !== false, compilationMode, dtsTransforms);
+        this.options.compileNonExportedClasses !== false, compilationMode, dtsTransforms,
+        semanticDepGraphUpdater);
 
     const templateTypeChecker = new TemplateTypeCheckerImpl(
         this.tsProgram, this.typeCheckingProgramStrategy, traitCompiler,

--- a/packages/compiler-cli/src/ngtsc/incremental/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/incremental/BUILD.bazel
@@ -11,6 +11,7 @@ ts_library(
         ":api",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/imports",
+        "//packages/compiler-cli/src/ngtsc/incremental/semantic_graph",
         "//packages/compiler-cli/src/ngtsc/metadata",
         "//packages/compiler-cli/src/ngtsc/partial_evaluator",
         "//packages/compiler-cli/src/ngtsc/reflection",
@@ -27,6 +28,7 @@ ts_library(
     srcs = ["api.ts"],
     deps = [
         "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/incremental/README.md
+++ b/packages/compiler-cli/src/ngtsc/incremental/README.md
@@ -1,154 +1,291 @@
-# What is the `incremental` package?
+# Incremental Compilation
+
+The `incremental` package contains logic related to incremental compilation in ngtsc. Its goal is to
+ensure that the compiler's incremental performance is largely O(number of files changed in that
+iteration) instead of O(size of the program as a whole), by allowing the compiler to optimize away
+as much work as possible without sacrificing the correctness of its output.
+
+An incremental compilation receives information about the prior compilation, including
+its `ts.Program` and the result of ngtsc's analyses of each class in that program. Depending on the
+nature of any changes made to files in the program between its prior and current versions, and on
+the semantic effect of those changes, ngtsc may perform 3 different optimizations as it processes
+the new build:
+
+* It can reuse analysis work performed in the previous program
+
+ngtsc receives the analyses of all decorated classes performed as part of the previous compilation,
+and can reuse that work for a class if it can prove that the results are not stale.
+
+* It can skip emitting a file
 
-This package contains logic related to incremental compilation in ngtsc.
+Emitting a file is a very expensive operation in TypeScript, involving the execution of many
+internal TS transforms (downleveling, module system, etc) as well as the synthesis of a large text
+buffer for the final JS output. Skipping emit of a file is the most effective optimizations ngtsc
+can do. It's also one of the most challenging. Even if ngtsc's _analysis_ of a specific file is not
+stale, that file may still need to be re-emitted if other changes in the program impact its
+semantics. For example, a change to a component selector affects other components which use that
+selector in their templates, even though no direct dependency exists between them.
 
-In particular, it tracks dependencies between `ts.SourceFile`s, so the compiler can make intelligent decisions about when it's safe to skip certain operations.
+* It can reuse template type-checking code
+
+Template type-checking code is generated using semantic information extracted from the user's
+program. This generation can be expensive, and ngtsc attempts to reuse previous results as much as
+possible. This optimization can be thought of as a special case of the above re-emit optimization,
+since template type-checking code is a particular flavor of "emit" for a component.
+
+Due to the way that template type-checking works (creation of a second `ts.Program`
+with `.ngtypecheck` files containing template type-checking blocks, or TCBs), reuse of template
+type-checking code is critical for good performance. Not only is generation of these TCBs expensive,
+but forcing TypeScript to re-parse and re-analyze every `.ngtypecheck` file on each incremental
+change would be costly as well.
 
-# What optimizations are made?
+The `incremental` package is dedicated to allowing ngtsc to make these important optimizations
+safely.
+
+During an incremental compilation, the compiler begins with a process called "reconciliation",
+focused on understanding the differences between the incoming, new `ts.Program` and the
+last `ts.Program`. In TypeScript, an unchanged file will have its `ts.SourceFile` AST completely
+reused. Reconciliation therefore examines the `ts.SourceFile`s of both the old and new programs, and
+identifies files which have been added, removed, or changed. This information feeds in to the rest
+of the incremental compilation process.
+
+## Reuse of analysis results
+
+Angular's process of understanding an individual component, directive, or other decorated class is
+known as "analysis". Analysis is always performed on a class-by-class basis, so the analysis of a
+component only takes into consideration information present in the `@Component` decorator, and not
+for example in the `@NgModule` which declares the component.
+
+However, analysis _can_ depend on information outside of the decorated class's file. This can happen
+in two ways:
+
+* External resources, such as templates or stylesheets, are covered by analysis.
+* The partial evaluation of expressions within a class's metadata may descend into symbols imported
+  from other files.
+
+For example, a directive's selector may be determined via an imported constant:
+
+```typescript=
+import {Directive} from '@angular/core';
+import {DIR_SELECTOR} from './selectors';
+
+@Directive({
+  selector: DIR_SELECTOR,
+})
+export class Dir {}
+```
+
+The analysis of this directive _depends on_ the value of `DIR_SELECTOR` from `selectors.ts`.
+Consequently, if `selectors.ts` changes, `Dir` needs to be re-analyzed, even if `dir.ts` has not
+changed.
+
+The `incremental` system provides a mechanism which tracks such dependencies at the file level. The
+partial evaluation system records dependencies for any given evaluation operation when an import
+boundary is crossed, building up a file-to-file dependency graph. This graph is then transmitted to
+the next incremental compilation, where it can be used to determine, based on the set of files
+physically changed on disk, which files have _logically_ changed and need to be re-analyzed.
+
+## Reuse of emit results
+
+In plain TypeScript programs, the compiled JavaScript code for any given input file (e.g. `foo.ts`)
+depends only on the code within that input file. That is, only the contents of `foo.ts` can affect
+the generated contents written to `foo.js`. The TypeScript compiler can therefore perform a very
+simple optimization, and avoid generating and emitting code for any input files which do not change.
+This is important for good incremental build performance, as emitting a file is a very expensive
+operation.
+
+(in practice, the TypeScript feature of `const enum` declarations breaks this overly simple model)
+
+In Angular applications, however, this optimization is not nearly so simple. The emit of a `.js`
+file in Angular is affected in four main ways:
 
-ngtsc currently makes two optimizations: reuse of prior analysis work, and the skipping of file emits.
+* Just as in plain TS, it depends on the contents of the input `.ts` file.
+* It can be affected by expressions that were statically evaluated during analysis of any decorated
+  classes in the input, and these expressions can depend on other files.
 
-## Reuse of analyses
+For example, the directive with its selector specified via the imported `DIR_SELECTOR` constant
+above has compilation output which depends on the value of `DIR_SELECTOR`. Therefore, the `dir.js`
+file needs to be emitted whenever the value of the selector constant in `selectors.ts` changes, even
+if `dir.ts` itself is unchanged. The compiler therefore will re-emit `dir.js` if the `dir.ts` file
+is determined to have _logically_ changed, using the same dependency graph that powers analysis
+reuse.
 
-If a build has succeeded previously, ngtsc has available the analyses of all Angular classes in the prior program, as well as the dependency graph which outlines inter-file dependencies. This is known as the "last good compilation".
+* Components can have external templates and CSS stylesheets which influence their compilation.
 
-When the next build begins, ngtsc follows a simple algorithm which reuses prior work where possible:
+These are incorporated into a component's analysis dependencies.
 
-1) For each input file, ngtsc makes a determination as to whether the file is "logically changed".
+* Components (and NgModules) are influenced by the NgModule graph, which controls which directives
+  and pipes are "in scope" for each component's template.
 
-"Logically changed" means that either:
+This last relationship is the most difficult, as there is no import relationship between a component
+and the directives and pipes it uses in its template. That means that a component file can be
+logically unchanged, but still require re-emit if one of its dependencies has been updated in a way
+that influences the compilation of the component.
 
-* The file itself has physically changed on disk, or
-* One of the file's dependencies has physically changed on disk.
+### Example
 
-Either of these conditions invalidates the previous analysis of the file.
+For example, the output of a compiled component includes an array called `directiveDefs`, listing
+all of the directives and components actually used within the component's template. This array is
+built by combining the template (from analysis) with the "scope" of the component - the set of
+directives and pipes which are available for use in its template. This scope is synthesized from the
+analysis of not just the component's NgModule, but other NgModules which might be imported, and the
+components/directives that those NgModules export, and their analysis data as well.
 
-2) ngtsc begins constructing a new dependency graph.
+These dependencies of a component on the directives/pipes it consumes, and the NgModule structures
+that made them visible, are not captured in the file-level dependency graph. This is due to the
+peculiar nature of NgModule and component relationships: NgModules import components, so there is
+never a reference from a component to its NgModule, or any of its directive or pipe dependencies.
 
-For each logically unchanged file, its dependencies are copied wholesale into the new graph.
+In code, this looks like:
 
-3) ngtsc begins analyzing each file in the program.
+```typescript=
+// dir.ts
+@Directive({selector: '[dir]'})
+export class Dir {}
 
-If the file is logically unchanged, ngtsc will reuse the previous analysis and only call the 'register' phase of compilation, to apply any necessary side effects.
+// cmp.ts
+@Component({
+  selector: 'cmp',
+  template: '<div dir></div>', // Matches the `[dir]` selector
+})
+export class Cmp {}
 
-If the file is logically changed, ngtsc will re-analyze it.
+// mod.ts
+import {Dir} from './dir';
+import {Cmp} from './cmp';
 
-## Reuse of template type-checking code
+@NgModule({declarations: [Dir, Cmp]})
+export class Mod {}
+```
 
-Generally speaking, the generation of a template type-checking "shim" for an input component file is a time-consuming operation. Such generation produces several outputs:
+Here, `Cmp` never directly imports or refers to `Dir`, but it _does_ consume the directive in its
+template. During emit, `Cmp` would receive a `directiveDefs` array:
 
-1) The text of the template type-checking shim file, which can later be fed to TypeScript for the production of raw diagnostics.
-2) Metadata regarding source mappings within the template type-checking shim, which can be used to convert the raw diagnostics into mapped template diagnostics.
-3) "Construction" diagnostics, which are diagnostics produced as a side effect of generation of the shim itself.
+```typescript=
+// cmp.js
+import * as i1 from './dir';
 
-When a component file is logically unchanged, ngtsc attempts to reuse this generation work. As part of creating both the new emit program and template type-checking program, the `ts.SourceFile` of the shim for the component file is included directly and not re-generated.
+export class Cmp {
+  static cmp = defineComponent({
+    ...
+    directiveDefs: [i1.Dir],
+  });
+}
+```
 
-At the same time, the metadata and construction diagnostics are passed via the incremental build system. When TS gets diagnostics for the shim file, this metadata is used to convert them into mapped template diagnostics for delivery to the user.
+If `Dir`'s selector were to change to `[other]` in an incremental step, it might no longer
+match `Cmp`'s template, in which case `cmp.js` would need to be re-emitted.
 
-### Limitations on template type-checking reuse
+### SemanticSymbols
 
-In certain cases the template type-checking system is unable to use the existing shim code. If the component is logically changed, the shim is regenerated in case its contents may have changed. If generating the shim itself required the use of any "inline" code (type-checking code which needs to be inserted into the component file instead for some reason), it also becomes ineligible for reuse.
+For each decorated class being processed, the compiler creates a `SemanticSymbol` representing the
+data regarding that class that's involved in these "indirect" relationships. During the
+compiler's `resolve` phase, these `SemanticSymbol`s are connected together to form a "semantic
+dependency graph". Two classes of data are recorded:
 
-## Skipping emit
+* Information about the public shape API of the class.
 
-ngtsc makes a decision to skip the emit of a file if it can prove that the contents of the file will not have changed since the last good compilation. To prove this, two conditions must be true.
+For example, directives have a public API which includes their selector, any inputs or outputs, and
+their `exportAs` name if any.
 
-* The input file itself must not have changed since the previous compilation.
+* Information about the emit shape of the class, including any dependencies on
+  other `SemanticSymbol`s.
 
-* None of the files on which the input file is dependent have changed since the previous compilation.
+This information allows the compiler to determine which classes have been semantically affected by
+other changes in the program (and therefore need to be re-emitted) according to a simple algorithm:
 
-The second condition is challenging to prove, as Angular allows statically evaluated expressions in lots of contexts that could result in changes from file to file. For example, the `name` of an `@Pipe` could be a reference to a constant in a different file. As part of analyzing the program, the compiler keeps track of such dependencies in order to answer this question.
+1. Determine the set of `SemanticSymbol`s which have had their public API changed.
+2. For each `SemanticSymbol`, determine if its emit shape was affected by any of the public API
+   changes (that is, if it depends on a symbol with public API changes).
 
-The emit of a file is the most expensive part of TypeScript/Angular compilation, so skipping emits when they are not necessary is one of the most valuable things the compiler can do to improve incremental build performance.
+### Determination of public API changes
 
-## The two dependency graphs
+The first step of this algorithm is to determine, for each `SemanticSymbol`, if its public API has
+been affected. Doing this requires knowing which `SemanticSymbol` in the previous program
+corresponds to the current version of the symbol. There are two ways that symbols can be "matched":
 
-For both of the above optimizations, ngtsc makes use of dependency information extracted from the program. But these usages are subtly different.
+* The old and new symbols share the same `ts.ClassDeclaration`.
 
-To reuse previous analyses, ngtsc uses the _prior_ compilation's dependency graph, plus the information about which files have changed, to determine whether it's safe to reuse the prior compilation's work.
+This is true whenever the `ts.SourceFile` declaring the class has not changed between the old and
+new programs. The public API of the symbol may still have changed (such as when a directive's
+selector is determined by a constant imported from another file, like in one of the examples above).
+But if the declaration file itself has not changed, then the previous symbol can be directly found
+this way.
 
-To skip emit, ngtsc uses the _current_ compilation's dependency graph, coupled with the information about which files have changed since the last successful build, to determine the set of outputs that need to be re-emitted.
+* By its unique path and name.
 
-# How does incremental compilation work?
+If the file _has_ changed, then symbols can be located by their declaration path plus their name, if
+they have a name that's guaranteed to be unique. Currently, this means that the classes are declared
+at the top level of the source file, so their names are in the module's scope. If this is the case,
+then a symbol can be matched to its ancestor even if the declaration itself has changed in the
+meantime. Note that there is no guarantee the symbol will be of the same type - an incremental step
+may change a directive into a component, or even into a pipe or injectable.
 
-The initial compilation is no different from a standalone compilation; the compiler is unaware that incremental compilation will be utilized.
+Once a previous symbol is located, its public API can be compared against the current version of the
+symbol. Symbols without a valid ancestor are assumed to have changed in their public API.
 
-When an `NgtscProgram` is created for a _subsequent_ compilation, it is initialized with the `NgtscProgram` from the previous compilation. It is therefore able to take advantage of any information present in the previous compilation to optimize the next one.
+The compiler processes all `SemanticSymbol`s and determines the `Set` of them which have experienced
+public API changes. In the example above, this `Set` would include the `DirectiveSymbol` for `Dir`,
+since its selector would have changed.
 
-This information is leveraged in two major ways:
+### Determination of emit requirements
 
-1) The previous `ts.Program` itself is used to create the next `ts.Program`, allowing TypeScript internally to leverage information from the previous compile in much the same way.
+For each potential output file, the compiler then looks at all declared `SemanticSymbol`s and uses
+their ancestor symbol (if present) as well as the `Set` of public API changes to make a
+determination if that file needs be emitted.
 
-2) An `IncrementalDriver` instance is constructed from the old and new `ts.Program`s, and the previous program's `IncrementalDriver`.
+In the case of a `ComponentSymbol`, for example, the symbol tracks the dependencies of the component
+which will go into the `directiveDefs` array. If that array is different, the component needs to be
+re-emitted. Even if the same directives are referenced, if one of those directives has changed in
+its public API, the emitted output (especially when generating prelink library code) may be
+affected, and the component needs to be re-emitted.
 
-The compiler then proceeds normally, using the `IncrementalDriver` to manage the reuse of any pertinent information while processing the new program. As a part of this process, the compiler (again) maps out all of the dependencies between files.
+### `SemanticReference`s
 
-## Determination of files to emit
+`ComponentSymbol`s track their dependencies via an intermediate type, a `SemanticReference`. Such
+references track not only the `SemanticSymbol` of the dependency, but also the name by which it was
+imported previously. Even if a dependency's identity and public API remain the same, changes in how
+it was exported can affect the import which needs to be emitted within the component consuming it,
+and thus would require a re-emit.
 
-The principle question the incremental build system must answer is "which TS files need to be emitted for a given compilation?"
+## Reuse of template type-checking results
 
-To determine whether an individual TS file needs to be emitted, the compiler must determine 3 things about the file:
+Since type-checking block (TCB) generation for template type-checking is a form of
+emit, `SemanticSymbol`s also track the type-checking shape of decorated classes. This includes any
+data which is not public API, but upon which the TCB generation for components might depend. Such
+data includes:
 
-1. Have its contents changed since the last time it was emitted?
-2. Has any resource file that the TS file depends on (like an HTML template) changed since the last time it was emitted?
-3. Have any of the dependencies of the TS file changed since the last time it was emitted?
+* Type-checking API shape from any base classes, since TCB generation uses information from the full
+  inheritance chain of a directive/pipe.
+* The generic signature shape of the class.
+* Private field names for `@Input`s and `@Output`s.
 
-If the answer to any of these questions is yes, then the TS file needs to be re-emitted.
+Using a similar algorithm to the `emit` optimization, the compiler can determine which files need
+their type-checking code regenerated, and which can continue to use TCB code from the previous
+program, even if some dependencies have unrelated changes.
 
-## Tracking of changes
+## Unsuccessful compilation attempts
 
-On every invocation, the compiler receives (or can easily determine) several pieces of information:
+Often, incremental compilations will fail. The user's input program may contain incomplete changes,
+typos, semantic errors, or other problems which prevent the compiler from fully analyzing or
+emitting it. Such errors create problems for incremental build correctness, as the compiler relies
+on information extracted from the previous program to correctly optimize the next compilation. If
+the previous compilation failed, such information may be unreliable.
 
-* The set of `ts.SourceFile`s that have changed since the last invocation.
-* The set of resources (`.html` files) that have changed since the last invocation.
+In theory, the compiler could simply not perform incremental compilation on top of a broken build,
+and assume that it must redo all analysis and re-emit all files, but this would result in
+devestatingly poor performance for common developer workflows that rely on automatically running
+builds and/or tests on every change. The compiler must deal with such scenarios more gracefully.
 
-With this information, the compiler can perform rebuild optimizations:
+ngtsc solves this problem by always performing its incremental steps from a "last known good"
+compilation. Thus, if compilation A succeeds, and a subsequent compilation B fails, compilation C
+will begin using the state of compilation A as a starting point. This requires tracking of two
+important pieces of state:
 
-1. The compiler uses the last good compilation's dependency graph to determine which parts of its analysis work can be reused, and an initial set of files which need to be re-emitted.
-2. The compiler analyzes the rest of the program and generates an updated dependency graph, which describes the relationships between files in the program as they are currently.
-3. Based on this graph, the compiler can make a final determination for each TS file whether it needs to be re-emitted or can safely be skipped. This produces a set called `pendingEmit` of every file which requires a re-emit.
-4. The compiler cycles through the files and emits those which are necessary, removing them from `pendingEmit`.
+* Reusable information, such as analysis results, from the last known good compilation.
+* The accumulated set of files which have physically changed since the last known good compilation.
 
-Theoretically, after this process `pendingEmit` should be empty. As a precaution against errors which might happen in the future, `pendingEmit` is also passed into future compilations, so any files which previously were determined to need an emit (but have not been successfully produced yet) will be retried on subsequent compilations. This is mostly relevant if a client of `ngtsc` attempts to implement emit-on-error functionality.
-
-However, normally the execution of these steps requires a correct input program. In the presence of TypeScript errors, the compiler cannot perform this process. It might take many invocations for the user to fix all their TypeScript errors and reach a compilation that can be analyzed.
-
-As a result, the compiler must accumulate the set of these changes (to source files and resource files) from build to build until analysis can succeed.
-
-This accumulation happens via a type called `BuildState`. This type is a union of two possible states.
-
-### `PendingBuildState`
-
-This is the initial state of any build, and the final state of any unsuccessful build. This state tracks both `pendingEmit` files from the previous program as well as any source or resource files which have changed since the last successful analysis.
-
-If a new build starts and inherits from a failed build, it will merge the failed build's `PendingBuildState` into its own, including the sets of changed files.
-
-### `AnalyzedBuildState`
-
-After analysis is successfully performed, the compiler uses its dependency graph to evaluate the impact of any accumulated changes from the `PendingBuildState`, and updates `pendingEmit` with all of the pending files. At this point, the compiler transitions from a `PendingBuildState` to an `AnalyzedBuildState`, which only tracks `pendingEmit`. In `AnalyzedBuildState` this set is complete, and the raw changes can be forgotten.
-
-If a new build is started after a successful build, only `pendingEmit` from the `AnalyzedBuildState` needs to be merged into the new build's `PendingBuildState`.
-
-## Component to NgModule dependencies
-
-The dependency of a component on its NgModule is slightly problematic, because its arrow is in the opposite direction of the source dependency (which is from NgModule to the component, via `declarations`). This creates a scenario where, if the NgModule is changed to no longer include the component, the component still needs to be re-emitted because the module has changed.
-
-This is one of very few cases where `pendingEmit` must be populated with the logical changes from the previous program (those files determined to be changed in step 1 under "Tracking of changes" above), and cannot simply be created from the current dependency graph.
-
-# What optimizations are possible in the future?
-
-There is plenty of room for improvement here, with diminishing returns for the work involved.
-
-## Semantic dependency tracking
-
-Currently the compiler tracks dependencies only at the file level, and will re-emit dependent files if they _may_ have been affected by a change. Often times a change though does _not_ require updates to dependent files.
-
-For example, today a component's `NgModule` and all of the other components which consume that module's export scope are considered to depend on the component file itself. If the component's template changes, this triggers a re-emit of not only the component's file, but the entire chain of its NgModule and that module's export scope. This happens even though the template of a component _does not have any impact_ on any components which consume it - these other emits are deeply unnecessary.
-
-In contrast, if the component's _selector_ changes, then all those dependent files do need to be updated since their `directiveDefs` might have changed.
-
-Currently the compiler does not distinguish these two cases, and conservatively always re-emits the entire NgModule chain. It would be possible to break the dependency graph down into finer-grained nodes and distinguish between updates that affect the component, vs updates that affect its dependents. This would be a huge win, but is exceedingly complex.
-
-## Skipping template type-checking
-
-Under ideal conditions, after an initial template type-checking program is created, it may be possible to reuse it for emit _and_ type-checking in subsequent builds. This would be a pretty advanced optimization but would save creation of a second `ts.Program` on each valid rebuild.
+Using this information, ngtsc is able to "forget" about the intermediate failed attempts and begin
+each new compilation as if it were a single step from the last successful build. It can then ensure
+complete correctness of its reuse optimization, since it has reliable data extracted from the "
+previous" successful build.

--- a/packages/compiler-cli/src/ngtsc/incremental/api.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/api.ts
@@ -50,22 +50,6 @@ export interface DependencyTracker<T extends {fileName: string} = ts.SourceFile>
   addResourceDependency(from: T, on: AbsoluteFsPath): void;
 
   /**
-   * Record that the file `from` depends on the file `on` as well as `on`'s direct dependencies.
-   *
-   * This operation is reified immediately, so if future dependencies are added to `on` they will
-   * not automatically be added to `from`.
-   */
-  addTransitiveDependency(from: T, on: T): void;
-
-  /**
-   * Record that the file `from` depends on the resource dependencies of `resourcesOf`.
-   *
-   * This operation is reified immediately, so if future resource dependencies are added to
-   * `resourcesOf` they will not automatically be added to `from`.
-   */
-  addTransitiveResources(from: T, resourcesOf: T): void;
-
-  /**
    * Record that the given file contains unresolvable dependencies.
    *
    * In practice, this means that the dependency graph cannot provide insight into the effects of

--- a/packages/compiler-cli/src/ngtsc/incremental/semantic_graph/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/incremental/semantic_graph/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "semantic_graph",
+    srcs = ["index.ts"] + glob([
+        "src/**/*.ts",
+    ]),
+    deps = [
+        "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/compiler-cli/src/ngtsc/reflection",
+        "@npm//typescript",
+    ],
+)

--- a/packages/compiler-cli/src/ngtsc/incremental/semantic_graph/index.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/semantic_graph/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export {SemanticReference, SemanticSymbol} from './src/api';
+export {SemanticDepGraph, SemanticDepGraphUpdater} from './src/graph';
+export {areTypeParametersEqual, extractSemanticTypeParameters, SemanticTypeParameter} from './src/type_parameters';
+export {isArrayEqual, isReferenceEqual, isSetEqual, isSymbolEqual} from './src/util';

--- a/packages/compiler-cli/src/ngtsc/incremental/semantic_graph/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/semantic_graph/src/api.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+
+import {absoluteFromSourceFile, AbsoluteFsPath} from '../../../file_system';
+import {ClassDeclaration} from '../../../reflection';
+
+/**
+ * Represents a symbol that is recognizable across incremental rebuilds, which enables the captured
+ * metadata to be compared to the prior compilation. This allows for semantic understanding of
+ * the changes that have been made in a rebuild, which potentially enables more reuse of work
+ * from the prior compilation.
+ */
+export abstract class SemanticSymbol {
+  /**
+   * The path of the file that declares this symbol.
+   */
+  public readonly path: AbsoluteFsPath;
+
+  /**
+   * The identifier of this symbol, or null if no identifier could be determined. It should
+   * uniquely identify the symbol relative to `file`. This is typically just the name of a
+   * top-level class declaration, as that uniquely identifies the class within the file.
+   *
+   * If the identifier is null, then this symbol cannot be recognized across rebuilds. In that
+   * case, the symbol is always assumed to have semantically changed to guarantee a proper
+   * rebuild.
+   */
+  public readonly identifier: string|null;
+
+  constructor(
+      /**
+       * The declaration for this symbol.
+       */
+      public readonly decl: ClassDeclaration,
+  ) {
+    this.path = absoluteFromSourceFile(decl.getSourceFile());
+    this.identifier = getSymbolIdentifier(decl);
+  }
+
+  /**
+   * Allows the symbol to be compared to the equivalent symbol in the previous compilation. The
+   * return value indicates whether the symbol has been changed in a way such that its public API
+   * is affected.
+   *
+   * This method determines whether a change to _this_ symbol require the symbols that
+   * use to this symbol to be re-emitted.
+   *
+   * Note: `previousSymbol` is obtained from the most recently succeeded compilation. Symbols of
+   * failed compilations are never provided.
+   *
+   * @param previousSymbol The symbol from a prior compilation.
+   */
+  abstract isPublicApiAffected(previousSymbol: SemanticSymbol): boolean;
+
+  /**
+   * Allows the symbol to determine whether its emit is affected. The equivalent symbol from a prior
+   * build is given, in addition to the set of symbols of which the public API has changed.
+   *
+   * This method determines whether a change to _other_ symbols, i.e. those present in
+   * `publicApiAffected`, should cause _this_ symbol to be re-emitted.
+   *
+   * @param previousSymbol The equivalent symbol from a prior compilation. Note that it may be a
+   * different type of symbol, if e.g. a Component was changed into a Directive with the same name.
+   * @param publicApiAffected The set of symbols of which the public API has changed.
+   */
+  isEmitAffected?(previousSymbol: SemanticSymbol, publicApiAffected: Set<SemanticSymbol>): boolean;
+
+  /**
+   * Similar to `isPublicApiAffected`, but here equivalent symbol from a prior compilation needs
+   * to be compared to see if the type-check block of components that use this symbol is affected.
+   *
+   * This method determines whether a change to _this_ symbol require the symbols that
+   * use to this symbol to have their type-check block regenerated.
+   *
+   * Note: `previousSymbol` is obtained from the most recently succeeded compilation. Symbols of
+   * failed compilations are never provided.
+   *
+   * @param previousSymbol The symbol from a prior compilation.
+   */
+  abstract isTypeCheckApiAffected(previousSymbol: SemanticSymbol): boolean;
+
+  /**
+   * Similar to `isEmitAffected`, but focused on the type-check block of this symbol. This method
+   * determines whether a change to _other_ symbols, i.e. those present in `typeCheckApiAffected`,
+   * should cause _this_ symbol's type-check block to be regenerated.
+   *
+   * @param previousSymbol The equivalent symbol from a prior compilation. Note that it may be a
+   * different type of symbol, if e.g. a Component was changed into a Directive with the same name.
+   * @param typeCheckApiAffected The set of symbols of which the type-check API has changed.
+   */
+  isTypeCheckBlockAffected?
+      (previousSymbol: SemanticSymbol, typeCheckApiAffected: Set<SemanticSymbol>): boolean;
+}
+
+/**
+ * Represents a reference to a semantic symbol that has been emitted into a source file. The
+ * reference may refer to the symbol using a different name than the semantic symbol's declared
+ * name, e.g. in case a re-export under a different name was chosen by a reference emitter.
+ * Consequently, to know that an emitted reference is still valid not only requires that the
+ * semantic symbol is still valid, but also that the path by which the symbol is imported has not
+ * changed.
+ */
+export interface SemanticReference {
+  symbol: SemanticSymbol;
+
+  /**
+   * The path by which the symbol has been referenced.
+   */
+  importPath: string|null;
+}
+
+function getSymbolIdentifier(decl: ClassDeclaration): string|null {
+  if (!ts.isSourceFile(decl.parent)) {
+    return null;
+  }
+
+  // If this is a top-level class declaration, the class name is used as unique identifier.
+  // Other scenarios are currently not supported and causes the symbol not to be identified
+  // across rebuilds, unless the declaration node has not changed.
+  return decl.name.text;
+}

--- a/packages/compiler-cli/src/ngtsc/incremental/semantic_graph/src/graph.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/semantic_graph/src/graph.ts
@@ -1,0 +1,281 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Expression, ExternalExpr} from '@angular/compiler';
+import {AbsoluteFsPath} from '../../../file_system';
+import {ClassDeclaration} from '../../../reflection';
+import {SemanticReference, SemanticSymbol} from './api';
+
+export interface SemanticDependencyResult {
+  /**
+   * The files that need to be re-emitted.
+   */
+  needsEmit: Set<AbsoluteFsPath>;
+
+  /**
+   * The files for which the type-check block should be regenerated.
+   */
+  needsTypeCheckEmit: Set<AbsoluteFsPath>;
+
+  /**
+   * The newly built graph that represents the current compilation.
+   */
+  newGraph: SemanticDepGraph;
+}
+
+/**
+ * Represents a declaration for which no semantic symbol has been registered. For example,
+ * declarations from external dependencies have not been explicitly registered and are represented
+ * by this symbol. This allows the unresolved symbol to still be compared to a symbol from a prior
+ * compilation.
+ */
+class OpaqueSymbol extends SemanticSymbol {
+  isPublicApiAffected(): false {
+    return false;
+  }
+
+  isTypeCheckApiAffected(): false {
+    return false;
+  }
+}
+
+/**
+ * The semantic dependency graph of a single compilation.
+ */
+export class SemanticDepGraph {
+  readonly files = new Map<AbsoluteFsPath, Map<string, SemanticSymbol>>();
+  readonly symbolByDecl = new Map<ClassDeclaration, SemanticSymbol>();
+
+  /**
+   * Registers a symbol in the graph. The symbol is given a unique identifier if possible, such that
+   * its equivalent symbol can be obtained from a prior graph even if its declaration node has
+   * changed across rebuilds. Symbols without an identifier are only able to find themselves in a
+   * prior graph if their declaration node is identical.
+   */
+  registerSymbol(symbol: SemanticSymbol): void {
+    this.symbolByDecl.set(symbol.decl, symbol);
+
+    if (symbol.identifier !== null) {
+      // If the symbol has a unique identifier, record it in the file that declares it. This enables
+      // the symbol to be requested by its unique name.
+      if (!this.files.has(symbol.path)) {
+        this.files.set(symbol.path, new Map<string, SemanticSymbol>());
+      }
+      this.files.get(symbol.path)!.set(symbol.identifier, symbol);
+    }
+  }
+
+  /**
+   * Attempts to resolve a symbol in this graph that represents the given symbol from another graph.
+   * If no matching symbol could be found, null is returned.
+   *
+   * @param symbol The symbol from another graph for which its equivalent in this graph should be
+   * found.
+   */
+  getEquivalentSymbol(symbol: SemanticSymbol): SemanticSymbol|null {
+    // First lookup the symbol by its declaration. It is typical for the declaration to not have
+    // changed across rebuilds, so this is likely to find the symbol. Using the declaration also
+    // allows to diff symbols for which no unique identifier could be determined.
+    let previousSymbol = this.getSymbolByDecl(symbol.decl);
+    if (previousSymbol === null && symbol.identifier !== null) {
+      // The declaration could not be resolved to a symbol in a prior compilation, which may
+      // happen because the file containing the declaration has changed. In that case we want to
+      // lookup the symbol based on its unique identifier, as that allows us to still compare the
+      // changed declaration to the prior compilation.
+      previousSymbol = this.getSymbolByName(symbol.path, symbol.identifier);
+    }
+
+    return previousSymbol;
+  }
+
+  /**
+   * Attempts to find the symbol by its identifier.
+   */
+  private getSymbolByName(path: AbsoluteFsPath, identifier: string): SemanticSymbol|null {
+    if (!this.files.has(path)) {
+      return null;
+    }
+    const file = this.files.get(path)!;
+    if (!file.has(identifier)) {
+      return null;
+    }
+    return file.get(identifier)!;
+  }
+
+  /**
+   * Attempts to resolve the declaration to its semantic symbol.
+   */
+  getSymbolByDecl(decl: ClassDeclaration): SemanticSymbol|null {
+    if (!this.symbolByDecl.has(decl)) {
+      return null;
+    }
+    return this.symbolByDecl.get(decl)!;
+  }
+}
+
+/**
+ * Implements the logic to go from a previous dependency graph to a new one, along with information
+ * on which files have been affected.
+ */
+export class SemanticDepGraphUpdater {
+  private readonly newGraph = new SemanticDepGraph();
+
+  /**
+   * Contains opaque symbols that were created for declarations for which there was no symbol
+   * registered, which happens for e.g. external declarations.
+   */
+  private readonly opaqueSymbols = new Map<ClassDeclaration, OpaqueSymbol>();
+
+  constructor(
+      /**
+       * The semantic dependency graph of the most recently succeeded compilation, or null if this
+       * is the initial build.
+       */
+      private priorGraph: SemanticDepGraph|null) {}
+
+  /**
+   * Registers the symbol in the new graph that is being created.
+   */
+  registerSymbol(symbol: SemanticSymbol): void {
+    this.newGraph.registerSymbol(symbol);
+  }
+
+  /**
+   * Takes all facts that have been gathered to create a new semantic dependency graph. In this
+   * process, the semantic impact of the changes is determined which results in a set of files that
+   * need to be emitted and/or type-checked.
+   */
+  finalize(): SemanticDependencyResult {
+    if (this.priorGraph === null) {
+      // If no prior dependency graph is available then this was the initial build, in which case
+      // we don't need to determine the semantic impact as everything is already considered
+      // logically changed.
+      return {
+        needsEmit: new Set<AbsoluteFsPath>(),
+        needsTypeCheckEmit: new Set<AbsoluteFsPath>(),
+        newGraph: this.newGraph,
+      };
+    }
+
+    const needsEmit = this.determineInvalidatedFiles(this.priorGraph);
+    const needsTypeCheckEmit = this.determineInvalidatedTypeCheckFiles(this.priorGraph);
+    return {
+      needsEmit,
+      needsTypeCheckEmit,
+      newGraph: this.newGraph,
+    };
+  }
+
+  private determineInvalidatedFiles(priorGraph: SemanticDepGraph): Set<AbsoluteFsPath> {
+    const isPublicApiAffected = new Set<SemanticSymbol>();
+
+    // The first phase is to collect all symbols which have their public API affected. Any symbols
+    // that cannot be matched up with a symbol from the prior graph are considered affected.
+    for (const symbol of this.newGraph.symbolByDecl.values()) {
+      const previousSymbol = priorGraph.getEquivalentSymbol(symbol);
+      if (previousSymbol === null || symbol.isPublicApiAffected(previousSymbol)) {
+        isPublicApiAffected.add(symbol);
+      }
+    }
+
+    // The second phase is to find all symbols for which the emit result is affected, either because
+    // their used declarations have changed or any of those used declarations has had its public API
+    // affected as determined in the first phase.
+    const needsEmit = new Set<AbsoluteFsPath>();
+    for (const symbol of this.newGraph.symbolByDecl.values()) {
+      if (symbol.isEmitAffected === undefined) {
+        continue;
+      }
+
+      const previousSymbol = priorGraph.getEquivalentSymbol(symbol);
+      if (previousSymbol === null || symbol.isEmitAffected(previousSymbol, isPublicApiAffected)) {
+        needsEmit.add(symbol.path);
+      }
+    }
+
+    return needsEmit;
+  }
+
+  private determineInvalidatedTypeCheckFiles(priorGraph: SemanticDepGraph): Set<AbsoluteFsPath> {
+    const isTypeCheckApiAffected = new Set<SemanticSymbol>();
+
+    // The first phase is to collect all symbols which have their public API affected. Any symbols
+    // that cannot be matched up with a symbol from the prior graph are considered affected.
+    for (const symbol of this.newGraph.symbolByDecl.values()) {
+      const previousSymbol = priorGraph.getEquivalentSymbol(symbol);
+      if (previousSymbol === null || symbol.isTypeCheckApiAffected(previousSymbol)) {
+        isTypeCheckApiAffected.add(symbol);
+      }
+    }
+
+    // The second phase is to find all symbols for which the emit result is affected, either because
+    // their used declarations have changed or any of those used declarations has had its public API
+    // affected as determined in the first phase.
+    const needsTypeCheckEmit = new Set<AbsoluteFsPath>();
+    for (const symbol of this.newGraph.symbolByDecl.values()) {
+      if (symbol.isTypeCheckBlockAffected === undefined) {
+        continue;
+      }
+
+      const previousSymbol = priorGraph.getEquivalentSymbol(symbol);
+      if (previousSymbol === null ||
+          symbol.isTypeCheckBlockAffected(previousSymbol, isTypeCheckApiAffected)) {
+        needsTypeCheckEmit.add(symbol.path);
+      }
+    }
+
+    return needsTypeCheckEmit;
+  }
+
+  /**
+   * Creates a `SemanticReference` for the reference to `decl` using the expression `expr`. See
+   * the documentation of `SemanticReference` for details.
+   */
+  getSemanticReference(decl: ClassDeclaration, expr: Expression): SemanticReference {
+    return {
+      symbol: this.getSymbol(decl),
+      importPath: getImportPath(expr),
+    };
+  }
+
+  /**
+   * Gets the `SemanticSymbol` that was registered for `decl` during the current compilation, or
+   * returns an opaque symbol that represents `decl`.
+   */
+  getSymbol(decl: ClassDeclaration): SemanticSymbol {
+    const symbol = this.newGraph.getSymbolByDecl(decl);
+    if (symbol === null) {
+      // No symbol has been recorded for the provided declaration, which would be the case if the
+      // declaration is external. Return an opaque symbol in that case, to allow the external
+      // declaration to be compared to a prior compilation.
+      return this.getOpaqueSymbol(decl);
+    }
+    return symbol;
+  }
+
+  /**
+   * Gets or creates an `OpaqueSymbol` for the provided class declaration.
+   */
+  private getOpaqueSymbol(decl: ClassDeclaration): OpaqueSymbol {
+    if (this.opaqueSymbols.has(decl)) {
+      return this.opaqueSymbols.get(decl)!;
+    }
+
+    const symbol = new OpaqueSymbol(decl);
+    this.opaqueSymbols.set(decl, symbol);
+    return symbol;
+  }
+}
+
+function getImportPath(expr: Expression): string|null {
+  if (expr instanceof ExternalExpr) {
+    return `${expr.value.moduleName}\$${expr.value.name}`;
+  } else {
+    return null;
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/incremental/semantic_graph/src/type_parameters.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/semantic_graph/src/type_parameters.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+
+import {ClassDeclaration} from '../../../reflection';
+import {isArrayEqual} from './util';
+
+/**
+ * Describes a generic type parameter of a semantic symbol. A class declaration with type parameters
+ * needs special consideration in certain contexts. For example, template type-check blocks may
+ * contain type constructors of used directives which include the type parameters of the directive.
+ * As a consequence, if a change is made that affects the type parameters of said directive, any
+ * template type-check blocks that use the directive need to be regenerated.
+ *
+ * This type represents a single generic type parameter. It currently only tracks whether the
+ * type parameter has a constraint, i.e. has an `extends` clause. When a constraint is present, we
+ * currently assume that the type parameter is affected in each incremental rebuild; proving that
+ * a type parameter with constraint is not affected is non-trivial as it requires full semantic
+ * understanding of the type constraint.
+ */
+export interface SemanticTypeParameter {
+  /**
+   * Whether a type constraint, i.e. an `extends` clause is present on the type parameter.
+   */
+  hasGenericTypeBound: boolean;
+}
+
+/**
+ * Converts the type parameters of the given class into their semantic representation. If the class
+ * does not have any type parameters, then `null` is returned.
+ */
+export function extractSemanticTypeParameters(node: ClassDeclaration): SemanticTypeParameter[]|
+    null {
+  if (!ts.isClassDeclaration(node) || node.typeParameters === undefined) {
+    return null;
+  }
+
+  return node.typeParameters.map(
+      typeParam => ({hasGenericTypeBound: typeParam.constraint !== undefined}));
+}
+
+/**
+ * Compares the list of type parameters to determine if they can be considered equal.
+ */
+export function areTypeParametersEqual(
+    current: SemanticTypeParameter[]|null, previous: SemanticTypeParameter[]|null): boolean {
+  // First compare all type parameters one-to-one; any differences mean that the list of type
+  // parameters has changed.
+  if (!isArrayEqual(current, previous, isTypeParameterEqual)) {
+    return false;
+  }
+
+  // If there is a current list of type parameters and if any of them has a generic type constraint,
+  // then the meaning of that type parameter may have changed without us being aware; as such we
+  // have to assume that the type parameters have in fact changed.
+  if (current !== null && current.some(typeParam => typeParam.hasGenericTypeBound)) {
+    return false;
+  }
+
+  return true;
+}
+
+function isTypeParameterEqual(a: SemanticTypeParameter, b: SemanticTypeParameter): boolean {
+  return a.hasGenericTypeBound === b.hasGenericTypeBound;
+}

--- a/packages/compiler-cli/src/ngtsc/incremental/semantic_graph/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/semantic_graph/src/util.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {SemanticReference, SemanticSymbol} from './api';
+
+/**
+ * Determines whether the provided symbols represent the same declaration.
+ */
+export function isSymbolEqual(a: SemanticSymbol, b: SemanticSymbol): boolean {
+  if (a.decl === b.decl) {
+    // If the declaration is identical then it must represent the same symbol.
+    return true;
+  }
+
+  if (a.identifier === null || b.identifier === null) {
+    // Unidentifiable symbols are assumed to be different.
+    return false;
+  }
+
+  return a.path === b.path && a.identifier === b.identifier;
+}
+
+/**
+ * Determines whether the provided references to a semantic symbol are still equal, i.e. represent
+ * the same symbol and are imported by the same path.
+ */
+export function isReferenceEqual(a: SemanticReference, b: SemanticReference): boolean {
+  if (!isSymbolEqual(a.symbol, b.symbol)) {
+    // If the reference's target symbols are different, the reference itself is different.
+    return false;
+  }
+
+  if (a.importPath === null || b.importPath === null) {
+    // If no import path is known for either of the references they are considered different.
+    return false;
+  }
+
+  return a.importPath === b.importPath;
+}
+
+export function referenceEquality<T>(a: T, b: T): boolean {
+  return a === b;
+}
+
+/**
+ * Determines if the provided arrays are equal to each other, using the provided equality tester
+ * that is called for all entries in the array.
+ */
+export function isArrayEqual<T>(
+    a: readonly T[]|null, b: readonly T[]|null,
+    equalityTester: (a: T, b: T) => boolean = referenceEquality): boolean {
+  if (a === null || b === null) {
+    return a === b;
+  }
+
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  return !a.some((item, index) => !equalityTester(item, b[index]));
+}
+
+/**
+ * Determines if the provided sets are equal to each other, using the provided equality tester.
+ * Sets that only differ in ordering are considered equal.
+ */
+export function isSetEqual<T>(
+    a: ReadonlySet<T>|null, b: ReadonlySet<T>|null,
+    equalityTester: (a: T, b: T) => boolean = referenceEquality): boolean {
+  if (a === null || b === null) {
+    return a === b;
+  }
+
+  if (a.size !== b.size) {
+    return false;
+  }
+
+  for (const itemA of a) {
+    let found = false;
+    for (const itemB of b) {
+      if (equalityTester(itemA, itemB)) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/compiler-cli/src/ngtsc/incremental/semantic_graph/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/semantic_graph/src/util.ts
@@ -34,11 +34,8 @@ export function isReferenceEqual(a: SemanticReference, b: SemanticReference): bo
     return false;
   }
 
-  if (a.importPath === null || b.importPath === null) {
-    // If no import path is known for either of the references they are considered different.
-    return false;
-  }
-
+  // The reference still corresponds with the same symbol, now check that the path by which it is
+  // imported has not changed.
   return a.importPath === b.importPath;
 }
 

--- a/packages/compiler-cli/src/ngtsc/incremental/src/dependency_tracking.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/src/dependency_tracking.ts
@@ -35,24 +35,6 @@ export class FileDependencyGraph<T extends {fileName: string} = ts.SourceFile> i
     this.nodeFor(from).usesResources.add(resource);
   }
 
-  addTransitiveDependency(from: T, on: T): void {
-    const nodeFrom = this.nodeFor(from);
-    nodeFrom.dependsOn.add(on.fileName);
-
-    const nodeOn = this.nodeFor(on);
-    for (const dep of nodeOn.dependsOn) {
-      nodeFrom.dependsOn.add(dep);
-    }
-  }
-
-  addTransitiveResources(from: T, resourcesOf: T): void {
-    const nodeFrom = this.nodeFor(from);
-    const nodeOn = this.nodeFor(resourcesOf);
-    for (const dep of nodeOn.usesResources) {
-      nodeFrom.usesResources.add(dep);
-    }
-  }
-
   recordDependencyAnalysisFailure(file: T): void {
     this.nodeFor(file).failedAnalysis = true;
   }
@@ -61,10 +43,6 @@ export class FileDependencyGraph<T extends {fileName: string} = ts.SourceFile> i
     const node = this.nodes.get(from);
 
     return node ? [...node.usesResources] : [];
-  }
-
-  isStale(sf: T, changedTsPaths: Set<string>, changedResources: Set<AbsoluteFsPath>): boolean {
-    return isLogicallyChanged(sf, this.nodeFor(sf), changedTsPaths, EMPTY_SET, changedResources);
   }
 
   /**
@@ -160,5 +138,3 @@ interface FileNode {
   usesResources: Set<AbsoluteFsPath>;
   failedAnalysis: boolean;
 }
-
-const EMPTY_SET: ReadonlySet<any> = new Set<any>();

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
@@ -989,7 +989,5 @@ runInEachFileSystem(() => {
 const fakeDepTracker: DependencyTracker = {
   addDependency: () => undefined,
   addResourceDependency: () => undefined,
-  addTransitiveDependency: () => undefined,
-  addTransitiveResources: () => undefined,
   recordDependencyAnalysisFailure: () => undefined,
 };

--- a/packages/compiler-cli/src/ngtsc/scope/src/local.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/local.ts
@@ -33,16 +33,6 @@ export interface LocalModuleScope extends ExportScope {
 }
 
 /**
- * Information about the compilation scope of a registered declaration.
- */
-export interface CompilationScope extends ScopeData {
-  /** The declaration whose compilation scope is described here. */
-  declaration: ClassDeclaration;
-  /** The declaration of the NgModule that declares this `declaration`. */
-  ngModule: ClassDeclaration;
-}
-
-/**
  * A registry which collects information about NgModules, Directives, Components, and Pipes which
  * are local (declared in the ts.Program being compiled), and can produce `LocalModuleScope`s
  * which summarize the compilation scope of a component.
@@ -185,20 +175,6 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
     } else {
       return null;
     }
-  }
-
-  /**
-   * Returns a collection of the compilation scope for each registered declaration.
-   */
-  getCompilationScopes(): CompilationScope[] {
-    const scopes: CompilationScope[] = [];
-    this.declarationToModule.forEach((declData, declaration) => {
-      const scope = this.getScopeOfModule(declData.ngModule);
-      if (scope !== null) {
-        scopes.push({declaration, ngModule: declData.ngModule, ...scope.compilation});
-      }
-    });
-    return scopes;
   }
 
   private registerDeclarationOfModule(

--- a/packages/compiler-cli/src/ngtsc/transform/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/transform/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/diagnostics",
         "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/incremental:api",
+        "//packages/compiler-cli/src/ngtsc/incremental/semantic_graph",
         "//packages/compiler-cli/src/ngtsc/indexer",
         "//packages/compiler-cli/src/ngtsc/modulewithproviders",
         "//packages/compiler-cli/src/ngtsc/perf",

--- a/packages/compiler-cli/src/ngtsc/transform/src/trait.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/trait.ts
@@ -7,6 +7,7 @@
  */
 
 import * as ts from 'typescript';
+import {SemanticSymbol} from '../../incremental/semantic_graph';
 import {DecoratorHandler, DetectResult} from './api';
 
 export enum TraitState {
@@ -44,22 +45,23 @@ export enum TraitState {
  * This not only simplifies the implementation, but ensures traits are monomorphic objects as
  * they're all just "views" in the type system of the same object (which never changes shape).
  */
-export type Trait<D, A, R> =
-    PendingTrait<D, A, R>|SkippedTrait<D, A, R>|AnalyzedTrait<D, A, R>|ResolvedTrait<D, A, R>;
+export type Trait<D, A, S extends SemanticSymbol|null, R> = PendingTrait<D, A, S, R>|
+    SkippedTrait<D, A, S, R>|AnalyzedTrait<D, A, S, R>|ResolvedTrait<D, A, S, R>;
 
 /**
  * The value side of `Trait` exposes a helper to create a `Trait` in a pending state (by delegating
  * to `TraitImpl`).
  */
 export const Trait = {
-  pending: <D, A, R>(handler: DecoratorHandler<D, A, R>, detected: DetectResult<D>):
-      PendingTrait<D, A, R> => TraitImpl.pending(handler, detected),
+  pending: <D, A, S extends SemanticSymbol|null, R>(
+      handler: DecoratorHandler<D, A, S, R>, detected: DetectResult<D>): PendingTrait<D, A, S, R> =>
+      TraitImpl.pending(handler, detected),
 };
 
 /**
  * The part of the `Trait` interface that's common to all trait states.
  */
-export interface TraitBase<D, A, R> {
+export interface TraitBase<D, A, S extends SemanticSymbol|null, R> {
   /**
    * Current state of the trait.
    *
@@ -70,7 +72,7 @@ export interface TraitBase<D, A, R> {
   /**
    * The `DecoratorHandler` which matched on the class to create this trait.
    */
-  handler: DecoratorHandler<D, A, R>;
+  handler: DecoratorHandler<D, A, S, R>;
 
   /**
    * The detection result (of `handler.detect`) which indicated that this trait applied to the
@@ -86,20 +88,22 @@ export interface TraitBase<D, A, R> {
  *
  * Pending traits have yet to be analyzed in any way.
  */
-export interface PendingTrait<D, A, R> extends TraitBase<D, A, R> {
+export interface PendingTrait<D, A, S extends SemanticSymbol|null, R> extends
+    TraitBase<D, A, S, R> {
   state: TraitState.Pending;
 
   /**
    * This pending trait has been successfully analyzed, and should transition to the "analyzed"
    * state.
    */
-  toAnalyzed(analysis: A|null, diagnostics: ts.Diagnostic[]|null): AnalyzedTrait<D, A, R>;
+  toAnalyzed(analysis: A|null, diagnostics: ts.Diagnostic[]|null, symbol: S):
+      AnalyzedTrait<D, A, S, R>;
 
   /**
    * During analysis it was determined that this trait is not eligible for compilation after all,
    * and should be transitioned to the "skipped" state.
    */
-  toSkipped(): SkippedTrait<D, A, R>;
+  toSkipped(): SkippedTrait<D, A, S, R>;
 }
 
 /**
@@ -109,7 +113,8 @@ export interface PendingTrait<D, A, R> extends TraitBase<D, A, R> {
  *
  * This is a terminal state.
  */
-export interface SkippedTrait<D, A, R> extends TraitBase<D, A, R> {
+export interface SkippedTrait<D, A, S extends SemanticSymbol|null, R> extends
+    TraitBase<D, A, S, R> {
   state: TraitState.Skipped;
 }
 
@@ -118,8 +123,10 @@ export interface SkippedTrait<D, A, R> extends TraitBase<D, A, R> {
  *
  * Analyzed traits have analysis results available, and are eligible for resolution.
  */
-export interface AnalyzedTrait<D, A, R> extends TraitBase<D, A, R> {
+export interface AnalyzedTrait<D, A, S extends SemanticSymbol|null, R> extends
+    TraitBase<D, A, S, R> {
   state: TraitState.Analyzed;
+  symbol: S;
 
   /**
    * Analysis results of the given trait (if able to be produced), or `null` if analysis failed
@@ -136,7 +143,7 @@ export interface AnalyzedTrait<D, A, R> extends TraitBase<D, A, R> {
    * This analyzed trait has been successfully resolved, and should be transitioned to the
    * "resolved" state.
    */
-  toResolved(resolution: R|null, diagnostics: ts.Diagnostic[]|null): ResolvedTrait<D, A, R>;
+  toResolved(resolution: R|null, diagnostics: ts.Diagnostic[]|null): ResolvedTrait<D, A, S, R>;
 }
 
 /**
@@ -147,8 +154,10 @@ export interface AnalyzedTrait<D, A, R> extends TraitBase<D, A, R> {
  *
  * This is a terminal state.
  */
-export interface ResolvedTrait<D, A, R> extends TraitBase<D, A, R> {
+export interface ResolvedTrait<D, A, S extends SemanticSymbol|null, R> extends
+    TraitBase<D, A, S, R> {
   state: TraitState.Resolved;
+  symbol: S;
 
   /**
    * Resolved traits must have produced valid analysis results.
@@ -176,30 +185,33 @@ export interface ResolvedTrait<D, A, R> extends TraitBase<D, A, R> {
  * An implementation of the `Trait` type which transitions safely between the various
  * `TraitState`s.
  */
-class TraitImpl<D, A, R> {
+class TraitImpl<D, A, S extends SemanticSymbol|null, R> {
   state: TraitState = TraitState.Pending;
-  handler: DecoratorHandler<D, A, R>;
+  handler: DecoratorHandler<D, A, S, R>;
   detected: DetectResult<D>;
   analysis: Readonly<A>|null = null;
+  symbol: S|null = null;
   resolution: Readonly<R>|null = null;
   analysisDiagnostics: ts.Diagnostic[]|null = null;
   resolveDiagnostics: ts.Diagnostic[]|null = null;
 
-  constructor(handler: DecoratorHandler<D, A, R>, detected: DetectResult<D>) {
+  constructor(handler: DecoratorHandler<D, A, S, R>, detected: DetectResult<D>) {
     this.handler = handler;
     this.detected = detected;
   }
 
-  toAnalyzed(analysis: A|null, diagnostics: ts.Diagnostic[]|null): AnalyzedTrait<D, A, R> {
+  toAnalyzed(analysis: A|null, diagnostics: ts.Diagnostic[]|null, symbol: S):
+      AnalyzedTrait<D, A, S, R> {
     // Only pending traits can be analyzed.
     this.assertTransitionLegal(TraitState.Pending, TraitState.Analyzed);
     this.analysis = analysis;
     this.analysisDiagnostics = diagnostics;
+    this.symbol = symbol;
     this.state = TraitState.Analyzed;
-    return this as AnalyzedTrait<D, A, R>;
+    return this as AnalyzedTrait<D, A, S, R>;
   }
 
-  toResolved(resolution: R|null, diagnostics: ts.Diagnostic[]|null): ResolvedTrait<D, A, R> {
+  toResolved(resolution: R|null, diagnostics: ts.Diagnostic[]|null): ResolvedTrait<D, A, S, R> {
     // Only analyzed traits can be resolved.
     this.assertTransitionLegal(TraitState.Analyzed, TraitState.Resolved);
     if (this.analysis === null) {
@@ -208,14 +220,14 @@ class TraitImpl<D, A, R> {
     this.resolution = resolution;
     this.state = TraitState.Resolved;
     this.resolveDiagnostics = diagnostics;
-    return this as ResolvedTrait<D, A, R>;
+    return this as ResolvedTrait<D, A, S, R>;
   }
 
-  toSkipped(): SkippedTrait<D, A, R> {
+  toSkipped(): SkippedTrait<D, A, S, R> {
     // Only pending traits can be skipped.
     this.assertTransitionLegal(TraitState.Pending, TraitState.Skipped);
     this.state = TraitState.Skipped;
-    return this as SkippedTrait<D, A, R>;
+    return this as SkippedTrait<D, A, S, R>;
   }
 
   /**
@@ -236,8 +248,8 @@ class TraitImpl<D, A, R> {
   /**
    * Construct a new `TraitImpl` in the pending state.
    */
-  static pending<D, A, R>(handler: DecoratorHandler<D, A, R>, detected: DetectResult<D>):
-      PendingTrait<D, A, R> {
-    return new TraitImpl(handler, detected) as PendingTrait<D, A, R>;
+  static pending<D, A, S extends SemanticSymbol|null, R>(
+      handler: DecoratorHandler<D, A, S, R>, detected: DetectResult<D>): PendingTrait<D, A, S, R> {
+    return new TraitImpl(handler, detected) as PendingTrait<D, A, S, R>;
   }
 }

--- a/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
@@ -23,7 +23,7 @@ runInEachFileSystem(() => {
     beforeEach(() => _ = absoluteFrom);
 
     it('should not run decoration handlers against declaration files', () => {
-      class FakeDecoratorHandler implements DecoratorHandler<{}|null, unknown, unknown> {
+      class FakeDecoratorHandler implements DecoratorHandler<{}|null, unknown, null, unknown> {
         name = 'FakeDecoratorHandler';
         precedence = HandlerPrecedence.PRIMARY;
 
@@ -32,6 +32,9 @@ runInEachFileSystem(() => {
         }
         analyze(): AnalysisOutput<unknown> {
           throw new Error('analyze should not have been called');
+        }
+        symbol(): null {
+          throw new Error('symbol should not have been called');
         }
         compileFull(): CompileResult {
           throw new Error('compile should not have been called');
@@ -46,7 +49,7 @@ runInEachFileSystem(() => {
       const reflectionHost = new TypeScriptReflectionHost(checker);
       const compiler = new TraitCompiler(
           [new FakeDecoratorHandler()], reflectionHost, NOOP_PERF_RECORDER, NOOP_INCREMENTAL_BUILD,
-          true, CompilationMode.FULL, new DtsTransformRegistry());
+          true, CompilationMode.FULL, new DtsTransformRegistry(), null);
       const sourceFile = program.getSourceFile('lib.d.ts')!;
       const analysis = compiler.analyzeSync(sourceFile);
 
@@ -55,7 +58,7 @@ runInEachFileSystem(() => {
     });
 
     describe('compilation mode', () => {
-      class PartialDecoratorHandler implements DecoratorHandler<{}, {}, unknown> {
+      class PartialDecoratorHandler implements DecoratorHandler<{}, {}, null, unknown> {
         name = 'PartialDecoratorHandler';
         precedence = HandlerPrecedence.PRIMARY;
 
@@ -68,6 +71,10 @@ runInEachFileSystem(() => {
 
         analyze(): AnalysisOutput<unknown> {
           return {analysis: {}};
+        }
+
+        symbol(): null {
+          return null;
         }
 
         compileFull(): CompileResult {
@@ -89,7 +96,7 @@ runInEachFileSystem(() => {
         }
       }
 
-      class FullDecoratorHandler implements DecoratorHandler<{}, {}, unknown> {
+      class FullDecoratorHandler implements DecoratorHandler<{}, {}, null, unknown> {
         name = 'FullDecoratorHandler';
         precedence = HandlerPrecedence.PRIMARY;
 
@@ -102,6 +109,10 @@ runInEachFileSystem(() => {
 
         analyze(): AnalysisOutput<unknown> {
           return {analysis: {}};
+        }
+
+        symbol(): null {
+          return null;
         }
 
         compileFull(): CompileResult {
@@ -127,7 +138,7 @@ runInEachFileSystem(() => {
         const compiler = new TraitCompiler(
             [new PartialDecoratorHandler(), new FullDecoratorHandler()], reflectionHost,
             NOOP_PERF_RECORDER, NOOP_INCREMENTAL_BUILD, true, CompilationMode.PARTIAL,
-            new DtsTransformRegistry());
+            new DtsTransformRegistry(), null);
         const sourceFile = program.getSourceFile('test.ts')!;
         compiler.analyzeSync(sourceFile);
         compiler.resolve();
@@ -157,7 +168,7 @@ runInEachFileSystem(() => {
         const compiler = new TraitCompiler(
             [new PartialDecoratorHandler(), new FullDecoratorHandler()], reflectionHost,
             NOOP_PERF_RECORDER, NOOP_INCREMENTAL_BUILD, true, CompilationMode.FULL,
-            new DtsTransformRegistry());
+            new DtsTransformRegistry(), null);
         const sourceFile = program.getSourceFile('test.ts')!;
         compiler.analyzeSync(sourceFile);
         compiler.resolve();

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -161,7 +161,9 @@ export class NgtscTestEnvironment {
     const absFilePath = this.fs.resolve(this.basePath, fileName);
     if (this.multiCompileHostExt !== null) {
       this.multiCompileHostExt.invalidate(absFilePath);
-      this.changedResources!.add(absFilePath);
+      if (!fileName.endsWith('.ts')) {
+        this.changedResources!.add(absFilePath);
+      }
     }
     this.fs.ensureDir(this.fs.dirname(absFilePath));
     this.fs.writeFile(absFilePath, content);
@@ -173,6 +175,9 @@ export class NgtscTestEnvironment {
       throw new Error(`Not caching files - call enableMultipleCompilations()`);
     }
     this.multiCompileHostExt.invalidate(absFilePath);
+    if (!fileName.endsWith('.ts')) {
+      this.changedResources!.add(absFilePath);
+    }
   }
 
   tsconfig(

--- a/packages/compiler-cli/test/ngtsc/incremental_error_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/incremental_error_spec.ts
@@ -239,12 +239,13 @@ runInEachFileSystem(() => {
         export class TargetCmp {}
       `);
       env.write('module.ts', `
-        import {NgModule} from '@angular/core';
+        import {NgModule, NO_ERRORS_SCHEMA} from '@angular/core';
         import {TargetCmp} from './target';
         import {TestCmp} from './test';
 
         @NgModule({
           declarations: [TestCmp, TargetCmp],
+          schemas: [NO_ERRORS_SCHEMA],
         })
         export class Module {}
       `);
@@ -268,7 +269,7 @@ runInEachFileSystem(() => {
       env.write('test.ts', `
         import {Component} from '@angular/core';
 
-        @Component({selector: 'test-cmp', template: '...'})
+        @Component({selector: 'test-cmp-fixed', template: '...'})
         export class TestCmp {}
       `);
 
@@ -283,7 +284,7 @@ runInEachFileSystem(() => {
         '/module.js',
 
         // Because TargetCmp also belongs to the same module, it should be re-emitted since
-        // TestCmp's elector may have changed.
+        // TestCmp's selector was changed.
         '/target.js',
       ]);
     });
@@ -329,7 +330,7 @@ runInEachFileSystem(() => {
       env.write('a.ts', `
         import {Component} from '@angular/core';
 
-        @Component({selector: 'test-cmp', template: '...'})
+        @Component({selector: 'test-cmp', template: '<div dir></div>'})
         export class CmpA {}
       `);
       env.write('b.ts', `
@@ -357,17 +358,16 @@ runInEachFileSystem(() => {
         export class Module {}
       `);
       env.write('lib.ts', `
-        import {Component, NgModule} from '@angular/core';
+        import {Directive, NgModule} from '@angular/core';
 
-        @Component({
-          selector: 'lib-cmp',
-          template: '...',
+        @Directive({
+          selector: '[dir]',
         })
-        export class LibCmp {}
+        export class LibDir {}
 
         @NgModule({
-          declarations: [LibCmp],
-          exports: [LibCmp],
+          declarations: [LibDir],
+          exports: [LibDir],
         })
         export class LibModule {}
       `);
@@ -378,17 +378,27 @@ runInEachFileSystem(() => {
 
       // Introduce the error in LibModule
       env.write('lib.ts', `
-      import {Component, NgModule} from '@angular/core';
+      import {Directive, NgModule} from '@angular/core';
 
-      @Component({
-        selector: 'lib-cmp',
-        template: '...',
+      @Directive({
+        selector: '[dir]',
       })
-      export class LibCmp {}
+      export class LibDir {}
+
+      @Directive({
+        selector: '[dir]',
+      })
+      export class NewDir {}
 
       @NgModule({
-        declarations: [LibCmp],
-        exports: [LibCmp],
+        declarations: [NewDir],
+      })
+      export class NewModule {}
+
+      @NgModule({
+        declarations: [LibDir],
+        imports: [NewModule],
+        exports: [LibDir, NewModule],
       })
       export class LibModule // missing braces
       `);
@@ -407,9 +417,13 @@ runInEachFileSystem(() => {
       })
       export class LibCmp {}
 
+      @NgModule({})
+      export class NewModule {}
+
       @NgModule({
         declarations: [LibCmp],
-        exports: [LibCmp],
+        imports: [NewModule],
+        exports: [LibCmp, NewModule],
       })
       export class LibModule {}
       `);
@@ -417,9 +431,10 @@ runInEachFileSystem(() => {
       env.driveMain();
 
       expectToHaveWritten([
-        // Both CmpA and CmpB should be re-emitted.
+        // CmpA should be re-emitted as `NewModule` was added since the successful emit, which added
+        // `NewDir` as a matching directive to CmpA. Alternatively, CmpB should not be re-emitted
+        // as it does not use the newly added directive.
         '/a.js',
-        '/b.js',
 
         // So should the module itself.
         '/module.js',
@@ -468,8 +483,7 @@ runInEachFileSystem(() => {
           '/other.js',
           '/a.js',
 
-          // Bcause they depend on a.ts
-          '/b.js',
+          // Because they depend on a.ts
           '/module.js',
         ]);
       });
@@ -512,7 +526,10 @@ runInEachFileSystem(() => {
           '/other.js',
 
           // Because a.html changed
-          '/a.js', '/module.js',
+          '/a.js',
+
+          // module.js should not be re-emitted, as it is not affected by the change and its remote
+          // scope is unaffected.
 
           // b.js and module.js should not be re-emitted, because specifically when tracking
           // resource dependencies, the compiler knows that a change to a resource file only affects

--- a/packages/compiler-cli/test/ngtsc/incremental_semantic_changes_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/incremental_semantic_changes_spec.ts
@@ -1,0 +1,2271 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../src/ngtsc/testing';
+
+import {NgtscTestEnvironment} from './env';
+
+const testFiles = loadStandardTestFiles();
+
+runInEachFileSystem(() => {
+  describe('ngtsc incremental compilation (semantic changes)', () => {
+    let env!: NgtscTestEnvironment;
+
+    beforeEach(() => {
+      env = NgtscTestEnvironment.setup(testFiles);
+      env.enableMultipleCompilations();
+      env.tsconfig();
+    });
+
+    function expectToHaveWritten(files: string[]): void {
+      const set = env.getFilesWrittenSinceLastFlush();
+
+      const expectedSet = new Set<string>();
+      for (const file of files) {
+        expectedSet.add(file);
+        expectedSet.add(file.replace(/\.js$/, '.d.ts'));
+      }
+
+      expect(set).toEqual(expectedSet);
+
+      // Reset for the next compilation.
+      env.flushWrittenFileTracking();
+    }
+
+    describe('changes to public api', () => {
+      it('should not recompile dependent components when public api is unchanged', () => {
+        // Testing setup: ADep is a component with an input and an output, and is consumed by two
+        // other components - ACmp within its same NgModule, and BCmp which depends on ADep via an
+        // NgModule import.
+        //
+        // ADep is changed during the test without affecting its public API, and the test asserts
+        // that both ACmp and BCmp which consume ADep are not re-emitted.
+        env.write('a/dep.ts', `
+          import {Component, Input, Output, EventEmitter} from '@angular/core';
+
+          @Component({
+            selector: 'a-dep',
+            template: 'a-dep',
+          })
+          export class ADep {
+            @Input()
+            input!: string;
+
+            @Output()
+            output = new EventEmitter<string>();
+          }
+        `);
+        env.write('a/cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'a-cmp',
+            template: '<a-dep></a-dep>',
+          })
+          export class ACmp {}
+        `);
+        env.write('a/mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {ADep} from './dep';
+          import {ACmp} from './cmp';
+
+          @NgModule({
+            declarations: [ADep, ACmp],
+            exports: [ADep],
+          })
+          export class AMod {}
+        `);
+        env.write('b/cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'b-cmp',
+            template: '<a-dep></a-dep>',
+          })
+          export class BCmp {}
+        `);
+        env.write('b/mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {BCmp} from './cmp';
+          import {AMod} from '../a/mod';
+
+          @NgModule({
+            declarations: [BCmp],
+            imports: [AMod],
+          })
+          export class BMod {}
+        `);
+
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        // Change ADep without affecting its public API.
+        env.write('a/dep.ts', `
+          import {Component, Input, Output, EventEmitter} from '@angular/core';
+
+          @Component({
+            selector: 'a-dep',
+            template: 'a-dep',
+          })
+          export class ADep {
+            @Input()
+            input!: string;
+
+            @Output()
+            output = new EventEmitter<number>(); // changed from string to number
+          }
+        `);
+
+        env.driveMain();
+        expectToHaveWritten([
+          // ADep is written because it was updated.
+          '/a/dep.js',
+
+          // AMod is written because it has a direct dependency on ADep.
+          '/a/mod.js',
+
+          // Nothing else is written because the public API of AppCmpB was not affected
+        ]);
+      });
+
+      it('should not recompile components that do not use a changed directive', () => {
+        // Testing setup: ADep is a directive with an input and output, which is visible to two
+        // components which do not use ADep in their templates - ACmp within the same NgModule, and
+        // BCmp which has visibility of ADep via an NgModule import.
+        //
+        // During the test, ADep's public API is changed, and the test verifies that neither ACmp
+        // nor BCmp are re-emitted.
+
+        env.write('a/dep.ts', `
+          import {Directive, Input, Output, EventEmitter} from '@angular/core';
+
+          @Directive({
+            selector: '[a-dep]',
+          })
+          export class ADep {
+            @Input()
+            input!: string;
+
+            @Output()
+            output = new EventEmitter<string>();
+          }
+        `);
+        env.write('a/cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'a-cmp',
+            template: 'Does not use a-dep.',
+          })
+          export class ACmp {}
+        `);
+        env.write('a/mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {ADep} from './dep';
+          import {ACmp} from './cmp';
+
+          @NgModule({
+            declarations: [ADep, ACmp],
+            exports: [ADep],
+          })
+          export class AMod {}
+        `);
+        env.write('b/cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'b-cmp',
+            template: 'Does not use a-dep.',
+          })
+          export class BCmp {}
+        `);
+        env.write('b/mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {BCmp} from './cmp';
+          import {AMod} from '../a/mod';
+
+          @NgModule({
+            declarations: [BCmp],
+            imports: [AMod],
+          })
+          export class BMod {}
+        `);
+
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        // Update ADep and change its public API.
+        env.write('a/dep.ts', `
+          import {Directive, Input, Output, EventEmitter} from '@angular/core';
+
+          @Directive({
+            selector: '[a-dep]',
+            template: 'a-dep',
+          })
+          export class ADep {
+            @Input()
+            input!: string;
+
+            @Output('output-renamed') // public binding name of the @Output is changed.
+            output = new EventEmitter<string>();
+          }
+        `);
+
+        env.driveMain();
+        expectToHaveWritten([
+          // ADep is written because it was updated.
+          '/a/dep.js',
+
+          // AMod is written because it has a direct dependency on ADep.
+          '/a/mod.js',
+
+          // Nothing else is written because neither ACmp nor BCmp depend on ADep.
+        ]);
+      });
+
+      it('should recompile components for which a directive usage is introduced', () => {
+        // Testing setup: Cmp is a component with a template that would match a directive with the
+        // selector '[dep]' if one existed. Dep is a directive with a different selector initially.
+        //
+        // During the test, Dep's selector is updated to '[dep]', causing it to begin matching the
+        // template of Cmp. The test verifies that Cmp is re-emitted after this change.
+        env.write('dep.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[does-not-match]',
+          })
+          export class Dep {}
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp',
+            template: '<div dep></div>',
+          })
+          export class Cmp {}
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dep} from './dep';
+
+          @NgModule({
+            declarations: [Cmp, Dep],
+          })
+          export class Mod {}
+        `);
+
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        env.write('dep.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]', // selector changed to now match inside Cmp's template
+          })
+          export class Dep {}
+        `);
+        env.driveMain();
+
+        expectToHaveWritten([
+          // Dep is written because it was directly updated.
+          '/dep.js',
+
+          // Mod is written because it has a direct dependency on Dep.
+          '/mod.js',
+
+          // Cmp is written because the directives matched in its template have changed.
+          '/cmp.js',
+        ]);
+      });
+
+      it('should recompile components for which a directive usage is removed', () => {
+        // Testing setup: Cmp is a component with a template that matches a directive Dep with the
+        // initial selector '[dep]'.
+        //
+        // During the test, Dep's selector is changed, causing it to no longer match the template of
+        // Cmp. The test verifies that Cmp is re-emitted after this change.
+
+        env.write('dep.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {}
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp',
+            template: '<div dep></div>',
+          })
+          export class Cmp {}
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dep} from './dep';
+
+          @NgModule({
+            declarations: [Cmp, Dep],
+          })
+          export class Mod {}
+        `);
+
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        env.write('dep.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[does-not-match]', // selector changed to no longer match Cmp's template
+          })
+          export class Dep {}
+        `);
+        env.driveMain();
+
+        expectToHaveWritten([
+          // Dep is written because it was directly updated.
+          '/dep.js',
+
+          // Mod is written because it has a direct dependency on Dep.
+          '/mod.js',
+
+          // Cmp is written because the directives matched in its template have changed.
+          '/cmp.js',
+        ]);
+      });
+
+      it('should recompile dependent components when an input is added', () => {
+        // Testing setup: Cmp is a component with a template that matches a directive Dep with the
+        // initial selector '[dep]'.
+        //
+        // During the test, an input is added to Dep, and the test verifies that Cmp is re-emitted.
+
+        env.write('dep.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {}
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp',
+            template: '<div dep></div>',
+          })
+          export class Cmp {}
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dep} from './dep';
+
+          @NgModule({
+            declarations: [Cmp, Dep],
+          })
+          export class Mod {}
+        `);
+
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        env.write('dep.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {
+            @Input() input!: string; // adding this changes Dep's public API
+          }
+        `);
+        env.driveMain();
+
+        expectToHaveWritten([
+          // Dep is written because it was directly updated.
+          '/dep.js',
+
+          // Mod is written because it has a direct dependency on Dep.
+          '/mod.js',
+
+          // Cmp is written because it depends on Dep, which has changed in its public API.
+          '/cmp.js',
+        ]);
+      });
+
+      it('should recompile dependent components when an input is renamed', () => {
+        // Testing setup: Cmp is a component with a template that matches a directive Dep with the
+        // initial selector '[dep]'.
+        //
+        // During the test, an input of Dep is renamed, and the test verifies that Cmp is
+        // re-emitted.
+
+        env.write('dep.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {
+            @Input() input!: string;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp',
+            template: '<div dep></div>',
+          })
+          export class Cmp {}
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dep} from './dep';
+
+          @NgModule({
+            declarations: [Cmp, Dep],
+          })
+          export class Mod {}
+        `);
+
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        env.write('dep.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {
+            @Input('renamed') input!: string; // renaming this changes Dep's public API
+          }
+        `);
+        env.driveMain();
+
+        expectToHaveWritten([
+          // Dep is written because it was directly updated.
+          '/dep.js',
+
+          // Mod is written because it has a direct dependency on Dep.
+          '/mod.js',
+
+          // Cmp is written because it depends on Dep, which has changed in its public API.
+          '/cmp.js',
+        ]);
+      });
+
+      it('should recompile dependent components when an input is removed', () => {
+        // Testing setup: Cmp is a component with a template that matches a directive Dep with the
+        // initial selector '[dep]'.
+        //
+        // During the test, an input of Dep is removed, and the test verifies that Cmp is
+        // re-emitted.
+
+        env.write('dep.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {
+            @Input() input!: string;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp',
+            template: '<div dep></div>',
+          })
+          export class Cmp {}
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dep} from './dep';
+
+          @NgModule({
+            declarations: [Cmp, Dep],
+          })
+          export class Mod {}
+        `);
+
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        env.write('dep.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {
+            // Dep's input has been removed, which changes its public API
+          }
+        `);
+        env.driveMain();
+
+        expectToHaveWritten([
+          // Dep is written because it was directly updated.
+          '/dep.js',
+
+          // Mod is written because it has a direct dependency on Dep.
+          '/mod.js',
+
+          // Cmp is written because it depends on Dep, which has changed in its public API.
+          '/cmp.js',
+        ]);
+      });
+
+      it('should recompile dependent components when an output is added', () => {
+        // Testing setup: Cmp is a component with a template that matches a directive Dep with the
+        // initial selector '[dep]'.
+        //
+        // During the test, an output of Dep is added, and the test verifies that Cmp is re-emitted.
+
+        env.write('dep.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {}
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp',
+            template: '<div dep></div>',
+          })
+          export class Cmp {}
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dep} from './dep';
+
+          @NgModule({
+            declarations: [Cmp, Dep],
+          })
+          export class Mod {}
+        `);
+
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        env.write('dep.ts', `
+          import {Directive, Output, EventEmitter} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {
+            @Output()
+            output = new EventEmitter<string>(); // added, which changes Dep's public API
+          }
+        `);
+        env.driveMain();
+
+        expectToHaveWritten([
+          // Dep is written because it was directly updated.
+          '/dep.js',
+
+          // Mod is written because it has a direct dependency on Dep.
+          '/mod.js',
+
+          // Cmp is written because it depends on Dep, which has changed in its public API.
+          '/cmp.js',
+        ]);
+      });
+
+      it('should recompile dependent components when an output is renamed', () => {
+        // Testing setup: Cmp is a component with a template that matches a directive Dep with the
+        // initial selector '[dep]'.
+        //
+        // During the test, an output of Dep is renamed, and the test verifies that Cmp is
+        // re-emitted.
+
+        env.write('dep.ts', `
+          import {Directive, Output, EventEmitter} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {
+            @Output() output = new EventEmitter<string>();
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp',
+            template: '<div dep></div>',
+          })
+          export class Cmp {}
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dep} from './dep';
+
+          @NgModule({
+            declarations: [Cmp, Dep],
+          })
+          export class Mod {}
+        `);
+
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        env.write('dep.ts', `
+          import {Directive, Output, EventEmitter} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {
+            @Output('renamed') output = new EventEmitter<string>(); // public API changed
+          }
+        `);
+        env.driveMain();
+
+        expectToHaveWritten([
+          // Dep is written because it was directly updated.
+          '/dep.js',
+
+          // Mod is written because it has a direct dependency on Dep.
+          '/mod.js',
+
+          // Cmp is written because it depends on Dep, which has changed in its public API.
+          '/cmp.js',
+        ]);
+      });
+
+      it('should recompile dependent components when an output is removed', () => {
+        // Testing setup: Cmp is a component with a template that matches a directive Dep with the
+        // initial selector '[dep]'.
+        //
+        // During the test, an output of Dep is removed, and the test verifies that Cmp is
+        // re-emitted.
+
+        env.write('dep.ts', `
+          import {Directive, Output, EventEmitter} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {
+            @Output() output = new EventEmitter<string>();
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp',
+            template: '<div dep></div>',
+          })
+          export class Cmp {}
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dep} from './dep';
+
+          @NgModule({
+            declarations: [Cmp, Dep],
+          })
+          export class Mod {}
+        `);
+
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        env.write('dep.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {
+            // Dep's output has been removed, which changes its public API
+          }
+        `);
+        env.driveMain();
+
+        expectToHaveWritten([
+          // Dep is written because it was directly updated.
+          '/dep.js',
+
+          // Mod is written because it has a direct dependency on Dep.
+          '/mod.js',
+
+          // Cmp is written because it depends on Dep, which has changed in its public API.
+          '/cmp.js',
+        ]);
+      });
+
+      it('should recompile dependent components when exportAs clause changes', () => {
+        // Testing setup: Cmp is a component with a template that matches a directive Dep with the
+        // initial selector '[dep]' and an exportAs clause.
+        //
+        // During the test, the exportAs clause of Dep is changed, and the test verifies that Cmp is
+        // re-emitted.
+
+        env.write('dep.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+            exportAs: 'depExport1',
+          })
+          export class Dep {}
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp',
+            template: '<div dep></div>',
+          })
+          export class Cmp {}
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dep} from './dep';
+
+          @NgModule({
+            declarations: [Cmp, Dep],
+          })
+          export class Mod {}
+        `);
+
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        env.write('dep.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+            exportAs: 'depExport2', // changing this changes Dep's public API
+          })
+          export class Dep {}
+        `);
+        env.driveMain();
+
+        expectToHaveWritten([
+          // Dep is written because it was directly updated.
+          '/dep.js',
+
+          // Mod is written because it has a direct dependency on Dep.
+          '/mod.js',
+
+          // Cmp is written because it depends on Dep, which has changed in its public API.
+          '/cmp.js',
+        ]);
+      });
+
+      it('should recompile components when a pipe is newly matched because it was renamed', () => {
+        // Testing setup: Cmp uses two pipes (PipeA and PipeB) in its template.
+        //
+        // During the test, the selectors of these pipes are swapped. This ensures that Cmp's
+        // template is still valid, since both pipe names continue to be valid within it. However,
+        // as the identity of each pipe is now different, the effective public API of those pipe
+        // usages has changed. The test then verifies that Cmp is re-emitted.
+
+        env.write('pipes.ts', `
+          import {Pipe} from '@angular/core';
+
+          @Pipe({
+            name: 'pipeA',
+          })
+          export class PipeA {
+            transform(value: any): any { return value; }
+          }
+
+          @Pipe({
+            name: 'pipeB',
+          })
+          export class PipeB {
+            transform(value: any): any { return value; }
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp',
+            template: '{{ value | pipeA }} {{ value | pipeB }}',
+          })
+          export class Cmp {
+            value!: string;
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {PipeA, PipeB} from './pipes';
+          import {Cmp} from './cmp';
+
+          @NgModule({
+            declarations: [Cmp, PipeA, PipeB],
+          })
+          export class Mod {}
+        `);
+
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        env.write('pipes.ts', `
+          import {Pipe} from '@angular/core';
+
+          @Pipe({
+            name: 'pipeB', // swapped with PipeB's selector
+          })
+          export class PipeA {
+            transform(value: any): any { return value; }
+          }
+
+          @Pipe({
+            name: 'pipeA', // swapped with PipeA's selector
+          })
+          export class PipeB {
+            transform(value: any): any { return value; }
+          }
+        `);
+
+        env.driveMain();
+        expectToHaveWritten([
+          // PipeA and PipeB have directly changed.
+          '/pipes.js',
+
+          // Mod depends directly on PipeA and PipeB.
+          '/mod.js',
+
+          // Cmp depends on the public APIs of PipeA and PipeB, which have changed (as they've
+          // swapped).
+          '/cmp.js',
+        ]);
+      });
+    });
+
+    describe('external declarations', () => {
+      it('should not recompile components that use external declarations that are not changed',
+         () => {
+           // Testing setup: Two components (MyCmpA and MyCmpB) both depend on an external directive
+           // which matches their templates, via an NgModule import.
+           //
+           // During the test, MyCmpA is invalidated, and the test verifies that only MyCmpA and not
+           // MyCmpB is re-emitted.
+           env.write('node_modules/external/index.d.ts', `
+             import * as ng from '@angular/core';
+
+             export declare class ExternalDir {
+               static ɵdir: ng.ɵɵDirectiveDefWithMeta<ExternalDir, "[external]", never, {}, {}, never>;
+             }
+
+             export declare class ExternalMod {
+               static ɵmod: ng.ɵɵNgModuleDefWithMeta<ExternalMod, [typeof ExternalDir], never, [typeof ExternalDir]>;
+             }
+           `);
+           env.write('cmp-a.ts', `
+             import {Component} from '@angular/core';
+
+             @Component({
+               template: '<div external></div>',
+             })
+             export class MyCmpA {}
+           `);
+           env.write('cmp-b.ts', `
+             import {Component} from '@angular/core';
+
+             @Component({
+               template: '<div external></div>',
+             })
+             export class MyCmpB {}
+           `);
+           env.write('mod.ts', `
+             import {NgModule} from '@angular/core';
+             import {ExternalMod} from 'external';
+             import {MyCmpA} from './cmp-a';
+             import {MyCmpB} from './cmp-b';
+
+             @NgModule({
+               declarations: [MyCmpA, MyCmpB],
+               imports: [ExternalMod],
+             })
+             export class MyMod {}
+           `);
+           env.driveMain();
+           env.flushWrittenFileTracking();
+
+           // Invalidate MyCmpA, causing it to be re-emitted.
+           env.invalidateCachedFile('cmp-a.ts');
+
+           env.driveMain();
+           expectToHaveWritten([
+             // MyMod is written because it has a direct reference to MyCmpA, which was invalidated.
+             '/mod.js',
+
+             // MyCmpA is written because it was invalidated.
+             '/cmp-a.js',
+
+             // MyCmpB should not be written because it is unaffected.
+           ]);
+         });
+
+      it('should recompile components once an external declaration is changed', () => {
+        // Testing setup: Two components (MyCmpA and MyCmpB) both depend on an external directive
+        // which matches their templates, via an NgModule import.
+        //
+        // During the test, the external directive is invalidated, and the test verifies that both
+        // components are re-emitted as a result.
+        env.write('node_modules/external/index.d.ts', `
+          import * as ng from '@angular/core';
+
+          export declare class ExternalDir {
+            static ɵdir: ng.ɵɵDirectiveDefWithMeta<ExternalDir, "[external]", never, {}, {}, never>;
+          }
+
+          export declare class ExternalMod {
+            static ɵmod: ng.ɵɵNgModuleDefWithMeta<ExternalMod, [typeof ExternalDir], never, [typeof ExternalDir]>;
+          }
+        `);
+        env.write('cmp-a.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: '<div external></div>',
+          })
+          export class MyCmpA {}
+        `);
+        env.write('cmp-b.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: '<div external></div>',
+          })
+          export class MyCmpB {}
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {ExternalMod} from 'external';
+          import {MyCmpA} from './cmp-a';
+          import {MyCmpB} from './cmp-b';
+
+          @NgModule({
+            declarations: [MyCmpA, MyCmpB],
+            imports: [ExternalMod],
+          })
+          export class MyMod {}
+        `);
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        // Invalidate the external file. Only the referential identity of external symbols matters
+        // for emit reuse, so invalidating this should cause all dependent components to be
+        // re-emitted.
+        env.invalidateCachedFile('node_modules/external/index.d.ts');
+        env.driveMain();
+
+        expectToHaveWritten([
+          // MyMod is written because it has a direct reference to ExternalMod, which was
+          // invalidated.
+          '/mod.js',
+
+          // MyCmpA is written because it uses ExternalDir, which has not changed public API but has
+          // changed identity.
+          '/cmp-a.js',
+
+          // MyCmpB is written because it uses ExternalDir, which has not changed public API but has
+          // changed identity.
+          '/cmp-b.js',
+        ]);
+      });
+    });
+
+    describe('symbol identity', () => {
+      it('should recompile components when their declaration name changes', () => {
+        // Testing setup: component Cmp depends on component Dep, which is directly exported.
+        //
+        // During the test, Dep's name is changed while keeping its public API the same. The test
+        // verifies that Cmp is re-emitted.
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp',
+            template: '<dep></dep>',
+          })
+          export class Cmp {}
+        `);
+        env.write('dep.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'dep',
+            template: 'Dep',
+          })
+          export class Dep {}
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dep} from './dep';
+
+          @NgModule({
+            declarations: [Cmp, Dep]
+          })
+          export class Mod {}
+        `);
+
+        env.driveMain();
+
+        env.write('dep.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'dep',
+            template: 'Dep',
+          })
+          export class ChangedDep {} // Dep renamed to ChangedDep.
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+
+          import {Cmp} from './cmp';
+          import {ChangedDep} from './dep';
+
+          @NgModule({
+            declarations: [Cmp, ChangedDep]
+          })
+          export class Mod {}
+        `);
+
+        env.flushWrittenFileTracking();
+        env.driveMain();
+
+        expectToHaveWritten([
+          // Dep and Mod were directly updated.
+          '/dep.js',
+          '/mod.js',
+
+          // Cmp required a re-emit because the name of Dep changed.
+          '/cmp.js',
+        ]);
+      });
+
+      it('should recompile components when the name by which they are exported changes', () => {
+        // Testing setup: component Cmp depends on component Dep, which is directly exported.
+        //
+        // During the test, Dep's exported name is changed while keeping its declaration name the
+        // same. The test verifies that Cmp is re-emitted.
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp',
+            template: '<dep></dep>',
+          })
+          export class Cmp {}
+        `);
+        env.write('dep.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'dep',
+            template: 'Dep',
+          })
+          export class Dep {}
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dep} from './dep';
+
+          @NgModule({
+            declarations: [Cmp, Dep]
+          })
+          export class Mod {}
+        `);
+
+        env.driveMain();
+
+        env.write('dep.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'dep',
+            template: 'Dep',
+          })
+          class Dep {}
+          export {Dep as ChangedDep}; // the export name of Dep is changed.
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+
+          import {Cmp} from './cmp';
+          import {ChangedDep} from './dep';
+
+          @NgModule({
+            declarations: [Cmp, ChangedDep]
+          })
+          export class Mod {}
+        `);
+
+        env.flushWrittenFileTracking();
+        env.driveMain();
+
+        expectToHaveWritten([
+          // Dep and Mod were directly updated.
+          '/dep.js',
+          '/mod.js',
+
+          // Cmp required a re-emit because the exported name of Dep changed.
+          '/cmp.js',
+        ]);
+      });
+
+      it('should recompile components when a re-export is renamed', () => {
+        // Testing setup: CmpUser uses CmpDep in its template. CmpDep is both directly and
+        // indirectly exported, and the compiler is guided into using the indirect export.
+        //
+        // During the test, the indirect export name is changed, and the test verifies that CmpUser
+        // is re-emitted.
+
+        env.write('cmp-user.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp-user',
+            template: '<cmp-dep></cmp-dep>',
+          })
+          export class CmpUser {}
+        `);
+        env.write('cmp-dep.ts', `
+          import {Component} from '@angular/core';
+
+          export {CmpDep as CmpDepExport};
+
+          @Component({
+            selector: 'cmp-dep',
+            template: 'Dep',
+          })
+          export class CmpDep {}
+        `);
+        env.write('module.ts', `
+          import {NgModule} from '@angular/core';
+          import {CmpUser} from './cmp-user';
+          import {CmpDepExport} from './cmp-dep';
+
+          @NgModule({
+            declarations: [CmpUser, CmpDepExport]
+          })
+          export class Module {}
+        `);
+
+        env.driveMain();
+
+        // Verify that the reference emitter used the export of `CmpDep` that appeared first in
+        // the source, i.e. `CmpDepExport`.
+        const userCmpJs = env.getContents('cmp-user.js');
+        expect(userCmpJs).toContain('CmpDepExport');
+
+        env.write('cmp-dep.ts', `
+          import {Component} from '@angular/core';
+
+          export {CmpDep as CmpDepExport2};
+
+          @Component({
+            selector: 'cmp-dep',
+            template: 'Dep',
+          })
+          export class CmpDep {}
+        `);
+        env.write('module.ts', `
+          import {NgModule} from '@angular/core';
+          import {CmpUser} from './cmp-user';
+          import {CmpDepExport2} from './cmp-dep';
+
+          @NgModule({
+            declarations: [CmpUser, CmpDepExport2]
+          })
+          export class Module {}
+        `);
+
+        env.flushWrittenFileTracking();
+        env.driveMain();
+
+        expectToHaveWritten([
+          // CmpDep and its module were directly updated.
+          '/cmp-dep.js',
+          '/module.js',
+
+          // CmpUser required a re-emit because it was previous emitted as `CmpDepExport`, but
+          // that export has since been renamed.
+          '/cmp-user.js',
+        ]);
+
+        // Verify that `CmpUser` now correctly imports `CmpDep` using its renamed
+        // re-export `CmpDepExport2`.
+        const userCmp2Js = env.getContents('cmp-user.js');
+        expect(userCmp2Js).toContain('CmpDepExport2');
+      });
+
+
+      it('should not recompile components when a directive is changed into a component', () => {
+        env.write('cmp-user.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp-user',
+            template: '<div dep></div>',
+          })
+          export class CmpUser {}
+        `);
+        env.write('dep.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {}
+        `);
+        env.write('module.ts', `
+          import {NgModule} from '@angular/core';
+          import {CmpUser} from './cmp-user';
+          import {Dep} from './dep';
+
+          @NgModule({
+            declarations: [CmpUser, Dep]
+          })
+          export class Module {}
+        `);
+
+        env.driveMain();
+        env.write('dep.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: '[dep]',
+            template: 'Dep',
+          })
+          export class Dep {}
+        `);
+
+        env.flushWrittenFileTracking();
+        env.driveMain();
+
+        expectToHaveWritten([
+          // Dep was directly changed.
+          '/dep.js',
+
+          // Module required a re-emit because its direct dependency (Dep) was changed.
+          '/module.js',
+
+          // CmpUser did not require a re-emit because its semantic dependencies were not affected.
+          // Dep is still matched and still has the same public API.
+        ]);
+      });
+
+      it('should recompile components when a directive and pipe are swapped', () => {
+        // CmpUser uses a directive DepA and a pipe DepB, with the same selector/name 'dep'.
+        //
+        // During the test, the decorators of DepA and DepB are swapped, effectively changing the
+        // SemanticSymbol types for them into different species while ensuring that CmpUser's
+        // template is still valid. The test then verifies that CmpUser is re-emitted.
+
+        env.write('cmp-user.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp-user',
+            template: '<dep>{{1 | dep}}</dep>',
+          })
+          export class CmpUser {}
+        `);
+        env.write('dep.ts', `
+          import {Directive, Pipe} from '@angular/core';
+
+          @Directive({
+            selector: 'dep',
+          })
+          export class DepA {}
+
+          @Pipe({
+            name: 'dep',
+          })
+          export class DepB {}
+        `);
+        env.write('module.ts', `
+          import {NgModule} from '@angular/core';
+          import {CmpUser} from './cmp-user';
+          import {DepA, DepB} from './dep';
+
+          @NgModule({
+            declarations: [CmpUser, DepA, DepB],
+          })
+          export class Module {}
+        `);
+
+        env.driveMain();
+
+        // The annotations on DepA and DepB are swapped. This ensures that when we're comparing the
+        // public API of these symbols to the prior program, the prior symbols are of a different
+        // type (pipe vs directive) than the new symbols, which should lead to a re-emit.
+        env.write('dep.ts', `
+          import {Directive, Pipe} from '@angular/core';
+
+          @Pipe({
+            name: 'dep',
+          })
+          export class DepA {}
+
+          @Directive({
+            selector: 'dep',
+          })
+          export class DepB {}
+        `);
+
+        env.flushWrittenFileTracking();
+        env.driveMain();
+
+        expectToHaveWritten([
+          // Dep was directly changed.
+          '/dep.js',
+
+          // Module required a re-emit because its direct dependency (Dep) was changed.
+          '/module.js',
+
+          // CmpUser required a re-emit because the shape of its matched symbols changed.
+          '/cmp-user.js',
+        ]);
+      });
+
+      it('should not recompile components when a component is changed into a directive', () => {
+        // Testing setup: CmpUser depends on a component Dep with an attribute selector.
+        //
+        // During the test, Dep is changed into a directive, and the test verifies that CmpUser is
+        // not re-emitted (as the public API of a directive and a component are the same).
+
+        env.write('cmp-user.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp-user',
+            template: '<div dep></div>',
+          })
+          export class CmpUser {}
+        `);
+        env.write('dep.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: '[dep]',
+            template: 'Dep',
+          })
+          export class Dep {}
+        `);
+        env.write('module.ts', `
+          import {NgModule} from '@angular/core';
+          import {CmpUser} from './cmp-user';
+          import {Dep} from './dep';
+
+          @NgModule({
+            declarations: [CmpUser, Dep]
+          })
+          export class Module {}
+        `);
+
+        env.driveMain();
+
+        env.write('dep.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dep]',
+          })
+          export class Dep {}
+        `);
+
+        env.flushWrittenFileTracking();
+        env.driveMain();
+
+        expectToHaveWritten([
+          // Dep was directly changed.
+          '/dep.js',
+
+          // Module required a re-emit because its direct dependency (Dep) was changed.
+          '/module.js',
+
+          // CmpUser did not require a re-emit because its semantic dependencies were not affected.
+          // Dep is still matched and still has the same public API.
+        ]);
+      });
+    });
+
+    describe('remote scoping', () => {
+      it('should not recompile an NgModule nor component when remote scoping is unaffected', () => {
+        // Testing setup: MyCmpA and MyCmpB are two components with an indirect import cycle. That
+        // is, each component consumes the other in its template. This forces the compiler to use
+        // remote scoping to set the directiveDefs of at least one of the components in their
+        // NgModule.
+        //
+        // During the test, an unrelated change is made to the template of MyCmpB, and the test
+        // verifies that the NgModule for the components is not re-emitted.
+
+        env.write('cmp-a-template.html', `<cmp-b><cmp-b>`);
+        env.write('cmp-a.ts', `
+             import {Component} from '@angular/core';
+
+             @Component({
+               selector: 'cmp-a',
+               templateUrl: './cmp-a-template.html',
+             })
+             export class MyCmpA {}
+           `);
+        env.write('cmp-b-template.html', `<cmp-a><cmp-a>`);
+        env.write('cmp-b.ts', `
+             import {Component} from '@angular/core';
+
+             @Component({
+               selector: 'cmp-b',
+               templateUrl: './cmp-b-template.html',
+             })
+             export class MyCmpB {}
+           `);
+        env.write('mod.ts', `
+             import {NgModule} from '@angular/core';
+             import {MyCmpA} from './cmp-a';
+             import {MyCmpB} from './cmp-b';
+
+             @NgModule({
+               declarations: [MyCmpA, MyCmpB],
+             })
+             export class MyMod {}
+           `);
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        env.write('cmp-b-template.html', `<cmp-a>Update</cmp-a>`);
+        env.driveMain();
+        expectToHaveWritten([
+          // MyCmpB is written because its template was updated.
+          '/cmp-b.js',
+
+          // MyCmpA should not be written because MyCmpB's public API didn't change.
+          // MyMod should not be written because remote scoping didn't change.
+        ]);
+      });
+
+      it('should recompile an NgModule and component when an import cycle is introduced', () => {
+        // Testing setup: MyCmpA and MyCmpB are two components where MyCmpB consumes MyCmpA in its
+        // template.
+        //
+        // During the test, MyCmpA's template is updated to consume MyCmpB, creating an effective
+        // import cycle and forcing the compiler to use remote scoping for at least one of the
+        // components. The test verifies that the components' NgModule is emitted as a result.
+
+        env.write('cmp-a-template.html', ``);
+        env.write('cmp-a.ts', `
+             import {Component} from '@angular/core';
+
+             @Component({
+               selector: 'cmp-a',
+               templateUrl: './cmp-a-template.html',
+             })
+             export class MyCmpA {}
+           `);
+        env.write('cmp-b-template.html', `<cmp-a><cmp-a>`);
+        env.write('cmp-b.ts', `
+             import {Component} from '@angular/core';
+
+             @Component({
+               selector: 'cmp-b',
+               templateUrl: './cmp-b-template.html',
+             })
+             export class MyCmpB {}
+           `);
+        env.write('mod.ts', `
+             import {NgModule} from '@angular/core';
+             import {MyCmpA} from './cmp-a';
+             import {MyCmpB} from './cmp-b';
+
+             @NgModule({
+               declarations: [MyCmpA, MyCmpB],
+             })
+             export class MyMod {}
+           `);
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        env.write('cmp-a-template.html', `<cmp-b><cmp-b>`);
+        env.driveMain();
+        expectToHaveWritten([
+          // MyMod is written because its remote scopes have changed.
+          '/mod.js',
+
+          // MyCmpA is written because its template was updated.
+          '/cmp-a.js',
+
+          // MyCmpB is written because it now requires remote scoping, where previously it did not.
+          '/cmp-b.js',
+        ]);
+
+        // Validate the correctness of the assumptions made above:
+        // * CmpA should not be using remote scoping.
+        // * CmpB should be using remote scoping.
+        const moduleJs = env.getContents('mod.js');
+        expect(moduleJs).not.toContain('setComponentScope(MyCmpA,');
+        expect(moduleJs).toContain('setComponentScope(MyCmpB,');
+      });
+
+      it('should recompile an NgModule and component when an import cycle is removed', () => {
+        // Testing setup: MyCmpA and MyCmpB are two components that each consume the other in their
+        // template, forcing the compiler to utilize remote scoping for at least one of them.
+        //
+        // During the test, MyCmpA's template is updated to no longer consume MyCmpB, breaking the
+        // effective import cycle and causing remote scoping to no longer be required. The test
+        // verifies that the components' NgModule is emitted as a result.
+
+        env.write('cmp-a-template.html', `<cmp-b><cmp-b>`);
+        env.write('cmp-a.ts', `
+             import {Component} from '@angular/core';
+
+             @Component({
+               selector: 'cmp-a',
+               templateUrl: './cmp-a-template.html',
+             })
+             export class MyCmpA {}
+           `);
+        env.write('cmp-b-template.html', `<cmp-a><cmp-a>`);
+        env.write('cmp-b.ts', `
+             import {Component} from '@angular/core';
+
+             @Component({
+               selector: 'cmp-b',
+               templateUrl: './cmp-b-template.html',
+             })
+             export class MyCmpB {}
+           `);
+        env.write('mod.ts', `
+             import {NgModule} from '@angular/core';
+             import {MyCmpA} from './cmp-a';
+             import {MyCmpB} from './cmp-b';
+
+             @NgModule({
+               declarations: [MyCmpA, MyCmpB],
+             })
+             export class MyMod {}
+           `);
+        env.driveMain();
+
+        // Validate the correctness of the assumption that CmpB will be the remotely scoped
+        // component due to the above cycle:
+        const moduleJs = env.getContents('mod.js');
+        expect(moduleJs).not.toContain('setComponentScope(MyCmpA,');
+        expect(moduleJs).toContain('setComponentScope(MyCmpB,');
+
+        env.flushWrittenFileTracking();
+        env.write('cmp-a-template.html', ``);
+
+        env.driveMain();
+        expectToHaveWritten([
+          // MyMod is written because its remote scopes have changed.
+          '/mod.js',
+
+          // MyCmpA is written because its template was updated.
+          '/cmp-a.js',
+
+          // MyCmpB is written because it no longer needs remote scoping.
+          '/cmp-b.js',
+        ]);
+      });
+
+      it('should recompile an NgModule when a remotely scoped component\'s scope is changed',
+         () => {
+           // Testing setup: MyCmpA and MyCmpB are two components that each consume the other in
+           // their template, forcing the compiler to utilize remote scoping for MyCmpB (which is
+           // verified). Dir is a directive which is initially unused by either component.
+           //
+           // During the test, MyCmpB is updated to additionally consume Dir in its template. This
+           // changes the remote scope of MyCmpB, requiring a re-emit of its NgModule which the test
+           // verifies.
+
+           env.write('dir.ts', `
+               import {Directive} from '@angular/core';
+
+               @Directive({
+                 selector: '[dir]',
+               })
+               export class Dir {}
+           `);
+           env.write('cmp-a-template.html', `<cmp-b><cmp-b>`);
+           env.write('cmp-a.ts', `
+               import {Component} from '@angular/core';
+
+               @Component({
+                 selector: 'cmp-a',
+                 templateUrl: './cmp-a-template.html',
+               })
+               export class MyCmpA {}
+             `);
+           env.write('cmp-b-template.html', `<cmp-a><cmp-a>`);
+           env.write('cmp-b.ts', `
+               import {Component} from '@angular/core';
+
+               @Component({
+                 selector: 'cmp-b',
+                 templateUrl: './cmp-b-template.html',
+               })
+               export class MyCmpB {}
+             `);
+           env.write('mod.ts', `
+               import {NgModule} from '@angular/core';
+               import {MyCmpA} from './cmp-a';
+               import {MyCmpB} from './cmp-b';
+               import {Dir} from './dir';
+
+               @NgModule({
+                 declarations: [MyCmpA, MyCmpB, Dir],
+               })
+               export class MyMod {}
+             `);
+           env.driveMain();
+           env.flushWrittenFileTracking();
+
+           // Validate the correctness of the assumption that MyCmpB will be remotely scoped:
+           const moduleJs = env.getContents('mod.js');
+           expect(moduleJs).not.toContain('setComponentScope(MyCmpA,');
+           expect(moduleJs).toContain('setComponentScope(MyCmpB,');
+
+           env.write('cmp-b-template.html', `<cmp-a dir>Update</cmp-a>`);
+
+           env.driveMain();
+
+           expectToHaveWritten([
+             // MyCmpB is written because its template was updated.
+             '/cmp-b.js',
+
+             // MyMod should be written because one of its remotely scoped components has a changed
+             // scope.
+             '/mod.js'
+
+             // MyCmpA should not be written because none of its dependencies have changed in their
+             // public API.
+           ]);
+         });
+
+
+      it('should recompile an NgModule when its set of remotely scoped components changes', () => {
+        // Testing setup: three components (MyCmpA, MyCmpB, and MyCmpC) are declared. MyCmpA
+        // consumes the other two in its template, and MyCmpB consumes MyCmpA creating an effective
+        // import cycle that forces the compiler to use remote scoping for MyCmpB (which is
+        // verified).
+        //
+        // During the test, MyCmpC's template is changed to depend on MyCmpA, forcing remote
+        // scoping for it as well. The test verifies that the NgModule is re-emitted as a new
+        // component within it now requires remote scoping.
+
+        env.write('cmp-a-template.html', `<cmp-b><cmp-b> <cmp-c></cmp-c>`);
+        env.write('cmp-a.ts', `
+           import {Component} from '@angular/core';
+
+           @Component({
+             selector: 'cmp-a',
+             templateUrl: './cmp-a-template.html',
+           })
+           export class MyCmpA {}
+         `);
+        env.write('cmp-b-template.html', `<cmp-a><cmp-a>`);
+        env.write('cmp-b.ts', `
+           import {Component} from '@angular/core';
+
+           @Component({
+             selector: 'cmp-b',
+             templateUrl: './cmp-b-template.html',
+           })
+           export class MyCmpB {}
+         `);
+
+        env.write('cmp-c-template.html', ``);
+        env.write('cmp-c.ts', `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'cmp-c',
+          templateUrl: './cmp-c-template.html',
+        })
+        export class MyCmpC {}
+      `);
+        env.write('mod.ts', `
+           import {NgModule} from '@angular/core';
+           import {MyCmpA} from './cmp-a';
+           import {MyCmpB} from './cmp-b';
+           import {MyCmpC} from './cmp-c';
+
+           @NgModule({
+             declarations: [MyCmpA, MyCmpB, MyCmpC],
+           })
+           export class MyMod {}
+         `);
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        // Validate the correctness of the assumption that MyCmpB will be the only remotely
+        // scoped component due to the MyCmpA <-> MyCmpB cycle:
+        const moduleJsBefore = env.getContents('mod.js');
+        expect(moduleJsBefore).not.toContain('setComponentScope(MyCmpA,');
+        expect(moduleJsBefore).toContain('setComponentScope(MyCmpB,');
+        expect(moduleJsBefore).not.toContain('setComponentScope(MyCmpC,');
+
+        env.write('cmp-c-template.html', `<cmp-a>Update</cmp-a>`);
+        env.driveMain();
+
+        // Validate the correctness of the assumption that MyCmpB and MyCmpC are now both
+        // remotely scoped due to the MyCmpA <-> MyCmpB and MyCmpA <-> MyCmpC cycles:
+        const moduleJsAfter = env.getContents('mod.js');
+        expect(moduleJsAfter).not.toContain('setComponentScope(MyCmpA,');
+        expect(moduleJsAfter).toContain('setComponentScope(MyCmpB,');
+        expect(moduleJsAfter).toContain('setComponentScope(MyCmpC,');
+
+        expectToHaveWritten([
+          // MyCmpC is written because its template was updated.
+          '/cmp-c.js',
+
+          // MyMod should be written because MyCmpC became remotely scoped
+          '/mod.js'
+
+          // MyCmpA and MyCmpB should not be written because none of their dependencies have
+          // changed in their public API.
+        ]);
+      });
+    });
+
+    describe('NgModule declarations', () => {
+      it('should recompile components when a matching directive is added in the direct scope',
+         () => {
+           // Testing setup: A component Cmp has a template which would match a directive Dir,
+           // except Dir is not included in Cmp's NgModule.
+           //
+           // During the test, Dir is added to the NgModule, causing it to begin matching in Cmp's
+           // template. The test verifies that Cmp is re-emitted to account for this.
+
+           env.write('dir.ts', `
+             import {Directive} from '@angular/core';
+
+             @Directive({
+               selector: '[dir]',
+             })
+             export class Dir {}
+           `);
+
+           env.write('cmp.ts', `
+             import {Component} from '@angular/core';
+
+             @Component({
+               selector: 'test-cmp',
+               template: '<div dir></div>',
+             })
+             export class Cmp {}
+           `);
+
+           env.write('mod.ts', `
+             import {NgModule} from '@angular/core';
+             import {Cmp} from './cmp';
+
+             @NgModule({
+               declarations: [Cmp],
+             })
+             export class Mod {}
+           `);
+
+           env.driveMain();
+           env.flushWrittenFileTracking();
+
+           env.write('mod.ts', `
+             import {NgModule} from '@angular/core';
+             import {Cmp} from './cmp';
+             import {Dir} from './dir';
+
+             @NgModule({
+               declarations: [Cmp, Dir],
+             })
+             export class Mod {}
+           `);
+
+           env.driveMain();
+           expectToHaveWritten([
+             // Mod is written as it was directly changed.
+             '/mod.js',
+
+             // Cmp is written as a matching directive was added to Mod's scope.
+             '/cmp.js',
+           ]);
+         });
+
+      it('should recompile components when a matching directive is removed from the direct scope',
+         () => {
+           // Testing setup: Cmp is a component with a template that matches a directive Dir.
+           //
+           // During the test, Dir is removed from Cmp's NgModule, which causes it to stop matching
+           // in Cmp's template. The test verifies that Cmp is re-emitted as a result.
+
+           env.write('dir.ts', `
+            import {Directive} from '@angular/core';
+
+            @Directive({
+              selector: '[dir]',
+            })
+            export class Dir {}
+          `);
+
+           env.write('cmp.ts', `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'test-cmp',
+              template: '<div dir></div>',
+            })
+            export class Cmp {}
+          `);
+
+           env.write('mod.ts', `
+            import {NgModule} from '@angular/core';
+            import {Cmp} from './cmp';
+            import {Dir} from './dir';
+
+            @NgModule({
+              declarations: [Cmp, Dir],
+            })
+            export class Mod {}
+          `);
+
+           env.driveMain();
+           env.flushWrittenFileTracking();
+
+           env.write('mod.ts', `
+            import {NgModule} from '@angular/core';
+            import {Cmp} from './cmp';
+
+            @NgModule({
+              declarations: [Cmp],
+            })
+            export class Mod {}
+          `);
+
+           env.driveMain();
+           expectToHaveWritten([
+             // Mod is written as it was directly changed.
+             '/mod.js',
+
+             // Cmp is written as a matching directive was removed from Mod's scope.
+             '/cmp.js',
+           ]);
+         });
+
+      it('should recompile components when a matching directive is added in the transitive scope',
+         () => {
+           // Testing setup: A component Cmp has a template which would match a directive Dir,
+           // except Dir is not included in Cmp's NgModule.
+           //
+           // During the test, Dir is added to the NgModule via an import, causing it to begin
+           // matching in Cmp's template. The test verifies that Cmp is re-emitted to account for
+           // this.
+
+           env.write('dir.ts', `
+            import {Directive} from '@angular/core';
+
+            @Directive({
+              selector: '[dir]',
+            })
+            export class Dir {}
+          `);
+
+           env.write('cmp.ts', `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'test-cmp',
+              template: '<div dir></div>',
+            })
+            export class Cmp {}
+          `);
+
+           env.write('deep.ts', `
+            import {NgModule} from '@angular/core';
+
+            @NgModule({
+              declarations: [],
+              exports: [],
+            })
+            export class Deep {}
+          `);
+
+           env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Deep} from './deep';
+
+          @NgModule({
+            declarations: [Cmp],
+            imports: [Deep],
+          })
+          export class Mod {}
+        `);
+
+           env.driveMain();
+           env.flushWrittenFileTracking();
+
+
+           env.write('deep.ts', `
+            import {NgModule} from '@angular/core';
+            import {Dir} from './dir';
+
+            @NgModule({
+              declarations: [Dir],
+              exports: [Dir],
+            })
+            export class Deep {}
+          `);
+
+           env.driveMain();
+           expectToHaveWritten([
+             // Mod is written as it was directly changed.
+             '/deep.js',
+
+             // Mod is written as its direct dependency (Deep) was changed.
+             '/mod.js',
+
+             // Cmp is written as a matching directive was added to Mod's transitive scope.
+             '/cmp.js',
+           ]);
+         });
+
+      it('should recompile components when a matching directive is removed from the transitive scope',
+         () => {
+           // Testing setup: Cmp is a component with a template that matches a directive Dir, due to
+           // Dir's NgModule being imported into Cmp's NgModule.
+           //
+           // During the test, this import link is removed, which causes Dir to stop matching in
+           // Cmp's template. The test verifies that Cmp is re-emitted as a result.
+
+           env.write('dir.ts', `
+            import {Directive} from '@angular/core';
+
+            @Directive({
+              selector: '[dir]',
+            })
+            export class Dir {}
+          `);
+
+           env.write('cmp.ts', `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'test-cmp',
+              template: '<div dir></div>',
+            })
+            export class Cmp {}
+          `);
+
+           env.write('deep.ts', `
+            import {NgModule} from '@angular/core';
+            import {Dir} from './dir';
+
+            @NgModule({
+              declarations: [Dir],
+              exports: [Dir],
+            })
+            export class Deep {}
+          `);
+
+           env.write('mod.ts', `
+            import {NgModule} from '@angular/core';
+            import {Cmp} from './cmp';
+            import {Deep} from './deep';
+
+            @NgModule({
+              declarations: [Cmp],
+              imports: [Deep],
+            })
+            export class Mod {}
+          `);
+
+           env.driveMain();
+           env.flushWrittenFileTracking();
+
+           env.write('deep.ts', `
+            import {NgModule} from '@angular/core';
+
+            @NgModule({
+              declarations: [],
+              exports: [],
+            })
+            export class Deep {}
+          `);
+
+           env.driveMain();
+           expectToHaveWritten([
+             // Mod is written as it was directly changed.
+             '/deep.js',
+
+             // Mod is written as its direct dependency (Deep) was changed.
+             '/mod.js',
+
+             // Cmp is written as a matching directive was removed from Mod's transitive scope.
+             '/cmp.js',
+           ]);
+         });
+
+      it('should not recompile components when a non-matching directive is added in scope', () => {
+        // Testing setup: A component Cmp has a template which does not match a directive Dir,
+        // and Dir is not included in Cmp's NgModule.
+        //
+        // During the test, Dir is added to the NgModule, making it visible in Cmp's template.
+        // However, Dir still does not match the template. The test verifies that Cmp is not
+        // re-emitted.
+
+        env.write('dir.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir {}
+        `);
+
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div></div>',
+          })
+          export class Cmp {}
+        `);
+
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+
+          @NgModule({
+            declarations: [Cmp],
+          })
+          export class Mod {}
+        `);
+
+        env.driveMain();
+        env.flushWrittenFileTracking();
+
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+
+        env.driveMain();
+        expectToHaveWritten([
+          // Mod is written as it was directly changed.
+          '/mod.js',
+
+          // Cmp is not written as its used directives remains the same, since Dir does not match
+          // within its template.
+        ]);
+      });
+    });
+
+    describe('error recovery', () => {
+      it('should recompile a component when a matching directive is added that first contains an error',
+         () => {
+           // Testing setup: Cmp is a component which would match a directive with the selector
+           // '[dir]'.
+           //
+           // During the test, an initial incremental compilation adds an import to a hypothetical
+           // directive Dir to the NgModule, and adds Dir as a declaration. However, the import
+           // points to a non-existent file.
+           //
+           // During a second incremental compilation, that missing file is added with a declaration
+           // for Dir as a directive with the selector '[dir]', causing it to begin matching in
+           // Cmp's template. The test verifies that Cmp is re-emitted once the program is correct.
+
+           env.write('cmp.ts', `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'test-cmp',
+              template: '<div dir></div>',
+            })
+            export class Cmp {}
+          `);
+
+           env.write('mod.ts', `
+            import {NgModule} from '@angular/core';
+            import {Cmp} from './cmp';
+
+            @NgModule({
+              declarations: [Cmp],
+            })
+            export class Mod {}
+          `);
+
+           env.driveMain();
+           env.flushWrittenFileTracking();
+
+           env.write('mod.ts', `
+            import {NgModule} from '@angular/core';
+            import {Cmp} from './cmp';
+            import {Dir} from './dir';
+
+            @NgModule({
+              declarations: [Cmp, Dir],
+            })
+            export class Mod {}
+          `);
+
+           expect(env.driveDiagnostics().length).not.toBe(0);
+
+           env.write('dir.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir {}
+        `);
+
+           env.flushWrittenFileTracking();
+           env.driveMain();
+
+           expectToHaveWritten([
+             // Mod is written as it was changed in the first incremental compilation, but had
+             // errors and so was not written then.
+             '/mod.js',
+
+             // Dir is written as it was added in the second incremental compilation.
+             '/dir.js',
+
+             // Cmp is written as the cumulative effect of the two changes was to add Dir to its
+             // scope and thus match in Cmp's template.
+             '/cmp.js',
+           ]);
+         });
+    });
+
+    it('should correctly emit components when public API changes during a broken program', () => {
+      // Testing setup: a component Cmp exists with a template that matches directive Dir. Cmp also
+      // references an extra file with a constant declaration.
+      //
+      // During the test, a first incremental compilation both adds an input to Dir (changing its
+      // public API) as well as introducing a compilation error by adding invalid syntax to the
+      // extra file.
+      //
+      // A second incremental compilation then fixes the invalid syntax, and the test verifies that
+      // Cmp is re-emitted due to the earlier public API change to Dir.
+
+      env.write('other.ts', `
+        export const FOO = true;
+      `);
+      env.write('dir.ts', `
+        import {Directive, Input} from '@angular/core';
+
+        @Directive({
+          selector: '[dir]',
+        })
+        export class Dir {
+          @Input()
+          dirIn!: string;
+        }
+      `);
+      env.write('cmp.ts', `
+        import {Component} from '@angular/core';
+        import './other';
+
+        @Component({
+          selector: 'test-cmp',
+          template: '<div dir></div>',
+        })
+        export class Cmp {}
+      `);
+
+      env.write('mod.ts', `
+        import {NgModule} from '@angular/core';
+        import {Cmp} from './cmp';
+        import {Dir} from './dir';
+
+        @NgModule({
+          declarations: [Cmp, Dir],
+        })
+        export class Mod {}
+      `);
+
+      env.driveMain();
+
+      env.flushWrittenFileTracking();
+      env.write('dir.ts', `
+      import {Directive, Input} from '@angular/core';
+
+      @Directive({
+        selector: '[dir]',
+      })
+      export class Dir {
+        @Input()
+        dirIn_changed!: string;
+      }
+    `);
+
+      env.write('other.ts', `
+        export const FOO = ;
+      `);
+      expect(env.driveDiagnostics().length).not.toBe(0);
+
+      env.flushWrittenFileTracking();
+      env.write('other.ts', `
+        export const FOO = false;
+      `);
+
+      env.driveMain();
+      expectToHaveWritten([
+        // Mod is written as its direct dependency (Dir) was changed.
+        '/mod.js',
+
+        // Dir is written as it was directly changed.
+        '/dir.js',
+
+        // other.js is written as it was directly changed.
+        '/other.js',
+
+        // Cmp is written as Dir's public API has changed.
+        '/cmp.js',
+      ]);
+    });
+  });
+});

--- a/packages/compiler-cli/test/ngtsc/incremental_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/incremental_typecheck_spec.ts
@@ -1,0 +1,1396 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {absoluteFrom} from '../../src/ngtsc/file_system';
+import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../src/ngtsc/testing';
+
+import {NgtscTestEnvironment} from './env';
+
+const testFiles = loadStandardTestFiles();
+
+runInEachFileSystem(() => {
+  describe('ngtsc incremental compilation (template typecheck)', () => {
+    let env!: NgtscTestEnvironment;
+
+    beforeEach(() => {
+      env = NgtscTestEnvironment.setup(testFiles);
+      env.enableMultipleCompilations();
+      env.tsconfig({strictTemplates: true});
+    });
+
+    describe('type-check api surface', () => {
+      it('should type-check correctly when a backing input field is renamed', () => {
+        // This test verifies that renaming the class field of an input is correctly reflected into
+        // the TCB.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir {
+            @Input('dir')
+            dir!: string;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div [dir]="foo"></div>',
+          })
+          export class Cmp {
+            foo = 'foo';
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        env.driveMain();
+
+        // Now rename the backing field of the input; the TCB should be updated such that the `dir`
+        // input binding is still valid.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir {
+            @Input('dir')
+            dirRenamed!: string;
+          }
+        `);
+        env.driveMain();
+      });
+
+      it('should type-check correctly when a backing output field is renamed', () => {
+        // This test verifies that renaming the class field of an output is correctly reflected into
+        // the TCB.
+        env.write('dir.ts', `
+          import {Directive, EventEmitter, Output} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir {
+            @Output('dir')
+            dir = new EventEmitter<string>();
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div (dir)="foo($event)"></div>',
+          })
+          export class Cmp {
+            foo(bar: string) {}
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        env.driveMain();
+
+        // Now rename the backing field of the output; the TCB should be updated such that the `dir`
+        // input binding is still valid.
+        env.write('dir.ts', `
+          import {Directive, EventEmitter, Output} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir {
+            @Output('dir')
+            dirRenamed = new EventEmitter<string>();
+          }
+        `);
+        env.driveMain();
+      });
+
+      it('should type-check correctly when the backing field of an input is removed', () => {
+        // For inputs that are only declared in the decorator but for which no backing field is
+        // declared in the TypeScript class, the TCB should not contain a write to the field as it
+        // would be an error. This test verifies that the TCB is regenerated when a backing field
+        // is removed.
+        env.write('dir.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+            inputs: ['dir'],
+          })
+          export class Dir {
+            dir!: string;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div [dir]="foo"></div>',
+          })
+          export class Cmp {
+            foo = true;
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toContain(`Type 'boolean' is not assignable to type 'string'.`);
+
+        // Now remove the backing field for the `dir` input. The compilation should now succeed
+        // as there are no type-check errors.
+        env.write('dir.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+            inputs: ['dir'],
+          })
+          export class Dir {}
+        `);
+        env.driveMain();
+      });
+
+      it('should type-check correctly when the backing field of an input is made readonly', () => {
+        // When an input is declared as readonly and if `strictInputAccessModifiers` is disabled,
+        // the TCB contains an indirect write to the property to silence the error that a value
+        // cannot be assigned to a readonly property. This test verifies that changing a field to
+        // become readonly does result in the TCB being updated to use such an indirect write, as
+        // otherwise an error would incorrectly be reported.
+        env.tsconfig({strictTemplates: true, strictInputAccessModifiers: false});
+        env.write('dir.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+            inputs: ['dir'],
+          })
+          export class Dir {
+            dir!: string;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div [dir]="foo"></div>',
+          })
+          export class Cmp {
+            foo = 'foo';
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        env.driveMain();
+
+        // Now change the `dir` input to be readonly. Because `strictInputAccessModifiers` is
+        // disabled this should be allowed.
+        env.write('dir.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+            inputs: ['dir'],
+          })
+          export class Dir {
+            readonly dir!: string;
+          }
+        `);
+        env.driveMain();
+      });
+
+      it('should type-check correctly when an ngAcceptInputType field is declared', () => {
+        // Declaring a static `ngAcceptInputType` member requires that the TCB is regenerated, as
+        // writes to an input property should then be targeted against this static member instead
+        // of the input field itself.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir {
+            @Input()
+            dir!: string;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div [dir]="foo"></div>',
+          })
+          export class Cmp {
+            foo = true;
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toContain(`Type 'boolean' is not assignable to type 'string'.`);
+
+        // Now add an `ngAcceptInputType` static member to the directive such that its `dir` input
+        // also accepts `boolean`, unlike the type of `dir`'s class field. This should therefore
+        // allow the compilation to succeed.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir {
+            @Input()
+            dir!: string;
+
+            static ngAcceptInputType_dir: string | boolean;
+          }
+        `);
+        env.driveMain();
+      });
+
+      it('should type-check correctly when an ngTemplateContextGuard field is declared', () => {
+        // This test adds an `ngTemplateContextGuard` static member to verify that the TCB is
+        // regenerated for the template context to take effect.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir {
+            @Input()
+            dir!: string;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div *dir="let bar">{{ foo(bar) }}</div>',
+          })
+          export class Cmp {
+            foo(bar: string) {}
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        env.driveMain();
+
+        // Now add the template context to declare the `$implicit` variable to be of type `number`.
+        // Doing so should report an error for `Cmp`, as the type of `bar` which binds to
+        // `$implicit` is no longer compatible with the method signature which requires a `string`.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          export interface TemplateContext {
+            $implicit: number;
+          }
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir {
+            @Input()
+            dir!: string;
+
+            static ngTemplateContextGuard(dir: Dir, ctx: any): ctx is TemplateContext { return true; }
+          }
+        `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toContain(
+                `Argument of type 'number' is not assignable to parameter of type 'string'.`);
+      });
+
+      it('should type-check correctly when an ngTemplateGuard field is declared', () => {
+        // This test verifies that adding an `ngTemplateGuard` static member has the desired effect
+        // of type-narrowing the bound input expression within the template.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir {
+            @Input()
+            dir!: boolean;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div *dir="foo !== null">{{ test(foo) }}</div>',
+          })
+          export class Cmp {
+            foo!: string | null;
+            test(foo: string) {}
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '\n'))
+            .toContain(
+                `Argument of type 'string | null' is not assignable to parameter of type 'string'.`);
+
+        // Now resolve the compilation error by adding the `ngTemplateGuard_dir` static member to
+        // specify that the bound expression for `dir` should be used as template guard. This
+        // should allow the compilation to succeed.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          export interface TemplateContext {
+            $implicit: number;
+          }
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir {
+            @Input()
+            dir!: boolean;
+
+            static ngTemplateGuard_dir: 'binding';
+          }
+        `);
+        env.driveMain();
+      });
+
+      it('should type-check correctly when the type of an ngTemplateGuard field changes', () => {
+        // This test verifies that changing the type of an `ngTemplateGuard` static member has the
+        // desired effect of type-narrowing the bound input expression within the template according
+        // to the new type of the `ngTemplateGuard` static member. Initially, an "invocation" type
+        // context guard is used, but it's ineffective at narrowing an expression that explicitly
+        // compares against null. An incremental step changes the type of the guard to be of type
+        // `binding`.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T> {
+            @Input()
+            dir!: T;
+
+            static ngTemplateGuard_dir<T>(dir: Dir<T>, expr: any): expr is NonNullable<T> { return true; };
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div *dir="foo !== null">{{ test(foo) }}</div>',
+          })
+          export class Cmp {
+            foo!: string | null;
+            test(foo: string) {}
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '\n'))
+            .toContain(
+                `Argument of type 'string | null' is not assignable to parameter of type 'string'.`);
+
+        // Now change the type of the template guard into "binding" to achieve the desired narrowing
+        // of `foo`, allowing the compilation to succeed.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          export interface TemplateContext {
+            $implicit: number;
+          }
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T> {
+            @Input()
+            dir!: T;
+
+            static ngTemplateGuard_dir: 'binding';
+          }
+        `);
+        env.driveMain();
+      });
+
+      it('should type-check correctly when the name of an ngTemplateGuard field changes', () => {
+        // This test verifies that changing the name of the field to which an `ngTemplateGuard`
+        // static member applies correctly removes its narrowing effect on the original input
+        // binding expression.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T> {
+            @Input()
+            dir!: T;
+
+            static ngTemplateGuard_dir: 'binding';
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div *dir="foo !== null">{{ test(foo) }}</div>',
+          })
+          export class Cmp {
+            foo!: string | null;
+            test(foo: string) {}
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        env.driveMain();
+
+        // Now change the `ngTemplateGuard` to target a different field. The `dir` binding should
+        // no longer be narrowed, causing the template of `Cmp` to become invalid.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          export interface TemplateContext {
+            $implicit: number;
+          }
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T> {
+            @Input()
+            dir!: T;
+
+            static ngTemplateGuard_dir_renamed: 'binding';
+          }
+        `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(ts.flattenDiagnosticMessageText(diags[0].messageText, '\n'))
+            .toContain(
+                `Argument of type 'string | null' is not assignable to parameter of type 'string'.`);
+      });
+    });
+
+    describe('type parameters', () => {
+      it('should type-check correctly when directive becomes generic', () => {
+        // This test verifies that changing a non-generic directive `Dir` into a generic directive
+        // correctly type-checks component `Cmp` that uses `Dir` in its template. The introduction
+        // of the generic type requires that `Cmp`'s local declaration of `Dir` is also updated,
+        // otherwise the prior declaration without generic type argument would be invalid.
+
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir {
+            @Input()
+            dir!: string;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div [dir]="foo"></div>',
+          })
+          export class Cmp {
+            foo = 'foo';
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        env.driveMain();
+
+        // Adding a generic type should still allow the compilation to succeed.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T> {
+            @Input()
+            dir!: string;
+          }
+        `);
+        env.driveMain();
+      });
+
+      it('should type-check correctly when a type parameter is added to a directive', () => {
+        // This test verifies that adding an additional generic type to directive `Dir` correctly
+        // type-checks component `Cmp` that uses `Dir` in its template. The addition of a generic
+        // type requires that `Cmp`'s local declaration of `Dir` is also updated, otherwise the
+        // prior declaration with fewer generic type argument would be invalid.
+
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T> {
+            @Input()
+            dir!: T;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div [dir]="foo"></div>',
+          })
+          export class Cmp {
+            foo = 'foo';
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        env.driveMain();
+
+        // Add generic type parameter `U` should continue to allow the compilation to succeed.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T, U> {
+            @Input()
+            dir!: T;
+          }
+        `);
+        env.driveMain();
+      });
+
+      it('should type-check correctly when directive removes its generic type parameter', () => {
+        // This test verifies that removing a type parameter from generic directive `Dir` such that
+        // it becomes non-generic correctly type-checks component `Cmp` that uses `Dir` in its
+        // template. The removal of the generic type requires that `Cmp`'s local declaration of
+        // `Dir` is also updated, as otherwise the prior declaration with a generic type argument
+        // would be invalid.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T> {
+            @Input()
+            dir!: string;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div [dir]="foo"></div>',
+          })
+          export class Cmp {
+            foo = 'foo';
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        env.driveMain();
+
+        // Changing `Dir` to become non-generic should allow the compilation to succeed.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir {
+            @Input()
+            dir!: string;
+          }
+        `);
+        env.driveMain();
+      });
+
+      it('should type-check correctly when a type parameter is removed from a directive', () => {
+        // This test verifies that removing a type parameter from generic directive `Dir` correctly
+        // type-checks component `Cmp` that uses `Dir` in its template. The removal of the generic
+        // type requires that `Cmp`'s local declaration of `Dir` is also updated, as otherwise the
+        // prior declaration with the initial number of generic type arguments would be invalid.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T, U> {
+            @Input()
+            dir!: T;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div [dir]="foo"></div>',
+          })
+          export class Cmp {
+            foo = 'foo';
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        env.driveMain();
+
+        // Removing type parameter `U` should allow the compilation to succeed.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T> {
+            @Input()
+            dir!: T;
+          }
+        `);
+        env.driveMain();
+      });
+
+      it('should type-check correctly when a generic type bound is added', () => {
+        // This test verifies that changing an unbound generic type parameter of directive `Dir`
+        // to have a type constraint properly applies the newly added type constraint during
+        // type-checking of `Cmp` that uses `Dir` in its template.
+        env.write('node_modules/foo/index.ts', `
+          export interface Foo {
+            a: boolean;
+          }
+        `);
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T> {
+            @Input()
+            dir!: T;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div [dir]="foo"></div>',
+          })
+          export class Cmp {
+            foo: string;
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        env.driveMain();
+
+        // Update `Dir` such that its generic type parameter `T` is constrained to type `Foo`. The
+        // template of `Cmp` should now fail to type-check, as its bound value for `T` does not
+        // conform to the `Foo` constraint.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+          import {Foo} from 'foo';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T extends Foo> {
+            @Input()
+            dir!: T;
+          }
+        `);
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toContain(`Type 'string' is not assignable to type 'Foo'.`);
+
+        // Now update `Dir` again to remove the constraint of `T`, which should allow the template
+        // of `Cmp` to succeed type-checking.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T> {
+            @Input()
+            dir!: T;
+          }
+        `);
+        env.driveMain();
+      });
+
+      it('should type-check correctly when a generic type bound indirectly changes', () => {
+        // This test verifies the scenario where a generic type constraint is updated indirectly,
+        // i.e. without the type parameter itself changing. The setup of this test is as follows:
+        //
+        // - Have two external modules `foo-a` and `foo-b` that both export a type named `Foo`,
+        //   each having an incompatible shape.
+        // - Have a directive `Dir` that has a type parameter constrained to `Foo` from `foo-a`.
+        // - Have a component `Cmp` that uses `Dir` in its template and binds a `Foo` from `foo-a`
+        //   to an input of `Dir` of generic type `T`. This should succeed as it conforms to the
+        //   constraint of `T`.
+        // - Perform an incremental compilation where the import of `Foo` is changed into `foo-b`.
+        //   The binding in `Cmp` should now report an error, as its value of `Foo` from `foo-a`
+        //   no longer conforms to the new type constraint of `Foo` from 'foo-b'.
+        env.write('node_modules/foo-a/index.ts', `
+          export interface Foo {
+            a: boolean;
+          }
+        `);
+        env.write('node_modules/foo-b/index.ts', `
+          export interface Foo {
+            b: boolean;
+          }
+        `);
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+          import {Foo} from 'foo-a';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T extends Foo> {
+            @Input()
+            dir!: T;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+          import {Foo} from 'foo-a';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div [dir]="foo"></div>',
+          })
+          export class Cmp {
+            foo: Foo = {a: true};
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+        env.driveMain();
+
+        // Now switch the import of `Foo` from `foo-a` to `foo-b`. This should cause a type-check
+        // failure in `Cmp`, as its binding into `Dir` still provides an incompatible `Foo`
+        // from `foo-a`.
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+          import {Foo} from 'foo-b';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir<T extends Foo> {
+            @Input()
+            dir!: T;
+          }
+        `);
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toContain(`Type 'import("${
+                absoluteFrom(
+                    '/node_modules/foo-a/index')}").Foo' is not assignable to type 'import("${
+                absoluteFrom('/node_modules/foo-b/index')}").Foo'.`);
+
+        // For completeness, update `Cmp` to address the previous template type-check error by
+        // changing the type of the binding into `Dir` to also be the `Foo` from `foo-b`. This
+        // should result in a successful compilation.
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+          import {Foo} from 'foo-b';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div [dir]="foo"></div>',
+          })
+          export class Cmp {
+            foo: Foo = {b: true};
+          }
+        `);
+        env.driveMain();
+      });
+    });
+
+    describe('inheritance', () => {
+      it('should type-check derived directives when the public API of the parent class is affected',
+         () => {
+           // This test verifies that an indirect change to the public API of `Dir` as caused by a
+           // change to `Dir`'s base class `Parent` causes the type-check result of component `Cmp`
+           // that uses `Dir` to be updated accordingly.
+           env.write('parent.ts', `
+             import {Directive, Input} from '@angular/core';
+
+             @Directive()
+             export class Parent {
+               @Input()
+               parent!: string;
+             }
+           `);
+           env.write('dir.ts', `
+             import {Directive, Input} from '@angular/core';
+             import {Parent} from './parent';
+
+             @Directive({
+               selector: '[dir]',
+             })
+             export class Dir extends Parent {
+               @Input()
+               dir!: string;
+             }
+           `);
+           env.write('cmp.ts', `
+             import {Component} from '@angular/core';
+
+             @Component({
+               selector: 'test-cmp',
+               template: '<div [dir]="foo" [parent]="foo"></div>',
+             })
+             export class Cmp {
+               foo = 'foo';
+             }
+           `);
+           env.write('mod.ts', `
+             import {NgModule} from '@angular/core';
+             import {Cmp} from './cmp';
+             import {Dir} from './dir';
+
+             @NgModule({
+               declarations: [Cmp, Dir],
+             })
+             export class Mod {}
+           `);
+           env.driveMain();
+
+           // Now remove an input from `Parent`. This invalidates the binding in `Cmp`'s template,
+           // so an error diagnostic should be reported.
+           env.write('parent.ts', `
+             import {Directive, Input} from '@angular/core';
+
+             @Directive()
+             export class Parent {
+
+             }
+           `);
+           const diags = env.driveDiagnostics();
+           expect(diags.length).toBe(1);
+           expect(diags[0].messageText)
+               .toContain(`Can't bind to 'parent' since it isn't a known property of 'div'.`);
+         });
+
+      it('should type-check derived directives when the public API of the grandparent class is affected',
+         () => {
+           // This test verifies that an indirect change to the public API of `Dir` as caused by a
+           // change to `Dir`'s transitive base class `Grandparent` causes the type-check result of
+           // component `Cmp` that uses `Dir` to be updated accordingly.
+           env.write('grandparent.ts', `
+             import {Directive, Input} from '@angular/core';
+
+             @Directive()
+             export class Grandparent {
+               @Input()
+               grandparent!: string;
+             }
+           `);
+           env.write('parent.ts', `
+             import {Directive, Input} from '@angular/core';
+             import {Grandparent} from './grandparent';
+
+             @Directive()
+             export class Parent extends Grandparent {
+               @Input()
+               parent!: string;
+             }
+           `);
+           env.write('dir.ts', `
+             import {Directive, Input} from '@angular/core';
+             import {Parent} from './parent';
+
+             @Directive({
+               selector: '[dir]',
+             })
+             export class Dir extends Parent {
+               @Input()
+               dir!: string;
+             }
+           `);
+           env.write('cmp.ts', `
+             import {Component} from '@angular/core';
+
+             @Component({
+               selector: 'test-cmp',
+               template: '<div [dir]="foo" [parent]="foo" [grandparent]="foo"></div>',
+             })
+             export class Cmp {
+               foo = 'foo';
+             }
+           `);
+           env.write('mod.ts', `
+             import {NgModule} from '@angular/core';
+             import {Cmp} from './cmp';
+             import {Dir} from './dir';
+
+             @NgModule({
+               declarations: [Cmp, Dir],
+             })
+             export class Mod {}
+           `);
+           env.driveMain();
+
+           // Now remove an input from `Grandparent`. This invalidates the binding in `Cmp`'s
+           // template, so an error diagnostic should be reported.
+           env.write('grandparent.ts', `
+             import {Directive, Input} from '@angular/core';
+
+             @Directive()
+             export class Grandparent {
+
+             }
+          `);
+           const diags = env.driveDiagnostics();
+           expect(diags.length).toBe(1);
+           expect(diags[0].messageText)
+               .toContain(`Can't bind to 'grandparent' since it isn't a known property of 'div'.`);
+         });
+
+      it('should type-check derived directives when a base class is added to a grandparent', () => {
+        // This test verifies that an indirect change to the public API of `Dir` as caused by
+        // adding a base class `Grandgrandparent` to `Dir`'s transitive base class `Grandparent`
+        // causes the type-check result of component `Cmp` that uses `Dir` to be
+        // updated accordingly.
+        env.write('grandgrandparent.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive()
+          export class Grandgrandparent {
+            @Input()
+            grandgrandparent!: string;
+          }
+        `);
+        env.write('grandparent.ts', `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive()
+          export class Grandparent {
+            @Input()
+            grandparent!: string;
+          }
+        `);
+        env.write('parent.ts', `
+          import {Directive, Input} from '@angular/core';
+          import {Grandparent} from './grandparent';
+
+          @Directive()
+          export class Parent extends Grandparent {
+            @Input()
+            parent!: string;
+          }
+        `);
+        env.write('dir.ts', `
+          import {Directive, Input} from '@angular/core';
+          import {Parent} from './parent';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class Dir extends Parent {
+            @Input()
+            dir!: string;
+          }
+        `);
+        env.write('cmp.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '<div [dir]="foo" [parent]="foo" [grandgrandparent]="foo"></div>',
+          })
+          export class Cmp {
+            foo = 'foo';
+          }
+        `);
+        env.write('mod.ts', `
+          import {NgModule} from '@angular/core';
+          import {Cmp} from './cmp';
+          import {Dir} from './dir';
+
+          @NgModule({
+            declarations: [Cmp, Dir],
+          })
+          export class Mod {}
+        `);
+
+        // `Cmp` already binds to the `grandgrandparent` input but it's not available, as
+        // `Granparent` does not yet extend from `Grandgrandparent`.
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toContain(
+                `Can't bind to 'grandgrandparent' since it isn't a known property of 'div'.`);
+
+        // Now fix the issue by adding the base class to `Grandparent`; this should allow
+        // type-checking to succeed.
+        env.write('grandparent.ts', `
+          import {Directive, Input} from '@angular/core';
+          import {Grandgrandparent} from './grandgrandparent';
+
+          @Directive()
+          export class Grandparent extends Grandgrandparent {
+            @Input()
+            grandparent!: string;
+          }
+        `);
+        env.driveMain();
+      });
+
+      it('should type-check derived directives when a base class is removed from a grandparent',
+         () => {
+           // This test verifies that an indirect change to the public API of `Dir` as caused by
+           // removing a base class `Grandgrandparent` from `Dir`'s transitive base class
+           // `Grandparent` causes the type-check result of component `Cmp` that uses `Dir` to be
+           // updated accordingly.
+           env.write('grandgrandparent.ts', `
+             import {Directive, Input} from '@angular/core';
+
+             @Directive()
+             export class Grandgrandparent {
+               @Input()
+               grandgrandparent!: string;
+             }
+           `);
+           env.write('grandparent.ts', `
+             import {Directive, Input} from '@angular/core';
+             import {Grandgrandparent} from './grandgrandparent';
+
+             @Directive()
+             export class Grandparent extends Grandgrandparent {
+               @Input()
+               grandparent!: string;
+             }
+           `);
+           env.write('parent.ts', `
+             import {Directive, Input} from '@angular/core';
+             import {Grandparent} from './grandparent';
+
+             @Directive()
+             export class Parent extends Grandparent {
+               @Input()
+               parent!: string;
+             }
+           `);
+           env.write('dir.ts', `
+             import {Directive, Input} from '@angular/core';
+             import {Parent} from './parent';
+
+             @Directive({
+               selector: '[dir]',
+             })
+             export class Dir extends Parent {
+               @Input()
+               dir!: string;
+             }
+           `);
+           env.write('cmp.ts', `
+             import {Component} from '@angular/core';
+
+             @Component({
+               selector: 'test-cmp',
+               template: '<div [dir]="foo" [parent]="foo" [grandgrandparent]="foo"></div>',
+             })
+             export class Cmp {
+               foo = 'foo';
+             }
+           `);
+           env.write('mod.ts', `
+             import {NgModule} from '@angular/core';
+             import {Cmp} from './cmp';
+             import {Dir} from './dir';
+
+             @NgModule({
+               declarations: [Cmp, Dir],
+             })
+             export class Mod {}
+           `);
+           env.driveMain();
+
+           // Removing the base class from `Grandparent` should start to report a type-check
+           // error in `Cmp`'s template, as its binding to the `grandgrandparent` input is no
+           // longer valid.
+           env.write('grandparent.ts', `
+             import {Directive, Input} from '@angular/core';
+
+             @Directive()
+             export class Grandparent {
+               @Input()
+               grandparent!: string;
+             }
+           `);
+           const diags = env.driveDiagnostics();
+           expect(diags.length).toBe(1);
+           expect(diags[0].messageText)
+               .toContain(
+                   `Can't bind to 'grandgrandparent' since it isn't a known property of 'div'.`);
+         });
+
+      it('should type-check derived directives when the base class of a grandparent changes',
+         () => {
+           // This test verifies that an indirect change to the public API of `Dir` as caused by
+           // changing the base class of `Dir`'s transitive base class `Grandparent` causes the
+           // type-check result of component `Cmp` that uses `Dir` to be updated accordingly.
+           env.write('grandgrandparent-a.ts', `
+             import {Directive, Input} from '@angular/core';
+
+             @Directive()
+             export class GrandgrandparentA {
+               @Input()
+               grandgrandparentA!: string;
+             }
+           `);
+           env.write('grandgrandparent-b.ts', `
+             import {Directive, Input} from '@angular/core';
+
+             @Directive()
+             export class GrandgrandparentB {
+               @Input()
+               grandgrandparentB!: string;
+             }
+           `);
+           env.write('grandparent.ts', `
+             import {Directive, Input} from '@angular/core';
+             import {GrandgrandparentA} from './grandgrandparent-a';
+
+             @Directive()
+             export class Grandparent extends GrandgrandparentA {
+               @Input()
+               grandparent!: string;
+             }
+           `);
+           env.write('parent.ts', `
+             import {Directive, Input} from '@angular/core';
+             import {Grandparent} from './grandparent';
+
+             @Directive()
+             export class Parent extends Grandparent {
+               @Input()
+               parent!: string;
+             }
+           `);
+           env.write('dir.ts', `
+             import {Directive, Input} from '@angular/core';
+             import {Parent} from './parent';
+
+             @Directive({
+               selector: '[dir]',
+             })
+             export class Dir extends Parent {
+               @Input()
+               dir!: string;
+             }
+           `);
+           env.write('cmp.ts', `
+             import {Component} from '@angular/core';
+
+             @Component({
+               selector: 'test-cmp',
+               template: '<div [dir]="foo" [parent]="foo" [grandgrandparentA]="foo"></div>',
+             })
+             export class Cmp {
+               foo = 'foo';
+             }
+           `);
+           env.write('mod.ts', `
+             import {NgModule} from '@angular/core';
+             import {Cmp} from './cmp';
+             import {Dir} from './dir';
+
+             @NgModule({
+               declarations: [Cmp, Dir],
+             })
+             export class Mod {}
+           `);
+           env.driveMain();
+
+           // Now switch the base class of `Grandparent` from `GrandgrandparentA` to
+           // `GrandgrandparentB` causes the input binding to `grandgrandparentA` to be reported as
+           // an error, as it's no longer available.
+           env.write('grandparent.ts', `
+             import {Directive, Input} from '@angular/core';
+             import {GrandgrandparentB} from './grandgrandparent-b';
+
+             @Directive()
+             export class Grandparent extends GrandgrandparentB {
+               @Input()
+               grandparent!: string;
+             }
+           `);
+           const diags = env.driveDiagnostics();
+           expect(diags.length).toBe(1);
+           expect(diags[0].messageText)
+               .toContain(
+                   `Can't bind to 'grandgrandparentA' since it isn't a known property of 'div'.`);
+         });
+    });
+  });
+});


### PR DESCRIPTION
In Angular programs, changing a file may require other files to be
emitted as well due to implicit NgModule dependencies. For example, if
the selector of a directive is changed then all components that have
that directive in their compilation scope need to be recompiled, as the
change of selector may affect the directive matching results.

Until now, the compiler solved this problem using a single dependency
graph. The implicit NgModule dependencies were represented in this
graph, such that a changed file would correctly also cause other files
to be re-emitted. This approach is limited in a few ways:

1. The file dependency graph is used to determine whether it is safe to
   reuse the analysis data of an Angular decorated class. This analysis
   data is invariant to unrelated changes to the NgModule scope, but
   because the single dependency graph also tracked the implicit
   NgModule dependencies the compiler had to consider analysis data as
   stale far more often than necessary.
2. It is typical for a change to e.g. a directive to not affect its
   public API—its selector, inputs, outputs, or exportAs clause—in which
   case there is no need to re-emit all declarations in scope, as their
   compilation output wouldn't have changed.

This commit implements a mechanism by which the compiler is able to
determine the impact of a change by comparing it to the prior
compilation. To achieve this, a new graph is maintained that tracks all
public API information of all Angular decorated symbols. During an
incremental compilation this information is compared to the information
that was captured in the most recently succeeded compilation. This
determines the exact impact of the changes to the public API, which
is then used to determine which files need to be re-emitted.

Note that the file dependency graph remains, as it is still used to
track the dependencies of analysis data. This graph does no longer track
the implicit NgModule dependencies, which allows for better reuse of
analysis data.

This commit also fixes an incorrectness where a change to a declaration
in NgModule `A` would not cause the declarations in NgModules that
import from NgModule `A` to be re-emitted. This was intentionally
incorrect as otherwise the performance of incremental rebuilds would
have been far worse. This is no longer a concern, as the compiler is now
able to only re-emit when actually necessary.

Fixes #34867
Fixes #40635
Closes #40728