### PR TITLE
perf(forms): make `FormBuilder` and `RadioControlRegistry` tree-shakable

### DIFF
--- a/goldens/public-api/forms/forms.d.ts
+++ b/goldens/public-api/forms/forms.d.ts
@@ -477,7 +477,7 @@ export declare class RadioControlValueAccessor extends ɵangular_packages_forms_
     onChange: () => void;
     onTouched: () => void;
     value: any;
-    constructor(_renderer: Renderer2, _elementRef: ElementRef, _registry: ɵangular_packages_forms_forms_o, _injector: Injector);
+    constructor(_renderer: Renderer2, _elementRef: ElementRef, _registry: ɵangular_packages_forms_forms_p, _injector: Injector);
     fireUncheck(value: any): void;
     ngOnDestroy(): void;
     ngOnInit(): void;

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -450,7 +450,7 @@
     "name": "R3ViewContainerRef"
   },
   {
-    "name": "RadioControlRegistry"
+    "name": "RadioControlRegistryModule"
   },
   {
     "name": "ReactiveFormsComponent"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -447,7 +447,7 @@
     "name": "REQUIRED_VALIDATOR"
   },
   {
-    "name": "RadioControlRegistry"
+    "name": "RadioControlRegistryModule"
   },
   {
     "name": "RecordViewTuple"

--- a/packages/forms/src/directives.ts
+++ b/packages/forms/src/directives.ts
@@ -16,7 +16,7 @@ import {NgModel} from './directives/ng_model';
 import {NgModelGroup} from './directives/ng_model_group';
 import {NgNoValidate} from './directives/ng_no_validate_directive';
 import {NumberValueAccessor} from './directives/number_value_accessor';
-import {RadioControlValueAccessor} from './directives/radio_control_value_accessor';
+import {RadioControlRegistryModule, RadioControlValueAccessor} from './directives/radio_control_value_accessor';
 import {RangeValueAccessor} from './directives/range_value_accessor';
 import {FormControlDirective} from './directives/reactive_directives/form_control_directive';
 import {FormControlName} from './directives/reactive_directives/form_control_name';
@@ -77,6 +77,7 @@ export const REACTIVE_DRIVEN_DIRECTIVES: Type<any>[] =
  */
 @NgModule({
   declarations: SHARED_FORM_DIRECTIVES,
+  imports: [RadioControlRegistryModule],
   exports: SHARED_FORM_DIRECTIVES,
 })
 export class ɵInternalFormsSharedModule {

--- a/packages/forms/src/directives/radio_control_value_accessor.ts
+++ b/packages/forms/src/directives/radio_control_value_accessor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, forwardRef, Injectable, Injector, Input, OnDestroy, OnInit, Renderer2} from '@angular/core';
+import {Directive, ElementRef, forwardRef, Injectable, Injector, Input, NgModule, OnDestroy, OnInit, Renderer2} from '@angular/core';
 
 import {BuiltInControlValueAccessor, ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 import {NgControl} from './ng_control';
@@ -25,10 +25,20 @@ function throwNameError() {
 }
 
 /**
+ * Internal-only NgModule that works as a host for the `RadioControlRegistry` tree-shakable
+ * provider. Note: the `InternalFormsSharedModule` can not be used here directly, since it's
+ * declared *after* the `RadioControlRegistry` class and the `providedIn` doesn't support
+ * `forwardRef` logic.
+ */
+@NgModule()
+export class RadioControlRegistryModule {
+}
+
+/**
  * @description
  * Class used by Angular to track radio buttons. For internal use only.
  */
-@Injectable()
+@Injectable({providedIn: RadioControlRegistryModule})
 export class RadioControlRegistry {
   private _accessors: any[] = [];
 

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -9,6 +9,7 @@
 import {Injectable} from '@angular/core';
 
 import {AsyncValidatorFn, ValidatorFn} from './directives/validators';
+import {ReactiveFormsModule} from './form_providers';
 import {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormGroup, FormHooks} from './model';
 
 function isAbstractControlOptions(options: AbstractControlOptions|
@@ -30,7 +31,7 @@ function isAbstractControlOptions(options: AbstractControlOptions|
  *
  * @publicApi
  */
-@Injectable()
+@Injectable({providedIn: ReactiveFormsModule})
 export class FormBuilder {
   /**
    * @description

--- a/packages/forms/src/form_providers.ts
+++ b/packages/forms/src/form_providers.ts
@@ -10,7 +10,6 @@ import {ModuleWithProviders, NgModule} from '@angular/core';
 
 import {InternalFormsSharedModule, NG_MODEL_WITH_FORM_CONTROL_WARNING, REACTIVE_DRIVEN_DIRECTIVES, TEMPLATE_DRIVEN_DIRECTIVES} from './directives';
 import {RadioControlRegistry} from './directives/radio_control_value_accessor';
-import {FormBuilder} from './form_builder';
 
 /**
  * Exports the required providers and directives for template-driven forms,
@@ -40,7 +39,9 @@ export class FormsModule {
  */
 @NgModule({
   declarations: [REACTIVE_DRIVEN_DIRECTIVES],
-  providers: [FormBuilder, RadioControlRegistry],
+  // Note: FormBuilder is also provided in this module as a tree-shakable provider,
+  // see packages/forms/src/form_builder.ts.
+  providers: [RadioControlRegistry],
   exports: [InternalFormsSharedModule, REACTIVE_DRIVEN_DIRECTIVES]
 })
 export class ReactiveFormsModule {

--- a/packages/forms/src/form_providers.ts
+++ b/packages/forms/src/form_providers.ts
@@ -9,11 +9,13 @@
 import {ModuleWithProviders, NgModule} from '@angular/core';
 
 import {InternalFormsSharedModule, NG_MODEL_WITH_FORM_CONTROL_WARNING, REACTIVE_DRIVEN_DIRECTIVES, TEMPLATE_DRIVEN_DIRECTIVES} from './directives';
-import {RadioControlRegistry} from './directives/radio_control_value_accessor';
 
 /**
  * Exports the required providers and directives for template-driven forms,
  * making them available for import by NgModules that import this module.
+ *
+ * Providers associated with this module:
+ * * `RadioControlRegistry`
  *
  * @see [Forms Overview](/guide/forms-overview)
  * @see [Template-driven Forms Guide](/guide/forms)
@@ -22,7 +24,6 @@ import {RadioControlRegistry} from './directives/radio_control_value_accessor';
  */
 @NgModule({
   declarations: TEMPLATE_DRIVEN_DIRECTIVES,
-  providers: [RadioControlRegistry],
   exports: [InternalFormsSharedModule, TEMPLATE_DRIVEN_DIRECTIVES]
 })
 export class FormsModule {
@@ -32,6 +33,10 @@ export class FormsModule {
  * Exports the required infrastructure and directives for reactive forms,
  * making them available for import by NgModules that import this module.
  *
+ * Providers associated with this module:
+ * * `FormBuilder`
+ * * `RadioControlRegistry`
+ *
  * @see [Forms Overview](guide/forms-overview)
  * @see [Reactive Forms Guide](guide/reactive-forms)
  *
@@ -39,9 +44,6 @@ export class FormsModule {
  */
 @NgModule({
   declarations: [REACTIVE_DRIVEN_DIRECTIVES],
-  // Note: FormBuilder is also provided in this module as a tree-shakable provider,
-  // see packages/forms/src/form_builder.ts.
-  providers: [RadioControlRegistry],
   exports: [InternalFormsSharedModule, REACTIVE_DRIVEN_DIRECTIVES]
 })
 export class ReactiveFormsModule {


### PR DESCRIPTION
This PR makes the `FormBuilder` and `RadioControlRegistry` classes tree-shakable by adding the `providedIn` property to corresponding `@Injectable` decorators and excluding these classes from NgModule definitions.

Note: this improvement is a part of #41011.

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: performance optimization.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No