### PR TITLE
docs: fix broken link to angular elements overview

### DIFF
--- a/packages/elements/PACKAGE.md
+++ b/packages/elements/PACKAGE.md
@@ -5,4 +5,4 @@ A custom element extends HTML by allowing you to define a tag whose content is c
 
 The `createCustomElement()` function provides a bridge from Angular's component interface and change detection functionality to the built-in DOM API. 
 
-For more information, see [Angular Elements Overview](guide/elements).
+For more information, see [Angular Elements Overview](../../aio/content/guide/elements.md).


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Link to Angular Elements Overview is broken

Issue Number: N/A


## What is the new behavior?
Link to Angular Elements Overview works

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
