### PR TITLE
feat(ngcc): support `__spreadArray` helper as used by TypeScript 4.2

### DIFF
--- a/packages/compiler-cli/ngcc/src/utils.ts
+++ b/packages/compiler-cli/ngcc/src/utils.ts
@@ -163,6 +163,8 @@ export function getTsHelperFnFromIdentifier(id: ts.Identifier): KnownDeclaration
       return KnownDeclaration.TsHelperSpreadArrays;
     case '__spreadArray':
       return KnownDeclaration.TsHelperSpreadArray;
+    case '__read':
+      return KnownDeclaration.TsHelperRead;
     default:
       return null;
   }

--- a/packages/compiler-cli/ngcc/src/utils.ts
+++ b/packages/compiler-cli/ngcc/src/utils.ts
@@ -161,6 +161,8 @@ export function getTsHelperFnFromIdentifier(id: ts.Identifier): KnownDeclaration
       return KnownDeclaration.TsHelperSpread;
     case '__spreadArrays':
       return KnownDeclaration.TsHelperSpreadArrays;
+    case '__spreadArray':
+      return KnownDeclaration.TsHelperSpreadArray;
     default:
       return null;
   }

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -1999,10 +1999,12 @@ exports.MissingClass2 = MissingClass2;
               function __assign(t, ...sources) { /* ... */ }
               function __spread(...args) { /* ... */ }
               function __spreadArrays(...args) { /* ... */ }
+              function __spreadArray(to, from) { /* ... */ }
 
               var a = __assign({foo: 'bar'}, {baz: 'qux'});
               var b = __spread(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+              var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
             `,
           };
           loadTestFiles([file]);
@@ -2018,6 +2020,7 @@ exports.MissingClass2 = MissingClass2;
           testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+          testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
         });
 
         it('should recognize suffixed TypeScript helpers (as function declarations)', () => {
@@ -2027,10 +2030,12 @@ exports.MissingClass2 = MissingClass2;
               function __assign$1(t, ...sources) { /* ... */ }
               function __spread$2(...args) { /* ... */ }
               function __spreadArrays$3(...args) { /* ... */ }
+              function __spreadArray$3(to, from) { /* ... */ }
 
               var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
               var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+              var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
             `,
           };
           loadTestFiles([file]);
@@ -2046,6 +2051,7 @@ exports.MissingClass2 = MissingClass2;
           testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+          testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
         });
 
         it('should recognize TypeScript helpers (as variable declarations)', () => {
@@ -2055,10 +2061,12 @@ exports.MissingClass2 = MissingClass2;
               var __assign = (this && this.__assign) || function (t, ...sources) { /* ... */ }
               var __spread = (this && this.__spread) || function (...args) { /* ... */ }
               var __spreadArrays = (this && this.__spreadArrays) || function (...args) { /* ... */ }
+              var __spreadArray = (this && this.__spreadArray) || function (to, from) { /* ... */ }
 
               var a = __assign({foo: 'bar'}, {baz: 'qux'});
               var b = __spread(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+              var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
             `,
           };
           loadTestFiles([file]);
@@ -2074,6 +2082,7 @@ exports.MissingClass2 = MissingClass2;
           testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+          testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
         });
 
         it('should recognize suffixed TypeScript helpers (as variable declarations)', () => {
@@ -2083,10 +2092,12 @@ exports.MissingClass2 = MissingClass2;
               var __assign$1 = (this && this.__assign$1) || function (t, ...sources) { /* ... */ }
               var __spread$2 = (this && this.__spread$2) || function (...args) { /* ... */ }
               var __spreadArrays$3 = (this && this.__spreadArrays$3) || function (...args) { /* ... */ }
+              var __spreadArray$3 = (this && this.__spreadArray$3) || function (to, from) { /* ... */ }
 
               var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
               var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+              var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
             `,
           };
           loadTestFiles([file]);
@@ -2102,6 +2113,7 @@ exports.MissingClass2 = MissingClass2;
           testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+          testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
         });
 
         it('should recognize imported TypeScript helpers', () => {
@@ -2114,6 +2126,7 @@ exports.MissingClass2 = MissingClass2;
                 var a = tslib_1.__assign({foo: 'bar'}, {baz: 'qux'});
                 var b = tslib_1.__spread(['foo', 'bar'], ['baz', 'qux']);
                 var c = tslib_1.__spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+                var d = tslib_1.__spreadArray(['foo', 'bar'], ['baz', 'qux']);
               `,
             },
             {
@@ -2122,6 +2135,7 @@ exports.MissingClass2 = MissingClass2;
                 export declare function __assign(t: any, ...sources: any[]): any;
                 export declare function __spread(...args: any[][]): any[];
                 export declare function __spreadArrays(...args: any[][]): any[];
+                export declare function __spreadArray(to: any[], from: any[]): any[];
               `,
             },
           ];
