### PR TITLE
fix(compiler-cli): fix extending angularCompilerOptions from non relative extension less TypeScript configuration files

### DIFF
--- a/packages/compiler-cli/test/perform_compile_spec.ts
+++ b/packages/compiler-cli/test/perform_compile_spec.ts
@@ -103,7 +103,7 @@ describe('perform_compile', () => {
     }));
   });
 
-  it('should merge tsconfig "angularCompilerOptions" when extends point to node package', () => {
+  it('should merge tsconfig "angularCompilerOptions" when extends points to node package', () => {
     support.writeFiles({
       'tsconfig-level-1.json': `{
           "extends": "@angular-ru/tsconfig",
@@ -136,4 +136,62 @@ describe('perform_compile', () => {
       enableIvy: false,
     }));
   });
+
+  it('should merge tsconfig "angularCompilerOptions" when extends points to an extension less non rooted file',
+     () => {
+       support.writeFiles({
+         'tsconfig-level-1.json': `{
+            "extends": "@1stg/tsconfig/angular",
+            "angularCompilerOptions": {
+              "enableIvy": false
+            }
+          }`,
+         'node_modules/@1stg/tsconfig/angular.json': `{
+            "compilerOptions": {
+              "strict": true
+            },
+            "angularCompilerOptions": {
+              "skipMetadataEmit": true
+            }
+          }`,
+         'node_modules/@1stg/tsconfig/package.json': `{
+            "name": "@1stg/tsconfig",
+            "version": "0.0.0"
+          }`,
+       });
+
+       const {options} = readConfiguration(path.resolve(basePath, 'tsconfig-level-1.json'));
+       expect(options).toEqual(jasmine.objectContaining({
+         strict: true,
+         skipMetadataEmit: true,
+         enableIvy: false,
+       }));
+     });
+
+  it('should merge tsconfig "angularCompilerOptions" when extends points to a non rooted file without json extension',
+     () => {
+       support.writeFiles({
+         'tsconfig-level-1.json': `{
+            "extends": "./tsconfig.app",
+            "angularCompilerOptions": {
+              "enableIvy": false
+            }
+          }`,
+         'tsconfig.app.json': `{
+            "compilerOptions": {
+              "strict": true
+            },
+            "angularCompilerOptions": {
+              "skipMetadataEmit": true
+            }
+          }`,
+       });
+
+       const {options} = readConfiguration(path.resolve(basePath, 'tsconfig-level-1.json'));
+       expect(options).toEqual(jasmine.objectContaining({
+         strict: true,
+         skipMetadataEmit: true,
+         enableIvy: false,
+       }));
+     });
 });


### PR DESCRIPTION
close #41343

cc @alan-agius4 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #41343


## What is the new behavior?

support sub file of node package and relative path without json extension

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
