### PR TITLE
fix(dev-infra): use all non-header content for checking commit body length

### DIFF
--- a/dev-infra/commit-message/validate.spec.ts
+++ b/dev-infra/commit-message/validate.spec.ts
@@ -253,6 +253,14 @@ describe('validate-commit-message.js', () => {
         ]);
       });
 
+      it('should pass validation even if the total non-header content is longer than `minBodyLength`, even if the body contains a `#` reference usage',
+         () => {
+           expectValidationResult(
+               validateCommitMessage(
+                   'fix(core): something\n\n Explanation of how #123 motivated this change'),
+               VALID);
+         });
+
       it('should pass validation if the body is shorter than `minBodyLength` but the commit type is in the `minBodyLengthTypeExclusions` list',
          () => {
            expectValidationResult(validateCommitMessage('docs: just fixing a typo'), VALID);

--- a/dev-infra/commit-message/validate.ts
+++ b/dev-infra/commit-message/validate.ts
@@ -131,8 +131,14 @@ export function validateCommitMessage(
     // Checking commit body //
     //////////////////////////
 
+    // Due to an issue in which conventional-commits-parser considers all parts of a commit after
+    // a `#` reference to be the footer, we check the length of all of the commit content after the
+    // header. In the future, we expect to be able to check only the body once the parser properly
+    // handles this case.
+    const allNonHeaderContent = `${commit.body.trim()}\n${commit.footer.trim()}`;
+
     if (!config.minBodyLengthTypeExcludes?.includes(commit.type) &&
-        commit.body.trim().length < config.minBodyLength) {
+        allNonHeaderContent.length < config.minBodyLength) {
       errors.push(`The commit message body does not meet the minimum length of ${
           config.minBodyLength} characters`);
       return false;

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -1881,8 +1881,13 @@ function validateCommitMessage(commitMsg, options = {}) {
         //////////////////////////
         // Checking commit body //
         //////////////////////////
+        // Due to an issue in which conventional-commits-parser considers all parts of a commit after
+        // a `#` reference to be the footer, we check the length of all of the commit content after the
+        // header. In the future, we expect to be able to check only the body once the parser properly
+        // handles this case.
+        const allNonHeaderContent = `${commit.body.trim()}\n${commit.footer.trim()}`;
         if (!((_a = config.minBodyLengthTypeExcludes) === null || _a === void 0 ? void 0 : _a.includes(commit.type)) &&
-            commit.body.trim().length < config.minBodyLength) {
+            allNonHeaderContent.length < config.minBodyLength) {
             errors.push(`The commit message body does not meet the minimum length of ${config.minBodyLength} characters`);
             return false;
         }


### PR DESCRIPTION
As discovered in #41316, commit body length checks should consider all of the non-header
content as the commit body rather than the conventional-commit-parser's current method
of considering everything after a commit reference to be the footer.