### PR TITLE
refactor(core): remove `getFactoryOf()` from public facing role

### DIFF
--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -419,7 +419,7 @@ export declare abstract class ViewportScroller {
     abstract scrollToPosition(position: [number, number]): void;
     abstract setHistoryScrollRestoration(scrollRestoration: 'auto' | 'manual'): void;
     abstract setOffset(offset: [number, number] | (() => [number, number])): void;
-    static ɵprov: never;
+    static ɵprov: unknown;
 }
 
 export declare enum WeekDay {

--- a/goldens/public-api/core/core.d.ts
+++ b/goldens/public-api/core/core.d.ts
@@ -421,7 +421,7 @@ export declare interface InjectableDecorator {
 export declare type InjectableProvider = ValueSansProvider | ExistingSansProvider | StaticClassSansProvider | ConstructorSansProvider | FactorySansProvider | ClassSansProvider;
 
 export declare interface InjectableType<T> extends Type<T> {
-    ɵprov: never;
+    ɵprov: unknown;
 }
 
 export declare interface InjectDecorator {
@@ -439,7 +439,7 @@ export declare enum InjectFlags {
 
 export declare class InjectionToken<T> {
     protected _desc: string;
-    readonly ɵprov: never | undefined;
+    readonly ɵprov: unknown;
     constructor(_desc: string, options?: {
         providedIn?: Type<any> | 'root' | 'platform' | 'any' | null;
         factory: () => T;
@@ -452,7 +452,7 @@ export declare abstract class Injector {
     /** @deprecated */ abstract get(token: any, notFoundValue?: any): any;
     static NULL: Injector;
     static THROW_IF_NOT_FOUND: {};
-    static ɵprov: never;
+    static ɵprov: unknown;
     /** @deprecated */ static create(providers: StaticProvider[], parent?: Injector): Injector;
     static create(options: {
         providers: StaticProvider[];
@@ -464,7 +464,7 @@ export declare abstract class Injector {
 export declare const INJECTOR: InjectionToken<Injector>;
 
 export declare interface InjectorType<T> extends Type<T> {
-    ɵinj: never;
+    ɵinj: unknown;
 }
 
 export declare interface Input {
@@ -510,7 +510,7 @@ export declare class IterableDiffers {
     /** @deprecated */ factories: IterableDifferFactory[];
     constructor(factories: IterableDifferFactory[]);
     find(iterable: any): IterableDifferFactory;
-    static ɵprov: never;
+    static ɵprov: unknown;
     static create(factories: IterableDifferFactory[], parent?: IterableDiffers): IterableDiffers;
     static extend(factories: IterableDifferFactory[]): StaticProvider;
 }
@@ -545,7 +545,7 @@ export declare class KeyValueDiffers {
     /** @deprecated */ factories: KeyValueDifferFactory[];
     constructor(factories: KeyValueDifferFactory[]);
     find(kv: any): KeyValueDifferFactory;
-    static ɵprov: never;
+    static ɵprov: unknown;
     static create<S>(factories: KeyValueDifferFactory[], parent?: KeyValueDiffers): KeyValueDiffers;
     static extend<S>(factories: KeyValueDifferFactory[]): StaticProvider;
 }
@@ -676,7 +676,7 @@ export declare function ɵɵdefineInjectable<T>(opts: {
     token: unknown;
     providedIn?: Type<any> | 'root' | 'platform' | 'any' | null;
     factory: () => T;
-}): never;
+}): unknown;
 
 /** @codeGenApi */
 export declare function ɵɵinject<T>(token: Type<T> | AbstractType<T> | InjectionToken<T>): T;
@@ -859,7 +859,7 @@ export declare function resolveForwardRef<T>(type: T): T;
 
 export declare abstract class Sanitizer {
     abstract sanitize(context: SecurityContext, value: {} | string | null): string | null;
-    static ɵprov: never;
+    static ɵprov: unknown;
 }
 
 export declare interface SchemaMetadata {

--- a/packages/compiler/src/aot/compiler.ts
+++ b/packages/compiler/src/aot/compiler.ts
@@ -15,23 +15,16 @@ import {createTokenForExternalReference, Identifiers} from '../identifiers';
 import {InjectableCompiler} from '../injectable_compiler';
 import {CompileMetadataResolver} from '../metadata_resolver';
 import {HtmlParser} from '../ml_parser/html_parser';
-import {removeWhitespaces} from '../ml_parser/html_whitespaces';
-import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../ml_parser/interpolation_config';
+import {InterpolationConfig} from '../ml_parser/interpolation_config';
 import {NgModuleCompiler} from '../ng_module_compiler';
 import {OutputEmitter} from '../output/abstract_emitter';
 import * as o from '../output/output_ast';
 import {ParseError} from '../parse_util';
-import {compileNgModuleFromRender2 as compileR3Module} from '../render3/r3_module_compiler';
-import {compilePipeFromRender2 as compileR3Pipe} from '../render3/r3_pipe_compiler';
-import {htmlAstToRender3Ast} from '../render3/r3_template_transform';
-import {compileComponentFromRender2 as compileR3Component, compileDirectiveFromRender2 as compileR3Directive} from '../render3/view/compiler';
-import {DomElementSchemaRegistry} from '../schema/dom_element_schema_registry';
 import {CompiledStylesheet, StyleCompiler} from '../style_compiler';
 import {SummaryResolver} from '../summary_resolver';
-import {BindingParser} from '../template_parser/binding_parser';
 import {TemplateAst} from '../template_parser/template_ast';
 import {TemplateParser} from '../template_parser/template_parser';
-import {error, newArray, OutputContext, syntaxError, ValueVisitor, visitValue} from '../util';
+import {newArray, OutputContext, syntaxError, ValueVisitor, visitValue} from '../util';
 import {TypeCheckCompiler} from '../view_compiler/type_check_compiler';
 import {ViewCompiler, ViewCompileResult} from '../view_compiler/view_compiler';
 
@@ -339,107 +332,6 @@ export class AotCompiler {
     }
 
     return messageBundle;
-  }
-
-  emitAllPartialModules(
-      {ngModuleByPipeOrDirective, files}: NgAnalyzedModules,
-      r3Files: NgAnalyzedFileWithInjectables[]): PartialModule[] {
-    const contextMap = new Map<string, OutputContext>();
-
-    const getContext = (fileName: string): OutputContext => {
-      if (!contextMap.has(fileName)) {
-        contextMap.set(fileName, this._createOutputContext(fileName));
-      }
-      return contextMap.get(fileName)!;
-    };
-
-    files.forEach(
-        file => this._compilePartialModule(
-            file.fileName, ngModuleByPipeOrDirective, file.directives, file.pipes, file.ngModules,
-            file.injectables, getContext(file.fileName)));
-    r3Files.forEach(
-        file => this._compileShallowModules(
-            file.fileName, file.shallowModules, getContext(file.fileName)));
-
-    return Array.from(contextMap.values())
-        .map(context => ({
-               fileName: context.genFilePath,
-               statements: [...context.constantPool.statements, ...context.statements],
-             }));
-  }
-
-  private _compileShallowModules(
-      fileName: string, shallowModules: CompileShallowModuleMetadata[],
-      context: OutputContext): void {
-    shallowModules.forEach(module => compileR3Module(context, module, this._injectableCompiler));
-  }
-
-  private _compilePartialModule(
-      fileName: string, ngModuleByPipeOrDirective: Map<StaticSymbol, CompileNgModuleMetadata>,
-      directives: StaticSymbol[], pipes: StaticSymbol[], ngModules: CompileNgModuleMetadata[],
-      injectables: CompileInjectableMetadata[], context: OutputContext): void {
-    const errors: ParseError[] = [];
-
-    const schemaRegistry = new DomElementSchemaRegistry();
-    const hostBindingParser = new BindingParser(
-        this._templateParser.expressionParser, DEFAULT_INTERPOLATION_CONFIG, schemaRegistry, [],
-        errors);
-
-    // Process all components and directives
-    directives.forEach(directiveType => {
-      const directiveMetadata = this._metadataResolver.getDirectiveMetadata(directiveType);
-      if (directiveMetadata.isComponent) {
-        const module = ngModuleByPipeOrDirective.get(directiveType)!;
-        module ||
-            error(`Cannot determine the module for component '${
-                identifierName(directiveMetadata.type)}'`);
-
-        let htmlAst = directiveMetadata.template !.htmlAst!;
-        const preserveWhitespaces = directiveMetadata!.template !.preserveWhitespaces;
-
-        if (!preserveWhitespaces) {
-          htmlAst = removeWhitespaces(htmlAst);
-        }
-        const render3Ast = htmlAstToRender3Ast(htmlAst.rootNodes, hostBindingParser);
-
-        // Map of StaticType by directive selectors
-        const directiveTypeBySel = new Map<string, any>();
-
-        const directives = module.transitiveModule.directives.map(
-            dir => this._metadataResolver.getDirectiveSummary(dir.reference));
-
-        directives.forEach(directive => {
-          if (directive.selector) {
-            directiveTypeBySel.set(directive.selector, directive.type.reference);
-          }
-        });
-
-        // Map of StaticType by pipe names
-        const pipeTypeByName = new Map<string, any>();
-
-        const pipes = module.transitiveModule.pipes.map(
-            pipe => this._metadataResolver.getPipeSummary(pipe.reference));
-
-        pipes.forEach(pipe => {
-          pipeTypeByName.set(pipe.name, pipe.type.reference);
-        });
-
-        compileR3Component(
-            context, directiveMetadata, render3Ast, this.reflector, hostBindingParser,
-            directiveTypeBySel, pipeTypeByName);
-      } else {
-        compileR3Directive(context, directiveMetadata, this.reflector, hostBindingParser);
-      }
-    });
-
-    pipes.forEach(pipeType => {
-      const pipeMetadata = this._metadataResolver.getPipeMetadata(pipeType);
-      if (pipeMetadata) {
-        compileR3Pipe(context, pipeMetadata, this.reflector);
-      }
-    });
-
-    injectables.forEach(injectable => this._injectableCompiler.compile(injectable, context));
   }
 
   emitAllPartialModules2(files: NgAnalyzedFileWithInjectables[]): PartialModule[] {

--- a/packages/compiler/src/render3/r3_module_compiler.ts
+++ b/packages/compiler/src/render3/r3_module_compiler.ts
@@ -293,11 +293,6 @@ export function compileNgModuleFromRender2(
       /* methods */[]));
 }
 
-function accessExportScope(module: o.Expression): o.Expression {
-  const selectorScope = new o.ReadPropExpr(module, 'ɵmod');
-  return new o.ReadPropExpr(selectorScope, 'exported');
-}
-
 function tupleTypeOf(exp: R3Reference[]): o.Type {
   const types = exp.map(ref => o.typeofExpr(ref.type));
   return exp.length > 0 ? o.expressionType(o.literalArr(types)) : o.NONE_TYPE;

--- a/packages/compiler/src/render3/r3_module_compiler.ts
+++ b/packages/compiler/src/render3/r3_module_compiler.ts
@@ -6,15 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CompileShallowModuleMetadata, identifierName} from '../compile_metadata';
-import {InjectableCompiler} from '../injectable_compiler';
-import {mapLiteral} from '../output/map_util';
 import * as o from '../output/output_ast';
-import {OutputContext} from '../util';
 
 import {compileFactoryFunction, R3DependencyMetadata, R3FactoryTarget} from './r3_factory';
 import {Identifiers as R3} from './r3_identifiers';
-import {convertMetaToOutput, jitOnlyGuardedExpression, mapToMapExpression, R3Reference} from './util';
+import {jitOnlyGuardedExpression, mapToMapExpression, R3Reference} from './util';
 
 export interface R3NgModuleDef {
   expression: o.Expression;
@@ -259,38 +255,6 @@ export function compileInjector(meta: R3InjectorMetadata): R3InjectorDef {
   const type =
       new o.ExpressionType(o.importExpr(R3.InjectorDef, [new o.ExpressionType(meta.type.type)]));
   return {expression, type, statements: result.statements};
-}
-
-// TODO(alxhub): integrate this with `compileNgModule`. Currently the two are separate operations.
-export function compileNgModuleFromRender2(
-    ctx: OutputContext, ngModule: CompileShallowModuleMetadata,
-    injectableCompiler: InjectableCompiler): void {
-  const className = identifierName(ngModule.type)!;
-
-  const rawImports = ngModule.rawImports ? [ngModule.rawImports] : [];
-  const rawExports = ngModule.rawExports ? [ngModule.rawExports] : [];
-
-  const injectorDefArg = mapLiteral({
-    'factory':
-        injectableCompiler.factoryFor({type: ngModule.type, symbol: ngModule.type.reference}, ctx),
-    'providers': convertMetaToOutput(ngModule.rawProviders, ctx),
-    'imports': convertMetaToOutput([...rawImports, ...rawExports], ctx),
-  });
-
-  const injectorDef = o.importExpr(R3.defineInjector).callFn([injectorDefArg]);
-
-  ctx.statements.push(new o.ClassStmt(
-      /* name */ className,
-      /* parent */ null,
-      /* fields */[new o.ClassField(
-          /* name */ 'ɵinj',
-          /* type */ o.INFERRED_TYPE,
-          /* modifiers */[o.StmtModifier.Static],
-          /* initializer */ injectorDef,
-          )],
-      /* getters */[],
-      /* constructorMethod */ new o.ClassMethod(null, [], []),
-      /* methods */[]));
 }
 
 function tupleTypeOf(exp: R3Reference[]): o.Type {

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -145,7 +145,6 @@ export {
   ɵɵenableBindings,
   ɵɵFactoryDef,
   ɵɵgetCurrentView,
-  ɵɵgetFactoryOf,
   ɵɵgetInheritedFactory,
   ɵɵhostProperty,
   ɵɵi18n,

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -55,7 +55,7 @@ export class InjectionToken<T> {
   /** @internal */
   readonly ngMetadataName = 'InjectionToken';
 
-  readonly ɵprov: never|undefined;
+  readonly ɵprov: unknown;
 
   constructor(protected _desc: string, options?: {
     providedIn?: Type<any>|'root'|'platform'|'any'|null, factory: () => T
@@ -82,5 +82,5 @@ export class InjectionToken<T> {
 }
 
 export interface InjectableDefToken<T> extends InjectionToken<T> {
-  ɵprov: never;
+  ɵprov: unknown;
 }

--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -91,7 +91,7 @@ export interface InjectableType<T> extends Type<T> {
   /**
    * Opaque type whose structure is highly version dependent. Do not rely on any properties.
    */
-  ɵprov: never;
+  ɵprov: unknown;
 }
 
 /**
@@ -105,7 +105,7 @@ export interface InjectorType<T> extends Type<T> {
   /**
    * Opaque type whose structure is highly version dependent. Do not rely on any properties.
    */
-  ɵinj: never;
+  ɵinj: unknown;
 }
 
 /**
@@ -143,13 +143,13 @@ export interface InjectorTypeWithProviders<T> {
 export function ɵɵdefineInjectable<T>(opts: {
   token: unknown,
   providedIn?: Type<any>|'root'|'platform'|'any'|null, factory: () => T,
-}): never {
-  return ({
-           token: opts.token,
-           providedIn: opts.providedIn as any || null,
-           factory: opts.factory,
-           value: undefined,
-         } as ɵɵInjectableDef<T>) as never;
+}): unknown {
+  return {
+    token: opts.token,
+    providedIn: opts.providedIn as any || null,
+    factory: opts.factory,
+    value: undefined,
+  } as ɵɵInjectableDef<T>;
 }
 
 /**
@@ -180,12 +180,12 @@ export const defineInjectable = ɵɵdefineInjectable;
  * @codeGenApi
  */
 export function ɵɵdefineInjector(options: {factory: () => any, providers?: any[], imports?: any[]}):
-    never {
-  return ({
-           factory: options.factory,
-           providers: options.providers || [],
-           imports: options.imports || [],
-         } as ɵɵInjectorDef<any>) as never;
+    unknown {
+  return {
+    factory: options.factory,
+    providers: options.providers || [],
+    imports: options.imports || [],
+  } as ɵɵInjectorDef<any>;
 }
 
 /**

--- a/packages/core/src/di/jit/environment.ts
+++ b/packages/core/src/di/jit/environment.ts
@@ -5,13 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
-import {Type} from '../../interface/type';
-import {isForwardRef, resolveForwardRef} from '../forward_ref';
 import {ɵɵinject, ɵɵinvalidFactoryDep} from '../injector_compatibility';
-import {getInjectableDef, getInjectorDef, ɵɵdefineInjectable, ɵɵdefineInjector} from '../interface/defs';
-
-
+import {ɵɵdefineInjectable, ɵɵdefineInjector} from '../interface/defs';
 
 /**
  * A mapping of the @angular/core API surface used in generated expressions to the actual symbols.
@@ -22,23 +17,5 @@ export const angularCoreDiEnv: {[name: string]: Function} = {
   'ɵɵdefineInjectable': ɵɵdefineInjectable,
   'ɵɵdefineInjector': ɵɵdefineInjector,
   'ɵɵinject': ɵɵinject,
-  'ɵɵgetFactoryOf': getFactoryOf,
   'ɵɵinvalidFactoryDep': ɵɵinvalidFactoryDep,
 };
-
-function getFactoryOf<T>(type: Type<any>): ((type?: Type<T>) => T)|null {
-  const typeAny = type as any;
-
-  if (isForwardRef(type)) {
-    return (() => {
-             const factory = getFactoryOf<T>(resolveForwardRef(typeAny));
-             return factory ? factory() : null;
-           }) as any;
-  }
-
-  const def = getInjectableDef<T>(typeAny) || getInjectorDef<T>(typeAny);
-  if (!def || def.factory === undefined) {
-    return null;
-  }
-  return def.factory;
-}

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -288,67 +288,65 @@ export function ɵɵdefineComponent<T>(componentDefinition: {
    * The set of schemas that declare elements to be allowed in the component's template.
    */
   schemas?: SchemaMetadata[] | null;
-}): never {
+}): unknown {
   return noSideEffects(() => {
-           // Initialize ngDevMode. This must be the first statement in ɵɵdefineComponent.
-           // See the `initNgDevMode` docstring for more information.
-           (typeof ngDevMode === 'undefined' || ngDevMode) && initNgDevMode();
+    // Initialize ngDevMode. This must be the first statement in ɵɵdefineComponent.
+    // See the `initNgDevMode` docstring for more information.
+    (typeof ngDevMode === 'undefined' || ngDevMode) && initNgDevMode();
 
-           const type = componentDefinition.type;
-           const typePrototype = type.prototype;
-           const declaredInputs: {[key: string]: string} = {} as any;
-           const def: Mutable<ComponentDef<any>, keyof ComponentDef<any>> = {
-             type: type,
-             providersResolver: null,
-             decls: componentDefinition.decls,
-             vars: componentDefinition.vars,
-             factory: null,
-             template: componentDefinition.template || null!,
-             consts: componentDefinition.consts || null,
-             ngContentSelectors: componentDefinition.ngContentSelectors,
-             hostBindings: componentDefinition.hostBindings || null,
-             hostVars: componentDefinition.hostVars || 0,
-             hostAttrs: componentDefinition.hostAttrs || null,
-             contentQueries: componentDefinition.contentQueries || null,
-             declaredInputs: declaredInputs,
-             inputs: null!,   // assigned in noSideEffects
-             outputs: null!,  // assigned in noSideEffects
-             exportAs: componentDefinition.exportAs || null,
-             onPush: componentDefinition.changeDetection === ChangeDetectionStrategy.OnPush,
-             directiveDefs: null!,  // assigned in noSideEffects
-             pipeDefs: null!,       // assigned in noSideEffects
-             selectors: componentDefinition.selectors || EMPTY_ARRAY,
-             viewQuery: componentDefinition.viewQuery || null,
-             features: componentDefinition.features as DirectiveDefFeature[] || null,
-             data: componentDefinition.data || {},
-             // TODO(misko): convert ViewEncapsulation into const enum so that it can be used
-             // directly in the next line. Also `None` should be 0 not 2.
-             encapsulation: componentDefinition.encapsulation || ViewEncapsulation.Emulated,
-             id: 'c',
-             styles: componentDefinition.styles || EMPTY_ARRAY,
-             _: null as never,
-             setInput: null,
-             schemas: componentDefinition.schemas || null,
-             tView: null,
-           };
-           const directiveTypes = componentDefinition.directives!;
-           const feature = componentDefinition.features;
-           const pipeTypes = componentDefinition.pipes!;
-           def.id += _renderCompCount++;
-           def.inputs = invertObject(componentDefinition.inputs, declaredInputs),
-           def.outputs = invertObject(componentDefinition.outputs),
-           feature && feature.forEach((fn) => fn(def));
-           def.directiveDefs = directiveTypes ?
-               () => (typeof directiveTypes === 'function' ? directiveTypes() : directiveTypes)
-                         .map(extractDirectiveDef) :
-               null;
-           def.pipeDefs = pipeTypes ?
-               () =>
-                   (typeof pipeTypes === 'function' ? pipeTypes() : pipeTypes).map(extractPipeDef) :
-               null;
+    const type = componentDefinition.type;
+    const declaredInputs: {[key: string]: string} = {} as any;
+    const def: Mutable<ComponentDef<any>, keyof ComponentDef<any>> = {
+      type: type,
+      providersResolver: null,
+      decls: componentDefinition.decls,
+      vars: componentDefinition.vars,
+      factory: null,
+      template: componentDefinition.template || null!,
+      consts: componentDefinition.consts || null,
+      ngContentSelectors: componentDefinition.ngContentSelectors,
+      hostBindings: componentDefinition.hostBindings || null,
+      hostVars: componentDefinition.hostVars || 0,
+      hostAttrs: componentDefinition.hostAttrs || null,
+      contentQueries: componentDefinition.contentQueries || null,
+      declaredInputs: declaredInputs,
+      inputs: null!,   // assigned in noSideEffects
+      outputs: null!,  // assigned in noSideEffects
+      exportAs: componentDefinition.exportAs || null,
+      onPush: componentDefinition.changeDetection === ChangeDetectionStrategy.OnPush,
+      directiveDefs: null!,  // assigned in noSideEffects
+      pipeDefs: null!,       // assigned in noSideEffects
+      selectors: componentDefinition.selectors || EMPTY_ARRAY,
+      viewQuery: componentDefinition.viewQuery || null,
+      features: componentDefinition.features as DirectiveDefFeature[] || null,
+      data: componentDefinition.data || {},
+      // TODO(misko): convert ViewEncapsulation into const enum so that it can be used
+      // directly in the next line. Also `None` should be 0 not 2.
+      encapsulation: componentDefinition.encapsulation || ViewEncapsulation.Emulated,
+      id: 'c',
+      styles: componentDefinition.styles || EMPTY_ARRAY,
+      _: null,
+      setInput: null,
+      schemas: componentDefinition.schemas || null,
+      tView: null,
+    };
+    const directiveTypes = componentDefinition.directives!;
+    const feature = componentDefinition.features;
+    const pipeTypes = componentDefinition.pipes!;
+    def.id += _renderCompCount++;
+    def.inputs = invertObject(componentDefinition.inputs, declaredInputs),
+    def.outputs = invertObject(componentDefinition.outputs),
+    feature && feature.forEach((fn) => fn(def));
+    def.directiveDefs = directiveTypes ?
+        () => (typeof directiveTypes === 'function' ? directiveTypes() : directiveTypes)
+                  .map(extractDirectiveDef) :
+        null;
+    def.pipeDefs = pipeTypes ?
+        () => (typeof pipeTypes === 'function' ? pipeTypes() : pipeTypes).map(extractPipeDef) :
+        null;
 
-           return def as never;
-         }) as never;
+    return def;
+  });
 }
 
 /**
@@ -412,7 +410,7 @@ export function ɵɵdefineNgModule<T>(def: {
 
   /** Unique ID for the module that is used with `getModuleFactory`. */
   id?: string | null;
-}): never {
+}): unknown {
   const res: NgModuleDef<T> = {
     type: def.type,
     bootstrap: def.bootstrap || EMPTY_ARRAY,
@@ -428,7 +426,7 @@ export function ɵɵdefineNgModule<T>(def: {
       autoRegisterModuleById[def.id!] = def.type as unknown as NgModuleType;
     });
   }
-  return res as never;
+  return res;
 }
 
 /**
@@ -453,13 +451,13 @@ export function ɵɵsetNgModuleScope(type: any, scope: {
    * module.
    */
   exports?: Type<any>[] | (() => Type<any>[]);
-}): void {
+}): unknown {
   return noSideEffects(() => {
-           const ngModuleDef = getNgModuleDef(type, true);
-           ngModuleDef.declarations = scope.declarations || EMPTY_ARRAY;
-           ngModuleDef.imports = scope.imports || EMPTY_ARRAY;
-           ngModuleDef.exports = scope.exports || EMPTY_ARRAY;
-         }) as never;
+    const ngModuleDef = getNgModuleDef(type, true);
+    ngModuleDef.declarations = scope.declarations || EMPTY_ARRAY;
+    ngModuleDef.imports = scope.imports || EMPTY_ARRAY;
+    ngModuleDef.exports = scope.exports || EMPTY_ARRAY;
+  });
 }
 
 /**
@@ -718,14 +716,14 @@ export function ɵɵdefinePipe<T>(pipeDef: {
 
   /** Whether the pipe is pure. */
   pure?: boolean
-}): never {
+}): unknown {
   return (<PipeDef<T>>{
-           type: pipeDef.type,
-           name: pipeDef.name,
-           factory: null,
-           pure: pipeDef.pure !== false,
-           onDestroy: pipeDef.type.prototype.ngOnDestroy || null
-         }) as never;
+    type: pipeDef.type,
+    name: pipeDef.name,
+    factory: null,
+    pure: pipeDef.pure !== false,
+    onDestroy: pipeDef.type.prototype.ngOnDestroy || null
+  });
 }
 
 /**

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -701,37 +701,16 @@ export class NodeInjector implements Injector {
 /**
  * @codeGenApi
  */
