### PR TITLE
feat(ngcc): support processing only the typings files of packages

### DIFF
--- a/packages/compiler-cli/ngcc/src/command_line_options.ts
+++ b/packages/compiler-cli/ngcc/src/command_line_options.ts
@@ -49,7 +49,14 @@ export function parseCommandLineOptions(args: string[]): NgccOptions {
           })
           .option('first-only', {
             describe:
-                'If specified then only the first matching package.json property will be compiled.',
+                'If specified then only the first matching package.json property will be compiled.\n' +
+                'This option is overridden by `--typings-only`.',
+            type: 'boolean',
+          })
+          .option('typings-only', {
+            describe:
+                'If specified then only the typings files are processed, and no JS source files will be modified.\n' +
+                'Setting this option will force `--first-only` to be set, since only one format is needed to process the typings',
             type: 'boolean',
           })
           .option('create-ivy-entry-points', {
@@ -122,6 +129,7 @@ export function parseCommandLineOptions(args: string[]): NgccOptions {
   const propertiesToConsider = options.p;
   const targetEntryPointPath = options.t;
   const compileAllFormats = !options['first-only'];
+  const typingsOnly = options['typings-only'];
   const createNewEntryPointFormats = options['create-ivy-entry-points'];
   const logLevel = options.l as keyof typeof LogLevel | undefined;
   const enableI18nLegacyMessageIdFormat = options['legacy-message-ids'];
@@ -139,6 +147,7 @@ export function parseCommandLineOptions(args: string[]): NgccOptions {
     basePath: baseSourcePath,
     propertiesToConsider,
     targetEntryPointPath,
+    typingsOnly,
     compileAllFormats,
     createNewEntryPointFormats,
     logger,

--- a/packages/compiler-cli/ngcc/src/execution/tasks/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/tasks/api.ts
@@ -32,8 +32,30 @@ export interface Task extends JsonObject {
    */
   formatPropertiesToMarkAsProcessed: EntryPointJsonProperty[];
 
-  /** Whether to also process typings for this entry-point as part of the task. */
-  processDts: boolean;
+  /**
+   * Whether to process typings for this entry-point as part of the task.
+   */
+  processDts: DtsProcessing;
+}
+
+/**
+ * The options for processing Typescript typings (.d.ts) files.
+ */
+export enum DtsProcessing {
+  /**
+   * Yes, process the typings for this entry point as part of the task.
+   */
+  Yes,
+  /**
+     No, do not process the typings as part of this task - they must have already been processed by
+     another task or previous ngcc process.
+   */
+  No,
+  /**
+     Only process the typings for this entry-point; do not render any JavaScript files for the
+     `formatProperty` of this task.
+   */
+  Only,
 }
 
 /**

--- a/packages/compiler-cli/ngcc/src/execution/tasks/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/tasks/api.ts
@@ -47,13 +47,13 @@ export enum DtsProcessing {
    */
   Yes,
   /**
-     No, do not process the typings as part of this task - they must have already been processed by
-     another task or previous ngcc process.
+   * No, do not process the typings as part of this task - they must have already been processed by
+   * another task or previous ngcc process.
    */
   No,
   /**
-     Only process the typings for this entry-point; do not render any JavaScript files for the
-     `formatProperty` of this task.
+   * Only process the typings for this entry-point; do not render any JavaScript files for the
+   * `formatProperty` of this task.
    */
   Only,
 }

--- a/packages/compiler-cli/ngcc/src/execution/tasks/completion.ts
+++ b/packages/compiler-cli/ngcc/src/execution/tasks/completion.ts
@@ -82,9 +82,9 @@ export function createLogErrorHandler(
 }
 
 function createErrorMessage(fs: ReadonlyFileSystem, task: Task, message: string|null): string {
-  const format = task.typingsOnly ?
-      'typings only' :
+  const jsFormat =
       `${task.formatProperty} as ${getEntryPointFormat(fs, task.entryPoint, task.formatProperty)}`;
-  return `Failed to compile entry-point ${task.entryPoint.name} (${format})` +
-      (message !== null ? ` due to ${message}` : '');
+  const format = task.typingsOnly ? `typings only using ${jsFormat}` : jsFormat;
+  message = message !== null ? ` due to ${message}` : '';
+  return `Failed to compile entry-point ${task.entryPoint.name} (${format})` + message;
 }

--- a/packages/compiler-cli/ngcc/src/execution/tasks/completion.ts
+++ b/packages/compiler-cli/ngcc/src/execution/tasks/completion.ts
@@ -11,7 +11,7 @@ import {markAsProcessed} from '../../packages/build_marker';
 import {getEntryPointFormat, PackageJsonFormatProperties} from '../../packages/entry_point';
 import {PackageJsonUpdater} from '../../writing/package_json_updater';
 
-import {Task, TaskCompletedCallback, TaskProcessingOutcome, TaskQueue} from './api';
+import {DtsProcessing, Task, TaskCompletedCallback, TaskProcessingOutcome, TaskQueue} from './api';
 
 /**
  * A function that can handle a specific outcome of a task completion.
@@ -53,7 +53,7 @@ export function createMarkAsProcessedHandler(
     const packageJsonPath = fs.resolve(entryPoint.path, 'package.json');
     const propsToMarkAsProcessed: PackageJsonFormatProperties[] =
         [...formatPropertiesToMarkAsProcessed];
-    if (processDts) {
+    if (processDts !== DtsProcessing.No) {
       propsToMarkAsProcessed.push('typings');
     }
     markAsProcessed(
@@ -66,11 +66,7 @@ export function createMarkAsProcessedHandler(
  */
 export function createThrowErrorHandler(fs: ReadonlyFileSystem): TaskCompletedHandler {
   return (task: Task, message: string|null): void => {
-    const format = getEntryPointFormat(fs, task.entryPoint, task.formatProperty);
-    throw new Error(
-        `Failed to compile entry-point ${task.entryPoint.name} (${task.formatProperty} as ${
-            format})` +
-        (message !== null ? ` due to ${message}` : ''));
+    throw new Error(createErrorMessage(fs, task, message));
   };
 }
 
@@ -81,10 +77,14 @@ export function createLogErrorHandler(
     logger: Logger, fs: ReadonlyFileSystem, taskQueue: TaskQueue): TaskCompletedHandler {
   return (task: Task, message: string|null): void => {
     taskQueue.markAsFailed(task);
-    const format = getEntryPointFormat(fs, task.entryPoint, task.formatProperty);
-    logger.error(
-        `Failed to compile entry-point ${task.entryPoint.name} (${task.formatProperty} as ${
-            format})` +
-        (message !== null ? ` due to ${message}` : ''));
+    logger.error(createErrorMessage(fs, task, message));
   };
+}
+
+function createErrorMessage(fs: ReadonlyFileSystem, task: Task, message: string|null): string {
+  const format = task.typingsOnly ?
+      'typings only' :
+      `${task.formatProperty} as ${getEntryPointFormat(fs, task.entryPoint, task.formatProperty)}`;
+  return `Failed to compile entry-point ${task.entryPoint.name} (${format})` +
+      (message !== null ? ` due to ${message}` : '');
 }

--- a/packages/compiler-cli/ngcc/src/execution/tasks/utils.ts
+++ b/packages/compiler-cli/ngcc/src/execution/tasks/utils.ts
@@ -7,11 +7,12 @@
  */
 import {DepGraph} from 'dependency-graph';
 import {EntryPoint} from '../../packages/entry_point';
-import {PartiallyOrderedTasks, Task, TaskDependencies} from './api';
+import {DtsProcessing, PartiallyOrderedTasks, Task, TaskDependencies} from './api';
 
 /** Stringify a task for debugging purposes. */
-export const stringifyTask = (task: Task): string => `{entryPoint: ${
-    task.entryPoint.name}, formatProperty: ${task.formatProperty}, processDts: ${task.processDts}}`;
+export const stringifyTask = (task: Task): string =>
+    `{entryPoint: ${task.entryPoint.name}, formatProperty: ${task.formatProperty}, ` +
+    `processDts: ${DtsProcessing[task.processDts]}}`;
 
 /**
  * Compute a mapping of tasks to the tasks that are dependent on them (if any).
@@ -55,7 +56,7 @@ export function computeTaskDependencies(
       }
     }
 
-    if (task.processDts) {
+    if (task.processDts !== DtsProcessing.No) {
       // SANITY CHECK:
       // There should only be one task per entry-point that generates typings (and thus can be a
       // dependency of other tasks), so the following should theoretically never happen, but check

--- a/packages/compiler-cli/ngcc/src/main.ts
+++ b/packages/compiler-cli/ngcc/src/main.ts
@@ -56,6 +56,7 @@ export function mainNgcc(options: AsyncNgccOptions|SyncNgccOptions): void|Promis
     basePath,
     targetEntryPointPath,
     propertiesToConsider,
+    typingsOnly,
     compileAllFormats,
     logger,
     pathMappings,
@@ -96,7 +97,7 @@ export function mainNgcc(options: AsyncNgccOptions|SyncNgccOptions): void|Promis
   const inParallel = workerCount > 1;
 
   const analyzeEntryPoints = getAnalyzeEntryPointsFn(
-      logger, finder, fileSystem, supportedPropertiesToConsider, compileAllFormats,
+      logger, finder, fileSystem, supportedPropertiesToConsider, typingsOnly, compileAllFormats,
       propertiesToConsider, inParallel);
 
   // Create an updater that will actually write to disk.

--- a/packages/compiler-cli/ngcc/src/ngcc_options.ts
+++ b/packages/compiler-cli/ngcc/src/ngcc_options.ts
@@ -43,8 +43,20 @@ export interface SyncNgccOptions {
   propertiesToConsider?: string[];
 
   /**
+   * Whether to only process the typings files for this entry-point.
+   *
+   * This is useful when running ngcc only to provide typings files to downstream tooling such as
+   * the Angular Language Service or ng-packagr. Defaults to `false`.
+   *
+   * If this is set to `true` then `compileAllFormats` is forced to `false`.
+   */
+  typingsOnly?: boolean;
+
+  /**
    * Whether to process all formats specified by (`propertiesToConsider`)  or to stop processing
-   * this entry-point at the first matching format. Defaults to `true`.
+   * this entry-point at the first matching format.
+   *
+   * Defaults to `true`, but is forced to `false` if `typingsOnly` is `true`.
    */
   compileAllFormats?: boolean;
 
@@ -172,6 +184,7 @@ export function getSharedSetup(options: NgccOptions): SharedSetup&RequiredNgccOp
     basePath,
     targetEntryPointPath,
     propertiesToConsider = SUPPORTED_FORMAT_PROPERTIES,
+    typingsOnly = false,
     compileAllFormats = true,
     createNewEntryPointFormats = false,
     logger = new ConsoleLogger(LogLevel.info),
@@ -188,12 +201,19 @@ export function getSharedSetup(options: NgccOptions): SharedSetup&RequiredNgccOp
     errorOnFailedEntryPoint = true;
   }
 
+  if (typingsOnly) {
+    // If we only want to process the typpings then we do not want to waste time trying to process
+    // multiple JS formats.
+    compileAllFormats = false;
+  }
+
   checkForSolutionStyleTsConfig(fileSystem, logger, projectPath, options.tsConfigPath, tsConfig);
 
   return {
     basePath,
     targetEntryPointPath,
     propertiesToConsider,
+    typingsOnly,
     compileAllFormats,
     createNewEntryPointFormats,
     logger,

--- a/packages/compiler-cli/ngcc/src/ngcc_options.ts
+++ b/packages/compiler-cli/ngcc/src/ngcc_options.ts
@@ -202,7 +202,7 @@ export function getSharedSetup(options: NgccOptions): SharedSetup&RequiredNgccOp
   }
 
   if (typingsOnly) {
-    // If we only want to process the typpings then we do not want to waste time trying to process
+    // If we only want to process the typings then we do not want to waste time trying to process
     // multiple JS formats.
     compileAllFormats = false;
   }

--- a/packages/compiler-cli/ngcc/src/packages/transformer.ts
+++ b/packages/compiler-cli/ngcc/src/packages/transformer.ts
@@ -17,6 +17,7 @@ import {NgccReferencesRegistry} from '../analysis/ngcc_references_registry';
 import {ExportInfo, PrivateDeclarationsAnalyzer} from '../analysis/private_declarations_analyzer';
 import {SwitchMarkerAnalyses, SwitchMarkerAnalyzer} from '../analysis/switch_marker_analyzer';
 import {CompiledFile} from '../analysis/types';
+import {DtsProcessing} from '../execution/tasks/api';
 import {CommonJsReflectionHost} from '../host/commonjs_host';
 import {DelegatingReflectionHost} from '../host/delegating_host';
 import {Esm2015ReflectionHost} from '../host/esm2015_host';
@@ -92,12 +93,16 @@ export class Transformer {
     }
 
     // Transform the source files and source maps.
-    const srcFormatter = this.getRenderingFormatter(ngccReflectionHost, bundle);
+    let renderedFiles: FileToWrite[] = [];
 
-    const renderer =
-        new Renderer(reflectionHost, srcFormatter, this.fs, this.logger, bundle, this.tsConfig);
-    let renderedFiles = renderer.renderProgram(
-        decorationAnalyses, switchMarkerAnalyses, privateDeclarationsAnalyses);
+    if (bundle.dtsProcessing !== DtsProcessing.Only) {
+      // Render the transformed JavaScript files only if we are not doing "typings-only" processing.
+      const srcFormatter = this.getRenderingFormatter(ngccReflectionHost, bundle);
+      const renderer =
+          new Renderer(reflectionHost, srcFormatter, this.fs, this.logger, bundle, this.tsConfig);
+      renderedFiles = renderer.renderProgram(
+          decorationAnalyses, switchMarkerAnalyses, privateDeclarationsAnalyses);
+    }
 
     if (bundle.dts) {
       const dtsFormatter = new EsmRenderingFormatter(this.fs, reflectionHost, bundle.isCore);

--- a/packages/compiler-cli/ngcc/test/execution/cluster/worker_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/cluster/worker_spec.ts
@@ -15,7 +15,7 @@ import {AbsoluteFsPath} from '../../../../src/ngtsc/file_system';
 import {MockLogger} from '../../../../src/ngtsc/logging/testing';
 import {CreateCompileFn} from '../../../src/execution/api';
 import {startWorker} from '../../../src/execution/cluster/worker';
-import {Task, TaskCompletedCallback, TaskProcessingOutcome} from '../../../src/execution/tasks/api';
+import {DtsProcessing, Task, TaskCompletedCallback, TaskProcessingOutcome} from '../../../src/execution/tasks/api';
 import {FileToWrite} from '../../../src/rendering/utils';
 import {mockProperty, spyProperty} from '../../helpers/spy_utils';
 
@@ -124,7 +124,7 @@ describe('startWorker()', () => {
       const mockTask = {
         entryPoint: {name: 'foo'},
         formatProperty: 'es2015',
-        processDts: true,
+        processDts: DtsProcessing.Yes,
       } as unknown as Task;
 
       startWorker(mockLogger, createCompileFnSpy);
@@ -134,7 +134,7 @@ describe('startWorker()', () => {
       expect(processSendSpy).not.toHaveBeenCalled();
 
       expect(mockLogger.logs.debug[0]).toEqual([
-        '[Worker #42] Processing task: {entryPoint: foo, formatProperty: es2015, processDts: true}',
+        '[Worker #42] Processing task: {entryPoint: foo, formatProperty: es2015, processDts: Yes}',
       ]);
     });
 
@@ -142,7 +142,7 @@ describe('startWorker()', () => {
       const mockTask = {
         entryPoint: {name: 'foo'},
         formatProperty: 'es2015',
-        processDts: true,
+        processDts: DtsProcessing.Yes,
       } as unknown as Task;
 
       let err: string|Error;
@@ -178,7 +178,7 @@ describe('startWorker()', () => {
         const mockTask = {
           entryPoint: {name: 'foo'},
           formatProperty: 'es2015',
-          processDts: true,
+          processDts: DtsProcessing.Yes,
         } as unknown as Task;
 
         const noMemError = Object.assign(new Error('ENOMEM: not enough memory'), {code: 'ENOMEM'});

--- a/packages/compiler-cli/ngcc/test/execution/helpers.ts
+++ b/packages/compiler-cli/ngcc/test/execution/helpers.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {DepGraph} from 'dependency-graph';
-import {PartiallyOrderedTasks, Task} from '../../src/execution/tasks/api';
+import {DtsProcessing, PartiallyOrderedTasks, Task} from '../../src/execution/tasks/api';
 import {EntryPoint} from '../../src/packages/entry_point';
 
 /**
@@ -52,7 +52,8 @@ export function createTasksAndGraph(
     graph.addNode(entryPoint.path);
 
     for (let tIdx = 0; tIdx < tasksPerEntryPointCount; tIdx++) {
-      tasks.push({entryPoint, formatProperty: `prop-${tIdx}`, processDts: tIdx === 0} as Task);
+      const processDts = tIdx === 0 ? DtsProcessing.Yes : DtsProcessing.No;
+      tasks.push({entryPoint, formatProperty: `prop-${tIdx}`, processDts} as Task);
     }
   }
 

--- a/packages/compiler-cli/ngcc/test/execution/utils_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/utils_spec.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {DtsProcessing} from '../../src/execution/tasks/api';
 import {computeTaskDependencies, sortTasksByPriority} from '../../src/execution/tasks/utils';
 import {createTasksAndGraph} from './helpers';
 
@@ -16,14 +17,14 @@ describe('execution utils', () => {
            0: [],   // Entry-point #0 does not depend on anything.
            1: [0],  // Entry-point #1 depends on #0.
          });
-         tasks[1].processDts = true;  // Tweak task #1 to also generate typings.
+         tasks[1].processDts = DtsProcessing.Yes;  // Tweak task #1 to also generate typings.
 
          expect(() => computeTaskDependencies(tasks, graph))
              .toThrowError(
                  'Invariant violated: Multiple tasks are assigned generating typings for ' +
                  '\'/path/to/entry/point/0\':\n' +
-                 '  - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: true}\n' +
-                 '  - {entryPoint: entry-point-0, formatProperty: prop-1, processDts: true}');
+                 '  - {entryPoint: entry-point-0, formatProperty: prop-0, processDts: Yes}\n' +
+                 '  - {entryPoint: entry-point-0, formatProperty: prop-1, processDts: Yes}');
        });
 
     it('should add non-typings tasks to the dependents of typings tasks', () => {

--- a/packages/compiler-cli/ngcc/test/helpers/utils.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/utils.ts
@@ -9,6 +9,7 @@ import * as ts from 'typescript';
 
 import {absoluteFrom, AbsoluteFsPath, getFileSystem, NgtscCompilerHost} from '../../../src/ngtsc/file_system';
 import {TestFile} from '../../../src/ngtsc/file_system/testing';
+import {DtsProcessing} from '../../src/execution/tasks/api';
 import {BundleProgram, makeBundleProgram} from '../../src/packages/bundle_program';
 import {NgccEntryPointConfig} from '../../src/packages/configuration';
 import {EntryPoint, EntryPointFormat} from '../../src/packages/entry_point';
@@ -55,6 +56,7 @@ export function makeTestEntryPointBundle(
     rootDirs: [absoluteFrom('/')],
     src,
     dts,
+    dtsProcessing: dtsRootNames ? DtsProcessing.Yes : DtsProcessing.No,
     isCore,
     isFlatCore,
     enableI18nLegacyMessageIdFormat

--- a/packages/compiler-cli/ngcc/test/ngcc_options_spec.ts
+++ b/packages/compiler-cli/ngcc/test/ngcc_options_spec.ts
@@ -99,6 +99,23 @@ runInEachFileSystem(() => {
       expect(setup.tsConfig?.rootNames).toEqual([]);
       expect((setup.logger as MockLogger).logs.warn).toEqual([]);
     });
+
+    it('should not modify `compileAllFormats` if `typingsOnly` is falsy', () => {
+      let setup = getSharedSetup({...createOptions(), compileAllFormats: true, typingsOnly: false});
+      expect(setup.typingsOnly).toBe(false);
+      expect(setup.compileAllFormats).toBe(true);
+
+      setup = getSharedSetup({...createOptions(), compileAllFormats: true});
+      expect(setup.typingsOnly).toBe(false);
+      expect(setup.compileAllFormats).toBe(true);
+    });
+
+    it('should force `compileAllFormats` to false if `typingsOnly` is true', () => {
+      const setup =
+          getSharedSetup({...createOptions(), compileAllFormats: true, typingsOnly: true});
+      expect(setup.typingsOnly).toBe(true);
+      expect(setup.compileAllFormats).toBe(false);
+    });
   });
 
   describe('getMaxNumberOfWorkers', () => {

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_bundle_spec.ts
@@ -8,6 +8,7 @@
 import {absoluteFrom, getFileSystem} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadTestFiles} from '../../../src/ngtsc/testing';
+import {DtsProcessing} from '../../src/execution/tasks/api';
 import {EntryPoint} from '../../src/packages/entry_point';
 import {makeEntryPointBundle} from '../../src/packages/entry_point_bundle';
 import {createModuleResolutionCache, SharedFileCache} from '../../src/packages/source_file_cache';
@@ -184,7 +185,7 @@ runInEachFileSystem(() => {
          const moduleResolutionCache = createModuleResolutionCache(fs);
          const esm5bundle = makeEntryPointBundle(
              fs, entryPoint, new SharedFileCache(fs), moduleResolutionCache, './index.js', false,
-             'esm5', true);
+             'esm5', DtsProcessing.Yes);
 
          expect(esm5bundle.src.program.getSourceFiles().map(sf => sf.fileName))
              .toEqual(jasmine.arrayWithExactContents([
@@ -298,8 +299,7 @@ runInEachFileSystem(() => {
       const moduleResolutionCache = createModuleResolutionCache(fs);
       const esm5bundle = makeEntryPointBundle(
           fs, entryPoint, new SharedFileCache(fs), moduleResolutionCache, './index.js', false,
-          'esm5',
-          /* transformDts */ true,
+          'esm5', DtsProcessing.Yes,
           /* pathMappings */ undefined, /* mirrorDtsFromSrc */ true);
 
       expect(esm5bundle.src.program.getSourceFiles().map(sf => _(sf.fileName)))
@@ -338,8 +338,7 @@ runInEachFileSystem(() => {
             const moduleResolutionCache = createModuleResolutionCache(fs);
             const esm5bundle = makeEntryPointBundle(
                 fs, entryPoint, new SharedFileCache(fs), moduleResolutionCache, './index.js', false,
-                'esm5',
-                /* transformDts */ true,
+                'esm5', DtsProcessing.Yes,
                 /* pathMappings */ undefined, /* mirrorDtsFromSrc */ true);
             expect(esm5bundle.src.program.getSourceFiles().map(sf => sf.fileName))
                 .toContain(absoluteFrom('/node_modules/test/internal.js'));
@@ -364,8 +363,7 @@ runInEachFileSystem(() => {
             const moduleResolutionCache = createModuleResolutionCache(fs);
             const esm5bundle = makeEntryPointBundle(
                 fs, entryPoint, new SharedFileCache(fs), moduleResolutionCache,
-                './esm2015/index.js', false, 'esm2015',
-                /* transformDts */ true,
+                './esm2015/index.js', false, 'esm2015', DtsProcessing.Yes,
                 /* pathMappings */ undefined, /* mirrorDtsFromSrc */ true);
             expect(esm5bundle.src.program.getSourceFiles().map(sf => sf.fileName))
                 .toContain(absoluteFrom('/node_modules/internal/esm2015/src/internal.js'));
@@ -390,8 +388,7 @@ runInEachFileSystem(() => {
             const moduleResolutionCache = createModuleResolutionCache(fs);
             const esm5bundle = makeEntryPointBundle(
                 fs, entryPoint, new SharedFileCache(fs), moduleResolutionCache, './index.js', false,
-                'esm5',
-                /* transformDts */ true,
+                'esm5', DtsProcessing.Yes,
                 /* pathMappings */ undefined, /* mirrorDtsFromSrc */ false);
             expect(esm5bundle.src.program.getSourceFiles().map(sf => sf.fileName))
                 .toContain(absoluteFrom('/node_modules/test/internal.js'));
@@ -417,8 +414,7 @@ runInEachFileSystem(() => {
       const moduleResolutionCache = createModuleResolutionCache(fs);
       const bundle = makeEntryPointBundle(
           fs, entryPoint, new SharedFileCache(fs), moduleResolutionCache, './index.js', false,
-          'esm2015',
-          /* transformDts */ true,
+          'esm2015', DtsProcessing.Yes,
           /* pathMappings */ undefined, /* mirrorDtsFromSrc */ true);
       expect(bundle.rootDirs).toEqual([absoluteFrom('/node_modules/primary')]);
     });

--- a/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/new_entry_point_file_writer_spec.ts
@@ -10,6 +10,7 @@ import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
 import {RawSourceMap} from '../../../src/ngtsc/sourcemaps';
 import {loadTestFiles} from '../../../src/ngtsc/testing';
+import {DtsProcessing} from '../../src/execution/tasks/api';
 import {NgccConfiguration} from '../../src/packages/configuration';
 import {EntryPoint, EntryPointFormat, EntryPointJsonProperty, getEntryPointInfo, isEntryPoint} from '../../src/packages/entry_point';
 import {EntryPointBundle, makeEntryPointBundle} from '../../src/packages/entry_point_bundle';
@@ -731,6 +732,6 @@ runInEachFileSystem(() => {
     const moduleResolutionCache = createModuleResolutionCache(fs);
     return makeEntryPointBundle(
         fs, entryPoint, new SharedFileCache(fs), moduleResolutionCache,
-        entryPoint.packageJson[formatProperty]!, false, format, true);
+        entryPoint.packageJson[formatProperty]!, false, format, DtsProcessing.Yes);
   }
 });


### PR DESCRIPTION
Some tools (such as Language Server and ng-packagr) only care about
the processed typings generated by ngcc. Forcing these tools to process
the JavaScript files as well has two disadvantages:

First, unnecessary work is being done, which is time consuming.
But more importantly, It is not always possible to know how the final bundling
tools will want the processed JavaScript to be configured. For example,
the CLI would prefer the `--create-ivy-entry-points` optiion but this would
break non-CLI build tooling.

This commit adds a new option (`--typings-only` on the command line, and
`typingsOnly` via programmatic API) that instructs ngcc to only render changes
to the typings files for the entry-points that it finds, and not to write and JavaScript
files.

In order to process the typings, a JavaScript format will need to be analysed, but
it will not be rendered to disk. When using this option, it is best to offer ngcc a
wide range of possible JavaScript formats to choose from, and it will use the
first format that it finds. Ideally you would configure it to try the `ES2015` FESM
format first, since this will be most performant.

Fixes #40969
