### PR TITLE
docs: update Angular Global Summit on event pages

### DIFF
--- a/aio/content/marketing/events.json
+++ b/aio/content/marketing/events.json
@@ -1,5 +1,14 @@
 [
   {
+    "name": "Angular Global Summit",
+    "location": "Online",
+    "linkUrl": "https://link.geekle.us/angular/offsite",
+    "date": {
+      "start": "2021-06-01",
+      "end": "2021-06-02"
+    }
+  },
+  {
     "name": "ng-conf",
     "location": "Online",
     "linkUrl": "https://www.2021.ng-conf.org/",
@@ -10,15 +19,6 @@
     "workshopsDate": {
       "start": "2021-04-12",
       "end": "2021-04-15"
-    }
-  },
-  {
-    "name": "Angular Global Summit",
-    "location": "Online",
-    "linkUrl": "https://angular.geekle.us/",
-    "date": {
-      "start": "2021-04-13",
-      "end": "2021-04-14"
     }
   },
   {


### PR DESCRIPTION
After my speaker meeting with the Geekle team, they communicated that they moved the date to avoid colliding with ng-conf. Originally added in #40697, /cc @mgechev and @AndrewKushnir