### PR TITLE
perf(compiler-cli): avoid module resolution of absolute module names

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm2015_host.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 
 import {absoluteFromSourceFile} from '../../../src/ngtsc/file_system';
 import {Logger} from '../../../src/ngtsc/logging';
-import {ClassDeclaration, ClassMember, ClassMemberKind, CtorParameter, Declaration, DeclarationNode, Decorator, EnumMember, Import, isConcreteDeclaration, isDecoratorIdentifier, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, reflectObjectLiteral, SpecialDeclarationKind, TypeScriptReflectionHost, TypeValueReference, TypeValueReferenceKind, ValueUnavailableKind} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, ClassMember, ClassMemberKind, CtorParameter, Declaration, DeclarationNode, Decorator, EnumMember, getModuleNameFromSpecifier, Import, isConcreteDeclaration, isDecoratorIdentifier, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration, KnownDeclaration, reflectObjectLiteral, SpecialDeclarationKind, TypeScriptReflectionHost, TypeValueReference, TypeValueReferenceKind, ValueUnavailableKind} from '../../../src/ngtsc/reflection';
 import {isWithinPackage} from '../analysis/util';
 import {BundleProgram} from '../packages/bundle_program';
 import {findAll, getNameText, hasNameIdentifier, isDefined, stripDollarSuffix} from '../utils';
@@ -1649,7 +1649,7 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
     return {
       kind: TypeValueReferenceKind.IMPORTED,
       valueDeclaration: decl.node,
-      moduleName: imp.from,
+      moduleName: getModuleNameFromSpecifier(imp.from),
       importedName: imp.name,
       nestedPath: null,
     };
@@ -1783,9 +1783,10 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
    */
   protected isFromCore(decorator: Decorator): boolean {
     if (this.isCore) {
-      return !decorator.import || /^\./.test(decorator.import.from);
+      return !decorator.import || /^\./.test(getModuleNameFromSpecifier(decorator.import.from));
     } else {
-      return !!decorator.import && decorator.import.from === '@angular/core';
+      return !!decorator.import &&
+          getModuleNameFromSpecifier(decorator.import.from) === '@angular/core';
     }
   }
 

--- a/packages/compiler-cli/ngcc/src/migrations/missing_injectable_migration.ts
+++ b/packages/compiler-cli/ngcc/src/migrations/missing_injectable_migration.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 import {forwardRefResolver} from '../../../src/ngtsc/annotations';
 import {Reference} from '../../../src/ngtsc/imports';
 import {ResolvedValue, ResolvedValueMap} from '../../../src/ngtsc/partial_evaluator';
-import {ClassDeclaration, Decorator} from '../../../src/ngtsc/reflection';
+import {ClassDeclaration, Decorator, getModuleNameFromSpecifier} from '../../../src/ngtsc/reflection';
 
 import {Migration, MigrationHost} from './migration';
 import {createInjectableDecorator, isClassDeclaration} from './utils';
