### PR TITLE
test(bazel): use bazel runfiles helper for resolving file names

### DIFF
--- a/packages/bazel/test/ng_package/common_package.spec.ts
+++ b/packages/bazel/test/ng_package/common_package.spec.ts
@@ -11,10 +11,13 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as shx from 'shelljs';
 
+/** Runfiles helper from bazel to resolve file name paths.  */
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']!);
+
 // Resolve the "npm_package" directory by using the runfile resolution. Note that we need to
 // resolve the "package.json" of the package since otherwise NodeJS would resolve the "main"
 // file, which is not necessarily at the root of the "npm_package".
-shx.cd(path.dirname(require.resolve('angular/packages/common/npm_package/package.json')));
+shx.cd(path.dirname(runfiles.resolve('angular/packages/common/npm_package/package.json')));
 
 describe('@angular/common ng_package', () => {
   describe('should have the locales files', () => {

--- a/packages/bazel/test/ng_package/core_package.spec.ts
+++ b/packages/bazel/test/ng_package/core_package.spec.ts
@@ -10,10 +10,13 @@ import {ivyEnabled, obsoleteInIvy} from '@angular/private/testing';
 import * as path from 'path';
 import * as shx from 'shelljs';
 
+/** Runfiles helper from bazel to resolve file name paths.  */
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']!);
+
 // Resolve the "npm_package" directory by using the runfile resolution. Note that we need to
 // resolve the "package.json" of the package since otherwise NodeJS would resolve the "main"
 // file, which is not necessarily at the root of the "npm_package".
-shx.cd(path.dirname(require.resolve('angular/packages/core/npm_package/package.json')));
+shx.cd(path.dirname(runfiles.resolve('angular/packages/core/npm_package/package.json')));
 
 /**
  * Utility functions that allows me to create fs paths

--- a/packages/bazel/test/ng_package/example_package.spec.ts
+++ b/packages/bazel/test/ng_package/example_package.spec.ts
@@ -11,6 +11,9 @@ import {createPatch} from 'diff';
 import * as fs from 'fs';
 import * as path from 'path';
 
+/** Runfiles helper from bazel to resolve file name paths.  */
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']!);
+
 type TestPackage = {
   displayName: string; packagePath: string; goldenFilePath: string;
 };
@@ -21,18 +24,18 @@ const packagesToTest: TestPackage[] = [
     // Resolve the "npm_package" directory by using the runfile resolution. Note that we need to
     // resolve the "package.json" of the package since otherwise NodeJS would resolve the "main"
     // file, which is not necessarily at the root of the "npm_package".
-    packagePath: path.dirname(
-        require.resolve('angular/packages/bazel/test/ng_package/example/npm_package/package.json')),
-    goldenFilePath: require.resolve('./example_package.golden')
+    packagePath: path.dirname(runfiles.resolve(
+        'angular/packages/bazel/test/ng_package/example/npm_package/package.json')),
+    goldenFilePath: runfiles.resolvePackageRelative('./example_package.golden')
   },
   {
     displayName: 'Example with ts_library NPM package',
     // Resolve the "npm_package" directory by using the runfile resolution. Note that we need to
     // resolve the "package.json" of the package since otherwise NodeJS would resolve the "main"
     // file, which is not necessarily at the root of the "npm_package".
-    packagePath: path.dirname(require.resolve(
+    packagePath: path.dirname(runfiles.resolve(
         'angular/packages/bazel/test/ng_package/example-with-ts-library/npm_package/package.json')),
-    goldenFilePath: require.resolve('./example_with_ts_library_package.golden')
+    goldenFilePath: runfiles.resolvePackageRelative('./example_with_ts_library_package.golden')
   },
 ];
 

--- a/packages/bazel/test/ngc-wrapped/flat_module_test.ts
+++ b/packages/bazel/test/ngc-wrapped/flat_module_test.ts
@@ -10,13 +10,16 @@ import {obsoleteInIvy, onlyInIvy} from '@angular/private/testing';
 import {existsSync, readFileSync} from 'fs';
 import {dirname, join} from 'path';
 
+/** Runfiles helper from bazel to resolve file name paths.  */
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']!);
+
 describe('flat_module ng_module', () => {
   let packageOutput: string;
   let flatModuleOutFile: string;
 
   beforeAll(() => {
     packageOutput =
-        dirname(require.resolve('angular/packages/bazel/test/ngc-wrapped/flat_module/index.js'));
+        dirname(runfiles.resolve('angular/packages/bazel/test/ngc-wrapped/flat_module/index.js'));
     flatModuleOutFile = join(packageOutput, 'flat_module.js');
   });
 


### PR DESCRIPTION
Use bazel's runfiles helper to resolve file name paths rather than
require.
