### PR TITLE
fix(docs-infra): fix search results layout on narrow screens

### DIFF
--- a/aio/content/file-not-found.md
+++ b/aio/content/file-not-found.md
@@ -1,10 +1,10 @@
-@description
-
-<div class="nf-container l-flex-wrap flex-center">
+<div class="center-layout-wide">
+  <div class="nf-container l-flex-wrap flex-center">
     <img src="assets/images/support/angular-404.svg" width="300" height="300"/>
     <div class="nf-response l-flex-wrap">
-        <h1 class="no-anchor no-toc">Page Not Found</h1>
-        <p>We're sorry. The page you are looking for cannot be found.</p>
+      <h1 class="no-anchor no-toc">Page Not Found</h1>
+      <p>We're sorry. The page you are looking for cannot be found.</p>
     </div>
+  </div>
+  <aio-file-not-found-search></aio-file-not-found-search>
 </div>
-<aio-file-not-found-search></aio-file-not-found-search>

--- a/aio/src/styles/1-layouts/_content-layout.scss
+++ b/aio/src/styles/1-layouts/_content-layout.scss
@@ -20,7 +20,9 @@
     padding: 80px 1rem 1rem;
   }
 
-  @include marketing-pages($extraSelectors: ('.page-api', '.page-guide-cheatsheet'), $nestParentSelector: true) {
+  @include marketing-pages(
+      $extraSelectors: ('.page-api', '.page-file-not-found', '.page-guide-cheatsheet'),
+      $nestParentSelector: true) {
     max-width: none;
   }
 

--- a/aio/src/styles/2-modules/_search-results.scss
+++ b/aio/src/styles/2-modules/_search-results.scss
@@ -4,7 +4,6 @@ aio-search-results {
   .search-results {
     display: flex;
     flex-direction: row;
-    justify-content: space-around;
     overflow: auto;
     padding: 0px 32px;
     border-top: 68px solid transparent;
@@ -20,8 +19,8 @@ aio-search-results {
     box-sizing: border-box;
 
     .search-area {
-      margin: 16px;
-      height: 100%;
+      margin: 0 auto;
+      padding: 16px;
 
       .search-section-header {
         @include font-size(16);


### PR DESCRIPTION
A couple of fixes related to search results on narrow screens.
See individual commits for details.

##
To see an example of the changes in action compare [master][1] vs [this PR][2].

[1]: https://next.angular.io/guide/test-code-cverage?mode=stable
[2]: https://pr41275-72f283b.ngbuilds.io/guide/test-code-cverage