### PR TITLE
fix(router): handle new navigations from a NavigationEnd event

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1290,7 +1290,6 @@ export class Router {
               .next(new NavigationEnd(
                   t.id, this.serializeUrl(t.extractedUrl), this.serializeUrl(this.currentUrlTree)));
           this.lastSuccessfulNavigation = this.currentNavigation;
-          this.currentNavigation = null;
           t.resolve(true);
         },
         e => {


### PR DESCRIPTION
This commit removes the line to set `currentNavigation` to `null` in the
navigation transitions subscription of the router. This logic is
already handled in the `finalize` stage of the transition pipe and has
been found to cause issues if a new navigation is triggered from a
subscription to the `NavigationEnd` event.

fixes #37460
