### PR TITLE
perf(compiler): store parsed directive and component selectors

### DIFF
--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {compileComponentFromMetadata, ConstantPool, DeclarationListEmitMode, DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig, makeBindingParser, parseTemplate, R3ComponentMetadata, R3DeclareComponentMetadata, R3DeclareUsedDirectiveMetadata, R3PartialDeclaration, R3UsedDirectiveMetadata} from '@angular/compiler';
+import {compileComponentFromMetadata, ConstantPool, CssSelectors, DeclarationListEmitMode, DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig, makeBindingParser, parseTemplate, R3ComponentMetadata, R3DeclareComponentMetadata, R3DeclareUsedDirectiveMetadata, R3PartialDeclaration, R3UsedDirectiveMetadata} from '@angular/compiler';
 import {ChangeDetectionStrategy, ViewEncapsulation} from '@angular/compiler/src/core';
 import * as o from '@angular/compiler/src/output/output_ast';
 
@@ -65,32 +65,33 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression> implements
     let declarationListEmitMode = DeclarationListEmitMode.Direct;
 
     const collectUsedDirectives =
-        (directives: AstValue<R3DeclareUsedDirectiveMetadata, TExpression>[]) => {
-          return directives.map(directive => {
-            const directiveExpr = directive.getObject();
-            const type = directiveExpr.getValue('type');
-            const selector = directiveExpr.getString('selector');
+        (directives: AstValue<R3DeclareUsedDirectiveMetadata, TExpression>[]):
+            R3UsedDirectiveMetadata[] => {
+              return directives.map(directive => {
+                const directiveExpr = directive.getObject();
+                const type = directiveExpr.getValue('type');
+                const selector = directiveExpr.getString('selector');
 
-            const {expression: typeExpr, isForwardRef} = extractForwardRef(type);
-            if (isForwardRef) {
-              declarationListEmitMode = DeclarationListEmitMode.Closure;
-            }
+                const {expression: typeExpr, isForwardRef} = extractForwardRef(type);
+                if (isForwardRef) {
+                  declarationListEmitMode = DeclarationListEmitMode.Closure;
+                }
 
-            return {
-              type: typeExpr,
-              selector: selector,
-              inputs: directiveExpr.has('inputs') ?
-                  directiveExpr.getArray('inputs').map(input => input.getString()) :
-                  [],
-              outputs: directiveExpr.has('outputs') ?
-                  directiveExpr.getArray('outputs').map(input => input.getString()) :
-                  [],
-              exportAs: directiveExpr.has('exportAs') ?
-                  directiveExpr.getArray('exportAs').map(exportAs => exportAs.getString()) :
-                  null,
+                return {
+                  type: typeExpr,
+                  selector: CssSelectors.parse(selector),
+                  inputs: directiveExpr.has('inputs') ?
+                      directiveExpr.getArray('inputs').map(input => input.getString()) :
+                      [],
+                  outputs: directiveExpr.has('outputs') ?
+                      directiveExpr.getArray('outputs').map(input => input.getString()) :
+                      [],
+                  exportAs: directiveExpr.has('exportAs') ?
+                      directiveExpr.getArray('exportAs').map(exportAs => exportAs.getString()) :
+                      null,
+                };
+              });
             };
-          });
-        };
 
     let directives: R3UsedDirectiveMetadata[] = [];
     if (metaObj.has('components')) {

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_directive_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_directive_linker_1.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {compileDirectiveFromMetadata, ConstantPool, makeBindingParser, ParseLocation, ParseSourceFile, ParseSourceSpan, R3DeclareDirectiveMetadata, R3DeclareQueryMetadata, R3DirectiveMetadata, R3HostMetadata, R3PartialDeclaration, R3QueryMetadata} from '@angular/compiler';
+import {compileDirectiveFromMetadata, ConstantPool, CssSelectors, makeBindingParser, ParseLocation, ParseSourceFile, ParseSourceSpan, R3DeclareDirectiveMetadata, R3DeclareQueryMetadata, R3DirectiveMetadata, R3HostMetadata, R3PartialDeclaration, R3QueryMetadata} from '@angular/compiler';
 import * as o from '@angular/compiler/src/output/output_ast';
 
 import {AbsoluteFsPath} from '../../../../src/ngtsc/file_system';
@@ -63,7 +63,7 @@ export function toR3DirectiveMeta<TExpression>(
         [],
     providers: metaObj.has('providers') ? metaObj.getOpaque('providers') : null,
     fullInheritance: false,
-    selector: metaObj.has('selector') ? metaObj.getString('selector') : null,
+    selector: metaObj.has('selector') ? CssSelectors.parse(metaObj.getString('selector')) : null,
     exportAs: metaObj.has('exportAs') ?
         metaObj.getArray('exportAs').map(entry => entry.getString()) :
         null,

--- a/packages/compiler-cli/ngcc/src/migrations/utils.ts
+++ b/packages/compiler-cli/ngcc/src/migrations/utils.ts
@@ -5,9 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {CssSelectors} from '@angular/compiler';
 import * as ts from 'typescript';
+
 import {Reference} from '../../../src/ngtsc/imports';
 import {ClassDeclaration, Decorator, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
+
 import {MigrationHost} from './migration';
 
 export function isClassDeclaration(clazz: ts.Node): clazz is ClassDeclaration<ts.Declaration> {
@@ -43,12 +46,12 @@ export function hasConstructor(host: MigrationHost, clazz: ClassDeclaration): bo
  */
 export function createDirectiveDecorator(
     clazz: ClassDeclaration,
-    metadata?: {selector: string|null, exportAs: string[]|null}): Decorator {
+    metadata?: {selector: CssSelectors|null, exportAs: string[]|null}): Decorator {
   const args: ts.Expression[] = [];
   if (metadata !== undefined) {
     const metaArgs: ts.PropertyAssignment[] = [];
     if (metadata.selector !== null) {
-      metaArgs.push(property('selector', metadata.selector));
+      metaArgs.push(property('selector', metadata.selector.text));
     }
     if (metadata.exportAs !== null) {
       metaArgs.push(property('exportAs', metadata.exportAs.join(', ')));
@@ -70,12 +73,12 @@ export function createDirectiveDecorator(
  */
 export function createComponentDecorator(
     clazz: ClassDeclaration,
-    metadata: {selector: string|null, exportAs: string[]|null}): Decorator {
+    metadata: {selector: CssSelectors|null, exportAs: string[]|null}): Decorator {
   const metaArgs: ts.PropertyAssignment[] = [
     property('template', ''),
   ];
   if (metadata.selector !== null) {
-    metaArgs.push(property('selector', metadata.selector));
+    metaArgs.push(property('selector', metadata.selector.text));
   }
   if (metadata.exportAs !== null) {
     metaArgs.push(property('exportAs', metadata.exportAs.join(', ')));

--- a/packages/compiler-cli/ngcc/test/analysis/migration_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/migration_host_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {CssSelectors} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {makeDiagnostic} from '../../../src/ngtsc/diagnostics';
@@ -76,7 +77,8 @@ runInEachFileSystem(() => {
         const entryPoint =
             makeTestEntryPointBundle('test', 'esm2015', false, [_('/node_modules/test/index.js')]);
         const {host, compiler} = createMigrationHost({entryPoint, handlers: [handler]});
-        const decorator = createComponentDecorator(mockClazz, {selector: 'comp', exportAs: null});
+        const decorator = createComponentDecorator(
+            mockClazz, {selector: CssSelectors.parse('comp'), exportAs: null});
         host.injectSyntheticDecorator(mockClazz, decorator);
 
         const record = compiler.recordFor(mockClazz)!;

--- a/packages/compiler-cli/ngcc/test/analysis/ngcc_trait_compiler_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/ngcc_trait_compiler_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {CssSelectors} from '@angular/compiler';
 import {ErrorCode, makeDiagnostic, ngErrorCode} from '../../../src/ngtsc/diagnostics';
 import {absoluteFrom} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
@@ -231,7 +232,8 @@ runInEachFileSystem(() => {
         const entryPoint =
             makeTestEntryPointBundle('test', 'esm2015', false, [_('/node_modules/test/index.js')]);
         const compiler = createCompiler({entryPoint, handlers: [handler]});
-        const decorator = createComponentDecorator(mockClazz, {selector: 'comp', exportAs: null});
+        const decorator = createComponentDecorator(
+            mockClazz, {selector: CssSelectors.parse('comp'), exportAs: null});
         compiler.injectSyntheticDecorator(mockClazz, decorator);
 
         const record = compiler.recordFor(mockClazz)!;

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -512,10 +512,11 @@ export class ComponentDecoratorHandler implements
   }
 
   symbol(node: ClassDeclaration, analysis: Readonly<ComponentAnalysisData>): ComponentSymbol {
+    const selector = analysis.meta.selector !== null ? analysis.meta.selector.text : null;
     const typeParameters = extractSemanticTypeParameters(node);
 
     return new ComponentSymbol(
-        node, analysis.meta.selector, analysis.inputs, analysis.outputs, analysis.meta.exportAs,
+        node, selector, analysis.inputs, analysis.outputs, analysis.meta.exportAs,
         analysis.typeCheckMeta, typeParameters);
   }
 
@@ -559,7 +560,7 @@ export class ComponentDecoratorHandler implements
 
       for (const directive of scope.compilation.directives) {
         if (directive.selector !== null) {
-          matcher.addSelectables(CssSelector.parse(directive.selector), directive);
+          matcher.addSelectables(directive.selector.selectors, directive);
         }
       }
     }
@@ -568,7 +569,7 @@ export class ComponentDecoratorHandler implements
 
     context.addComponent({
       declaration: node,
-      selector,
+      selector: selector !== null ? selector.text : null,
       boundTemplate,
       templateMeta: {
         isInline: analysis.template.declaration.isInline,
@@ -651,7 +652,7 @@ export class ComponentDecoratorHandler implements
 
       for (const dir of scope.compilation.directives) {
         if (dir.selector !== null) {
-          matcher.addSelectables(CssSelector.parse(dir.selector), dir as MatchedDirective);
+          matcher.addSelectables(dir.selector.selectors, dir as MatchedDirective);
         }
       }
       const pipes = new Map<string, Reference<ClassDeclaration>>();

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {compileClassMetadata, compileDeclareClassMetadata, compileDeclareDirectiveFromMetadata, compileDirectiveFromMetadata, ConstantPool, Expression, ExternalExpr, FactoryTarget, getSafePropertyAccessString, makeBindingParser, ParsedHostBindings, ParseError, parseHostBindings, R3ClassMetadata, R3DirectiveMetadata, R3FactoryMetadata, R3QueryMetadata, Statement, verifyHostBindings, WrappedNodeExpr} from '@angular/compiler';
+import {compileClassMetadata, compileDeclareClassMetadata, compileDeclareDirectiveFromMetadata, compileDirectiveFromMetadata, ConstantPool, CssSelectors, Expression, ExternalExpr, FactoryTarget, getSafePropertyAccessString, makeBindingParser, ParsedHostBindings, ParseError, parseHostBindings, R3ClassMetadata, R3DirectiveMetadata, R3FactoryMetadata, R3QueryMetadata, Statement, verifyHostBindings, WrappedNodeExpr} from '@angular/compiler';
 import {emitDistinctChangesOnlyDefaultValue} from '@angular/compiler/src/core';
 import * as ts from 'typescript';
 
@@ -244,10 +244,11 @@ export class DirectiveDecoratorHandler implements
   }
 
   symbol(node: ClassDeclaration, analysis: Readonly<DirectiveHandlerData>): DirectiveSymbol {
+    const selector = analysis.meta.selector !== null ? analysis.meta.selector.text : null;
     const typeParameters = extractSemanticTypeParameters(node);
 
     return new DirectiveSymbol(
-        node, analysis.meta.selector, analysis.inputs, analysis.outputs, analysis.meta.exportAs,
+        node, selector, analysis.inputs, analysis.outputs, analysis.meta.exportAs,
         analysis.typeCheckMeta, typeParameters);
   }
 
@@ -504,7 +505,7 @@ export function extractDirectiveMetadata(
     outputs: outputs.toDirectMappedObject(),
     queries,
     viewQueries,
-    selector,
+    selector: CssSelectors.parse(selector),
     fullInheritance: !!(flags & HandlerFlags.FULL_INHERITANCE),
     type,
     internalType,

--- a/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {CssSelector, DirectiveMeta as T2DirectiveMeta, parseTemplate, R3TargetBinder, SelectorMatcher, TmplAstElement} from '@angular/compiler';
+import {CssSelector, CssSelectors, DirectiveMeta as T2DirectiveMeta, parseTemplate, R3TargetBinder, SelectorMatcher, TmplAstElement} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {absoluteFrom} from '../../file_system';
@@ -105,7 +105,7 @@ runInEachFileSystem(() => {
         outputs: analysis.outputs,
         isComponent: false,
         name: 'Dir',
-        selector: '[dir]',
+        selector: CssSelectors.parse('[dir]'),
         isStructural: false,
       };
       matcher.addSelectables(CssSelector.parse('[dir]'), dirMeta);

--- a/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/context.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BoundTarget, DirectiveMeta, ParseSourceFile} from '@angular/compiler';
+import {BoundTarget, CssSelectors, DirectiveMeta, ParseSourceFile} from '@angular/compiler';
 import {Reference} from '../../imports';
 import {ClassDeclaration} from '../../reflection';
 
 export interface ComponentMeta extends DirectiveMeta {
   ref: Reference<ClassDeclaration>;
   /**
-   * Unparsed selector of the directive, or null if the directive does not have a selector.
+   * Selector of the directive, or null if the directive does not have a selector.
    */
-  selector: string|null;
+  selector: CssSelectors|null;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -258,7 +258,7 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
       usedDirectives: new Set(usedDirectives.map(dir => {
         return {
           node: dir.ref.node,
-          selector: dir.selector,
+          selector: dir.selector !== null ? dir.selector.text : null,
         };
       })),
       // cast b/c pre-TypeScript 3.5 unions aren't well discriminated

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BoundTarget, CssSelector, parseTemplate, ParseTemplateOptions, R3TargetBinder, SelectorMatcher} from '@angular/compiler';
+import {BoundTarget, CssSelector, CssSelectors, parseTemplate, ParseTemplateOptions, R3TargetBinder, SelectorMatcher} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {absoluteFrom, AbsoluteFsPath} from '../../file_system';
@@ -48,7 +48,7 @@ export function getBoundTemplate(
   components.forEach(({selector, declaration}) => {
     matcher.addSelectables(CssSelector.parse(selector), {
       ref: new Reference(declaration),
-      selector,
+      selector: CssSelectors.parse(selector),
       name: declaration.name.getText(),
       isComponent: true,
       inputs: ClassPropertyMapping.fromMappedObject({}),

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DirectiveMeta as T2DirectiveMeta, SchemaMetadata} from '@angular/compiler';
+import {CssSelectors, DirectiveMeta as T2DirectiveMeta, SchemaMetadata} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {Reference} from '../../imports';
@@ -86,9 +86,9 @@ export interface DirectiveTypeCheckMeta {
 export interface DirectiveMeta extends T2DirectiveMeta, DirectiveTypeCheckMeta {
   ref: Reference<ClassDeclaration>;
   /**
-   * Unparsed selector of the directive, or null if the directive does not have a selector.
+   * Selector of the directive, or null if the directive does not have a selector.
    */
-  selector: string|null;
+  selector: CssSelectors|null;
   queries: string[];
 
   /**

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {CssSelectors} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {Reference} from '../../imports';
@@ -98,7 +99,7 @@ export class DtsMetadataReader implements MetadataReader {
       ref,
       name: clazz.name.text,
       isComponent,
-      selector: readStringType(def.type.typeArguments[1]),
+      selector: CssSelectors.parse(readStringType(def.type.typeArguments[1])),
       exportAs: readStringArrayType(def.type.typeArguments[2]),
       inputs,
       outputs,

--- a/packages/compiler-cli/src/ngtsc/scope/src/typecheck.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/typecheck.ts
@@ -92,7 +92,7 @@ export class TypeCheckScopeRegistry {
     for (const meta of scope.compilation.directives) {
       if (meta.selector !== null) {
         const extMeta = this.getTypeCheckDirectiveMetadata(meta.ref);
-        matcher.addSelectables(CssSelector.parse(meta.selector), extMeta);
+        matcher.addSelectables(meta.selector.selectors, extMeta);
         directives.push(extMeta);
       }
     }

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {CssSelectors} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {Reference, ReferenceEmitter} from '../../imports';
@@ -234,7 +235,7 @@ function fakeDirective(ref: Reference<ClassDeclaration>): DirectiveMeta {
   return {
     ref,
     name,
-    selector: `[${ref.debugName}]`,
+    selector: CssSelectors.parse(`[${ref.debugName}]`),
     isComponent: name.startsWith('Cmp'),
     inputs: ClassPropertyMapping.fromMappedObject({}),
     outputs: ClassPropertyMapping.fromMappedObject({}),

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {CssSelectors} from '@angular/compiler';
 import * as ts from 'typescript';
+
 import {ClassDeclaration} from '../../reflection';
 
 /**
@@ -26,7 +28,7 @@ export interface DirectiveInScope {
   /**
    * The selector for the directive or component.
    */
-  selector: string;
+  selector: CssSelectors;
 
   /**
    * `true` if this directive is a component.

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -526,7 +526,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     const scope = this.getScopeData(component);
     if (scope !== null) {
       for (const directive of scope.directives) {
-        for (const selector of CssSelector.parse(directive.selector)) {
+        for (const selector of directive.selector.selectors) {
           if (selector.element === null || tagMap.has(selector.element)) {
             // Skip this directive if it doesn't match an element tag, or if another directive has
             // already been included with the same element name.

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CssSelector, ParseSourceFile, ParseSourceSpan, parseTemplate, R3TargetBinder, SchemaMetadata, SelectorMatcher, TmplAstElement, Type} from '@angular/compiler';
+import {CssSelector, CssSelectors, ParseSourceFile, ParseSourceSpan, parseTemplate, R3TargetBinder, SchemaMetadata, SelectorMatcher, TmplAstElement, Type} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {absoluteFrom, AbsoluteFsPath, getSourceFileOrError, LogicalFileSystem} from '../../file_system';
@@ -198,7 +198,7 @@ export interface TestDirective extends Partial<Pick<
     TypeCheckableDirectiveMeta,
     Exclude<
         keyof TypeCheckableDirectiveMeta,
-        'ref'|'coercedInputFields'|'restrictedInputFields'|'stringLiteralInputFields'|
+        'ref'|'selector'|'coercedInputFields'|'restrictedInputFields'|'stringLiteralInputFields'|
         'undeclaredInputFields'|'inputs'|'outputs'>>> {
   selector: string;
   name: string;
@@ -539,7 +539,7 @@ function prepareDeclarations(
       name: decl.name,
       ref: new Reference(resolveDeclaration(decl)),
       exportAs: decl.exportAs || null,
-      selector: decl.selector || null,
+      selector: CssSelectors.parse(decl.selector || null),
       hasNgTemplateContextGuard: decl.hasNgTemplateContextGuard || false,
       inputs: ClassPropertyMapping.fromMappedObject(decl.inputs || {}),
       isComponent: decl.isComponent || false,
@@ -598,7 +598,7 @@ function makeScope(program: ts.Program, sf: ts.SourceFile, decls: TestDeclaratio
         ref: new Reference(declClass),
         baseClass: null,
         name: decl.name,
-        selector: decl.selector,
+        selector: CssSelectors.parse(decl.selector),
         queries: [],
         inputs: decl.inputs !== undefined ? ClassPropertyMapping.fromMappedObject(decl.inputs) :
                                             ClassPropertyMapping.empty(),

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__completion_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__completion_spec.ts
@@ -107,7 +107,7 @@ runInEachFileSystem(() => {
 
       const directives = templateTypeChecker.getDirectivesInScope(SomeCmp) ?? [];
       const pipes = templateTypeChecker.getPipesInScope(SomeCmp) ?? [];
-      expect(directives.map(dir => dir.selector)).toEqual(['other-dir']);
+      expect(directives.map(dir => dir.selector.text)).toEqual(['other-dir']);
       expect(pipes.map(pipe => pipe.name)).toEqual(['otherPipe']);
     });
   });

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
@@ -1472,7 +1472,7 @@ runInEachFileSystem(() => {
         expect(actualDirectives).toEqual(expectedDirectives);
 
         const expectedSelectors = ['[dir]', '[dir2]', 'div'].sort();
-        const actualSelectors = symbol.directives.map(dir => dir.selector).sort();
+        const actualSelectors = symbol.directives.map(dir => dir.selector.text).sort();
         expect(actualSelectors).toEqual(expectedSelectors);
 
         // Testing this fully requires an integration test with a real `NgCompiler` (like in the

--- a/packages/compiler/src/core.ts
+++ b/packages/compiler/src/core.ts
@@ -12,7 +12,7 @@
 // This is important to prevent a build cycle, as @angular/core needs to
 // be compiled with the compiler.
 
-import {CssSelector} from './selector';
+import {CssSelector, CssSelectors} from './selector';
 
 export interface Inject {
   token: any;
@@ -410,6 +410,10 @@ function parserSelectorToR3Selector(selector: CssSelector): R3CssSelector {
 
 export function parseSelectorToR3Selector(selector: string|null): R3CssSelectorList {
   return selector ? CssSelector.parse(selector).map(parserSelectorToR3Selector) : [];
+}
+
+export function parseSelectorsToR3Selector(selector: CssSelectors|null): R3CssSelectorList {
+  return selector?.text ? selector.selectors.map(parserSelectorToR3Selector) : [];
 }
 
 // Pasted from render3/interfaces/definition since it cannot be referenced directly

--- a/packages/compiler/src/render3/partial/component.ts
+++ b/packages/compiler/src/render3/partial/component.ts
@@ -171,7 +171,7 @@ function compileUsedDirectiveMetadata(
   return toOptionalLiteralArray(directives, directive => {
     const dirMeta = new DefinitionMap<R3DeclareUsedDirectiveMetadata>();
     dirMeta.set('type', wrapType(directive.type));
-    dirMeta.set('selector', o.literal(directive.selector));
+    dirMeta.set('selector', o.literal(directive.selector.text));
     dirMeta.set('inputs', toOptionalLiteralArray(directive.inputs, o.literal));
     dirMeta.set('outputs', toOptionalLiteralArray(directive.outputs, o.literal));
     dirMeta.set('exportAs', toOptionalLiteralArray(directive.exportAs, o.literal));

--- a/packages/compiler/src/render3/partial/directive.ts
+++ b/packages/compiler/src/render3/partial/directive.ts
@@ -52,7 +52,7 @@ export function createDirectiveDefinitionMap(meta: R3DirectiveMetadata):
 
   // e.g. `selector: 'some-dir'`
   if (meta.selector !== null) {
-    definitionMap.set('selector', o.literal(meta.selector));
+    definitionMap.set('selector', o.literal(meta.selector.text));
   }
 
   definitionMap.set('inputs', conditionallyCreateMapObjectLiteral(meta.inputs, true));

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -10,6 +10,7 @@ import {ChangeDetectionStrategy, ViewEncapsulation} from '../../core';
 import {InterpolationConfig} from '../../ml_parser/interpolation_config';
 import * as o from '../../output/output_ast';
 import {ParseSourceSpan} from '../../parse_util';
+import {CssSelectors} from '../../selector';
 import * as t from '../r3_ast';
 import {R3DependencyMetadata} from '../r3_factory';
 import {R3Reference} from '../util';
@@ -54,9 +55,9 @@ export interface R3DirectiveMetadata {
   deps: R3DependencyMetadata[]|'invalid'|null;
 
   /**
-   * Unparsed selector of the directive, or `null` if there was no selector.
+   * Selector of the directive, or `null` if there was no selector.
    */
-  selector: string|null;
+  selector: CssSelectors|null;
 
   /**
    * Information about the content queries made by the directive.
@@ -261,7 +262,7 @@ export interface R3UsedDirectiveMetadata {
   /**
    * The selector of the directive.
    */
-  selector: string;
+  selector: CssSelectors;
 
   /**
    * The binding property names of the inputs of the directive.

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -36,7 +36,7 @@ function baseDirectiveFields(
     meta: R3DirectiveMetadata, constantPool: ConstantPool,
     bindingParser: BindingParser): DefinitionMap {
   const definitionMap = new DefinitionMap();
-  const selectors = core.parseSelectorToR3Selector(meta.selector);
+  const selectors = core.parseSelectorsToR3Selector(meta.selector);
 
   // e.g. `type: MyDirective`
   definitionMap.set('type', meta.internalType);
@@ -61,7 +61,7 @@ function baseDirectiveFields(
   definitionMap.set(
       'hostBindings',
       createHostBindingsFunction(
-          meta.host, meta.typeSourceSpan, bindingParser, constantPool, meta.selector || '',
+          meta.host, meta.typeSourceSpan, bindingParser, constantPool, meta.selector?.text || '',
           meta.name, definitionMap));
 
   // e.g 'inputs: {a: 'a'}`
@@ -132,7 +132,7 @@ export function compileComponentFromMetadata(
   const definitionMap = baseDirectiveFields(meta, constantPool, bindingParser);
   addFeatures(definitionMap, meta);
 
-  const selector = meta.selector && CssSelector.parse(meta.selector);
+  const selector = meta.selector && meta.selector.selectors;
   const firstSelector = selector && selector[0];
 
   // e.g. `attr: ["class", ".my.app"]`
@@ -155,7 +155,7 @@ export function compileComponentFromMetadata(
   if (meta.directives.length > 0) {
     const matcher = new SelectorMatcher();
     for (const {selector, type} of meta.directives) {
-      matcher.addSelectables(CssSelector.parse(selector), type);
+      matcher.addSelectables(selector.selectors, type);
     }
     directiveMatcher = matcher;
   }
@@ -409,7 +409,7 @@ function stringArrayAsType(arr: ReadonlyArray<string|null>): o.Type {
 export function createDirectiveTypeParams(meta: R3DirectiveMetadata): o.Type[] {
   // On the type side, remove newlines from the selector as it will need to fit into a TypeScript
   // string literal, which must be on one line.
-  const selectorForType = meta.selector !== null ? meta.selector.replace(/\n/g, '') : null;
+  const selectorForType = meta.selector !== null ? meta.selector.text.replace(/\n/g, '') : null;
 
   return [
     typeWithParameters(meta.type.type, meta.typeArgumentCount),

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -7,6 +7,7 @@
  */
 
 import {AST} from '../../expression_parser/ast';
+import {CssSelectors} from '../../selector';
 import {BoundAttribute, BoundEvent, Element, Node, Reference, Template, TextAttribute, Variable} from '../r3_ast';
 
 
@@ -47,7 +48,7 @@ export interface DirectiveMeta {
   name: string;
 
   /** The selector for the directive or `null` if there isn't one. */
-  selector: string|null;
+  selector: CssSelectors|null;
 
   /**
    * Whether the directive is a component.

--- a/packages/compiler/src/selector.ts
+++ b/packages/compiler/src/selector.ts
@@ -34,6 +34,20 @@ const enum SelectorRegexp {
   NOT_END = 7,
   SEPARATOR = 8,
 }
+
+export class CssSelectors {
+  static parse(selector: string): CssSelectors;
+  static parse(selector: string|null): CssSelectors|null;
+  static parse(selector: string|null): CssSelectors|null {
+    if (selector === null) {
+      return null;
+    }
+    return new CssSelectors(selector, CssSelector.parse(selector));
+  }
+
+  constructor(readonly text: string, readonly selectors: CssSelector[]) {}
+}
+
 /**
  * A css selector contains an element name,
  * css classes and attribute/value pairs with the purpose

--- a/packages/compiler/test/render3/view/binding_spec.ts
+++ b/packages/compiler/test/render3/view/binding_spec.ts
@@ -11,7 +11,7 @@ import * as a from '../../../src/render3/r3_ast';
 import {DirectiveMeta, InputOutputPropertySet} from '../../../src/render3/view/t2_api';
 import {R3TargetBinder} from '../../../src/render3/view/t2_binder';
 import {parseTemplate} from '../../../src/render3/view/template';
-import {CssSelector, SelectorMatcher} from '../../../src/selector';
+import {CssSelector, CssSelectors, SelectorMatcher} from '../../../src/selector';
 
 import {findExpression} from './util';
 
@@ -39,7 +39,7 @@ function makeSelectorMatcher(): SelectorMatcher<DirectiveMeta> {
     outputs: new IdentityInputMapping([]),
     isComponent: false,
     isStructural: true,
-    selector: '[ngFor][ngForOf]',
+    selector: CssSelectors.parse('[ngFor][ngForOf]'),
   });
   matcher.addSelectables(CssSelector.parse('[dir]'), {
     name: 'Dir',
@@ -48,7 +48,7 @@ function makeSelectorMatcher(): SelectorMatcher<DirectiveMeta> {
     outputs: new IdentityInputMapping([]),
     isComponent: false,
     isStructural: false,
-    selector: '[dir]'
+    selector: CssSelectors.parse('[dir]'),
   });
   matcher.addSelectables(CssSelector.parse('[hasOutput]'), {
     name: 'HasOutput',
@@ -57,7 +57,7 @@ function makeSelectorMatcher(): SelectorMatcher<DirectiveMeta> {
     outputs: new IdentityInputMapping(['outputBinding']),
     isComponent: false,
     isStructural: false,
-    selector: '[hasOutput]'
+    selector: CssSelectors.parse('[hasOutput]'),
   });
   matcher.addSelectables(CssSelector.parse('[hasInput]'), {
     name: 'HasInput',
@@ -66,7 +66,7 @@ function makeSelectorMatcher(): SelectorMatcher<DirectiveMeta> {
     outputs: new IdentityInputMapping([]),
     isComponent: false,
     isStructural: false,
-    selector: '[hasInput]'
+    selector: CssSelectors.parse('[hasInput]'),
   });
   return matcher;
 }
@@ -112,7 +112,7 @@ describe('t2 binding', () => {
       outputs: new IdentityInputMapping([]),
       isComponent: false,
       isStructural: false,
-      selector: 'text[dir]'
+      selector: CssSelectors.parse('text[dir]'),
     });
     const binder = new R3TargetBinder(matcher);
     const res = binder.bind({template: template.nodes});

--- a/packages/language-service/ivy/attribute_completions.ts
+++ b/packages/language-service/ivy/attribute_completions.ts
@@ -257,11 +257,10 @@ export function buildAttributeCompletionTable(
         // a hypothetical version of the element with those attributes. A match indicates that
         // adding that attribute/input/output binding would cause the directive to become present,
         // meaning that such a binding is a valid completion.
-        const selectors = CssSelector.parse(meta.selector);
         const matcher = new SelectorMatcher();
-        matcher.addSelectables(selectors);
+        matcher.addSelectables(meta.selector.selectors);
 
-        for (const selector of selectors) {
+        for (const selector of meta.selector.selectors) {
           for (const [attrName, attrValue] of selectorAttributes(selector)) {
             if (attrValue !== '') {
               // This attribute selector requires a value, which is not supported in completion.
@@ -503,8 +502,7 @@ function getStructuralAttributes(meta: TypeCheckableDirectiveMeta): string[] {
   }
 
   const structuralAttributes: string[] = [];
-  const selectors = CssSelector.parse(meta.selector);
-  for (const selector of selectors) {
+  for (const selector of meta.selector.selectors) {
     if (selector.element !== null && selector.element !== 'ng-template') {
       // This particular selector does not apply under structural directive syntax.
       continue;

--- a/packages/language-service/ivy/utils.ts
+++ b/packages/language-service/ivy/utils.ts
@@ -277,7 +277,7 @@ function getDirectiveMatchesForSelector(
     }
 
     const matcher = new SelectorMatcher();
-    matcher.addSelectables(CssSelector.parse(dir.selector));
+    matcher.addSelectables(dir.selector.selectors);
 
     return selectors.some(selector => matcher.match(selector, null));
   }));


### PR DESCRIPTION
Prior to this change the selector of a directive/component was only
parsed when building selector matchers. Such selector matchers are
created for all components during each incremental compilation which
meant that selector parsing had to be redone repeatedly. Since selector
matching needs the selectors of all directives in an NgModule's scope,
this could result in a large overhead of selector parsing. This commit
changes the metadata of directives to store a parsed representation
along with the textual representation, as to avoid repeated parsing
of selector strings.

Note that this change has minimum effect on memory usage, as the parsed
`CssSelector` instances are already retained in the persistent
`TypeCheckScopeRegistry`'s selector matchers. In fact, reusing parsed
selector instances should result in deduplication of parsed selectors
and less memory pressure in general, as the number of short-lived memory
allocations that are needed for parsing are greatly reduced.