### PR TITLE
refactor(common): remove `XhrFactory` re-export from `@angular/common/http`

### DIFF
--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -6,10 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// TODO(alan-agius4): remove this export once migration has been done in Google3. (Should happen
-// prior to V12 RC).
-export {XhrFactory} from '@angular/common';
-
 export {HttpBackend, HttpHandler} from './src/backend';
 export {HttpClient} from './src/client';
 export {HttpContext, HttpContextToken} from './src/context';


### PR DESCRIPTION


This was only done temporary to allow migration in Google3. The removal breaking change message has already been included in #41313

**Blocked until @kyliau finishes migration in G3.**