### PR TITLE
fix(dev-infra): properly tag github releases as prerelease as appropriate

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -5899,12 +5899,12 @@ class ReleaseAction {
      * Creates a Github release for the specified version in the configured project.
      * The release is created by tagging the specified commit SHA.
      */
-    _createGithubReleaseForVersion(newVersion, versionBumpCommitSha) {
+    _createGithubReleaseForVersion(newVersion, versionBumpCommitSha, prerelease) {
         return tslib.__awaiter(this, void 0, void 0, function* () {
             const tagName = newVersion.format();
             yield this.git.github.git.createRef(Object.assign(Object.assign({}, this.git.remoteParams), { ref: `refs/tags/${tagName}`, sha: versionBumpCommitSha }));
             info(green(`  ✓   Tagged v${newVersion} release upstream.`));
-            yield this.git.github.repos.createRelease(Object.assign(Object.assign({}, this.git.remoteParams), { name: `v${newVersion}`, tag_name: tagName }));
+            yield this.git.github.repos.createRelease(Object.assign(Object.assign({}, this.git.remoteParams), { name: `v${newVersion}`, tag_name: tagName, prerelease }));
             info(green(`  ✓   Created v${newVersion} release in Github.`));
         });
     }
@@ -5935,7 +5935,7 @@ class ReleaseAction {
             // Verify the packages built are the correct version.
             yield this._verifyPackageVersions(newVersion, builtPackages);
             // Create a Github release for the new version.
-            yield this._createGithubReleaseForVersion(newVersion, versionBumpCommitSha);
+            yield this._createGithubReleaseForVersion(newVersion, versionBumpCommitSha, npmDistTag === 'next');
             // Walk through all built packages and publish them to NPM.
             for (const builtPackage of builtPackages) {
                 yield this._publishBuiltPackageToNpm(builtPackage, npmDistTag);

--- a/dev-infra/release/publish/actions.ts
+++ b/dev-infra/release/publish/actions.ts
@@ -472,7 +472,7 @@ export abstract class ReleaseAction {
    * The release is created by tagging the specified commit SHA.
    */
   private async _createGithubReleaseForVersion(
-      newVersion: semver.SemVer, versionBumpCommitSha: string) {
+      newVersion: semver.SemVer, versionBumpCommitSha: string, prerelease: boolean) {
     const tagName = newVersion.format();
     await this.git.github.git.createRef({
       ...this.git.remoteParams,
@@ -485,6 +485,8 @@ export abstract class ReleaseAction {
       ...this.git.remoteParams,
       name: `v${newVersion}`,
       tag_name: tagName,
+      prerelease,
+
     });
     info(green(`  ✓   Created v${newVersion} release in Github.`));
   }
@@ -521,7 +523,8 @@ export abstract class ReleaseAction {
     await this._verifyPackageVersions(newVersion, builtPackages);
 
     // Create a Github release for the new version.
-    await this._createGithubReleaseForVersion(newVersion, versionBumpCommitSha);
+    await this._createGithubReleaseForVersion(
+        newVersion, versionBumpCommitSha, npmDistTag === 'next');
 
     // Walk through all built packages and publish them to NPM.
     for (const builtPackage of builtPackages) {


### PR DESCRIPTION
Previously all github releases created by the release tooling tagged
releases as `latest`. Instead releases which are created for the `next`
tag on NPM should be tagged as `prerelease` for github.
