### PR TITLE
fix(language-service): Add plugin option to force strictTemplates

### DIFF
--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -14,6 +14,24 @@
 
 import * as ts from 'typescript';
 
+export interface PluginConfig {
+  /**
+   * If true, return only Angular results. Otherwise, return Angular + TypeScript
+   * results.
+   */
+  angularOnly: boolean;
+  /**
+   * If true, return factory function for Ivy LS during plugin initialization.
+   * Otherwise return factory function for View Engine LS.
+   */
+  ivy: boolean;
+  /**
+   * If true, enable `strictTemplates` in Angular compiler options regardless
+   * of its value in tsconfig.json.
+   */
+  forceStrictTemplates?: true;
+}
+
 export type GetTcbResponse = {
   /**
    * The filename of the SourceFile this typecheck block belongs to.

--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -27,6 +27,14 @@ import {getTargetAtPosition, TargetContext, TargetNodeKind} from './template_tar
 import {findTightestNode, getClassDeclFromDecoratorProp, getPropertyAssignmentFromValue} from './ts_utils';
 import {getTemplateInfoAtPosition, isTypeScriptFile} from './utils';
 
+interface LanguageServiceConfig {
+  /**
+   * If true, enable `strictTemplates` in Angular compiler options regardless
+   * of its value in tsconfig.json.
+   */
+  forceStrictTemplates?: true;
+}
+
 export class LanguageService {
   private options: CompilerOptions;
   readonly compilerFactory: CompilerFactory;
@@ -35,9 +43,12 @@ export class LanguageService {
   private readonly parseConfigHost: LSParseConfigHost;
 
   constructor(
-      private readonly project: ts.server.Project, private readonly tsLS: ts.LanguageService) {
+      private readonly project: ts.server.Project,
+      private readonly tsLS: ts.LanguageService,
+      private readonly config: LanguageServiceConfig,
+  ) {
     this.parseConfigHost = new LSParseConfigHost(project.projectService.host);
-    this.options = parseNgCompilerOptions(project, this.parseConfigHost);
+    this.options = parseNgCompilerOptions(project, this.parseConfigHost, config);
     logCompilerOptions(project, this.options);
     this.strategy = createTypeCheckingProgramStrategy(project);
     this.adapter = new LanguageServiceAdapter(project);
@@ -315,7 +326,7 @@ export class LanguageService {
         project.getConfigFilePath(), (fileName: string, eventKind: ts.FileWatcherEventKind) => {
           project.log(`Config file changed: ${fileName}`);
           if (eventKind === ts.FileWatcherEventKind.Changed) {
-            this.options = parseNgCompilerOptions(project, this.parseConfigHost);
+            this.options = parseNgCompilerOptions(project, this.parseConfigHost, this.config);
             logCompilerOptions(project, this.options);
           }
         });
@@ -329,7 +340,8 @@ function logCompilerOptions(project: ts.server.Project, options: CompilerOptions
 }
 
 function parseNgCompilerOptions(
-    project: ts.server.Project, host: ConfigurationHost): CompilerOptions {
+    project: ts.server.Project, host: ConfigurationHost,
+    config: LanguageServiceConfig): CompilerOptions {
   if (!(project instanceof ts.server.ConfiguredProject)) {
     return {};
   }
@@ -349,6 +361,12 @@ function parseNgCompilerOptions(
   // are not exported. In many cases, this ensures the test NgModules are ignored by the compiler
   // and only the real component declaration is used.
   options.compileNonExportedClasses = false;
+
+  // If `forceStrictTemplates` is true, always enable `strictTemplates`
+  // regardless of its value in tsconfig.json.
+  if (config.forceStrictTemplates === true) {
+    options.strictTemplates = true;
+  }
 
   return options;
 }

--- a/packages/language-service/ivy/test/legacy/definitions_spec.ts
+++ b/packages/language-service/ivy/test/legacy/definitions_spec.ts
@@ -18,7 +18,7 @@ describe('definitions', () => {
   beforeAll(() => {
     const {project, service: _service, tsLS} = setup();
     service = _service;
-    ngLS = new LanguageService(project, tsLS);
+    ngLS = new LanguageService(project, tsLS, {});
   });
 
   beforeEach(() => {

--- a/packages/language-service/ivy/test/legacy/diagnostic_spec.ts
+++ b/packages/language-service/ivy/test/legacy/diagnostic_spec.ts
@@ -17,7 +17,7 @@ describe('getSemanticDiagnostics', () => {
   beforeAll(() => {
     const {project, service: _service, tsLS} = setup();
     service = _service;
-    ngLS = new LanguageService(project, tsLS);
+    ngLS = new LanguageService(project, tsLS, {});
   });
 
   beforeEach(() => {

--- a/packages/language-service/ivy/test/legacy/language_service_spec.ts
+++ b/packages/language-service/ivy/test/legacy/language_service_spec.ts
@@ -23,7 +23,7 @@ describe('language service adapter', () => {
     const {project: _project, tsLS, service: _service, configFileFs: _configFileFs} = setup();
     project = _project;
     service = _service;
-    ngLS = new LanguageService(project, tsLS);
+    ngLS = new LanguageService(project, tsLS, {});
     configFileFs = _configFileFs;
   });
 
@@ -55,6 +55,33 @@ describe('language service adapter', () => {
 
       expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
         strictTemplates: false,
+      }));
+    });
+
+    it('should always enable strictTemplates if forceStrictTemplates is true', () => {
+      const {project, tsLS, configFileFs} = setup();
+      const ngLS = new LanguageService(project, tsLS, {
+        forceStrictTemplates: true,
+      });
+
+      // First make sure the default for strictTemplates is true
+      expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
+        enableIvy: true,  // default for ivy is true
+        strictTemplates: true,
+        strictInjectionParameters: true,
+      }));
+
+      // Change strictTemplates to false
+      configFileFs.overwriteConfigFile(TSCONFIG, {
+        angularCompilerOptions: {
+          strictTemplates: false,
+        }
+      });
+
+      // Make sure strictTemplates is still true because forceStrictTemplates
+      // is enabled.
+      expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
+        strictTemplates: true,
       }));
     });
   });

--- a/packages/language-service/ivy/test/legacy/ts_plugin_spec.ts
+++ b/packages/language-service/ivy/test/legacy/ts_plugin_spec.ts
@@ -19,7 +19,7 @@ describe('getExternalFiles()', () => {
     // a global analysis
     expect(externalFiles).toEqual([]);
     // Trigger global analysis
-    const ngLS = new LanguageService(project, tsLS);
+    const ngLS = new LanguageService(project, tsLS, {});
     ngLS.getSemanticDiagnostics(APP_COMPONENT);
     // Now that global analysis is run, we should have all the typecheck files
     externalFiles = getExternalFiles(project);

--- a/packages/language-service/ivy/test/legacy/type_definitions_spec.ts
+++ b/packages/language-service/ivy/test/legacy/type_definitions_spec.ts
@@ -18,7 +18,7 @@ describe('type definitions', () => {
   beforeAll(() => {
     const {project, service: _service, tsLS} = setup();
     service = _service;
-    ngLS = new LanguageService(project, tsLS);
+    ngLS = new LanguageService(project, tsLS, {});
   });
 
   const possibleArrayDefFiles = new Set([

--- a/packages/language-service/ivy/testing/src/project.ts
+++ b/packages/language-service/ivy/testing/src/project.ts
@@ -92,7 +92,7 @@ export class Project {
 
     // The following operation forces a ts.Program to be created.
     this.tsLS = tsProject.getLanguageService();
-    this.ngLS = new LanguageService(tsProject, this.tsLS);
+    this.ngLS = new LanguageService(tsProject, this.tsLS, {});
   }
 
   openFile(projectFileName: string): OpenBuffer {

--- a/packages/language-service/ivy/ts_plugin.ts
+++ b/packages/language-service/ivy/ts_plugin.ts
@@ -14,7 +14,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
   const {project, languageService: tsLS, config} = info;
   const angularOnly = config?.angularOnly === true;
 
-  const ngLS = new LanguageService(project, tsLS);
+  const ngLS = new LanguageService(project, tsLS, config);
 
   function getSemanticDiagnostics(fileName: string): ts.Diagnostic[] {
     const diagnostics: ts.Diagnostic[] = [];


### PR DESCRIPTION
This is patch PR for #41062.

This commit adds a new configuration option, `forceStrictTemplates` to the
language service plugin to allow users to force enable `strictTemplates`.

This is needed so that the Angular extension can be used inside Google without
changing the underlying compiler options in the `ng_module` build rule.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
