### PR TITLE
feat(dev-infra): validate breaking changes commit messages

### DIFF
--- a/dev-infra/commit-message/validate.spec.ts
+++ b/dev-infra/commit-message/validate.spec.ts
@@ -295,7 +295,7 @@ describe('validate-commit-message.js', () => {
             'BREAKING CHANGE This is a summary of a breaking change.';
         expectValidationResult(
             validateCommitMessage(msgWithSummary), INVALID,
-            [`The commit message body contains a non valid breaking change description.`]);
+            [`The commit message body contains an invalid breaking change description.`]);
 
         const msgWithDescription = 'feat(compiler): this is just an usual commit message tile\n\n' +
             'This is a normal commit message body which does not exceed the max length\n' +
@@ -304,7 +304,7 @@ describe('validate-commit-message.js', () => {
             'This is a full description of the breaking change.';
         expectValidationResult(
             validateCommitMessage(msgWithDescription), INVALID,
-            [`The commit message body contains a non valid breaking change description.`]);
+            [`The commit message body contains an invalid breaking change description.`]);
 
         const msgWithSummaryAndDescription =
             'feat(compiler): this is just an usual commit message tile\n\n' +
@@ -314,7 +314,7 @@ describe('validate-commit-message.js', () => {
             'This is a full description of the breaking change.';
         expectValidationResult(
             validateCommitMessage(msgWithSummaryAndDescription), INVALID,
-            [`The commit message body contains a non valid breaking change description.`]);
+            [`The commit message body contains an invalid breaking change description.`]);
       });
 
       it('should fail for when "BREAKING CHANGE" is in lowercase.', () => {

--- a/dev-infra/commit-message/validate.spec.ts
+++ b/dev-infra/commit-message/validate.spec.ts
@@ -286,6 +286,11 @@ describe('validate-commit-message.js', () => {
             'BREAKING CHANGE: This is a summary of a breaking change.\n\n' +
             'This is a full description of the breaking change.';
         expectValidationResult(validateCommitMessage(msgWithSummaryAndDescription), VALID);
+
+        const msgWithNonBreaking = 'feat(compiler): this is just an usual commit message tile\n\n' +
+            'This is not a\n' +
+            'breaking change commit.';
+        expectValidationResult(validateCommitMessage(msgWithNonBreaking), VALID);
       });
 
       it('should fail for non-valid breaking change commit descriptions', () => {

--- a/dev-infra/commit-message/validate.spec.ts
+++ b/dev-infra/commit-message/validate.spec.ts
@@ -263,5 +263,78 @@ describe('validate-commit-message.js', () => {
                VALID);
          });
     });
+
+    describe('breaking change', () => {
+      it('should allow valid breaking change commit descriptions', () => {
+        const msgWithSummary = 'feat(compiler): this is just an usual commit message tile\n\n' +
+            'This is a normal commit message body which does not exceed the max length\n' +
+            'limit. For more details see the following super long URL:\n\n' +
+            'BREAKING CHANGE: This is a summary of a breaking change.';
+        expectValidationResult(validateCommitMessage(msgWithSummary), VALID);
+
+        const msgWithDescription = 'feat(compiler): this is just an usual commit message tile\n\n' +
+            'This is a normal commit message body which does not exceed the max length\n' +
+            'limit. For more details see the following super long URL:\n\n' +
+            'BREAKING CHANGE:\n\n' +
+            'This is a full description of the breaking change.';
+        expectValidationResult(validateCommitMessage(msgWithDescription), VALID);
+
+        const msgWithSummaryAndDescription =
+            'feat(compiler): this is just an usual commit message tile\n\n' +
+            'This is a normal commit message body which does not exceed the max length\n' +
+            'limit. For more details see the following super long URL:\n\n' +
+            'BREAKING CHANGE: This is a summary of a breaking change.\n\n' +
+            'This is a full description of the breaking change.';
+        expectValidationResult(validateCommitMessage(msgWithSummaryAndDescription), VALID);
+      });
+
+      it('should fail for non-valid breaking change commit descriptions', () => {
+        const msgWithSummary = 'feat(compiler): this is just an usual commit message tile\n\n' +
+            'This is a normal commit message body which does not exceed the max length\n' +
+            'limit. For more details see the following super long URL:\n\n' +
+            'BREAKING CHANGE This is a summary of a breaking change.';
+        expectValidationResult(
+            validateCommitMessage(msgWithSummary), INVALID,
+            [`The commit message body contains a non valid breaking change description.`]);
+
+        const msgWithDescription = 'feat(compiler): this is just an usual commit message tile\n\n' +
+            'This is a normal commit message body which does not exceed the max length\n' +
+            'limit. For more details see the following super long URL:\n\n' +
+            'BREAKING CHANGE:\n' +
+            'This is a full description of the breaking change.';
+        expectValidationResult(
+            validateCommitMessage(msgWithDescription), INVALID,
+            [`The commit message body contains a non valid breaking change description.`]);
+
+        const msgWithSummaryAndDescription =
+            'feat(compiler): this is just an usual commit message tile\n\n' +
+            'This is a normal commit message body which does not exceed the max length\n' +
+            'limit. For more details see the following super long URL:\n\n' +
+            'BREAKING CHANGE\n\n' +
+            'This is a full description of the breaking change.';
+        expectValidationResult(
+            validateCommitMessage(msgWithSummaryAndDescription), INVALID,
+            [`The commit message body contains a non valid breaking change description.`]);
+      });
+
+      it('should fail for when "BREAKING CHANGE" is in lowercase.', () => {
+        const msgWithSummary = 'feat(compiler): this is just an usual commit message tile\n\n' +
+            'This is a normal commit message body which does not exceed the max length\n' +
+            'limit. For more details see the following super long URL:\n\n' +
+            'Breaking change: This is a summary of a breaking change.';
+        expectValidationResult(validateCommitMessage(msgWithSummary), INVALID, [
+          `The commit message body contains breaking change description but it doesn't start with 'BREAKING CHANGE'.`
+        ]);
+
+        const msgWithDescription = 'feat(compiler): this is just an usual commit message tile\n\n' +
+            'This is a normal commit message body which does not exceed the max length\n' +
+            'limit. For more details see the following super long URL:\n\n' +
+            'Breaking change\n\n' +
+            'This is a full description of the breaking change.';
+        expectValidationResult(validateCommitMessage(msgWithDescription), INVALID, [
+          `The commit message body contains breaking change description but it doesn't start with 'BREAKING CHANGE'.`
+        ]);
+      });
+    });
   });
 });

