### PR TITLE
fix(docs-infra): yet more style fixes/improvements for angular.io

### DIFF
--- a/aio/content/guide/cheatsheet.md
+++ b/aio/content/guide/cheatsheet.md
@@ -1,3 +1,5 @@
+<div class="center-layout-wide">
+
 <h1 class="no-toc">Cheat Sheet</h1>
 
 <table class="is-full-width is-fixed-layout">
@@ -390,3 +392,5 @@ so the <code>@Directive</code> configuration applies to components as well</p>
 </td>
 </tr>
 </tbody></table>
+
+</div>

--- a/aio/content/guide/cheatsheet.md
+++ b/aio/content/guide/cheatsheet.md
@@ -1,6 +1,5 @@
 <h1 class="no-toc">Cheat Sheet</h1>
 
-<div id="cheatsheet">
 <table class="is-full-width is-fixed-layout">
 <tbody><tr>
 <th>Bootstrapping</th>
@@ -391,4 +390,3 @@ so the <code>@Directive</code> configuration applies to components as well</p>
 </td>
 </tr>
 </tbody></table>
-</div>

--- a/aio/content/guide/cheatsheet.md
+++ b/aio/content/guide/cheatsheet.md
@@ -24,7 +24,12 @@
 </th>
 </tr>
 <tr>
-<td><code>@<b>NgModule</b>({<br>&emsp;declarations: ..., imports: ..., exports: ...,<br>&emsp;providers: ..., bootstrap: ...<br>})<br>class MyModule {}</code></td>
+<td><code>@<b>NgModule</b>({
+  declarations: ..., imports: ..., exports: ...,
+  providers: ..., bootstrap: ...
+})
+class MyModule {}
+</code></td>
 <td><p>Defines a module that contains components, directives, pipes, and providers.</p>
 </td>
 </tr><tr>
@@ -93,7 +98,9 @@ is available to <code>declarations</code> of this module.</p>
 <td><p>Sets up two-way data binding. Equivalent to: <code>&lt;my-cmp [title]="name" (titleChange)="name=$event"&gt;</code></p>
 </td>
 </tr><tr>
-<td><code>&lt;video <b>#movieplayer</b> ...&gt;&lt;/video&gt;<br>&lt;button <b>(click)</b>="movieplayer.play()"&gt;Play&lt;/button&gt;</code></td>
+<td><code>&lt;video <b>#movieplayer</b> ...&gt;&lt;/video&gt;
+&lt;button <b>(click)</b>="movieplayer.play()"&gt;Play&lt;/button&gt;
+</code></td>
 <td><p>Creates a local variable <code>movieplayer</code> that provides access to the <code>video</code> element instance in data-binding and event-binding expressions in the current template.</p>
 </td>
 </tr><tr>
@@ -114,7 +121,10 @@ is available to <code>declarations</code> of this module.</p>
 <td><p>An SVG snippet template needs an <code>svg:</code> prefix on its root element to disambiguate the SVG element from an HTML component.</p>
 </td>
 </tr><tr>
-<td><code>&lt;<b>svg</b>&gt;<br>&emsp;&lt;rect x="0" y="0" width="100" height="100"/&gt;<br>&lt;/<b>svg</b>&gt;</code></td>
+<td><code>&lt;<b>svg</b>&gt;
+  &lt;rect x="0" y="0" width="100" height="100"/&gt;
+&lt;/<b>svg</b>&gt;
+</code></td>
 <td><p>An <code>&lt;svg&gt;</code> root element is detected as an SVG element automatically, without the prefix.</p>
 </td>
 </tr>
@@ -136,7 +146,12 @@ is available to <code>declarations</code> of this module.</p>
 <td><p>Turns the li element and its contents into a template, and uses that to instantiate a view for each item in list.</p>
 </td>
 </tr><tr>
-<td><code>&lt;div <b>[ngSwitch]</b>="conditionExpression"&gt;<br>&emsp;&lt;ng-template <b>[<b>ngSwitchCase</b>]</b>="case1Exp"&gt;...&lt;/ng-template&gt;<br>&emsp;&lt;ng-template <b>ngSwitchCase</b>="case2LiteralString"&gt;...&lt;/ng-template&gt;<br>&emsp;&lt;ng-template <b>ngSwitchDefault</b>&gt;...&lt;/ng-template&gt;<br>&lt;/div&gt;</code></td>
+<td><code>&lt;div <b>[ngSwitch]</b>="conditionExpression"&gt;
+  &lt;ng-template <b>[<b>ngSwitchCase</b>]</b>="case1Exp"&gt;...&lt;/ng-template&gt;
+  &lt;ng-template <b>ngSwitchCase</b>="case2LiteralString"&gt;...&lt;/ng-template&gt;
+  &lt;ng-template <b>ngSwitchDefault</b>&gt;...&lt;/ng-template&gt;
+&lt;/div&gt;
+</code></td>
 <td><p>Conditionally swaps the contents of the div by selecting one of the embedded templates based on the current value of <code>conditionExpression</code>.</p>
 </td>
 </tr><tr>
@@ -145,7 +160,9 @@ is available to <code>declarations</code> of this module.</p>
 </td>
 </tr>
 <tr>
-<td><code>&lt;div <b>[ngStyle]</b>="{'property': 'value'}"&gt;</code><br><code>&lt;div <b>[ngStyle]</b>="dynamicStyles()"&gt;</code></td>
+<td><code>&lt;div <b>[ngStyle]</b>="{'property': 'value'}"&gt;
+&lt;div <b>[ngStyle]</b>="dynamicStyles()"&gt;
+</code></td>
 <td><p>Allows you to assign styles to an HTML element using CSS. You can use CSS directly, as in the first example, or you can call a method from the component.</p>
 </td>
 </tr>
@@ -173,19 +190,27 @@ is available to <code>declarations</code> of this module.</p>
 </th>
 </tr>
 <tr>
-<td><code><b>@Component({...})</b><br>class MyComponent() {}</code></td>
+<td><code><b>@Component({...})</b>
+class MyComponent() {}
+</code></td>
 <td><p>Declares that a class is a component and provides metadata about the component.</p>
 </td>
 </tr><tr>
-<td><code><b>@Directive({...})</b><br>class MyDirective() {}</code></td>
+<td><code><b>@Directive({...})</b>
+class MyDirective() {}
+</code></td>
 <td><p>Declares that a class is a directive and provides metadata about the directive.</p>
 </td>
 </tr><tr>
-<td><code><b>@Pipe({...})</b><br>class MyPipe() {}</code></td>
+<td><code><b>@Pipe({...})</b>
+class MyPipe() {}
+</code></td>
 <td><p>Declares that a class is a pipe and provides metadata about the pipe.</p>
 </td>
 </tr><tr>
-<td><code><b>@Injectable()</b><br>class MyService() {}</code></td>
+<td><code><b>@Injectable()</b>
+class MyService() {}
+</code></td>
 <td><p>Declares that a class can be provided and injected by other classes. Without this decorator, the compiler won't generate enough metadata to allow the class to be created properly when it's injected somewhere.</p>
 </td>
 </tr>
@@ -228,11 +253,15 @@ so the <code>@Directive</code> configuration applies to components as well</p>
 <td><p>List of dependency injection providers scoped to this component's view.</p>
 </td>
 </tr><tr>
-<td><code><b>template:</b> 'Hello {{name}}'<br><b>templateUrl:</b> 'my-component.html'</code></td>
+<td><code><b>template:</b> 'Hello {{name}}'
+<b>templateUrl:</b> 'my-component.html'
+</code></td>
 <td><p>Inline template or external template URL of the component's view.</p>
 </td>
 </tr><tr>
-<td><code><b>styles:</b> ['.primary {color: red}']<br><b>styleUrls:</b> ['my-component.css']</code></td>
+<td><code><b>styles:</b> ['.primary {color: red}']
+<b>styleUrls:</b> ['my-component.css']
+</code></td>
 <td><p>List of inline CSS styles or external stylesheet URLs for styling the component’s view.</p>
 </td>
 </tr>
