### PR TITLE
feat(compiler-cli): support producing Closure-specific PURE annotations

### DIFF
--- a/packages/compiler-cli/linker/test/ast/ast_value_spec.ts
+++ b/packages/compiler-cli/linker/test/ast/ast_value_spec.ts
@@ -23,7 +23,7 @@ interface TestObject {
 }
 
 const host: AstHost<ts.Expression> = new TypeScriptAstHost();
-const factory = new TypeScriptAstFactory();
+const factory = new TypeScriptAstFactory(/* annotateForClosureCompiler */ false);
 const nestedObj = factory.createObjectLiteral([
   {propertyName: 'x', quoted: false, value: factory.createLiteral(42)},
   {propertyName: 'y', quoted: false, value: factory.createLiteral('X')},

--- a/packages/compiler-cli/linker/test/file_linker/emit_scopes/emit_scope_spec.ts
+++ b/packages/compiler-cli/linker/test/file_linker/emit_scopes/emit_scope_spec.ts
@@ -16,7 +16,7 @@ import {generate} from '../helpers';
 describe('EmitScope', () => {
   describe('translateDefinition()', () => {
     it('should translate the given output AST into a TExpression', () => {
-      const factory = new TypeScriptAstFactory();
+      const factory = new TypeScriptAstFactory(/* annotateForClosureCompiler */ false);
       const translator = new Translator<ts.Statement, ts.Expression>(factory);
       const ngImport = factory.createIdentifier('core');
       const emitScope = new EmitScope<ts.Statement, ts.Expression>(ngImport, translator);
@@ -26,7 +26,7 @@ describe('EmitScope', () => {
     });
 
     it('should use the `ngImport` idenfifier for imports when translating', () => {
-      const factory = new TypeScriptAstFactory();
+      const factory = new TypeScriptAstFactory(/* annotateForClosureCompiler */ false);
       const translator = new Translator<ts.Statement, ts.Expression>(factory);
       const ngImport = factory.createIdentifier('core');
       const emitScope = new EmitScope<ts.Statement, ts.Expression>(ngImport, translator);
@@ -37,7 +37,7 @@ describe('EmitScope', () => {
     });
 
     it('should not emit any shared constants in the replacement expression', () => {
-      const factory = new TypeScriptAstFactory();
+      const factory = new TypeScriptAstFactory(/* annotateForClosureCompiler */ false);
       const translator = new Translator<ts.Statement, ts.Expression>(factory);
       const ngImport = factory.createIdentifier('core');
       const emitScope = new EmitScope<ts.Statement, ts.Expression>(ngImport, translator);
@@ -54,7 +54,7 @@ describe('EmitScope', () => {
 
   describe('getConstantStatements()', () => {
     it('should return any constant statements that were added to the `constantPool`', () => {
-      const factory = new TypeScriptAstFactory();
+      const factory = new TypeScriptAstFactory(/* annotateForClosureCompiler */ false);
       const translator = new Translator<ts.Statement, ts.Expression>(factory);
       const ngImport = factory.createIdentifier('core');
       const emitScope = new EmitScope<ts.Statement, ts.Expression>(ngImport, translator);

--- a/packages/compiler-cli/linker/test/file_linker/emit_scopes/iief_emit_scope_spec.ts
+++ b/packages/compiler-cli/linker/test/file_linker/emit_scopes/iief_emit_scope_spec.ts
@@ -16,7 +16,7 @@ import {generate} from '../helpers';
 describe('IifeEmitScope', () => {
   describe('translateDefinition()', () => {
     it('should translate the given output AST into a TExpression, wrapped in an IIFE', () => {
-      const factory = new TypeScriptAstFactory();
+      const factory = new TypeScriptAstFactory(/* annotateForClosureCompiler */ false);
       const translator = new Translator<ts.Statement, ts.Expression>(factory);
       const ngImport = factory.createIdentifier('core');
       const emitScope =
@@ -27,7 +27,7 @@ describe('IifeEmitScope', () => {
     });
 
     it('should use the `ngImport` idenfifier for imports when translating', () => {
-      const factory = new TypeScriptAstFactory();
+      const factory = new TypeScriptAstFactory(/* annotateForClosureCompiler */ false);
       const translator = new Translator<ts.Statement, ts.Expression>(factory);
       const ngImport = factory.createIdentifier('core');
       const emitScope =
@@ -39,7 +39,7 @@ describe('IifeEmitScope', () => {
     });
 
     it('should emit any shared constants in the replacement expression IIFE', () => {
-      const factory = new TypeScriptAstFactory();
+      const factory = new TypeScriptAstFactory(/* annotateForClosureCompiler */ false);
       const translator = new Translator<ts.Statement, ts.Expression>(factory);
       const ngImport = factory.createIdentifier('core');
       const emitScope =
@@ -58,7 +58,7 @@ describe('IifeEmitScope', () => {
 
   describe('getConstantStatements()', () => {
     it('should throw an error', () => {
-      const factory = new TypeScriptAstFactory();
+      const factory = new TypeScriptAstFactory(/* annotateForClosureCompiler */ false);
       const translator = new Translator<ts.Statement, ts.Expression>(factory);
       const ngImport = factory.createIdentifier('core');
       const emitScope =

--- a/packages/compiler-cli/linker/test/file_linker/file_linker_spec.ts
+++ b/packages/compiler-cli/linker/test/file_linker/file_linker_spec.ts
@@ -23,7 +23,7 @@ import {generate} from './helpers';
 
 describe('FileLinker', () => {
   let factory: TypeScriptAstFactory;
-  beforeEach(() => factory = new TypeScriptAstFactory());
+  beforeEach(() => factory = new TypeScriptAstFactory(/* annotateForClosureCompiler */ false));
 
   describe('isPartialDeclaration()', () => {
     it('should return true if the callee is recognized', () => {
@@ -154,7 +154,8 @@ describe('FileLinker', () => {
     const fs = new MockFileSystemNative();
     const logger = new MockLogger();
     const linkerEnvironment = LinkerEnvironment.create<ts.Statement, ts.Expression>(
-        fs, logger, new TypeScriptAstHost(), new TypeScriptAstFactory(), DEFAULT_LINKER_OPTIONS);
+        fs, logger, new TypeScriptAstHost(),
+        new TypeScriptAstFactory(/* annotateForClosureCompiler */ false), DEFAULT_LINKER_OPTIONS);
     const fileLinker = new FileLinker<MockConstantScopeRef, ts.Statement, ts.Expression>(
         linkerEnvironment, fs.resolve('/test.js'), '// test code');
     return {host: linkerEnvironment.host, fileLinker};

--- a/packages/compiler-cli/linker/test/file_linker/partial_linkers/partial_linker_selector_spec.ts
+++ b/packages/compiler-cli/linker/test/file_linker/partial_linkers/partial_linker_selector_spec.ts
@@ -33,7 +33,8 @@ describe('PartialLinkerSelector', () => {
     fs = new MockFileSystemNative();
     const logger = new MockLogger();
     environment = LinkerEnvironment.create<ts.Statement, ts.Expression>(
-        fs, logger, new TypeScriptAstHost(), new TypeScriptAstFactory(), options);
+        fs, logger, new TypeScriptAstHost(),
+        new TypeScriptAstFactory(/* annotateForClosureCompiler */ false), options);
   });
 
   describe('supportsDeclaration()', () => {

--- a/packages/compiler-cli/linker/test/file_linker/translator_spec.ts
+++ b/packages/compiler-cli/linker/test/file_linker/translator_spec.ts
@@ -14,7 +14,7 @@ import {generate} from './helpers';
 
 describe('Translator', () => {
   let factory: TypeScriptAstFactory;
-  beforeEach(() => factory = new TypeScriptAstFactory());
+  beforeEach(() => factory = new TypeScriptAstFactory(/* annotateForClosureCompiler */ false));
 
   describe('translateExpression()', () => {
     it('should generate expression specific output', () => {

--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -42,6 +42,7 @@ export interface TranslatorOptions<TExpression> {
   downlevelTaggedTemplates?: boolean;
   downlevelVariableDeclarations?: boolean;
   recordWrappedNodeExpr?: RecordWrappedNodeExprFn<TExpression>;
+  annotateForClosureCompiler?: boolean;
 }
 
 export class ExpressionTranslatorVisitor<TStatement, TExpression> implements o.ExpressionVisitor,

--- a/packages/compiler-cli/src/ngtsc/translator/src/typescript_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/typescript_translator.ts
@@ -19,7 +19,7 @@ export function translateExpression(
     options: TranslatorOptions<ts.Expression> = {}): ts.Expression {
   return expression.visitExpression(
       new ExpressionTranslatorVisitor<ts.Statement, ts.Expression>(
-          new TypeScriptAstFactory(), imports, options),
+          new TypeScriptAstFactory(options.annotateForClosureCompiler === true), imports, options),
       new Context(false));
 }
 
@@ -28,6 +28,6 @@ export function translateStatement(
     options: TranslatorOptions<ts.Expression> = {}): ts.Statement {
   return statement.visitStatement(
       new ExpressionTranslatorVisitor<ts.Statement, ts.Expression>(
-          new TypeScriptAstFactory(), imports, options),
+          new TypeScriptAstFactory(options.annotateForClosureCompiler === true), imports, options),
       new Context(true));
 }

--- a/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
@@ -12,7 +12,7 @@ import {TypeScriptAstFactory} from '../src/typescript_ast_factory';
 
 describe('TypeScriptAstFactory', () => {
   let factory: TypeScriptAstFactory;
-  beforeEach(() => factory = new TypeScriptAstFactory());
+  beforeEach(() => factory = new TypeScriptAstFactory(/* annotateForClosureCompiler */ false));
 
   describe('attachComments()', () => {
     it('should add the comments to the given statement', () => {
@@ -76,6 +76,14 @@ describe('TypeScriptAstFactory', () => {
       const {items: [callee, arg1, arg2], generate} = setupExpressions(`foo`, `42`, `"moo"`);
       const call = factory.createCallExpression(callee, [arg1, arg2], true);
       expect(generate(call)).toEqual('/*@__PURE__*/ foo(42, "moo")');
+    });
+
+    it('should create a call marked with a closure-style pure comment if `pure` is true', () => {
+      factory = new TypeScriptAstFactory(/* annotateForClosureCompiler */ true);
+
+      const {items: [callee, arg1, arg2], generate} = setupExpressions(`foo`, `42`, `"moo"`);
+      const call = factory.createCallExpression(callee, [arg1, arg2], true);
+      expect(generate(call)).toEqual('/** @pureOrBreakMyCode */ foo(42, "moo")');
     });
   });
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -393,6 +393,31 @@ runInEachFileSystem(os => {
     // that start with `C:`.
     if (os !== 'Windows' || platform() === 'win32') {
       describe('when closure annotations are requested', () => {
+        it('should add @pureOrBreakMyCode to getInheritedFactory calls', () => {
+          env.tsconfig({
+            'annotateForClosureCompiler': true,
+          });
+          env.write(`test.ts`, `
+            import {Directive} from '@angular/core';
+    
+            @Directive({
+              selector: '[base]',
+            })
+            class Base {}
+    
+            @Directive({
+              selector: '[test]',
+            })
+            class Dir extends Base {
+            }
+        `);
+
+          env.driveMain();
+
+          const jsContents = env.getContents('test.js');
+          expect(jsContents).toContain('/** @pureOrBreakMyCode */ i0.ɵɵgetInheritedFactory(Dir)');
+        });
+
         it('should add @nocollapse to static fields', () => {
           env.tsconfig({
             'annotateForClosureCompiler': true,


### PR DESCRIPTION
For certain generated function calls, the compiler emits a 'PURE' annotation
which informs Terser (the optimizer) about the purity of a specific function
call. This commit expands that system to produce a new Closure-specific
'pureOrBreakMyCode' annotation when targeting the Closure optimizer instead
of Terser.
