### PR TITLE
Perf in logs

### DIFF
--- a/packages/compiler-cli/src/ngtsc/perf/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/perf/src/api.ts
@@ -111,6 +111,40 @@ export enum PerfPhase {
   LsReferencesAndRenames,
 
   /**
+   * Time spent by the Angular Language Service calculating a "quick info" operation.
+   */
+  LsQuickInfo,
+
+  /**
+   * Time spent by the Angular Language Service calculating a "get type definition" or "get
+   * definition" operation.
+   */
+  LsDefinition,
+
+  /**
+   * Time spent by the Angular Language Service calculating a "get completions" (AKA autocomplete)
+   * operation.
+   */
+  LsCompletions,
+
+  /**
+   * Time spent by the Angular Language Service calculating a "view template typecheck block"
+   * operation.
+   */
+  LsTcb,
+
+  /**
+   * Time spent by the Angular Language Service calculating diagnostics.
+   */
+  LsDiagnostics,
+
+  /**
+   * Time spent by the Angular Language Service calculating a "get component locations for template"
+   * operation.
+   */
+  LsComponentLocations,
+
+  /**
    * Tracks the number of `PerfPhase`s, and must appear at the end of the list.
    */
   LAST,

--- a/packages/language-service/ivy/test/diagnostic_spec.ts
+++ b/packages/language-service/ivy/test/diagnostic_spec.ts
@@ -275,6 +275,28 @@ describe('getSemanticDiagnostics', () => {
     expect(diag.category).toBe(ts.DiagnosticCategory.Suggestion);
     expect(getTextOfDiagnostic(diag)).toBe('user');
   });
+
+  it('logs perf tracing', () => {
+    const files = {
+      'app.ts': `
+        import {Component} from '@angular/core';
+        @Component({ template: '' })
+        export class MyComponent {}
+      `
+    };
+
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+
+    const logger = project.getLogger();
+    spyOn(logger, 'hasLevel').and.returnValue(true);
+    spyOn(logger, 'perftrc').and.callFake(() => {});
+
+    const diags = project.getDiagnosticsForFile('app.ts');
+    expect(diags.length).toEqual(0);
+    expect(logger.perftrc)
+        .toHaveBeenCalledWith(jasmine.stringMatching(
+            /LanguageService\#LsDiagnostics\:.*\"LsDiagnostics\":\s*\d+.*/g));
+  });
 });
 
 function getTextOfDiagnostic(diag: ts.Diagnostic): string {

--- a/packages/language-service/ivy/testing/src/project.ts
+++ b/packages/language-service/ivy/testing/src/project.ts
@@ -179,6 +179,10 @@ export class Project {
   getTemplateTypeChecker(): TemplateTypeChecker {
     return this.ngLS.compilerFactory.getOrCreate().getTemplateTypeChecker();
   }
+
+  getLogger(): ts.server.Logger {
+    return this.tsProject.projectService.logger;
+  }
 }
 
 function getClassOrError(sf: ts.SourceFile, name: string): ts.ClassDeclaration {


### PR DESCRIPTION
## feat(language-service): add perf tracing to LanguageService

Adds perf tracing for the public methods in LanguageService. If the log level is verbose or higher,
trace performance results to the tsServer logger. This logger is implemented on the extension side
in angular/vscode-ng-language-service.

## how to view perf tracing in vscode.
1. set angular log level to verbose <img width="600" alt="Screen Shot 2021-03-19 at 10 34 19 AM" src="https://user-images.githubusercontent.com/7720245/112059493-2409d700-8b19-11eb-9e21-77bc3f98b4f1.png">
2. Run vscode action: "Open Angular Server Log" ![image](https://user-images.githubusercontent.com/7720245/112059607-47348680-8b19-11eb-8530-7fa492e58f6b.png)
3. Search for lines matching `LanguageService#`

### grepping for log files
while testing, I saved the patch to the angular server log to an environment variable and use grep to search for perf tracing.
```
# grep --text LanguageService# $NG_SERVER_LOG
```

## Test plan
This PR was tested manually against a local build of the vscode extension. I made sure that perf tracing showed up for each public method in `LanguageService`
![image](https://user-images.githubusercontent.com/7720245/112059855-a85c5a00-8b19-11eb-9188-a83b47d14bb5.png)

