### PR TITLE
fix(router): remove child outlet context from parent on deactivation

### DIFF
--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -123,6 +123,11 @@ export class ActivateRoutes {
       context.outlet.deactivate();
       // Destroy the contexts for all the outlets that were in the component
       context.children.onOutletDeactivated();
+      // Clear the information about the attached component on the context but keep the reference to
+      // the outlet.
+      context.attachRef = null;
+      context.resolver = null;
+      context.route = null;
     }
   }
 


### PR DESCRIPTION
When we deactivate a child route, we deactivate its outlet as well as
its children. We also need to remove this context from the parent `Map`.
If we do not, the parent will hold on to a reference to this deactivated
context and can result in reactivating an outlet that was deactivated by
the previous navigation.

Fixes #41379
