### PR TITLE
Type Constructors for Generic Directives

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -658,6 +658,8 @@ export class NgCompiler {
     // is not disabled when `strictTemplates` is enabled.
     const strictTemplates = !!this.options.strictTemplates;
 
+    const useInlineTypeConstructors = this.typeCheckingProgramStrategy.supportsInlineOperations;
+
     // First select a type-checking configuration, based on whether full template type-checking is
     // requested.
     let typeCheckingConfig: TypeCheckingConfig;
@@ -689,6 +691,7 @@ export class NgCompiler {
         useContextGenericType: strictTemplates,
         strictLiteralTypes: true,
         enableTemplateTypeChecker: this.enableTemplateTypeChecker,
+        useInlineTypeConstructors,
       };
     } else {
       typeCheckingConfig = {
@@ -713,6 +716,7 @@ export class NgCompiler {
         useContextGenericType: false,
         strictLiteralTypes: false,
         enableTemplateTypeChecker: this.enableTemplateTypeChecker,
+        useInlineTypeConstructors,
       };
     }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -260,6 +260,21 @@ export interface TypeCheckingConfig {
    * literals are cast to `any` when declared.
    */
   strictLiteralTypes: boolean;
+
+  /**
+   * Whether to use inline type constructors.
+   *
+   * If this is `true`, create inline type constructors when required. For example, if a type
+   * constructor's parameters has private types, it cannot be created normally, so we inline it in
+   * the directives definition file.
+   *
+   * If false, do not create inline type constructors. Fall back to using `any` type for
+   * constructors that normally require inlining.
+   *
+   * This option requires the environment to support inlining. If the environment does not support
+   * inlining, this must be set to `false`.
+   */
+  useInlineTypeConstructors: boolean;
 }
 
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -385,7 +385,8 @@ export class TypeCheckContextImpl implements TypeCheckContext {
           path: pendingShimData.file.fileName,
           templates: pendingShimData.templates,
         });
-        updates.set(pendingShimData.file.fileName, pendingShimData.file.render());
+        updates.set(
+            pendingShimData.file.fileName, pendingShimData.file.render(false /* removeComments */));
       }
     }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