-export function ɵɵgetFactoryOf<T>(type: Type<any>): FactoryFn<T>|null {
-  const typeAny = type as any;
-
-  if (isForwardRef(type)) {
-    return (() => {
-             const factory = ɵɵgetFactoryOf<T>(resolveForwardRef(typeAny));
-             return factory ? factory() : null;
-           }) as any;
-  }
-
-  let factory = getFactoryDef<T>(typeAny);
-  if (factory === null) {
-    const injectorDef = getInjectorDef<T>(typeAny);
-    factory = injectorDef && injectorDef.factory;
-  }
-  return factory || null;
-}
-
-/**
- * @codeGenApi
- */
 export function ɵɵgetInheritedFactory<T>(type: Type<any>): (type: Type<T>) => T {
   return noSideEffects(() => {
     const ownConstructor = type.prototype.constructor;
-    const ownFactory = ownConstructor[NG_FACTORY_DEF] || ɵɵgetFactoryOf(ownConstructor);
+    const ownFactory = ownConstructor[NG_FACTORY_DEF] || getFactoryOf(ownConstructor);
     const objectPrototype = Object.prototype;
     let parent = Object.getPrototypeOf(type.prototype).constructor;
 
     // Go up the prototype until we hit `Object`.
     while (parent && parent !== objectPrototype) {
-      const factory = parent[NG_FACTORY_DEF] || ɵɵgetFactoryOf(parent);
+      const factory = parent[NG_FACTORY_DEF] || getFactoryOf(parent);
 
       // If we hit something that has a factory and the factory isn't the same as the type,
       // we've found the inherited factory. Note the check that the factory isn't the type's
@@ -751,4 +730,22 @@ export function ɵɵgetInheritedFactory<T>(type: Type<any>): (type: Type<T>) => 
     // latter has to be assumed.
     return t => new t();
   });
+}
+
+function getFactoryOf<T>(type: Type<any>): FactoryFn<T>|null {
+  const typeAny = type as any;
+
+  if (isForwardRef(type)) {
+    return (() => {
+             const factory = getFactoryOf<T>(resolveForwardRef(typeAny));
+             return factory ? factory() : null;
+           }) as any;
+  }
+
+  let factory = getFactoryDef<T>(typeAny);
+  if (factory === null) {
+    const injectorDef = getInjectorDef<T>(typeAny);
+    factory = injectorDef && injectorDef.factory;
+  }
+  return factory || null;
 }

--- a/packages/core/src/render3/errors.ts
+++ b/packages/core/src/render3/errors.ts
@@ -22,7 +22,7 @@ export function throwMultipleComponentError(tNode: TNode): never {
 
 /** Throws an ExpressionChangedAfterChecked error if checkNoChanges mode is on. */
 export function throwErrorIfNoChangesMode(
-    creationMode: boolean, oldValue: any, currValue: any, propName?: string): never|void {
+    creationMode: boolean, oldValue: any, currValue: any, propName?: string): never {
   const field = propName ? ` for '${propName}'` : '';
   let msg =
       `ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked. Previous value${

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -16,7 +16,7 @@ import {getComponent, getDirectives, getHostElement, getRenderedText} from './ut
 
 export {NgModuleType} from '../metadata/ng_module_def';
 export {ComponentFactory, ComponentFactoryResolver, ComponentRef, injectComponentFactoryResolver} from './component_ref';
-export {ɵɵgetFactoryOf, ɵɵgetInheritedFactory} from './di';
+export {ɵɵgetInheritedFactory} from './di';
 export {getLocaleId, setLocaleId} from './i18n/i18n_locale_id';
 // clang-format off
 export {

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -59,7 +59,7 @@ export const enum RenderFlags {
  * consumable for rendering.
  */
 export interface ComponentType<T> extends Type<T> {
-  ɵcmp: never;
+  ɵcmp: unknown;
 }
 
 /**
@@ -67,8 +67,8 @@ export interface ComponentType<T> extends Type<T> {
  * consumable for rendering.
  */
 export interface DirectiveType<T> extends Type<T> {
-  ɵdir: never;
-  ɵfac: () => T;
+  ɵdir: unknown;
+  ɵfac: unknown;
 }
 
 /**
@@ -76,7 +76,7 @@ export interface DirectiveType<T> extends Type<T> {
  * consumable for rendering.
  */
 export interface PipeType<T> extends Type<T> {
-  ɵpipe: never;
+  ɵpipe: unknown;
 }
 
 /**
@@ -370,7 +370,7 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
    * Used to store the result of `noSideEffects` function so that it is not removed by closure
    * compiler. The property should never be read.
    */
-  readonly _?: never;
+  readonly _?: unknown;
 }
 
 /**

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -37,7 +37,6 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵdefineNgModule': r3.ɵɵdefineNgModule,
        'ɵɵdefinePipe': r3.ɵɵdefinePipe,
        'ɵɵdirectiveInject': r3.ɵɵdirectiveInject,
-       'ɵɵgetFactoryOf': r3.ɵɵgetFactoryOf,
        'ɵɵgetInheritedFactory': r3.ɵɵgetInheritedFactory,
        'ɵɵinject': ɵɵinject,
        'ɵɵinjectAttribute': r3.ɵɵinjectAttribute,

--- a/packages/core/src/render3/util/discovery_utils.ts
+++ b/packages/core/src/render3/util/discovery_utils.ts
@@ -250,7 +250,7 @@ export function getLocalRefs(target: {}): {[key: string]: any} {
  * @globalApi ng
  */
 export function getHostElement(componentOrDirective: {}): Element {
-  return getLContext(componentOrDirective)!.native as never as Element;
+  return getLContext(componentOrDirective)!.native as unknown as Element;
 }
 
 /**

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -1005,6 +1005,9 @@
     "name": "getFactoryDef"
   },
   {
+    "name": "getFactoryOf"
+  },
+  {
     "name": "getFirstLContainer"
   },
   {
@@ -1717,9 +1720,6 @@
   },
   {
     "name": "ɵɵelementStart"
-  },
-  {
-    "name": "ɵɵgetFactoryOf"
   },
   {
     "name": "ɵɵgetInheritedFactory"

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -1419,7 +1419,7 @@ function declareTests(config?: {useJit: boolean}) {
               }
 
               class Bar {
-                static ɵprov: ɵɵInjectableDef<Bar> = ɵɵdefineInjectable({
+                static ɵprov = ɵɵdefineInjectable({
                   token: Bar,
                   factory: () => new Bar(),
                   providedIn: SomeModule,
@@ -1452,7 +1452,7 @@ function declareTests(config?: {useJit: boolean}) {
               }
 
               class Bar {
-                static ɵprov: ɵɵInjectableDef<Bar> = ɵɵdefineInjectable({
+                static ɵprov = ɵɵdefineInjectable({
                   token: Bar,
                   factory: () => new Bar(),
                   providedIn: SomeModule,

--- a/packages/core/test/render3/instructions/lview_debug_spec.ts
+++ b/packages/core/test/render3/instructions/lview_debug_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, Injectable, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdirectiveInject, ɵɵProvidersFeature} from '@angular/core/src/core';
-import {getLContext} from '@angular/core/src/render3/context_discovery';
+import {ComponentDef, DirectiveDef} from '@angular/core/src/render3';
 import {ɵɵelement, ɵɵelementEnd, ɵɵelementStart} from '@angular/core/src/render3/instructions/element';
 import {TNodeDebug} from '@angular/core/src/render3/instructions/lview_debug';
 import {createTNode, createTView} from '@angular/core/src/render3/instructions/shared';
@@ -227,7 +227,10 @@ describe('lView_debug', () => {
       expect(myCompNode.injector).toEqual({
         bloom: jasmine.anything(),
         cumulativeBloom: jasmine.anything(),
-        providers: [DepA, String, MyComponent.ɵcmp, MyDirective.ɵdir],
+        providers: [
+          DepA, String, MyComponent.ɵcmp as ComponentDef<MyComponent>,
+          MyDirective.ɵdir as DirectiveDef<MyDirective>
+        ],
         viewProviders: [DepB, Number],
         parentInjectorIndex: -1,
       });

--- a/packages/core/test/render3/jit_environment_spec.ts
+++ b/packages/core/test/render3/jit_environment_spec.ts
@@ -18,6 +18,7 @@ const INTERFACE_EXCEPTIONS = new Set<string>([
   'ɵɵNgModuleDefWithMeta',
   'ɵɵPipeDefWithMeta',
   'ɵɵFactoryDef',
+  'ɵɵgetFactoryOf',
   'ModuleWithProviders',
 ]);
 

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -294,13 +294,13 @@ export function renderTemplate<T>(
         providedRendererFactory, renderer, null, null);
     enterView(hostLView);
 
-    const def: ComponentDef<any> = ɵɵdefineComponent({
-      type: Object,
-      template: templateFn,
-      decls: decls,
-      vars: vars,
-      consts: consts,
-    });
+    const def = ɵɵdefineComponent({
+                  type: Object,
+                  template: templateFn,
+                  decls: decls,
+                  vars: vars,
+                  consts: consts,
+                }) as ComponentDef<any>;
     def.directiveDefs = directives || null;
     def.pipeDefs = pipes || null;
 

--- a/packages/core/test/view/ng_module_spec.ts
+++ b/packages/core/test/view/ng_module_spec.ts
@@ -10,7 +10,7 @@ import {NgModuleRef, ɵINJECTOR_SCOPE as INJECTOR_SCOPE} from '@angular/core';
 import {inject, InjectFlags} from '@angular/core/src/di';
 import {Injector} from '@angular/core/src/di/injector';
 import {INJECTOR} from '@angular/core/src/di/injector_token';
-import {ɵɵdefineInjectable, ɵɵInjectableDef} from '@angular/core/src/di/interface/defs';
+import {ɵɵdefineInjectable} from '@angular/core/src/di/interface/defs';
 import {NgModuleDefinition, NgModuleProviderDef, NodeFlags} from '@angular/core/src/view';
 import {moduleDef} from '@angular/core/src/view/ng_module';
 import {createNgModuleRef} from '@angular/core/src/view/refs';
@@ -25,7 +25,7 @@ class MyChildModule {}
 class NotMyModule {}
 
 class Bar {
-  static ɵprov: ɵɵInjectableDef<Bar> = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: Bar,
     factory: () => new Bar(),
     providedIn: MyModule,
@@ -33,7 +33,7 @@ class Bar {
 }
 
 class Baz {
-  static ɵprov: ɵɵInjectableDef<Baz> = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: Baz,
     factory: () => new Baz(),
     providedIn: NotMyModule,
@@ -43,7 +43,7 @@ class Baz {
 class HasNormalDep {
   constructor(public foo: Foo) {}
 
-  static ɵprov: ɵɵInjectableDef<HasNormalDep> = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: HasNormalDep,
     factory: () => new HasNormalDep(inject(Foo)),
     providedIn: MyModule,
@@ -53,7 +53,7 @@ class HasNormalDep {
 class HasDefinedDep {
   constructor(public bar: Bar) {}
 
-  static ɵprov: ɵɵInjectableDef<HasDefinedDep> = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: HasDefinedDep,
     factory: () => new HasDefinedDep(inject(Bar)),
     providedIn: MyModule,
@@ -63,7 +63,7 @@ class HasDefinedDep {
 class HasOptionalDep {
   constructor(public baz: Baz|null) {}
 
-  static ɵprov: ɵɵInjectableDef<HasOptionalDep> = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: HasOptionalDep,
     factory: () => new HasOptionalDep(inject(Baz, InjectFlags.Optional)),
     providedIn: MyModule,
@@ -71,7 +71,7 @@ class HasOptionalDep {
 }
 
 class ChildDep {
-  static ɵprov: ɵɵInjectableDef<ChildDep> = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: ChildDep,
     factory: () => new ChildDep(),
     providedIn: MyChildModule,
@@ -80,7 +80,7 @@ class ChildDep {
 
 class FromChildWithOptionalDep {
   constructor(public baz: Baz|null) {}
-  static ɵprov: ɵɵInjectableDef<FromChildWithOptionalDep> = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: FromChildWithOptionalDep,
     factory: () => new FromChildWithOptionalDep(inject(Baz, InjectFlags.Default)),
     providedIn: MyChildModule,
@@ -91,7 +91,7 @@ class FromChildWithSkipSelfDep {
   constructor(
       public skipSelfChildDep: ChildDep|null, public selfChildDep: ChildDep|null,
       public optionalSelfBar: Bar|null) {}
-  static ɵprov: ɵɵInjectableDef<FromChildWithSkipSelfDep> = ɵɵdefineInjectable({
+  static ɵprov = ɵɵdefineInjectable({
     token: FromChildWithSkipSelfDep,
     factory: () => new FromChildWithSkipSelfDep(
         inject(ChildDep, InjectFlags.SkipSelf|InjectFlags.Optional),
@@ -228,7 +228,7 @@ describe('NgModuleRef_ injector', () => {
         Service.destroyed++;
       }
 
-      static ɵprov: ɵɵInjectableDef<Service> = ɵɵdefineInjectable({
+      static ɵprov = ɵɵdefineInjectable({
         token: Service,
         factory: () => new Service(),
         providedIn: 'root',


### PR DESCRIPTION
This sits on top of https://github.com/angular/angular/pull/41040. Only the last two commits are relevant here.