### PR TITLE
fix(localize): trim extracted `equiv-text` values

### DIFF
--- a/packages/localize/src/tools/src/extract/extraction.ts
+++ b/packages/localize/src/tools/src/extract/extraction.ts
@@ -123,7 +123,7 @@ export class MessageExtractor {
         sourceFile.sources.find(sf => sf?.sourcePath === originalStart.file)!;
     const startPos = originalSourceFile.startOfLinePositions[start.line] + start.column;
     const endPos = originalSourceFile.startOfLinePositions[end.line] + end.column;
-    const text = originalSourceFile.contents.substring(startPos, endPos);
+    const text = originalSourceFile.contents.substring(startPos, endPos).trim();
     return {file: originalStart.file, start, end, text};
   }
 }

--- a/packages/localize/src/tools/test/extract/integration/main_spec.ts
+++ b/packages/localize/src/tools/test/extract/integration/main_spec.ts
@@ -399,7 +399,8 @@ runInNativeFileSystem(() => {
              // These source file paths are due to how Bazel TypeScript compilation source-maps
              // work
              `          <context context-type="sourcefile">../packages/localize/src/tools/test/extract/integration/test_files/src/a.ts</context>`,
-             `          <context context-type="linenumber">3</context>`,
+             `          <context context-type="linenumber">3,${
+                 target === 'es2015' ? 7 : 5}</context>`,
              `        </context-group>`,
              `      </trans-unit>`,
              `      <trans-unit id="7829869508202074508" datatype="html">`,

--- a/packages/localize/src/tools/test/extract/integration/test_files/src/a.ts
+++ b/packages/localize/src/tools/test/extract/integration/test_files/src/a.ts
@@ -1,3 +1,7 @@
 declare const $localize: any;
 const file = 'a.ts';
-export const messageA = $localize`Message in ${file}:a-file:!`;
+export const messageA = $localize`Message in ${
+
+    file
+
+}:a-file:!`;


### PR DESCRIPTION
The ViewEngine message extraction would trim the values
of the `equiv-text` attributes. This commit aligns the Ivy
extraction of these attributes.

Fixes #41176

