### PR TITLE
fix(router): call ngOnInit hook of routed component with NoopNgZone

### DIFF
--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -449,7 +449,7 @@ export declare class RouterOutlet implements OnDestroy, OnInit, RouterOutletCont
     get component(): Object;
     deactivateEvents: EventEmitter<any>;
     get isActivated(): boolean;
-    constructor(parentContexts: ChildrenOutletContexts, location: ViewContainerRef, resolver: ComponentFactoryResolver, name: string, changeDetector: ChangeDetectorRef);
+    constructor(parentContexts: ChildrenOutletContexts, location: ViewContainerRef, resolver: ComponentFactoryResolver, name: string, changeDetector: ChangeDetectorRef, ngZone: NgZone);
     activateWith(activatedRoute: ActivatedRoute, resolver: ComponentFactoryResolver | null): void;
     attach(ref: ComponentRef<any>, activatedRoute: ActivatedRoute): void;
     deactivate(): void;

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {APP_BASE_HREF, DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
-import {ApplicationRef, Component, CUSTOM_ELEMENTS_SCHEMA, destroyPlatform, NgModule} from '@angular/core';
+import {ApplicationRef, Component, CUSTOM_ELEMENTS_SCHEMA, destroyPlatform, NgModule, OnInit} from '@angular/core';
 import {inject} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
@@ -365,6 +365,39 @@ describe('bootstrap', () => {
     await router.navigateByUrl('/aa#marker3');
     expect(window.pageYOffset).toBeGreaterThanOrEqual(8900);
     expect(window.pageYOffset).toBeLessThan(9000);
+    done();
+  });
+
+  it('Should call ngOnInit hook of routed component with NoopNgZone', async (done) => {
+    @Component({selector: 'oninit-cmp', template: 'test'})
+    class OnInitCmp implements OnInit {
+      constructor() {
+        log.push('OnInitCmp');
+      }
+
+      ngOnInit(): void {
+        log.push('ngOnInit');
+      }
+    }
+
+    @NgModule({
+      imports: [
+        BrowserModule, RouterModule.forRoot([{
+          path: '**',
+          component: OnInitCmp,
+        }])
+      ],
+      declarations: [RootCmp, OnInitCmp],
+      bootstrap: [RootCmp],
+      providers: testProviders,
+    })
+    class TestModule {
+    }
+
+    await platformBrowserDynamic([]).bootstrapModule(TestModule, {ngZone: 'noop'});
+
+    expect(log).toEqual(['RootCmp', 'OnInitCmp', 'ngOnInit']);
+
     done();
   });
 


### PR DESCRIPTION
When using Router without Zone, ngOnInit method of the routed component is not called.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using Router without Zone, ngOnInit method of the routed component is not called.

Issue Number: N/A

## What is the new behavior?

When using Router without Zone, ngOnInit method of the routed component is now called.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I don't know if this is the right way to fix the issue but at least you have a test reproducing the issue :)