--- a/dev-infra/commit-message/validate.spec.ts
+++ b/dev-infra/commit-message/validate.spec.ts
@@ -316,25 +316,6 @@ describe('validate-commit-message.js', () => {
             validateCommitMessage(msgWithSummaryAndDescription), INVALID,
             [`The commit message body contains an invalid breaking change description.`]);
       });
-
-      it('should fail for when "BREAKING CHANGE" is in lowercase.', () => {
-        const msgWithSummary = 'feat(compiler): this is just an usual commit message tile\n\n' +
-            'This is a normal commit message body which does not exceed the max length\n' +
-            'limit. For more details see the following super long URL:\n\n' +
-            'Breaking change: This is a summary of a breaking change.';
-        expectValidationResult(validateCommitMessage(msgWithSummary), INVALID, [
-          `The commit message body contains breaking change description but it doesn't start with 'BREAKING CHANGE'.`
-        ]);
-
-        const msgWithDescription = 'feat(compiler): this is just an usual commit message tile\n\n' +
-            'This is a normal commit message body which does not exceed the max length\n' +
-            'limit. For more details see the following super long URL:\n\n' +
-            'Breaking change\n\n' +
-            'This is a full description of the breaking change.';
-        expectValidationResult(validateCommitMessage(msgWithDescription), INVALID, [
-          `The commit message body contains breaking change description but it doesn't start with 'BREAKING CHANGE'.`
-        ]);
-      });
     });
   });
 });

