### PR TITLE
fix(platform-browser): improve error message for missing animation tr…

### DIFF
--- a/packages/core/test/animation/animation_integration_spec.ts
+++ b/packages/core/test/animation/animation_integration_spec.ts
@@ -3827,29 +3827,65 @@ describe('animation tests', function() {
       });
     });
 
-    it('should throw when using an @prop binding without the animation module', () => {
-      @Component({template: `<div [@myAnimation]="true"></div>`})
-      class Cmp {
-      }
 
-      TestBed.configureTestingModule({declarations: [Cmp]});
-      const comp = TestBed.createComponent(Cmp);
-      expect(() => comp.detectChanges())
-          .toThrowError(
-              'Found the synthetic property @myAnimation. Please include either "BrowserAnimationsModule" or "NoopAnimationsModule" in your application.');
+    function syntheticPropError(name: string, nameKind: string) {
+      return `Unexpected synthetic ${nameKind} ${name} found. Please make sure that:
+  - Either \`BrowserAnimationsModule\` or \`NoopAnimationsModule\` are imported in your application.
+  - There is corresponding configuration for the animation named \`${
+          name}\` defined in the \`animations\` field of the \`@Component\` decorator (see https://angular.io/api/core/Component#animations).`;
+    }
+
+    describe('when modules are missing', () => {
+      it('should throw when using an @prop binding without the animation module', () => {
+        @Component({template: `<div [@myAnimation]="true"></div>`})
+        class Cmp {
+        }
+
+        TestBed.configureTestingModule({declarations: [Cmp]});
+        const comp = TestBed.createComponent(Cmp);
+        expect(() => comp.detectChanges())
+            .toThrowError(syntheticPropError('@myAnimation', 'property'));
+      });
+
+      it('should throw when using an @prop listener without the animation module', () => {
+        @Component({template: `<div (@myAnimation.start)="a = true"></div>`})
+        class Cmp {
+          a = false;
+        }
+
+        TestBed.configureTestingModule({declarations: [Cmp]});
+
+        expect(() => TestBed.createComponent(Cmp))
+            .toThrowError(syntheticPropError('@myAnimation.start', 'listener'));
+      });
     });
 
-    it('should throw when using an @prop listener without the animation module', () => {
-      @Component({template: `<div (@myAnimation.start)="a = true"></div>`})
-      class Cmp {
-        a: any;
-      }
+    describe('when modules are present, but animations are missing', () => {
+      it('should throw when using an @prop property, BrowserAnimationModule is imported, but there is no animation rule',
+         () => {
+           @Component({template: `<div [@myAnimation]="true"></div>`})
+           class Cmp {
+           }
 
-      TestBed.configureTestingModule({declarations: [Cmp]});
+           TestBed.configureTestingModule(
+               {declarations: [Cmp], imports: [BrowserAnimationsModule]});
+           const comp = TestBed.createComponent(Cmp);
+           expect(() => comp.detectChanges())
+               .toThrowError(syntheticPropError('@myAnimation', 'property'));
+         });
 
-      expect(() => TestBed.createComponent(Cmp))
-          .toThrowError(
-              'Found the synthetic listener @myAnimation.start. Please include either "BrowserAnimationsModule" or "NoopAnimationsModule" in your application.');
+      it('should throw when using an @prop listener, BrowserAnimationModule is imported, but there is no animation rule',
+         () => {
+           @Component({template: `<div (@myAnimation.start)="true"></div>`})
+           class Cmp {
+           }
+
+           TestBed.configureTestingModule(
+               {declarations: [Cmp], imports: [BrowserAnimationsModule]});
+
+           expect(() => TestBed.createComponent(Cmp))
+               .toThrowError(syntheticPropError('@myAnimation.start', 'listener'));
+         });
     });
   });
 });

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -280,8 +280,10 @@ class DefaultDomRenderer2 implements Renderer2 {
 const AT_CHARCODE = (() => '@'.charCodeAt(0))();
 function checkNoSyntheticProp(name: string, nameKind: string) {
   if (name.charCodeAt(0) === AT_CHARCODE) {
-    throw new Error(`Found the synthetic ${nameKind} ${
-        name}. Please include either "BrowserAnimationsModule" or "NoopAnimationsModule" in your application.`);
+    throw new Error(`Unexpected synthetic ${nameKind} ${name} found. Please make sure that:
+  - Either \`BrowserAnimationsModule\` or \`NoopAnimationsModule\` are imported in your application.
+  - There is corresponding configuration for the animation named \`${
+        name}\` defined in the \`animations\` field of the \`@Component\` decorator (see https://angular.io/api/core/Component#animations).`);
   }
 }
 

--- a/packages/platform-server/src/server_renderer.ts
+++ b/packages/platform-server/src/server_renderer.ts
@@ -241,8 +241,10 @@ class DefaultServerRenderer2 implements Renderer2 {
 const AT_CHARCODE = '@'.charCodeAt(0);
 function checkNoSyntheticProp(name: string, nameKind: string) {
   if (name.charCodeAt(0) === AT_CHARCODE) {
-    throw new Error(`Found the synthetic ${nameKind} ${
-        name}. Please include either "BrowserAnimationsModule" or "NoopAnimationsModule" in your application.`);
+    throw new Error(`Unexpected synthetic ${nameKind} ${name} found. Please make sure that:
+  - Either \`BrowserAnimationsModule\` or \`NoopAnimationsModule\` are imported in your application.
+  - There is corresponding configuration for the animation named \`${
+        name}\` defined in the \`animations\` field of the \`@Component\` decorator (see https://angular.io/api/core/Component#animations).`);
   }
 }
 


### PR DESCRIPTION
…igger

There are two reasons why this error can be called, but only one was covered before.

Fixes #15581

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [n/a] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #15581 


## What is the new behavior?
An example of a new error message is: 
```
Found the synthetic property @myAnimation. Possible reasons:
  - "BrowserAnimationsModule" or "NoopAnimationsModule" are missing in your application.
  - There is no corresponding configuration for the animation named `@myAnimation` defined in the `animations` field of the `@Component` decorator (see https://angular.io/api/core/Component#animations).

```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
