### PR TITLE
[patch only] docs: add youtube to social icons (#40987)

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -31,6 +31,9 @@
       <a href="https://github.com/angular/angular" title="GitHub" aria-label="Angular on github">
         <mat-icon svgIcon="logos:github"></mat-icon>
       </a>
+      <a href="https://youtube.com/angular" title="YouTube" aria-label="Angular on YouTube">
+        <mat-icon svgIcon="logos:youtube"></mat-icon>
+      </a>
     </div>
   </mat-toolbar-row>
 </mat-toolbar>

--- a/aio/src/app/app.module.ts
+++ b/aio/src/app/app.module.ts
@@ -127,6 +127,20 @@ export const svgIconProviders = [
     },
     multi: true,
   },
+  {
+    provide: SVG_ICONS,
+    useValue: {
+      namespace: 'logos',
+      name: 'youtube',
+      svgSource:
+        '<svg focusable="false" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">' +
+          '<path d="M21.58 7.19c-.23-.86-.91-1.54-1.77-1.77C18.25 5 12 5 12 5s-6.25 0-7.81.42c-.86.23-1.54.91-1.77 1.77' +
+            'C2 8.75 2 12 2 12s0 3.25.42 4.81c.23.86.91 1.54 1.77 1.77C5.75 19 12 19 12 19s6.25 0 7.81-.42' +
+            'c.86-.23 1.54-.91 1.77-1.77C22 15.25 22 12 22 12s0-3.25-.42-4.81zM10 15V9l5.2 3-5.2 3z" />' +
+        '</svg>',
+    },
+    multi: true,
+  },
 ];
 // tslint:enable: max-line-length
 

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3033,
-        "main-es2015": 450333,
+        "main-es2015": 450953,
         "polyfills-es2015": 52215
       }
     }
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3033,
-        "main-es2015": 450363,
+        "main-es2015": 450955,
         "polyfills-es2015": 52215
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3153,
-        "main-es2015": 435185,
+        "main-es2015": 436404,
         "polyfills-es2015": 52215
       }
     }


### PR DESCRIPTION
This PR contains a cherry-picked commit from PR #40987 (already merged to master) that adds YouTube icon to the top right corner on angular.io. The original commit was not merged to the patch branch due to the merge conflicts in payload size tracking JSON file.