### PR TITLE
refactor(compiler): option to include html comments in ParsedTemplate

### DIFF
--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -16,6 +16,19 @@ export interface Node {
   visit<Result>(visitor: Visitor<Result>): Result;
 }
 
+/**
+ * This is an R3 `Node`-like wrapper for a raw `html.Comment` node. We do not currently
+ * require the implementation of a visitor for Comments as they are only collected at
+ * the top-level of the R3 AST, and only if `Render3ParseOptions['collectCommentNodes']`
+ * is true.
+ */
+export class Comment implements Node {
+  constructor(public value: string, public sourceSpan: ParseSourceSpan) {}
+  visit<Result>(_visitor: Visitor<Result>): Result {
+    throw new Error('visit() not implemented for Comment');
+  }
+}
+
 export class Text implements Node {
   constructor(public value: string, public sourceSpan: ParseSourceSpan) {}
   visit<Result>(visitor: Visitor<Result>): Result {

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -51,23 +51,34 @@ export interface Render3ParseResult {
   styles: string[];
   styleUrls: string[];
   ngContentSelectors: string[];
+  // Will be defined if `Render3ParseOptions['collectCommentNodes']` is true
+  commentNodes?: t.Comment[];
+}
+
+interface Render3ParseOptions {
+  collectCommentNodes: boolean;
 }
 
 export function htmlAstToRender3Ast(
-    htmlNodes: html.Node[], bindingParser: BindingParser): Render3ParseResult {
-  const transformer = new HtmlAstToIvyAst(bindingParser);
+    htmlNodes: html.Node[], bindingParser: BindingParser,
+    options: Render3ParseOptions): Render3ParseResult {
+  const transformer = new HtmlAstToIvyAst(bindingParser, options);
   const ivyNodes = html.visitAll(transformer, htmlNodes);
 
   // Errors might originate in either the binding parser or the html to ivy transformer
   const allErrors = bindingParser.errors.concat(transformer.errors);
 
-  return {
+  const result: Render3ParseResult = {
     nodes: ivyNodes,
     errors: allErrors,
     styleUrls: transformer.styleUrls,
     styles: transformer.styles,
-    ngContentSelectors: transformer.ngContentSelectors,
+    ngContentSelectors: transformer.ngContentSelectors
   };
+  if (options.collectCommentNodes) {
+    result.commentNodes = transformer.commentNodes;
+  }
+  return result;
 }
 
 class HtmlAstToIvyAst implements html.Visitor {
@@ -75,9 +86,11 @@ class HtmlAstToIvyAst implements html.Visitor {
   styles: string[] = [];
   styleUrls: string[] = [];
   ngContentSelectors: string[] = [];
+  // This array will be populated if `Render3ParseOptions['collectCommentNodes']` is true
+  commentNodes: t.Comment[] = [];
   private inI18nBlock: boolean = false;
 
-  constructor(private bindingParser: BindingParser) {}
+  constructor(private bindingParser: BindingParser, private options: Render3ParseOptions) {}
 
   // HTML visitor
   visitElement(element: html.Element): t.Node|null {
@@ -287,6 +300,9 @@ class HtmlAstToIvyAst implements html.Visitor {
   }
 
   visitComment(comment: html.Comment): null {
+    if (this.options.collectCommentNodes) {
+      this.commentNodes.push(new t.Comment(comment.value || '', comment.sourceSpan));
+    }
     return null;
   }
 

--- a/packages/compiler/test/render3/view/parse_template_options_spec.ts
+++ b/packages/compiler/test/render3/view/parse_template_options_spec.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ParseSourceSpan} from '../../../src/parse_util';
+import {Comment} from '../../../src/render3/r3_ast';
+import {parseTemplate} from '../../../src/render3/view/template';
+
+describe('collectCommentNodes', () => {
+  it('should include an array of HTML comment nodes on the returned R3 AST', () => {
+    const html = `
+      <!-- eslint-disable-next-line -->
+      <div *ngFor="let item of items">
+        {{item.name}}
+      </div>
+
+      <div>
+        <p>
+          <!-- some nested comment -->
+          <span>Text</span>
+        </p>
+      </div>
+    `;
+
+    const templateNoCommentsOption = parseTemplate(html, '', {});
+    expect(templateNoCommentsOption.commentNodes).toBeUndefined();
+
+    const templateCommentsOptionDisabled = parseTemplate(html, '', {collectCommentNodes: false});
+    expect(templateCommentsOptionDisabled.commentNodes).toBeUndefined();
+
+    const templateCommentsOptionEnabled = parseTemplate(html, '', {collectCommentNodes: true});
+    expect(templateCommentsOptionEnabled.commentNodes!.length).toEqual(2);
+    expect(templateCommentsOptionEnabled.commentNodes![0]).toBeInstanceOf(Comment);
+    expect(templateCommentsOptionEnabled.commentNodes![0].value)
+        .toEqual('eslint-disable-next-line');
+    expect(templateCommentsOptionEnabled.commentNodes![0].sourceSpan)
+        .toBeInstanceOf(ParseSourceSpan);
+    expect(templateCommentsOptionEnabled.commentNodes![1]).toBeInstanceOf(Comment);
+    expect(templateCommentsOptionEnabled.commentNodes![1].value).toEqual('some nested comment');
+    expect(templateCommentsOptionEnabled.commentNodes![1].sourceSpan)
+        .toBeInstanceOf(ParseSourceSpan);
+  });
+});

--- a/packages/compiler/test/render3/view/util.ts
+++ b/packages/compiler/test/render3/view/util.ts
@@ -107,7 +107,7 @@ export function parseR3(
       ['onEvent'], ['onEvent']);
   const bindingParser =
       new BindingParser(expressionParser, DEFAULT_INTERPOLATION_CONFIG, schemaRegistry, null, []);
-  const r3Result = htmlAstToRender3Ast(htmlNodes, bindingParser);
+  const r3Result = htmlAstToRender3Ast(htmlNodes, bindingParser, {collectCommentNodes: false});
 
   if (r3Result.errors.length > 0 && !options.ignoreError) {
     const msg = r3Result.errors.map(e => e.toString()).join('\n');


### PR DESCRIPTION
Adds a "comments" option on ParseTemplateOptions which will cause the returned ParsedTemplate to include an array of all html comments found in the template.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #41112


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Existing test coverage for existing parse template options seems to be implicit, captured through usage of `parseTemplate()` in other test suites. For this new option that has no real interaction with existing options and is purely additive, I felt it made sense to start a `parse_template_options_spec.ts` which could potentially also be used for some explicit coverage for other options in the future.
