### PR TITLE
test(docs-infra): minor improvements to the PWA/a11y test scripts

### DIFF
--- a/aio/scripts/test-aio-a11y.js
+++ b/aio/scripts/test-aio-a11y.js
@@ -26,8 +26,9 @@ const MIN_SCORES_PER_PAGE = {
   'cli': 98,
   'cli/add': 98,
   'docs': 100,
-  'guide/docs-style-guide': 95,
+  'guide/docs-style-guide': 96,
   'start': 98,
+  'tutorial': 98,
 };
 
 // Run


### PR DESCRIPTION
- **test(docs-infra): print the browser version in `audit-web-app.js` to help debugging**:
    This commit updates the `audit-web-app.js` script (used to run PWA and a11y tests on angular.io) to also print the version of the browser used to run the tests. This can help when debugging a CI failure.

- **test(docs-infra): run a11y tests against `/tutorial` and update a11y scores**:
    This commit adds `/tutorial` to the list of angular.io pages that we run a11y tests against and updates the required scores to match the current ones (to avoid a future regression going unnoticed).