@@ -43,7 +43,7 @@ export class Environment {
 
   constructor(
       readonly config: TypeCheckingConfig, protected importManager: ImportManager,
-      private refEmitter: ReferenceEmitter, private reflector: ReflectionHost,
+      private refEmitter: ReferenceEmitter, readonly reflector: ReflectionHost,
       protected contextFile: ts.SourceFile) {}
 
   /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
@@ -49,12 +49,12 @@ export class TypeCheckFile extends Environment {
     this.tcbStatements.push(fn);
   }
 
-  render(): string {
+  render(removeComments: boolean): string {
     let source: string = this.importManager.getAllImports(this.contextFile.fileName)
                              .map(i => `import * as ${i.qualifier.text} from '${i.specifier}';`)
                              .join('\n') +
         '\n\n';
-    const printer = ts.createPrinter();
+    const printer = ts.createPrinter({removeComments});
     source += '\n';
     for (const stmt of this.pipeInstStatements) {
       source += printer.printNode(ts.EmitHint.Unspecified, stmt, this.contextFile) + '\n';

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -6,9 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {initMockFileSystem} from '../../file_system/testing';
 import {tcb, TestDeclaration} from './test_utils';
 
 describe('type check blocks diagnostics', () => {
+  beforeEach(() => initMockFileSystem('Native'));
+
   describe('parse spans', () => {
     it('should annotate unary ops', () => {
       expect(tcbWithSpans('{{ -a }}')).toContain('(-((ctx).a /*4,5*/) /*4,5*/) /*3,5*/');
@@ -146,8 +149,9 @@ describe('type check blocks diagnostics', () => {
         pipeName: 'test',
       }];
       const block = tcbWithSpans(TEMPLATE, PIPES);
+      expect(block).toContain('var _pipe1: i0.TestPipe = null!');
       expect(block).toContain(
-          '((null as TestPipe).transform /*7,11*/(((ctx).a /*3,4*/) /*3,4*/, ((ctx).b /*12,13*/) /*12,13*/) /*3,13*/);');
+          '(_pipe1.transform /*7,11*/(((ctx).a /*3,4*/) /*3,4*/, ((ctx).b /*12,13*/) /*12,13*/) /*3,13*/);');
     });
 
     describe('attaching multiple comments for multiple references', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -745,6 +745,7 @@ describe('type check blocks', () => {
       useContextGenericType: true,
       strictLiteralTypes: true,
       enableTemplateTypeChecker: false,
+      useInlineTypeConstructors: true
     };
 
     describe('config.applyTemplateContextGuards', () => {
@@ -1077,4 +1078,35 @@ describe('type check blocks', () => {
       });
     });
   });
+
+  it('should use `any` type for type constructors with bound generic params ' +
+         'when `useInlineTypeConstructors` is `false`',
+     () => {
+       const template = `
+    <div dir
+      [inputA]='foo'
+      [inputB]='bar'
+      ></div>
+    `;
+       const declarations: TestDeclaration[] = [{
+         code: `
+           interface PrivateInterface{};
+           export class Dir<T extends PrivateInterface, U extends string> {};
+        `,
+         type: 'directive',
+         name: 'Dir',
+         selector: '[dir]',
+         inputs: {
+           inputA: 'inputA',
+           inputB: 'inputB',
+         },
+         isGeneric: true
+       }];
+
+       const renderedTcb = tcb(template, declarations, {useInlineTypeConstructors: false});
+
+       expect(renderedTcb).toContain(`var _t1: i0.Dir<any, any> = null!;`);
+       expect(renderedTcb).toContain(`_t1.inputA = (((ctx).foo));`);
+       expect(renderedTcb).toContain(`_t1.inputB = (((ctx).bar));`);
+     });
 });

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
@@ -1587,6 +1587,8 @@ function assertDomBindingSymbol(tSymbol: Symbol): asserts tSymbol is DomBindingS
 }
 
 export function setup(targets: TypeCheckingTarget[], config?: Partial<TypeCheckingConfig>) {
-  return baseTestSetup(
-      targets, {inlining: false, config: {...config, enableTemplateTypeChecker: true}});
+  return baseTestSetup(targets, {
+    inlining: false,
+    config: {...config, enableTemplateTypeChecker: true, useInlineTypeConstructors: false}
+  });
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker_spec.ts
@@ -168,49 +168,8 @@ runInEachFileSystem(() => {
         expect(diags.length).toBe(1);
         expect(diags[0].code).toBe(ngErrorCode(ErrorCode.INLINE_TCB_REQUIRED));
       });
-
-      it('should produce errors for components that require type constructor inlining', () => {
-        const fileName = absoluteFrom('/main.ts');
-        const dirFile = absoluteFrom('/dir.ts');
-        const {program, templateTypeChecker} = setup(
-            [
-              {
-                fileName,
-                source: `export class Cmp {}`,
-                templates: {'Cmp': '<div dir></div>'},
-                declarations: [{
-                  name: 'TestDir',
-                  selector: '[dir]',
-                  file: dirFile,
-                  type: 'directive',
-                  isGeneric: true,
-                }]
-              },
-              {
-                fileName: dirFile,
-                source: `
-                // A non-exported interface used as a type bound for a generic directive causes
-                // an inline type constructor to be required.
-                interface NotExported {}
-                export class TestDir<T extends NotExported> {}`,
-                templates: {},
-              }
-            ],
-            {inlining: false});
-        const sf = getSourceFileOrError(program, fileName);
-        const diags = templateTypeChecker.getDiagnosticsForFile(sf, OptimizeFor.WholeProgram);
-        expect(diags.length).toBe(1);
-        expect(diags[0].code).toBe(ngErrorCode(ErrorCode.INLINE_TYPE_CTOR_REQUIRED));
-
-        // The relatedInformation of the diagnostic should point to the directive which required
-        // the inline type constructor.
-        const dirSf = getSourceFileOrError(program, dirFile);
-        expect(diags[0].relatedInformation).not.toBeUndefined();
-        expect(diags[0].relatedInformation!.length).toBe(1);
-        expect(diags[0].relatedInformation![0].file).not.toBeUndefined();
-        expect(absoluteFromSourceFile(diags[0].relatedInformation![0].file!)).toBe(dirSf.fileName);
-      });
     });
+
     describe('getTemplateOfComponent()', () => {
       it('should provide access to a component\'s real template', () => {
         const fileName = absoluteFrom('/main.ts');

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
@@ -43,7 +43,7 @@ runInEachFileSystem(() => {
       const file = new TypeCheckFile(
           _('/_typecheck_.ts'), ALL_ENABLED_CONFIG, new ReferenceEmitter([]),
           /* reflector */ null!, host);
-      const sf = file.render();
+      const sf = file.render(false /* removeComments */);
       expect(sf).toContain('export const IS_A_MODULE = true;');
     });
 

--- a/packages/language-service/ivy/test/quick_info_spec.ts
+++ b/packages/language-service/ivy/test/quick_info_spec.ts
@@ -479,6 +479,49 @@ describe('quick info', () => {
     });
   });
 
+  describe('generics', () => {
+    beforeEach(() => {
+      initMockFileSystem('Native');
+      env = LanguageServiceTestEnv.setup();
+    });
+
+    it('should get quick info for the generic input of a directive that normally requires inlining',
+       () => {
+         // When compiling normally, we would have to inline the type constructor of `GenericDir`
+         // because its generic type parameter references `PrivateInterface`, which is not exported.
+         project = env.addProject('test', {
+           'app.ts': `
+          import {Directive, Component, Input, NgModule} from '@angular/core';
+
+          interface PrivateInterface {}
+
+          @Directive({
+            selector: '[dir]'
+          })export class GenericDir <T extends PrivateInterface>{
+            @Input('input') input: T = null!;
+          }
+
+          @Component({
+            selector: 'some-cmp',
+            templateUrl: './app.html'
+          })export class SomeCmp{}
+
+          @NgModule({
+            declarations: [GenericDir, SomeCmp],
+          })export class AppModule{}
+        `,
+           'app.html': ``,
+         });
+
+         expectQuickInfo({
+           templateOverride: `<div dir [inp¦ut]='{value: 42}'></div>`,
+           expectedSpanText: 'input',
+           expectedDisplayString: '(property) GenericDir<any>.input: any'
+         });
+       });
+  });
+
+
   describe('non-strict compiler options', () => {
     beforeEach(() => {
       initMockFileSystem('Native');
@@ -511,6 +554,7 @@ describe('quick info', () => {
           {templateOverride, expectedSpanText: 'date', expectedDisplayString: '(pipe) DatePipe'});
     });
   });
+
 
   function expectQuickInfo(
       {templateOverride, expectedSpanText, expectedDisplayString}:


### PR DESCRIPTION
## Background Knowledge Required
This requires a bit of background knowledge
 - How to use bound generics in typescript
 - How to create a Directive in angular
 - [type-check-block (tcb) generation](https://github.com/angular/angular/pull/41004)
 -- type constructors
 -- `TcbOp`s
 -- inlining, specifically of type constructors
 

## Motivation

This PR came from an edge case with generic directives – specifically directives with bound generic parameters.

Creating a generic directive with a bound parameters creates an edge case for TCB generation. Let's see the behavior in VSCode for this situation.

In this screenshot, we have a two confusing error messages.

1. `ng serve` reports that we cannot bind to `notAnInput` because that property does not exist. This error is expected, but it doesn't show up in the IDE.

2. the language service threw an exception with `This component requires inline type checking which is not available in this environment.`

<img width="1357" alt="Screen Shot 2021-03-05 at 9 31 03 AM" src="https://user-images.githubusercontent.com/7720245/110152577-c6466280-7d96-11eb-839e-0c6b08651312.png">

The type generation code cannot inline the type constructor for this component, which causes it to throw an exception before finishing type checking the template. This means that part of the template will not be typechecked and VSCode will not be able to present diagnostics in the skipped sections.

### Why bound generics are a "no-go" for compiling TCBs

Bound generics can reference private members which are impossible for the compiler to import into the tcb. They can also contain other things such as symbols which would be impossible to import.

Application Code
```
interface PrivateInterface{}

@Componet({ selector: 'bad' })
export class BadComponent <T extends PrivateInterface>{}
```

TCB bad.component.typecheck.ts
```
  var ctor1: ()<T extends PrivateInterface> => BadComponent<T> = () => (null!);
  // but wait, how do we import PrivateInterface?
```

The solutions approach is to assign `any` to generic arguments for constructors with bound parameters.

```
var ctor1: BadComponent<any> = (null!);
```

### Why inline type constructors impact performance.

When we compile a program that requires inlining type constructors, we change add generated code to the component file that the user originally wrote.

bad.component.ts
```
...
export class BadComponent <T extends PrivateInterface>{
...
// type constructor will look something like this, but not exactly like this
ngTypeConstructor: ()<T> => BadComponent<T> = () => (null!) 
}
```

Changing this file can trigger a second compile, which increases the total compilation time.

Also, we cannot change a user's file while it's been edited, which is why inlining is not available for the language service. It's only available when we compile a build target for the program.

## Solution
This is a 2-part PR.

The first commit refactors our tests, which allows use to use TDD in the next commit, which fixes the bug.

### Part 1: refactor tests

For the tests in //packages/compiler-cli/src/ngtsc/typecheck, this
commits uses a `TypeCheckFile` for the environment, rather than a
`FakeEnvironment`. Using a real environment gives us more flexibility
with testing.

### Part 2: implement fix for generic directives with bound parameters

This commit fixes the behavior when creating a type constructor for a directive when the following conditions are met.
1. The directive has bound generic parameters.
2. Inlining is not available. (This happens for language service compiles).

Previously, we would throw an error saying 'Inlining is not supported in this environment.' The compiler would stop type checking, and the developer could lose out on getting errors after the compiler gives up.

This commit adds a `useInlineTypeConstructors` to the type check config. When set to false, we use `any` type for bound generic parameters to avoid crashing. When set to true, we inline the type constructor when inlining is required.
