### PR TITLE
feat(docs-infra): add profile picture size check

### DIFF
--- a/aio/scripts/contributors/validate-data.js
+++ b/aio/scripts/contributors/validate-data.js
@@ -2,7 +2,7 @@
 
 // Imports
 const {existsSync, readFileSync, statSync} = require('fs');
-const {join, resolve} = require('path');
+const {basename, join, resolve} = require('path');
 
 // Constants
 const MAX_IMAGE_SIZE = 30 * 1024;  // 30kb
@@ -44,7 +44,7 @@ function _main() {
 
   // Check that there are no images that exceed the size limit.
   const tooLargeImages = expectedImages
-       .filter(path => !EXCLUDE_FROM_SIZE_CHECK.has(path.split('/').pop()))
+       .filter(path => !EXCLUDE_FROM_SIZE_CHECK.has(basename(path)))
        .filter(path => statSync(path).size > MAX_IMAGE_SIZE);
   if (tooLargeImages.length > 0) {
     throw new Error(

--- a/aio/scripts/contributors/validate-data.js
+++ b/aio/scripts/contributors/validate-data.js
@@ -1,14 +1,27 @@
 #!/usr/bin/env node
 
 // Imports
-const {existsSync, readFileSync} = require('fs');
+const {existsSync, readFileSync, statSync} = require('fs');
 const {join, resolve} = require('path');
 
 // Constants
+const MAX_IMAGE_SIZE = 30 * 1024;  // 30kb
 const CONTENT_DIR = resolve(__dirname, '../../content');
 const IMAGES_DIR = join(CONTENT_DIR, 'images/bios');
 const CONTRIBUTORS_PATH = join(CONTENT_DIR, 'marketing/contributors.json');
 const EXISTING_GROUPS = new Set(['Angular', 'GDE', 'Collaborators']);
+
+// The list of profile images that exceed specified `MAX_IMAGE_SIZE` limit.
+// These images were added before the size check was introduced. Exclude these images
+// from size check for now, but still check other images (more importantly run the check
+// for new PRs where profile images are added).
+const EXCLUDE_FROM_SIZE_CHECK = new Set([
+  'alainchautard.png', 'ahsanayaz.jpg', 'alan-agius4.jpg', 'andrew-kushnir.jpg',
+  'brian-love.jpg', 'cexbrayat.jpg', 'christianliebel.jpg', 'patovargas.png', 'gerardsans.jpg',
+  'jessicajaniuk.jpg', 'JiaLiPassion.jpg', 'juristr.jpg', 'katerina.jpg', 'kimmaida.jpg',
+  'kyliau.jpg', 'lacolaco.jpg', 'leonardo.jpg', 'nirkaufman.jpg', 'sajee.jpg', 'sonukapoor.jpg',
+  'tracylee.jpg', 'twerske.jpg', 'wesgrimes.jpg'
+]);
 
 // Run
 _main();
@@ -27,6 +40,16 @@ function _main() {
     throw new Error(
         'The following pictures are referenced in \'contributors.json\' but do not exist:' +
         missingImages.map(path => `\n  - ${path}`).join(''));
+  }
+
+  // Check that there are no images that exceed the size limit.
+  const tooLargeImages = expectedImages
+       .filter(path => !EXCLUDE_FROM_SIZE_CHECK.has(path.split('/').pop()))
+       .filter(path => statSync(path).size > MAX_IMAGE_SIZE);
+  if (tooLargeImages.length > 0) {
+    throw new Error(
+        `The following pictures exceed maximum size limit of ${MAX_IMAGE_SIZE / 1024}kb:` +
+        tooLargeImages.map(path => `\n  - ${path}`).join(''));
   }
 
   // Verify that all keys are sorted alphabetically


### PR DESCRIPTION
This commit updates the logic that validates contributors.json data and introduces a new check that verifies that profile images don't exceed specified limit.


## PR Type
What kind of change does this PR introduce?

- [x] angular.io application / infrastructure changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No