@@ -355,15 +384,32 @@ so the <code>@Directive</code> configuration applies to components as well</p>
 </th>
 </tr>
 <tr>
-<td><code>const routes: <b>Routes</b> = [<br>&emsp;{ path: '', component: HomeComponent },<br>&emsp;{ path: 'path/:routeParam', component: MyComponent },<br>&emsp;{ path: 'staticPath', component: ... },<br>&emsp;{ path: '**', component: ... },<br>&emsp;{ path: 'oldPath', redirectTo: '/staticPath' },<br>&emsp;{ path: ..., component: ..., data: { message: 'Custom' } }<br>]);<br><br>const routing = RouterModule.forRoot(routes);</code></td>
+<td><code>const routes: <b>Routes</b> = [
+  { path: '', component: HomeComponent },
+  { path: 'path/:routeParam', component: MyComponent },
+  { path: 'staticPath', component: ... },
+  { path: '**', component: ... },
+  { path: 'oldPath', redirectTo: '/staticPath' },
+  { path: ..., component: ..., data: { message: 'Custom' } }
+]);
+
+const routing = RouterModule.forRoot(routes);
+</code></td>
 <td><p>Configures routes for the application. Supports static, parameterized, redirect, and wildcard routes. Also supports custom route data and resolve.</p>
 </td>
 </tr><tr>
-<td><code><br>&lt;<b>router-outlet</b>&gt;&lt;/<b>router-outlet</b>&gt;<br>&lt;<b>router-outlet</b> name="aux"&gt;&lt;/<b>router-outlet</b>&gt;<br></code></td>
+<td><code>&lt;<b>router-outlet</b>&gt;&lt;/<b>router-outlet</b>&gt;
+&lt;<b>router-outlet</b> name="aux"&gt;&lt;/<b>router-outlet</b>&gt;
+</code></td>
 <td><p>Marks the location to load the component of the active route.</p>
 </td>
 </tr><tr>
-<td><code><br>&lt;a <b>routerLink</b>="/path"&gt;<br>&lt;a <b>[routerLink]</b>="[ '/path', routeParam ]"&gt;<br>&lt;a <b>[routerLink]</b>="[ '/path', { matrixParam: 'value' } ]"&gt;<br>&lt;a <b>[routerLink]</b>="[ '/path' ]" [queryParams]="{ page: 1 }"&gt;<br>&lt;a <b>[routerLink]</b>="[ '/path' ]" fragment="anchor"&gt;<br></code></td>
+<td><code>&lt;a <b>routerLink</b>="/path"&gt;
+&lt;a <b>[routerLink]</b>="[ '/path', routeParam ]"&gt;
+&lt;a <b>[routerLink]</b>="[ '/path', { matrixParam: 'value' } ]"&gt;
+&lt;a <b>[routerLink]</b>="[ '/path' ]" [queryParams]="{ page: 1 }"&gt;
+&lt;a <b>[routerLink]</b>="[ '/path' ]" fragment="anchor"&gt;
+</code></td>
 <td><p>Creates a link to a different view based on a route instruction consisting of a route path, required and optional parameters, query parameters, and a fragment. To navigate to a root route, use the <code>/</code> prefix; for a child route, use the <code>./</code>prefix; for a sibling or parent, use the <code>../</code> prefix.</p>
 </td>
 </tr><tr>
@@ -371,23 +417,64 @@ so the <code>@Directive</code> configuration applies to components as well</p>
 <td><p>The provided classes are added to the element when the <code>routerLink</code> becomes the current active route.</p>
 </td>
 </tr><tr>
-<td><code>class <b>CanActivate</b>Guard implements <b>CanActivate</b> {<br>&emsp;canActivate(<br>&emsp;&emsp;route: ActivatedRouteSnapshot,<br>&emsp;&emsp;state: RouterStateSnapshot<br>&emsp;):&nbsp;Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }<br>}<br><br>{ path: ..., canActivate: [<b>CanActivate</b>Guard] }</code></td>
+<td><code>class <b>CanActivate</b>Guard implements <b>CanActivate</b> {
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }
+}
+
+{ path: ..., canActivate: [<b>CanActivate</b>Guard] }
+</code></td>
 <td><p>An interface for defining a class that the router should call first to determine if it should activate this component. Should return a boolean|UrlTree or an Observable/Promise that resolves to a boolean|UrlTree.</p>
 </td>
 </tr><tr>
-<td><code>class <b>CanDeactivate</b>Guard implements <b>CanDeactivate</b>&lt;T&gt; {<br>&emsp;canDeactivate(<br>&emsp;&emsp;component: T,<br>&emsp;&emsp;route: ActivatedRouteSnapshot,<br>&emsp;&emsp;state: RouterStateSnapshot<br>&emsp;):&nbsp;Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }<br>}<br><br>{ path: ..., canDeactivate: [<b>CanDeactivate</b>Guard] }</code></td>
+<td><code>class <b>CanDeactivate</b>Guard implements <b>CanDeactivate</b>&lt;T&gt; {
+  canDeactivate(
+    component: T,
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }
+}
+
+{ path: ..., canDeactivate: [<b>CanDeactivate</b>Guard] }
+</code></td>
 <td><p>An interface for defining a class that the router should call first to determine if it should deactivate this component after a navigation. Should return a boolean|UrlTree or an Observable/Promise that resolves to a boolean|UrlTree.</p>
 </td>
 </tr><tr>
-<td><code>class <b>CanActivateChild</b>Guard implements <b>CanActivateChild</b> {<br>&emsp;canActivateChild(<br>&emsp;&emsp;route: ActivatedRouteSnapshot,<br>&emsp;&emsp;state: RouterStateSnapshot<br>&emsp;):&nbsp;Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }<br>}<br><br>{ path: ..., canActivateChild: [CanActivateGuard],<br>&emsp;children: ... }</code></td>
+<td><code>class <b>CanActivateChild</b>Guard implements <b>CanActivateChild</b> {
+  canActivateChild(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }
+}
+
+{ path: ..., canActivateChild: [CanActivateGuard],
+  children: ... }
+</code></td>
 <td><p>An interface for defining a class that the router should call first to determine if it should activate the child route. Should return a boolean|UrlTree or an Observable/Promise that resolves to a boolean|UrlTree.</p>
 </td>
 </tr><tr>
-<td><code>class <b>Resolve</b>Guard implements <b>Resolve</b>&lt;T&gt; {<br>&emsp;resolve(<br>&emsp;&emsp;route: ActivatedRouteSnapshot,<br>&emsp;&emsp;state: RouterStateSnapshot<br>&emsp;): Observable&lt;any&gt;|Promise&lt;any&gt;|any { ... }<br>}<br><br>{ path: ..., resolve: [<b>Resolve</b>Guard] }</code></td>
+<td><code>class <b>Resolve</b>Guard implements <b>Resolve</b>&lt;T&gt; {
+  resolve(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable&lt;any&gt;|Promise&lt;any&gt;|any { ... }
+}
+
+{ path: ..., resolve: [<b>Resolve</b>Guard] }
+</code></td>
 <td><p>An interface for defining a class that the router should call first to resolve route data before rendering the route. Should return a value or an Observable/Promise that resolves to a value.</p>
 </td>
 </tr><tr>
-<td><code>class <b>CanLoad</b>Guard implements <b>CanLoad</b> {<br>&emsp;canLoad(<br>&emsp;&emsp;route: Route<br>&emsp;):&nbsp;Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }<br>}<br><br>{ path: ..., canLoad: [<b>CanLoad</b>Guard], loadChildren: ... }</code></td>
+<td><code>class <b>CanLoad</b>Guard implements <b>CanLoad</b> {
+  canLoad(
+    route: Route
+  ): Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }
+}
+
+{ path: ..., canLoad: [<b>CanLoad</b>Guard], loadChildren: ... }
+</code></td>
 <td><p>An interface for defining a class that the router should call first to check if the lazy loaded module should be loaded. Should return a boolean|UrlTree or an Observable/Promise that resolves to a boolean|UrlTree.</p>
 </td>
 </tr>

