### PR TITLE
docs: change the app name reference

### DIFF
--- a/aio/content/tutorial/toh-pt0.md
+++ b/aio/content/tutorial/toh-pt0.md
@@ -40,7 +40,7 @@ The Angular CLI installs the necessary Angular `npm` packages and other dependen
 It also creates the following workspace and starter project files:
 
   * A new workspace, with a root folder named `angular-tour-of-heroes`.
-  * An initial skeleton app project, also called `angular-tour-of-heroes` (in the `src` subfolder).
+  * An initial set of files and folders that Angular requires to launch a basic application.
   * An end-to-end test project (in the e2e subfolder).
   * Related configuration files.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The tutorial indicates : 
`An initial skeleton app project, also called angular-tour-of-heroes (in the src subfolder).`

The src subfolder of the skeleton app project is always named `app`, regardless of the name of the workspace


## What is the new behavior?

The next test is :
`An initial skeleton app project, called app (in the src subfolder).`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
