### PR TITLE
docs: extend :host selector documentation

### DIFF
--- a/aio/content/guide/component-styles.md
+++ b/aio/content/guide/component-styles.md
@@ -88,7 +88,7 @@ Add selectors behind the `:host` to select child elements, for example using `:h
 
 <div class="alert is-helpful">
 
-You should not add selectors (other than `:host-context`) in front of the `:host` selector to style a component based on outer context of component's view. Such selectors are not scoped to a component's view and will select the outer context, but it's not native behavior. Use `:host-context` selector for that purpose instead.
+You should not add selectors (other than `:host-context`) in front of the `:host` selector to style a component based on the outer context of the component's view. Such selectors are not scoped to a component's view and will select the outer context, but it's not native behavior. Use `:host-context` selector for that purpose instead.
 
 </div>
 

--- a/aio/content/guide/component-styles.md
+++ b/aio/content/guide/component-styles.md
@@ -83,6 +83,15 @@ The next example targets the host element again, but only when it also has the `
 
 <code-example path="component-styles/src/app/hero-details.component.css" region="hostfunction" header="src/app/hero-details.component.css"></code-example>
 
+The `:host` selector can also be combined with other selectors.
+Add selectors behind the `:host` to select child elements, for example using `:host h2` to target all `<h2>` elements inside a component's view.
+
+<div class="alert is-helpful">
+
+You should not add selectors (other than `:host-context`) in front of the `:host` selector to style a component based on outer context of component's view. Such selectors are not scoped to a component's view and will select the outer context, but it's not native behavior. Use `:host-context` selector for that purpose instead.
+
+</div>
+
 ### :host-context
 
 Sometimes it's useful to apply styles based on some condition *outside* of a component's view.


### PR DESCRIPTION
Based on https://github.com/angular/angular/issues/41039 I've extended `:host` selector documentation to mention that adding selectors *before* `:host` allows to select context similar to `:host-context` and that it's not scoped to component's view as someone could expect.
I don't know how to create the `<code-example` sections, sorry, it could help here a bit. But I tried to explain it with minimal amount of changes.

See changes here: https://pr41055-20021cd.ngbuilds.io/component-styles#host

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/41039


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
