### PR TITLE
build: remove commit message max line length limit

### DIFF
--- a/.ng-dev/commit-message.ts
+++ b/.ng-dev/commit-message.ts
@@ -4,7 +4,7 @@ import {CommitMessageConfig} from '../dev-infra/commit-message/config';
  * The configuration for `ng-dev commit-message` commands.
  */
 export const commitMessage: CommitMessageConfig = {
-  maxLineLength: 120,
+  maxLineLength: Infinity,
   minBodyLength: 20,
   minBodyLengthTypeExcludes: ['docs'],
   scopes: [


### PR DESCRIPTION
With this change we remove the lines length restriction in commit message body. This was previously in place due to a bug in GitHub UI, which is now fixed.