### PR TITLE
ci: fix `elements` test on older browsers

### DIFF
--- a/packages/elements/test/BUILD.bazel
+++ b/packages/elements/test/BUILD.bazel
@@ -39,6 +39,10 @@ filegroup(
     # do not sort
     srcs = [
         "@npm//:node_modules/core-js/client/core.js",
+        # Required for browsers that do not natively support Custom Elements.
+        "@npm//:node_modules/@webcomponents/custom-elements/custom-elements.min.js",
+        # Required for ES5 code to work with a native Custom Elements implementation.
+        # (See https://www.npmjs.com/package/@webcomponents/custom-elements#es5-vs-es2015.)
         ":custom_elements_native_shim",
         "@npm//:node_modules/reflect-metadata/Reflect.js",
         "//packages/zone.js/bundles:zone.umd.js",


### PR DESCRIPTION
Some `elements` tests rely on `window.customElements` being available. On browsers where this was not present, the tests were skipped.

This commit includes the `@webcomponents/custom-elements` polyfill in order to be able to run all `elements` tests on older browsers, which do not natively support Custom Elements.

This, also, fixes the [saucelabs_ivy][1] and [saucelabs_view_engine][2] CI jobs (part of the `monitoring` workflow), which have been failing recently on IE 11 (probably due to the update to TS 4.2.3).

[1]: https://circleci.com/gh/angular/angular/944291
[2]: https://circleci.com/gh/angular/angular/944289