--- a/aio/content/guide/cheatsheet.md
+++ b/aio/content/guide/cheatsheet.md
@@ -22,7 +22,7 @@
 </th>
 </tr>
 <tr>
-<td><code>@<b>NgModule</b>({ declarations: ..., imports: ...,<br>     exports: ..., providers: ..., bootstrap: ...})<br>class MyModule {}</code></td>
+<td><code>@<b>NgModule</b>({<br>&emsp;declarations: ..., imports: ..., exports: ...,<br>&emsp;providers: ..., bootstrap: ...<br>})<br>class MyModule {}</code></td>
 <td><p>Defines a module that contains components, directives, pipes, and providers.</p>
 </td>
 </tr><tr>
@@ -91,7 +91,7 @@ is available to <code>declarations</code> of this module.</p>
 <td><p>Sets up two-way data binding. Equivalent to: <code>&lt;my-cmp [title]="name" (titleChange)="name=$event"&gt;</code></p>
 </td>
 </tr><tr>
-<td><code>&lt;video <b>#movieplayer</b> ...&gt;<br>  &lt;button <b>(click)</b>="movieplayer.play()"&gt;<br>&lt;/video&gt;</code></td>
+<td><code>&lt;video <b>#movieplayer</b> ...&gt;&lt;/video&gt;<br>&lt;button <b>(click)</b>="movieplayer.play()"&gt;Play&lt;/button&gt;</code></td>
 <td><p>Creates a local variable <code>movieplayer</code> that provides access to the <code>video</code> element instance in data-binding and event-binding expressions in the current template.</p>
 </td>
 </tr><tr>
@@ -112,7 +112,7 @@ is available to <code>declarations</code> of this module.</p>
 <td><p>An SVG snippet template needs an <code>svg:</code> prefix on its root element to disambiguate the SVG element from an HTML component.</p>
 </td>
 </tr><tr>
-<td><code>&lt;<b>svg</b>&gt;<br>  &lt;rect x="0" y="0" width="100" height="100"/&gt;<br>&lt;/<b>svg</b>&gt;</code></td>
+<td><code>&lt;<b>svg</b>&gt;<br>&emsp;&lt;rect x="0" y="0" width="100" height="100"/&gt;<br>&lt;/<b>svg</b>&gt;</code></td>
 <td><p>An <code>&lt;svg&gt;</code> root element is detected as an SVG element automatically, without the prefix.</p>
 </td>
 </tr>
@@ -134,7 +134,7 @@ is available to <code>declarations</code> of this module.</p>
 <td><p>Turns the li element and its contents into a template, and uses that to instantiate a view for each item in list.</p>
 </td>
 </tr><tr>
-<td><code>&lt;div <b>[ngSwitch]</b>="conditionExpression"&gt;<br>  &lt;ng-template <b>[<b>ngSwitchCase</b>]</b>="case1Exp"&gt;...&lt;/ng-template&gt;<br>  &lt;ng-template <b>ngSwitchCase</b>="case2LiteralString"&gt;...&lt;/ng-template&gt;<br>  &lt;ng-template <b>ngSwitchDefault</b>&gt;...&lt;/ng-template&gt;<br>&lt;/div&gt;</code></td>
+<td><code>&lt;div <b>[ngSwitch]</b>="conditionExpression"&gt;<br>&emsp;&lt;ng-template <b>[<b>ngSwitchCase</b>]</b>="case1Exp"&gt;...&lt;/ng-template&gt;<br>&emsp;&lt;ng-template <b>ngSwitchCase</b>="case2LiteralString"&gt;...&lt;/ng-template&gt;<br>&emsp;&lt;ng-template <b>ngSwitchDefault</b>&gt;...&lt;/ng-template&gt;<br>&lt;/div&gt;</code></td>
 <td><p>Conditionally swaps the contents of the div by selecting one of the embedded templates based on the current value of <code>conditionExpression</code>.</p>
 </td>
 </tr><tr>
@@ -353,7 +353,7 @@ so the <code>@Directive</code> configuration applies to components as well</p>
 </th>
 </tr>
 <tr>
-<td><code>const routes: <b>Routes</b> = [<br>  { path: '', component: HomeComponent },<br>  { path: 'path/:routeParam', component: MyComponent },<br>  { path: 'staticPath', component: ... },<br>  { path: '**', component: ... },<br>  { path: 'oldPath', redirectTo: '/staticPath' },<br>  { path: ..., component: ..., data: { message: 'Custom' } }<br>]);<br><br>const routing = RouterModule.forRoot(routes);</code></td>
+<td><code>const routes: <b>Routes</b> = [<br>&emsp;{ path: '', component: HomeComponent },<br>&emsp;{ path: 'path/:routeParam', component: MyComponent },<br>&emsp;{ path: 'staticPath', component: ... },<br>&emsp;{ path: '**', component: ... },<br>&emsp;{ path: 'oldPath', redirectTo: '/staticPath' },<br>&emsp;{ path: ..., component: ..., data: { message: 'Custom' } }<br>]);<br><br>const routing = RouterModule.forRoot(routes);</code></td>
 <td><p>Configures routes for the application. Supports static, parameterized, redirect, and wildcard routes. Also supports custom route data and resolve.</p>
 </td>
 </tr><tr>
@@ -361,31 +361,31 @@ so the <code>@Directive</code> configuration applies to components as well</p>
 <td><p>Marks the location to load the component of the active route.</p>
 </td>
 </tr><tr>
-<td><code><br>&lt;a routerLink="/path"&gt;<br>&lt;a <b>[routerLink]</b>="[ '/path', routeParam ]"&gt;<br>&lt;a <b>[routerLink]</b>="[ '/path', { matrixParam: 'value' } ]"&gt;<br>&lt;a <b>[routerLink]</b>="[ '/path' ]" [queryParams]="{ page: 1 }"&gt;<br>&lt;a <b>[routerLink]</b>="[ '/path' ]" fragment="anchor"&gt;<br></code></td>
+<td><code><br>&lt;a <b>routerLink</b>="/path"&gt;<br>&lt;a <b>[routerLink]</b>="[ '/path', routeParam ]"&gt;<br>&lt;a <b>[routerLink]</b>="[ '/path', { matrixParam: 'value' } ]"&gt;<br>&lt;a <b>[routerLink]</b>="[ '/path' ]" [queryParams]="{ page: 1 }"&gt;<br>&lt;a <b>[routerLink]</b>="[ '/path' ]" fragment="anchor"&gt;<br></code></td>
 <td><p>Creates a link to a different view based on a route instruction consisting of a route path, required and optional parameters, query parameters, and a fragment. To navigate to a root route, use the <code>/</code> prefix; for a child route, use the <code>./</code>prefix; for a sibling or parent, use the <code>../</code> prefix.</p>
 </td>
 </tr><tr>
-<td><code>&lt;a [routerLink]="[ '/path' ]" routerLinkActive="active"&gt;</code></td>
+<td><code>&lt;a [routerLink]="[ '/path' ]" <b>routerLinkActive</b>="active"&gt;</code></td>
 <td><p>The provided classes are added to the element when the <code>routerLink</code> becomes the current active route.</p>
 </td>
 </tr><tr>
-<td><code>class <b>CanActivate</b>Guard implements <b>CanActivate</b> {<br>    canActivate(<br>      route: ActivatedRouteSnapshot,<br>      state: RouterStateSnapshot<br>    ): Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }<br>}<br><br>{ path: ..., canActivate: [<b>CanActivate</b>Guard] }</code></td>
+<td><code>class <b>CanActivate</b>Guard implements <b>CanActivate</b> {<br>&emsp;canActivate(<br>&emsp;&emsp;route: ActivatedRouteSnapshot,<br>&emsp;&emsp;state: RouterStateSnapshot<br>&emsp;):&nbsp;Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }<br>}<br><br>{ path: ..., canActivate: [<b>CanActivate</b>Guard] }</code></td>
 <td><p>An interface for defining a class that the router should call first to determine if it should activate this component. Should return a boolean|UrlTree or an Observable/Promise that resolves to a boolean|UrlTree.</p>
 </td>
 </tr><tr>
