### PR TITLE
docs: fixes Tour of Heros tutorial ch 4 so it compiles in strict mode

### DIFF
--- a/aio/content/examples/toh-pt4/src/app/heroes/heroes.component.ts
+++ b/aio/content/examples/toh-pt4/src/app/heroes/heroes.component.ts
@@ -15,10 +15,10 @@ import { MessageService } from '../message.service';
 })
 export class HeroesComponent implements OnInit {
 
-  selectedHero: Hero;
+  selectedHero?: Hero;
 
   // #docregion heroes
-  heroes: Hero[];
+  heroes: Hero[] = [];
   // #enddocregion heroes
 
   constructor(private heroService: HeroService, private messageService: MessageService) { }


### PR DESCRIPTION
fixes error: `TS2564: Property 'heroes' has no initializer and is not definitely assigned in the constructor`
and makes `hero` property consistent with ch 3 (ref: #40942)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The Tour of Heros tutorial throws a number of errors when "strict" is set to true. This fixes the errors in chapter 4. The tracking issue is https://github.com/angular/angular/issues/39344. You can also see https://github.com/angular/angular/issues/40941 for a description of the error.

Issue Number: N/A


## What is the new behavior?
Chapter 4 compiles when "strict" is set to true. The tracking issue ha a [list](https://github.com/angular/angular/issues/39344#issuecomment-713053570) of failures that needs to be fixed and this fixes everything in [chapter 4](https://angular.io/tutorial/toh-pt4).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
