### PR TITLE
fix(dev-infra): Correctly place comments in dockerfile

### DIFF
--- a/.devcontainer/recommended-Dockerfile
+++ b/.devcontainer/recommended-Dockerfile
@@ -1,6 +1,8 @@
 # Image metadata and config.
-FROM circleci/node:10-browsers  # Ideally, the image version should be what we use on CI.
-                                # See `executors > browsers-executor` in `.circleci/config.yml`.
+# Ideally, the image version should be what we use on CI.
+# See `executors > browsers-executor` in `.circleci/config.yml`.
+FROM circleci/node:10-browsers  
+                                
 
 LABEL name="Angular dev environment" \
       description="This image can be used to create a dev environment for building Angular." \
@@ -16,8 +18,10 @@ USER root
 
 # Configure `Node.js`/`npm` and install utilities.
 RUN npm config --global set user root
-RUN npm install --global yarn@latest  # Ideally, the version should be what we use on CI.
-                                      # See `commands > overwrite_yarn` in `.circleci/config.yml`.
+
+# Ideally, the version should be what we use on CI.
+# See `commands > overwrite_yarn` in `.circleci/config.yml`.
+RUN npm install --global yarn@latest
 
 
 # Go! (And keep going.)


### PR DESCRIPTION
The doc in https://docs.docker.com/engine/reference/builder/#format says that 
"Docker treats lines that begin with # as a comment, unless the line is a valid parser directive. A # marker anywhere else in a line is treated as an argument."

(Probably?) Fixes #41361

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Probably issues creating the docker container from the dockerfile

Issue Number: #41361


## What is the new behavior?
Just replaced comments

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
