### PR TITLE
feat(bazel): allow setting `compilationMode` in `ng_module` rule

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -339,6 +339,7 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
         # Summaries are only enabled if Angular outputs are to be produced.
         "enableSummariesForJit": is_legacy_ngc,
         "enableIvy": is_ivy_enabled(ctx),
+        "compilationMode": ctx.attr.compilation_mode,
         "fullTemplateTypeCheck": ctx.attr.type_check,
         # In Google3 we still want to use the symbol factory re-exports in order to
         # not break existing apps inside Google. Unlike Bazel, Google3 does not only
@@ -725,6 +726,13 @@ NG_MODULE_ATTRIBUTES = {
     "filter_summaries": attr.bool(default = False),
     "type_check": attr.bool(default = True),
     "inline_resources": attr.bool(default = True),
+    "compilation_mode": attr.string(
+        doc = """Set the compilation mode for the Angular compiler.
+
+        This attribute is a noop if Ivy is not enabled.
+        """,
+        default = "",
+    ),
     "no_i18n": attr.bool(default = False),
     "compiler": attr.label(
         doc = """Sets a different ngc compiler binary to use for this library.

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -731,6 +731,7 @@ NG_MODULE_ATTRIBUTES = {
 
         This attribute is a noop if Ivy is not enabled.
         """,
+        values = ["partial", "full", ""],
         default = "",
     ),
     "no_i18n": attr.bool(default = False),

--- a/packages/bazel/test/ngc-wrapped/ivy_enabled/BUILD.bazel
+++ b/packages/bazel/test/ngc-wrapped/ivy_enabled/BUILD.bazel
@@ -16,6 +16,15 @@ ng_module(
     deps = ["//packages/core"],
 )
 
+# `ng_module` with `compilation_mode` explicitly set to `full`.
+ng_module(
+    name = "test_module_full_compilation",
+    srcs = ["test_module_full_compilation.ts"],
+    compilation_mode = "full",
+    tags = ["ivy-only"],
+    deps = ["//packages/core"],
+)
+
 # `ng_module` with no specific `compilation_mode` attribute specified.
 ng_module(
     name = "test_module_default_compilation",
@@ -29,6 +38,7 @@ jasmine_node_test(
     srcs = [":ng_module_ivy_test_lib"],
     data = [
         ":test_module_default_compilation",
+        ":test_module_full_compilation",
         ":test_module_partial_compilation",
     ],
     tags = ["ivy-only"],

--- a/packages/bazel/test/ngc-wrapped/ivy_enabled/BUILD.bazel
+++ b/packages/bazel/test/ngc-wrapped/ivy_enabled/BUILD.bazel
@@ -1,0 +1,35 @@
+load("//tools:defaults.bzl", "jasmine_node_test", "ng_module", "ts_library")
+
+ts_library(
+    name = "ng_module_ivy_test_lib",
+    testonly = True,
+    srcs = ["ng_module_ivy_test.ts"],
+    tags = ["ivy-only"],
+)
+
+# `ng_module` with `compilation_mode` explicitly set to `partial`.
+ng_module(
+    name = "test_module_partial_compilation",
+    srcs = ["test_module_partial_compilation.ts"],
+    compilation_mode = "partial",
+    tags = ["ivy-only"],
+    deps = ["//packages/core"],
+)
+
+# `ng_module` with no specific `compilation_mode` attribute specified.
+ng_module(
+    name = "test_module_default_compilation",
+    srcs = ["test_module_default_compilation.ts"],
+    tags = ["ivy-only"],
+    deps = ["//packages/core"],
+)
+
+jasmine_node_test(
+    name = "ng_module_ivy_test",
+    srcs = [":ng_module_ivy_test_lib"],
+    data = [
+        ":test_module_default_compilation",
+        ":test_module_partial_compilation",
+    ],
+    tags = ["ivy-only"],
+)

--- a/packages/bazel/test/ngc-wrapped/ivy_enabled/ng_module_ivy_test.ts
+++ b/packages/bazel/test/ngc-wrapped/ivy_enabled/ng_module_ivy_test.ts
@@ -21,6 +21,15 @@ describe('ng_module with ivy enabled', () => {
     });
   });
 
+  describe('full compilation mode', () => {
+    it('should generate definitions', () => {
+      const outputFile = runfiles.resolveWorkspaceRelative(
+          'packages/bazel/test/ngc-wrapped/ivy_enabled/test_module_full_compilation.js');
+      const fileContent = readFileSync(outputFile, 'utf8');
+      expect(fileContent).toContain(`TestComponent.ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent(`);
+    });
+  });
+
   describe('partial compilation mode', () => {
     it('should generate declarations', () => {
       const outputFile = runfiles.resolveWorkspaceRelative(

--- a/packages/bazel/test/ngc-wrapped/ivy_enabled/ng_module_ivy_test.ts
+++ b/packages/bazel/test/ngc-wrapped/ivy_enabled/ng_module_ivy_test.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {readFileSync} from 'fs';
+
+/** Runfiles helper from bazel to resolve file name paths.  */
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']!);
+
+describe('ng_module with ivy enabled', () => {
+  describe('default compilation mode', () => {
+    it('should generate definitions', () => {
+      const outputFile = runfiles.resolveWorkspaceRelative(
+          'packages/bazel/test/ngc-wrapped/ivy_enabled/test_module_default_compilation.js');
+      const fileContent = readFileSync(outputFile, 'utf8');
+      expect(fileContent).toContain(`TestComponent.ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent(`);
+    });
+  });
+
+  describe('partial compilation mode', () => {
+    it('should generate declarations', () => {
+      const outputFile = runfiles.resolveWorkspaceRelative(
+          'packages/bazel/test/ngc-wrapped/ivy_enabled/test_module_partial_compilation.js');
+      const fileContent = readFileSync(outputFile, 'utf8');
+      expect(fileContent).toContain(`TestComponent.ɵcmp = i0.ɵɵngDeclareComponent(`);
+    });
+  });
+});

--- a/packages/bazel/test/ngc-wrapped/ivy_enabled/test_module_default_compilation.ts
+++ b/packages/bazel/test/ngc-wrapped/ivy_enabled/test_module_default_compilation.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+
+@Component({
+  template: 'Hello',
+})
+export class TestComponent {
+}

--- a/packages/bazel/test/ngc-wrapped/ivy_enabled/test_module_full_compilation.ts
+++ b/packages/bazel/test/ngc-wrapped/ivy_enabled/test_module_full_compilation.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+
+@Component({
+  template: 'Hello',
+})
+export class TestComponent {
+}

--- a/packages/bazel/test/ngc-wrapped/ivy_enabled/test_module_partial_compilation.ts
+++ b/packages/bazel/test/ngc-wrapped/ivy_enabled/test_module_partial_compilation.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+
+@Component({
+  template: 'Hello',
+})
+export class TestComponent {
+}


### PR DESCRIPTION
Adds a new attribute to the `ng_module` rule that allows users to
set the Angular compiler `compilationMode` flag. An alternative
would have been to just enable the option in the user-specified
tsconfig. Though that is more inconvenient if a Bazel workspace
wants to change the compilation mode conditionally at anaylsis
phase through build settings.

Related to: https://github.com/angular/components/pull/22351