### PR TITLE
fix(language-service): Only provide Angular property completions in t…

### DIFF
--- a/packages/language-service/ivy/completions.ts
+++ b/packages/language-service/ivy/completions.ts
@@ -57,7 +57,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
   constructor(
       private readonly tsLS: ts.LanguageService, private readonly compiler: NgCompiler,
       private readonly component: ts.ClassDeclaration, private readonly node: N,
-      private readonly targetDetails: TemplateTarget, private readonly inlineTemplate: boolean) {}
+      private readonly targetDetails: TemplateTarget) {}
 
   /**
    * Analogue for `ts.LanguageService.getCompletionsAtPosition`.
@@ -371,11 +371,9 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
     const replacementSpan: ts.TextSpan = {start, length};
 
     let potentialTags = Array.from(templateTypeChecker.getPotentialElementTags(this.component));
-    if (!this.inlineTemplate) {
-      // If we are in an external template, don't provide non-Angular tags (directive === null)
-      // because we expect other extensions (i.e. Emmet) to provide those for HTML files.
-      potentialTags = potentialTags.filter(([_, directive]) => directive !== null);
-    }
+    // Don't provide non-Angular tags (directive === null) because we expect other extensions (i.e.
+    // Emmet) to provide those for HTML files.
+    potentialTags = potentialTags.filter(([_, directive]) => directive !== null);
     const entries: ts.CompletionEntry[] = potentialTags.map(([tag, directive]) => ({
                                                               kind: tagCompletionKind(directive),
                                                               name: tag,
@@ -462,7 +460,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
     }
 
     const attrTable = buildAttributeCompletionTable(
-        this.component, element, this.compiler.getTemplateTypeChecker(), this.inlineTemplate);
+        this.component, element, this.compiler.getTemplateTypeChecker());
 
     let entries: ts.CompletionEntry[] = [];
 
@@ -536,7 +534,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
     }
 
     const attrTable = buildAttributeCompletionTable(
-        this.component, element, this.compiler.getTemplateTypeChecker(), this.inlineTemplate);
+        this.component, element, this.compiler.getTemplateTypeChecker());
 
     if (!attrTable.has(name)) {
       return undefined;
@@ -603,7 +601,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
     }
 
     const attrTable = buildAttributeCompletionTable(
-        this.component, element, this.compiler.getTemplateTypeChecker(), this.inlineTemplate);
+        this.component, element, this.compiler.getTemplateTypeChecker());
 
     if (!attrTable.has(name)) {
       return undefined;

--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -201,8 +201,7 @@ export class LanguageService {
         positionDetails.context.nodes[0] :
         positionDetails.context.node;
     return new CompletionBuilder(
-        this.tsLS, compiler, templateInfo.component, node, positionDetails,
-        isTypeScriptFile(fileName));
+        this.tsLS, compiler, templateInfo.component, node, positionDetails);
   }
 
   getCompletionsAtPosition(

--- a/packages/language-service/ivy/test/completions_spec.ts
+++ b/packages/language-service/ivy/test/completions_spec.ts
@@ -308,11 +308,11 @@ describe('completions', () => {
           ['div', 'span']);
     });
 
-    it('should return DOM completions', () => {
+    it('should not return DOM completions for inline template', () => {
       const {appFile} = setupInlineTemplate(`<div>`, '');
       appFile.moveCursorToText('<div¦>');
       const completions = appFile.getCompletionsAtPosition();
-      expectContain(
+      expectDoesNotContain(
           completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.ELEMENT),
           ['div', 'span']);
     });
@@ -431,20 +431,25 @@ describe('completions', () => {
 
     describe('element attribute scope', () => {
       describe('dom completions', () => {
-        it('should not return completions dom completions in external template', () => {
+        it('should return dom property completions in external template', () => {
           const {templateFile} = setup(`<input >`, '');
           templateFile.moveCursorToText('<input ¦>');
 
           const completions = templateFile.getCompletionsAtPosition();
-          expect(completions?.entries.length).toBe(0);
+          expectDoesNotContain(
+              completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.ATTRIBUTE),
+              ['value']);
+          expectContain(
+              completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.PROPERTY),
+              ['[value]']);
         });
 
-        it('should return completions for a new element attribute', () => {
+        it('should return completions for a new element property', () => {
           const {appFile} = setupInlineTemplate(`<input >`, '');
           appFile.moveCursorToText('<input ¦>');
 
           const completions = appFile.getCompletionsAtPosition();
-          expectContain(
+          expectDoesNotContain(
               completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.ATTRIBUTE),
               ['value']);
           expectContain(
@@ -457,7 +462,7 @@ describe('completions', () => {
           appFile.moveCursorToText('<input val¦>');
 
           const completions = appFile.getCompletionsAtPosition();
-          expectContain(
+          expectDoesNotContain(
               completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.ATTRIBUTE),
               ['value']);
           expectContain(
@@ -477,7 +482,7 @@ describe('completions', () => {
           expectDoesNotContain(
               completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.PROPERTY),
               ['[value]']);
-          expectContain(
+          expectDoesNotContain(
               completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.PROPERTY),
               ['value']);
           expectReplacementText(completions, appFile.contents, 'val');


### PR DESCRIPTION
…emplates

When possible, the @angular/language-service should only provide
information related to Angular. When there is an embedded language, like
inline templates, editor extensions should have the ability to create
virtual documents and forward the requests to the relevant providers for
that language type (see https://github.com/angular/vscode-ng-language-service/pull/1212).

This commit removes all dom schema completions in both inline and
external templates and provides only the Angular syntax for property completions
on elements.


Merge target note: This PR targets `minor` (which will be v12) because the corresponding change to the vscode extension will not land in patch since it is 