### PR TITLE
build(language-service): use 'export =' syntax for default export

### DIFF
--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -8,6 +8,7 @@ ts_library(
         "api.ts",
         "index.ts",
     ],
+    prodmode_module = "commonjs",
     deps = [
         "@npm//@types/node",
         "@npm//typescript",

--- a/packages/language-service/index.ts
+++ b/packages/language-service/index.ts
@@ -9,8 +9,6 @@
 import * as ts from 'typescript/lib/tsserverlibrary';
 import {NgLanguageService, PluginConfig} from './api';
 
-export * from './api';
-
 interface PluginModule extends ts.server.PluginModule {
   create(createInfo: ts.server.PluginCreateInfo): NgLanguageService;
   onConfigurationChanged?(config: PluginConfig): void;
@@ -35,4 +33,9 @@ const factory: ts.server.PluginModuleFactory = (tsModule): PluginModule => {
   };
 };
 
-module.exports = factory;
+/**
+ * Tsserver expects `@angular/language-service` to provide a factory function
+ * as the default export of the package. See
+ * https://github.com/microsoft/TypeScript/blob/f4d0ea6539edb6d8f70b626132d6f9ac1ac4281a/src/server/project.ts#L1611
+ */
+export = factory;


### PR DESCRIPTION
Tsserver expects `@angular/language-service` to provide a factory function
as the default export (commonjs-style) of the package.

The current implementation side steps TypeScript's import syntax by using
`module.exports = factory`.
This allows the code to incorrectly re-export other symbols:

```ts
export * from './api';
```

which transpiles to:

```js
var tslib_1 = require("tslib");
tslib_1.__exportStar(require("@angular/language-service/api"), exports);
```

Doing this meant that the package now has a runtime dependency on `tslib`,
which is totally unnecessary.

With the proper `export =` syntax, `tslib` is removed, and no other exports
are allowed.

Output:
```js
(function (factory) {
    if (typeof module === "object" && typeof module.exports === "object") {
        var v = factory(require, exports);
        if (v !== undefined) module.exports = v;
    }
    else if (typeof define === "function" && define.amd) {
        define("@angular/language-service", ["require", "exports"], factory);
    }
})(function (require, exports) {
    "use strict";
    return function factory(tsModule) {
        var plugin;
        return {
            create: function (info) {
                var config = info.config;
                var bundleName = config.ivy ? 'ivy.js' : 'language-service.js';
                plugin = require("./bundles/" + bundleName)(tsModule);
                return plugin.create(info);
            },
            getExternalFiles: function (project) {
                var _a, _b;
                return (_b = (_a = plugin === null || plugin === void 0 ? void 0 : plugin.getExternalFiles) === null || _a === void 0 ? void 0 : _a.call(plugin, project)) !== null && _b !== void 0 ? _b : [];
            },
            onConfigurationChanged: function (config) {
                var _a;
                (_a = plugin === null || plugin === void 0 ? void 0 : plugin.onConfigurationChanged) === null || _a === void 0 ? void 0 : _a.call(plugin, config);
            },
        };
    };
});
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
