### PR TITLE
docs: add deprecation note next to IE 11 in browser-support page

### DIFF
--- a/aio/content/guide/browser-support.md
+++ b/aio/content/guide/browser-support.md
@@ -53,7 +53,8 @@ Angular supports most recent browsers. This includes the following specific vers
       IE
     </td>
     <td>
-      <div>11</div>
+      <div>11<br>
+      <em>*deprecated since version 12, see the <a href="guide/deprecations#internet-explorer-11">deprecations guide</a></em></div>
     </td>
   </tr>
  <tr>

--- a/aio/content/guide/browser-support.md
+++ b/aio/content/guide/browser-support.md
@@ -54,7 +54,7 @@ Angular supports most recent browsers. This includes the following specific vers
     </td>
     <td>
       <div>11<br>
-      <em>*deprecated since version 12, see the <a href="guide/deprecations#internet-explorer-11">deprecations guide</a></em></div>
+      <em>*deprecated, see the <a href="guide/deprecations#internet-explorer-11">deprecations guide</a></em></div>
     </td>
   </tr>
  <tr>

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -431,7 +431,7 @@ If you rely on the behavior that the same object instance should cause change de
 - Explicitly call [`ChangeDetectorRef.detectChanges()`](api/core/ChangeDetectorRef#detectchanges) to force the update.
 
 ### Internet Explorer 11
-Angular support for Microsoft's Internet Explorer 11 (IE11) is deprecated and will end in a future version. Maintaining support for IE11 incurs ongoing costs, including increased bundle size, code complexity, and test load. Global usage of IE11 has fallen to a point where these costs no longer warrant the additional maintenance effort. Ending IE11 support additionally allows Angular to take advantage of platform APIs present only in evergreen browsers.
+Angular support for Microsoft's Internet Explorer 11 (IE11) is deprecated. Maintaining support for IE11 incurs ongoing costs, including increased bundle size, code complexity, and test load. Global usage of IE11 has fallen to a point where these costs no longer warrant the additional maintenance effort. Ending IE11 support additionally allows Angular to take advantage of platform APIs present only in evergreen browsers.
 
 Microsoft announced that its 365 services will no longer support IE11 starting August 17, 2021. Microsoft previously ended support for IE11 in Microsoft Teams on November 30, 2020. For more information, see [Microsoft 365 apps say farewell to Internet Explorer 11](https://techcommunity.microsoft.com/t5/microsoft-365-blog/microsoft-365-apps-say-farewell-to-internet-explorer-11-and/ba-p/1591666).
 

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -430,6 +430,14 @@ If you rely on the behavior that the same object instance should cause change de
 - Clone the resulting value so that it has a new identity.
 - Explicitly call [`ChangeDetectorRef.detectChanges()`](api/core/ChangeDetectorRef#detectchanges) to force the update.
 
+### Internet Explorer 11
+Support for IE 11 has been deprecated and will be dropped in a future version. Supporting outdated browsers like this increases bundle size, code complexity, and test load, and also requires time and effort that could be spent on improvements to the framework. For example, fixing issues can be more difficult, as a straightforward fix for modern browsers could break old ones that have quirks due to not receiving updates from vendors.
+
+Microsoft announced that its 365 apps and services no longer support Internet Explorer 11 (IE 11) from August 17, 2020. Additionally, Microsoft dropped support for IE 11 from Microsoft Teams web app in November 30, 2020. 
+
+For more information, see [Microsoft 365 apps say farewell to Internet Explorer 11](https://techcommunity.microsoft.com/t5/microsoft-365-blog/microsoft-365-apps-say-farewell-to-internet-explorer-11-and/ba-p/1591666).
+
+
 {@a deprecated-cli-flags}
 ## Deprecated CLI APIs and Options
 

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -431,12 +431,9 @@ If you rely on the behavior that the same object instance should cause change de
 - Explicitly call [`ChangeDetectorRef.detectChanges()`](api/core/ChangeDetectorRef#detectchanges) to force the update.
 
 ### Internet Explorer 11
-Support for IE 11 has been deprecated and will be dropped in a future version. Supporting outdated browsers like this increases bundle size, code complexity, and test load, and also requires time and effort that could be spent on improvements to the framework. For example, fixing issues can be more difficult, as a straightforward fix for modern browsers could break old ones that have quirks due to not receiving updates from vendors.
+Angular support for Microsoft's Internet Explorer 11 (IE11) is deprecated and will end in a future version. Maintaining support for IE11 incurs ongoing costs, including increased bundle size, code complexity, and test load. Global usage of IE11 has fallen to a point where these costs no longer warrant the additional maintenance effort. Ending IE11 support additionally allows Angular to take advantage of platform APIs present only in evergreen browsers.
 
-Microsoft announced that its 365 apps and services no longer support Internet Explorer 11 (IE 11) from August 17, 2020. Additionally, Microsoft dropped support for IE 11 from Microsoft Teams web app in November 30, 2020. 
-
-For more information, see [Microsoft 365 apps say farewell to Internet Explorer 11](https://techcommunity.microsoft.com/t5/microsoft-365-blog/microsoft-365-apps-say-farewell-to-internet-explorer-11-and/ba-p/1591666).
-
+Microsoft announced that its 365 services will no longer support IE11 starting August 17, 2021. Microsoft previously ended support for IE11 in Microsoft Teams on November 30, 2020. For more information, see [Microsoft 365 apps say farewell to Internet Explorer 11](https://techcommunity.microsoft.com/t5/microsoft-365-blog/microsoft-365-apps-say-farewell-to-internet-explorer-11-and/ba-p/1591666).
 
 {@a deprecated-cli-flags}
 ## Deprecated CLI APIs and Options


### PR DESCRIPTION

Add a deprecation note, that IE 11 will be deprecated in version 12.

See https://github.com/angular/angular-cli/pull/20225 and https://techcommunity.microsoft.com/t5/microsoft-365-blog/microsoft-365-apps-say-farewell-to-internet-explorer-11-and/ba-p/1591666