-<td><code>class <b>CanDeactivate</b>Guard implements <b>CanDeactivate</b>&lt;T&gt; {<br>    canDeactivate(<br>      component: T,<br>      route: ActivatedRouteSnapshot,<br>      state: RouterStateSnapshot<br>    ): Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }<br>}<br><br>{ path: ..., canDeactivate: [<b>CanDeactivate</b>Guard] }</code></td>
+<td><code>class <b>CanDeactivate</b>Guard implements <b>CanDeactivate</b>&lt;T&gt; {<br>&emsp;canDeactivate(<br>&emsp;&emsp;component: T,<br>&emsp;&emsp;route: ActivatedRouteSnapshot,<br>&emsp;&emsp;state: RouterStateSnapshot<br>&emsp;):&nbsp;Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }<br>}<br><br>{ path: ..., canDeactivate: [<b>CanDeactivate</b>Guard] }</code></td>
 <td><p>An interface for defining a class that the router should call first to determine if it should deactivate this component after a navigation. Should return a boolean|UrlTree or an Observable/Promise that resolves to a boolean|UrlTree.</p>
 </td>
 </tr><tr>
-<td><code>class <b>CanActivateChild</b>Guard implements <b>CanActivateChild</b> {<br>    canActivateChild(<br>      route: ActivatedRouteSnapshot,<br>      state: RouterStateSnapshot<br>    ): Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }<br>}<br><br>{ path: ..., canActivateChild: [CanActivateGuard],<br>    children: ... }</code></td>
+<td><code>class <b>CanActivateChild</b>Guard implements <b>CanActivateChild</b> {<br>&emsp;canActivateChild(<br>&emsp;&emsp;route: ActivatedRouteSnapshot,<br>&emsp;&emsp;state: RouterStateSnapshot<br>&emsp;):&nbsp;Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }<br>}<br><br>{ path: ..., canActivateChild: [CanActivateGuard],<br>&emsp;children: ... }</code></td>
 <td><p>An interface for defining a class that the router should call first to determine if it should activate the child route. Should return a boolean|UrlTree or an Observable/Promise that resolves to a boolean|UrlTree.</p>
 </td>
 </tr><tr>
-<td><code>class <b>Resolve</b>Guard implements <b>Resolve</b>&lt;T&gt; {<br>    resolve(<br>      route: ActivatedRouteSnapshot,<br>      state: RouterStateSnapshot<br>    ): Observable&lt;any&gt;|Promise&lt;any&gt;|any { ... }<br>}<br><br>{ path: ..., resolve: [<b>Resolve</b>Guard] }</code></td>
+<td><code>class <b>Resolve</b>Guard implements <b>Resolve</b>&lt;T&gt; {<br>&emsp;resolve(<br>&emsp;&emsp;route: ActivatedRouteSnapshot,<br>&emsp;&emsp;state: RouterStateSnapshot<br>&emsp;): Observable&lt;any&gt;|Promise&lt;any&gt;|any { ... }<br>}<br><br>{ path: ..., resolve: [<b>Resolve</b>Guard] }</code></td>
 <td><p>An interface for defining a class that the router should call first to resolve route data before rendering the route. Should return a value or an Observable/Promise that resolves to a value.</p>
 </td>
 </tr><tr>
-<td><code>class <b>CanLoad</b>Guard implements <b>CanLoad</b> {<br>    canLoad(<br>      route: Route<br>    ): Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }<br>}<br><br>{ path: ..., canLoad: [<b>CanLoad</b>Guard], loadChildren: ... }</code></td>
+<td><code>class <b>CanLoad</b>Guard implements <b>CanLoad</b> {<br>&emsp;canLoad(<br>&emsp;&emsp;route: Route<br>&emsp;):&nbsp;Observable&lt;boolean|UrlTree&gt;|Promise&lt;boolean|UrlTree&gt;|boolean|UrlTree { ... }<br>}<br><br>{ path: ..., canLoad: [<b>CanLoad</b>Guard], loadChildren: ... }</code></td>
 <td><p>An interface for defining a class that the router should call first to check if the lazy loaded module should be loaded. Should return a boolean|UrlTree or an Observable/Promise that resolves to a boolean|UrlTree.</p>
 </td>
 </tr>

--- a/aio/content/marketing/about.html
+++ b/aio/content/marketing/about.html
@@ -2,7 +2,7 @@
   <h1 class="banner-headline no-toc no-anchor">Angular Contributors</h1>
 </header>
 
-<article>
+<article class="center-layout-wide">
   <h2>Building For the Future</h2>
   <p>
     Angular is built by a team of engineers who share a passion for making web development feel

--- a/aio/content/marketing/api.html
+++ b/aio/content/marketing/api.html
@@ -1,2 +1,4 @@
-<h1 class="no-toc">API List</h1>
-<aio-api-list></aio-api-list>
+<div class="center-layout">
+  <h1 class="no-toc">API List</h1>
+  <aio-api-list></aio-api-list>
+</div>

--- a/aio/content/marketing/contribute.html
+++ b/aio/content/marketing/contribute.html
@@ -2,7 +2,7 @@
   <h1 class="banner-headline no-toc no-anchor">Contribute to Angular</h1>
 </header>
 
-<article class="contribute-container flex-center">
+<article class="contribute-container center-layout">
   <div>
 
     <h2 class="no-anchor">Angular Projects</h2>

--- a/aio/content/marketing/events.html
+++ b/aio/content/marketing/events.html
@@ -2,6 +2,6 @@
   <h1 class="banner-headline no-toc no-anchor">Events</h1>
 </header>
 
-<article class="events-container">
+<article class="center-layout">
   <aio-events></aio-events>
 </article>

--- a/aio/content/marketing/features.html
+++ b/aio/content/marketing/features.html
@@ -2,107 +2,103 @@
   <h1 class="banner-headline no-toc no-anchor">Features & Benefits</h1>
 </header>
 
-<article>
-  <div class="flex-center">
-    <div>
-      <div class="feature-section">
-        <div class="feature-header">
-          <div class="text-headline">Cross Platform</div>
-          <img src="generated/images/marketing/features/feature-icon.svg" height="70px" alt="">
-        </div>
-        <div class="feature-row">
+<article class="center-layout">
+  <div class="feature-section">
+    <div class="feature-header">
+      <div class="text-headline">Cross Platform</div>
+      <img src="generated/images/marketing/features/feature-icon.svg" height="70px" alt="">
+    </div>
+    <div class="feature-row">
 
-          <div class="feature">
-            <div class="feature-title">Progressive Web Apps</div>
-            <p class="text-body">Use modern web platform capabilities to deliver app-like experiences.
-              High performance, offline, and zero-step installation.</p>
-          </div>
-
-          <div class="feature">
-            <div class="feature-title">Native</div>
-            <p class="text-body">Build native mobile apps with strategies from Cordova, Ionic, or NativeScript.</p>
-          </div>
-
-          <div class="feature">
-            <div class="feature-title">Desktop</div>
-            <p class="text-body">Create desktop-installed apps across Mac, Windows, and Linux using the same Angular methods you've learned for the web plus the ability to access native OS APIs.</p>
-          </div>
-        </div>
-        <hr>
+      <div class="feature">
+        <div class="feature-title">Progressive Web Apps</div>
+        <p class="text-body">Use modern web platform capabilities to deliver app-like experiences.
+          High performance, offline, and zero-step installation.</p>
       </div>
 
-      <div class="feature-section">
-        <div class="feature-header">
-          <div class="text-headline">Speed and Performance</div>
-          <img src="generated/images/marketing/features/feature-icon.svg" height="70px" alt="">
-        </div>
-        <div class="feature-row">
-
-          <div class="feature">
-            <div class="feature-title">Code Generation</div>
-            <p class="text-body">Angular turns your templates into code that's highly optimized for today's JavaScript virtual machines, giving you all the benefits of hand-written code with the productivity of a framework.</p>
-          </div>
-
-          <div class="feature">
-            <div class="feature-title">Universal</div>
-            <p class="text-body">Serve the first view of your application on Node.js®, .NET, PHP, and other servers for near-instant rendering in just HTML and CSS. Also paves the way for sites that optimize for SEO.</p>
-          </div>
-
-          <div class="feature">
-            <div class="feature-title">Code Splitting</div>
-            <p class="text-body">Angular apps load quickly with the new Component Router, which delivers automatic code-splitting so users only load code required to render the view they request.</p>
-          </div>
-        </div>
-        <hr>
+      <div class="feature">
+        <div class="feature-title">Native</div>
+        <p class="text-body">Build native mobile apps with strategies from Cordova, Ionic, or NativeScript.</p>
       </div>
 
