### PR TITLE
refactor(core): explore approach to avoid storing LView in __ngContext__

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -112,6 +112,33 @@
     "packages/core/src/change_detection/change_detection.ts",
     "packages/core/src/change_detection/change_detector_ref.ts",
     "packages/core/src/render3/view_ref.ts",
+    "packages/core/src/render3/collect_native_nodes.ts",
+    "packages/core/src/render3/node_manipulation.ts",
+    "packages/core/src/render3/context_discovery.ts",
+    "packages/core/src/render3/instructions/shared.ts",
+    "packages/core/src/error_handler.ts",
+    "packages/core/src/errors.ts",
+    "packages/core/src/view/types.ts",
+    "packages/core/src/linker/component_factory.ts"
+  ],
+  [
+    "packages/core/src/change_detection/change_detection.ts",
+    "packages/core/src/change_detection/change_detector_ref.ts",
+    "packages/core/src/render3/view_ref.ts",
+    "packages/core/src/render3/collect_native_nodes.ts",
+    "packages/core/src/render3/node_manipulation.ts",
+    "packages/core/src/render3/util/view_traversal_utils.ts",
+    "packages/core/src/render3/context_discovery.ts",
+    "packages/core/src/render3/instructions/shared.ts",
+    "packages/core/src/error_handler.ts",
+    "packages/core/src/errors.ts",
+    "packages/core/src/view/types.ts",
+    "packages/core/src/linker/component_factory.ts"
+  ],
+  [
+    "packages/core/src/change_detection/change_detection.ts",
+    "packages/core/src/change_detection/change_detector_ref.ts",
+    "packages/core/src/render3/view_ref.ts",
     "packages/core/src/render3/instructions/shared.ts",
     "packages/core/src/error_handler.ts",
     "packages/core/src/errors.ts",
@@ -208,6 +235,10 @@
   [
     "packages/core/src/metadata/ng_module.ts",
     "packages/core/src/render3/jit/module.ts"
+  ],
+  [
+    "packages/core/src/render3/context_discovery.ts",
+    "packages/core/src/render3/instructions/shared.ts"
   ],
   [
     "packages/core/src/render3/interfaces/container.ts",

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -7,7 +7,8 @@
  */
 
 import {Injector} from '../di/injector';
-import {assertTNodeForLView} from '../render3/assert';
+import {assertLView, assertTNodeForLView} from '../render3/assert';
+import {getLViewById} from '../render3/instructions/shared';
 import {CONTAINER_HEADER_OFFSET, LContainer, NATIVE} from '../render3/interfaces/container';
 import {TElementNode, TNode, TNodeFlags, TNodeType} from '../render3/interfaces/node';
 import {isComponentHost, isLContainer} from '../render3/interfaces/type_checks';
@@ -263,8 +264,9 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
   get name(): string {
     try {
       const context = loadLContext(this.nativeNode)!;
-      const lView = context.lView;
-      const tData = lView[TVIEW].data;
+      const lView = getLViewById(context.lViewId);
+      ngDevMode && assertLView(lView);
+      const tData = lView![TVIEW].data;
       const tNode = tData[context.nodeIndex] as TNode;
       return tNode.value!;
     } catch (e) {
@@ -290,8 +292,9 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
       return {};
     }
 
-    const lView = context.lView;
-    const tData = lView[TVIEW].data;
+    const lView = getLViewById(context.lViewId);
+    ngDevMode && assertLView(lView);
+    const tData = lView![TVIEW].data;
     const tNode = tData[context.nodeIndex] as TNode;
 
     const properties: {[key: string]: string} = {};
@@ -299,7 +302,7 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
     copyDomProperties(this.nativeElement, properties);
     // Collect properties from the bindings. This is needed for animation renderer which has
     // synthetic properties which don't get reflected into the DOM.
-    collectPropertyBindings(properties, tNode, lView, tData);
+    collectPropertyBindings(properties, tNode, lView!, tData);
     return properties;
   }
 
@@ -316,8 +319,9 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
       return {};
     }
 
-    const lView = context.lView;
-    const tNodeAttrs = (lView[TVIEW].data[context.nodeIndex] as TNode).attrs;
+    const lView = getLViewById(context.lViewId);
+    ngDevMode && assertLView(lView);
+    const tNodeAttrs = (lView![TVIEW].data[context.nodeIndex] as TNode).attrs;
     const lowercaseTNodeAttrs: string[] = [];
 
     // For debug nodes we take the element's attribute directly from the DOM since it allows us
@@ -503,9 +507,11 @@ function _queryAllR3(
     matches: DebugElement[]|DebugNode[], elementsOnly: boolean) {
   const context = loadLContext(parentElement.nativeNode, false);
   if (context !== null) {
-    const parentTNode = context.lView[TVIEW].data[context.nodeIndex] as TNode;
+    const lView = getLViewById(context.lViewId);
+    ngDevMode && assertLView(lView);
+    const parentTNode = lView![TVIEW].data[context.nodeIndex] as TNode;
     _queryNodeChildrenR3(
-        parentTNode, context.lView, predicate, matches, elementsOnly, parentElement.nativeNode);
+        parentTNode, lView!, predicate, matches, elementsOnly, parentElement.nativeNode);
   } else {
     // If the context is null, then `parentElement` was either created with Renderer2 or native DOM
     // APIs.

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -9,7 +9,7 @@
 import {Injector} from '../di/injector';
 import {assertNodeInjector} from '../render3/assert';
 import {getParentInjectorLocation, NodeInjector} from '../render3/di';
-import {addToViewTree, createLContainer} from '../render3/instructions/shared';
+import {addToViewTree, createLContainer, destroyLView} from '../render3/instructions/shared';
 import {CONTAINER_HEADER_OFFSET, LContainer, NATIVE, VIEW_REFS} from '../render3/interfaces/container';
 import {NodeInjectorOffset} from '../render3/interfaces/injector';
 import {TContainerNode, TDirectiveHostNode, TElementContainerNode, TElementNode, TNodeType} from '../render3/interfaces/node';
@@ -17,7 +17,7 @@ import {RComment, RElement} from '../render3/interfaces/renderer_dom';
 import {isLContainer} from '../render3/interfaces/type_checks';
 import {LView, PARENT, RENDERER, T_HOST, TVIEW} from '../render3/interfaces/view';
 import {assertTNodeType} from '../render3/node_assert';
-import {addViewToContainer, destroyLView, detachView, getBeforeNodeForView, insertView, nativeInsertBefore, nativeNextSibling, nativeParentNode} from '../render3/node_manipulation';
+import {addViewToContainer, detachView, getBeforeNodeForView, insertView, nativeInsertBefore, nativeNextSibling, nativeParentNode} from '../render3/node_manipulation';
 import {getCurrentTNode, getLView} from '../render3/state';
 import {getParentInjectorIndex, getParentInjectorView, hasParentInjector} from '../render3/util/injector_utils';
 import {getNativeByTNode, unwrapRNode, viewAttachedToContainer} from '../render3/util/view_utils';

--- a/packages/core/src/render3/instructions/lview_debug.ts
+++ b/packages/core/src/render3/instructions/lview_debug.ts
@@ -25,7 +25,7 @@ import {LQueries, TQueries} from '../interfaces/query';
 import {Renderer3, RendererFactory3} from '../interfaces/renderer';
 import {RComment, RElement, RNode} from '../interfaces/renderer_dom';
 import {getTStylingRangeNext, getTStylingRangeNextDuplicate, getTStylingRangePrev, getTStylingRangePrevDuplicate, TStylingKey, TStylingRange} from '../interfaces/styling';
-import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DebugNode, DECLARATION_VIEW, DestroyHookData, FLAGS, HEADER_OFFSET, HookData, HOST, HostBindingOpCodes, INJECTOR, LContainerDebug as ILContainerDebug, LView, LViewDebug as ILViewDebug, LViewDebugRange, LViewDebugRangeContent, LViewFlags, NEXT, NodeInjectorDebug, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, SANITIZER, T_HOST, TData, TView as ITView, TVIEW, TView, TViewType, TViewTypeAsString} from '../interfaces/view';
+import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DebugNode, DECLARATION_VIEW, DestroyHookData, FLAGS, HEADER_OFFSET, HookData, HOST, HostBindingOpCodes, ID, INJECTOR, LContainerDebug as ILContainerDebug, LView, LViewDebug as ILViewDebug, LViewDebugRange, LViewDebugRangeContent, LViewFlags, NEXT, NodeInjectorDebug, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, SANITIZER, T_HOST, TData, TView as ITView, TVIEW, TView, TViewType, TViewTypeAsString} from '../interfaces/view';
 import {attachDebugObject} from '../util/debug_utils';
 import {getParentInjectorIndex, getParentInjectorView} from '../util/injector_utils';
 import {unwrapRNode} from '../util/view_utils';
