### PR TITLE
docs: remove deprecated Angular CLI APIs that have been removed

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -441,17 +441,8 @@ This section contains a complete list all of the currently deprecated CLI flags.
 | `extractCss`                    | <!--v11--> v13     | No longer required to disable CSS extraction during development.               |
 | `i18nFormat`                    | <!--v9--> v12      | Format is now automatically detected.                                           |
 | `i18nLocale`                    | <!--v9--> v12      | New [localization option](/guide/i18n#localize-config) in version 9 and later.  |
-| `lazyModules`                   | <!--v9--> v12      | Used with deprecated SystemJsNgModuleLoader.                                    |
 | `hmrWarning`                    | <!--v11--> v13     | No longer has an effect.                                                       |
 | `servePathDefaultWarning`       | <!--v11--> v13     | No longer has an effect.                                                       |
-
-### @ngtools/webpack
-
-| API/Option                      | May be removed in | Notes                                                                           |
-| ------------------------------- | ----------------- |-------------------------------------------------------------------------------- |
-| `discoverLazyRoutes`            | <!--v9--> v12     | Used with deprecated SystemJsNgModuleLoader.                                    |
-| `additionalLazyModules`         | <!--v9--> v12     | Used with deprecated SystemJsNgModuleLoader.                                    |
-| `additionalLazyModuleResources` | <!--v9--> v12     | Used with deprecated SystemJsNgModuleLoader.                                    |
 
 ### @schematics/angular
 


### PR DESCRIPTION
With this change we remove deprecated Angular CLI APIs that have been removed in version 12.
