### PR TITLE
refactor: optimize calls to `split` and `slice` in the version.ts files

### DIFF
--- a/packages/animations/src/version.ts
+++ b/packages/animations/src/version.ts
@@ -23,10 +23,10 @@ export class Version {
   public readonly patch: string;
 
   constructor(public full: string) {
-    const splits = full.split('.');
-    this.major = splits[0];
-    this.minor = splits[1];
-    this.patch = splits.slice(2).join('.');
+    const [major, minor, ...rest] = full.split('.');
+    this.major = major;
+    this.minor = minor;
+    this.patch = rest.join('.');
   }
 }
 

--- a/packages/compiler-cli/src/version.ts
+++ b/packages/compiler-cli/src/version.ts
@@ -9,7 +9,7 @@
 /**
  * @module
  * @description
- * Entry point for all public APIs of the common package.
+ * Entry point for all public APIs of the compiler-cli package.
  */
 
 import {Version} from '@angular/compiler';

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -236,10 +236,10 @@ export class Version {
   public readonly patch: string;
 
   constructor(public full: string) {
-    const splits = full.split('.');
-    this.major = splits[0];
-    this.minor = splits[1];
-    this.patch = splits.slice(2).join('.');
+    const [major, minor, ...rest] = full.split('.');
+    this.major = major;
+    this.minor = minor;
+    this.patch = rest.join('.');
   }
 }
 

--- a/packages/compiler/src/version.ts
+++ b/packages/compiler/src/version.ts
@@ -9,7 +9,7 @@
 /**
  * @module
  * @description
- * Entry point for all public APIs of the common package.
+ * Entry point for all public APIs of the compiler package.
  */
 
 import {Version} from './util';

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -17,9 +17,10 @@ export class Version {
   public readonly patch: string;
 
   constructor(public full: string) {
-    this.major = full.split('.')[0];
-    this.minor = full.split('.')[1];
-    this.patch = full.split('.').slice(2).join('.');
+    const [major, minor, ...rest] = full.split('.');
+    this.major = major;
+    this.minor = minor;
+    this.patch = rest.join('.');
   }
 }
 

--- a/packages/elements/src/version.ts
+++ b/packages/elements/src/version.ts
@@ -7,6 +7,7 @@
  */
 
 import {Version} from '@angular/core';
+
 /**
  * @publicApi
  */

--- a/packages/forms/src/version.ts
+++ b/packages/forms/src/version.ts
@@ -9,7 +9,7 @@
 /**
  * @module
  * @description
- * Entry point for all public APIs of the common package.
+ * Entry point for all public APIs of the forms package.
  */
 
 import {Version} from '@angular/core';

--- a/packages/platform-browser-dynamic/src/version.ts
+++ b/packages/platform-browser-dynamic/src/version.ts
@@ -9,7 +9,7 @@
 /**
  * @module
  * @description
- * Entry point for all public APIs of the common package.
+ * Entry point for all public APIs of the platform-browser-dynamic package.
  */
 
 import {Version} from '@angular/core';

--- a/packages/platform-browser/src/version.ts
+++ b/packages/platform-browser/src/version.ts
@@ -9,7 +9,7 @@
 /**
  * @module
  * @description
- * Entry point for all public APIs of the common package.
+ * Entry point for all public APIs of the platform-browser package.
  */
 
 import {Version} from '@angular/core';

--- a/packages/platform-server/src/version.ts
+++ b/packages/platform-server/src/version.ts
@@ -9,7 +9,7 @@
 /**
  * @module
  * @description
- * Entry point for all public APIs of the common package.
+ * Entry point for all public APIs of the platform-server package.
  */
 
 import {Version} from '@angular/core';

--- a/packages/router/src/version.ts
+++ b/packages/router/src/version.ts
@@ -9,7 +9,7 @@
 /**
  * @module
  * @description
- * Entry point for all public APIs of the common package.
+ * Entry point for all public APIs of the router package.
  */
 
 import {Version} from '@angular/core';

--- a/packages/upgrade/src/common/src/version.ts
+++ b/packages/upgrade/src/common/src/version.ts
@@ -9,7 +9,7 @@
 /**
  * @module
  * @description
- * Entry point for all public APIs of the common package.
+ * Entry point for all public APIs of the upgrade package.
  */
 
 import {Version} from '@angular/core';


### PR DESCRIPTION
Reduce the number of calls made to `split` and `slice` in the version.ts files by storing the result the first time.

## PR Checklist

- [x] The commit message follows our guidelines: [CONTRIBUTING.md](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

When trying to commit, I got a warning about the `refactor` commit needing the `<scope>` field, but the [CONTRIBUTING.md](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#scope) documentation says it can be empty :

> none/empty string: useful for test and refactor changes that are done across all packages

So I'm not sure if I did it correctly.