### PR TITLE
fix(language-service): Add plugin option to force strictTemplates

### DIFF
--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -14,7 +14,7 @@
 
 import * as ts from 'typescript';
 
-export interface NgLanguageServiceConfig {
+export interface PluginConfig {
   /**
    * If true, return only Angular results. Otherwise, return Angular + TypeScript
    * results.
@@ -25,6 +25,11 @@ export interface NgLanguageServiceConfig {
    * Otherwise return factory function for View Engine LS.
    */
   ivy: boolean;
+  /**
+   * If true, enable `strictTemplates` in Angular compiler options regardless
+   * of its value in tsconfig.json.
+   */
+  forceStrictTemplates?: true;
 }
 
 export type GetTcbResponse = {

--- a/packages/language-service/index.ts
+++ b/packages/language-service/index.ts
@@ -7,13 +7,13 @@
  */
 
 import * as ts from 'typescript/lib/tsserverlibrary';
-import {NgLanguageService, NgLanguageServiceConfig} from './api';
+import {NgLanguageService, PluginConfig} from './api';
 
 export * from './api';
 
 interface PluginModule extends ts.server.PluginModule {
   create(createInfo: ts.server.PluginCreateInfo): NgLanguageService;
-  onConfigurationChanged?(config: NgLanguageServiceConfig): void;
+  onConfigurationChanged?(config: PluginConfig): void;
 }
 
 const factory: ts.server.PluginModuleFactory = (tsModule): PluginModule => {
@@ -21,7 +21,7 @@ const factory: ts.server.PluginModuleFactory = (tsModule): PluginModule => {
 
   return {
     create(info: ts.server.PluginCreateInfo): NgLanguageService {
-      const config: NgLanguageServiceConfig = info.config;
+      const config: PluginConfig = info.config;
       const bundleName = config.ivy ? 'ivy.js' : 'language-service.js';
       plugin = require(`./bundles/${bundleName}`)(tsModule);
       return plugin.create(info);
@@ -29,7 +29,7 @@ const factory: ts.server.PluginModuleFactory = (tsModule): PluginModule => {
     getExternalFiles(project: ts.server.Project): string[] {
       return plugin?.getExternalFiles?.(project) ?? [];
     },
-    onConfigurationChanged(config: NgLanguageServiceConfig): void {
+    onConfigurationChanged(config: PluginConfig): void {
       plugin?.onConfigurationChanged?.(config);
     },
   };

--- a/packages/language-service/ivy/test/legacy/definitions_spec.ts
+++ b/packages/language-service/ivy/test/legacy/definitions_spec.ts
@@ -18,7 +18,7 @@ describe('definitions', () => {
   beforeAll(() => {
     const {project, service: _service, tsLS} = setup();
     service = _service;
-    ngLS = new LanguageService(project, tsLS);
+    ngLS = new LanguageService(project, tsLS, {});
   });
 
   beforeEach(() => {

--- a/packages/language-service/ivy/test/legacy/diagnostic_spec.ts
+++ b/packages/language-service/ivy/test/legacy/diagnostic_spec.ts
@@ -17,7 +17,7 @@ describe('getSemanticDiagnostics', () => {
   beforeAll(() => {
     const {project, service: _service, tsLS} = setup();
     service = _service;
-    ngLS = new LanguageService(project, tsLS);
+    ngLS = new LanguageService(project, tsLS, {});
   });
 
   beforeEach(() => {

--- a/packages/language-service/ivy/test/legacy/language_service_spec.ts
+++ b/packages/language-service/ivy/test/legacy/language_service_spec.ts
@@ -23,7 +23,7 @@ describe('language service adapter', () => {
     const {project: _project, tsLS, service: _service, configFileFs: _configFileFs} = setup();
     project = _project;
     service = _service;
-    ngLS = new LanguageService(project, tsLS);
+    ngLS = new LanguageService(project, tsLS, {});
     configFileFs = _configFileFs;
   });
 
@@ -55,6 +55,33 @@ describe('language service adapter', () => {
 
       expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
         strictTemplates: false,
+      }));
+    });
+
+    it('should always enable strictTemplates if forceStrictTemplates is true', () => {
+      const {project, tsLS, configFileFs} = setup();
+      const ngLS = new LanguageService(project, tsLS, {
+        forceStrictTemplates: true,
+      });
+
+      // First make sure the default for strictTemplates is true
+      expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
+        enableIvy: true,  // default for ivy is true
+        strictTemplates: true,
+        strictInjectionParameters: true,
+      }));
+
+      // Change strictTemplates to false
+      configFileFs.overwriteConfigFile(TSCONFIG, {
+        angularCompilerOptions: {
+          strictTemplates: false,
+        }
+      });
+
+      // Make sure strictTemplates is still true because forceStrictTemplates
+      // is enabled.
+      expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
+        strictTemplates: true,
       }));
     });
   });

--- a/packages/language-service/ivy/test/legacy/ts_plugin_spec.ts
+++ b/packages/language-service/ivy/test/legacy/ts_plugin_spec.ts
@@ -19,7 +19,7 @@ describe('getExternalFiles()', () => {
     // a global analysis
     expect(externalFiles).toEqual([]);
     // Trigger global analysis
-    const ngLS = new LanguageService(project, tsLS);
+    const ngLS = new LanguageService(project, tsLS, {});
     ngLS.getSemanticDiagnostics(APP_COMPONENT);
     // Now that global analysis is run, we should have all the typecheck files
     externalFiles = getExternalFiles(project);

--- a/packages/language-service/ivy/test/legacy/type_definitions_spec.ts
+++ b/packages/language-service/ivy/test/legacy/type_definitions_spec.ts
@@ -18,7 +18,7 @@ describe('type definitions', () => {
   beforeAll(() => {
     const {project, service: _service, tsLS} = setup();
     service = _service;
-    ngLS = new LanguageService(project, tsLS);
+    ngLS = new LanguageService(project, tsLS, {});
   });
 
   const possibleArrayDefFiles = new Set([

--- a/packages/language-service/ivy/testing/src/project.ts
+++ b/packages/language-service/ivy/testing/src/project.ts
@@ -92,7 +92,7 @@ export class Project {
 
     // The following operation forces a ts.Program to be created.
     this.tsLS = tsProject.getLanguageService();
-    this.ngLS = new LanguageService(tsProject, this.tsLS);
+    this.ngLS = new LanguageService(tsProject, this.tsLS, {});
   }
 
   openFile(projectFileName: string): OpenBuffer {

--- a/packages/language-service/ivy/ts_plugin.ts
+++ b/packages/language-service/ivy/ts_plugin.ts
@@ -16,7 +16,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
   const {project, languageService: tsLS, config} = info;
   const angularOnly = config?.angularOnly === true;
 
-  const ngLS = new LanguageService(project, tsLS);
+  const ngLS = new LanguageService(project, tsLS, config);
 
   function getSemanticDiagnostics(fileName: string): ts.Diagnostic[] {
     const diagnostics: ts.Diagnostic[] = [];


### PR DESCRIPTION
This commit adds a new configuration option, `forceStrictTemplates` to the
language service plugin to allow users to force enable `strictTemplates`.

This is needed so that the Angular extension can be used inside Google without
changing the underlying compiler options in the `ng_module` build rule.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
