### PR TITLE
ci: remove *.bazel from dev-infra ownership

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1166,7 +1166,7 @@ groups:
     conditions:
       - *can-be-global-approved
       - >
-        contains_any_globs(files.exclude("packages/compiler-cli/**/BUILD.bazel"), [
+        contains_any_globs(files, [
           '*',
           '.circleci/**',
           '.devcontainer/**',
@@ -1203,8 +1203,7 @@ groups:
           'tools/utils/**',
           'tools/yarn/**',
           'tools/*',
-          '**/*.bzl',
-          '**/*.bazel'
+          '**/*.bzl'
           ])
     reviewers:
       users:


### PR DESCRIPTION
Historically all .bazel files were owned by dev-infra to assist in ensuring that
consistency was maintained in how rules were being used.  As this now has reached
a point of maturity in the repository where the check is mostly a rubber stamping,
this requirement can be removed.  Notably this is different than the requirement
of dev-infra approval for .bzl files as these contain the implementation of macros
rather than just the usage.
