### PR TITLE
refactor(compiler-cli): separate out constant target of g3 patch

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -33,6 +33,8 @@ import {OptimizeFor, TemplateTypeChecker, TypeCheckingConfig, TypeCheckingProgra
 import {getSourceFileOrNull, isDtsPath, resolveModuleName} from '../../util/src/typescript';
 import {LazyRoute, NgCompilerAdapter, NgCompilerOptions} from '../api';
 
+import {compileUndecoratedClassesWithAngularFeatures} from './config';
+
 /**
  * State information about a compilation which is only generated once some data is requested from
  * the `NgCompiler` (for example, by calling `getDiagnostics`).
@@ -1012,10 +1014,7 @@ export class NgCompiler {
         new DirectiveDecoratorHandler(
             reflector, evaluator, metaRegistry, scopeRegistry, metaReader,
             defaultImportTracker, injectableRegistry, isCore, this.closureCompilerEnabled,
-            // In ngtsc we no longer want to compile undecorated classes with Angular features.
-            // Migrations for these patterns ran as part of `ng update` and we want to ensure
-            // that projects do not regress. See https://hackmd.io/@alx/ryfYYuvzH for more details.
-            /* compileUndecoratedClassesWithAngularFeatures */ false
+            compileUndecoratedClassesWithAngularFeatures,
         ) as Readonly<DecoratorHandler<unknown, unknown, unknown>>,
       // clang-format on
       // Pipe handler must be before injectable handler in list so pipe factories are printed

--- a/packages/compiler-cli/src/ngtsc/core/src/config.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/config.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// This file exists as a target for g3 patches which change the Angular compiler's behavior.
+// Separating the patched code in a separate file eliminates the possibility of conflicts with the
+// patch diffs when making changes to the rest of the compiler codebase.
+
+// In ngtsc we no longer want to compile undecorated classes with Angular features.
+// Migrations for these patterns ran as part of `ng update` and we want to ensure
+// that projects do not regress. See https://hackmd.io/@alx/ryfYYuvzH for more details.
+export const compileUndecoratedClassesWithAngularFeatures = false;


### PR DESCRIPTION
This commit moves a constant which is affected by a g3 sync patch into a
separate file. This way, changes to the rest of the compiler codebase have
no chance of conflicting with the patched code.
