### PR TITLE
fix(dev-infra): clear cached bazel outputs before building artifacts for publishing

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -5392,6 +5392,25 @@ function invokeYarnInstallCommand(projectDir) {
         }
     });
 }
+/**
+ * Invokes the `yarn bazel clean` command in order to clean the output tree and ensure new artifacts
+ * are created for builds.
+ */
+function invokeBazelCleanCommand(projectDir) {
+    return tslib.__awaiter(this, void 0, void 0, function* () {
+        try {
+            // Note: No progress indicator needed as that is the responsibility of the command.
+            // TODO: Consider using an Ora spinner instead to ensure minimal console output.
+            yield spawnWithDebugOutput('yarn', ['bazel', 'clean'], { cwd: projectDir });
+            info(green('  ✓   Cleaned bazel output tree.'));
+        }
+        catch (e) {
+            error(e);
+            error(red('  ✘   An error occurred while cleaning the bazel output tree.'));
+            throw new FatalReleaseActionError();
+        }
+    });
+}
 
 /**
  * @license
@@ -5931,6 +5950,7 @@ class ReleaseAction {
             // created in the `next` branch. The new package would not be part of the patch branch,
             // so we cannot build and publish it.
             yield invokeYarnInstallCommand(this.projectDir);
+            yield invokeBazelCleanCommand(this.projectDir);
             const builtPackages = yield invokeReleaseBuildCommand();
             // Verify the packages built are the correct version.
             yield this._verifyPackageVersions(newVersion, builtPackages);

--- a/dev-infra/release/publish/actions.ts
+++ b/dev-infra/release/publish/actions.ts
@@ -21,7 +21,7 @@ import {runNpmPublish} from '../versioning/npm-publish';
 import {FatalReleaseActionError, UserAbortedReleaseActionError} from './actions-error';
 import {getCommitMessageForRelease, getReleaseNoteCherryPickCommitMessage} from './commit-message';
 import {changelogPath, packageJsonPath, waitForPullRequestInterval} from './constants';
-import {invokeReleaseBuildCommand, invokeYarnInstallCommand} from './external-commands';
+import {invokeBazelCleanCommand, invokeReleaseBuildCommand, invokeYarnInstallCommand} from './external-commands';
 import {findOwnedForksOfRepoQuery} from './graphql-queries';
 import {getPullRequestState} from './pull-request-state';
 import {getDefaultExtractReleaseNotesPattern, getLocalChangelogFilePath} from './release-notes';
@@ -515,6 +515,7 @@ export abstract class ReleaseAction {
     // created in the `next` branch. The new package would not be part of the patch branch,
     // so we cannot build and publish it.
     await invokeYarnInstallCommand(this.projectDir);
+    await invokeBazelCleanCommand(this.projectDir);
     const builtPackages = await invokeReleaseBuildCommand();
 
     // Verify the packages built are the correct version.

--- a/dev-infra/release/publish/external-commands.ts
+++ b/dev-infra/release/publish/external-commands.ts
@@ -90,3 +90,20 @@ export async function invokeYarnInstallCommand(projectDir: string): Promise<void
     throw new FatalReleaseActionError();
   }
 }
+
+/**
+ * Invokes the `yarn bazel clean` command in order to clean the output tree and ensure new artifacts
+ * are created for builds.
+ */
+export async function invokeBazelCleanCommand(projectDir: string): Promise<void> {
+  try {
+    // Note: No progress indicator needed as that is the responsibility of the command.
+    // TODO: Consider using an Ora spinner instead to ensure minimal console output.
+    await spawnWithDebugOutput('yarn', ['bazel', 'clean'], {cwd: projectDir});
+    info(green('  ✓   Cleaned bazel output tree.'));
+  } catch (e) {
+    error(e);
+    error(red('  ✘   An error occurred while cleaning the bazel output tree.'));
+    throw new FatalReleaseActionError();
+  }
+}

--- a/dev-infra/release/publish/test/test-utils.ts
+++ b/dev-infra/release/publish/test/test-utils.ts
@@ -92,6 +92,7 @@ export function setupReleaseActionForTesting<T extends ReleaseAction>(
   spyOn(npm, 'runNpmPublish').and.resolveTo();
   spyOn(externalCommands, 'invokeSetNpmDistCommand').and.resolveTo();
   spyOn(externalCommands, 'invokeYarnInstallCommand').and.resolveTo();
+  spyOn(externalCommands, 'invokeBazelCleanCommand').and.resolveTo();
   spyOn(externalCommands, 'invokeReleaseBuildCommand').and.resolveTo([
     {name: '@angular/pkg1', outputPath: `${testTmpDir}/dist/pkg1`},
     {name: '@angular/pkg2', outputPath: `${testTmpDir}/dist/pkg2`}


### PR DESCRIPTION
Clearing the cached bazel outputs before building the artifacts for
publishing prevents an intermittent error found when the version is
cached between publishes.
