### PR TITLE
docs: add language none option to code-example

### DIFF
--- a/aio/src/app/custom-elements/code/code.component.spec.ts
+++ b/aio/src/app/custom-elements/code/code.component.spec.ts
@@ -117,6 +117,15 @@ describe('CodeComponent', () => {
       expect(getFormattedCode()).toBe(
           `Formatted code (language: auto, linenums: true): ${bigMultiLineCode}`);
     });
+
+    it('should skip prettify if language is `\'none\'`', () => {
+      hostComponent.setCode(bigMultiLineCode);
+      hostComponent.language = 'none';
+
+      fixture.detectChanges();
+
+      expect(getFormattedCode()).toBe(bigMultiLineCode);
+    });
   });
 
   describe('whitespace handling', () => {

--- a/aio/src/app/custom-elements/code/code.component.ts
+++ b/aio/src/app/custom-elements/code/code.component.ts
@@ -3,7 +3,7 @@ import { Clipboard } from '@angular/cdk/clipboard';
 import { Logger } from 'app/shared/logger.service';
 import { PrettyPrinter } from './pretty-printer.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
 /**
@@ -123,7 +123,7 @@ export class CodeComponent implements OnChanges {
       this.logger.warn(`Using 'linenums' with 'language: none' is currently not supported.`);
     }
 
-        (this.language === 'none' ? skipPrettify : prettifyCode)
+    ((this.language === 'none' ? skipPrettify : prettifyCode) as Observable<unknown>)
         .subscribe(() => this.codeFormatted.emit(), () => { /* ignore failure to format */ });
   }
 

--- a/aio/src/app/custom-elements/code/code.component.ts
+++ b/aio/src/app/custom-elements/code/code.component.ts
@@ -3,6 +3,7 @@ import { Clipboard } from '@angular/cdk/clipboard';
 import { Logger } from 'app/shared/logger.service';
 import { PrettyPrinter } from './pretty-printer.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { of } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
 /**
@@ -108,15 +109,22 @@ export class CodeComponent implements OnChanges {
   }
 
   private formatDisplayedCode() {
+    const linenums = this.getLinenums();
     const leftAlignedCode = leftAlign(this.code);
     this.setCodeHtml(leftAlignedCode); // start with unformatted code
     this.codeText = this.getCodeText(); // store the unformatted code as text (for copying)
 
-    this.pretty
-        .formatCode(leftAlignedCode, this.language, this.getLinenums())
-        .pipe(tap(() => this.codeFormatted.emit()))
-        .subscribe(c => this.setCodeHtml(c), () => { /* ignore failure to format */ }
-    );
+    const skipPrettify = of(undefined);
+    const prettifyCode = this.pretty
+        .formatCode(leftAlignedCode, this.language, linenums)
+        .pipe(tap(formattedCode => this.setCodeHtml(formattedCode)));
+
+    if (linenums !== false && this.language === 'none') {
+      this.logger.warn(`Using 'linenums' with 'language: none' is currently not supported.`);
+    }
+
+        (this.language === 'none' ? skipPrettify : prettifyCode)
+        .subscribe(() => this.codeFormatted.emit(), () => { /* ignore failure to format */ });
   }
 
   /** Sets the message showing that the code could not be found. */


### PR DESCRIPTION
Adds language none option to code-example so writers can opt out of color in a code snippet.
