### PR TITLE
docs: add mention to CSS styles for hero-detail component

### DIFF
--- a/aio/content/tutorial/toh-pt5.md
+++ b/aio/content/tutorial/toh-pt5.md
@@ -470,6 +470,9 @@ Refresh the browser and start clicking.
 Users can navigate around the app, from the dashboard to hero details and back,
 from heroes list to the mini detail to the hero details and back to the heroes again.
 
+The details will look better when you add the private CSS styles to `hero-detail.component.css`
+as listed in one of the ["final code review"](#final-code-review) tabs below.
+
 ## Final code review
 
 Here are the code files discussed on this page.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the [Tour of Heroes tutorial](), each time a stylesheet is provided into the *Final code review* part, there is a mention about it when the component is added or when changes occurs.

For the *HeroDetailComponent*, a stylesheet is provided during the [part 5](https://angular.io/tutorial/toh-pt5) but there is no mention about it into the tutorial itself.


## What is the new behavior?
To make the tutorial more consistent about stylesheet additions, a paragraph is included for the *HeroDetailComponent* once the *goBack* button has been added : 

```
The details will look better when you add the private CSS styles to `hero-detail.component.css`
as listed in one of the ["final code review"](#final-code-review) tabs below.
```

It follows the wording used in previous steps of the tutorial.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