-      <div class="feature-section">
-        <div class="feature-header">
-          <div class="text-headline">Productivity</div>
-          <img src="generated/images/marketing/features/feature-icon.svg" height="70px" alt="">
-        </div>
-        <div class="feature-row">
+      <div class="feature">
+        <div class="feature-title">Desktop</div>
+        <p class="text-body">Create desktop-installed apps across Mac, Windows, and Linux using the same Angular methods you've learned for the web plus the ability to access native OS APIs.</p>
+      </div>
+    </div>
+    <hr>
+  </div>
 
-          <div class="feature">
-            <div class="feature-title">Templates</div>
-            <p class="text-body">Quickly create UI views with simple and powerful template syntax.</p>
-          </div>
+  <div class="feature-section">
+    <div class="feature-header">
+      <div class="text-headline">Speed and Performance</div>
+      <img src="generated/images/marketing/features/feature-icon.svg" height="70px" alt="">
+    </div>
+    <div class="feature-row">
 
-          <div class="feature">
-            <div class="feature-title">Angular CLI</div>
-            <p class="text-body">Command line tools: start building fast, add components and tests, then instantly deploy.</p>
-          </div>
-
-          <div class="feature">
-            <div class="feature-title">IDEs</div>
-            <p class="text-body">Get intelligent code completion, instant errors, and other feedback in popular editors and IDEs.</p>
-          </div>
-        </div>
-        <hr>
+      <div class="feature">
+        <div class="feature-title">Code Generation</div>
+        <p class="text-body">Angular turns your templates into code that's highly optimized for today's JavaScript virtual machines, giving you all the benefits of hand-written code with the productivity of a framework.</p>
       </div>
 
-      <div class="feature-section">
-        <div class="feature-header">
-          <div class="text-headline">Full Development Story</div>
-          <img src="generated/images/marketing/features/feature-icon.svg" height="70px" alt="">
-        </div>
-        <div class="feature-row">
+      <div class="feature">
+        <div class="feature-title">Universal</div>
+        <p class="text-body">Serve the first view of your application on Node.js®, .NET, PHP, and other servers for near-instant rendering in just HTML and CSS. Also paves the way for sites that optimize for SEO.</p>
+      </div>
 
-          <div class="feature">
-            <div class="feature-title">Testing</div>
-            <p class="text-body">With Karma for unit tests, you can know if you've broken things every time you save. And Protractor makes your scenario tests run faster and in a stable manner.</p>
-          </div>
+      <div class="feature">
+        <div class="feature-title">Code Splitting</div>
+        <p class="text-body">Angular apps load quickly with the new Component Router, which delivers automatic code-splitting so users only load code required to render the view they request.</p>
+      </div>
+    </div>
+    <hr>
+  </div>
 
-          <div class="feature">
-            <div class="feature-title">Animation</div>
-            <p class="text-body">Create high-performance, complex choreographies and animation timelines with very little code through Angular's intuitive API.</p>
-          </div>
+  <div class="feature-section">
+    <div class="feature-header">
+      <div class="text-headline">Productivity</div>
+      <img src="generated/images/marketing/features/feature-icon.svg" height="70px" alt="">
+    </div>
+    <div class="feature-row">
 
-          <div class="feature">
-            <div class="feature-title">Accessibility</div>
-            <p class="text-body">Create accessible applications with ARIA-enabled components, developer guides, and built-in a11y test infrastructure.</p>
-          </div>
-        </div>
+      <div class="feature">
+        <div class="feature-title">Templates</div>
+        <p class="text-body">Quickly create UI views with simple and powerful template syntax.</p>
+      </div>
+
+      <div class="feature">
+        <div class="feature-title">Angular CLI</div>
+        <p class="text-body">Command line tools: start building fast, add components and tests, then instantly deploy.</p>
+      </div>
+
+      <div class="feature">
+        <div class="feature-title">IDEs</div>
+        <p class="text-body">Get intelligent code completion, instant errors, and other feedback in popular editors and IDEs.</p>
+      </div>
+    </div>
+    <hr>
+  </div>
+
+  <div class="feature-section">
+    <div class="feature-header">
+      <div class="text-headline">Full Development Story</div>
+      <img src="generated/images/marketing/features/feature-icon.svg" height="70px" alt="">
+    </div>
+    <div class="feature-row">
+
+      <div class="feature">
+        <div class="feature-title">Testing</div>
+        <p class="text-body">With Karma for unit tests, you can know if you've broken things every time you save. And Protractor makes your scenario tests run faster and in a stable manner.</p>
+      </div>
+
+      <div class="feature">
+        <div class="feature-title">Animation</div>
+        <p class="text-body">Create high-performance, complex choreographies and animation timelines with very little code through Angular's intuitive API.</p>
+      </div>
+
+      <div class="feature">
+        <div class="feature-title">Accessibility</div>
+        <p class="text-body">Create accessible applications with ARIA-enabled components, developer guides, and built-in a11y test infrastructure.</p>
       </div>
     </div>
   </div>

--- a/aio/scripts/test-aio-a11y.js
+++ b/aio/scripts/test-aio-a11y.js
@@ -27,7 +27,7 @@ const MIN_SCORES_PER_PAGE = {
   'cli/add': 98,
   'docs': 100,
   'guide/docs-style-guide': 96,
-  'start': 98,
+  'start-routing': 93,
   'tutorial': 98,
 };
 

