### PR TITLE
fix(bazel): fix incorrect rollup plugin method signature

### DIFF
--- a/packages/bazel/src/ng_package/rollup.config.js
+++ b/packages/bazel/src/ng_package/rollup.config.js
@@ -49,15 +49,16 @@ function fileExists(filePath) {
 
 // This resolver mimics the TypeScript Path Mapping feature, which lets us resolve
 // modules based on a mapping of short names to paths.
-function resolveBazel(
-    importee, importer, baseDir = process.cwd(), resolve = require.resolve, root = rootDir) {
+function resolveBazel(importee, importer) {
   log_verbose(`resolving '${importee}' from ${importer}`);
 
+  const baseDir = process.cwd();
+
   function resolveInRootDir(importee) {
-    var candidate = path.join(baseDir, root, importee);
+    var candidate = path.join(baseDir, rootDir, importee);
     log_verbose(`try to resolve '${importee}' at '${candidate}'`);
     try {
-      var result = resolve(candidate);
+      var result = require.resolve(candidate);
       return result;
     } catch (e) {
       return undefined;
@@ -80,7 +81,7 @@ function resolveBazel(
     // relative import
     if (importer) {
       let importerRootRelative = path.dirname(importer);
-      const relative = path.relative(path.join(baseDir, root), importerRootRelative);
+      const relative = path.relative(path.join(baseDir, rootDir), importerRootRelative);
       if (!relative.startsWith('.')) {
         importerRootRelative = relative;
       }


### PR DESCRIPTION
Update the resolveBazel method signature to align with the rollup plugin
resolveId API: https://rollupjs.org/guide/en/#resolveid

## PR Type
Bugfix

## What is the current behavior?

The incorrect plugin signature causes a crash in rollup >=2.29.0 after the extra argument was added: https://github.com/rollup/rollup/commit/1ad8289205b7af3d5adf3043f782934adbcb8b65#diff-2651238122dc82e0e84b4e3cb1499b8cbd4c01a21a36c9c2fae5812e95cd8ec8R233

## What is the new behavior?

It doesn't crash

## Does this PR introduce a breaking change?

No

## Other information

I hope minor bug fixes are still accepted for `@angular/bazel`?

#35149 suggests updating the `@angular/bazel` peer deps to more modern versions of rollup + plugins which I'd also like to do if such changes are still accepted? However this PR is a minor fix without any breaking changes so I thought I'd start with this...