### PR TITLE
test(dev-infra): fix test order failure in tests for the release command

### DIFF
--- a/dev-infra/release/publish/test/common.spec.ts
+++ b/dev-infra/release/publish/test/common.spec.ts
@@ -11,6 +11,7 @@ import {join} from 'path';
 import * as semver from 'semver';
 
 import {getBranchPushMatcher} from '../../../utils/testing';
+import {_npmPackageInfoCache} from '../../versioning';
 import {ActiveReleaseTrains} from '../../versioning/active-release-trains';
 import * as npm from '../../versioning/npm-publish';
 import {ReleaseTrain} from '../../versioning/release-trains';
@@ -35,6 +36,13 @@ describe('common release action logic', () => {
     };
 
     it('should not modify release train versions and cause invalid other actions', async () => {
+      // The cached npm package information needs to be deleted as depending on the test order
+      // their may or may not be packages in the cache, causing the number of active LTS branches
+      // in this test to be 2 instead of 0.
+      for (const packageName in _npmPackageInfoCache) {
+        delete _npmPackageInfoCache[packageName];
+      }
+
       const {releaseConfig, gitClient} = getTestingMocksForReleaseAction();
       const descriptions: string[] = [];
 


### PR DESCRIPTION
Depending on test order, the `_npmPackageInfoCache` contains information
which causes the prompt results to be slightly different text.
