### PR TITLE
ci: re-activate "devversion" in pullapprove after OOO

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -292,7 +292,7 @@ groups:
       users:
         - alxhub
         - crisbeto
-        # OOO as of 2020-09-28 - devversion
+        - devversion
 
 
   # =========================================================
@@ -1208,7 +1208,7 @@ groups:
           ])
     reviewers:
       users:
-        # OOO as of 2020-09-28 - devversion
+        - devversion
         - filipesilva
         - gkalpak
         - IgorMinar


### PR DESCRIPTION
After being OOO for a while, I have been denoted as OOO in the pullapprove
configuration (by commenting out the username in the reviewer lists). See 3ba97ab3917b682b6d08b9e71599051e77e2d3ac.

This PR re-activates myself in the pullapprove configuration as I'd like to start reviewing
dev-infra/migration PRs again (and get notified) 😛 