--- a/dev-infra/commit-message/validate.spec.ts
+++ b/dev-infra/commit-message/validate.spec.ts
@@ -297,6 +297,14 @@ describe('validate-commit-message.js', () => {
             validateCommitMessage(msgWithSummary), INVALID,
             [`The commit message body contains an invalid breaking change description.`]);
 
+        const msgWithPlural = 'feat(compiler): this is just an usual commit message tile\n\n' +
+            'This is a normal commit message body which does not exceed the max length\n' +
+            'limit. For more details see the following super long URL:\n\n' +
+            'BREAKING CHANGES: This is a summary of a breaking change.';
+        expectValidationResult(
+            validateCommitMessage(msgWithPlural), INVALID,
+            [`The commit message body contains an invalid breaking change description.`]);
+
         const msgWithDescription = 'feat(compiler): this is just an usual commit message tile\n\n' +
             'This is a normal commit message body which does not exceed the max length\n' +
             'limit. For more details see the following super long URL:\n\n' +

--- a/dev-infra/commit-message/validate.ts
+++ b/dev-infra/commit-message/validate.ts
@@ -34,7 +34,7 @@ const COMMIT_BODY_URL_LINE_RE = /^https?:\/\/.*$/;
  *
  * NB: Anything after `BREAKING CHANGE` is optional to facilitate the validation.
  */
-const COMMIT_BODY_BREAKING_CHANGE_RE = /^(BREAKING CHANGE)(\:( |\n{2}))?/mi;
+const COMMIT_BODY_BREAKING_CHANGE_RE = /^(BREAKING CHANGE)(:( |\n{2}))?/mi;
 
 /** Validate a commit message against using the local repo's config. */
 export function validateCommitMessage(
@@ -167,7 +167,7 @@ export function validateCommitMessage(
 
       if (!breakingChangeDescription) {
         // Not followed by :, space or two consecutive new lines,
-        errors.push(`The commit message body contains a non valid breaking change description.`);
+        errors.push(`The commit message body contains an invalid breaking change description.`);
         return false;
       }
     }

--- a/dev-infra/commit-message/validate.ts
+++ b/dev-infra/commit-message/validate.ts
@@ -34,7 +34,7 @@ const COMMIT_BODY_URL_LINE_RE = /^https?:\/\/.*$/;
  *
  * NB: Anything after `BREAKING CHANGE` is optional to facilitate the validation.
  */
-const COMMIT_BODY_BREAKING_CHANGE_RE = /^BREAKING CHANGE(:( |\n{2}))?/m;
+const COMMIT_BODY_BREAKING_CHANGE_RE = /^BREAKING CHANGE(S)?(:( |\n{2}))?/m;
 
 /** Validate a commit message against using the local repo's config. */
 export function validateCommitMessage(
@@ -157,8 +157,8 @@ export function validateCommitMessage(
     // https://github.com/angular/angular/blob/88fbc066775ab1a2f6a8c75f933375b46d8fa9a4/CONTRIBUTING.md#commit-message-footer
     const hasBreakingChange = COMMIT_BODY_BREAKING_CHANGE_RE.exec(commit.body);
     if (hasBreakingChange !== null) {
-      const [, breakingChangeDescription] = hasBreakingChange;
-      if (!breakingChangeDescription) {
+      const [, breakingChangePlural, breakingChangeDescription] = hasBreakingChange;
+      if (breakingChangePlural || !breakingChangeDescription) {
         // Not followed by :, space or two consecutive new lines,
         errors.push(`The commit message body contains an invalid breaking change description.`);
         return false;

--- a/dev-infra/commit-message/validate.ts
+++ b/dev-infra/commit-message/validate.ts
@@ -34,7 +34,7 @@ const COMMIT_BODY_URL_LINE_RE = /^https?:\/\/.*$/;
  *
  * NB: Anything after `BREAKING CHANGE` is optional to facilitate the validation.
  */
-const COMMIT_BODY_BREAKING_CHANGE_RE = /^BREAKING CHANGE(S)?(:( |\n{2}))?/m;
+const COMMIT_BODY_BREAKING_CHANGE_RE = /^BREAKING CHANGE(:( |\n{2}))?/m;
 
 /** Validate a commit message against using the local repo's config. */
 export function validateCommitMessage(
@@ -157,8 +157,8 @@ export function validateCommitMessage(
     // https://github.com/angular/angular/blob/88fbc066775ab1a2f6a8c75f933375b46d8fa9a4/CONTRIBUTING.md#commit-message-footer
     const hasBreakingChange = COMMIT_BODY_BREAKING_CHANGE_RE.exec(commit.body);
     if (hasBreakingChange !== null) {
-      const [, breakingChangePlural, breakingChangeDescription] = hasBreakingChange;
-      if (breakingChangePlural || !breakingChangeDescription) {
+      const [, breakingChangeDescription] = hasBreakingChange;
+      if (!breakingChangeDescription) {
         // Not followed by :, space or two consecutive new lines,
         errors.push(`The commit message body contains an invalid breaking change description.`);
         return false;

--- a/dev-infra/commit-message/validate.ts
+++ b/dev-infra/commit-message/validate.ts
@@ -25,6 +25,16 @@ export interface ValidateCommitMessageResult {
 
 /** Regex matching a URL for an entire commit body line. */
 const COMMIT_BODY_URL_LINE_RE = /^https?:\/\/.*$/;
+/**
+ * Regex matching a breaking change.
+ *
+ * - Starts with BREAKING CHANGE
+ * - Followed by a colon
+ * - Followed by a single space or two consecutive new lines
+ *
+ * NB: Anything after `BREAKING CHANGE` is optional to facilitate the validation.
+ */
+const COMMIT_BODY_BREAKING_CHANGE_RE = /^(BREAKING CHANGE)(\:( |\n{2}))?/mi;
 
 /** Validate a commit message against using the local repo's config. */
 export function validateCommitMessage(
@@ -137,9 +147,29 @@ export function validateCommitMessage(
     });
 
     if (lineExceedsMaxLength) {
-      errors.push(
-          `The commit message body contains lines greater than ${config.maxLineLength} characters`);
+      errors.push(`The commit message body contains lines greater than ${
+          config.maxLineLength} characters.`);
       return false;
+    }
+
+    // Breaking change
+    // Check if the commit message contains a valid break change description.
+    // https://github.com/angular/angular/blob/88fbc066775ab1a2f6a8c75f933375b46d8fa9a4/CONTRIBUTING.md#commit-message-footer
+    const hasBreakingChange = COMMIT_BODY_BREAKING_CHANGE_RE.exec(commit.body);
+    if (hasBreakingChange !== null) {
+      const [, breakingChange, breakingChangeDescription] = hasBreakingChange;
+      if (breakingChange !== 'BREAKING CHANGE') {
+        // Not in uppercase.
+        errors.push(
+            `The commit message body contains breaking change description but it doesn't start with 'BREAKING CHANGE'.`);
+        return false;
+      }
+
+      if (!breakingChangeDescription) {
+        // Not followed by :, space or two consecutive new lines,
+        errors.push(`The commit message body contains a non valid breaking change description.`);
+        return false;
+      }
     }
 
     return true;
@@ -159,5 +189,10 @@ export function printValidationErrors(errors: string[], print = error) {
   print('<type>(<scope>): <summary>');
   print();
   print('<body>');
+  print();
+  print(`BREAKING CHANGE: <breaking change summary>`);
+  print();
+  print(`<breaking change description>`);
+  print();
   print();
 }

--- a/dev-infra/commit-message/validate.ts
+++ b/dev-infra/commit-message/validate.ts
@@ -34,7 +34,7 @@ const COMMIT_BODY_URL_LINE_RE = /^https?:\/\/.*$/;
  *
  * NB: Anything after `BREAKING CHANGE` is optional to facilitate the validation.
  */
-const COMMIT_BODY_BREAKING_CHANGE_RE = /^(BREAKING CHANGE)(:( |\n{2}))?/mi;
+const COMMIT_BODY_BREAKING_CHANGE_RE = /^BREAKING CHANGE(:( |\n{2}))?/m;
 
 /** Validate a commit message against using the local repo's config. */
 export function validateCommitMessage(
@@ -157,14 +157,7 @@ export function validateCommitMessage(
     // https://github.com/angular/angular/blob/88fbc066775ab1a2f6a8c75f933375b46d8fa9a4/CONTRIBUTING.md#commit-message-footer
     const hasBreakingChange = COMMIT_BODY_BREAKING_CHANGE_RE.exec(commit.body);
     if (hasBreakingChange !== null) {
-      const [, breakingChange, breakingChangeDescription] = hasBreakingChange;
-      if (breakingChange !== 'BREAKING CHANGE') {
-        // Not in uppercase.
-        errors.push(
-            `The commit message body contains breaking change description but it doesn't start with 'BREAKING CHANGE'.`);
-        return false;
-      }
-
+      const [, breakingChangeDescription] = hasBreakingChange;
       if (!breakingChangeDescription) {
         // Not followed by :, space or two consecutive new lines,
         errors.push(`The commit message body contains an invalid breaking change description.`);

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -1826,7 +1826,7 @@ const COMMIT_BODY_URL_LINE_RE = /^https?:\/\/.*$/;
  *
  * NB: Anything after `BREAKING CHANGE` is optional to facilitate the validation.
  */
-const COMMIT_BODY_BREAKING_CHANGE_RE = /^(BREAKING CHANGE)(:( |\n{2}))?/mi;
+const COMMIT_BODY_BREAKING_CHANGE_RE = /^BREAKING CHANGE(:( |\n{2}))?/m;
 /** Validate a commit message against using the local repo's config. */
 function validateCommitMessage(commitMsg, options = {}) {
     const config = getCommitMessageConfig().commitMessage;
@@ -1921,12 +1921,7 @@ function validateCommitMessage(commitMsg, options = {}) {
         // https://github.com/angular/angular/blob/88fbc066775ab1a2f6a8c75f933375b46d8fa9a4/CONTRIBUTING.md#commit-message-footer
         const hasBreakingChange = COMMIT_BODY_BREAKING_CHANGE_RE.exec(commit.body);
         if (hasBreakingChange !== null) {
-            const [, breakingChange, breakingChangeDescription] = hasBreakingChange;
-            if (breakingChange !== 'BREAKING CHANGE') {
-                // Not in uppercase.
-                errors.push(`The commit message body contains breaking change description but it doesn't start with 'BREAKING CHANGE'.`);
-                return false;
-            }
+            const [, breakingChangeDescription] = hasBreakingChange;
             if (!breakingChangeDescription) {
                 // Not followed by :, space or two consecutive new lines,
                 errors.push(`The commit message body contains an invalid breaking change description.`);

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -1817,6 +1817,16 @@ function parseCommitMessagesForRange(range) {
  */
 /** Regex matching a URL for an entire commit body line. */
 const COMMIT_BODY_URL_LINE_RE = /^https?:\/\/.*$/;
+/**
+ * Regex matching a breaking change.
+ *
+ * - Starts with BREAKING CHANGE
+ * - Followed by a colon
+ * - Followed by a single space or two consecutive new lines
+ *
+ * NB: Anything after `BREAKING CHANGE` is optional to facilitate the validation.
+ */
+const COMMIT_BODY_BREAKING_CHANGE_RE = /^(BREAKING CHANGE)(\:( |\n{2}))?/mi;
 /** Validate a commit message against using the local repo's config. */
 function validateCommitMessage(commitMsg, options = {}) {
     const config = getCommitMessageConfig().commitMessage;
@@ -1903,8 +1913,25 @@ function validateCommitMessage(commitMsg, options = {}) {
             return line.length > config.maxLineLength && !COMMIT_BODY_URL_LINE_RE.test(line);
         });
         if (lineExceedsMaxLength) {
-            errors.push(`The commit message body contains lines greater than ${config.maxLineLength} characters`);
+            errors.push(`The commit message body contains lines greater than ${config.maxLineLength} characters.`);
             return false;
+        }
+        // Breaking change
+        // Check if the commit message contains a valid break change description.
+        // https://github.com/angular/angular/blob/88fbc066775ab1a2f6a8c75f933375b46d8fa9a4/CONTRIBUTING.md#commit-message-footer
+        const hasBreakingChange = COMMIT_BODY_BREAKING_CHANGE_RE.exec(commit.body);
+        if (hasBreakingChange !== null) {
+            const [, breakingChange, breakingChangeDescription] = hasBreakingChange;
+            if (breakingChange !== 'BREAKING CHANGE') {
+                // Not in uppercase.
+                errors.push(`The commit message body contains breaking change description but it doesn't start with 'BREAKING CHANGE'.`);
+                return false;
+            }
+            if (!breakingChangeDescription) {
+                // Not followed by :, space or two consecutive new lines,
+                errors.push(`The commit message body contains a non valid breaking change description.`);
+                return false;
+            }
         }
         return true;
     }
@@ -1920,6 +1947,11 @@ function printValidationErrors(errors, print = error) {
     print('<type>(<scope>): <summary>');
     print();
     print('<body>');
+    print();
+    print(`BREAKING CHANGE: <breaking change summary>`);
+    print();
+    print(`<breaking change description>`);
+    print();
     print();
 }
 

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -1826,7 +1826,7 @@ const COMMIT_BODY_URL_LINE_RE = /^https?:\/\/.*$/;
  *
  * NB: Anything after `BREAKING CHANGE` is optional to facilitate the validation.
  */
-const COMMIT_BODY_BREAKING_CHANGE_RE = /^(BREAKING CHANGE)(\:( |\n{2}))?/mi;
+const COMMIT_BODY_BREAKING_CHANGE_RE = /^(BREAKING CHANGE)(:( |\n{2}))?/mi;
 /** Validate a commit message against using the local repo's config. */
 function validateCommitMessage(commitMsg, options = {}) {
     const config = getCommitMessageConfig().commitMessage;
@@ -1929,7 +1929,7 @@ function validateCommitMessage(commitMsg, options = {}) {
             }
             if (!breakingChangeDescription) {
                 // Not followed by :, space or two consecutive new lines,
-                errors.push(`The commit message body contains a non valid breaking change description.`);
+                errors.push(`The commit message body contains an invalid breaking change description.`);
                 return false;
             }
         }

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -1826,7 +1826,7 @@ const COMMIT_BODY_URL_LINE_RE = /^https?:\/\/.*$/;
  *
  * NB: Anything after `BREAKING CHANGE` is optional to facilitate the validation.
  */
-const COMMIT_BODY_BREAKING_CHANGE_RE = /^BREAKING CHANGE(:( |\n{2}))?/m;
+const COMMIT_BODY_BREAKING_CHANGE_RE = /^BREAKING CHANGE(S)?(:( |\n{2}))?/m;
 /** Validate a commit message against using the local repo's config. */
 function validateCommitMessage(commitMsg, options = {}) {
     const config = getCommitMessageConfig().commitMessage;
@@ -1921,8 +1921,8 @@ function validateCommitMessage(commitMsg, options = {}) {
         // https://github.com/angular/angular/blob/88fbc066775ab1a2f6a8c75f933375b46d8fa9a4/CONTRIBUTING.md#commit-message-footer
         const hasBreakingChange = COMMIT_BODY_BREAKING_CHANGE_RE.exec(commit.body);
         if (hasBreakingChange !== null) {
-            const [, breakingChangeDescription] = hasBreakingChange;
-            if (!breakingChangeDescription) {
+            const [, breakingChangePlural, breakingChangeDescription] = hasBreakingChange;
+            if (breakingChangePlural || !breakingChangeDescription) {
                 // Not followed by :, space or two consecutive new lines,
                 errors.push(`The commit message body contains an invalid breaking change description.`);
                 return false;

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -1826,7 +1826,7 @@ const COMMIT_BODY_URL_LINE_RE = /^https?:\/\/.*$/;
  *
  * NB: Anything after `BREAKING CHANGE` is optional to facilitate the validation.
  */
-const COMMIT_BODY_BREAKING_CHANGE_RE = /^BREAKING CHANGE(S)?(:( |\n{2}))?/m;
+const COMMIT_BODY_BREAKING_CHANGE_RE = /^BREAKING CHANGE(:( |\n{2}))?/m;
 /** Validate a commit message against using the local repo's config. */
 function validateCommitMessage(commitMsg, options = {}) {
     const config = getCommitMessageConfig().commitMessage;
@@ -1921,8 +1921,8 @@ function validateCommitMessage(commitMsg, options = {}) {
         // https://github.com/angular/angular/blob/88fbc066775ab1a2f6a8c75f933375b46d8fa9a4/CONTRIBUTING.md#commit-message-footer
         const hasBreakingChange = COMMIT_BODY_BREAKING_CHANGE_RE.exec(commit.body);
         if (hasBreakingChange !== null) {
-            const [, breakingChangePlural, breakingChangeDescription] = hasBreakingChange;
-            if (breakingChangePlural || !breakingChangeDescription) {
+            const [, breakingChangeDescription] = hasBreakingChange;
+            if (!breakingChangeDescription) {
                 // Not followed by :, space or two consecutive new lines,
                 errors.push(`The commit message body contains an invalid breaking change description.`);
                 return false;


### PR DESCRIPTION
With this change we valid breaking changes descriptions as per our contribution guidelines

See: https://github.com/angular/angular/blob/88fbc066775ab1a2f6a8c75f933375b46d8fa9a4/CONTRIBUTING.md#commit-message-footer

This gets me all the time.