### PR TITLE
fix(language-service): Only provide dom completions for inline templates

### DIFF
--- a/packages/language-service/ivy/attribute_completions.ts
+++ b/packages/language-service/ivy/attribute_completions.ts
@@ -180,7 +180,8 @@ export type AttributeCompletion = DomAttributeCompletion|DomPropertyCompletion|
  */
 export function buildAttributeCompletionTable(
     component: ts.ClassDeclaration, element: TmplAstElement|TmplAstTemplate,
-    checker: TemplateTypeChecker): Map<string, AttributeCompletion> {
+    checker: TemplateTypeChecker,
+    includeDomSchemaAttributes: boolean): Map<string, AttributeCompletion> {
   const table = new Map<string, AttributeCompletion>();
 
   // Use the `ElementSymbol` or `TemplateSymbol` to iterate over directives present on the node, and
@@ -332,7 +333,7 @@ export function buildAttributeCompletionTable(
   }
 
   // Finally, add any DOM attributes not already covered by inputs.
-  if (element instanceof TmplAstElement) {
+  if (element instanceof TmplAstElement && includeDomSchemaAttributes) {
     for (const {attribute, property} of checker.getPotentialDomBindings(element.name)) {
       const isAlsoProperty = attribute === property;
       if (!table.has(attribute)) {

--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -201,7 +201,8 @@ export class LanguageService {
         positionDetails.context.nodes[0] :
         positionDetails.context.node;
     return new CompletionBuilder(
-        this.tsLS, compiler, templateInfo.component, node, positionDetails);
+        this.tsLS, compiler, templateInfo.component, node, positionDetails,
+        isTypeScriptFile(fileName));
   }
 
   getCompletionsAtPosition(


### PR DESCRIPTION
We currently provide completions for DOM elements in the schema as well
as attributes when we are in the context of an external template.
However, these completions are already provided by other extensions for
HTML contexts (like Emmet). To avoid duplication of results, this commit
updates the language service to exclude DOM completions for external
templates. They are still provided for inline templates because those
are not handled by the HTML language extensions.
