### PR TITLE
fix(core): remove obsolete check for [class] and [className] presence

### DIFF
--- a/packages/compiler/src/render3/view/styling_builder.ts
+++ b/packages/compiler/src/render3/view/styling_builder.ts
@@ -246,10 +246,6 @@ export class StylingBuilder {
     const entry:
         BoundStylingEntry = {name: property, value, sourceSpan, hasOverrideFlag, suffix: null};
     if (isMapBased) {
-      if (this._classMapInput) {
-        throw new Error(
-            '[class] and [className] bindings cannot be used on the same element simultaneously');
-      }
       this._classMapInput = entry;
     } else {
       (this._singleClassInputs = this._singleClassInputs || []).push(entry);

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -3080,7 +3080,7 @@ describe('styling', () => {
       one = 'one';
     }
 
-    TestBed.configureTestingModule({declarations: [MyComp]})
+    TestBed.configureTestingModule({declarations: [MyComp]});
     const fixture = TestBed.createComponent(MyComp);
     fixture.detectChanges();
 
@@ -3106,7 +3106,7 @@ describe('styling', () => {
       margin = '10px';
     }
 
-    TestBed.configureTestingModule({declarations: [MyComp]})
+    TestBed.configureTestingModule({declarations: [MyComp]});
     const fixture = TestBed.createComponent(MyComp);
     fixture.detectChanges();
 

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -3069,6 +3069,56 @@ describe('styling', () => {
     expect(fixture.debugElement.nativeElement.innerHTML).toContain('three');
   });
 
+  it('should allow static and bound `class` attribute, but use last occurrence', () => {
+    @Component({
+      template: `
+        <div id="first" class="zero {{one}}" [class]="'two'"></div>
+        <div id="second" [class]="'two'" class="zero {{one}}"></div>
+      `,
+    })
+    class MyComp {
+      one = 'one';
+    }
+
+    TestBed.configureTestingModule({declarations: [MyComp]})
+    const fixture = TestBed.createComponent(MyComp);
+    fixture.detectChanges();
+
+    const first = fixture.nativeElement.querySelector('#first').outerHTML;
+    expect(first).not.toContain('zero');
+    expect(first).not.toContain('one');
+    expect(first).toContain('two');
+
+    const second = fixture.nativeElement.querySelector('#second').outerHTML;
+    expect(second).toContain('zero');
+    expect(second).toContain('one');
+    expect(second).not.toContain('two');
+  });
+
+  it('should allow static and bound `style` attribute, but use last occurrence', () => {
+    @Component({
+      template: `
+        <div id="first" style="margin: {{margin}}" [style]="'padding: 20px;'"></div>
+        <div id="second" [style]="'padding: 20px;'" style="margin: {{margin}}"></div>
+      `,
+    })
+    class MyComp {
+      margin = '10px';
+    }
+
+    TestBed.configureTestingModule({declarations: [MyComp]})
+    const fixture = TestBed.createComponent(MyComp);
+    fixture.detectChanges();
+
+    const first = fixture.nativeElement.querySelector('#first').outerHTML;
+    expect(first).not.toContain('margin');
+    expect(first).toContain('padding');
+
+    const second = fixture.nativeElement.querySelector('#second').outerHTML;
+    expect(second).toContain('margin');
+    expect(second).not.toContain('padding');
+  });
+
   it('should allow to reset style property value defined using [style.prop.px] binding', () => {
     @Component({
       template: '<div [style.left.px]="left"></div>',


### PR DESCRIPTION
Previously, presence of both [class] and [className] bindings on an element was treated as compiler error (implemented in https://github.com/angular/angular/commit/6f203c9575fe9a2da04529fbdf1e5f7b51e85e09). Later, the situation was improved to actually allow both bindings to co-exist (see https://github.com/angular/angular/commit/a153b610983389de6408f7a723fd5714a11c168e), however the compiler check was not removed completely. The only situation where the error is thrown at this moment is when static (but with interpolation) and bound `class` attributes are present on an element, for ex.:

```
<div class="{{ one }}" [class]="'two'"></div>
```

In the current situation the error is actually misleading (as it refers to `[className]`).

This commit removes the mentioned compiler check as obsolete and makes the `class` and `style` attribute processing logically the same (the last occurrence is used to compute the value).

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No