### PR TITLE
feat(common): add params percent encoding encoder

### DIFF
--- a/goldens/public-api/common/http/http.d.ts
+++ b/goldens/public-api/common/http/http.d.ts
@@ -1786,6 +1786,14 @@ export declare class HttpUrlEncodingCodec implements HttpParameterCodec {
     encodeValue(value: string): string;
 }
 
+export declare class HttpUrlPercentEncodingCodec implements HttpParameterCodec {
+    decodeKey(key: string): string;
+    decodeValue(value: string): string;
+    encodeKey(key: string): string;
+    encodeValue(value: string): string;
+}
+
+
 export declare interface HttpUserEvent<T> {
     type: HttpEventType.User;
 }

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -12,7 +12,7 @@ export {HttpHeaders} from './src/headers';
 export {HTTP_INTERCEPTORS, HttpInterceptor} from './src/interceptor';
 export {JsonpClientBackend, JsonpInterceptor} from './src/jsonp';
 export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule, HttpInterceptingHandler as ɵHttpInterceptingHandler} from './src/module';
-export {HttpParameterCodec, HttpParams, HttpParamsOptions, HttpUrlEncodingCodec} from './src/params';
+export {HttpParameterCodec, HttpParams, HttpParamsOptions, HttpUrlEncodingCodec, HttpUrlPercentEncodingCodec} from './src/params';
 export {HttpRequest} from './src/request';
 export {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpProgressEvent, HttpResponse, HttpResponseBase, HttpSentEvent, HttpStatusCode, HttpUploadProgressEvent, HttpUserEvent} from './src/response';
 export {HttpXhrBackend, XhrFactory} from './src/xhr';

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -174,7 +174,6 @@ export interface HttpParamsOptions {
 
   /** Encoding codec used to parse and serialize the parameters. */
   encoder?: HttpParameterCodec;
-  percentEncoding?: boolean;
 }
 
 /**
@@ -193,9 +192,6 @@ export class HttpParams {
 
   constructor(options: HttpParamsOptions = {} as HttpParamsOptions) {
     this.encoder = options.encoder || new HttpUrlEncodingCodec();
-    if (!!options.percentEncoding) {
-      this.encoder = new HttpUrlPercentEncodingCodec();
-    }
     if (!!options.fromString) {
       if (!!options.fromObject) {
         throw new Error(`Cannot specify both fromString and fromObject.`);

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -70,6 +70,55 @@ export class HttpUrlEncodingCodec implements HttpParameterCodec {
 }
 
 
+/**
+ * Provides percent encoding and decoding of URL parameter and query-string values.
+ *
+ * Serializes and parses URL parameter keys and values to encode and decode them.
+ * If you pass URL query parameters without encoding,
+ * the query parameters can be misinterpreted at the receiving end.
+ *
+ *
+ * @publicApi
+ */
+export class HttpUrlPercentEncodingCodec implements HttpParameterCodec {
+  /**
+   * Encodes a key name for a URL parameter or query-string.
+   * @param key The key name.
+   * @returns The encoded key name.
+   */
+  encodeKey(key: string): string {
+    return encodeURIComponent(key);
+  }
+
+  /**
+   * Encodes the value of a URL parameter or query-string.
+   * @param value The value.
+   * @returns The encoded value.
+   */
+  encodeValue(value: string): string {
+    return encodeURIComponent(value);
+  }
+
+  /**
+   * Decodes an encoded URL parameter or query-string key.
+   * @param key The encoded key name.
+   * @returns The decoded key name.
+   */
+  decodeKey(key: string): string {
+    return decodeURIComponent(key);
+  }
+
+  /**
+   * Decodes an encoded URL parameter or query-string value.
+   * @param value The encoded value.
+   * @returns The decoded value.
+   */
+  decodeValue(value: string) {
+    return decodeURIComponent(value);
+  }
+}
+
+
 function paramParser(rawParams: string, codec: HttpParameterCodec): Map<string, string[]> {
   const map = new Map<string, string[]>();
   if (rawParams.length > 0) {
@@ -125,6 +174,7 @@ export interface HttpParamsOptions {
 
   /** Encoding codec used to parse and serialize the parameters. */
   encoder?: HttpParameterCodec;
+  percentEncoding?: boolean;
 }
 
 /**
@@ -143,6 +193,9 @@ export class HttpParams {
 
   constructor(options: HttpParamsOptions = {} as HttpParamsOptions) {
     this.encoder = options.encoder || new HttpUrlEncodingCodec();
+    if (!!options.percentEncoding) {
+      this.encoder = new HttpUrlPercentEncodingCodec();
+    }
     if (!!options.fromString) {
       if (!!options.fromObject) {
         throw new Error(`Cannot specify both fromString and fromObject.`);

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpParams} from '@angular/common/http/src/params';
+import {HttpParams, HttpUrlPercentEncodingCodec} from '@angular/common/http/src/params';
 
 {
   describe('HttpUrlEncodedParams', () => {
@@ -113,7 +113,9 @@ import {HttpParams} from '@angular/common/http/src/params';
 
     describe('percent encoding toString', () => {
       it('should encode and stringify string params', () => {
-        const body = new HttpParams({fromObject: {a: '@:$,;+=?/', b: '2'}, percentEncoding: true});
+        const encoder = new HttpUrlPercentEncodingCodec();
+        const body = new HttpParams({fromObject: {a: '@:$,;+=?/', b: '2'}, encoder: encoder});
+
         expect(body.toString()).toBe('a=%40%3A%24%2C%3B%2B%3D%3F%2F&b=2');
       });
       it('should stringify array params', () => {

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -110,5 +110,16 @@ import {HttpParams} from '@angular/common/http/src/params';
         expect(body.toString()).toBe('a=&c=3');
       });
     });
+
+    describe('percent encoding toString', () => {
+      it('should encode and stringify string params', () => {
+        const body = new HttpParams({fromObject: {a: '@:$,;+=?/', b: '2'}, percentEncoding: true});
+        expect(body.toString()).toBe('a=%40%3A%24%2C%3B%2B%3D%3F%2F&b=2');
+      });
+      it('should stringify array params', () => {
+        const body = new HttpParams({fromObject: {a: '@:$,;+=?/', b: '2'}});
+        expect(body.toString()).toBe('a=@:$,;+=?/&b=2');
+      });
+    });
   });
 }


### PR DESCRIPTION
Previously, if a http param's value contains reserved characters such as
";", the value is not encoded correctly. It was encoded and then replaced.
But change the encoding method may cause some problems for old projects.
So this commit adds param percent encoding encoder.

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [11058](https://github.com/angular/angular/issues/11058)  [26979](https://github.com/angular/angular/issues/26979 )  


## What is the new behavior?

  If create a http with option percentEncoding=true, the params will be percent encoded.
     var params  = new HttpParams({percentEncoding: true}); 

## Does this PR introduce a breaking change?

- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