@@ -184,7 +184,8 @@ function needsInjectableDecorator(clazz: ClassDeclaration, host: MigrationHost):
  * null is returned.
  */
 export function getAngularCoreDecoratorName(decorator: Decorator): string|null {
-  if (decorator.import === null || decorator.import.from !== '@angular/core') {
+  if (decorator.import === null ||
+      getModuleNameFromSpecifier(decorator.import.from) !== '@angular/core') {
     return null;
   }
 

--- a/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/esm_rendering_formatter.ts
@@ -11,6 +11,7 @@ import * as ts from 'typescript';
 
 import {absoluteFromSourceFile, AbsoluteFsPath, PathManipulation, toRelativeImport} from '../../../src/ngtsc/file_system';
 import {Reexport} from '../../../src/ngtsc/imports';
+import {getModuleNameFromSpecifier} from '../../../src/ngtsc/reflection';
 import {Import, ImportManager, translateStatement} from '../../../src/ngtsc/translator';
 import {isDtsPath} from '../../../src/ngtsc/util/src/typescript';
 import {ModuleWithProvidersInfo} from '../analysis/module_with_providers_analyzer';
@@ -202,7 +203,7 @@ export class EsmRenderingFormatter implements RenderingFormatter {
       const ngModuleFile = absoluteFromSourceFile(info.ngModule.node.getSourceFile());
       const relativePath = this.fs.relative(this.fs.dirname(declarationFile), ngModuleFile);
       const relativeImport = toRelativeImport(relativePath);
-      const importPath = info.ngModule.ownedByModuleGuess ||
+      const importPath = getModuleNameFromSpecifier(info.ngModule.ownedByModuleGuess) ||
           (declarationFile !== ngModuleFile ? stripExtension(relativeImport) : null);
       const ngModule = generateImportString(importManager, importPath, ngModuleName);
 
@@ -274,7 +275,8 @@ export class EsmRenderingFormatter implements RenderingFormatter {
     const id =
         typeName && ts.isIdentifier(typeName) ? this.host.getImportOfIdentifier(typeName) : null;
     return (
-        id && id.name === 'ModuleWithProviders' && (this.isCore || id.from === '@angular/core'));
+        id && id.name === 'ModuleWithProviders' &&
+        (this.isCore || getModuleNameFromSpecifier(id.from) === '@angular/core'));
   }
 }
 

--- a/packages/compiler-cli/ngcc/test/analysis/module_with_providers_analyzer_spec.ts
+++ b/packages/compiler-cli/ngcc/test/analysis/module_with_providers_analyzer_spec.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 import {absoluteFrom, AbsoluteFsPath, getSourceFileOrError} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
-import {DeclarationNode} from '../../../src/ngtsc/reflection';
+import {DeclarationNode, getModuleNameFromSpecifier} from '../../../src/ngtsc/reflection';
 import {getDeclaration, isNamedDeclaration, loadTestFiles} from '../../../src/ngtsc/testing';
 import {ModuleWithProvidersAnalyses, ModuleWithProvidersAnalyzer} from '../../src/analysis/module_with_providers_analyzer';
 import {NgccReferencesRegistry} from '../../src/analysis/ngcc_references_registry';
@@ -655,7 +655,7 @@ runInEachFileSystem(() => {
                               info =>
                                   [getName(info.container) + info.declaration.name!.getText(),
                                    (info.ngModule.node as ts.ClassDeclaration).name!.getText(),
-                                   info.ngModule.ownedByModuleGuess]) :
+                                   getModuleNameFromSpecifier(info.ngModule.ownedByModuleGuess)]) :
                           [];
       }
 

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_import_helper_spec.ts
@@ -205,7 +205,10 @@ runInEachFileSystem(() => {
             const decorator = decorators[0];
             expect(decorator.name).toEqual('Directive');
             expect(decorator.identifier!.getText()).toEqual('Directive');
-            expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+            expect(decorator.import).toEqual({
+              name: 'Directive',
+              from: jasmine.objectContaining({text: '@angular/core'})
+            });
             expect(decorator.args!.map(arg => arg.getText())).toEqual([
               '{ selector: \'[someDirective]\' }',
             ]);
@@ -226,7 +229,10 @@ runInEachFileSystem(() => {
                const decorator = decorators[0];
                expect(decorator.name).toEqual('Directive');
                expect(decorator.identifier!.getText()).toEqual('Directive');
-               expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+               expect(decorator.import).toEqual({
+                 name: 'Directive',
+                 from: jasmine.objectContaining({text: '@angular/core'})
+               });
                expect(decorator.args!.map(arg => arg.getText())).toEqual([
                  '{ selector: \'[someDirective]\' }',
                ]);
@@ -247,7 +253,10 @@ runInEachFileSystem(() => {
                const decorator = decorators[0];
                expect(decorator.name).toEqual('Directive');
                expect(decorator.identifier!.getText()).toEqual('Directive');
-               expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+               expect(decorator.import).toEqual({
+                 name: 'Directive',
+                 from: jasmine.objectContaining({text: '@angular/core'})
+               });
                expect(decorator.args!.map(arg => arg.getText())).toEqual([
                  '{ selector: \'[someDirective]\' }',
                ]);
@@ -268,7 +277,10 @@ runInEachFileSystem(() => {
             const decorator = decorators[0];
             expect(decorator.name).toEqual('Directive');
             expect(decorator.identifier!.getText()).toEqual('Directive');
-            expect(decorator.import).toEqual({name: 'Directive', from: './directives'});
+            expect(decorator.import).toEqual({
+              name: 'Directive',
+              from: jasmine.objectContaining({text: './directives'})
+            });
             expect(decorator.args!.map(arg => arg.getText())).toEqual([
               '{ selector: \'[someDirective]\' }',
             ]);
@@ -443,7 +455,9 @@ runInEachFileSystem(() => {
                const decorators = parameters![2].decorators!;
                expect(decorators.length).toEqual(1);
                expect(decorators[0].name).toBe('Inject');
-               expect(decorators[0].import!.from).toBe('@angular/core');
+               expect(decorators[0].import!.from).toEqual(jasmine.objectContaining({
+                 text: '@angular/core'
+               }));
                expect(decorators[0].import!.name).toBe('Inject');
              });
         });
@@ -470,7 +484,9 @@ runInEachFileSystem(() => {
              const decorators = parameters![2].decorators!;
              expect(decorators.length).toEqual(1);
              expect(decorators[0].name).toBe('Inject');
-             expect(decorators[0].import!.from).toBe('@angular/core');
+             expect(decorators[0].import!.from).toEqual(jasmine.objectContaining({
+               text: '@angular/core'
+             }));
              expect(decorators[0].import!.name).toBe('Inject');
            });
 
@@ -515,7 +531,9 @@ runInEachFileSystem(() => {
             const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective!);
             expect(actualDeclaration).not.toBe(null);
             expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
-            expect(actualDeclaration!.viaModule).toBe('@angular/core');
+            expect(actualDeclaration!.viaModule).toEqual(jasmine.objectContaining({
+              text: '@angular/core'
+            }));
           });
         });
 

--- a/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm2015_host_spec.ts
@@ -725,7 +725,8 @@ runInEachFileSystem(() => {
 
         const decorator = decorators[0];
         expect(decorator.name).toEqual('Directive');
-        expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+        expect(decorator.import)
+            .toEqual({name: 'Directive', from: jasmine.objectContaining({text: '@angular/core'})});
         expect(decorator.args!.map(arg => arg.getText())).toEqual([
           '{ selector: \'[someDirective]\' }',
         ]);
@@ -744,7 +745,8 @@ runInEachFileSystem(() => {
 
         const decorator = decorators[0];
         expect(decorator.name).toEqual('Directive');
-        expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+        expect(decorator.import)
+            .toEqual({name: 'Directive', from: jasmine.objectContaining({text: '@angular/core'})});
         expect(decorator.args!.map(arg => arg.getText())).toEqual([
           '{ selector: \'[someDirective]\' }',
         ]);
@@ -764,7 +766,8 @@ runInEachFileSystem(() => {
 
         const decorator = decorators[0];
         expect(decorator.name).toEqual('Directive');
-        expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+        expect(decorator.import)
+            .toEqual({name: 'Directive', from: jasmine.objectContaining({text: '@angular/core'})});
         expect(decorator.args!.map(arg => arg.getText())).toEqual([
           '{ selector: \'[someDirective]\' }',
         ]);
@@ -848,7 +851,8 @@ runInEachFileSystem(() => {
         const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators.length).toEqual(1);
-        expect(decorators[0].import).toEqual({name: 'Directive', from: '@angular/core'});
+        expect(decorators[0].import)
+            .toEqual({name: 'Directive', from: jasmine.objectContaining({text: '@angular/core'})});
       });
 
       describe('(returned decorators `args`)', () => {
@@ -912,13 +916,15 @@ runInEachFileSystem(() => {
         expect(input1.kind).toEqual(ClassMemberKind.Property);
         expect(input1.isStatic).toEqual(false);
         expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
-        expect(input1.decorators![0].import).toEqual({name: 'Input', from: '@angular/core'});
+        expect(input1.decorators![0].import)
+            .toEqual({name: 'Input', from: jasmine.objectContaining({text: '@angular/core'})});
 
         const input2 = members.find(member => member.name === 'input2')!;
         expect(input2.kind).toEqual(ClassMemberKind.Property);
         expect(input2.isStatic).toEqual(false);
         expect(input2.decorators!.map(d => d.name)).toEqual(['Input']);
-        expect(input2.decorators![0].import).toEqual({name: 'Input', from: '@angular/core'});
+        expect(input2.decorators![0].import)
+            .toEqual({name: 'Input', from: jasmine.objectContaining({text: '@angular/core'})});
       });
 
       it('should find non decorated properties on a class', () => {
@@ -1450,7 +1456,8 @@ runInEachFileSystem(() => {
           const decorators = parameters[2].decorators!;
 
           expect(decorators.length).toEqual(1);
-          expect(decorators[0].import).toEqual({name: 'Inject', from: '@angular/core'});
+          expect(decorators[0].import)
+              .toEqual({name: 'Inject', from: jasmine.objectContaining({text: '@angular/core'})});
         });
       });
 
@@ -1581,7 +1588,8 @@ runInEachFileSystem(() => {
             getDeclaration(bundle.program, _('/b.js'), 'b', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
 
-        expect(importOfIdent).toEqual({name: 'a', from: './a.js'});
+        expect(importOfIdent)
+            .toEqual({name: 'a', from: jasmine.objectContaining({text: './a.js'})});
       });
 
       it('should find the name by which the identifier was exported, not imported', () => {
@@ -1592,7 +1600,8 @@ runInEachFileSystem(() => {
             getDeclaration(bundle.program, _('/b.js'), 'c', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
 
-        expect(importOfIdent).toEqual({name: 'a', from: './a.js'});
+        expect(importOfIdent)
+            .toEqual({name: 'a', from: jasmine.objectContaining({text: './a.js'})});
       });
 
       it('should return null if the identifier was not imported', () => {
@@ -1641,7 +1650,9 @@ runInEachFileSystem(() => {
         const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective);
         expect(actualDeclaration).not.toBe(null);
         expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
-        expect(actualDeclaration!.viaModule).toBe('@angular/core');
+        expect(actualDeclaration!.viaModule).toEqual(jasmine.objectContaining({
+          text: '@angular/core'
+        }));
       });
 
       it('should return the source-file of an import namespace', () => {
@@ -1663,7 +1674,9 @@ runInEachFileSystem(() => {
         const actualDeclaration = host.getDeclarationOfIdentifier(identifier);
         expect(actualDeclaration).not.toBe(null);
         expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
-        expect(actualDeclaration!.viaModule).toBe('@angular/core');
+        expect(actualDeclaration!.viaModule).toEqual(jasmine.objectContaining({
+          text: '@angular/core'
+        }));
       });
 
       it('should return the original declaration of an aliased class', () => {

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_import_helper_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_import_helper_spec.ts
@@ -235,7 +235,10 @@ export { AliasedDirective$1 };
             const decorator = decorators[0];
             expect(decorator.name).toEqual('Directive');
             expect(decorator.identifier!.getText()).toEqual('Directive');
-            expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+            expect(decorator.import).toEqual({
+              name: 'Directive',
+              from: jasmine.objectContaining({text: '@angular/core'})
+            });
             expect(decorator.args!.map(arg => arg.getText())).toEqual([
               '{ selector: \'[someDirective]\' }',
             ]);
@@ -255,7 +258,10 @@ export { AliasedDirective$1 };
             const decorator = decorators[0];
             expect(decorator.name).toEqual('Directive');
             expect(decorator.identifier!.getText()).toEqual('Directive');
-            expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+            expect(decorator.import).toEqual({
+              name: 'Directive',
+              from: jasmine.objectContaining({text: '@angular/core'})
+            });
             expect(decorator.args!.map(arg => arg.getText())).toEqual([
               '{ selector: \'[someDirective]\' }',
             ]);
@@ -275,7 +281,10 @@ export { AliasedDirective$1 };
             const decorator = decorators[0];
             expect(decorator.name).toEqual('Directive');
             expect(decorator.identifier!.getText()).toEqual('Directive');
-            expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+            expect(decorator.import).toEqual({
+              name: 'Directive',
+              from: jasmine.objectContaining({text: '@angular/core'})
+            });
             expect(decorator.args!.map(arg => arg.getText())).toEqual([
               '{ selector: \'[someDirective]\' }',
             ]);
@@ -296,7 +305,10 @@ export { AliasedDirective$1 };
                const decorator = decorators[0];
                expect(decorator.name).toEqual('Directive');
                expect(decorator.identifier!.getText()).toEqual('Directive');
-               expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+               expect(decorator.import).toEqual({
+                 name: 'Directive',
+                 from: jasmine.objectContaining({text: '@angular/core'})
+               });
                expect(decorator.args!.map(arg => arg.getText())).toEqual([
                  '{ selector: \'[someDirective]\' }',
                ]);
@@ -317,7 +329,10 @@ export { AliasedDirective$1 };
             const decorator = decorators[0];
             expect(decorator.name).toEqual('Directive');
             expect(decorator.identifier!.getText()).toEqual('Directive');
-            expect(decorator.import).toEqual({name: 'Directive', from: './directives'});
+            expect(decorator.import).toEqual({
+              name: 'Directive',
+              from: jasmine.objectContaining({text: './directives'})
+            });
             expect(decorator.args!.map(arg => arg.getText())).toEqual([
               '{ selector: \'[someDirective]\' }',
             ]);
@@ -486,7 +501,10 @@ export { AliasedDirective$1 };
               const decorators = parameters![2].decorators!;
 
               expect(decorators.length).toEqual(1);
-              expect(decorators[0].import).toEqual({name: 'Inject', from: '@angular/core'});
+              expect(decorators[0].import).toEqual({
+                name: 'Inject',
+                from: jasmine.objectContaining({text: '@angular/core'})
+              });
             });
           });
         });
@@ -577,7 +595,9 @@ export { AliasedDirective$1 };
             const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective!);
             expect(actualDeclaration).not.toBe(null);
             expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
-            expect(actualDeclaration!.viaModule).toBe('@angular/core');
+            expect(actualDeclaration!.viaModule).toEqual(jasmine.objectContaining({
+              text: '@angular/core'
+            }));
           });
 
           it('should find the "actual" declaration of an aliased variable identifier', () => {

--- a/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/ngcc/test/host/esm5_host_spec.ts
@@ -803,7 +803,8 @@ runInEachFileSystem(() => {
 
         const decorator = decorators[0];
         expect(decorator.name).toEqual('Directive');
-        expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+        expect(decorator.import)
+            .toEqual({name: 'Directive', from: jasmine.objectContaining({text: '@angular/core'})});
         expect(decorator.args!.map(arg => arg.getText())).toEqual([
           '{ selector: \'[someDirective]\' }',
         ]);
@@ -823,7 +824,8 @@ runInEachFileSystem(() => {
 
         const decorator = decorators[0];
         expect(decorator.name).toEqual('Directive');
-        expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+        expect(decorator.import)
+            .toEqual({name: 'Directive', from: jasmine.objectContaining({text: '@angular/core'})});
         expect(decorator.args!.map(arg => arg.getText())).toEqual([
           '{ selector: \'[someDirective]\' }',
         ]);
@@ -908,7 +910,8 @@ runInEachFileSystem(() => {
         const decorators = host.getDecoratorsOfDeclaration(classNode)!;
 
         expect(decorators.length).toEqual(1);
-        expect(decorators[0].import).toEqual({name: 'Directive', from: '@angular/core'});
+        expect(decorators[0].import)
+            .toEqual({name: 'Directive', from: jasmine.objectContaining({text: '@angular/core'})});
       });
 
       describe('(returned decorators `args`)', () => {
@@ -970,13 +973,15 @@ runInEachFileSystem(() => {
         expect(input1.kind).toEqual(ClassMemberKind.Property);
         expect(input1.isStatic).toEqual(false);
         expect(input1.decorators!.map(d => d.name)).toEqual(['Input']);
-        expect(input1.decorators![0].import).toEqual({name: 'Input', from: '@angular/core'});
+        expect(input1.decorators![0].import)
+            .toEqual({name: 'Input', from: jasmine.objectContaining({text: '@angular/core'})});
 
         const input2 = members.find(member => member.name === 'input2')!;
         expect(input2.kind).toEqual(ClassMemberKind.Property);
         expect(input2.isStatic).toEqual(false);
         expect(input2.decorators!.map(d => d.name)).toEqual(['Input']);
-        expect(input2.decorators![0].import).toEqual({name: 'Input', from: '@angular/core'});
+        expect(input2.decorators![0].import)
+            .toEqual({name: 'Input', from: jasmine.objectContaining({text: '@angular/core'})});
       });
 
       it('should find decorated members on a class', () => {
@@ -1474,7 +1479,8 @@ runInEachFileSystem(() => {
           const decorators = parameters![2].decorators!;
 
           expect(decorators.length).toEqual(1);
-          expect(decorators[0].import).toEqual({name: 'Inject', from: '@angular/core'});
+          expect(decorators[0].import)
+              .toEqual({name: 'Inject', from: jasmine.objectContaining({text: '@angular/core'})});
         });
       });
 
@@ -1918,7 +1924,8 @@ runInEachFileSystem(() => {
             getDeclaration(bundle.program, _('/b.js'), 'b', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
 
-        expect(importOfIdent).toEqual({name: 'a', from: './a.js'});
+        expect(importOfIdent)
+            .toEqual({name: 'a', from: jasmine.objectContaining({text: './a.js'})});
       });
 
       it('should find the name by which the identifier was exported, not imported', () => {
@@ -1929,7 +1936,8 @@ runInEachFileSystem(() => {
             getDeclaration(bundle.program, _('/b.js'), 'c', isNamedVariableDeclaration);
         const importOfIdent = host.getImportOfIdentifier(variableNode.initializer as ts.Identifier);
 
-        expect(importOfIdent).toEqual({name: 'a', from: './a.js'});
+        expect(importOfIdent)
+            .toEqual({name: 'a', from: jasmine.objectContaining({text: './a.js'})});
       });
 
       it('should return null if the identifier was not imported', () => {
@@ -1960,7 +1968,8 @@ runInEachFileSystem(() => {
                   kind: DeclarationKind.Concrete,
                   known: knownAs,
                   node: getHelperDeclaration(helperName),
-                  viaModule,
+                  viaModule: viaModule !== null ? jasmine.objectContaining({text: viaModule}) :
+                                                  null,
                   identity: null,
                 });
               };
@@ -2016,7 +2025,9 @@ runInEachFileSystem(() => {
         const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective);
         expect(actualDeclaration).not.toBe(null);
         expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
-        expect(actualDeclaration!.viaModule).toBe('@angular/core');
+        expect(actualDeclaration!.viaModule).toEqual(jasmine.objectContaining({
+          text: '@angular/core'
+        }));
       });
 
       it('should return the source-file of an import namespace', () => {
@@ -2039,7 +2050,9 @@ runInEachFileSystem(() => {
         const actualDeclaration = host.getDeclarationOfIdentifier(identifier);
         expect(actualDeclaration).not.toBe(null);
         expect(actualDeclaration!.node).toBe(expectedDeclarationNode);
-        expect(actualDeclaration!.viaModule).toBe('@angular/core');
+        expect(actualDeclaration!.viaModule).toEqual(jasmine.objectContaining({
+          text: '@angular/core'
+        }));
       });
 
       it('should return the correct declaration for an inner function identifier inside an ES5 IIFE',

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -17,7 +17,7 @@ import {BindingPropertyName, ClassPropertyMapping, ClassPropertyName, DirectiveT
 import {extractDirectiveTypeCheckMeta} from '../../metadata/src/util';
 import {DynamicValue, EnumValue, PartialEvaluator} from '../../partial_evaluator';
 import {PerfEvent, PerfRecorder} from '../../perf';
-import {ClassDeclaration, ClassMember, ClassMemberKind, Decorator, filterToMembersWithDecorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
+import {ClassDeclaration, ClassMember, ClassMemberKind, Decorator, filterToMembersWithDecorator, getModuleNameFromSpecifier, ReflectionHost, reflectObjectLiteral} from '../../reflection';
 import {LocalModuleScopeRegistry} from '../../scope';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerFlags, HandlerPrecedence, ResolveResult} from '../../transform';
 
@@ -642,7 +642,7 @@ export function extractQueriesFromDecorator(
           'Decorator query metadata must be an instance of a query type');
     }
     const type = reflector.getImportOfIdentifier(queryType);
-    if (type === null || (!isCore && type.from !== '@angular/core') ||
+    if (type === null || (!isCore && getModuleNameFromSpecifier(type.from) !== '@angular/core') ||
         !QUERY_TYPES.has(type.name)) {
       throw new FatalDiagnosticError(
           ErrorCode.VALUE_HAS_WRONG_TYPE, queryData,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
 import {InjectableClassRegistry} from '../../metadata';
 import {PerfEvent, PerfRecorder} from '../../perf';
-import {ClassDeclaration, Decorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
+import {ClassDeclaration, Decorator, getModuleNameFromSpecifier, ReflectionHost, reflectObjectLiteral} from '../../reflection';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerPrecedence} from '../../transform';
 
 import {compileDeclareFactory, CompileFactoryFn, compileNgFactoryDefField} from './factory';
@@ -282,7 +282,7 @@ function getDep(dep: ts.Expression, reflector: ReflectionHost): R3DependencyMeta
   function maybeUpdateDecorator(
       dec: ts.Identifier, reflector: ReflectionHost, token?: ts.Expression): void {
     const source = reflector.getImportOfIdentifier(dec);
-    if (source === null || source.from !== '@angular/core') {
+    if (source === null || getModuleNameFromSpecifier(source.from) !== '@angular/core') {
       return;
     }
     switch (source.name) {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/metadata.ts
@@ -9,7 +9,7 @@
 import {Expression, FunctionExpr, LiteralArrayExpr, LiteralExpr, literalMap, R3ClassMetadata, ReturnStatement, WrappedNodeExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {CtorParameter, DeclarationNode, Decorator, ReflectionHost, TypeValueReferenceKind} from '../../reflection';
+import {CtorParameter, DeclarationNode, Decorator, getModuleNameFromSpecifier, ReflectionHost, TypeValueReferenceKind} from '../../reflection';
 
 import {valueReferenceToExpression, wrapFunctionExpressionsInParens} from './util';
 
@@ -151,7 +151,9 @@ function decoratorToMetadata(
  * Either it's used in @angular/core, or it's imported from there.
  */
 function isAngularDecorator(decorator: Decorator, isCore: boolean): boolean {
-  return isCore || (decorator.import !== null && decorator.import.from === '@angular/core');
+  return isCore ||
+      (decorator.import !== null &&
+       getModuleNameFromSpecifier(decorator.import.from) === '@angular/core');
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -15,7 +15,7 @@ import {isArrayEqual, isReferenceEqual, isSymbolEqual, SemanticReference, Semant
 import {InjectableClassRegistry, MetadataReader, MetadataRegistry} from '../../metadata';
 import {PartialEvaluator, ResolvedValue} from '../../partial_evaluator';
 import {PerfEvent, PerfRecorder} from '../../perf';
-import {ClassDeclaration, Decorator, isNamedClassDeclaration, ReflectionHost, reflectObjectLiteral, typeNodeToValueExpr} from '../../reflection';
+import {ClassDeclaration, Decorator, getModuleNameFromSpecifier, isNamedClassDeclaration, ReflectionHost, reflectObjectLiteral, typeNodeToValueExpr} from '../../reflection';
 import {NgModuleRouteAnalyzer} from '../../routing';
 import {LocalModuleScopeRegistry, ScopeData} from '../../scope';
 import {FactoryTracker} from '../../shims/api';
@@ -253,7 +253,8 @@ export class NgModuleDecoratorHandler implements
               rawExpr, result, 'NgModule.schemas must be an array of schemas');
         }
         const id = schemaRef.getIdentityIn(schemaRef.node.getSourceFile());
-        if (id === null || schemaRef.ownedByModuleGuess !== '@angular/core') {
+        if (id === null ||
+            getModuleNameFromSpecifier(schemaRef.ownedByModuleGuess) !== '@angular/core') {
           throw createValueHasWrongTypeError(
               rawExpr, result, 'NgModule.schemas must be an array of schemas');
         }
@@ -619,7 +620,7 @@ export class NgModuleDecoratorHandler implements
     }
 
     // If it's not from @angular/core, bail.
-    if (!this.isCore && id.from !== '@angular/core') {
+    if (!this.isCore && getModuleNameFromSpecifier(id.from) !== '@angular/core') {
       return null;
     }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -15,7 +15,7 @@ import {ErrorCode, FatalDiagnosticError, makeDiagnostic, makeRelatedInformation}
 import {ImportFlags, Reference, ReferenceEmitter} from '../../imports';
 import {attachDefaultImportDeclaration} from '../../imports/src/default';
 import {ForeignFunctionResolver, PartialEvaluator} from '../../partial_evaluator';
-import {ClassDeclaration, CtorParameter, Decorator, Import, ImportedTypeValueReference, isNamedClassDeclaration, LocalTypeValueReference, ReflectionHost, TypeValueReference, TypeValueReferenceKind, UnavailableValue, ValueUnavailableKind} from '../../reflection';
+import {ClassDeclaration, CtorParameter, Decorator, getModuleNameFromSpecifier, Import, ImportedTypeValueReference, isNamedClassDeclaration, LocalTypeValueReference, ReflectionHost, TypeValueReference, TypeValueReferenceKind, UnavailableValue, ValueUnavailableKind} from '../../reflection';
 import {DeclarationData} from '../../scope';
 import {CompileResult} from '../../transform';
 
@@ -270,11 +270,13 @@ export function toR3Reference(
 }
 
 export function isAngularCore(decorator: Decorator): decorator is Decorator&{import: Import} {
-  return decorator.import !== null && decorator.import.from === '@angular/core';
+  return decorator.import !== null &&
+      getModuleNameFromSpecifier(decorator.import.from) === '@angular/core';
 }
 
 export function isAngularCoreReference(reference: Reference, symbolName: string): boolean {
-  return reference.ownedByModuleGuess === '@angular/core' && reference.debugName === symbolName;
+  return getModuleNameFromSpecifier(reference.ownedByModuleGuess) === '@angular/core' &&
+      reference.debugName === symbolName;
 }
 
 export function findAngularDecorator(
@@ -357,7 +359,8 @@ export function tryUnwrapForwardRef(node: ts.Expression, reflector: ReflectionHo
   }
 
   const imp = reflector.getImportOfIdentifier(fn);
-  if (imp === null || imp.from !== '@angular/core' || imp.name !== 'forwardRef') {
+  if (imp === null || getModuleNameFromSpecifier(imp.from) !== '@angular/core' ||
+      imp.name !== 'forwardRef') {
     return null;
   }
 

--- a/packages/compiler-cli/src/ngtsc/imports/src/references.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/references.ts
@@ -8,11 +8,12 @@
 
 import {Expression} from '@angular/compiler';
 import * as ts from 'typescript';
+import {ModuleSpecifier} from '../../reflection';
 
 import {identifierOfNode} from '../../util/src/typescript';
 
 export interface OwningModule {
-  specifier: string;
+  specifier: ModuleSpecifier;
   resolutionContext: string;
 }
 
@@ -67,7 +68,7 @@ export class Reference<T extends ts.Node = ts.Node> {
    * The best guess at which module specifier owns this particular reference, or `null` if there
    * isn't one.
    */
-  get ownedByModuleGuess(): string|null {
+  get ownedByModuleGuess(): ModuleSpecifier|null {
     if (this.bestGuessOwningModule !== null) {
       return this.bestGuessOwningModule.specifier;
     } else {

--- a/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
@@ -9,14 +9,14 @@
 import * as ts from 'typescript';
 
 import {Reference} from '../../imports';
-import {ClassDeclaration, ClassMember, ClassMemberKind, isNamedClassDeclaration, ReflectionHost, reflectTypeEntityToDeclaration} from '../../reflection';
+import {ClassDeclaration, ClassMember, ClassMemberKind, isNamedClassDeclaration, ModuleSpecifier, ReflectionHost, reflectTypeEntityToDeclaration} from '../../reflection';
 import {nodeDebugInfo} from '../../util/src/typescript';
 
 import {DirectiveMeta, DirectiveTypeCheckMeta, MetadataReader, NgModuleMeta, PipeMeta, TemplateGuardMeta} from './api';
 import {ClassPropertyMapping, ClassPropertyName} from './property_mapping';
 
 export function extractReferencesFromType(
-    checker: ts.TypeChecker, def: ts.TypeNode, ngModuleImportedFrom: string|null,
+    checker: ts.TypeChecker, def: ts.TypeNode, ngModuleImportedFrom: ModuleSpecifier|null,
     resolutionContext: string): Reference<ClassDeclaration>[] {
   if (!ts.isTupleTypeNode(def)) {
     return [];
@@ -31,7 +31,7 @@ export function extractReferencesFromType(
     if (!isNamedClassDeclaration(node)) {
       throw new Error(`Expected named ClassDeclaration: ${nodeDebugInfo(node)}`);
     }
-    const specifier = (from !== null && !from.startsWith('.') ? from : ngModuleImportedFrom);
+    const specifier = (from !== null && !from.text.startsWith('.') ? from : ngModuleImportedFrom);
     if (specifier !== null) {
       return new Reference(node, {specifier, resolutionContext});
     } else {

--- a/packages/compiler-cli/src/ngtsc/modulewithproviders/src/scanner.ts
+++ b/packages/compiler-cli/src/ngtsc/modulewithproviders/src/scanner.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 
 import {ImportFlags, Reference, ReferenceEmitter} from '../../imports';
 import {PartialEvaluator, ResolvedValueMap} from '../../partial_evaluator';
-import {ReflectionHost} from '../../reflection';
+import {getModuleNameFromSpecifier, ReflectionHost} from '../../reflection';
 
 export interface DtsHandler {
   addTypeReplacement(node: ts.Declaration, type: Type): void;
@@ -130,7 +130,7 @@ export class ModuleWithProvidersScanner {
     }
 
     const importDecl = this.host.getImportOfIdentifier(typeId);
-    if (importDecl === null || importDecl.from !== '@angular/core' ||
+    if (importDecl === null || getModuleNameFromSpecifier(importDecl.from) !== '@angular/core' ||
         importDecl.name !== 'ModuleWithProviders') {
       return ReturnType.OTHER;
     }

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interface.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interface.ts
@@ -29,7 +29,7 @@ export class PartialEvaluator {
     const sourceFile = expr.getSourceFile();
     return interpreter.visit(expr, {
       originatingFile: sourceFile,
-      absoluteModuleName: null,
+      absoluteModuleSpecifier: null,
       resolutionContext: sourceFile.fileName,
       scope: new Map<ts.ParameterDeclaration, ResolvedValue>(),
       foreignFunctionResolver,

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/utils.ts
@@ -11,7 +11,7 @@ import {absoluteFrom} from '../../file_system';
 import {TestFile} from '../../file_system/testing';
 import {Reference} from '../../imports';
 import {DependencyTracker} from '../../incremental/api';
-import {TypeScriptReflectionHost} from '../../reflection';
+import {getModuleNameFromSpecifier, TypeScriptReflectionHost} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';
 import {ForeignFunctionResolver, PartialEvaluator} from '../src/interface';
 import {ResolvedValue} from '../src/result';
@@ -54,7 +54,7 @@ export function evaluate<T extends ResolvedValue>(
 }
 
 export function owningModuleOf(ref: Reference): string|null {
-  return ref.bestGuessOwningModule !== null ? ref.bestGuessOwningModule.specifier : null;
+  return getModuleNameFromSpecifier(ref.ownedByModuleGuess);
 }
 
 export function firstArgFfr(

--- a/packages/compiler-cli/src/ngtsc/reflection/index.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/index.ts
@@ -9,4 +9,4 @@
 export * from './src/host';
 export {typeNodeToValueExpr} from './src/type_to_value';
 export {TypeScriptReflectionHost, filterToMembersWithDecorator, reflectIdentifierOfDeclaration, reflectNameOfDeclaration, reflectObjectLiteral, reflectTypeEntityToDeclaration} from './src/typescript';
-export {isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from './src/util';
+export {getModuleNameFromSpecifier, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from './src/util';

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -507,6 +507,12 @@ export interface Parameter {
 }
 
 /**
+ * Represents the module name of an import or export. It can either be the string literal node
+ * that contains the module name, or a raw string if no such node is available.
+ */
+export type ModuleSpecifier = ts.StringLiteral|string;
+
+/**
  * The source of an imported symbol, including the original symbol name and the module from which it
  * was imported.
  */
@@ -521,7 +527,7 @@ export interface Import {
    *
    * This could either be an absolute module name (@angular/core for example) or a relative path.
    */
-  from: string;
+  from: ModuleSpecifier;
 }
 
 /**
@@ -577,7 +583,7 @@ export interface BaseDeclaration<T extends DeclarationNode> {
    * was imported via an absolute module (even through a chain of re-exports). If the symbol is part
    * of the application and was not imported from an absolute path, this will be `null`.
    */
-  viaModule: string|null;
+  viaModule: ModuleSpecifier|null;
 
   /**
    * TypeScript reference to the declaration itself, if one exists.

--- a/packages/compiler-cli/src/ngtsc/reflection/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/util.ts
@@ -7,7 +7,8 @@
  */
 
 import * as ts from 'typescript';
-import {ClassDeclaration} from './host';
+
+import {ClassDeclaration, ModuleSpecifier} from './host';
 
 export function isNamedClassDeclaration(node: ts.Node):
     node is ClassDeclaration<ts.ClassDeclaration> {
@@ -26,4 +27,13 @@ export function isNamedVariableDeclaration(node: ts.Node):
 
 function isIdentifier(node: ts.Node|undefined): node is ts.Identifier {
   return node !== undefined && ts.isIdentifier(node);
+}
+
+export function getModuleNameFromSpecifier(specifier: ModuleSpecifier): string;
+export function getModuleNameFromSpecifier(specifier: ModuleSpecifier|null): string|null;
+export function getModuleNameFromSpecifier(specifier: ModuleSpecifier|null): string|null {
+  if (specifier === null) {
+    return null;
+  }
+  return typeof specifier === 'string' ? specifier : specifier.text;
 }

--- a/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
@@ -11,7 +11,7 @@ import {runInEachFileSystem} from '../../file_system/testing';
 import {getDeclaration, makeProgram} from '../../testing';
 import {ClassMember, ClassMemberKind, CtorParameter, DeclarationKind, TypeValueReferenceKind} from '../src/host';
 import {TypeScriptReflectionHost} from '../src/typescript';
-import {isNamedClassDeclaration} from '../src/util';
+import {getModuleNameFromSpecifier, isNamedClassDeclaration} from '../src/util';
 
 runInEachFileSystem(() => {
   describe('reflector', () => {
@@ -260,7 +260,7 @@ runInEachFileSystem(() => {
         const directImport = host.getImportOfIdentifier(Target);
         expect(directImport).toEqual({
           name: 'Target',
-          from: 'absolute',
+          from: jasmine.objectContaining({text: 'absolute'}),
         });
       });
 
@@ -287,7 +287,7 @@ runInEachFileSystem(() => {
         const namespacedImport = host.getImportOfIdentifier(Target);
         expect(namespacedImport).toEqual({
           name: 'Target',
-          from: 'absolute',
+          from: jasmine.objectContaining({text: 'absolute'}),
         });
       });
     });
@@ -332,7 +332,7 @@ runInEachFileSystem(() => {
         expect(targetDecl.node!.getSourceFile())
             .toBe(getSourceFileOrError(program, _('/node_modules/absolute/index.ts')));
         expect(ts.isClassDeclaration(targetDecl.node!)).toBe(true);
-        expect(directTargetDecl.viaModule).toBe('absolute');
+        expect(directTargetDecl.viaModule).toEqual(jasmine.objectContaining({text: 'absolute'}));
         expect(directTargetDecl.node).toBe(targetDecl.node);
       });
 
@@ -363,7 +363,7 @@ runInEachFileSystem(() => {
           kind: DeclarationKind.Concrete,
           node: targetDecl,
           known: null,
-          viaModule: 'absolute',
+          viaModule: jasmine.objectContaining({text: 'absolute'}),
           identity: null,
         });
       });
@@ -394,7 +394,7 @@ runInEachFileSystem(() => {
         expect(decl).toEqual({
           node: targetDecl,
           known: null,
-          viaModule: 'absolute',
+          viaModule: jasmine.objectContaining({text: 'absolute'}),
           identity: null,
           kind: DeclarationKind.Concrete
         });
@@ -571,7 +571,7 @@ runInEachFileSystem(() => {
       expect(param.decorators!.length).toBeGreaterThan(0);
       expect(param.decorators!.some(
                  dec => dec.name === decorator && dec.import !== null &&
-                     dec.import.from === decoratorFrom))
+                     getModuleNameFromSpecifier(dec.import.from) === decoratorFrom))
           .toBe(true);
     }
   }

--- a/packages/compiler-cli/src/ngtsc/routing/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/routing/BUILD.bazel
@@ -1,6 +1,6 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "routing",
@@ -12,6 +12,7 @@ ts_library(
         "//packages/compiler",
         "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/partial_evaluator",
+        "//packages/compiler-cli/src/ngtsc/reflection",
         "@npm//@types/node",
         "@npm//typescript",
     ],

--- a/packages/compiler-cli/src/ngtsc/routing/src/lazy.ts
+++ b/packages/compiler-cli/src/ngtsc/routing/src/lazy.ts
@@ -10,6 +10,7 @@ import * as ts from 'typescript';
 
 import {Reference} from '../../imports';
 import {ForeignFunctionResolver, PartialEvaluator, ResolvedValue} from '../../partial_evaluator';
+import {getModuleNameFromSpecifier} from '../../reflection';
 
 import {NgModuleRawRouteData} from './analyzer';
 import {entryPointKeyFor, RouterEntryPoint, RouterEntryPointManager} from './route';
@@ -164,9 +165,7 @@ const routerModuleFFR: ForeignFunctionResolver =
         args: ReadonlyArray<ts.Expression>): ts.Expression|null {
   if (!isMethodNodeReference(ref) || !ts.isClassDeclaration(ref.node.parent)) {
     return null;
-  } else if (
-      ref.bestGuessOwningModule === null ||
-      ref.bestGuessOwningModule.specifier !== '@angular/router') {
+  } else if (getModuleNameFromSpecifier(ref.ownedByModuleGuess) !== '@angular/router') {
     return null;
   } else if (ref.node.parent.name === undefined || ref.node.parent.name.text !== 'RouterModule') {
     return null;
@@ -195,6 +194,7 @@ function isMethodNodeReference(
 }
 
 function isRouteToken(ref: ResolvedValue): boolean {
-  return ref instanceof Reference && ref.bestGuessOwningModule !== null &&
-      ref.bestGuessOwningModule.specifier === '@angular/router' && ref.debugName === 'ROUTES';
+  return ref instanceof Reference &&
+      getModuleNameFromSpecifier(ref.ownedByModuleGuess) === '@angular/router' &&
+      ref.debugName === 'ROUTES';
 }

--- a/packages/compiler-cli/src/ngtsc/scope/src/local.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/local.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
 import {ErrorCode, makeDiagnostic, makeRelatedInformation} from '../../diagnostics';
 import {AliasingHost, Reexport, Reference, ReferenceEmitter} from '../../imports';
 import {DirectiveMeta, MetadataReader, MetadataRegistry, NgModuleMeta, PipeMeta} from '../../metadata';
-import {ClassDeclaration, DeclarationNode} from '../../reflection';
+import {ClassDeclaration, DeclarationNode, getModuleNameFromSpecifier} from '../../reflection';
 import {identifierOfNode, nodeNameForError} from '../../util/src/typescript';
 
 import {ExportScope, RemoteScope, ScopeData} from './api';
@@ -559,7 +559,9 @@ function invalidRef(
       `Appears in the NgModule.${type}s of ${
           nodeNameForError(clazz)}, but could not be resolved to an ${resolveTarget} class.` +
       '\n\n';
-  const library = decl.ownedByModuleGuess !== null ? ` (${decl.ownedByModuleGuess})` : '';
+  const library = decl.ownedByModuleGuess !== null ?
+      ` (${getModuleNameFromSpecifier(decl.ownedByModuleGuess)})` :
+      '';
   const sf = decl.node.getSourceFile();
 
   // Provide extra context to the error for the user.

--- a/packages/compiler-cli/src/ngtsc/scope/test/dependency_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/dependency_spec.ts
@@ -69,7 +69,10 @@ function makeTestEnv(
       if (exportedSymbol !== undefined) {
         const decl = exportedSymbol.valueDeclaration as ts.ClassDeclaration;
         const specifier = MODULE_FROM_NODE_MODULES_PATH.exec(sf.fileName)![1];
-        return new Reference(decl, {specifier, resolutionContext: sf.fileName});
+        return new Reference(decl, {
+          specifier: jasmine.objectContaining({text: specifier}) as any,
+          resolutionContext: sf.fileName
+        });
       }
     }
     throw new Error('Class not found: ' + name);
@@ -146,7 +149,11 @@ runInEachFileSystem(() => {
       expect(scopeToRefs(scope)).toEqual([Dir]);
 
       // Explicitly verify that the directive has the correct owning module.
-      expect(scope.exported.directives[0].ref.ownedByModuleGuess).toBe('declaration');
+      const owningModule = scope.exported.directives[0].ref.ownedByModuleGuess;
+      if (owningModule === null || typeof owningModule === 'string') {
+        return fail('Owning module should be the ts.StringLiteral of the module specifier');
+      }
+      expect(owningModule.text).toBe('declaration');
     });
 
     it('should write correct aliases for deep dependencies', () => {

--- a/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
 import {DefaultImportTracker, ImportRewriter} from '../../imports';
 import {getDefaultImportDeclaration} from '../../imports/src/default';
 import {PerfPhase, PerfRecorder} from '../../perf';
-import {Decorator, ReflectionHost} from '../../reflection';
+import {Decorator, getModuleNameFromSpecifier, ReflectionHost} from '../../reflection';
 import {ImportManager, RecordWrappedNodeFn, translateExpression, translateStatement, TranslatorOptions} from '../../translator';
 import {visit, VisitListEntryResult, Visitor} from '../../util/src/visitor';
 
@@ -368,7 +368,8 @@ function maybeFilterDecorator(
 }
 
 function isFromAngularCore(decorator: Decorator): boolean {
-  return decorator.import !== null && decorator.import.from === '@angular/core';
+  return decorator.import !== null &&
+      getModuleNameFromSpecifier(decorator.import.from) === '@angular/core';
 }
 
 function createRecorderFn(defaultImportTracker: DefaultImportTracker):

--- a/packages/compiler-cli/src/transformers/downlevel_decorators_transform.ts
+++ b/packages/compiler-cli/src/transformers/downlevel_decorators_transform.ts
@@ -7,7 +7,9 @@
  */
 
 import * as ts from 'typescript';
-import {Decorator, ReflectionHost} from '../ngtsc/reflection';
+
+import {Decorator, getModuleNameFromSpecifier, ReflectionHost} from '../ngtsc/reflection';
+
 import {isAliasImportDeclaration, loadIsReferencedAliasDeclarationPatch} from './patch_alias_reference_resolution';
 
 /**
@@ -15,7 +17,9 @@ import {isAliasImportDeclaration, loadIsReferencedAliasDeclarationPatch} from '.
  * Either it's used in @angular/core, or it's imported from there.
  */
 function isAngularDecorator(decorator: Decorator, isCore: boolean): boolean {
-  return isCore || (decorator.import !== null && decorator.import.from === '@angular/core');
+  return isCore ||
+      (decorator.import !== null &&
+       getModuleNameFromSpecifier(decorator.import.from) === '@angular/core');
 }
 
 /*

--- a/packages/core/schematics/migrations/missing-injectable/providers_evaluator.ts
+++ b/packages/core/schematics/migrations/missing-injectable/providers_evaluator.ts
@@ -48,7 +48,7 @@ export class ProvidersEvaluator extends StaticInterpreter {
     this._providerLiterals = [];
     const resolvedValue = this.visit(expr, {
       originatingFile: expr.getSourceFile(),
-      absoluteModuleName: null,
+      absoluteModuleSpecifier: null,
       resolutionContext: expr.getSourceFile().fileName,
       scope: new Map(),
       foreignFunctionResolver: forwardRefResolver


### PR DESCRIPTION
The reference emitter mechanism has a strategy for dealing with the
`OwningModule` data that may be stored in a `Reference` which indicates
that the import should go through that absolute module specifier. The
module specifier used to be a string containing the module path, which
required the emitter to resolve that path into an actual module using
module resolution. We can avoid the module resolution work by storing
the `ts.StringLiteral` node of the module specifier instead; we can then
request the associated module using the `ts.TypeChecker`.