### PR TITLE
docs: add margin on nav links

### DIFF
--- a/aio/content/examples/toh-pt5/src/app/app.component.css
+++ b/aio/content/examples/toh-pt5/src/app/app.component.css
@@ -5,6 +5,7 @@ h1 {
 nav a {
   padding: 1rem;
   text-decoration: none;
+  margin-right: 10px;
   margin-top: 10px;
   display: inline-block;
   background-color: #e8e8e8;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
On part 5 of the [tutorial](https://angular.io/tutorial/toh-pt5#appcomponent), a stylesheet is provided for newly added nav links.
However, there is no spacing between the two links using the code sample : 

![image](https://user-images.githubusercontent.com/32737308/111082656-ccacab00-8509-11eb-9cd5-c7d9726c0c6d.png)

It differs from the screenshots provided into the tutorial and from the Stackblitz sample where a spacing has been added : 
![image](https://user-images.githubusercontent.com/32737308/111082750-244b1680-850a-11eb-80cb-0bc4f6a5e474.png)


## What is the new behavior?

There is an horizontal spacing added between the two links.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
