### PR TITLE
ci: improve error message when payload size check fails

### DIFF
--- a/scripts/ci/payload-size.js
+++ b/scripts/ci/payload-size.js
@@ -10,6 +10,7 @@
 
 // Imports
 const fs = require('fs');
+const path = require('path');
 
 // Get branch and project name from command line arguments.
 const [, , limitFile, project, branch, commit] = process.argv;
@@ -68,8 +69,10 @@ for (const compressionType in limitSizes) {
 successMessages.concat(failureMessages).forEach(message => console.error(message));
 
 if (failed) {
+  const projectRoot = path.resolve(__dirname, '../..');
+  const limitFileRelPath = path.relative(projectRoot, limitFile);
   console.info(
-      `If this is a desired change, please update the size limits in file '${limitFile}'.`);
+      `If this is a desired change, please update the size limits in file '${limitFileRelPath}'.`);
   process.exit(1);
 } else {
   console.info(`Payload size check passed. All diffs are less than 1% or 500 bytes.`);


### PR DESCRIPTION
Previously, when a payload size check failed, the error message prompted the user to update the size limits using a CI-specific file path, which was confusing (esp. for external contributors). See, for example, https://circleci.com/gh/angular/angular/932733.

This commit improves the error message by printing the file path relative to the repository root instead.
