### PR TITLE
refactor(dev-infra): separate the build and publish artifacts tasks

### DIFF
--- a/dev-infra/release/publish/actions.ts
+++ b/dev-infra/release/publish/actions.ts
@@ -497,7 +497,7 @@ export abstract class ReleaseAction {
    * @param publishBranch Name of the branch that contains the new version.
    * @param npmDistTag NPM dist tag where the version should be published to.
    */
-  protected async buildAndPublish(
+  protected async buildArtifactsForPublish(
       newVersion: semver.SemVer, publishBranch: string, npmDistTag: string) {
     const versionBumpCommitSha = await this._getCommitOfBranch(publishBranch);
 
@@ -523,16 +523,18 @@ export abstract class ReleaseAction {
     // Verify the packages built are the correct version.
     await this._verifyPackageVersions(newVersion, builtPackages);
 
-    // Create a Github release for the new version.
-    await this._createGithubReleaseForVersion(
-        newVersion, versionBumpCommitSha, npmDistTag === 'next');
+    return async () => {
+      // Create a Github release for the new version.
+      await this._createGithubReleaseForVersion(
+          newVersion, versionBumpCommitSha, npmDistTag === 'next');
 
-    // Walk through all built packages and publish them to NPM.
-    for (const builtPackage of builtPackages) {
-      await this._publishBuiltPackageToNpm(builtPackage, npmDistTag);
-    }
+      // Walk through all built packages and publish them to NPM.
+      for (const builtPackage of builtPackages) {
+        await this._publishBuiltPackageToNpm(builtPackage, npmDistTag);
+      }
 
-    info(green('  ✓   Published all packages successfully'));
+      info(green('  ✓   Published all packages successfully'));
+    };
   }
 
   /** Publishes the given built package to NPM with the specified NPM dist tag. */

--- a/dev-infra/release/publish/actions/cut-lts-patch.ts
+++ b/dev-infra/release/publish/actions/cut-lts-patch.ts
@@ -45,9 +45,9 @@ export class CutLongTermSupportPatchAction extends ReleaseAction {
 
     await this.waitForPullRequestToBeMerged(id);
     // TODO(josephperrott): Rearrange order of tasks within the action to be stage and then release.
-    const publishArtifacts =
-        await this.buildArtifactsForPublish(newVersion, ltsBranch.name, ltsBranch.npmDistTag);
-    await publishArtifacts();
+    const artifacts =
+        await this.stageArtifactsForPublish(newVersion, ltsBranch.name, ltsBranch.npmDistTag);
+    await this.publishStagedArtifacts(artifacts);
     await this.cherryPickChangelogIntoNextBranch(newVersion, ltsBranch.name);
   }
 

--- a/dev-infra/release/publish/actions/cut-lts-patch.ts
+++ b/dev-infra/release/publish/actions/cut-lts-patch.ts
@@ -44,7 +44,10 @@ export class CutLongTermSupportPatchAction extends ReleaseAction {
     const {id} = await this.checkoutBranchAndStageVersion(newVersion, ltsBranch.name);
 
     await this.waitForPullRequestToBeMerged(id);
-    await this.buildAndPublish(newVersion, ltsBranch.name, ltsBranch.npmDistTag);
+    // TODO(josephperrott): Rearrange order of tasks within the action to be stage and then release.
+    const publishArtifacts =
+        await this.buildArtifactsForPublish(newVersion, ltsBranch.name, ltsBranch.npmDistTag);
+    await publishArtifacts();
     await this.cherryPickChangelogIntoNextBranch(newVersion, ltsBranch.name);
   }
 

--- a/dev-infra/release/publish/actions/cut-new-patch.ts
+++ b/dev-infra/release/publish/actions/cut-new-patch.ts
@@ -32,8 +32,8 @@ export class CutNewPatchAction extends ReleaseAction {
 
     await this.waitForPullRequestToBeMerged(id);
     // TODO(josephperrott): Rearrange order of tasks within the action to be stage and then release.
-    const publishArtifacts = await this.buildArtifactsForPublish(newVersion, branchName, 'latest');
-    await publishArtifacts();
+    const artifacts = await this.stageArtifactsForPublish(newVersion, branchName, 'latest');
+    await this.publishStagedArtifacts(artifacts);
     await this.cherryPickChangelogIntoNextBranch(newVersion, branchName);
   }
 

--- a/dev-infra/release/publish/actions/cut-new-patch.ts
+++ b/dev-infra/release/publish/actions/cut-new-patch.ts
@@ -31,7 +31,9 @@ export class CutNewPatchAction extends ReleaseAction {
     const {id} = await this.checkoutBranchAndStageVersion(newVersion, branchName);
 
     await this.waitForPullRequestToBeMerged(id);
-    await this.buildAndPublish(newVersion, branchName, 'latest');
+    // TODO(josephperrott): Rearrange order of tasks within the action to be stage and then release.
+    const publishArtifacts = await this.buildArtifactsForPublish(newVersion, branchName, 'latest');
+    await publishArtifacts();
     await this.cherryPickChangelogIntoNextBranch(newVersion, branchName);
   }
 

--- a/dev-infra/release/publish/actions/cut-next-prerelease.ts
+++ b/dev-infra/release/publish/actions/cut-next-prerelease.ts
@@ -36,8 +36,8 @@ export class CutNextPrereleaseAction extends ReleaseAction {
 
     await this.waitForPullRequestToBeMerged(id);
     // TODO(josephperrott): Rearrange order of tasks within the action to be stage and then release.
-    const publishArtifacts = await this.buildArtifactsForPublish(newVersion, branchName, 'next');
-    await publishArtifacts();
+    const artifacts = await this.stageArtifactsForPublish(newVersion, branchName, 'next');
+    await this.publishStagedArtifacts(artifacts);
     // If the pre-release has been cut from a branch that is not corresponding
     // to the next release-train, cherry-pick the changelog into the primary
     // development branch. i.e. the `next` branch that is usually `master`.

--- a/dev-infra/release/publish/actions/cut-next-prerelease.ts
+++ b/dev-infra/release/publish/actions/cut-next-prerelease.ts
@@ -35,8 +35,9 @@ export class CutNextPrereleaseAction extends ReleaseAction {
     const {id} = await this.checkoutBranchAndStageVersion(newVersion, branchName);
 
     await this.waitForPullRequestToBeMerged(id);
-    await this.buildAndPublish(newVersion, branchName, 'next');
-
+    // TODO(josephperrott): Rearrange order of tasks within the action to be stage and then release.
+    const publishArtifacts = await this.buildArtifactsForPublish(newVersion, branchName, 'next');
+    await publishArtifacts();
     // If the pre-release has been cut from a branch that is not corresponding
     // to the next release-train, cherry-pick the changelog into the primary
     // development branch. i.e. the `next` branch that is usually `master`.

--- a/dev-infra/release/publish/actions/cut-release-candidate.ts
+++ b/dev-infra/release/publish/actions/cut-release-candidate.ts
@@ -29,7 +29,9 @@ export class CutReleaseCandidateAction extends ReleaseAction {
     const {id} = await this.checkoutBranchAndStageVersion(newVersion, branchName);
 
     await this.waitForPullRequestToBeMerged(id);
-    await this.buildAndPublish(newVersion, branchName, 'next');
+    // TODO(josephperrott): Rearrange order of tasks within the action to be stage and then release.
+    const publishArtifacts = await this.buildArtifactsForPublish(newVersion, branchName, 'next');
+    await publishArtifacts();
     await this.cherryPickChangelogIntoNextBranch(newVersion, branchName);
   }
 

--- a/dev-infra/release/publish/actions/cut-release-candidate.ts
+++ b/dev-infra/release/publish/actions/cut-release-candidate.ts
@@ -30,8 +30,8 @@ export class CutReleaseCandidateAction extends ReleaseAction {
 
     await this.waitForPullRequestToBeMerged(id);
     // TODO(josephperrott): Rearrange order of tasks within the action to be stage and then release.
-    const publishArtifacts = await this.buildArtifactsForPublish(newVersion, branchName, 'next');
-    await publishArtifacts();
+    const artifacts = await this.stageArtifactsForPublish(newVersion, branchName, 'next');
+    await this.publishStagedArtifacts(artifacts);
     await this.cherryPickChangelogIntoNextBranch(newVersion, branchName);
   }
 

--- a/dev-infra/release/publish/actions/cut-stable.ts
+++ b/dev-infra/release/publish/actions/cut-stable.ts
@@ -35,8 +35,8 @@ export class CutStableAction extends ReleaseAction {
 
     await this.waitForPullRequestToBeMerged(id);
     // TODO(josephperrott): Rearrange order of tasks within the action to be stage and then release.
-    const publishArtifacts = await this.buildArtifactsForPublish(newVersion, branchName, 'latest');
-    await publishArtifacts();
+    const artifacts = await this.stageArtifactsForPublish(newVersion, branchName, 'latest');
+    await this.publishStagedArtifacts(artifacts);
 
     // If a new major version is published and becomes the "latest" release-train, we need
     // to set the LTS npm dist tag for the previous latest release-train (the current patch).

--- a/dev-infra/release/publish/actions/cut-stable.ts
+++ b/dev-infra/release/publish/actions/cut-stable.ts
@@ -34,7 +34,9 @@ export class CutStableAction extends ReleaseAction {
     const {id} = await this.checkoutBranchAndStageVersion(newVersion, branchName);
 
     await this.waitForPullRequestToBeMerged(id);
-    await this.buildAndPublish(newVersion, branchName, 'latest');
+    // TODO(josephperrott): Rearrange order of tasks within the action to be stage and then release.
+    const publishArtifacts = await this.buildArtifactsForPublish(newVersion, branchName, 'latest');
+    await publishArtifacts();
 
     // If a new major version is published and becomes the "latest" release-train, we need
     // to set the LTS npm dist tag for the previous latest release-train (the current patch).

--- a/dev-infra/release/publish/actions/move-next-into-feature-freeze.ts
+++ b/dev-infra/release/publish/actions/move-next-into-feature-freeze.ts
@@ -47,8 +47,8 @@ export class MoveNextIntoFeatureFreezeAction extends ReleaseAction {
     // with bumping the version to the next minor too.
     await this.waitForPullRequestToBeMerged(stagingPullRequest.id);
     // TODO(josephperrott): Rearrange order of tasks within the action to be stage and then release.
-    const publishArtifacts = await this.buildArtifactsForPublish(newVersion, newBranch, 'next');
-    await publishArtifacts();
+    const artifacts = await this.stageArtifactsForPublish(newVersion, newBranch, 'next');
+    await this.publishStagedArtifacts(artifacts);
     await this._createNextBranchUpdatePullRequest(newVersion, newBranch);
   }
 

--- a/dev-infra/release/publish/actions/move-next-into-feature-freeze.ts
+++ b/dev-infra/release/publish/actions/move-next-into-feature-freeze.ts
@@ -46,7 +46,9 @@ export class MoveNextIntoFeatureFreezeAction extends ReleaseAction {
     // pre-release. Finally, cherry-pick the release notes into the next branch in combination
     // with bumping the version to the next minor too.
     await this.waitForPullRequestToBeMerged(stagingPullRequest.id);
-    await this.buildAndPublish(newVersion, newBranch, 'next');
+    // TODO(josephperrott): Rearrange order of tasks within the action to be stage and then release.
+    const publishArtifacts = await this.buildArtifactsForPublish(newVersion, newBranch, 'next');
+    await publishArtifacts();
     await this._createNextBranchUpdatePullRequest(newVersion, newBranch);
   }
 

--- a/dev-infra/release/publish/test/common.spec.ts
+++ b/dev-infra/release/publish/test/common.spec.ts
@@ -78,8 +78,8 @@ describe('common release action logic', () => {
       // Set up a custom NPM registry.
       releaseConfig.publishRegistry = customRegistryUrl;
 
-      const publish = await instance.testBuildAndPublish(version, branchName, 'latest');
-      await publish();
+      await instance.testBuildAndPublish(version, branchName, 'latest');
+
 
       expect(npm.runNpmPublish).toHaveBeenCalledTimes(2);
       expect(npm.runNpmPublish)
@@ -215,7 +215,8 @@ class TestAction extends ReleaseAction {
   }
 
   async testBuildAndPublish(newVersion: semver.SemVer, publishBranch: string, distTag: string) {
-    return await this.buildArtifactsForPublish(newVersion, publishBranch, distTag);
+    const artifacts = await this.stageArtifactsForPublish(newVersion, publishBranch, distTag);
+    await this.publishStagedArtifacts(artifacts);
   }
 
   async testCherryPickWithPullRequest(version: semver.SemVer, branch: string) {

--- a/dev-infra/release/publish/test/common.spec.ts
+++ b/dev-infra/release/publish/test/common.spec.ts
@@ -78,7 +78,8 @@ describe('common release action logic', () => {
       // Set up a custom NPM registry.
       releaseConfig.publishRegistry = customRegistryUrl;
 
-      await instance.testBuildAndPublish(version, branchName, 'latest');
+      const publish = await instance.testBuildAndPublish(version, branchName, 'latest');
+      await publish();
 
       expect(npm.runNpmPublish).toHaveBeenCalledTimes(2);
       expect(npm.runNpmPublish)
@@ -214,7 +215,7 @@ class TestAction extends ReleaseAction {
   }
 
   async testBuildAndPublish(newVersion: semver.SemVer, publishBranch: string, distTag: string) {
-    await this.buildAndPublish(newVersion, publishBranch, distTag);
+    return await this.buildArtifactsForPublish(newVersion, publishBranch, distTag);
   }
 
   async testCherryPickWithPullRequest(version: semver.SemVer, branch: string) {


### PR DESCRIPTION
In preparation for moving to be a more defined model of stage and then publish, separating
the building and publishing of artifacts apart allows for us to eventually reorder the
steps as appropriate.