--- a/aio/src/app/custom-elements/contributor/contributor-list.component.ts
+++ b/aio/src/app/custom-elements/contributor/contributor-list.component.ts
@@ -6,18 +6,19 @@ import { LocationService } from 'app/shared/location.service';
 @Component({
   selector: `aio-contributor-list`,
   template: `
-  <div class="flex-center group-buttons">
-<a *ngFor="let name of groupNames"
-    [class.selected]="name == selectedGroup.name"
-    class="button mat-button filter-button"
-    (click)="selectGroup(name)"
-    (keyup.enter)="selectGroup(name)">{{name}}</a>
-  </div>
-  <section *ngIf="selectedGroup" class="grid-fluid">
-    <div class="contributor-group">
-      <aio-contributor *ngFor="let person of selectedGroup.contributors" [person]="person"></aio-contributor>
+    <div class="flex-center group-buttons">
+      <a *ngFor="let name of groupNames"
+          class="button mat-button filter-button"
+          [class.selected]="name == selectedGroup.name"
+          (click)="selectGroup(name)"
+          (keyup.enter)="selectGroup(name)">{{name}}</a>
     </div>
-  </section>`
+    <section *ngIf="selectedGroup" class="grid-fluid">
+      <div class="contributor-group">
+        <aio-contributor *ngFor="let person of selectedGroup.contributors" [person]="person"></aio-contributor>
+      </div>
+    </section>
+  `,
 })
 export class ContributorListComponent implements OnInit {
   private groups: ContributorGroup[];

--- a/aio/src/app/custom-elements/resource/resource-list.component.html
+++ b/aio/src/app/custom-elements/resource/resource-list.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="center-layout">
   <div class="flex-center group-buttons">
     <a *ngFor="let category of categories"
       [class.selected]="category.id == selectedCategory.id"
@@ -6,19 +6,17 @@
       (click)="selectCategory(category.id)"
       (keyup.enter)="selectCategory(category.id)">{{category.title}}</a>
   </div>
-  <div class="resources-container">
-    <div class="showcase">
-      <div *ngFor="let subCategory of selectedCategory?.subCategories">
-        <a id="{{subCategory.id}}"></a>
-        <h3 class="subcategory-title">{{subCategory.title}}</h3>
+  <div class="showcase">
+    <div *ngFor="let subCategory of selectedCategory?.subCategories">
+      <a id="{{subCategory.id}}"></a>
+      <h3 class="subcategory-title">{{subCategory.title}}</h3>
 
-        <div *ngFor="let resource of subCategory.resources">
-          <div class="resource-item">
-            <a class="resource-row-link" rel="noopener" target="_blank" [href]="resource.url">
-              <h4>{{resource.title}}</h4>
-              <p class="resource-description">{{resource.desc || 'No Description'}}</p>
-            </a>
-          </div>
+      <div *ngFor="let resource of subCategory.resources">
+        <div class="resource-item">
+          <a class="resource-row-link" rel="noopener" target="_blank" [href]="resource.url">
+            <h4>{{resource.title}}</h4>
+            <p class="resource-description">{{resource.desc || 'No Description'}}</p>
+          </a>
         </div>
       </div>
     </div>

--- a/aio/src/styles/0-base/_typography.scss
+++ b/aio/src/styles/0-base/_typography.scss
@@ -204,25 +204,24 @@ code {
 // We add the icon to all external links which are identified as absolute links (those that start with `http:` or https:`).
 // For more info see PR #36601.
 @include docs-pages {
-  aio-doc-viewer{
-    a {
-      &[href^="http:"]::after,
-      &[href^="https:"]::after {
-        font-family: "Material Icons";
-        content: "open_in_new";
-        margin-left: 2px;
-        position: relative;
-        @include line-height(24);
-        vertical-align: middle;
-      }
-    }
+  aio-doc-viewer {
+    // The docs-viewer also contain links to GitHub (e.g. the "edit this page" icon) identified with
+    // the `.github-links` class. We don't want to add the external link icon to these links.
+    :not(.github-links) {
+      > a {
+        &[href^="http:"],
+        &[href^="https:"] {
+          display: inline-flex;
+          padding-right: calc(1em + 0.25rem);
+          position: relative;
 
-    // The docs-viewer also contain links to GitHub (e.g. the edit this page icon) identified with `.github-links` class.
-    // We don't want to add the external link icon to these links, so we hide them.
-    .github-links a {
-      &[href^="http:"]::after,
-      &[href^="https:"]::after {
-        display: none;
+          &::after {
+            content: "open_in_new";
+            font-family: "Material Icons";
+            position: absolute;
+            right: 0;
+          }
+        }
       }
     }
   }

--- a/aio/src/styles/1-layouts/_content-layout.scss
+++ b/aio/src/styles/1-layouts/_content-layout.scss
@@ -18,7 +18,7 @@
     padding: 80px 1rem 1rem;
   }
 
-  @include marketing-pages($extraSelectors: ('.page-guide-cheatsheet'), $nestParentSelector: true) {
+  @include marketing-pages($extraSelectors: ('.page-api', '.page-guide-cheatsheet'), $nestParentSelector: true) {
     max-width: none;
   }
 

--- a/aio/src/styles/1-layouts/_layout-global.scss
+++ b/aio/src/styles/1-layouts/_layout-global.scss
@@ -12,6 +12,11 @@ body,
   max-width: 62.5em;
 }
 
+.center-layout-wide {
+  margin: 0 auto;
+  max-width: 84em;
+}
+
 .github-links + .content h1 {
   max-width: 90%;
 }

--- a/aio/src/styles/1-layouts/_layout-global.scss
+++ b/aio/src/styles/1-layouts/_layout-global.scss
@@ -9,7 +9,7 @@ body,
 
 .center-layout {
   margin: 0 auto;
-  max-width: 50em;
+  max-width: 62.5em;
 }
 
 .github-links + .content h1 {

--- a/aio/src/styles/1-layouts/_marketing-layout.scss
+++ b/aio/src/styles/1-layouts/_marketing-layout.scss
@@ -402,7 +402,3 @@ div[layout=row]{
     margin-bottom: 20px;
   }
 }
-
-.events-container{
-  overflow-x: auto;
-}

--- a/aio/src/styles/1-layouts/_top-menu.scss
+++ b/aio/src/styles/1-layouts/_top-menu.scss
@@ -20,18 +20,10 @@ mat-toolbar.app-toolbar {
     @media (min-width: 481px) {
       &:not(.transitioning) {
         background-color: transparent;
+        box-shadow: none;
+        position: absolute;
         transition: background-color 0.2s linear;
       }
-    }
-  }
-
-  // MARKETING PAGES OVERRIDE: TOPNAV TOOLBAR AND HAMBURGER
-  @include marketing-pages($nestParentSelector: true) {
-    box-shadow: none;
-
-    // FIXED TOPNAV TOOLBAR FOR SMALL MOBILE
-    @media (min-width: 481px) {
-      position: absolute;
     }
   }
 

--- a/aio/src/styles/2-modules/_api-list.scss
+++ b/aio/src/styles/2-modules/_api-list.scss
@@ -89,9 +89,7 @@ aio-api-list {
   .api-list-container {
     display: flex;
     flex-direction: column;
-    margin: 0 auto;
-    max-width: 1100px;
-    padding: 16px 16px 16px 0;
+    padding: 16px 0;
     position: relative;
 
     @media handheld and (max-width: $phone-breakpoint),
@@ -124,7 +122,7 @@ aio-api-list {
         float: left;
         width: 33%;
         overflow: hidden;
-        min-width: 220px;
+        min-width: 330px;
         text-overflow: ellipsis;
         white-space: nowrap;
 

--- a/aio/src/styles/2-modules/_api-list.scss
+++ b/aio/src/styles/2-modules/_api-list.scss
@@ -130,13 +130,10 @@ aio-api-list {
 
         a {
           color: $blue-grey-600;
-          display: inline-block;
           @include line-height(16);
-          padding: 0 16px 0;
+          padding: 0 16px;
           text-decoration: none;
           transition: all .3s;
-          overflow: hidden;
-          text-overflow: ellipsis;
 
           &:hover {
             background: $blue-grey-50;

--- a/aio/src/styles/2-modules/_code.scss
+++ b/aio/src/styles/2-modules/_code.scss
@@ -182,6 +182,7 @@ aio-code {
       code {
         background-color: inherit;
         padding: 0;
+        white-space: pre-wrap;
       }
     }
   }

--- a/aio/src/styles/2-modules/_code.scss
+++ b/aio/src/styles/2-modules/_code.scss
@@ -176,6 +176,16 @@ aio-code {
     padding: 4px;
   }
 
+  #cheatsheet {
+    td:first-of-type,
+    th {
+      code {
+        background-color: inherit;
+        padding: 0;
+      }
+    }
+  }
+
   .code-anchor {
     cursor: pointer;
     text-decoration: none;

--- a/aio/src/styles/2-modules/_code.scss
+++ b/aio/src/styles/2-modules/_code.scss
@@ -176,7 +176,7 @@ aio-code {
     padding: 4px;
   }
 
-  #cheatsheet {
+  .page-guide-cheatsheet & {
     td:first-of-type,
     th {
       code {

--- a/aio/src/styles/2-modules/_code.scss
+++ b/aio/src/styles/2-modules/_code.scss
@@ -169,7 +169,7 @@ aio-code {
     }
   }
 
-  :not(h1, h2, h3, h4, h5, h6, pre) > code {
+  :not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(pre) > code {
     background-color: rgba($lightgray, 0.5);
     border-radius: 4px;
     color: $deepgray;

--- a/aio/src/styles/2-modules/_contribute.scss
+++ b/aio/src/styles/2-modules/_contribute.scss
@@ -5,7 +5,6 @@
 
   .card-section {
     justify-content: space-between;
-    max-width: 880px;
 
     @media (max-width: 600px) {
       flex-direction: column;

--- a/aio/src/styles/2-modules/_features.scss
+++ b/aio/src/styles/2-modules/_features.scss
@@ -24,7 +24,7 @@
     flex-wrap: wrap;
     justify-content: space-evenly;
 
-    @media (max-width: 600px) {
+    @media (max-width: 768px) {
       flex-direction: column;
     }
 

--- a/aio/src/styles/2-modules/_features.scss
+++ b/aio/src/styles/2-modules/_features.scss
@@ -24,7 +24,7 @@
     flex-wrap: wrap;
     justify-content: space-evenly;
 
-    @media (max-width: 768px) {
+    @media (max-width: 1057px) {
       flex-direction: column;
     }
 
@@ -32,8 +32,13 @@
       max-width: 300px;
       margin: 0 16px;
 
-      @media (max-width: 768px) {
+      @media (max-width: 1057px) {
         max-width: 100%;
+        padding: 8px 10%;
+      }
+
+      @media (max-width: 768px) {
+        padding: 8px 0;
       }
     }
   }

--- a/aio/src/styles/2-modules/_features.scss
+++ b/aio/src/styles/2-modules/_features.scss
@@ -22,6 +22,7 @@
   .feature-row {
     display: flex;
     flex-wrap: wrap;
+    justify-content: space-evenly;
 
     @media (max-width: 600px) {
       flex-direction: column;

--- a/aio/src/styles/2-modules/_presskit.scss
+++ b/aio/src/styles/2-modules/_presskit.scss
@@ -50,14 +50,16 @@
           padding: 0;
 
           a {
-            display: flex;
-            align-items: center;
+            display: inline-flex;
+            padding-right: 3rem;
+            position: relative;
 
-            &:after {
-              font-family: 'Material Icons';
-              content: 'cloud_download';
+            &::after {
+              content: "cloud_download";
+              font-family: "Material Icons";
               @include font-size(24);
-              margin-left: 0.5rem;
+              position: absolute;
+              right: 0;
             }
           }
         }

--- a/aio/src/styles/2-modules/_resources.scss
+++ b/aio/src/styles/2-modules/_resources.scss
@@ -4,7 +4,6 @@ aio-resource-list {
     box-shadow: 0 1px 4px 0 rgba($black, 0.37);
     border-radius: 4px;
     margin-bottom: 8px * 6;
-    max-width: 50em;
   }
 
   .resource-item {
@@ -16,12 +15,6 @@ aio-resource-list {
     p {
       margin: 0;
     }
-  }
-
-  .resources-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
   }
 
   .subcategory-title {

--- a/aio/src/styles/2-modules/_table.scss
+++ b/aio/src/styles/2-modules/_table.scss
@@ -109,7 +109,7 @@ table {
   }
 }
 
-.events-container {
+.page-events {
   tr > td, tr > th {
     width: 33%;
   }

--- a/aio/src/styles/2-modules/_table.scss
+++ b/aio/src/styles/2-modules/_table.scss
@@ -94,11 +94,6 @@ table {
       display: block;
       position: relative;
       max-width: 100%;
-
-      code {
-        padding: 0;
-        background-color: inherit;
-      }
     }
 
     th {

--- a/aio/src/styles/2-modules/_table.scss
+++ b/aio/src/styles/2-modules/_table.scss
@@ -81,7 +81,7 @@ table {
   }
 }
 
-#cheatsheet {
+.page-guide-cheatsheet {
 
   table tbody td {
     overflow: auto;


### PR DESCRIPTION
Yet more style fixes/improvements for angular.io:

<details>
  <summary><b>fix(docs-infra): do not underline link icons on hover</b> <i>(click to expand)</i></summary><br />

  The external links in the docs content and the download links in the "Press kit" page have icons next to their text (an external link icon and a download icon respectively).

  Previously, when hovering over one of those links, the icons used to get underlined along with the link text, which was not desirable.

  This commit fixes it by changing the mechanics of how these icons are positioned inside the anchor elements so that only the link text is underlined on hover.

  _**Before:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109340455-b64bf180-7871-11eb-923b-3113a237b8d8.png" alt="external links on hover before" width="500" />
  </p>

  _**Before:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109340461-b815b500-7871-11eb-9c9d-91b6ffb17346.png" alt="presskit links on hover before" width="500" />
  </p>

  _**After:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109340458-b77d1e80-7871-11eb-884c-c1093ec83e66.png" alt="external links on hover after" width="500" />
  </p>

  _**After:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109340462-b815b500-7871-11eb-8f00-702b2b61f6ac.png" alt="presskit links on hover after" width="500" />
  </p>

</details>

---
<details>
  <summary><b>fix(docs-infra): use a fixed top-menu on marketing pages as well</b> <i>(click to expand)</i></summary><br />

  Previously, in contrast to docs pages, marketing pages had a non-fixed top-menu, which meant that the top-menu would scroll out of the viewport along with the rest of the content. This had a couple of downsides:
  - The UI was different between pages (i.e. different top-menu behavior on docs vs marketing pages).
  - Since some of the marketing pages are long, it was not easy for people to navigate to a different page (i.e. they had to scroll all the way back up).

  This commit improves the UX by using the same, fixed top-menu on all pages, which restores consistency and allows the user to navigate around more easily.

  NOTE:
  The old behavior (non-fixed top-menu) is kept on the homepage, since its top-menu design in a little different than other pages (e.g. it uses a transparent top-menu) and would not play well with a fixed top-menu.

</details>

---
<details>
  <summary><b>fix(docs-infra): improve the layout of the "Features" page on medium screens</b> <i>(click to expand)</i></summary><br />

  The "Features" page organizes features in groups/rows of 3 features each. On wide screens, all 3 paragraphs of a group/row can be shown next to each other. On narrow screens, the layout changes to stack the paragraphs vertically. On medium screens, however, the 3rd paragragh is wrapped over to the next line.

  Previously, the wrapped content was left-aligned, which left a lot of empty space on the right.

  This commit improves the layout on medium screens by ensuring the paragraphs are horizontally centered (with space distributed evenly around them).

  _**Before:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109344670-b64ef000-7877-11eb-9013-890562ff2f3d.png" alt="features page before" height="250" />
  </p>

  _**After:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109344678-b7801d00-7877-11eb-9224-d7715f7d7235.png" alt="features page after" height="250" />
  </p>

</details>

---
<details>
  <summary><b>fix(docs-infra): fix styling of `&lt;code&gt;` elements on older browsers</b> <i>(click to expand)</i></summary><br />
  
  Previously, styling of `<code>` elements utilized the `:not()` CSS pseudo-class with multiple selectors (`:not(h1, h2, ...)`). It turns out that older browsers (such as IE11) do not support multiple selectors in a single `:not()` instance.
  (See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/:not#description:~:text=Using%20two%20selectors) and [CanIUse](https://caniuse.com/css-not-sel-list) for more info.)

  This commit fixes `<code>` styling to use multiple separate `:not()` instances instead (`:not(h1):not(h2)...`), so that they are styled correctly on older browsers as well.

  NOTE:
  This change seems to trigger some kind of bug in LightHouse that causes the a11y score of `/start` to be calculated as 0 (which is clearly wrong). This happens on Linux (tested on CI and locally using the Windows Subsystem for Linux (WSL)) - on Windows the score is computed correctly as 98/100.
  ([Example failure](https://circleci.com/gh/angular/angular/931038))

  The bug seems to be related to the layout of the content and goes away if we change the viewport size (for example, switching to LightHouse's `desktop` config) or make another change that affects the content's layout (for example, reducing the padding of `<code>` elements).

  To work around the issue, this commit updates the `test-aio-a11y.js` script to test `/start-routing` instead of `/start`.

</details>

---
<details>
  <summary><b>fix(docs-infra): fix `&lt;code&gt;` styling in the "Cheat sheet" guide</b> <i>(click to expand)</i></summary><br />
  
  Since #40944, `<code>` elements have a distinctive background to make them stand out from regular text. However, this styling is not desirable in certain cells of the "Cheat sheet" guide's tables, which exclusively contain code.

  This commit updates the `<code>` styling to remove the distinctive background in those "Cheat sheet" cells.

  _**Before #40944:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109383633-4f215200-78f0-11eb-95e2-2a2c4fb3a31f.png" alt="cheatsheet code before PR 40944" height="250" />
  </p>

  _**Since #40944:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109383634-50527f00-78f0-11eb-8c48-ff5f96918c4d.png" alt="cheatsheet code since PR 40944" height="250" />
  </p>

  _**After this commit:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109383635-50eb1580-78f0-11eb-9cf2-98851692ddd9.png" alt="cheatsheet code after" height="250" />
  </p>

</details>

---
<details>
  <summary><b>refactor(docs-infra): remove unnecessary wrapper `&lt;div&gt;` from the "Cheat sheet" guide</b> <i>(click to expand)</i></summary><br />

  This commit removes an unnecessary wrapper `<div>` from the "Cheat sheet" guide. The CSS styles that referenced the element's ID (`#cheatsheet`) have been updated to use `.page-guide-cheatsheet` instead.

</details>

---
<details>
  <summary><b>fix(docs): fix indentation of code snippets in the "Cheat sheet" guide</b> <i>(click to expand)</i></summary><br />

  Previously, the indentation of code snippets in the "Cheat sheet" guide was done using regular spaces. However, leading whitespace is ignored in HTML elements (by default), which resulted in the identation being lost.

  This commit fixes this by using the `&emsp;` HTML entity for indentation, ensuring the code snippets are easier to read.

  Some examples:

  _**Before:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109385242-218dd600-78fb-11eb-9261-18ab5f2c308c.png" alt="cheatsheet code indentation before" height="250" />
  </p>

  _**After:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109385246-25b9f380-78fb-11eb-8e82-d8a561deba21.png" alt="cheatsheet code since PR 40944" height="250" />
  </p>

</details>

---
<details>
  <summary><b>refactor(docs-infra): fix code indentation in `ContributorListComponent`'s template</b> <i>(click to expand)</i></summary><br />

  This commit fixes the indentation of the template of `ContributorListComponent` to make it more readable.

</details>

---
<details>
  <summary><b>refactor(docs-infra): use more consistent content width on marketing pages</b> <i>(click to expand)</i></summary><br />

  Previously, each marketing page used a different limit for its content's width (if it had a limit at all) and implemented the width limiting in a different way. Besides resulting in an inconsistent UX, this also made it difficult to apply site-wide layout changes.

  This commit makes the limit for most marketing pages consistent and uses the same CSS class to make it easier to apply site-wide changes in the future. The chosen limit is slightly larger than that of docs pages (62.5em/1000px vs 50em/800px), because marketing pages have a different type of content and layout (i.e. images, multi-column layout, etc.). Finally, this commit also removes obsolete wrapper elements, CSS classes and CSS styles, that are no longer necessary after the changes.

  Notably, the homepage (`/`) and the "Contributors" page (`/about`) have remained unchanged, because the former has its own layout that is different from other marketing pages and the latter would offer a worse UX with a small content width limit (as the one used on other marketing pages).

  The content widths of the rest of the marketing pages change slightly as a result of the changes in this commit, but not in a way that would have a negative impact on UX. More specifically:

  | Page (URL)    | Size before | Size after |
  |:--------------|------------:|-----------:|
  | `/contribute` |       880px |     1000px |
  | `/events`     |   unlimited |     1000px |
  | `/features`   |       996px |     1000px |
  | `/presskit`   |       800px |     1000px |
  | `/resources`  |       800px |     1000px |

</details>

---
<details>
  <summary><b>fix(docs-infra): limit max content width on "Contributors" and "Cheat sheet" pages</b> <i>(click to expand)</i></summary><br />

  Previously, the content width on the "Contributors" page (`/about`) and the "Cheat sheet" guide (`/guide/cheatsheet`) was unlimited (i.e. the content would take up all the available space horizontally). This was not very ergonomic on large screens. Especially on the "Cheat sheet" guide there was a lot of unnecessary whitespace between the code shown on the left column and the description shown on the right column.

  This commit fixes this by setting a max content width for both pages of 84em (1404px by default). This keeps the content at a more manageable width and avoids unnecessary whitespace.

  _**Before (contributors):**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109394323-1bb1e800-792f-11eb-9cd6-c5b83e5ae921.png" alt="contributors page on 2500px before" height="250" />
  </p>

  _**Before (cheatsheet):**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109394329-1fde0580-792f-11eb-91c0-4ed7ad408b17.png" alt="cheatsheet on 2500px before" height="250" />
  </p>

  _**After (contributors):**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109394319-181e6100-792f-11eb-9463-a281dfe80448.png" alt="contributors page on 2500px after" height="250" />
  </p>

  _**After (cheatsheet):**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109394330-210f3280-792f-11eb-9837-ddc7a8d01d19.png" alt="cheatsheet on 2500px after" height="250" />
  </p>

</details>

---
<details>
  <summary><b>fix(docs-infra): show ellipsis when text overflows in API list items</b> <i>(click to expand)</i></summary><br />

  Previously, when an API list item's text overflowed its container, it was just hidden. This made it often difficult to realize that there was more text.

  This commit fixes this by ensuring an ellipsis (`...`) is shown when the text overflows.

  _**Before:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109396186-0cd03300-7939-11eb-921c-00621a3889a4.png" alt="api-list truncated before" height="250" />
  </p>

  _**After:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109396187-0e016000-7939-11eb-9f3b-4535be083417.png" alt="api-list truncated after" height="250" />
  </p>

</details>

---
<details>
  <summary><b>fix(docs-infra): avoid truncating several API list items</b> <i>(click to expand)</i></summary><br />

  Previously, with the min width of 220px per item, several API list items were truncated.

  This commit increases the min width per item to 330px, which allows almost all items to have their full text shown. It also increases the API list page's max content width from 50em (800px) to 62.5em (1000px) to allow items to be shown on three columns despite their increased width. This increase in the content width shouldn't negatively affect UX, since the API list page uses a multi-column layout (i.e. it does not contain 1000px-lines of text.)

  _**Before:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109396457-5f5e1f00-793a-11eb-80cf-1418f409325a.png" alt="api-list before" height="250" />
  </p>

  _**After:**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109396659-499d2980-793b-11eb-95d3-f54250f7fab5.png" alt="api-list after" height="250" />
  </p>

</details>

---
New commits to address review feedback:

<details>
  <summary><b>fix(docs-infra): improve the layout of the "Features" page on medium screens</b> <i>(click to expand)</i></summary><br />

  The "Features" page organizes features in groups/rows of 3 features each. On wide screens, all 3 paragraphs of a group/row can be shown next to each other. On narrow screens (between 768px and 1057px), the layout changes to stack the paragraphs vertically. On medium screens, however, there is not enough space to show more than two paragraphs next to each other.

  Previously, the 3rd paragraph was wrapped over to the next line.

  This commit improves the layout on medium screens by switching to immediately stacking the paragraphs vertically as soon as there is not enough space for them to be displayed in one row. Since the total width is still too much for one paragraph, the paragraphs are limited to 80% of the total width.

  _**Before (on 1000px width):**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109825316-62128a00-7c42-11eb-8391-650201257274.png" alt="features page (on 1000px) before" height="250" />
  </p>

  _**After (on 1000px width):**_
  <p align="center">
    <img src="https://user-images.githubusercontent.com/8604205/109825323-6343b700-7c42-11eb-86c1-e8307c5a727a.png" alt="features page (on 1000px) after" height="250" />
  </p>

</details>

---
<details>
  <summary><b>refactor(docs-infra): simplify code snippet indentation in the "Cheat sheet" guide</b> <i>(click to expand)</i></summary><br />

  Previously, the indentation of code snippets in the "Cheat sheet" guide was done using `<br>` elements (for line breaks) and `&emsp;` HTML entities (for space). This was laborious and put the onus on the author to remember to use these symbols (instead of regular whitespace characters).
  (Discussed in #41051 (comment).)

  This commit changes the way `<code>` elements are styles inside the "Cheat sheet" guide to allow using regular whitespace characters in code snippets. It also changes all `<br>`/`&emsp;` occurrences to `\n`/`  ` respectively to make code snippets more readable in the source code.

</details>
