### PR TITLE
[11.2.x] fix(docs-infra): fix angular.io on IE 11

### DIFF
--- a/aio/angular.json
+++ b/aio/angular.json
@@ -46,11 +46,6 @@
               "src/pwa-manifest.json",
               "src/google385281288605d160.html",
               {
-                "glob": "custom-elements.min.js",
-                "input": "node_modules/@webcomponents/custom-elements",
-                "output": "/assets/js"
-              },
-              {
                 "glob": "native-shim.js",
                 "input": "node_modules/@webcomponents/custom-elements/src",
                 "output": "/assets/js"
@@ -157,11 +152,6 @@
               "src/generated",
               "src/pwa-manifest.json",
               "src/google385281288605d160.html",
-              {
-                "glob": "custom-elements.min.js",
-                "input": "node_modules/@webcomponents/custom-elements",
-                "output": "/assets/js"
-              },
               {
                 "glob": "native-shim.js",
                 "input": "node_modules/@webcomponents/custom-elements/src",

--- a/aio/angular.json
+++ b/aio/angular.json
@@ -49,6 +49,11 @@
                 "glob": "native-shim.js",
                 "input": "node_modules/@webcomponents/custom-elements/src",
                 "output": "/assets/js"
+              },
+              {
+                "glob": "es.reflect.construct.js",
+                "input": "node_modules/core-js/modules",
+                "output": "/assets/js"
               }
             ],
             "styles": [
@@ -155,6 +160,11 @@
               {
                 "glob": "native-shim.js",
                 "input": "node_modules/@webcomponents/custom-elements/src",
+                "output": "/assets/js"
+              },
+              {
+                "glob": "es.reflect.construct.js",
+                "input": "node_modules/core-js/modules",
                 "output": "/assets/js"
               }
             ],

--- a/aio/ngsw-config.json
+++ b/aio/ngsw-config.json
@@ -13,6 +13,7 @@
           "/assets/js/*.js",
           "/*.css",
           "/*.js",
+          "!/assets/js/native-shim.js",
           "!/*-es5*.js"
         ],
         "urls": [
@@ -39,6 +40,7 @@
       "resources": {
         "files": [
           "/assets/images/favicons/**",
+          "/assets/js/native-shim.js",
           "/*-es5*.js",
           "!/**/_unused/**"
         ]

--- a/aio/ngsw-config.json
+++ b/aio/ngsw-config.json
@@ -13,6 +13,7 @@
           "/assets/js/*.js",
           "/*.css",
           "/*.js",
+          "!/assets/js/es.reflect.construct.js",
           "!/assets/js/native-shim.js",
           "!/*-es5*.js"
         ],
@@ -40,6 +41,7 @@
       "resources": {
         "files": [
           "/assets/images/favicons/**",
+          "/assets/js/es.reflect.construct.js",
           "/assets/js/native-shim.js",
           "/*-es5*.js",
           "!/**/_unused/**"

--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -118,6 +118,7 @@
           - Samsung browser 5.0-8.1 (~0.43% global usage)
           - Opera 41-47 (~0.02% global usage)
   -->
+  <script src="assets/js/es.reflect.construct.js" nomodule></script>;
   <script src="assets/js/native-shim.js" nomodule></script>;
 
 </body>

--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -108,6 +108,18 @@
       <b><i>This website requires JavaScript.</i></b>
     </h2>
   </noscript>
+
+  <!--
+    Custom Element ES5 shim. Required for browsers that natively support Custom Elements, but do not
+    support ES2015 modules.
+    NOTE: Chrome, Firefox and Safari should not need this, because they added support for ES2015
+          modules before Custom Elements. It is still required for some other (less common) browsers:
+          - UC browser for android 11.8 (~3.5% global usage)
+          - Samsung browser 5.0-8.1 (~0.43% global usage)
+          - Opera 41-47 (~0.02% global usage)
+  -->
+  <script src="assets/js/native-shim.js" nomodule></script>;
+
 </body>
 
 </html>

--- a/aio/src/polyfills.ts
+++ b/aio/src/polyfills.ts
@@ -65,11 +65,3 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
  */
 // Custom Elements polyfill. Required for browsers that do not natively support Custom Elements.
 import '@webcomponents/custom-elements';
-// Custom Element ES5 shim. Required for browsers that natively support Custom Elements, but do not
-// support ES2015 modules.
-// NOTE: Chrome, Firefox and Safari should not need this, because they added support for ES2015
-//       modules before Custom Elements. It is still required for some other (less common) browsers:
-//       - UC browser for android 11.8 (~3.5% global usage)
-//       - Samsung browser 5.0-8.1 (~0.43% global usage)
-//       - Opera 41-47 (~0.02% global usage)
-import '@webcomponents/custom-elements/src/native-shim';

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -4,7 +4,7 @@
       "uncompressed": {
         "runtime-es2015": 3033,
         "main-es2015": 450333,
-        "polyfills-es2015": 52343
+        "polyfills-es2015": 52215
       }
     }
   },
@@ -13,7 +13,7 @@
       "uncompressed": {
         "runtime-es2015": 3033,
         "main-es2015": 450363,
-        "polyfills-es2015": 52493
+        "polyfills-es2015": 52215
       }
     }
   },
@@ -22,7 +22,7 @@
       "uncompressed": {
         "runtime-es2015": 3153,
         "main-es2015": 435185,
-        "polyfills-es2015": 52493
+        "polyfills-es2015": 52215
       }
     }
   }


### PR DESCRIPTION
_This is a backport of #41162 to the `11.2.x` branch._

##
- **fix(docs-infra): avoid unnecessarily loading Custom Elements ES5 shim:**
    The custom elements spec is not compatible with ES5 style classes. This means ES2015 code compiled to ES5 will not work with a native implementation of Custom Elements. To support browsers that natively support Custom Elements but not ES2015 modules, we load `@webcomponents/custom-elements/src/native-shim.js`, which minimally augments the native implementation to be compatible with ES5 code.
    (See [here](https://www.npmjs.com/package/@webcomponents/custom-elements#es5-vs-es2015) for more details.)

    Previously, the shim was included in `polyfills.ts`, which meant it was loaded in all browsers (even those supporting ES2015 modules and thus not needing the shim).

    This commit moves the shim from `polyfills.ts` to a `nomodule` script tag in `index.html`. This will ensure that it is only loaded in browsers that do not support ES2015 modules and thus do not needed the shim.

    NOTE:
    This commit also reduces size of the polyfills bundle by ~400B (52609B --> 52215B).

- **fix(docs-infra): fix angular.io on IE 11:**
    Previously, the angular.io app was broken on IE 11. In particular, pages that included Custom Elements would fail to load, because the `Reflect.construct()` method (which the Custom Elements ES5 shim relies on) was not available.

    This commit fixes this by loading the polyfill for `Reflect.construct()` on browsers that do not support ES2015 (including IE 11).