@@ -513,6 +513,9 @@ export class LViewDebug implements ILViewDebug {
   get tHost(): ITNode|null {
     return this._raw_lView[T_HOST];
   }
+  get id(): number {
+    return this._raw_lView[ID];
+  }
 
   get decls(): LViewDebugRange {
     return toLViewRange(this.tView, this._raw_lView, HEADER_OFFSET, this.tView.bindingStartIndex);
@@ -527,7 +530,6 @@ export class LViewDebug implements ILViewDebug {
     return toLViewRange(
         this.tView, this._raw_lView, this.tView.expandoStartIndex, this._raw_lView.length);
   }
-
   /**
    * Normalized view of child views (and containers) attached at this location.
    */

--- a/packages/core/src/render3/interfaces/context.ts
+++ b/packages/core/src/render3/interfaces/context.ts
@@ -8,7 +8,6 @@
 
 
 import {RNode} from './renderer_dom';
-import {LView} from './view';
 
 
 /**
@@ -23,9 +22,9 @@ import {LView} from './view';
  */
 export interface LContext {
   /**
-   * The component's parent view data.
+   * ID of the component's parent view data.
    */
-  lView: LView;
+  lViewId: number;
 
   /**
    * The index instance of the node.

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -47,6 +47,7 @@ export const DECLARATION_COMPONENT_VIEW = 16;
 export const DECLARATION_LCONTAINER = 17;
 export const PREORDER_HOOK_FLAGS = 18;
 export const QUERIES = 19;
+export const ID = 20;
 /**
  * Size of LView's header. Necessary to adjust for it when setting slots.
  *
@@ -54,7 +55,7 @@ export const QUERIES = 19;
  * instruction index into `LView` index. All other indexes should be in the `LView` index space and
  * there should be no need to refer to `HEADER_OFFSET` anywhere else.
  */
-export const HEADER_OFFSET = 20;
+export const HEADER_OFFSET = 21;
 
 
 // This interface replaces the real LView interface if it is an arg or a
@@ -326,6 +327,9 @@ export interface LView extends Array<any> {
    * are not `Dirty`/`CheckAlways`.
    */
   [TRANSPLANTED_VIEWS_TO_REFRESH]: number;
+
+  /** Unique ID of the view. */
+  [ID]: number;
 }
 
 /** Flags associated with an LView (saved in LView[FLAGS]) */

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -33,7 +33,7 @@ import {getNativeByTNode, unwrapRNode, updateTransplantedViewCount} from './util
 
 const unusedValueToPlacateAjd = unused1 + unused2 + unused3 + unused4 + unused5;
 
-const enum WalkTNodeTreeAction {
+export const enum WalkTNodeTreeAction {
   /** node create in the native environment. Run on initial creation. */
   Create = 0,
 
@@ -378,24 +378,6 @@ export function detachView(lContainer: LContainer, removeIndex: number): LView|u
     viewToDetach[FLAGS] &= ~LViewFlags.Attached;
   }
   return viewToDetach;
-}
-
-/**
- * A standalone function which destroys an LView,
- * conducting clean up (e.g. removing listeners, calling onDestroys).
- *
- * @param tView The `TView' of the `LView` to be destroyed
- * @param lView The view to be destroyed.
- */
-export function destroyLView(tView: TView, lView: LView) {
-  if (!(lView[FLAGS] & LViewFlags.Destroyed)) {
-    const renderer = lView[RENDERER];
-    if (isProceduralRenderer(renderer) && renderer.destroyNode) {
-      applyView(tView, lView, renderer, WalkTNodeTreeAction.Destroy, null, null);
-    }
-
-    destroyViewTree(lView);
-  }
 }
 
 /**
@@ -901,13 +883,13 @@ function applyNodes(
  * @param parentRElement parent DOM element for insertion (Removal does not need it).
  * @param beforeNode Before which node the insertions should happen.
  */
-function applyView(
+export function applyView(
     tView: TView, lView: LView, renderer: Renderer3, action: WalkTNodeTreeAction.Destroy,
     parentRElement: null, beforeNode: null): void;
-function applyView(
+export function applyView(
     tView: TView, lView: LView, renderer: Renderer3, action: WalkTNodeTreeAction,
     parentRElement: RElement|null, beforeNode: RNode|null): void;
-function applyView(
+export function applyView(
     tView: TView, lView: LView, renderer: Renderer3, action: WalkTNodeTreeAction,
     parentRElement: RElement|null, beforeNode: RNode|null): void {
   applyNodes(renderer, action, tView.firstChild, lView, parentRElement, beforeNode, false);

--- a/packages/core/src/render3/util/discovery_utils.ts
+++ b/packages/core/src/render3/util/discovery_utils.ts
@@ -12,6 +12,7 @@ import {assertLView} from '../assert';
 import {discoverLocalRefs, getComponentAtNodeIndex, getDirectivesAtNodeIndex, getLContext} from '../context_discovery';
 import {NodeInjector} from '../di';
 import {buildDebugNode} from '../instructions/lview_debug';
+import {getLViewById} from '../instructions/shared';
 import {LContext} from '../interfaces/context';
 import {DirectiveDef} from '../interfaces/definition';
 import {TElementNode, TNode, TNodeProviderIndexes} from '../interfaces/node';
@@ -54,7 +55,9 @@ export function getComponent<T>(element: Element): T|null {
   if (context === null) return null;
 
   if (context.component === undefined) {
-    context.component = getComponentAtNodeIndex(context.nodeIndex, context.lView);
+    const lView = getLViewById(context.lViewId)!;
+    ngDevMode && assertLView(lView);
+    context.component = getComponentAtNodeIndex(context.nodeIndex, lView);
   }
 
   return context.component as T;
@@ -76,7 +79,8 @@ export function getComponent<T>(element: Element): T|null {
 export function getContext<T>(element: Element): T|null {
   assertDomElement(element);
   const context = loadLContext(element, false);
-  return context === null ? null : context.lView[CONTEXT] as T;
+  const lView = context === null ? null : getLViewById(context.lViewId)!;
+  return lView === null ? null : lView[CONTEXT] as T;
 }
 
 /**
@@ -98,7 +102,8 @@ export function getOwningComponent<T>(elementOrDir: Element|{}): T|null {
   const context = loadLContext(elementOrDir, false);
   if (context === null) return null;
 
-  let lView = context.lView;
+  let lView = getLViewById(context.lViewId)!;
+  ngDevMode && assertLView(lView);
   let parent: LView|null;
   ngDevMode && assertLView(lView);
   while (lView[TVIEW].type === TViewType.Embedded && (parent = getLViewParent(lView)!)) {
@@ -136,8 +141,10 @@ export function getInjector(elementOrDir: Element|{}): Injector {
   const context = loadLContext(elementOrDir, false);
   if (context === null) return Injector.NULL;
 
-  const tNode = context.lView[TVIEW].data[context.nodeIndex] as TElementNode;
-  return new NodeInjector(tNode, context.lView);
+  const lView = getLViewById(context.lViewId)!;
+  ngDevMode && assertLView(lView);
+  const tNode = lView[TVIEW].data[context.nodeIndex] as TElementNode;
+  return new NodeInjector(tNode, lView);
 }
 
 /**
@@ -148,7 +155,8 @@ export function getInjector(elementOrDir: Element|{}): Injector {
 export function getInjectionTokens(element: Element): any[] {
   const context = loadLContext(element, false);
   if (context === null) return [];
-  const lView = context.lView;
+  const lView = getLViewById(context.lViewId)!;
+  ngDevMode && assertLView(lView);
   const tView = lView[TVIEW];
   const tNode = tView.data[context.nodeIndex] as TNode;
   const providerTokens: any[] = [];
@@ -195,7 +203,9 @@ export function getDirectives(element: Element): {}[] {
   const context = loadLContext(element)!;
 
   if (context.directives === undefined) {
-    context.directives = getDirectivesAtNodeIndex(context.nodeIndex, context.lView, false);
+    const lView = getLViewById(context.lViewId)!;
+    ngDevMode && assertLView(lView);
+    context.directives = getDirectivesAtNodeIndex(context.nodeIndex, lView, false);
   }
 
   // The `directives` in this case are a named array called `LComponentView`. Clone the
@@ -232,7 +242,9 @@ export function getLocalRefs(target: {}): {[key: string]: any} {
   if (context === null) return {};
 
   if (context.localRefs === undefined) {
-    context.localRefs = discoverLocalRefs(context.lView, context.nodeIndex);
+    const lView = getLViewById(context.lViewId)!;
+    ngDevMode && assertLView(lView);
+    context.localRefs = discoverLocalRefs(lView, context.nodeIndex);
   }
 
   return context.localRefs || {};
@@ -327,7 +339,8 @@ export function getListeners(element: Element): Listener[] {
   const lContext = loadLContext(element, false);
   if (lContext === null) return [];
 
-  const lView = lContext.lView;
+  const lView = getLViewById(lContext.lViewId)!;
+  ngDevMode && assertLView(lView);
   const tView = lView[TVIEW];
   const lCleanup = lView[CLEANUP];
   const tCleanup = tView.cleanup;
@@ -380,7 +393,8 @@ export function getDebugNode(element: Element): DebugNode|null {
   let debugNode: DebugNode|null = null;
 
   const lContext = loadLContextFromNode(element);
-  const lView = lContext.lView;
+  const lView = getLViewById(lContext.lViewId)!;
+  ngDevMode && assertLView(lView);
   const nodeIndex = lContext.nodeIndex;
   if (nodeIndex !== -1) {
     const valueInLView = lView[nodeIndex];
@@ -407,7 +421,8 @@ export function getDebugNode(element: Element): DebugNode|null {
 export function getComponentLView(target: any): LView {
   const lContext = loadLContext(target);
   const nodeIndx = lContext.nodeIndex;
-  const lView = lContext.lView;
+  const lView = getLViewById(lContext.lViewId)!;
+  ngDevMode && assertLView(lView);
   const componentLView = lView[nodeIndx];
   ngDevMode && assertLView(componentLView);
   return componentLView;

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -11,11 +11,11 @@ import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, InternalViewRef as viewEn
 import {removeFromArray} from '../util/array_utils';
 import {assertEqual} from '../util/assert';
 import {collectNativeNodes} from './collect_native_nodes';
-import {checkNoChangesInRootView, checkNoChangesInternal, detectChangesInRootView, detectChangesInternal, markViewDirty, storeCleanupWithContext} from './instructions/shared';
+import {checkNoChangesInRootView, checkNoChangesInternal, destroyLView, detectChangesInRootView, detectChangesInternal, markViewDirty, storeCleanupWithContext} from './instructions/shared';
 import {CONTAINER_HEADER_OFFSET, VIEW_REFS} from './interfaces/container';
 import {isLContainer} from './interfaces/type_checks';
 import {CONTEXT, FLAGS, LView, LViewFlags, PARENT, TVIEW} from './interfaces/view';
-import {destroyLView, detachView, renderDetachView} from './node_manipulation';
+import {detachView, renderDetachView} from './node_manipulation';
 
 
 

--- a/packages/core/test/acceptance/debug_spec.ts
+++ b/packages/core/test/acceptance/debug_spec.ts
@@ -9,6 +9,7 @@
 import {Component} from '@angular/core';
 import {getLContext} from '@angular/core/src/render3/context_discovery';
 import {LViewDebug} from '@angular/core/src/render3/instructions/lview_debug';
+import {getLViewById} from '@angular/core/src/render3/instructions/shared';
 import {TNodeType} from '@angular/core/src/render3/interfaces/node';
 import {HEADER_OFFSET} from '@angular/core/src/render3/interfaces/view';
 import {TestBed} from '@angular/core/testing';
@@ -27,7 +28,7 @@ onlyInIvy('Ivy specific').describe('Debug Representation', () => {
     const fixture = TestBed.createComponent(MyComponent);
     fixture.detectChanges();
 
-    const hostView = getLContext(fixture.componentInstance)!.lView.debug!;
+    const hostView = getLViewById(getLContext(fixture.componentInstance)!.lViewId)!.debug!;
     expect(hostView.hostHTML).toEqual(null);
     const myCompView = hostView.childViews[0] as LViewDebug;
     expect(myCompView.hostHTML).toContain('<div id="123">Hello World</div>');
@@ -47,7 +48,7 @@ onlyInIvy('Ivy specific').describe('Debug Representation', () => {
         const fixture = TestBed.createComponent(MyComponent);
         fixture.detectChanges();
 
-        const hostView = getLContext(fixture.componentInstance)!.lView.debug!;
+        const hostView = getLViewById(getLContext(fixture.componentInstance)!.lViewId)!.debug!;
         const myComponentView = hostView.childViews[0] as LViewDebug;
         expect(myComponentView.decls).toEqual({
           start: HEADER_OFFSET,

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -652,12 +652,12 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
         const lViewDebug = lView.debug!;
         fixture.detectChanges();
         expect((fixture.nativeElement as Element).textContent).toEqual('just now');
-        expect(lViewDebug.nodes.map(toTypeContent)).toEqual(['IcuContainer(<!--ICU 20:0-->)']);
+        expect(lViewDebug.nodes.map(toTypeContent)).toEqual(['IcuContainer(<!--ICU 21:0-->)']);
         // We want to ensure that the ICU container does not have any content!
         // This is because the content is instance dependent and therefore can't be shared
         // across `TNode`s.
         expect(lViewDebug.nodes[0].children.map(toTypeContent)).toEqual([]);
-        expect(fixture.nativeElement.innerHTML).toEqual('just now<!--ICU 20:0-->');
+        expect(fixture.nativeElement.innerHTML).toEqual('just now<!--ICU 21:0-->');
       });
 
       it('should support multiple ICUs', () => {
@@ -674,15 +674,15 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
         `);
         const lView = getComponentLView(fixture.componentInstance);
         expect(lView.debug!.nodes.map(toTypeContent)).toEqual([
-          'IcuContainer(<!--ICU 20:0-->)',
           'IcuContainer(<!--ICU 21:0-->)',
+          'IcuContainer(<!--ICU 22:0-->)',
         ]);
         // We want to ensure that the ICU container does not have any content!
         // This is because the content is instance dependent and therefore can't be shared
         // across `TNode`s.
         expect(lView.debug!.nodes[0].children.map(toTypeContent)).toEqual([]);
         expect(fixture.nativeElement.innerHTML)
-            .toEqual('just now<!--ICU 20:0-->Mr. Angular<!--ICU 21:0-->');
+            .toEqual('just now<!--ICU 21:0-->Mr. Angular<!--ICU 22:0-->');
       });
     });
   });
@@ -778,19 +778,19 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
         other {({{name}})}
       }</div>`);
       expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<div>aucun <b>email</b>!<!--ICU 21:0--> - (Angular)<!--ICU 21:3--></div>`);
+          .toEqual(`<div>aucun <b>email</b>!<!--ICU 22:0--> - (Angular)<!--ICU 22:3--></div>`);
 
       fixture.componentRef.instance.count = 4;
       fixture.detectChanges();
       expect(fixture.nativeElement.innerHTML)
           .toEqual(
-              `<div>4 <span title="Angular">emails</span><!--ICU 21:0--> - (Angular)<!--ICU 21:3--></div>`);
+              `<div>4 <span title="Angular">emails</span><!--ICU 22:0--> - (Angular)<!--ICU 22:3--></div>`);
 
       fixture.componentRef.instance.count = 0;
       fixture.componentRef.instance.name = 'John';
       fixture.detectChanges();
       expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<div>aucun <b>email</b>!<!--ICU 21:0--> - (John)<!--ICU 21:3--></div>`);
+          .toEqual(`<div>aucun <b>email</b>!<!--ICU 22:0--> - (John)<!--ICU 22:3--></div>`);
     });
 
     it('with custom interpolation config', () => {
@@ -829,9 +829,9 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       expect(fixture.nativeElement.innerHTML)
           .toEqual(
               `<div>` +
-              `<span>aucun <b>email</b>!<!--ICU 21:0--></span>` +
+              `<span>aucun <b>email</b>!<!--ICU 22:0--></span>` +
               ` - ` +
-              `<span>(Angular)<!--ICU 21:3--></span>` +
+              `<span>(Angular)<!--ICU 22:3--></span>` +
               `</div>`);
 
       fixture.componentRef.instance.count = 4;
@@ -839,9 +839,9 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       expect(fixture.nativeElement.innerHTML)
           .toEqual(
               `<div>` +
-              `<span>4 <span title="Angular">emails</span><!--ICU 21:0--></span>` +
+              `<span>4 <span title="Angular">emails</span><!--ICU 22:0--></span>` +
               ` - ` +
-              `<span>(Angular)<!--ICU 21:3--></span>` +
+              `<span>(Angular)<!--ICU 22:3--></span>` +
               `</div>`);
 
       fixture.componentRef.instance.count = 0;
@@ -850,9 +850,9 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       expect(fixture.nativeElement.innerHTML)
           .toEqual(
               `<div>` +
-              `<span>aucun <b>email</b>!<!--ICU 21:0--></span>` +
+              `<span>aucun <b>email</b>!<!--ICU 22:0--></span>` +
               ` - ` +
-              `<span>(John)<!--ICU 21:3--></span>` +
+              `<span>(John)<!--ICU 22:3--></span>` +
               `</div>`);
     });
 
@@ -867,7 +867,7 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
         other {({{name}})}
       }</span></div>`);
       expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<div><span>(Angular)<!--ICU 20:0--></span><!--bindings={
+          .toEqual(`<div><span>(Angular)<!--ICU 21:0--></span><!--bindings={
   "ng-reflect-ng-if": "true"
 }--></div>`);
 
@@ -887,7 +887,7 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
         other {({{name}})}
       }</ng-container>`);
       expect(fixture.nativeElement.innerHTML)
-          .toEqual(`(Angular)<!--ICU 21:0--><!--ng-container-->`);
+          .toEqual(`(Angular)<!--ICU 22:0--><!--ng-container-->`);
     });
 
     it('inside <ng-template>', () => {
@@ -922,12 +922,12 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
                        other {animals}
                      }!}
       }</div>`);
-      expect(fixture.nativeElement.innerHTML).toEqual(`<div>zero<!--ICU 21:1--></div>`);
+      expect(fixture.nativeElement.innerHTML).toEqual(`<div>zero<!--ICU 22:1--></div>`);
 
       fixture.componentRef.instance.count = 4;
       fixture.detectChanges();
       expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<div>4 animaux<!--nested ICU 0-->!<!--ICU 21:1--></div>`);
+          .toEqual(`<div>4 animaux<!--nested ICU 0-->!<!--ICU 22:1--></div>`);
     });
 
     it('nested with interpolations in "other" blocks', () => {
@@ -947,16 +947,16 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
                      }!}
         other {other - {{count}}}
       }</div>`);
-      expect(fixture.nativeElement.innerHTML).toEqual(`<div>zero<!--ICU 21:1--></div>`);
+      expect(fixture.nativeElement.innerHTML).toEqual(`<div>zero<!--ICU 22:1--></div>`);
 
       fixture.componentRef.instance.count = 2;
       fixture.detectChanges();
       expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<div>2 animaux<!--nested ICU 0-->!<!--ICU 21:1--></div>`);
+          .toEqual(`<div>2 animaux<!--nested ICU 0-->!<!--ICU 22:1--></div>`);
 
       fixture.componentRef.instance.count = 4;
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual(`<div>autre - 4<!--ICU 21:1--></div>`);
+      expect(fixture.nativeElement.innerHTML).toEqual(`<div>autre - 4<!--ICU 22:1--></div>`);
     });
 
     it('should return the correct plural form for ICU expressions when using "ro" locale', () => {
@@ -989,31 +989,31 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
             =other {lots of emails}
           }`);
 
-      expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 20:0-->');
+      expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 21:0-->');
 
       // Change detection cycle, no model changes
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 20:0-->');
+      expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 21:0-->');
 
       fixture.componentInstance.count = 3;
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual('a few emails<!--ICU 20:0-->');
+      expect(fixture.nativeElement.innerHTML).toEqual('a few emails<!--ICU 21:0-->');
 
       fixture.componentInstance.count = 1;
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual('one email<!--ICU 20:0-->');
+      expect(fixture.nativeElement.innerHTML).toEqual('one email<!--ICU 21:0-->');
 
       fixture.componentInstance.count = 10;
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual('a few emails<!--ICU 20:0-->');
+      expect(fixture.nativeElement.innerHTML).toEqual('a few emails<!--ICU 21:0-->');
 
       fixture.componentInstance.count = 20;
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual('lots of emails<!--ICU 20:0-->');
+      expect(fixture.nativeElement.innerHTML).toEqual('lots of emails<!--ICU 21:0-->');
 
       fixture.componentInstance.count = 0;
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 20:0-->');
+      expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 21:0-->');
     });
 
     it(`should return the correct plural form for ICU expressions when using "es" locale`, () => {
@@ -1040,31 +1040,31 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
             =other {lots of emails}
           }`);
 
-      expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 20:0-->');
+      expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 21:0-->');
 
       // Change detection cycle, no model changes
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 20:0-->');
+      expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 21:0-->');
 
       fixture.componentInstance.count = 3;
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual('lots of emails<!--ICU 20:0-->');
+      expect(fixture.nativeElement.innerHTML).toEqual('lots of emails<!--ICU 21:0-->');
 
       fixture.componentInstance.count = 1;
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual('one email<!--ICU 20:0-->');
+      expect(fixture.nativeElement.innerHTML).toEqual('one email<!--ICU 21:0-->');
 
       fixture.componentInstance.count = 10;
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual('lots of emails<!--ICU 20:0-->');
+      expect(fixture.nativeElement.innerHTML).toEqual('lots of emails<!--ICU 21:0-->');
 
       fixture.componentInstance.count = 20;
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual('lots of emails<!--ICU 20:0-->');
+      expect(fixture.nativeElement.innerHTML).toEqual('lots of emails<!--ICU 21:0-->');
 
       fixture.componentInstance.count = 0;
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 20:0-->');
+      expect(fixture.nativeElement.innerHTML).toEqual('no email<!--ICU 21:0-->');
     });
 
     it('projection', () => {
@@ -1159,12 +1159,12 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
       expect(fixture.debugElement.nativeElement.innerHTML)
-          .toContain('<my-cmp><div>ONE<!--ICU 21:0--></div><!--container--></my-cmp>');
+          .toContain('<my-cmp><div>ONE<!--ICU 22:0--></div><!--container--></my-cmp>');
 
       fixture.componentRef.instance.count = 2;
       fixture.detectChanges();
       expect(fixture.debugElement.nativeElement.innerHTML)
-          .toContain('<my-cmp><div>OTHER<!--ICU 21:0--></div><!--container--></my-cmp>');
+          .toContain('<my-cmp><div>OTHER<!--ICU 22:0--></div><!--container--></my-cmp>');
 
       // destroy component
       fixture.componentInstance.condition = false;
@@ -1176,7 +1176,7 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       fixture.componentInstance.count = 1;
       fixture.detectChanges();
       expect(fixture.debugElement.nativeElement.innerHTML)
-          .toContain('<my-cmp><div>ONE<!--ICU 21:0--></div><!--container--></my-cmp>');
+          .toContain('<my-cmp><div>ONE<!--ICU 22:0--></div><!--container--></my-cmp>');
     });
 
     it('with nested ICU expression and inside a container when creating a view via vcr.createEmbeddedView',
@@ -1248,12 +1248,12 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
          fixture.detectChanges();
          expect(fixture.debugElement.nativeElement.innerHTML)
              .toBe(
-                 '<my-cmp><div>2 animals<!--nested ICU 0-->!<!--ICU 21:1--></div><!--container--></my-cmp>');
+                 '<my-cmp><div>2 animals<!--nested ICU 0-->!<!--ICU 22:1--></div><!--container--></my-cmp>');
 
          fixture.componentRef.instance.count = 1;
          fixture.detectChanges();
          expect(fixture.debugElement.nativeElement.innerHTML)
-             .toBe('<my-cmp><div>ONE<!--ICU 21:1--></div><!--container--></my-cmp>');
+             .toBe('<my-cmp><div>ONE<!--ICU 22:1--></div><!--container--></my-cmp>');
        });
 
     it('with nested containers', () => {
@@ -2357,13 +2357,13 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       fixture.detectChanges();
       expect(fixture.nativeElement.innerHTML)
           .toEqual(
-              `<child><div>Contenu enfant et projection depuis Parent<!--ICU 21:0--></div></child>`);
+              `<child><div>Contenu enfant et projection depuis Parent<!--ICU 22:0--></div></child>`);
 
       fixture.componentRef.instance.name = 'angular';
       fixture.detectChanges();
       expect(fixture.nativeElement.innerHTML)
           .toEqual(
-              `<child><div>Contenu enfant et projection depuis Angular<!--ICU 21:0--></div></child>`);
+              `<child><div>Contenu enfant et projection depuis Angular<!--ICU 22:0--></div></child>`);
     });
 
     it(`shouldn't project deleted projections in i18n blocks`, () => {

--- a/packages/core/test/acceptance/ngdevmode_debug_spec.ts
+++ b/packages/core/test/acceptance/ngdevmode_debug_spec.ts
@@ -8,7 +8,7 @@
 
 import {CommonModule} from '@angular/common';
 import {Component} from '@angular/core';
-import {LView} from '@angular/core/src/render3/interfaces/view';
+import {getLViewById} from '@angular/core/src/render3/instructions/shared';
 import {getComponentLView, loadLContext} from '@angular/core/src/render3/util/discovery_utils';
 import {createNamedArrayType} from '@angular/core/src/util/named_array_type';
 import {TestBed} from '@angular/core/testing';
@@ -32,7 +32,7 @@ onlyInIvy('Debug information exist in ivy only').describe('ngDevMode debug', () 
 
       TestBed.configureTestingModule({declarations: [MyApp], imports: [CommonModule]});
       const fixture = TestBed.createComponent(MyApp);
-      const rootLView = loadLContext(fixture.nativeElement).lView;
+      const rootLView = getLViewById(loadLContext(fixture.nativeElement).lViewId)!;
       expect(rootLView.constructor.name).toEqual('LRootView');
 
       const componentLView = getComponentLView(fixture.componentInstance);
@@ -41,7 +41,7 @@ onlyInIvy('Debug information exist in ivy only').describe('ngDevMode debug', () 
       const element: HTMLElement = fixture.nativeElement;
       fixture.detectChanges();
       const li = element.querySelector('li')!;
-      const embeddedLView = loadLContext(li).lView;
+      const embeddedLView = getLViewById(loadLContext(li).lViewId)!;
       expect(embeddedLView.constructor.name).toEqual('LEmbeddedView_MyApp_li_1');
     });
   });

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -1,5 +1,8 @@
 [
   {
+    "name": "ACTIVE_LVIEWS"
+  },
+  {
     "name": "CLEAN_PROMISE"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1,5 +1,8 @@
 [
   {
+    "name": "ACTIVE_LVIEWS"
+  },
+  {
     "name": "ALLOW_MULTIPLE_PLATFORMS"
   },
   {
@@ -969,6 +972,9 @@
     "name": "getLView"
   },
   {
+    "name": "getLViewById"
+  },
+  {
     "name": "getLViewParent"
   },
   {
@@ -1576,6 +1582,9 @@
   },
   {
     "name": "viewAttachedToChangeDetector"
+  },
+  {
+    "name": "waitForApp"
   },
   {
     "name": "wrapListener"

--- a/packages/core/test/bundling/forms_reactive/forms_e2e_spec.ts
+++ b/packages/core/test/bundling/forms_reactive/forms_e2e_spec.ts
@@ -7,7 +7,6 @@
  */
 
 import '@angular/compiler';
-import {ɵwhenRendered as whenRendered} from '@angular/core';
 import {withBody} from '@angular/private/testing';
 import * as path from 'path';
 
@@ -18,8 +17,8 @@ describe('functional test for reactive forms', () => {
   BUNDLES.forEach((bundle) => {
     describe(`using ${bundle} bundle`, () => {
       it('should render template form', withBody('<app-root></app-root>', async () => {
-           require(path.join(PACKAGE, bundle));
-           await (window as any).waitForApp;
+           const {whenRendered, waitForApp} = require(path.join(PACKAGE, bundle));
+           await waitForApp;
 
            // Reactive forms
            const reactiveFormsComponent = (window as any).reactiveFormsComponent;

--- a/packages/core/test/bundling/forms_reactive/index.ts
+++ b/packages/core/test/bundling/forms_reactive/index.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Component, NgModule, ɵNgModuleFactory as NgModuleFactory} from '@angular/core';
+import {Component, NgModule, ɵNgModuleFactory as NgModuleFactory, ɵwhenRendered as whenRendered} from '@angular/core';
 import {FormArray, FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
@@ -93,5 +93,12 @@ class FormsExampleModule {
   }
 }
 
-(window as any).waitForApp = platformBrowser().bootstrapModuleFactory(
+const waitForApp = platformBrowser().bootstrapModuleFactory(
     new NgModuleFactory(FormsExampleModule), {ngZone: 'noop'});
+
+// Re-export these symbols, because they're used within the
+// tests and we want them to come from this bundle.
+module.exports = {
+  whenRendered,
+  waitForApp
+};

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1,5 +1,8 @@
 [
   {
+    "name": "ACTIVE_LVIEWS"
+  },
+  {
     "name": "ALLOW_MULTIPLE_PLATFORMS"
   },
   {
@@ -933,6 +936,9 @@
     "name": "getLView"
   },
   {
+    "name": "getLViewById"
+  },
+  {
     "name": "getLViewParent"
   },
   {
@@ -1549,6 +1555,9 @@
   },
   {
     "name": "viewAttachedToChangeDetector"
+  },
+  {
+    "name": "waitForApp"
   },
   {
     "name": "wrapListener"

--- a/packages/core/test/bundling/forms_template_driven/forms_e2e_spec.ts
+++ b/packages/core/test/bundling/forms_template_driven/forms_e2e_spec.ts
@@ -7,7 +7,6 @@
  */
 
 import '@angular/compiler';
-import {ɵwhenRendered as whenRendered} from '@angular/core';
 import {withBody} from '@angular/private/testing';
 import * as path from 'path';
 
@@ -18,8 +17,8 @@ describe('functional test for forms', () => {
   BUNDLES.forEach((bundle) => {
     describe(`using ${bundle} bundle`, () => {
       it('should render template form', withBody('<app-root></app-root>', async () => {
-           require(path.join(PACKAGE, bundle));
-           await (window as any).waitForApp;
+           const {waitForApp, whenRendered} = require(path.join(PACKAGE, bundle));
+           await waitForApp;
 
            // Template forms
            const templateFormsComponent = (window as any).templateFormsComponent;

--- a/packages/core/test/bundling/forms_template_driven/index.ts
+++ b/packages/core/test/bundling/forms_template_driven/index.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Component, NgModule, ɵNgModuleFactory as NgModuleFactory} from '@angular/core';
+import {Component, NgModule, ɵNgModuleFactory as NgModuleFactory, ɵwhenRendered as whenRendered} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
@@ -70,5 +70,12 @@ class FormsExampleModule {
   }
 }
 
-(window as any).waitForApp = platformBrowser().bootstrapModuleFactory(
+const waitForApp = platformBrowser().bootstrapModuleFactory(
     new NgModuleFactory(FormsExampleModule), {ngZone: 'noop'});
+
+// Re-export these symbols, because they're used within the
+// tests and we want them to come from this bundle.
+module.exports = {
+  whenRendered,
+  waitForApp
+};

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -1,5 +1,8 @@
 [
   {
+    "name": "ACTIVE_LVIEWS"
+  },
+  {
     "name": "CLEAN_PROMISE"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1,5 +1,8 @@
 [
   {
+    "name": "ACTIVE_LVIEWS"
+  },
+  {
     "name": "ALLOW_MULTIPLE_PLATFORMS"
   },
   {
@@ -1330,6 +1333,9 @@
   },
   {
     "name": "getLView"
+  },
+  {
+    "name": "getLViewById"
   },
   {
     "name": "getLViewParent"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1,5 +1,8 @@
 [
   {
+    "name": "ACTIVE_LVIEWS"
+  },
+  {
     "name": "CLEAN_PROMISE"
   },
   {
@@ -267,6 +270,9 @@
     "name": "createLContainer"
   },
   {
+    "name": "createLContext"
+  },
+  {
     "name": "createLFrame"
   },
   {
@@ -339,6 +345,12 @@
     "name": "findStylingValue"
   },
   {
+    "name": "findViaComponent"
+  },
+  {
+    "name": "findViaNativeElement"
+  },
+  {
     "name": "forwardRef"
   },
   {
@@ -379,6 +391,9 @@
   },
   {
     "name": "getLView"
+  },
+  {
+    "name": "getLViewById"
   },
   {
     "name": "getLViewParent"
@@ -739,6 +754,9 @@
   },
   {
     "name": "trackByIdentity"
+  },
+  {
+    "name": "traverseNextElement"
   },
   {
     "name": "unwrapRNode"

--- a/packages/core/test/bundling/todo/index.ts
+++ b/packages/core/test/bundling/todo/index.ts
@@ -9,7 +9,8 @@
 import '@angular/core/test/bundling/util/src/reflect_metadata';
 
 import {CommonModule} from '@angular/common';
-import {Component, Injectable, NgModule, ViewEncapsulation, ɵmarkDirty as markDirty, ɵrenderComponent as renderComponent} from '@angular/core';
+import {Component, Injectable, NgModule, ViewEncapsulation, ɵmarkDirty as markDirty, ɵrenderComponent as renderComponent, ɵwhenRendered as whenRendered} from '@angular/core';
+import {getComponent} from '@angular/core/src/render3';
 
 class Todo {
   editing: boolean;
@@ -133,7 +134,9 @@ class TodoStore {
 class ToDoAppComponent {
   newTodoText = '';
 
-  constructor(public todoStore: TodoStore) {}
+  constructor(public todoStore: TodoStore) {
+    (window as any).todoAppComponent = this;
+  }
 
   cancelEditingTodo(todo: Todo) {
     todo.editing = false;
@@ -200,3 +203,10 @@ class ToDoAppModule {
 }
 
 renderComponent(ToDoAppComponent);
+
+// Re-export these symbols, because they're used within the
+// tests and we want them to come from this bundle.
+module.exports = {
+  getComponent,
+  whenRendered
+};

--- a/packages/core/test/bundling/todo/todo_e2e_spec.ts
+++ b/packages/core/test/bundling/todo/todo_e2e_spec.ts
@@ -7,14 +7,9 @@
  */
 
 import '@angular/compiler';
-import {ɵwhenRendered as whenRendered} from '@angular/core';
-import {getComponent} from '@angular/core/src/render3';
 import {withBody} from '@angular/private/testing';
 import * as path from 'path';
 
-const UTF8 = {
-  encoding: 'utf-8'
-};
 const PACKAGE = 'angular/packages/core/test/bundling/todo';
 const BUNDLES = ['bundle.js', 'bundle.min_debug.js', 'bundle.min.js'];
 
@@ -22,7 +17,7 @@ describe('functional test for todo', () => {
   BUNDLES.forEach(bundle => {
     describe(bundle, () => {
       it('should render todo', withBody('<todo-app></todo-app>', async () => {
-           require(path.join(PACKAGE, bundle));
+           const {getComponent, whenRendered} = require(path.join(PACKAGE, bundle));
            const toDoAppComponent = getComponent(document.querySelector('todo-app')!);
            expect(document.body.textContent).toContain('todos');
            expect(document.body.textContent).toContain('Demonstrate Components');

--- a/packages/core/test/bundling/todo_i18n/index.ts
+++ b/packages/core/test/bundling/todo_i18n/index.ts
@@ -8,7 +8,8 @@
 import '@angular/core/test/bundling/util/src/reflect_metadata';
 import './translations';
 import {CommonModule} from '@angular/common';
-import {Component, Injectable, NgModule, ViewEncapsulation, ɵmarkDirty as markDirty, ɵrenderComponent as renderComponent} from '@angular/core';
+import {Component, Injectable, NgModule, ViewEncapsulation, ɵmarkDirty as markDirty, ɵrenderComponent as renderComponent, ɵwhenRendered as whenRendered} from '@angular/core';
+import {getComponent} from '@angular/core/src/render3';
 
 class Todo {
   editing: boolean;
@@ -194,3 +195,10 @@ class ToDoAppModule {
 }
 
 renderComponent(ToDoAppComponent);
+
+// Re-export these symbols, because they're used within the
+// tests and we want them to come from this bundle.
+module.exports = {
+  getComponent,
+  whenRendered
+};

--- a/packages/core/test/bundling/todo_i18n/todo_e2e_spec.ts
+++ b/packages/core/test/bundling/todo_i18n/todo_e2e_spec.ts
@@ -8,8 +8,6 @@
 import '@angular/localize/init';
 import '@angular/compiler';
 
-import {ɵwhenRendered as whenRendered} from '@angular/core';
-import {getComponent} from '@angular/core/src/render3';
 import {clearTranslations} from '@angular/localize';
 import {withBody} from '@angular/private/testing';
 import * as path from 'path';
@@ -22,7 +20,7 @@ describe('functional test for todo i18n', () => {
     describe(bundle, () => {
       it('should render todo i18n', withBody('<todo-app></todo-app>', async () => {
            clearTranslations();
-           require(path.join(PACKAGE, bundle));
+           const {getComponent, whenRendered} = require(path.join(PACKAGE, bundle));
            const toDoAppComponent = getComponent(document.querySelector('todo-app')!);
            expect(document.body.textContent).toContain('liste de tâches');
            expect(document.body.textContent).toContain('Démontrer les components');

--- a/packages/core/test/bundling/todo_r2/index.ts
+++ b/packages/core/test/bundling/todo_r2/index.ts
@@ -9,7 +9,7 @@
 import '@angular/core/test/bundling/util/src/reflect_metadata';
 
 import {CommonModule} from '@angular/common';
-import {Component, Injectable, NgModule, ɵNgModuleFactory as NgModuleFactory} from '@angular/core';
+import {Component, Injectable, NgModule, ɵNgModuleFactory as NgModuleFactory, ɵwhenRendered as whenRendered} from '@angular/core';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
 class Todo {
@@ -195,5 +195,12 @@ class ToDoAppModule {
   }
 }
 
-(window as any).waitForApp =
+const waitForApp =
     platformBrowser().bootstrapModuleFactory(new NgModuleFactory(ToDoAppModule), {ngZone: 'noop'});
+
+// Re-export these symbols, because they're used within the
+// tests and we want them to come from this bundle.
+module.exports = {
+  whenRendered,
+  waitForApp
+};

--- a/packages/core/test/bundling/todo_r2/todo_e2e_spec.ts
+++ b/packages/core/test/bundling/todo_r2/todo_e2e_spec.ts
@@ -7,13 +7,9 @@
  */
 
 import '@angular/compiler';
-import {ɵwhenRendered as whenRendered} from '@angular/core';
 import {withBody} from '@angular/private/testing';
 import * as path from 'path';
 
-const UTF8 = {
-  encoding: 'utf-8'
-};
 const PACKAGE = 'angular/packages/core/test/bundling/todo_r2';
 const BUNDLES = ['bundle.js', 'bundle.min_debug.js', 'bundle.min.js'];
 
@@ -22,8 +18,8 @@ describe('functional test for todo', () => {
     describe(bundle, () => {
       it('should place styles on the elements within the component',
          withBody('<todo-app></todo-app>', async () => {
-           require(path.join(PACKAGE, bundle));
-           await (window as any).waitForApp;
+           const {waitForApp, whenRendered} = require(path.join(PACKAGE, bundle));
+           await waitForApp;
            const toDoAppComponent = (window as any).toDoAppComponent;
            await whenRendered(toDoAppComponent);
 

--- a/packages/core/test/render3/i18n/i18n_insert_before_index_spec.ts
+++ b/packages/core/test/render3/i18n/i18n_insert_before_index_spec.ts
@@ -29,9 +29,9 @@ describe('addTNodeAndUpdateInsertBeforeIndex', () => {
 
   it('should add first node', () => {
     const previousTNodes: TNode[] = [];
-    addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(20));
+    addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(21));
     expect(previousTNodes).toEqual([
-      matchTNode({index: 20, insertBeforeIndex: null}),
+      matchTNode({index: 21, insertBeforeIndex: null}),
     ]);
   });
 
@@ -39,14 +39,14 @@ describe('addTNodeAndUpdateInsertBeforeIndex', () => {
     describe('whose index is greater than those already there', () => {
       it('should not update the `insertBeforeIndex` values', () => {
         const previousTNodes: TNode[] = [
-          tPlaceholderElementNode(20),
           tPlaceholderElementNode(21),
+          tPlaceholderElementNode(22),
         ];
-        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(22));
+        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(23));
         expect(previousTNodes).toEqual([
-          matchTNode({index: 20, insertBeforeIndex: null}),
           matchTNode({index: 21, insertBeforeIndex: null}),
           matchTNode({index: 22, insertBeforeIndex: null}),
+          matchTNode({index: 23, insertBeforeIndex: null}),
         ]);
       });
     });
@@ -54,44 +54,44 @@ describe('addTNodeAndUpdateInsertBeforeIndex', () => {
     describe('whose index is smaller than current nodes', () => {
       it('should update the previous insertBeforeIndex', () => {
         const previousTNodes: TNode[] = [
-          tPlaceholderElementNode(21),
           tPlaceholderElementNode(22),
+          tPlaceholderElementNode(23),
         ];
-        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(20));
+        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(21));
         expect(previousTNodes).toEqual([
-          matchTNode({index: 21, insertBeforeIndex: 20}),
-          matchTNode({index: 22, insertBeforeIndex: 20}),
-          matchTNode({index: 20, insertBeforeIndex: null}),
+          matchTNode({index: 22, insertBeforeIndex: 21}),
+          matchTNode({index: 23, insertBeforeIndex: 21}),
+          matchTNode({index: 21, insertBeforeIndex: null}),
         ]);
       });
 
       it('should not update the previous insertBeforeIndex if it is already set', () => {
         const previousTNodes: TNode[] = [
-          tPlaceholderElementNode(22, 21),
-          tPlaceholderElementNode(23, 21),
-          tPlaceholderElementNode(21),
+          tPlaceholderElementNode(23, 22),
+          tPlaceholderElementNode(24, 22),
+          tPlaceholderElementNode(22),
         ];
-        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(20));
+        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(21));
         expect(previousTNodes).toEqual([
+          matchTNode({index: 23, insertBeforeIndex: 22}),
+          matchTNode({index: 24, insertBeforeIndex: 22}),
           matchTNode({index: 22, insertBeforeIndex: 21}),
-          matchTNode({index: 23, insertBeforeIndex: 21}),
-          matchTNode({index: 21, insertBeforeIndex: 20}),
-          matchTNode({index: 20, insertBeforeIndex: null}),
+          matchTNode({index: 21, insertBeforeIndex: null}),
         ]);
       });
 
       it('should not update the previous insertBeforeIndex if it is created after', () => {
         const previousTNodes: TNode[] = [
-          tPlaceholderElementNode(25, 20),
-          tPlaceholderElementNode(26, 20),
-          tPlaceholderElementNode(20),
+          tPlaceholderElementNode(26, 21),
+          tPlaceholderElementNode(27, 21),
+          tPlaceholderElementNode(21),
         ];
-        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(23));
+        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(24));
         expect(previousTNodes).toEqual([
-          matchTNode({index: 25, insertBeforeIndex: 20}),
-          matchTNode({index: 26, insertBeforeIndex: 20}),
-          matchTNode({index: 20, insertBeforeIndex: null}),
-          matchTNode({index: 23, insertBeforeIndex: null}),
+          matchTNode({index: 26, insertBeforeIndex: 21}),
+          matchTNode({index: 27, insertBeforeIndex: 21}),
+          matchTNode({index: 21, insertBeforeIndex: null}),
+          matchTNode({index: 24, insertBeforeIndex: null}),
         ]);
       });
     });
@@ -101,14 +101,14 @@ describe('addTNodeAndUpdateInsertBeforeIndex', () => {
     describe('whose index is greater than those already there', () => {
       it('should not update the `insertBeforeIndex` values', () => {
         const previousTNodes: TNode[] = [
-          tPlaceholderElementNode(20),
           tPlaceholderElementNode(21),
+          tPlaceholderElementNode(22),
         ];
-        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tI18NTextNode(22));
+        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tI18NTextNode(23));
         expect(previousTNodes).toEqual([
-          matchTNode({index: 20, insertBeforeIndex: 22}),
-          matchTNode({index: 21, insertBeforeIndex: 22}),
-          matchTNode({index: 22, insertBeforeIndex: null}),
+          matchTNode({index: 21, insertBeforeIndex: 23}),
+          matchTNode({index: 22, insertBeforeIndex: 23}),
+          matchTNode({index: 23, insertBeforeIndex: null}),
         ]);
       });
     });
@@ -116,44 +116,44 @@ describe('addTNodeAndUpdateInsertBeforeIndex', () => {
     describe('whose index is smaller than current nodes', () => {
       it('should update the previous insertBeforeIndex', () => {
         const previousTNodes: TNode[] = [
-          tPlaceholderElementNode(21),
           tPlaceholderElementNode(22),
+          tPlaceholderElementNode(23),
         ];
-        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tI18NTextNode(20));
+        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tI18NTextNode(21));
         expect(previousTNodes).toEqual([
-          matchTNode({index: 21, insertBeforeIndex: 20}),
-          matchTNode({index: 22, insertBeforeIndex: 20}),
-          matchTNode({index: 20, insertBeforeIndex: null}),
+          matchTNode({index: 22, insertBeforeIndex: 21}),
+          matchTNode({index: 23, insertBeforeIndex: 21}),
+          matchTNode({index: 21, insertBeforeIndex: null}),
         ]);
       });
 
       it('should not update the previous insertBeforeIndex if it is already set', () => {
         const previousTNodes: TNode[] = [
-          tPlaceholderElementNode(22, 21),
-          tPlaceholderElementNode(23, 21),
-          tPlaceholderElementNode(21),
+          tPlaceholderElementNode(23, 22),
+          tPlaceholderElementNode(24, 22),
+          tPlaceholderElementNode(22),
         ];
-        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tI18NTextNode(20));
+        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tI18NTextNode(21));
         expect(previousTNodes).toEqual([
+          matchTNode({index: 23, insertBeforeIndex: 22}),
+          matchTNode({index: 24, insertBeforeIndex: 22}),
           matchTNode({index: 22, insertBeforeIndex: 21}),
-          matchTNode({index: 23, insertBeforeIndex: 21}),
-          matchTNode({index: 21, insertBeforeIndex: 20}),
-          matchTNode({index: 20, insertBeforeIndex: null}),
+          matchTNode({index: 21, insertBeforeIndex: null}),
         ]);
       });
 
       it('should not update the previous insertBeforeIndex if it is created after', () => {
         const previousTNodes: TNode[] = [
-          tPlaceholderElementNode(25, 20),
-          tPlaceholderElementNode(26, 20),
-          tPlaceholderElementNode(20),
+          tPlaceholderElementNode(26, 21),
+          tPlaceholderElementNode(27, 21),
+          tPlaceholderElementNode(21),
         ];
-        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tI18NTextNode(23));
+        addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tI18NTextNode(24));
         expect(previousTNodes).toEqual([
-          matchTNode({index: 25, insertBeforeIndex: 20}),
-          matchTNode({index: 26, insertBeforeIndex: 20}),
-          matchTNode({index: 20, insertBeforeIndex: 23}),
-          matchTNode({index: 23, insertBeforeIndex: null}),
+          matchTNode({index: 26, insertBeforeIndex: 21}),
+          matchTNode({index: 27, insertBeforeIndex: 21}),
+          matchTNode({index: 21, insertBeforeIndex: 24}),
+          matchTNode({index: 24, insertBeforeIndex: null}),
         ]);
       });
     });
@@ -162,21 +162,21 @@ describe('addTNodeAndUpdateInsertBeforeIndex', () => {
   describe('scenario', () => {
     it('should rearrange the nodes', () => {
       const previousTNodes: TNode[] = [];
-      addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(22));
-      addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(28));
-      addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(24));
-      addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(25));
-      addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tI18NTextNode(29));
       addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(23));
-      addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(27));
+      addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(29));
+      addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(25));
+      addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(26));
+      addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tI18NTextNode(30));
+      addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(24));
+      addTNodeAndUpdateInsertBeforeIndex(previousTNodes, tPlaceholderElementNode(28));
       expect(previousTNodes).toEqual([
-        matchTNode({index: 22, insertBeforeIndex: 29}),
-        matchTNode({index: 28, insertBeforeIndex: 24}),
-        matchTNode({index: 24, insertBeforeIndex: 29}),
-        matchTNode({index: 25, insertBeforeIndex: 29}),
-        matchTNode({index: 29, insertBeforeIndex: null}),
-        matchTNode({index: 23, insertBeforeIndex: null}),
-        matchTNode({index: 27, insertBeforeIndex: null}),
+        matchTNode({index: 23, insertBeforeIndex: 30}),
+        matchTNode({index: 29, insertBeforeIndex: 25}),
+        matchTNode({index: 25, insertBeforeIndex: 30}),
+        matchTNode({index: 26, insertBeforeIndex: 30}),
+        matchTNode({index: 30, insertBeforeIndex: null}),
+        matchTNode({index: 24, insertBeforeIndex: null}),
+        matchTNode({index: 28, insertBeforeIndex: null}),
       ]);
     });
   });

--- a/packages/core/test/render3/i18n/i18n_parse_spec.ts
+++ b/packages/core/test/render3/i18n/i18n_parse_spec.ts
@@ -95,22 +95,22 @@ describe('i18n_parse', () => {
 
       fixture.apply(() => {
         applyCreateOpCodes(fixture.lView, tI18n.create, fixture.host, null);
-        expect(fixture.host.innerHTML).toEqual('before|<!--ICU 20:0-->|after');
+        expect(fixture.host.innerHTML).toEqual('before|<!--ICU 21:0-->|after');
       });
       fixture.apply(() => {
         ɵɵi18nExp('A');
         ɵɵi18nApply(0);  // index 0 + HEADER_OFFSET = 20;
-        expect(fixture.host.innerHTML).toEqual('before|caseA<!--ICU 20:0-->|after');
+        expect(fixture.host.innerHTML).toEqual('before|caseA<!--ICU 21:0-->|after');
       });
       fixture.apply(() => {
         ɵɵi18nExp('x');
         ɵɵi18nApply(0);  // index 0 + HEADER_OFFSET = 20;
-        expect(fixture.host.innerHTML).toEqual('before|otherCase<!--ICU 20:0-->|after');
+        expect(fixture.host.innerHTML).toEqual('before|otherCase<!--ICU 21:0-->|after');
       });
       fixture.apply(() => {
         ɵɵi18nExp('A');
         ɵɵi18nApply(0);  // index 0 + HEADER_OFFSET = 20;
-        expect(fixture.host.innerHTML).toEqual('before|caseA<!--ICU 20:0-->|after');
+        expect(fixture.host.innerHTML).toEqual('before|caseA<!--ICU 21:0-->|after');
       });
     });
 
@@ -122,23 +122,23 @@ describe('i18n_parse', () => {
       }`);
       fixture.apply(() => {
         applyCreateOpCodes(fixture.lView, tI18n.create, fixture.host, null);
-        expect(fixture.host.innerHTML).toEqual('<!--ICU 20:0-->');
+        expect(fixture.host.innerHTML).toEqual('<!--ICU 21:0-->');
       });
       fixture.apply(() => {
         ɵɵi18nExp('A');
         ɵɵi18nApply(0);  // index 0 + HEADER_OFFSET = 20;
-        expect(fixture.host.innerHTML).toEqual('Hello <b>world<i>!</i></b><!--ICU 20:0-->');
+        expect(fixture.host.innerHTML).toEqual('Hello <b>world<i>!</i></b><!--ICU 21:0-->');
       });
       fixture.apply(() => {
         ɵɵi18nExp('x');
         ɵɵi18nApply(0);  // index 0 + HEADER_OFFSET = 20;
         expect(fixture.host.innerHTML)
-            .toEqual('<div>nestedOther<!--nested ICU 0--></div><!--ICU 20:0-->');
+            .toEqual('<div>nestedOther<!--nested ICU 0--></div><!--ICU 21:0-->');
       });
       fixture.apply(() => {
         ɵɵi18nExp('A');
         ɵɵi18nApply(0);  // index 0 + HEADER_OFFSET = 20;
-        expect(fixture.host.innerHTML).toEqual('Hello <b>world<i>!</i></b><!--ICU 20:0-->');
+        expect(fixture.host.innerHTML).toEqual('Hello <b>world<i>!</i></b><!--ICU 21:0-->');
       });
     });
 
@@ -244,7 +244,7 @@ describe('i18n_parse', () => {
 
       fixture.apply(() => {
         applyCreateOpCodes(fixture.lView, tI18n.create, fixture.host, null);
-        expect(fixture.host.innerHTML).toEqual('<!--ICU 20:0-->');
+        expect(fixture.host.innerHTML).toEqual('<!--ICU 21:0-->');
       });
       fixture.apply(() => {
         ɵɵi18nExp('A');
@@ -252,28 +252,28 @@ describe('i18n_parse', () => {
         ɵɵi18nExp('value1');
         ɵɵi18nApply(0);  // index 0 + HEADER_OFFSET = 20;
         expect(fixture.host.innerHTML)
-            .toEqual('parentA nested0<!--nested ICU 0-->!<!--ICU 20:0-->');
+            .toEqual('parentA nested0<!--nested ICU 0-->!<!--ICU 21:0-->');
       });
       fixture.apply(() => {
         ɵɵi18nExp('A');
         ɵɵi18nExp('x');
         ɵɵi18nExp('value1');
         ɵɵi18nApply(0);  // index 0 + HEADER_OFFSET = 20;
-        expect(fixture.host.innerHTML).toEqual('parentA value1<!--nested ICU 0-->!<!--ICU 20:0-->');
+        expect(fixture.host.innerHTML).toEqual('parentA value1<!--nested ICU 0-->!<!--ICU 21:0-->');
       });
       fixture.apply(() => {
         ɵɵi18nExp('x');
         ɵɵi18nExp('x');
         ɵɵi18nExp('value2');
         ɵɵi18nApply(0);  // index 0 + HEADER_OFFSET = 20;
-        expect(fixture.host.innerHTML).toEqual('parentOther<!--ICU 20:0-->');
+        expect(fixture.host.innerHTML).toEqual('parentOther<!--ICU 21:0-->');
       });
       fixture.apply(() => {
         ɵɵi18nExp('A');
         ɵɵi18nExp('A');
         ɵɵi18nExp('value2');
         ɵɵi18nApply(0);  // index 0 + HEADER_OFFSET = 20;
-        expect(fixture.host.innerHTML).toEqual('parentA value2<!--nested ICU 0-->!<!--ICU 20:0-->');
+        expect(fixture.host.innerHTML).toEqual('parentA value2<!--nested ICU 0-->!<!--ICU 21:0-->');
       });
     });
   });

--- a/packages/core/test/render3/i18n/i18n_spec.ts
+++ b/packages/core/test/render3/i18n/i18n_spec.ts
@@ -284,9 +284,9 @@ describe('Runtime i18n', () => {
           ]),
           matchDebug([
             'lView[31] = document.createTextNode("")',
-            '(lView[20] as Element).appendChild(lView[31])',
+            '(lView[21] as Element).appendChild(lView[31])',
             'lView[32] = document.createElement("span")',
-            '(lView[20] as Element).appendChild(lView[32])',
+            '(lView[21] as Element).appendChild(lView[32])',
             'lView[33] = document.createTextNode("emails")',
             '(lView[32] as Element).appendChild(lView[33])',
           ]),
@@ -361,7 +361,7 @@ describe('Runtime i18n', () => {
             'lView[26] = document.createComment("nested ICU 0")',
             `(lView[${HEADER_OFFSET + 0}] as Element).appendChild(lView[${HEADER_OFFSET + 6}])`,
             'lView[31] = document.createTextNode("!")',
-            '(lView[20] as Element).appendChild(lView[31])',
+            '(lView[21] as Element).appendChild(lView[31])',
           ]),
         ],
         update: [
@@ -398,7 +398,7 @@ describe('Runtime i18n', () => {
           ]),
           matchDebug([
             'lView[30] = document.createTextNode("animals")',
-            '(lView[20] as Element).appendChild(lView[30])',
+            '(lView[21] as Element).appendChild(lView[30])',
           ]),
         ],
         update: [
@@ -428,7 +428,7 @@ describe('Runtime i18n', () => {
       }, undefined, nbConsts, HEADER_OFFSET + index);
 
       expect(opCodes).toEqual(matchDebug([
-        'if (mask & 0b1) { (lView[20] as Element).setAttribute(\'title\', `Hello ${lView[i-1]}!`); }',
+        'if (mask & 0b1) { (lView[21] as Element).setAttribute(\'title\', `Hello ${lView[i-1]}!`); }',
       ]));
     });
 
@@ -444,7 +444,7 @@ describe('Runtime i18n', () => {
       }, undefined, nbConsts, HEADER_OFFSET + index);
 
       expect(opCodes).toEqual(matchDebug([
-        'if (mask & 0b11) { (lView[20] as Element).setAttribute(\'title\', `Hello ${lView[i-1]} and ${lView[i-2]}, again ${lView[i-1]}!`); }',
+        'if (mask & 0b11) { (lView[21] as Element).setAttribute(\'title\', `Hello ${lView[i-1]} and ${lView[i-2]}, again ${lView[i-1]}!`); }',
       ]));
     });
 
@@ -460,8 +460,8 @@ describe('Runtime i18n', () => {
       }, undefined, nbConsts, HEADER_OFFSET + index);
 
       expect(opCodes).toEqual(matchDebug([
-        'if (mask & 0b1) { (lView[20] as Element).setAttribute(\'title\', `Hello ${lView[i-1]}!`); }',
-        'if (mask & 0b1) { (lView[20] as Element).setAttribute(\'aria-label\', `Hello ${lView[i-1]}!`); }',
+        'if (mask & 0b1) { (lView[21] as Element).setAttribute(\'title\', `Hello ${lView[i-1]}!`); }',
+        'if (mask & 0b1) { (lView[21] as Element).setAttribute(\'aria-label\', `Hello ${lView[i-1]}!`); }',
       ]));
     });
   });

--- a/packages/core/test/render3/instructions/lview_debug_spec.ts
+++ b/packages/core/test/render3/instructions/lview_debug_spec.ts
@@ -242,7 +242,7 @@ describe('lView_debug', () => {
         cumulativeBloom: jasmine.anything(),
         providers: [MyChild.ɵdir],
         viewProviders: [],
-        parentInjectorIndex: 22,
+        parentInjectorIndex: 23,
       });
     });
   });

--- a/packages/core/test/render3/perf/view_destroy_hook/index.ts
+++ b/packages/core/test/render3/perf/view_destroy_hook/index.ts
@@ -8,11 +8,10 @@
 import {OnDestroy} from '@angular/core';
 
 import {ɵɵdefineDirective, ɵɵelement, ɵɵelementEnd, ɵɵelementStart} from '../../../../src/render3/index';
-import {createLView, createTNode, createTView} from '../../../../src/render3/instructions/shared';
+import {createLView, createTNode, createTView, destroyLView} from '../../../../src/render3/instructions/shared';
 import {RenderFlags} from '../../../../src/render3/interfaces/definition';
 import {TNodeType} from '../../../../src/render3/interfaces/node';
 import {LViewFlags, TViewType} from '../../../../src/render3/interfaces/view';
-import {destroyLView} from '../../../../src/render3/node_manipulation';
 import {createBenchmark} from '../micro_bench';
 import {createAndRenderLView} from '../setup';
 

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -13,7 +13,7 @@ import {ElementRef} from '@angular/core/src/linker/element_ref';
 import {TemplateRef} from '@angular/core/src/linker/template_ref';
 import {ViewContainerRef} from '@angular/core/src/linker/view_container_ref';
 import {Renderer2} from '@angular/core/src/render/api';
-import {createLView, createTView, getOrCreateTComponentView, getOrCreateTNode, renderComponentOrTemplate} from '@angular/core/src/render3/instructions/shared';
+import {createLView, createTView, destroyLView, getOrCreateTComponentView, getOrCreateTNode, renderComponentOrTemplate} from '@angular/core/src/render3/instructions/shared';
 import {TConstants, TNodeType} from '@angular/core/src/render3/interfaces/node';
 import {RComment, RElement, RNode, RText} from '@angular/core/src/render3/interfaces/renderer_dom';
 import {enterView, getLView} from '@angular/core/src/render3/state';
@@ -37,7 +37,6 @@ import {DirectiveDefList, DirectiveDefListOrFactory, DirectiveTypesOrFactory, Ho
 import {PlayerHandler} from '../../src/render3/interfaces/player';
 import {domRendererFactory3, ProceduralRenderer3, Renderer3, RendererFactory3, RendererStyleFlags3} from '../../src/render3/interfaces/renderer';
 import {LView, LViewFlags, TVIEW, TViewType} from '../../src/render3/interfaces/view';
-import {destroyLView} from '../../src/render3/node_manipulation';
 import {getRootView} from '../../src/render3/util/view_traversal_utils';
 import {Sanitizer} from '../../src/sanitization/sanitizer';
 


### PR DESCRIPTION
**Note:** this is mostly an exploratory PR to check whether the approach actually works and to start a discussion. There's more work to be done to make it mergeable (e.g. it introduces new circular dependencies, there are no unit tests etc.).

Explores adding a unique ID to each `LView` which is stored in `__ngContext__`, rather than the LView itself. This will avoid worsening memory leaks where a detached element is retained along with its `LView`.

Furthermore, it reworks `LContext` to store the ID of its `LView`, rather than the `LView` itself, because the `LContext` can also be stored in `__ngContext__`.