### PR TITLE
fix(language-service): no completion for two-way binding `ngModel`

### DIFF
--- a/packages/language-service/ivy/attribute_completions.ts
+++ b/packages/language-service/ivy/attribute_completions.ts
@@ -266,8 +266,13 @@ export function buildAttributeCompletionTable(
               continue;
             }
 
-            if (table.has(attrName)) {
-              // Skip this attribute as there's already a binding for it.
+            const completionItem = table.get(attrName);
+            if (completionItem &&
+                completionItem.kind !== AttributeCompletionKind.DirectiveAttribute) {
+              // Skip this attribute as it's a `DirectiveInput` or `DirectiveOutput`.
+              // An attribute may be in multiple directives. So the kind of attribute can be reset
+              // from `DirectiveAttribute` into `DirectiveInput` or `DirectiveOutput`, but not vice
+              // versa.
               continue;
             }
 

--- a/packages/language-service/ivy/test/completions_spec.ts
+++ b/packages/language-service/ivy/test/completions_spec.ts
@@ -91,6 +91,34 @@ const DIR_WITH_SELECTED_INPUT = {
   `
 };
 
+const ATTRIBUTE_IN_MULTIPLE_DIR = {
+  'DirOne': `
+    @Directive({
+      selector: '[model]',
+    })
+    export class DirOne {
+    }
+  `,
+  'DirTwo': `
+    @Directive({
+      selector: '[model]',
+      inputs: ['model'],
+      outputs: ['modelChange'],
+    })
+    export class DirTwo {
+      model!: any;
+      modelChange!: any;
+    }
+  `,
+  'DirThree': `
+    @Directive({
+      selector: '[model]',
+    })
+    export class DirThree {
+    }
+  `
+};
+
 const SOME_PIPE = {
   'SomePipe': `
     @Pipe({
@@ -644,6 +672,17 @@ describe('completions', () => {
             completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.EVENT),
             ['otherOutput']);
       });
+
+      it('should return two way binding completions when attribute is in multiple directives',
+         () => {
+           const {templateFile} = setup(`<h1 [(mod)]></h1>`, ``, ATTRIBUTE_IN_MULTIPLE_DIR);
+           templateFile.moveCursorToText('[(mod¦)]');
+
+           const completions = templateFile.getCompletionsAtPosition();
+           expectReplacementText(completions, templateFile.contents, 'mod');
+
+           expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['model']);
+         });
 
       it('should return input completions for a binding property name', () => {
         const {templateFile} =


### PR DESCRIPTION
The attribute `ngModel` is in two directive classes `NgControlStatus` and `NgModel`.
After the ivy LS resolves the first class `NgControlStatus` which has no input and
output and save it in the table, the second directive class will be skipped. So no
completion for `[(ngModel)]`. In this commit the kind of attribute can be reset from
`DirectiveAttribute` into `DirectiveInput` or `DirectiveOutput`, but not vice versa.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
