### PR TITLE
fix(platform-browser): configure `XhrFactory` to use `BrowserXhr`

### DIFF
--- a/aio/tools/ng-packages-installer/index.js
+++ b/aio/tools/ng-packages-installer/index.js
@@ -15,6 +15,7 @@ const LOCAL_MARKER_PATH = 'node_modules/_local_.json';
 const ANGULAR_ROOT_DIR = path.resolve(__dirname, '../../..');
 const ANGULAR_DIST_PACKAGES_DIR = path.join(ANGULAR_ROOT_DIR, 'dist/packages-dist');
 const ZONEJS_DIST_PACKAGES_DIR = path.join(ANGULAR_ROOT_DIR, 'dist/zone.js-dist');
+const ANGULAR_MISC_DIST_PACKAGES = path.join(ANGULAR_ROOT_DIR, 'dist/packages-dist/misc');
 const DIST_PACKAGES_BUILD_SCRIPT = path.join(ANGULAR_ROOT_DIR, 'scripts/build/build-packages-dist.js');
 const DIST_PACKAGES_BUILD_CMD = `"${process.execPath}" "${DIST_PACKAGES_BUILD_SCRIPT}"`;
 
@@ -183,7 +184,7 @@ class NgPackagesInstaller {
     } else {
       this._warn([
         'Automatically building the local Angular/Zone.js packages is currently not supported on Windows.',
-        `Please, ensure '${ANGULAR_DIST_PACKAGES_DIR}' and '${ZONEJS_DIST_PACKAGES_DIR}' exist and are up-to-date ` +
+        `Please, ensure '${ANGULAR_DIST_PACKAGES_DIR}', ${ZONEJS_DIST_PACKAGES_DIR} and '${ANGULAR_MISC_DIST_PACKAGES}' exist and are up-to-date ` +
           `(e.g. by running '${DIST_PACKAGES_BUILD_SCRIPT}' in Git Bash for Windows, Windows Subsystem for Linux or ` +
           'a Linux docker container or VM).',
         '',
@@ -222,6 +223,7 @@ class NgPackagesInstaller {
   _getDistPackages() {
     this._log(`Angular distributable directory: ${ANGULAR_DIST_PACKAGES_DIR}.`);
     this._log(`Zone.js distributable directory: ${ZONEJS_DIST_PACKAGES_DIR}.`);
+    this._log(`angular-in-memory-web-api distributable directory: ${ANGULAR_MISC_DIST_PACKAGES}.`);
 
     if (this.buildPackages) {
       this._buildDistPackages();
@@ -260,6 +262,7 @@ class NgPackagesInstaller {
     const packageConfigs = {
       ...collectPackages(ANGULAR_DIST_PACKAGES_DIR),
       ...collectPackages(ZONEJS_DIST_PACKAGES_DIR),
+      ...collectPackages(ANGULAR_MISC_DIST_PACKAGES),
     };
 
     this._log('Found the following Angular distributables:', Object.keys(packageConfigs).map(key => `\n - ${key}`));

--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -433,3 +433,7 @@ export declare enum WeekDay {
     Friday = 5,
     Saturday = 6
 }
+
+export declare abstract class XhrFactory {
+    abstract build(): XMLHttpRequest;
+}

--- a/goldens/public-api/common/http/http.d.ts
+++ b/goldens/public-api/common/http/http.d.ts
@@ -1947,7 +1947,3 @@ export declare class JsonpInterceptor {
     constructor(jsonp: JsonpClientBackend);
     intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>>;
 }
-
-export declare abstract class XhrFactory {
-    abstract build(): XMLHttpRequest;
-}

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3153,
-        "main-es2015": 437810,
+        "main-es2015": 437306,
         "polyfills-es2015": 52493
       }
     }

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1485,
-        "main-es2015": 144151,
+        "main-es2015": 144579,
         "polyfills-es2015": 36964
       }
     }
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2285,
-        "main-es2015": 240352,
+        "main-es2015": 240874,
         "polyfills-es2015": 36975,
         "5-es2015": 753
       }

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -16,5 +16,5 @@ export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule, HttpInter
 export {HttpParameterCodec, HttpParams, HttpParamsOptions, HttpUrlEncodingCodec} from './src/params';
 export {HttpRequest} from './src/request';
 export {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpProgressEvent, HttpResponse, HttpResponseBase, HttpSentEvent, HttpStatusCode, HttpUploadProgressEvent, HttpUserEvent} from './src/response';
-export {HttpXhrBackend, XhrFactory} from './src/xhr';
+export {HttpXhrBackend} from './src/xhr';
 export {HttpXsrfTokenExtractor} from './src/xsrf';

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -6,6 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+// TODO(alan-agius4): remove this export once migration has been done in Google3. (Should happen
+// prior to V12 RC).
+export {XhrFactory} from '@angular/common';
+
 export {HttpBackend, HttpHandler} from './src/backend';
 export {HttpClient} from './src/client';
 export {HttpContext, HttpContextToken} from './src/context';

--- a/packages/common/http/src/module.ts
+++ b/packages/common/http/src/module.ts
@@ -15,7 +15,7 @@ import {HTTP_INTERCEPTORS, HttpInterceptor, HttpInterceptorHandler, NoopIntercep
 import {JsonpCallbackContext, JsonpClientBackend, JsonpInterceptor} from './jsonp';
 import {HttpRequest} from './request';
 import {HttpEvent} from './response';
-import {BrowserXhr, HttpXhrBackend, XhrFactory} from './xhr';
+import {HttpXhrBackend} from './xhr';
 import {HttpXsrfCookieExtractor, HttpXsrfInterceptor, HttpXsrfTokenExtractor, XSRF_COOKIE_NAME, XSRF_HEADER_NAME} from './xsrf';
 
 /**
@@ -159,8 +159,6 @@ export class HttpClientXsrfModule {
     {provide: HttpHandler, useClass: HttpInterceptingHandler},
     HttpXhrBackend,
     {provide: HttpBackend, useExisting: HttpXhrBackend},
-    BrowserXhr,
-    {provide: XhrFactory, useExisting: BrowserXhr},
   ],
 })
 export class HttpClientModule {

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {XhrFactory} from '@angular/common';
 import {Injectable} from '@angular/core';
 import {Observable, Observer} from 'rxjs';
 
@@ -29,37 +30,6 @@ function getResponseUrl(xhr: any): string|null {
     return xhr.getResponseHeader('X-Request-URL');
   }
   return null;
-}
-
-/**
- * A wrapper around the `XMLHttpRequest` constructor.
- *
- * @publicApi
- */
-export abstract class XhrFactory {
-  abstract build(): XMLHttpRequest;
-}
-
-/**
- * A factory for `HttpXhrBackend` that uses the `XMLHttpRequest` browser API.
- *
- */
-@Injectable()
-export class BrowserXhr implements XhrFactory {
-  constructor() {}
-  build(): any {
-    return <any>(new XMLHttpRequest());
-  }
-}
-
-/**
- * Tracks a response from the server that does not yet have a body.
- */
-interface PartialResponse {
-  headers: HttpHeaders;
-  status: number;
-  statusText: string;
-  url: string;
 }
 
 /**

--- a/packages/common/http/test/BUILD.bazel
+++ b/packages/common/http/test/BUILD.bazel
@@ -16,6 +16,7 @@ ts_library(
     # Visible to //:saucelabs_unit_tests_poc target
     visibility = ["//:__pkg__"],
     deps = [
+        "//packages/common",
         "//packages/common/http",
         "//packages/common/http/testing",
         "//packages/core",

--- a/packages/common/http/test/xhr_mock.ts
+++ b/packages/common/http/test/xhr_mock.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {XhrFactory} from '@angular/common';
 import {HttpHeaders} from '@angular/common/http/src/headers';
-import {XhrFactory} from '@angular/common/http/src/xhr';
 
 export class MockXhrFactory implements XhrFactory {
   // TODO(issue/24571): remove '!'.

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -26,3 +26,4 @@ export {AsyncPipe, DatePipe, I18nPluralPipe, I18nSelectPipe, JsonPipe, LowerCase
 export {PLATFORM_BROWSER_ID as ɵPLATFORM_BROWSER_ID, PLATFORM_SERVER_ID as ɵPLATFORM_SERVER_ID, PLATFORM_WORKER_APP_ID as ɵPLATFORM_WORKER_APP_ID, PLATFORM_WORKER_UI_ID as ɵPLATFORM_WORKER_UI_ID, isPlatformBrowser, isPlatformServer, isPlatformWorkerApp, isPlatformWorkerUi} from './platform_id';
 export {VERSION} from './version';
 export {ViewportScroller, NullViewportScroller as ɵNullViewportScroller} from './viewport_scroller';
+export {XhrFactory} from './xhr';

--- a/packages/common/src/xhr.ts
+++ b/packages/common/src/xhr.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * A wrapper around the `XMLHttpRequest` constructor.
+ *
+ * @publicApi
+ */
+export abstract class XhrFactory {
+  abstract build(): XMLHttpRequest;
+}

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -28,5 +28,6 @@ pkg_npm(
         "//packages/core/schematics/migrations/undecorated-classes-with-decorated-fields",
         "//packages/core/schematics/migrations/undecorated-classes-with-di",
         "//packages/core/schematics/migrations/wait-for-async",
+        "//packages/core/schematics/migrations/xhr-factory",
     ],
 )

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -92,7 +92,7 @@
     },
     "migration-v12-xhr-factory": {
       "version": "12.0.0-next.6",
-      "description": "`XhrFactory` migration. `XhrFactory` has been moved from `@angular/common/http` to `@angular/common`.",
+      "description": "`XhrFactory` has been moved from `@angular/common/http` to `@angular/common`.",
       "factory": "./migrations/xhr-factory/index"
     }
   }

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -89,6 +89,11 @@
       "version": "12.0.0-beta",
       "description": "In Angular version 12, the type of ActivatedRouteSnapshot.fragment is nullable. This migration automatically adds non-null assertions to it.",
       "factory": "./migrations/activated-route-snapshot-fragment/index"