@@ -2140,6 +2154,7 @@ exports.MissingClass2 = MissingClass2;
           testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign, 'tslib');
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
+          testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray, 'tslib');
         });
 
         it('should recognize undeclared, unimported TypeScript helpers (by name)', () => {
@@ -2149,6 +2164,7 @@ exports.MissingClass2 = MissingClass2;
               var a = __assign({foo: 'bar'}, {baz: 'qux'});
               var b = __spread(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+              var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
             `,
           };
           loadTestFiles([file]);
@@ -2174,6 +2190,7 @@ exports.MissingClass2 = MissingClass2;
           testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+          testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
         });
 
         it('should recognize suffixed, undeclared, unimported TypeScript helpers (by name)', () => {
@@ -2183,6 +2200,7 @@ exports.MissingClass2 = MissingClass2;
               var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
               var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+              var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
             `,
           };
           loadTestFiles([file]);
@@ -2208,6 +2226,7 @@ exports.MissingClass2 = MissingClass2;
           testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+          testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
         });
 
         it('should recognize enum declarations with string values', () => {
@@ -2441,6 +2460,7 @@ exports.MissingClass2 = MissingClass2;
               export declare function __assign(t: any, ...sources: any[]): any;
               export declare function __spread(...args: any[][]): any[];
               export declare function __spreadArrays(...args: any[][]): any[];
+              export declare function __spreadArray(to: any[], from: any[]): any[];
               export declare function __unknownHelper(...args: any[]): any;
             `,
           };
@@ -2456,6 +2476,7 @@ exports.MissingClass2 = MissingClass2;
                 ['__assign', KnownDeclaration.TsHelperAssign],
                 ['__spread', KnownDeclaration.TsHelperSpread],
                 ['__spreadArrays', KnownDeclaration.TsHelperSpreadArrays],
+                ['__spreadArray', KnownDeclaration.TsHelperSpreadArray],
                 ['__unknownHelper', null],
               ]);
         });

--- a/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/commonjs_host_spec.ts
@@ -2000,11 +2000,13 @@ exports.MissingClass2 = MissingClass2;
               function __spread(...args) { /* ... */ }
               function __spreadArrays(...args) { /* ... */ }
               function __spreadArray(to, from) { /* ... */ }
+              function __read(o) { /* ... */ }
 
               var a = __assign({foo: 'bar'}, {baz: 'qux'});
               var b = __spread(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
               var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
+              var e = __read(['foo', 'bar']);
             `,
           };
           loadTestFiles([file]);
@@ -2021,6 +2023,7 @@ exports.MissingClass2 = MissingClass2;
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
           testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
+          testForHelper('e', '__read', KnownDeclaration.TsHelperRead);
         });
 
         it('should recognize suffixed TypeScript helpers (as function declarations)', () => {
@@ -2031,11 +2034,13 @@ exports.MissingClass2 = MissingClass2;
               function __spread$2(...args) { /* ... */ }
               function __spreadArrays$3(...args) { /* ... */ }
               function __spreadArray$3(to, from) { /* ... */ }
+              function __read$3(o) { /* ... */ }
 
               var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
               var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
               var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
+              var e = __read$3(['foo', 'bar']);
             `,
           };
           loadTestFiles([file]);
@@ -2052,6 +2057,7 @@ exports.MissingClass2 = MissingClass2;
           testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
           testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
+          testForHelper('e', '__read$3', KnownDeclaration.TsHelperRead);
         });
 
         it('should recognize TypeScript helpers (as variable declarations)', () => {
@@ -2062,11 +2068,13 @@ exports.MissingClass2 = MissingClass2;
               var __spread = (this && this.__spread) || function (...args) { /* ... */ }
               var __spreadArrays = (this && this.__spreadArrays) || function (...args) { /* ... */ }
               var __spreadArray = (this && this.__spreadArray) || function (to, from) { /* ... */ }
+              var __read = (this && this.__read) || function (o) { /* ... */ }
 
               var a = __assign({foo: 'bar'}, {baz: 'qux'});
               var b = __spread(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
               var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
+              var e = __read(['foo', 'bar']);
             `,
           };
           loadTestFiles([file]);
@@ -2083,6 +2091,7 @@ exports.MissingClass2 = MissingClass2;
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
           testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
+          testForHelper('e', '__read', KnownDeclaration.TsHelperRead);
         });
 
         it('should recognize suffixed TypeScript helpers (as variable declarations)', () => {
@@ -2093,11 +2102,13 @@ exports.MissingClass2 = MissingClass2;
               var __spread$2 = (this && this.__spread$2) || function (...args) { /* ... */ }
               var __spreadArrays$3 = (this && this.__spreadArrays$3) || function (...args) { /* ... */ }
               var __spreadArray$3 = (this && this.__spreadArray$3) || function (to, from) { /* ... */ }
+              var __read$3 = (this && this.__read$3) || function (o) { /* ... */ }
 
               var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
               var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
               var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
+              var e = __read$3(['foo', 'bar']);
             `,
           };
           loadTestFiles([file]);
@@ -2114,6 +2125,7 @@ exports.MissingClass2 = MissingClass2;
           testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
           testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
+          testForHelper('e', '__read$3', KnownDeclaration.TsHelperRead);
         });
 
         it('should recognize imported TypeScript helpers', () => {
@@ -2127,6 +2139,7 @@ exports.MissingClass2 = MissingClass2;
                 var b = tslib_1.__spread(['foo', 'bar'], ['baz', 'qux']);
                 var c = tslib_1.__spreadArrays(['foo', 'bar'], ['baz', 'qux']);
                 var d = tslib_1.__spreadArray(['foo', 'bar'], ['baz', 'qux']);
+                var e = tslib_1.__read(['foo', 'bar']);
               `,
             },
             {
@@ -2136,6 +2149,7 @@ exports.MissingClass2 = MissingClass2;
                 export declare function __spread(...args: any[][]): any[];
                 export declare function __spreadArrays(...args: any[][]): any[];
                 export declare function __spreadArray(to: any[], from: any[]): any[];
+                export declare function __read(o: any, n?: number): any[];
               `,
             },
           ];
@@ -2155,6 +2169,7 @@ exports.MissingClass2 = MissingClass2;
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
           testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray, 'tslib');
+          testForHelper('e', '__read', KnownDeclaration.TsHelperRead, 'tslib');
         });
 
         it('should recognize undeclared, unimported TypeScript helpers (by name)', () => {
@@ -2165,6 +2180,7 @@ exports.MissingClass2 = MissingClass2;
               var b = __spread(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
               var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
+              var e = __read(['foo', 'bar']);
             `,
           };
           loadTestFiles([file]);
@@ -2191,6 +2207,7 @@ exports.MissingClass2 = MissingClass2;
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
           testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
+          testForHelper('e', '__read', KnownDeclaration.TsHelperRead);
         });
 
         it('should recognize suffixed, undeclared, unimported TypeScript helpers (by name)', () => {
@@ -2201,6 +2218,7 @@ exports.MissingClass2 = MissingClass2;
               var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
               var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
+              var e = __read$3(['foo', 'bar']);
             `,
           };
           loadTestFiles([file]);
@@ -2227,6 +2245,7 @@ exports.MissingClass2 = MissingClass2;
           testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
           testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
+          testForHelper('e', '__read$3', KnownDeclaration.TsHelperRead);
         });
 
         it('should recognize enum declarations with string values', () => {
@@ -2461,6 +2480,7 @@ exports.MissingClass2 = MissingClass2;
               export declare function __spread(...args: any[][]): any[];
               export declare function __spreadArrays(...args: any[][]): any[];
               export declare function __spreadArray(to: any[], from: any[]): any[];
+              export declare function __read(o: any, n?: number): any[];
               export declare function __unknownHelper(...args: any[]): any;
             `,
           };
@@ -2477,6 +2497,7 @@ exports.MissingClass2 = MissingClass2;
                 ['__spread', KnownDeclaration.TsHelperSpread],
                 ['__spreadArrays', KnownDeclaration.TsHelperSpreadArrays],
                 ['__spreadArray', KnownDeclaration.TsHelperSpreadArray],
+                ['__read', KnownDeclaration.TsHelperRead],
                 ['__unknownHelper', null],
               ]);
         });

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -2060,11 +2060,13 @@ runInEachFileSystem(() => {
             function __spread(...args) { /* ... */ }
             function __spreadArrays(...args) { /* ... */ }
             function __spreadArray(to, from) { /* ... */ }
+            function __read(o) { /* ... */ }
 
             var a = __assign({foo: 'bar'}, {baz: 'qux'});
             var b = __spread(['foo', 'bar'], ['baz', 'qux']);
             var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
             var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
+            var e = __read(['foo', 'bar']);
           `,
         };
         loadTestFiles([file]);
@@ -2080,6 +2082,7 @@ runInEachFileSystem(() => {
         testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
         testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
         testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
+        testForHelper('e', '__read', KnownDeclaration.TsHelperRead);
       });
 
       it('should recognize suffixed TypeScript helpers (as function declarations)', () => {
@@ -2090,11 +2093,13 @@ runInEachFileSystem(() => {
             function __spread$2(...args) { /* ... */ }
             function __spreadArrays$3(...args) { /* ... */ }
             function __spreadArray$3(to, from) { /* ... */ }
+            function __read$3(o) { /* ... */ }
 
             var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
             var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
             var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
             var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
+            var e = __read$3(['foo', 'bar']);
           `,
         };
         loadTestFiles([file]);
@@ -2110,6 +2115,7 @@ runInEachFileSystem(() => {
         testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
         testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
         testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
+        testForHelper('e', '__read$3', KnownDeclaration.TsHelperRead);
       });
 
       it('should recognize TypeScript helpers (as variable declarations)', () => {
@@ -2120,11 +2126,13 @@ runInEachFileSystem(() => {
             var __spread = (this && this.__spread) || function (...args) { /* ... */ }
             var __spreadArrays = (this && this.__spreadArrays) || function (...args) { /* ... */ }
             var __spreadArray = (this && this.__spreadArray) || function (to, from) { /* ... */ }
+            var __read = (this && this._read) || function (o) { /* ... */ }
 
             var a = __assign({foo: 'bar'}, {baz: 'qux'});
             var b = __spread(['foo', 'bar'], ['baz', 'qux']);
             var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
             var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
+            var e = __read(['foo', 'bar']);
        `,
         };
         loadTestFiles([file]);
@@ -2140,6 +2148,7 @@ runInEachFileSystem(() => {
         testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
         testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
         testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
+        testForHelper('e', '__read', KnownDeclaration.TsHelperRead);
       });
 
       it('should recognize suffixed TypeScript helpers (as variable declarations)', () => {
@@ -2150,11 +2159,13 @@ runInEachFileSystem(() => {
             var __spread$2 = (this && this.__spread$2) || function (...args) { /* ... */ }
             var __spreadArrays$3 = (this && this.__spreadArrays$3) || function (...args) { /* ... */ }
             var __spreadArray$3 = (this && this.__spreadArray$3) || function (to, from) { /* ... */ }
+            var __read$3 = (this && this.__read$3) || function (o) { /* ... */ }
 
             var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
             var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
             var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
             var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
+            var e = __read$3(['foo', 'bar']);
           `,
         };
         loadTestFiles([file]);
@@ -2170,6 +2181,7 @@ runInEachFileSystem(() => {
         testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
         testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
         testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
+        testForHelper('e', '__read$3', KnownDeclaration.TsHelperRead);
       });
 
       it('should recognize imported TypeScript helpers (named imports)', () => {
@@ -2177,12 +2189,13 @@ runInEachFileSystem(() => {
           {
             name: _('/test.js'),
             contents: `
-              import {__assign, __spread, __spreadArrays, __spreadArray} from 'tslib';
+              import {__assign, __spread, __spreadArrays, __spreadArray, __read} from 'tslib';
 
               var a = __assign({foo: 'bar'}, {baz: 'qux'});
               var b = __spread(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
               var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
+              var e = __read(['foo', 'bar']);
             `,
           },
           {
@@ -2192,6 +2205,7 @@ runInEachFileSystem(() => {
               export declare function __spread(...args: any[][]): any[];
               export declare function __spreadArrays(...args: any[][]): any[];
               export declare function __spreadArray(to: any[], from: any[]): any[];
+              export declare function __read(o: any, n?: number): any[];
             `,
           },
         ];
@@ -2210,6 +2224,7 @@ runInEachFileSystem(() => {
         testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
         testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
         testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray, 'tslib');
+        testForHelper('e', '__read', KnownDeclaration.TsHelperRead, 'tslib');
       });
 
       it('should recognize imported TypeScript helpers (star import)', () => {
@@ -2223,6 +2238,7 @@ runInEachFileSystem(() => {
               var b = tslib_1.__spread(['foo', 'bar'], ['baz', 'qux']);
               var c = tslib_1.__spreadArrays(['foo', 'bar'], ['baz', 'qux']);
               var d = tslib_1.__spreadArray(['foo', 'bar'], ['baz', 'qux']);
+              var e = tslib_1.__read(['foo', 'bar']);
             `,
           },
           {
@@ -2232,6 +2248,7 @@ runInEachFileSystem(() => {
               export declare function __spread(...args: any[][]): any[];
               export declare function __spreadArrays(...args: any[][]): any[];
               export declare function __spreadArray(to: any[], from: any[]): any[];
+              export declare function __read(o: any, n?: number): any[];
             `,
           },
         ];
@@ -2250,6 +2267,7 @@ runInEachFileSystem(() => {
         testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
         testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
         testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray, 'tslib');
+        testForHelper('e', '__read', KnownDeclaration.TsHelperRead, 'tslib');
       });
 
       it('should recognize undeclared, unimported TypeScript helpers (by name)', () => {
@@ -2260,6 +2278,7 @@ runInEachFileSystem(() => {
             var b = __spread(['foo', 'bar'], ['baz', 'qux']);
             var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
             var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
+            var e = __read(['foo', 'bar']);
           `,
         };
         loadTestFiles([file]);
@@ -2283,6 +2302,7 @@ runInEachFileSystem(() => {
         testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
         testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
         testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
+        testForHelper('e', '__read', KnownDeclaration.TsHelperRead);
       });
 
       it('should recognize suffixed, undeclared, unimported TypeScript helpers (by name)', () => {
@@ -2293,6 +2313,7 @@ runInEachFileSystem(() => {
             var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
             var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
             var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
+            var e = __read$3(['foo', 'bar']);
           `,
         };
         loadTestFiles([file]);
@@ -2316,6 +2337,7 @@ runInEachFileSystem(() => {
         testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
         testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
         testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
+        testForHelper('e', '__read', KnownDeclaration.TsHelperRead);
       });
 
       it('should recognize enum declarations with string values', () => {
@@ -2479,6 +2501,7 @@ runInEachFileSystem(() => {
             export declare function __spread(...args: any[][]): any[];
             export declare function __spreadArrays(...args: any[][]): any[];
             export declare function __spreadArray(to: any[], from: any[]): any[];
+            export declare function __read(o: any, n?: number): any[];
             export declare function __unknownHelper(...args: any[]): any;
           `,
         };
@@ -2494,6 +2517,7 @@ runInEachFileSystem(() => {
               ['__spread', KnownDeclaration.TsHelperSpread],
               ['__spreadArrays', KnownDeclaration.TsHelperSpreadArrays],
               ['__spreadArray', KnownDeclaration.TsHelperSpreadArray],
+              ['__read', KnownDeclaration.TsHelperRead],
               ['__unknownHelper', null],
             ]);
       });

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -2059,10 +2059,12 @@ runInEachFileSystem(() => {
             function __assign(t, ...sources) { /* ... */ }
             function __spread(...args) { /* ... */ }
             function __spreadArrays(...args) { /* ... */ }
+            function __spreadArray(to, from) { /* ... */ }
 
             var a = __assign({foo: 'bar'}, {baz: 'qux'});
             var b = __spread(['foo', 'bar'], ['baz', 'qux']);
             var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+            var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
           `,
         };
         loadTestFiles([file]);
@@ -2077,6 +2079,7 @@ runInEachFileSystem(() => {
         testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
         testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
         testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+        testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
       });
 
       it('should recognize suffixed TypeScript helpers (as function declarations)', () => {
@@ -2086,10 +2089,12 @@ runInEachFileSystem(() => {
             function __assign$1(t, ...sources) { /* ... */ }
             function __spread$2(...args) { /* ... */ }
             function __spreadArrays$3(...args) { /* ... */ }
+            function __spreadArray$3(to, from) { /* ... */ }
 
             var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
             var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
             var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+            var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
           `,
         };
         loadTestFiles([file]);
@@ -2104,6 +2109,7 @@ runInEachFileSystem(() => {
         testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
         testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
         testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+        testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
       });
 
       it('should recognize TypeScript helpers (as variable declarations)', () => {
@@ -2113,11 +2119,13 @@ runInEachFileSystem(() => {
             var __assign = (this && this.__assign) || function (t, ...sources) { /* ... */ }
             var __spread = (this && this.__spread) || function (...args) { /* ... */ }
             var __spreadArrays = (this && this.__spreadArrays) || function (...args) { /* ... */ }
+            var __spreadArray = (this && this.__spreadArray) || function (to, from) { /* ... */ }
 
             var a = __assign({foo: 'bar'}, {baz: 'qux'});
             var b = __spread(['foo', 'bar'], ['baz', 'qux']);
             var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
-          `,
+            var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
+       `,
         };
         loadTestFiles([file]);
         const bundle = makeTestBundleProgram(file.name);
@@ -2131,6 +2139,7 @@ runInEachFileSystem(() => {
         testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
         testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
         testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+        testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
       });
 
       it('should recognize suffixed TypeScript helpers (as variable declarations)', () => {
@@ -2140,10 +2149,12 @@ runInEachFileSystem(() => {
             var __assign$1 = (this && this.__assign$1) || function (t, ...sources) { /* ... */ }
             var __spread$2 = (this && this.__spread$2) || function (...args) { /* ... */ }
             var __spreadArrays$3 = (this && this.__spreadArrays$3) || function (...args) { /* ... */ }
+            var __spreadArray$3 = (this && this.__spreadArray$3) || function (to, from) { /* ... */ }
 
             var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
             var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
             var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+            var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
           `,
         };
         loadTestFiles([file]);
@@ -2158,6 +2169,7 @@ runInEachFileSystem(() => {
         testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
         testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
         testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+        testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
       });
 
       it('should recognize imported TypeScript helpers (named imports)', () => {
@@ -2165,11 +2177,12 @@ runInEachFileSystem(() => {
           {
             name: _('/test.js'),
             contents: `
-              import {__assign, __spread, __spreadArrays} from 'tslib';
+              import {__assign, __spread, __spreadArrays, __spreadArray} from 'tslib';
 
               var a = __assign({foo: 'bar'}, {baz: 'qux'});
               var b = __spread(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+              var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
             `,
           },
           {
@@ -2178,6 +2191,7 @@ runInEachFileSystem(() => {
               export declare function __assign(t: any, ...sources: any[]): any;
               export declare function __spread(...args: any[][]): any[];
               export declare function __spreadArrays(...args: any[][]): any[];
+              export declare function __spreadArray(to: any[], from: any[]): any[];
             `,
           },
         ];
@@ -2195,6 +2209,7 @@ runInEachFileSystem(() => {
         testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign, 'tslib');
         testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
         testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
+        testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray, 'tslib');
       });
 
       it('should recognize imported TypeScript helpers (star import)', () => {
@@ -2207,6 +2222,7 @@ runInEachFileSystem(() => {
               var a = tslib_1.__assign({foo: 'bar'}, {baz: 'qux'});
               var b = tslib_1.__spread(['foo', 'bar'], ['baz', 'qux']);
               var c = tslib_1.__spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+              var d = tslib_1.__spreadArray(['foo', 'bar'], ['baz', 'qux']);
             `,
           },
           {
@@ -2215,6 +2231,7 @@ runInEachFileSystem(() => {
               export declare function __assign(t: any, ...sources: any[]): any;
               export declare function __spread(...args: any[][]): any[];
               export declare function __spreadArrays(...args: any[][]): any[];
+              export declare function __spreadArray(to: any[], from: any[]): any[];
             `,
           },
         ];
@@ -2232,6 +2249,7 @@ runInEachFileSystem(() => {
         testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign, 'tslib');
         testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
         testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
+        testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray, 'tslib');
       });
 
       it('should recognize undeclared, unimported TypeScript helpers (by name)', () => {
@@ -2241,6 +2259,7 @@ runInEachFileSystem(() => {
             var a = __assign({foo: 'bar'}, {baz: 'qux'});
             var b = __spread(['foo', 'bar'], ['baz', 'qux']);
             var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+            var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
           `,
         };
         loadTestFiles([file]);
@@ -2263,6 +2282,7 @@ runInEachFileSystem(() => {
         testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
         testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
         testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+        testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
       });
 
       it('should recognize suffixed, undeclared, unimported TypeScript helpers (by name)', () => {
@@ -2272,6 +2292,7 @@ runInEachFileSystem(() => {
             var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
             var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
             var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+            var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
           `,
         };
         loadTestFiles([file]);
@@ -2294,6 +2315,7 @@ runInEachFileSystem(() => {
         testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
         testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
         testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+        testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
       });
 
       it('should recognize enum declarations with string values', () => {
@@ -2456,6 +2478,7 @@ runInEachFileSystem(() => {
             export declare function __assign(t: any, ...sources: any[]): any;
             export declare function __spread(...args: any[][]): any[];
             export declare function __spreadArrays(...args: any[][]): any[];
+            export declare function __spreadArray(to: any[], from: any[]): any[];
             export declare function __unknownHelper(...args: any[]): any;
           `,
         };
@@ -2470,6 +2493,7 @@ runInEachFileSystem(() => {
               ['__assign', KnownDeclaration.TsHelperAssign],
               ['__spread', KnownDeclaration.TsHelperSpread],
               ['__spreadArrays', KnownDeclaration.TsHelperSpreadArrays],
+              ['__spreadArray', KnownDeclaration.TsHelperSpreadArray],
               ['__unknownHelper', null],
             ]);
       });

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -2332,11 +2332,13 @@ runInEachFileSystem(() => {
               function __spread(...args) { /* ... */ }
               function __spreadArrays(...args) { /* ... */ }
               function __spreadArray(to, from) { /* ... */ }
+              function __read(o) { /* ... */ }
 
               var a = __assign({foo: 'bar'}, {baz: 'qux'});
               var b = __spread(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
               var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
+              var e = __read(['foo', 'bar']);
             })));
           `,
           };
@@ -2352,6 +2354,7 @@ runInEachFileSystem(() => {
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
           testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
+          testForHelper('e', '__read', KnownDeclaration.TsHelperRead);
         });
 
         it('should recognize suffixed TypeScript helpers (as function declarations)', () => {
@@ -2367,11 +2370,13 @@ runInEachFileSystem(() => {
               function __spread$2(...args) { /* ... */ }
               function __spreadArrays$3(...args) { /* ... */ }
               function __spreadArray$3(to, from) { /* ... */ }
+              function __read$3(o) { /* ... */ }
 
               var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
               var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
               var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
+              var e = __read$3(['foo', 'bar']);
             })));
           `,
           };
@@ -2387,6 +2392,7 @@ runInEachFileSystem(() => {
           testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
           testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
+          testForHelper('e', '__read$3', KnownDeclaration.TsHelperRead);
         });
 
         it('should recognize TypeScript helpers (as variable declarations)', () => {
@@ -2402,11 +2408,13 @@ runInEachFileSystem(() => {
               var __spread = (this && this.__spread) || function (...args) { /* ... */ }
               var __spreadArrays = (this && this.__spreadArrays) || function (...args) { /* ... */ }
               var __spreadArray = (this && this.__spreadArray) || function (to, from) { /* ... */ }
+              var __read = (this && this.__read) || function (o) { /* ... */ }
 
               var a = __assign({foo: 'bar'}, {baz: 'qux'});
               var b = __spread(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
               var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
+              var e = __read(['foo', 'bar']);
             })));
           `,
           };
@@ -2422,6 +2430,7 @@ runInEachFileSystem(() => {
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
           testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
+          testForHelper('e', '__read', KnownDeclaration.TsHelperRead);
         });
 
         it('should recognize suffixed TypeScript helpers (as variable declarations)', () => {
@@ -2437,11 +2446,13 @@ runInEachFileSystem(() => {
               var __spread$2 = (this && this.__spread$2) || function (...args) { /* ... */ }
               var __spreadArrays$3 = (this && this.__spreadArrays$3) || function (...args) { /* ... */ }
               var __spreadArray$3 = (this && this.__spreadArray$3) || function (to, from) { /* ... */ }
+              var __read$3 = (this && this.__read$3) || function (o) { /* ... */ }
 
               var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
               var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
               var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
+              var e = __read$3(['foo', 'bar']);
             })));
           `,
           };
@@ -2457,6 +2468,7 @@ runInEachFileSystem(() => {
           testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
           testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
+          testForHelper('e', '__read$3', KnownDeclaration.TsHelperRead);
         });
 
         it('should recognize imported TypeScript helpers', () => {
@@ -2473,6 +2485,7 @@ runInEachFileSystem(() => {
                 var b = tslib_1.__spread(['foo', 'bar'], ['baz', 'qux']);
                 var c = tslib_1.__spreadArrays(['foo', 'bar'], ['baz', 'qux']);
                 var d = tslib_1.__spreadArray(['foo', 'bar'], ['baz', 'qux']);
+                var e = tslib_1.__read(['foo', 'bar']);
               })));
             `,
             },
@@ -2483,6 +2496,7 @@ runInEachFileSystem(() => {
               export declare function __spread(...args: any[][]): any[];
               export declare function __spreadArrays(...args: any[][]): any[];
               export declare function __spreadArray(to: any[], from: any[]): any[];
+              export declare function __read(o: any, n?: number): any[];
             `,
             },
           ];
@@ -2502,6 +2516,7 @@ runInEachFileSystem(() => {
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
           testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray, 'tslib');
+          testForHelper('e', '__read', KnownDeclaration.TsHelperRead, 'tslib');
         });
 
         it('should recognize undeclared, unimported TypeScript helpers (by name)', () => {
@@ -2517,6 +2532,7 @@ runInEachFileSystem(() => {
               var b = __spread(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
               var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
+              var e = __read(['foo', 'bar']);
             })));
           `,
           };
@@ -2544,6 +2560,7 @@ runInEachFileSystem(() => {
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
           testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
+          testForHelper('e', '__read', KnownDeclaration.TsHelperRead);
         });
 
         it('should recognize suffixed, undeclared, unimported TypeScript helpers (by name)', () => {
@@ -2559,6 +2576,7 @@ runInEachFileSystem(() => {
               var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
               var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
+              var e = __read$3(['foo', 'bar']);
             })));
           `,
           };
@@ -2586,6 +2604,7 @@ runInEachFileSystem(() => {
           testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
           testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
+          testForHelper('e', '__read$3', KnownDeclaration.TsHelperRead);
         });
 
         it('should recognize enum declarations with string values', () => {
@@ -2861,6 +2880,7 @@ runInEachFileSystem(() => {
             export declare function __spread(...args: any[][]): any[];
             export declare function __spreadArrays(...args: any[][]): any[];
             export declare function __spreadArray(to: any[], from: any[]): any[];
+            export declare function __read(o: any, n?: number): any[];
             export declare function __unknownHelper(...args: any[]): any;
           `,
           };
@@ -2876,6 +2896,7 @@ runInEachFileSystem(() => {
                 ['__spread', KnownDeclaration.TsHelperSpread],
                 ['__spreadArrays', KnownDeclaration.TsHelperSpreadArrays],
                 ['__spreadArray', KnownDeclaration.TsHelperSpreadArray],
+                ['__read', KnownDeclaration.TsHelperRead],
                 ['__unknownHelper', null],
               ]);
         });

--- a/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/umd_host_spec.ts
@@ -2331,10 +2331,12 @@ runInEachFileSystem(() => {
               function __assign(t, ...sources) { /* ... */ }
               function __spread(...args) { /* ... */ }
               function __spreadArrays(...args) { /* ... */ }
+              function __spreadArray(to, from) { /* ... */ }
 
               var a = __assign({foo: 'bar'}, {baz: 'qux'});
               var b = __spread(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+              var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
             })));
           `,
           };
@@ -2349,6 +2351,7 @@ runInEachFileSystem(() => {
           testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+          testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
         });
 
         it('should recognize suffixed TypeScript helpers (as function declarations)', () => {
@@ -2363,10 +2366,12 @@ runInEachFileSystem(() => {
               function __assign$1(t, ...sources) { /* ... */ }
               function __spread$2(...args) { /* ... */ }
               function __spreadArrays$3(...args) { /* ... */ }
+              function __spreadArray$3(to, from) { /* ... */ }
 
               var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
               var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+              var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
             })));
           `,
           };
@@ -2381,6 +2386,7 @@ runInEachFileSystem(() => {
           testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+          testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
         });
 
         it('should recognize TypeScript helpers (as variable declarations)', () => {
@@ -2395,10 +2401,12 @@ runInEachFileSystem(() => {
               var __assign = (this && this.__assign) || function (t, ...sources) { /* ... */ }
               var __spread = (this && this.__spread) || function (...args) { /* ... */ }
               var __spreadArrays = (this && this.__spreadArrays) || function (...args) { /* ... */ }
+              var __spreadArray = (this && this.__spreadArray) || function (to, from) { /* ... */ }
 
               var a = __assign({foo: 'bar'}, {baz: 'qux'});
               var b = __spread(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+              var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
             })));
           `,
           };
@@ -2413,6 +2421,7 @@ runInEachFileSystem(() => {
           testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+          testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
         });
 
         it('should recognize suffixed TypeScript helpers (as variable declarations)', () => {
@@ -2427,10 +2436,12 @@ runInEachFileSystem(() => {
               var __assign$1 = (this && this.__assign$1) || function (t, ...sources) { /* ... */ }
               var __spread$2 = (this && this.__spread$2) || function (...args) { /* ... */ }
               var __spreadArrays$3 = (this && this.__spreadArrays$3) || function (...args) { /* ... */ }
+              var __spreadArray$3 = (this && this.__spreadArray$3) || function (to, from) { /* ... */ }
 
               var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
               var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+              var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
             })));
           `,
           };
@@ -2445,6 +2456,7 @@ runInEachFileSystem(() => {
           testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+          testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
         });
 
         it('should recognize imported TypeScript helpers', () => {
@@ -2460,6 +2472,7 @@ runInEachFileSystem(() => {
                 var a = tslib_1.__assign({foo: 'bar'}, {baz: 'qux'});
                 var b = tslib_1.__spread(['foo', 'bar'], ['baz', 'qux']);
                 var c = tslib_1.__spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+                var d = tslib_1.__spreadArray(['foo', 'bar'], ['baz', 'qux']);
               })));
             `,
             },
@@ -2469,6 +2482,7 @@ runInEachFileSystem(() => {
               export declare function __assign(t: any, ...sources: any[]): any;
               export declare function __spread(...args: any[][]): any[];
               export declare function __spreadArrays(...args: any[][]): any[];
+              export declare function __spreadArray(to: any[], from: any[]): any[];
             `,
             },
           ];
@@ -2487,6 +2501,7 @@ runInEachFileSystem(() => {
           testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign, 'tslib');
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread, 'tslib');
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays, 'tslib');
+          testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray, 'tslib');
         });
 
         it('should recognize undeclared, unimported TypeScript helpers (by name)', () => {
@@ -2501,6 +2516,7 @@ runInEachFileSystem(() => {
               var a = __assign({foo: 'bar'}, {baz: 'qux'});
               var b = __spread(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays(['foo', 'bar'], ['baz', 'qux']);
+              var d = __spreadArray(['foo', 'bar'], ['baz', 'qux']);
             })));
           `,
           };
@@ -2527,6 +2543,7 @@ runInEachFileSystem(() => {
           testForHelper('a', '__assign', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays', KnownDeclaration.TsHelperSpreadArrays);
+          testForHelper('d', '__spreadArray', KnownDeclaration.TsHelperSpreadArray);
         });
 
         it('should recognize suffixed, undeclared, unimported TypeScript helpers (by name)', () => {
@@ -2541,6 +2558,7 @@ runInEachFileSystem(() => {
               var a = __assign$1({foo: 'bar'}, {baz: 'qux'});
               var b = __spread$2(['foo', 'bar'], ['baz', 'qux']);
               var c = __spreadArrays$3(['foo', 'bar'], ['baz', 'qux']);
+              var d = __spreadArray$3(['foo', 'bar'], ['baz', 'qux']);
             })));
           `,
           };
@@ -2567,6 +2585,7 @@ runInEachFileSystem(() => {
           testForHelper('a', '__assign$1', KnownDeclaration.TsHelperAssign);
           testForHelper('b', '__spread$2', KnownDeclaration.TsHelperSpread);
           testForHelper('c', '__spreadArrays$3', KnownDeclaration.TsHelperSpreadArrays);
+          testForHelper('d', '__spreadArray$3', KnownDeclaration.TsHelperSpreadArray);
         });
 
         it('should recognize enum declarations with string values', () => {
@@ -2841,6 +2860,7 @@ runInEachFileSystem(() => {
             export declare function __assign(t: any, ...sources: any[]): any;
             export declare function __spread(...args: any[][]): any[];
             export declare function __spreadArrays(...args: any[][]): any[];
+            export declare function __spreadArray(to: any[], from: any[]): any[];
             export declare function __unknownHelper(...args: any[]): any;
           `,
           };
@@ -2855,6 +2875,7 @@ runInEachFileSystem(() => {
                 ['__assign', KnownDeclaration.TsHelperAssign],
                 ['__spread', KnownDeclaration.TsHelperSpread],
                 ['__spreadArrays', KnownDeclaration.TsHelperSpreadArrays],
+                ['__spreadArray', KnownDeclaration.TsHelperSpreadArray],
                 ['__unknownHelper', null],
               ]);
         });

--- a/packages/compiler-cli/ngcc/test/utils_spec.ts
+++ b/packages/compiler-cli/ngcc/test/utils_spec.ts
@@ -108,6 +108,22 @@ describe('getTsHelperFnFromDeclaration()', () => {
     expect(getTsHelperFnFromDeclaration(decl2)).toBe(KnownDeclaration.TsHelperSpreadArrays);
   });
 
+  it('should recognize the `__spreadArray` helper as function declaration', () => {
+    const decl1 = createFunctionDeclaration('__spreadArray');
+    const decl2 = createFunctionDeclaration('__spreadArray$42');
+
+    expect(getTsHelperFnFromDeclaration(decl1)).toBe(KnownDeclaration.TsHelperSpreadArray);
+    expect(getTsHelperFnFromDeclaration(decl2)).toBe(KnownDeclaration.TsHelperSpreadArray);
+  });
+
+  it('should recognize the `__spreadArray` helper as variable declaration', () => {
+    const decl1 = createVariableDeclaration('__spreadArray');
+    const decl2 = createVariableDeclaration('__spreadArray$42');
+
+    expect(getTsHelperFnFromDeclaration(decl1)).toBe(KnownDeclaration.TsHelperSpreadArray);
+    expect(getTsHelperFnFromDeclaration(decl2)).toBe(KnownDeclaration.TsHelperSpreadArray);
+  });
+
   it('should return null for unrecognized helpers', () => {
     const decl1 = createFunctionDeclaration('__foo');
     const decl2 = createVariableDeclaration('spread');
@@ -156,6 +172,14 @@ describe('getTsHelperFnFromIdentifier()', () => {
 
     expect(getTsHelperFnFromIdentifier(id1)).toBe(KnownDeclaration.TsHelperSpreadArrays);
     expect(getTsHelperFnFromIdentifier(id2)).toBe(KnownDeclaration.TsHelperSpreadArrays);
+  });
+
+  it('should recognize the `__spreadArray` helper', () => {
+    const id1 = ts.createIdentifier('__spreadArray');
+    const id2 = ts.createIdentifier('__spreadArray$42');
+
+    expect(getTsHelperFnFromIdentifier(id1)).toBe(KnownDeclaration.TsHelperSpreadArray);
+    expect(getTsHelperFnFromIdentifier(id2)).toBe(KnownDeclaration.TsHelperSpreadArray);
   });
 
   it('should return null for unrecognized helpers', () => {

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/known_declaration.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/known_declaration.ts
@@ -10,7 +10,7 @@ import {KnownDeclaration} from '../../reflection/src/host';
 
 import {ObjectAssignBuiltinFn} from './builtin';
 import {ResolvedValue} from './result';
-import {AssignHelperFn, SpreadArrayHelperFn, SpreadHelperFn} from './ts_helpers';
+import {AssignHelperFn, ReadHelperFn, SpreadArrayHelperFn, SpreadHelperFn} from './ts_helpers';
 
 /** Resolved value for the JavaScript global `Object` declaration. */
 export const jsGlobalObjectValue = new Map([['assign', new ObjectAssignBuiltinFn()]]);
@@ -23,6 +23,9 @@ const spreadTsHelperFn = new SpreadHelperFn();
 
 /** Resolved value for the `__spreadArray()` TypeScript helper declarations. */
 const spreadArrayTsHelperFn = new SpreadArrayHelperFn();
+
+/** Resolved value for the `__read()` TypeScript helper declarations. */
+const readTsHelperFn = new ReadHelperFn();
 
 /**
  * Resolves the specified known declaration to a resolved value. For example,
@@ -40,6 +43,8 @@ export function resolveKnownDeclaration(decl: KnownDeclaration): ResolvedValue {
       return spreadTsHelperFn;
     case KnownDeclaration.TsHelperSpreadArray:
       return spreadArrayTsHelperFn;
+    case KnownDeclaration.TsHelperRead:
+      return readTsHelperFn;
     default:
       throw new Error(`Cannot resolve known declaration. Received: ${KnownDeclaration[decl]}.`);
   }

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/known_declaration.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/known_declaration.ts
@@ -10,7 +10,7 @@ import {KnownDeclaration} from '../../reflection/src/host';
 
 import {ObjectAssignBuiltinFn} from './builtin';
 import {ResolvedValue} from './result';
-import {AssignHelperFn, SpreadHelperFn} from './ts_helpers';
+import {AssignHelperFn, SpreadArrayHelperFn, SpreadHelperFn} from './ts_helpers';
 
 /** Resolved value for the JavaScript global `Object` declaration. */
 export const jsGlobalObjectValue = new Map([['assign', new ObjectAssignBuiltinFn()]]);
@@ -20,6 +20,9 @@ const assignTsHelperFn = new AssignHelperFn();
 
 /** Resolved value for the `__spread()` and `__spreadArrays()` TypeScript helper declarations. */
 const spreadTsHelperFn = new SpreadHelperFn();
+
+/** Resolved value for the `__spreadArray()` TypeScript helper declarations. */
+const spreadArrayTsHelperFn = new SpreadArrayHelperFn();
 
 /**
  * Resolves the specified known declaration to a resolved value. For example,
@@ -35,6 +38,8 @@ export function resolveKnownDeclaration(decl: KnownDeclaration): ResolvedValue {
     case KnownDeclaration.TsHelperSpread:
     case KnownDeclaration.TsHelperSpreadArrays:
       return spreadTsHelperFn;
+    case KnownDeclaration.TsHelperSpreadArray:
+      return spreadArrayTsHelperFn;
     default:
       throw new Error(`Cannot resolve known declaration. Received: ${KnownDeclaration[decl]}.`);
   }

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
@@ -59,3 +59,24 @@ export class SpreadArrayHelperFn extends KnownFn {
     return to.concat(from);
   }
 }
+
+// Used for `__read` TypeScript helper function.
+export class ReadHelperFn extends KnownFn {
+  evaluate(node: ts.Node, args: ResolvedValueArray): ResolvedValue {
+    if (args.length !== 1) {
+      // The `__read` helper accepts a second argument `n` but that case is not supported.
+      return DynamicValue.fromUnknown(node);
+    }
+
+    const [value] = args;
+    if (value instanceof DynamicValue) {
+      return DynamicValue.fromDynamicInput(node, value);
+    }
+
+    if (!Array.isArray(value)) {
+      return DynamicValue.fromInvalidExpressionType(node, value);
+    }
+
+    return value;
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 
 import {ObjectAssignBuiltinFn} from './builtin';
 import {DynamicValue} from './dynamic';
-import {KnownFn, ResolvedValueArray} from './result';
+import {KnownFn, ResolvedValue, ResolvedValueArray} from './result';
 
 
 // Use the same implementation we use for `Object.assign()`. Semantically these functions are the
@@ -33,5 +33,29 @@ export class SpreadHelperFn extends KnownFn {
     }
 
     return result;
+  }
+}
+
+// Used for `__spreadArray` TypeScript helper function.
+export class SpreadArrayHelperFn extends KnownFn {
+  evaluate(node: ts.Node, args: ResolvedValueArray): ResolvedValue {
+    if (args.length !== 2) {
+      return DynamicValue.fromUnknown(node);
+    }
+
+    const [to, from] = args;
+    if (to instanceof DynamicValue) {
+      return DynamicValue.fromDynamicInput(node, to);
+    } else if (from instanceof DynamicValue) {
+      return DynamicValue.fromDynamicInput(node, from);
+    }
+
+    if (!Array.isArray(to)) {
+      return DynamicValue.fromInvalidExpressionType(node, to);
+    } else if (!Array.isArray(from)) {
+      return DynamicValue.fromInvalidExpressionType(node, from);
+    }
+
+    return from.concat(to);
   }
 }

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
@@ -56,6 +56,6 @@ export class SpreadArrayHelperFn extends KnownFn {
       return DynamicValue.fromInvalidExpressionType(node, from);
     }
 
-    return from.concat(to);
+    return to.concat(from);
   }
 }

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
@@ -646,6 +646,7 @@ runInEachFileSystem(() => {
               export declare function __assign(t: any, ...sources: any[]): any;
               export declare function __spread(...args: any[][]): any[];
               export declare function __spreadArrays(...args: any[][]): any[];
+              export declare function __spreadArray(to: any[], from: any[]): any[];
             `,
           },
         ]);
@@ -733,6 +734,30 @@ runInEachFileSystem(() => {
 
         expect(arr).toEqual([4, 5, 6]);
       });
+
+      it('should evaluate `__spreadArray()` (named import)', () => {
+        const arr: number[] = evaluateExpression(
+            `
+              import {__spreadArray} from 'tslib';
+              const a = [4];
+              const b = [5, 6];
+            `,
+            '__spreadArray(a, b)');
+
+        expect(arr).toEqual([4, 5, 6]);
+      });
+
+      it('should evaluate `__spreadArray()` (star import)', () => {
+        const arr: number[] = evaluateExpression(
+            `
+              import * as tslib from 'tslib';
+              const a = [4];
+              const b = [5, 6];
+            `,
+            'tslib.__spreadArray(a, b)');
+
+        expect(arr).toEqual([4, 5, 6]);
+      });
     });
 
     describe('(with emitted TypeScript helpers as functions)', () => {
@@ -742,6 +767,7 @@ runInEachFileSystem(() => {
           function __assign(t, ...sources) { /* ... */ }
           function __spread(...args) { /* ... */ }
           function __spreadArrays(...args) { /* ... */ }
+          function __spreadArray(to, from) { /* ... */ }
         `;
         const {checker, expression} = makeExpression(helpers + code, expr);
 
@@ -786,6 +812,17 @@ runInEachFileSystem(() => {
 
         expect(arr).toEqual([4, 5, 6]);
       });
+
+      it('should evaluate `__spreadArray()`', () => {
+        const arr: number[] = evaluateExpression(
+            `
+              const a = [4];
+              const b = [5, 6];
+            `,
+            '__spreadArray(a, b)');
+
+        expect(arr).toEqual([4, 5, 6]);
+      });
     });
 
     describe('(with emitted TypeScript helpers as variables)', () => {
@@ -795,6 +832,7 @@ runInEachFileSystem(() => {
           var __assign = (this && this.__assign) || function (t, ...sources) { /* ... */ }
           var __spread = (this && this.__spread) || function (...args) { /* ... */ }
           var __spreadArrays = (this && this.__spreadArrays) || function (...args) { /* ... */ }
+          var __spreadArray = (this && this.__spreadArray) || function (to, from) { /* ... */ }
         `;
         const {checker, expression} = makeExpression(helpers + code, expr);
 
@@ -836,6 +874,17 @@ runInEachFileSystem(() => {
               const b = [5, 6];
             `,
             '__spreadArrays(a, b)');
+
+        expect(arr).toEqual([4, 5, 6]);
+      });
+
+      it('should evaluate `__spreadArray()`', () => {
+        const arr: number[] = evaluateExpression(
+            `
+              const a = [4];
+              const b = [5, 6];
+            `,
+            '__spreadArray(a, b)');
 
         expect(arr).toEqual([4, 5, 6]);
       });
@@ -980,6 +1029,8 @@ runInEachFileSystem(() => {
         return KnownDeclaration.TsHelperSpread;
       case '__spreadArrays':
         return KnownDeclaration.TsHelperSpreadArrays;
+      case '__spreadArray':
+        return KnownDeclaration.TsHelperSpreadArray;
       default:
         return null;
     }

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
@@ -647,6 +647,7 @@ runInEachFileSystem(() => {
               export declare function __spread(...args: any[][]): any[];
               export declare function __spreadArrays(...args: any[][]): any[];
               export declare function __spreadArray(to: any[], from: any[]): any[];
+              export declare function __read(o: any, n?: number): any[];
             `,
           },
         ]);
@@ -758,6 +759,28 @@ runInEachFileSystem(() => {
 
         expect(arr).toEqual([4, 5, 6]);
       });
+
+      it('should evaluate `__read()` (named import)', () => {
+        const arr: number[] = evaluateExpression(
+            `
+              import {__read} from 'tslib';
+              const a = [5, 6];
+            `,
+            '__read(a)');
+
+        expect(arr).toEqual([5, 6]);
+      });
+
+      it('should evaluate `__read()` (star import)', () => {
+        const arr: number[] = evaluateExpression(
+            `
+              import * as tslib from 'tslib';
+              const a = [5, 6];
+            `,
+            'tslib.__read(a)');
+
+        expect(arr).toEqual([5, 6]);
+      });
     });
 
     describe('(with emitted TypeScript helpers as functions)', () => {
@@ -768,6 +791,7 @@ runInEachFileSystem(() => {
           function __spread(...args) { /* ... */ }
           function __spreadArrays(...args) { /* ... */ }
           function __spreadArray(to, from) { /* ... */ }
+          function __read(o) { /* ... */ }
         `;
         const {checker, expression} = makeExpression(helpers + code, expr);
 
@@ -822,6 +846,16 @@ runInEachFileSystem(() => {
             '__spreadArray(a, b)');
 
         expect(arr).toEqual([4, 5, 6]);
+      });
+
+      it('should evaluate `__read()`', () => {
+        const arr: number[] = evaluateExpression(
+            `
+              const a = [5, 6];
+            `,
+            '__read(a)');
+
+        expect(arr).toEqual([5, 6]);
       });
     });
 
@@ -833,6 +867,7 @@ runInEachFileSystem(() => {
           var __spread = (this && this.__spread) || function (...args) { /* ... */ }
           var __spreadArrays = (this && this.__spreadArrays) || function (...args) { /* ... */ }
           var __spreadArray = (this && this.__spreadArray) || function (to, from) { /* ... */ }
+          var __read = (this && this.__read) || function (o) { /* ... */ }
         `;
         const {checker, expression} = makeExpression(helpers + code, expr);
 
@@ -887,6 +922,16 @@ runInEachFileSystem(() => {
             '__spreadArray(a, b)');
 
         expect(arr).toEqual([4, 5, 6]);
+      });
+
+      it('should evaluate `__read()`', () => {
+        const arr: number[] = evaluateExpression(
+            `
+              const a = [5, 6];
+            `,
+            '__read(a)');
+
+        expect(arr).toEqual([5, 6]);
       });
     });
 
@@ -1031,6 +1076,8 @@ runInEachFileSystem(() => {
         return KnownDeclaration.TsHelperSpreadArrays;
       case '__spreadArray':
         return KnownDeclaration.TsHelperSpreadArray;
+      case '__read':
+        return KnownDeclaration.TsHelperRead;
       default:
         return null;
     }

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -474,6 +474,11 @@ export enum KnownDeclaration {
    * Indicates the `__spreadArrays` TypeScript helper function.
    */
   TsHelperSpreadArrays,
+
+  /**
+   * Indicates the `__spreadArray` TypeScript helper function.
+   */
+  TsHelperSpreadArray,
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -479,6 +479,11 @@ export enum KnownDeclaration {
    * Indicates the `__spreadArray` TypeScript helper function.
    */
   TsHelperSpreadArray,
+
+  /**
+   * Indicates the `__read` TypeScript helper function.
+   */
+  TsHelperRead,
 }
 
 /**


### PR DESCRIPTION
In TypeScript 4.2 the `__spread` and `__spreadArrays` helpers were both
replaced by the new helper function `__spreadArray` in
microsoft/TypeScript#41523. These helpers may be used in downleveled
JavaScript bundles that ngcc has to process, so ngcc has the ability to
statically detect these helpers and provide evaluation logic for them.
Because Angular is adopting support for TypeScript 4.2 it becomes
possible for libraries to be compiled by TypeScript 4.2 and thus ngcc
has to add support for the `__spreadArray` helper. The deprecated
`__spread` and `__spreadArrays` helpers are not affected by this change.

Closes #40394