### PR TITLE
refactor(language-service): Misc improvements to LS APIs

### DIFF
--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -31,7 +31,7 @@ export type GetTcbResponse = {
    * code, `selections` is empty.
    */
   selections: ts.TextSpan[],
-}|undefined;
+};
 
 export type GetComponentLocationsForTemplateResponse = ts.DocumentSpan[];
 
@@ -40,6 +40,6 @@ export type GetComponentLocationsForTemplateResponse = ts.DocumentSpan[];
  * whose API surface is a strict superset of TypeScript's language service.
  */
 export interface NgLanguageService extends ts.LanguageService {
-  getTcb(fileName: string, position: number): GetTcbResponse;
+  getTcb(fileName: string, position: number): GetTcbResponse|undefined;
   getComponentLocationsForTemplate(fileName: string): GetComponentLocationsForTemplateResponse;
 }

--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -43,3 +43,8 @@ export interface NgLanguageService extends ts.LanguageService {
   getTcb(fileName: string, position: number): GetTcbResponse|undefined;
   getComponentLocationsForTemplate(fileName: string): GetComponentLocationsForTemplateResponse;
 }
+
+export function isNgLanguageService(ls: ts.LanguageService|
+                                    NgLanguageService): ls is NgLanguageService {
+  return 'getTcb' in ls;
+}

--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -244,8 +244,8 @@ export class LanguageService {
     });
   }
 
-  getTcb(fileName: string, position: number): GetTcbResponse {
-    return this.withCompiler<GetTcbResponse>(compiler => {
+  getTcb(fileName: string, position: number): GetTcbResponse|undefined {
+    return this.withCompiler<GetTcbResponse|undefined>(compiler => {
       const templateInfo = getTemplateInfoAtPosition(fileName, position, compiler);
       if (templateInfo === undefined) {
         return undefined;

--- a/packages/language-service/ivy/ts_plugin.ts
+++ b/packages/language-service/ivy/ts_plugin.ts
@@ -130,7 +130,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     return diagnostics;
   }
 
-  function getTcb(fileName: string, position: number): GetTcbResponse {
+  function getTcb(fileName: string, position: number): GetTcbResponse|undefined {
     return ngLS.getTcb(fileName, position);
   }
 


### PR DESCRIPTION
This PR consists of two commits:
- refactor(language-service): Clean up getTcb interface
    `GetTcbResponse` should not be a union type with `undefined`.
- refactor(language-service): add type guard for NgLanguageService
    Type guard should be colocated with the `NgLanguageService` interface,
    not in `@angular/vscode-ng-language-service`.


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
