### PR TITLE
refactor(core): don't use innerHTML in DOMTestComponentRenderer

### DIFF
--- a/packages/platform-browser-dynamic/testing/src/dom_test_component_renderer.ts
+++ b/packages/platform-browser-dynamic/testing/src/dom_test_component_renderer.ts
@@ -20,16 +20,15 @@ export class DOMTestComponentRenderer extends TestComponentRenderer {
   }
 
   insertRootElement(rootElId: string) {
-    const template = getDOM().getDefaultDocument().createElement('template');
-    template.innerHTML = `<div id="${rootElId}"></div>`;
-    const rootEl = <HTMLElement>getContent(template).firstChild;
+    const rootElement = getDOM().getDefaultDocument().createElement('div');
+    rootElement.setAttribute('id', rootElId);
 
     // TODO(juliemr): can/should this be optional?
     const oldRoots = this._doc.querySelectorAll('[id^=root]');
     for (let i = 0; i < oldRoots.length; i++) {
       getDOM().remove(oldRoots[i]);
     }
-    this._doc.body.appendChild(rootEl);
+    this._doc.body.appendChild(rootElement);
   }
 }
 

--- a/packages/platform-browser-dynamic/testing/src/dom_test_component_renderer.ts
+++ b/packages/platform-browser-dynamic/testing/src/dom_test_component_renderer.ts
@@ -31,11 +31,3 @@ export class DOMTestComponentRenderer extends TestComponentRenderer {
     this._doc.body.appendChild(rootElement);
   }
 }
-
-function getContent(node: Node): Node {
-  if ('content' in node) {
-    return (<any>node).content;
-  } else {
-    return node;
-  }
-}


### PR DESCRIPTION
The use of innerHTML is unnecessary and causes TrustedType violations.

// cc: @bjarkler this one is to unblock you