### PR TITLE
ci: remove `CHANGELOG.md` from the `public-api` group

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1159,7 +1159,7 @@ groups:
     conditions:
       - *can-be-global-approved
       - >
-        contains_any_globs(files.exclude("CHANGELOG.md").exclude("packages/compiler-cli/**/BUILD.bazel"), [
+        contains_any_globs(files.exclude("packages/compiler-cli/**/BUILD.bazel"), [
           '*',
           '.circleci/**',
           '.devcontainer/**',
@@ -1220,7 +1220,6 @@ groups:
       - >
         contains_any_globs(files, [
           'goldens/public-api/**',
-          'CHANGELOG.md',
           'docs/NAMING.md',
           'aio/content/errors/*.md',
           'aio/content/guide/glossary.md',


### PR DESCRIPTION
This commit changes the owning group for the `CHANGELOG.md` file from `public-api` to `dev-infra` (similar to other top-level `.md` files).

Internal discussion: https://angular-team.slack.com/archives/C040TF8UT/p1615218082023400
