### PR TITLE
fix(language-service): provide autocomplete results for incomplete element tags

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -975,6 +975,7 @@ export class ComponentDecoratorHandler implements
       enableI18nLegacyMessageIdFormat: this.enableI18nLegacyMessageIdFormat,
       i18nNormalizeLineEndingsInICUs,
       isInline: template.isInline,
+      alwaysAttemptHtmlToR3AstConversion: this.usePoisonedData,
     });
 
     // Unfortunately, the primary parse of the template above may not contain accurate source map
@@ -1002,6 +1003,7 @@ export class ComponentDecoratorHandler implements
       i18nNormalizeLineEndingsInICUs,
       leadingTriviaChars: [],
       isInline: template.isInline,
+      alwaysAttemptHtmlToR3AstConversion: this.usePoisonedData,
     });
 
     return {

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -116,6 +116,19 @@ describe('R3 template transform', () => {
   });
 
   describe('Nodes without binding', () => {
+    it('should parse incomplete tags terminated by EOF', () => {
+      expectFromHtml('<a', true /* ignoreError */).toEqual([
+        ['Element', 'a'],
+      ]);
+    });
+
+    it('should parse incomplete tags terminated by another tag', () => {
+      expectFromHtml('<a <span></span>', true /* ignoreError */).toEqual([
+        ['Element', 'a'],
+        ['Element', 'span'],
+      ]);
+    });
+
     it('should parse text nodes', () => {
       expectFromHtml('a').toEqual([
         ['Text', 'a'],

--- a/packages/language-service/ivy/completions.ts
+++ b/packages/language-service/ivy/completions.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, BindingPipe, EmptyExpr, ImplicitReceiver, LiteralPrimitive, MethodCall, ParseSourceSpan, PropertyRead, PropertyWrite, SafeMethodCall, SafePropertyRead, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstElement, TmplAstNode, TmplAstReference, TmplAstTemplate, TmplAstTextAttribute, TmplAstVariable} from '@angular/compiler';
+import {AST, BindingPipe, EmptyExpr, ImplicitReceiver, LiteralPrimitive, MethodCall, ParseSourceSpan, PropertyRead, PropertyWrite, SafeMethodCall, SafePropertyRead, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstElement, TmplAstNode, TmplAstReference, TmplAstTemplate, TmplAstText, TmplAstTextAttribute, TmplAstVariable} from '@angular/compiler';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 import {CompletionKind, DirectiveInScope, TemplateDeclarationSymbol} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import {BoundEvent} from '@angular/compiler/src/render3/r3_ast';
@@ -14,6 +14,7 @@ import * as ts from 'typescript';
 
 import {addAttributeCompletionEntries, AttributeCompletionKind, buildAttributeCompletionTable, getAttributeCompletionSymbol} from './attribute_completions';
 import {DisplayInfo, DisplayInfoKind, getDirectiveDisplayInfo, getSymbolDisplayInfo, getTsSymbolDisplayInfo, unsafeCastDisplayInfoKindToScriptElementKind} from './display_parts';
+import {TargetContext, TargetNodeKind, TemplateTarget} from './template_target';
 import {filterAliasImports} from './utils';
 
 type PropertyExpressionCompletionBuilder =
@@ -48,13 +49,15 @@ export enum CompletionNodeContext {
 export class CompletionBuilder<N extends TmplAstNode|AST> {
   private readonly typeChecker = this.compiler.getNextProgram().getTypeChecker();
   private readonly templateTypeChecker = this.compiler.getTemplateTypeChecker();
+  private readonly nodeParent = this.targetDetails.parent;
+  private readonly nodeContext = nodeContextFromTarget(this.targetDetails.context);
+  private readonly template = this.targetDetails.template;
+  private readonly position = this.targetDetails.position;
 
   constructor(
       private readonly tsLS: ts.LanguageService, private readonly compiler: NgCompiler,
       private readonly component: ts.ClassDeclaration, private readonly node: N,
-      private readonly nodeContext: CompletionNodeContext,
-      private readonly nodeParent: TmplAstNode|AST|null,
-      private readonly template: TmplAstTemplate|null) {}
+      private readonly targetDetails: TemplateTarget) {}
 
   /**
    * Analogue for `ts.LanguageService.getCompletionsAtPosition`.
@@ -335,20 +338,37 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
     }
   }
 
-  private isElementTagCompletion(): this is CompletionBuilder<TmplAstElement> {
-    return this.node instanceof TmplAstElement &&
-        this.nodeContext === CompletionNodeContext.ElementTag;
+  private isElementTagCompletion(): this is CompletionBuilder<TmplAstElement|TmplAstText> {
+    if (this.node instanceof TmplAstText) {
+      const positionInTextNode = this.position - this.node.sourceSpan.start.offset;
+      // We only provide element completions in a text node when there is an open tag immediately to
+      // the left of the position.
+      return this.node.value.substring(0, positionInTextNode).endsWith('<');
+    } else if (this.node instanceof TmplAstElement) {
+      return this.nodeContext === CompletionNodeContext.ElementTag;
+    }
+    return false;
   }
 
-  private getElementTagCompletion(this: CompletionBuilder<TmplAstElement>):
+  private getElementTagCompletion(this: CompletionBuilder<TmplAstElement|TmplAstText>):
       ts.WithMetadata<ts.CompletionInfo>|undefined {
     const templateTypeChecker = this.compiler.getTemplateTypeChecker();
 
-    // The replacementSpan is the tag name.
-    const replacementSpan: ts.TextSpan = {
-      start: this.node.sourceSpan.start.offset + 1,  // account for leading '<'
-      length: this.node.name.length,
-    };
+    let start: number;
+    let length: number;
+    if (this.node instanceof TmplAstElement) {
+      // The replacementSpan is the tag name.
+      start = this.node.sourceSpan.start.offset + 1;  // account for leading '<'
+      length = this.node.name.length;
+    } else {
+      const positionInTextNode = this.position - this.node.sourceSpan.start.offset;
+      const textToLeftOfPosition = this.node.value.substring(0, positionInTextNode);
+      start = this.node.sourceSpan.start.offset + textToLeftOfPosition.lastIndexOf('<') + 1;
+      // We only autocomplete immediately after the < so we don't replace any existing text
+      length = 0;
+    }
+
+    const replacementSpan: ts.TextSpan = {start, length};
 
     const entries: ts.CompletionEntry[] =
         Array.from(templateTypeChecker.getPotentialElementTags(this.component))
@@ -368,8 +388,8 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
   }
 
   private getElementTagCompletionDetails(
-      this: CompletionBuilder<TmplAstElement>, entryName: string): ts.CompletionEntryDetails
-      |undefined {
+      this: CompletionBuilder<TmplAstElement|TmplAstText>,
+      entryName: string): ts.CompletionEntryDetails|undefined {
     const templateTypeChecker = this.compiler.getTemplateTypeChecker();
 
     const tagMap = templateTypeChecker.getPotentialElementTags(this.component);
@@ -397,8 +417,8 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
     };
   }
 
-  private getElementTagCompletionSymbol(this: CompletionBuilder<TmplAstElement>, entryName: string):
-      ts.Symbol|undefined {
+  private getElementTagCompletionSymbol(
+      this: CompletionBuilder<TmplAstElement|TmplAstText>, entryName: string): ts.Symbol|undefined {
     const templateTypeChecker = this.compiler.getTemplateTypeChecker();
 
     const tagMap = templateTypeChecker.getPotentialElementTags(this.component);
@@ -662,5 +682,28 @@ function stripBindingSugar(binding: string): {name: string, kind: DisplayInfoKin
     return {name, kind: DisplayInfoKind.EVENT};
   } else {
     return {name, kind: DisplayInfoKind.ATTRIBUTE};
+  }
+}
+
+function nodeContextFromTarget(target: TargetContext): CompletionNodeContext {
+  switch (target.kind) {
+    case TargetNodeKind.ElementInTagContext:
+      return CompletionNodeContext.ElementTag;
+    case TargetNodeKind.ElementInBodyContext:
+      // Completions in element bodies are for new attributes.
+      return CompletionNodeContext.ElementAttributeKey;
+    case TargetNodeKind.TwoWayBindingContext:
+      return CompletionNodeContext.TwoWayBinding;
+    case TargetNodeKind.AttributeInKeyContext:
+      return CompletionNodeContext.ElementAttributeKey;
+    case TargetNodeKind.AttributeInValueContext:
+      if (target.node instanceof TmplAstBoundEvent) {
+        return CompletionNodeContext.EventValue;
+      } else {
+        return CompletionNodeContext.None;
+      }
+    default:
+      // No special context is available.
+      return CompletionNodeContext.None;
   }
 }

--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -180,9 +180,7 @@ export class LanguageService {
         positionDetails.context.nodes[0] :
         positionDetails.context.node;
     return new CompletionBuilder(
-        this.tsLS, compiler, templateInfo.component, node,
-        nodeContextFromTarget(positionDetails.context), positionDetails.parent,
-        positionDetails.template);
+        this.tsLS, compiler, templateInfo.component, node, positionDetails);
   }
 
   getCompletionsAtPosition(
@@ -448,29 +446,6 @@ function getOrCreateTypeCheckScriptInfo(
     project.addRoot(scriptInfo);
   }
   return scriptInfo;
-}
-
-function nodeContextFromTarget(target: TargetContext): CompletionNodeContext {
-  switch (target.kind) {
-    case TargetNodeKind.ElementInTagContext:
-      return CompletionNodeContext.ElementTag;
-    case TargetNodeKind.ElementInBodyContext:
-      // Completions in element bodies are for new attributes.
-      return CompletionNodeContext.ElementAttributeKey;
-    case TargetNodeKind.TwoWayBindingContext:
-      return CompletionNodeContext.TwoWayBinding;
-    case TargetNodeKind.AttributeInKeyContext:
-      return CompletionNodeContext.ElementAttributeKey;
-    case TargetNodeKind.AttributeInValueContext:
-      if (target.node instanceof TmplAstBoundEvent) {
-        return CompletionNodeContext.EventValue;
-      } else {
-        return CompletionNodeContext.None;
-      }
-    default:
-      // No special context is available.
-      return CompletionNodeContext.None;
-  }
 }
 
 function isTemplateContext(program: ts.Program, fileName: string, position: number): boolean {

--- a/packages/language-service/ivy/test/completions_spec.ts
+++ b/packages/language-service/ivy/test/completions_spec.ts
@@ -353,6 +353,23 @@ describe('completions', () => {
       expect(ts.displayPartsToString(details.documentation!)).toEqual('This is another component.');
     });
 
+    it('should return completions for an incomplete tag', () => {
+      const OTHER_CMP = {
+        'OtherCmp': `
+            /** This is another component. */
+            @Component({selector: 'other-cmp', template: 'unimportant'})
+            export class OtherCmp {}
+          `,
+      };
+      const {templateFile} = setup(`<other`, '', OTHER_CMP);
+      templateFile.moveCursorToText('<other¦');
+
+      const completions = templateFile.getCompletionsAtPosition();
+      expectContain(
+          completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.COMPONENT),
+          ['other-cmp']);
+    });
+
     it('should return completions with a blank open tag', () => {
       const OTHER_CMP = {
         'OtherCmp': `
@@ -397,6 +414,10 @@ describe('completions', () => {
 
       const completions = templateFile.getCompletionsAtPosition();
       expect(completions).toBeUndefined();
+
+
+      const details = templateFile.getCompletionEntryDetails('other-cmp')!;
+      expect(details).toBeUndefined();
     });
 
     describe('element attribute scope', () => {

--- a/packages/language-service/ivy/test/completions_spec.ts
+++ b/packages/language-service/ivy/test/completions_spec.ts
@@ -353,6 +353,52 @@ describe('completions', () => {
       expect(ts.displayPartsToString(details.documentation!)).toEqual('This is another component.');
     });
 
+    it('should return completions with a blank open tag', () => {
+      const OTHER_CMP = {
+        'OtherCmp': `
+            @Component({selector: 'other-cmp', template: 'unimportant'})
+            export class OtherCmp {}
+          `,
+      };
+      const {templateFile} = setup(`<`, '', OTHER_CMP);
+      templateFile.moveCursorToText('<¦');
+
+      const completions = templateFile.getCompletionsAtPosition();
+      expectContain(
+          completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.COMPONENT),
+          ['other-cmp']);
+    });
+
+    it('should return completions with a blank open tag a character before', () => {
+      const OTHER_CMP = {
+        'OtherCmp': `
+            @Component({selector: 'other-cmp', template: 'unimportant'})
+            export class OtherCmp {}
+          `,
+      };
+      const {templateFile} = setup(`a <`, '', OTHER_CMP);
+      templateFile.moveCursorToText('a <¦');
+
+      const completions = templateFile.getCompletionsAtPosition();
+      expectContain(
+          completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.COMPONENT),
+          ['other-cmp']);
+    });
+
+    it('should not return completions when cursor is not after the open tag', () => {
+      const OTHER_CMP = {
+        'OtherCmp': `
+            @Component({selector: 'other-cmp', template: 'unimportant'})
+            export class OtherCmp {}
+          `,
+      };
+      const {templateFile} = setup(`\n\n<         `, '', OTHER_CMP);
+      templateFile.moveCursorToText('< ¦');
+
+      const completions = templateFile.getCompletionsAtPosition();
+      expect(completions).toBeUndefined();
+    });
+
     describe('element attribute scope', () => {
       describe('dom completions', () => {
         it('should return completions for a new element attribute', () => {

--- a/packages/language-service/ivy/test/legacy/template_target_spec.ts
+++ b/packages/language-service/ivy/test/legacy/template_target_spec.ts
@@ -35,12 +35,23 @@ function parse(template: string): ParseResult {
       // `ComponentDecoratorHandler._parseTemplate`.
       leadingTriviaChars: [],
       preserveWhitespaces: true,
+      alwaysAttemptHtmlToR3AstConversion: true,
     }),
     position,
   };
 }
 
 describe('getTargetAtPosition for template AST', () => {
+  it('should locate incomplete tag', () => {
+    const {errors, nodes, position} = parse(`<div¦`);
+    expect(errors?.length).toBe(1);
+    expect(errors![0].msg).toContain('Opening tag "div" not terminated.');
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
+    expect(isTemplateNode(node!)).toBe(true);
+    expect(node).toBeInstanceOf(t.Element);
+  });
+
   it('should locate element in opening tag', () => {
     const {errors, nodes, position} = parse(`<di¦v></div>`);
     expect(errors).toBe(null);


### PR DESCRIPTION
(The first commit is included in https://github.com/angular/angular/pull/41054 and will get removed from this PR upon rebase)

Commit 1:
An opening tag `<` without any characters after it is interperted as a
text node (just a "less than" character) rather than the start of an
element in the template AST. This commit adjusts the autocomplete engine
to provide element autocompletions when the nearest character to the
left of the cursor is `<`.

Part of the fix for angular/vscode-ng-language-service#1140

Commit 2:
The current logic in the compiler is to bail when there are errors when
parsing a template into an HTML AST or when there are errors in the i18n
metadata. As a result, a template with these types of parse errors
_will not have any information for the language service_. This is because we
never attempt to convert the HTML AST to a template AST in these
scenarios, so there are no template AST nodes for the language service
to look at for information. In addition, this also means that the errors
are never displayed in the template to the user because there are no
nodes to map the error to.

This commit adds an option to the template parser to temporarily ignore
the html parse and i18n meta errors and always perform the template AST
conversion. At the end, the i18n and HTML parse errors are appended to
the returned errors list. While this seems risky, it at least provides
us with more information than we had before (which was 0) and it's only
done in the context of the language service, when the compiler is
configured to use poisoned data (HTML parse and i18n meta errors can be
interpreted as a "poisoned" template).

fixes angular/vscode-ng-language-service#1140