+    },
+    "migration-v12-xhr-factory": {
+      "version": "12.0.0-next.6",
+      "description": "`XhrFactory` migration. `XhrFactory` has been moved from `@angular/common/http` to `@angular/common`.",
+      "factory": "./migrations/xhr-factory/index"
     }
   }
 }

--- a/packages/core/schematics/migrations/xhr-factory/BUILD.bazel
+++ b/packages/core/schematics/migrations/xhr-factory/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//tools:defaults.bzl", "ts_library")
+
+ts_library(
+    name = "xhr-factory",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+    deps = [
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)

--- a/packages/core/schematics/migrations/xhr-factory/README.md
+++ b/packages/core/schematics/migrations/xhr-factory/README.md
@@ -1,0 +1,13 @@
+## XhrFactory migration
+
+Automatically migrates `XhrFactory` from `@angular/common/http` to `@angular/common`.
+
+#### Before
+```ts
+import { XhrFactory } from '@angular/common/http';
+```
+
+#### After
+```ts
+import { XhrFactory } from '@angular/common';
+```

--- a/packages/core/schematics/migrations/xhr-factory/index.ts
+++ b/packages/core/schematics/migrations/xhr-factory/index.ts
@@ -56,8 +56,8 @@ export default function(): Rule {
         continue;
       }
 
-      const commonHttpNamedBinding = httpCommonImport.importClause?.namedBindings;
-      if (commonHttpNamedBinding && ts.isNamedImports(commonHttpNamedBinding)) {
+      const commonHttpNamedBinding = getNamedImports(httpCommonImport);
+      if (commonHttpNamedBinding) {
         const commonHttpNamedImports = commonHttpNamedBinding.elements;
         const xhrFactorySpecifier = findImportSpecifier(commonHttpNamedImports, 'XhrFactory');
 
@@ -89,8 +89,8 @@ export default function(): Rule {
 
         // Import XhrFactory from @angular/common
         const commonImport = findImportDeclaration('@angular/common', allImportDeclarations);
-        const commonNamedBinding = commonImport?.importClause?.namedBindings;
-        if (commonImport && commonNamedBinding && ts.isNamedImports(commonNamedBinding)) {
+        const commonNamedBinding = getNamedImports(commonImport);
+        if (commonNamedBinding) {
           // Already has an import for '@angular/common', just add the named import.
           const index = commonNamedBinding.getStart();
           const length = commonNamedBinding.getWidth();
@@ -119,4 +119,14 @@ function findImportDeclaration(moduleSpecifier: string, importDeclarations: ts.I
     ts.ImportDeclaration|undefined {
   return importDeclarations.find(
       n => ts.isStringLiteral(n.moduleSpecifier) && n.moduleSpecifier.text === moduleSpecifier);
+}
+
+function getNamedImports(importDeclaration: ts.ImportDeclaration|undefined): ts.NamedImports|
+    undefined {
+  const namedBindings = importDeclaration?.importClause?.namedBindings;
+  if (namedBindings && ts.isNamedImports(namedBindings)) {
+    return namedBindings;
+  }
+
+  return undefined;
 }

--- a/packages/core/schematics/migrations/xhr-factory/index.ts
+++ b/packages/core/schematics/migrations/xhr-factory/index.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {DirEntry, Rule, UpdateRecorder} from '@angular-devkit/schematics';
+import * as ts from 'typescript';
+import {findImportSpecifier} from '../../utils/typescript/imports';
+
+function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
+  for (const path of directory.subfiles) {
+    if (path.endsWith('.ts') && !path.endsWith('.d.ts')) {
+      const entry = directory.file(path);
+      if (entry) {
+        const content = entry.content;
+        if (content.includes('XhrFactory')) {
+          const source = ts.createSourceFile(
+              entry.path,
+              content.toString().replace(/^\uFEFF/, ''),
+              ts.ScriptTarget.Latest,
+              true,
+          );
+
+          yield source;
+        }
+      }
+    }
+  }
+
+  for (const path of directory.subdirs) {
+    if (path === 'node_modules' || path.startsWith('.')) {
+      continue;
+    }
+
+    yield* visit(directory.dir(path));
+  }
+}
+
+export default function(): Rule {
+  return tree => {
+    const printer = ts.createPrinter({newLine: ts.NewLineKind.LineFeed});
+
+    for (const sourceFile of visit(tree.root)) {
+      let recorder: UpdateRecorder|undefined;
+
+      const allImportDeclarations =
+          sourceFile.statements.filter(n => ts.isImportDeclaration(n)) as ts.ImportDeclaration[];
+      if (allImportDeclarations.length === 0) {
+        continue;
+      }
+
+      const httpCommonImport = findImportDeclaration('@angular/common/http', allImportDeclarations);
+      if (!httpCommonImport) {
+        continue;
+      }
+
+      const commonHttpNamedBinding = httpCommonImport.importClause?.namedBindings;
+      if (commonHttpNamedBinding && ts.isNamedImports(commonHttpNamedBinding)) {
+        const commonHttpNamedImports = commonHttpNamedBinding.elements;
+        const xhrFactorySpecifier = findImportSpecifier(commonHttpNamedImports, 'XhrFactory');
+
+        if (!xhrFactorySpecifier) {
+          continue;
+        }
+
+        recorder = tree.beginUpdate(sourceFile.fileName);
+
+        // Remove 'XhrFactory' from '@angular/common/http'
+        if (commonHttpNamedImports.length > 1) {
+          // Remove 'XhrFactory' named import
+          const index = commonHttpNamedBinding.getStart();
+          const length = commonHttpNamedBinding.getWidth();
+
+          const newImports = printer.printNode(
+              ts.EmitHint.Unspecified,
+              ts.factory.updateNamedImports(
+                  commonHttpNamedBinding,
+                  commonHttpNamedBinding.elements.filter(e => e !== xhrFactorySpecifier)),
+              sourceFile);
+          recorder.remove(index, length).insertLeft(index, newImports);
+        } else {
+          // Remove '@angular/common/http' import
+          const index = httpCommonImport.getFullStart();
+          const length = httpCommonImport.getFullWidth();
+          recorder.remove(index, length);
+        }
+
+        // Import XhrFactory from @angular/common
+        const commonImport = findImportDeclaration('@angular/common', allImportDeclarations);
+        const commonNamedBinding = commonImport?.importClause?.namedBindings;
+        if (commonImport && commonNamedBinding && ts.isNamedImports(commonNamedBinding)) {
+          // Already has an import for '@angular/common', just add the named import.
+          const index = commonNamedBinding.getStart();
+          const length = commonNamedBinding.getWidth();
+          const newImports = printer.printNode(
+              ts.EmitHint.Unspecified,
+              ts.factory.updateNamedImports(
+                  commonNamedBinding, [...commonNamedBinding.elements, xhrFactorySpecifier]),
+              sourceFile);
+
+          recorder.remove(index, length).insertLeft(index, newImports);
+        } else {
+          // Add import to '@angular/common'
+          const index = httpCommonImport.getFullStart();
+          recorder.insertLeft(index, `\nimport { XhrFactory } from '@angular/common';`);
+        }
+      }
+
+      if (recorder) {
+        tree.commitUpdate(recorder);
+      }
+    }
+  };
+}
+
+function findImportDeclaration(moduleSpecifier: string, importDeclarations: ts.ImportDeclaration[]):
+    ts.ImportDeclaration|undefined {
+  return importDeclarations.find(
+      n => ts.isStringLiteral(n.moduleSpecifier) && n.moduleSpecifier.text === moduleSpecifier);
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -26,6 +26,7 @@ ts_library(
         "//packages/core/schematics/migrations/undecorated-classes-with-decorated-fields",
         "//packages/core/schematics/migrations/undecorated-classes-with-di",
         "//packages/core/schematics/migrations/wait-for-async",
+        "//packages/core/schematics/migrations/xhr-factory",
         "//packages/core/schematics/utils",
         "@npm//@angular-devkit/core",
         "@npm//@angular-devkit/schematics",

--- a/packages/core/schematics/test/xhr_factory_spec.ts
+++ b/packages/core/schematics/test/xhr_factory_spec.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {tags} from '@angular-devkit/core';
+import {EmptyTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+
+describe('XhrFactory migration', () => {
+  let tree: UnitTestTree;
+  const runner = new SchematicTestRunner('test', require.resolve('../migrations.json'));
+
+  beforeEach(() => {
+    tree = new UnitTestTree(new EmptyTree());
+  });
+
+  it(`should replace 'XhrFactory' from '@angular/common/http' to '@angular/common'`, async () => {
+    tree.create('/index.ts', tags.stripIndents`
+      import { HttpClient } from '@angular/common';
+      import { HttpErrorResponse, HttpResponse, XhrFactory } from '@angular/common/http';
+    `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toBe(tags.stripIndents`
+      import { HttpClient, XhrFactory } from '@angular/common';
+      import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
+    `);
+  });
+
+  it(`should replace import for 'XhrFactory' to '@angular/common'`, async () => {
+    tree.create('/index.ts', tags.stripIndents`
+      import { Injecable } from '@angular/core';
+      import { XhrFactory } from '@angular/common/http';
+      import { BrowserModule } from '@angular/platform-browser';
+    `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toBe(tags.stripIndents`
+      import { Injecable } from '@angular/core';
+      import { XhrFactory } from '@angular/common';
+      import { BrowserModule } from '@angular/platform-browser';
+    `);
+  });
+
+  it(`should remove http import when 'XhrFactory' is the only imported symbol`, async () => {
+    tree.create('/index.ts', tags.stripIndents`
+      import { HttpClient } from '@angular/common';
+      import { XhrFactory as XhrFactory2 } from '@angular/common/http';
+      import { Injecable } from '@angular/core';
+    `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toBe(tags.stripIndents`
+      import { HttpClient, XhrFactory as XhrFactory2 } from '@angular/common';
+      import { Injecable } from '@angular/core';
+    `);
+  });
+
+  it(`should add named import when '@angular/common' is a namespace import`, async () => {
+    tree.create('/index.ts', tags.stripIndents`
+      import * as common from '@angular/common';
+      import { XhrFactory } from '@angular/common/http';
+    `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toBe(tags.stripIndents`
+      import * as common from '@angular/common';
+      import { XhrFactory } from '@angular/common';
+    `);
+  });
+
+  async function runMigration(): Promise<void> {
+    await runner.runSchematicAsync('migration-v12-xhr-factory', {}, tree).toPromise();
+  }
+});

--- a/packages/core/schematics/tsconfig.json
+++ b/packages/core/schematics/tsconfig.json
@@ -3,7 +3,9 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "strict": true,
-    "lib": ["es2015"],
+    "moduleResolution": "node",
+    "target": "es2019",
+    "lib": ["es2019"],
     "types": ["jasmine"],
     "baseUrl": ".",
     "paths": {

--- a/packages/core/schematics/utils/typescript/imports.ts
+++ b/packages/core/schematics/utils/typescript/imports.ts
@@ -110,7 +110,7 @@ export function replaceImport(
 
 
 /** Finds an import specifier with a particular name. */
-function findImportSpecifier(
+export function findImportSpecifier(
     nodes: ts.NodeArray<ts.ImportSpecifier>, specifierName: string): ts.ImportSpecifier|undefined {
   return nodes.find(element => {
     const {name, propertyName} = element;

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -54,6 +54,9 @@
     "name": "BrowserModule"
   },
   {
+    "name": "BrowserXhr"
+  },
+  {
     "name": "BuiltInControlValueAccessor"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -54,6 +54,9 @@
     "name": "BrowserModule"
   },
   {
+    "name": "BrowserXhr"
+  },
+  {
     "name": "BuiltInControlValueAccessor"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -81,6 +81,9 @@
     "name": "BrowserViewportScroller"
   },
   {
+    "name": "BrowserXhr"
+  },
+  {
     "name": "CIRCULAR"
   },
   {

--- a/packages/misc/angular-in-memory-web-api/package.json
+++ b/packages/misc/angular-in-memory-web-api/package.json
@@ -5,10 +5,12 @@
   "author": "angular",
   "license": "MIT",
   "peerDependencies": {
-    "@angular/core": "^8.0.0",
-    "@angular/common": "^8.0.0",
-    "rxjs": "^6.5.3",
-    "tslib": "^1.10.0"
+    "@angular/core": "^12.0.0-next.6",
+    "@angular/common": "^12.0.0-next.6",
+    "rxjs": "^6.5.3"
+  },
+  "dependencies": {
+    "tslib": "^2.1.0"
   },
   "repository": {
     "type": "git",

--- a/packages/misc/angular-in-memory-web-api/src/http-client-backend-service.ts
+++ b/packages/misc/angular-in-memory-web-api/src/http-client-backend-service.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpBackend, HttpEvent, HttpHeaders, HttpParams, HttpRequest, HttpResponse, HttpXhrBackend, XhrFactory} from '@angular/common/http';
+import {XhrFactory} from '@angular/common';
+import {HttpBackend, HttpEvent, HttpHeaders, HttpParams, HttpRequest, HttpResponse, HttpXhrBackend} from '@angular/common/http';
 import {Inject, Injectable, Optional} from '@angular/core';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';

--- a/packages/misc/angular-in-memory-web-api/src/http-client-in-memory-web-api-module.ts
+++ b/packages/misc/angular-in-memory-web-api/src/http-client-in-memory-web-api-module.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpBackend, XhrFactory} from '@angular/common/http';
+import {XhrFactory} from '@angular/common';
+import {HttpBackend} from '@angular/common/http';
 import {ModuleWithProviders, NgModule, Type} from '@angular/core';
 
 import {HttpClientBackendService} from './http-client-backend-service';

--- a/packages/misc/angular-in-memory-web-api/src/in-memory-web-api-module.ts
+++ b/packages/misc/angular-in-memory-web-api/src/in-memory-web-api-module.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpBackend, XhrFactory} from '@angular/common/http';
+import {XhrFactory} from '@angular/common';
+import {HttpBackend} from '@angular/common/http';
 import {ModuleWithProviders, NgModule, Type} from '@angular/core';
 
 import {httpClientInMemBackendServiceFactory} from './http-client-in-memory-web-api-module';

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -6,12 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CommonModule, DOCUMENT, ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {APP_ID, ApplicationModule, createPlatformFactory, ErrorHandler, Inject, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, RendererFactory2, Sanitizer, SkipSelf, StaticProvider, Testability, ɵConsole as Console, ɵINJECTOR_SCOPE as INJECTOR_SCOPE, ɵsetDocument} from '@angular/core';
+import {CommonModule, DOCUMENT, XhrFactory, ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
+import {APP_ID, ApplicationModule, createPlatformFactory, ErrorHandler, Inject, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, RendererFactory2, Sanitizer, SkipSelf, StaticProvider, Testability, ɵINJECTOR_SCOPE as INJECTOR_SCOPE, ɵsetDocument} from '@angular/core';
 
 import {BrowserDomAdapter} from './browser/browser_adapter';
 import {SERVER_TRANSITION_PROVIDERS, TRANSITION_ID} from './browser/server-transition';
 import {BrowserGetTestability} from './browser/testability';
+import {BrowserXhr} from './browser/xhr';
 import {ELEMENT_PROBE_PROVIDERS} from './dom/debug/ng_probe';
 import {DomRendererFactory2} from './dom/dom_renderer';
 import {DomEventsPlugin} from './dom/events/dom_events';
@@ -88,6 +89,7 @@ export const BROWSER_MODULE_PROVIDERS: StaticProvider[] = [
   {provide: DomSharedStylesHost, useClass: DomSharedStylesHost, deps: [DOCUMENT]},
   {provide: Testability, useClass: Testability, deps: [NgZone]},
   {provide: EventManager, useClass: EventManager, deps: [EVENT_MANAGER_PLUGINS, NgZone]},
+  {provide: XhrFactory, useClass: BrowserXhr, deps: []},
   ELEMENT_PROBE_PROVIDERS,
 ];
 

--- a/packages/platform-browser/src/browser/xhr.ts
+++ b/packages/platform-browser/src/browser/xhr.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {XhrFactory} from '@angular/common';
+import {Injectable} from '@angular/core';
+
+/**
+ * A factory for `HttpXhrBackend` that uses the `XMLHttpRequest` browser API.
+ */
+@Injectable()
+export class BrowserXhr implements XhrFactory {
+  build(): XMLHttpRequest {
+    return new XMLHttpRequest();
+  }
+}

--- a/packages/platform-server/src/http.ts
+++ b/packages/platform-server/src/http.ts
@@ -11,8 +11,8 @@ import {INITIAL_CONFIG, PlatformConfig} from './tokens';
 const xhr2: any = require('xhr2');
 
 import {Injectable, Injector, Provider} from '@angular/core';
-import {PlatformLocation} from '@angular/common';
-import {HttpEvent, HttpRequest, HttpHandler, HttpBackend, XhrFactory, ɵHttpInterceptingHandler as HttpInterceptingHandler} from '@angular/common/http';
+import {PlatformLocation, XhrFactory} from '@angular/common';
+import {HttpEvent, HttpRequest, HttpHandler, HttpBackend, ɵHttpInterceptingHandler as HttpInterceptingHandler} from '@angular/common/http';
 import {Observable, Observer, Subscription} from 'rxjs';
 
 // @see https://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01#URI-syntax

--- a/scripts/build/angular-in-memory-web-api.js
+++ b/scripts/build/angular-in-memory-web-api.js
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+'use strict';
+
+const {chmod, cp, mkdir, rm} = require('shelljs');
+const {baseDir, bazelBin, bazelCmd, exec, scriptPath} = require('./package-builder');
+
+/**
+ * Build the `angular-in-memory-web-api` npm package and copy it to `dist/packages-dist/misc`.
+ */
+function buildAngularInMemoryWebAPIPackage() {
+  console.info('##############################');
+  console.info(`${scriptPath}:`);
+  console.info('  Building angular-in-memory-web-api npm package');
+  console.info('##############################');
+  exec(`${bazelCmd} build //packages/misc/angular-in-memory-web-api:npm_package`);
+
+  const buildOutputDir = `${bazelBin}/packages/misc/angular-in-memory-web-api/npm_package`;
+  const distTargetDir = `${baseDir}/dist/packages-dist/misc/angular-in-memory-web-api`;
+
+  console.info(`# Copy artifacts to ${distTargetDir}`);
+  mkdir('-p', distTargetDir);
+  rm('-rf', distTargetDir);
+  cp('-R', buildOutputDir, distTargetDir);
+  chmod('-R', 'u+w', distTargetDir);
+
+  console.info('');
+}
+
+module.exports = {buildAngularInMemoryWebAPIPackage};

--- a/scripts/build/build-packages-dist.js
+++ b/scripts/build/build-packages-dist.js
@@ -12,6 +12,7 @@
 const {buildZoneJsPackage} = require('./zone-js-builder');
 const {buildDevInfraPackage} = require('./dev-infra-builder');
 const {buildTargetPackages} = require('./package-builder');
+const {buildAngularInMemoryWebAPIPackage} = require('./angular-in-memory-web-api');
 
 
 // Build the legacy (view engine) npm packages into `dist/packages-dist/`.
@@ -23,3 +24,7 @@ buildZoneJsPackage('dist/zone.js-dist');
 
 // Build the `angular-dev-infra` npm package into `dist/packages-dist/@angular/dev-infra-private`
 buildDevInfraPackage();
+
+// Build the `angular-in-memory-web-api` npm package into
+// `dist/packages-dist/misc/angular-in-memory-web-api`
+buildAngularInMemoryWebAPIPackage();


### PR DESCRIPTION
**feat(core): add migration for  `XhrFactory` import**

Automatically migrates `XhrFactory` from `@angular/common/http` to `@angular/common`.

**build(docs-infra): support building the local `angular-in-memory-web-api` package in `NgPackagesInstaller`**

In some cases, we want to test the AIO app or docs examples against the locally built `angular-in-memory-web-api` for example to ensure that the changes in a commit do not introduce a breaking changes.

**fix(platform-browser): configure `XhrFactory` to use `BrowserXhr`**

With this change we move `XhrFactory` to the root entrypoint of `@angular/commmon`, this is needed so that we can configure `XhrFactory` DI token at a platform level, and not add a dependency between `@angular/platform-browser` and `@angular/common/http`.

Currently, when using `HttpClientModule` in a child module on the server, `ReferenceError: XMLHttpRequest is not defined` is being thrown because the child module has its own Injector and causes `XhrFactory` provider to be configured to use `BrowserXhr`.
Therefore, we should configure the `XhrFactory` at a platform level similar to other Browser specific providers.

**BREAKING CHANGE:**

`XhrFactory` has been moved from `@angular/common/http` to `@angular/common`.

**Before**
```ts
import {XhrFactory} from '@angular/common/http';
```

**After**
```ts
import {XhrFactory} from '@angular/common';
```

Closes #41311