### PR TITLE
fix(compiler): correctly process multiple rules containing `:host` selectors

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -720,6 +720,7 @@ function escapeBlocks(
  */
 function combineHostContextSelectors(contextSelectors: string[], otherSelectors: string): string {
   const hostMarker = _polyfillHostNoCombinator;
+  _polyfillHostRe.lastIndex = 0;  // reset the regex to ensure we get an accurate test
   const otherSelectorsHasHost = _polyfillHostRe.test(otherSelectors);
 
   // If there are no context selectors then just output a host marker

--- a/packages/compiler/test/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css_spec.ts
@@ -286,6 +286,17 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
         expect(s(':host-context(div) > :host(.x) > .y {}', 'contenta', 'a-host'))
             .toEqual('div > .x[a-host] > .y[contenta] {}');
       });
+
+      it('should parse multiple rules containing :host-context and :host', () => {
+        const input = `
+            :host-context(outer1) :host(bar) {}
+            :host-context(outer2) :host(foo) {}
+        `;
+        expect(s(input, 'contenta', 'a-host'))
+            .toEqual(
+                'outer1 bar[a-host] {} ' +
+                'outer2 foo[a-host] {}');
+      });
     });
 
     it('should support polyfill-next-selector', () => {


### PR DESCRIPTION
When there was more than one rule in a single style string, only the first
rule was having its `:host` selector processed correctly. Now subsequent
rules will also be processed accurately.

Fixes #41237
