### PR TITLE
refactor(compiler/core): remove unreachable code

### DIFF
--- a/packages/compiler-cli/src/ngtsc/scope/src/dependency.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/dependency.ts
@@ -124,7 +124,6 @@ export class MetadataDtsModuleScopeResolver implements DtsModuleScopeResolver {
 
       // The export was not a directive, a pipe, or a module. This is an error.
       // TODO(alxhub): produce a ts.Diagnostic
-      throw new Error(`Exported value ${exportRef.debugName} was not a directive, pipe, or module`);
     }
 
     const exportScope: ExportScope = {

--- a/packages/compiler-cli/src/transformers/node_emitter.ts
+++ b/packages/compiler-cli/src/transformers/node_emitter.ts
@@ -784,7 +784,6 @@ function modifierFromModifier(modifier: StmtModifier): ts.Modifier {
     case StmtModifier.Static:
       return ts.createToken(ts.SyntaxKind.StaticKeyword);
   }
-  return error(`unknown statement modifier`);
 }
 
 function translateModifiers(modifiers: StmtModifier[]|null): ts.Modifier[]|undefined {

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -252,8 +252,6 @@ export class ConstantPool {
       case DefinitionKind.Pipe:
         return this.pipeDefinitions;
     }
-    error(`Unknown definition kind ${kind}`);
-    return this.componentDefinitions;
   }
 
   public propertyNameOf(kind: DefinitionKind): string {
@@ -267,8 +265,6 @@ export class ConstantPool {
       case DefinitionKind.Pipe:
         return 'ɵpipe';
     }
-    error(`Unknown definition kind ${kind}`);
-    return '<unknown>';
   }
 
   private freshName(): string {

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -432,7 +432,6 @@ function selectorsFromGlobalMetadata(
   }
 
   error('Unexpected query form');
-  return o.NULL_EXPR;
 }
 
 function prepareQueryParams(query: R3QueryMetadata, constantPool: ConstantPool): o.Expression[] {

--- a/packages/core/schematics/migrations/renderer-to-renderer2/helpers.ts
+++ b/packages/core/schematics/migrations/renderer-to-renderer2/helpers.ts
@@ -56,8 +56,6 @@ function getHelperDeclaration(name: HelperFunction): ts.Node {
     case HelperFunction.splitNamespace:
       return getSplitNamespaceHelper();
   }
-
-  throw new Error(`Unsupported helper called "${name}".`);
 }
 
 /** Creates a helper for a custom `any` type during the migration. */

--- a/packages/core/src/render3/instructions/lview_debug.ts
+++ b/packages/core/src/render3/instructions/lview_debug.ts
@@ -102,7 +102,6 @@ function getLViewToClone(type: TViewType, name: string|null): Array<any> {
       }
       return embeddedArray;
   }
-  throw new Error('unreachable code');
 }
 
 function nameSuffix(text: string|null|undefined): string {


### PR DESCRIPTION
1. The error function throws, so no code after it is reachable.
2. Some switch statements are exhaustive, so no code after them are reachable.
