### PR TITLE
fix(common): temporarily re-export and deprecate `XhrFactory`

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -40,6 +40,7 @@ v12 - v15
 | ----------------------------- | ---------------------------------------------------------------------------   | ----------------- |
 | `@angular/common`             | [`ReflectiveInjector`](#reflectiveinjector)                                   | <!--v8--> v11 |
 | `@angular/common`             | [`CurrencyPipe` - `DEFAULT_CURRENCY_CODE`](api/common/CurrencyPipe#currency-code-deprecation) | <!--v9--> v11 |
+| `@angular/common/http`        | [`XhrFactory`](api/common/http/XhrFactory)                                    | <!--v12--> v15 |
 | `@angular/core`               | [`DefaultIterableDiffer`](#core)                                              | <!--v7--> v11 |
 | `@angular/core`               | [`ReflectiveKey`](#core)                                                      | <!--v8--> v11 |
 | `@angular/core`               | [`RenderComponentType`](#core)                                                | <!--v7--> v11 |
@@ -80,6 +81,14 @@ Tip: In the [API reference section](api) of this doc site, deprecated APIs are i
 | API                                                                                           | Replacement                                         | Deprecation announced | Notes |
 | --------------------------------------------------------------------------------------------- | --------------------------------------------------- | --------------------- | ----- |
 | [`CurrencyPipe` - `DEFAULT_CURRENCY_CODE`](api/common/CurrencyPipe#currency-code-deprecation) | `{provide: DEFAULT_CURRENCY_CODE, useValue: 'USD'}` | v9                    | From v11 the default code will be extracted from the locale data given by `LOCAL_ID`, rather than `USD`. |
+
+
+{@a common-http}
+### @angular/common/http
+
+| API                                          | Replacement                          | Deprecation announced | Notes |
+| -------------------------------------------- | ------------------------------------ | --------------------- | ----- |
+| [`XhrFactory`](api/common/http/XhrFactory)   | `XhrFactory` in `@angular/common`    | v12                   | The `XhrFactory` has moved from `@angular/common/http` to `@angular/common`. |
 
 
 {@a core}

--- a/goldens/public-api/common/http/http.d.ts
+++ b/goldens/public-api/common/http/http.d.ts
@@ -1930,7 +1930,7 @@ export declare interface HttpUserEvent<T> {
 }
 
 export declare class HttpXhrBackend implements HttpBackend {
-    constructor(xhrFactory: XhrFactory);
+    constructor(xhrFactory: XhrFactory_2);
     handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
 }
 
@@ -1947,3 +1947,6 @@ export declare class JsonpInterceptor {
     constructor(jsonp: JsonpClientBackend);
     intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>>;
 }
+
+/** @deprecated */
+export declare type XhrFactory = XhrFactory_2;

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -6,6 +6,27 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {XhrFactory as XhrFactory_fromAngularCommon} from '@angular/common';
+
+/**
+ * A wrapper around the `XMLHttpRequest` constructor.
+ *
+ * @publicApi
+ * @see `XhrFactory`
+ * @deprecated
+ * `XhrFactory` has moved, please import `XhrFactory` from `@angular/common` instead.
+ */
+export type XhrFactory = XhrFactory_fromAngularCommon;
+/**
+ * A wrapper around the `XMLHttpRequest` constructor.
+ *
+ * @publicApi
+ * @see `XhrFactory`
+ * @deprecated
+ * `XhrFactory` has moved, please import `XhrFactory` from `@angular/common` instead.
+ */
+export const XhrFactory = XhrFactory_fromAngularCommon;
+
 export {HttpBackend, HttpHandler} from './src/backend';
 export {HttpClient} from './src/client';
 export {HttpContext, HttpContextToken} from './src/context';

--- a/packages/misc/angular-in-memory-web-api/src/in-memory-web-api-module.ts
+++ b/packages/misc/angular-in-memory-web-api/src/in-memory-web-api-module.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpBackend, XhrFactory} from '@angular/common/http';
+import {XhrFactory} from '@angular/common';
+import {HttpBackend} from '@angular/common/http';
 import {ModuleWithProviders, NgModule, Type} from '@angular/core';
 
 import {httpClientInMemBackendServiceFactory} from './http-client-in-memory-web-api-module';

--- a/packages/misc/angular-in-memory-web-api/src/in-memory-web-api-module.ts
+++ b/packages/misc/angular-in-memory-web-api/src/in-memory-web-api-module.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {XhrFactory} from '@angular/common';
-import {HttpBackend} from '@angular/common/http';
+import {HttpBackend, XhrFactory} from '@angular/common/http';
 import {ModuleWithProviders, NgModule, Type} from '@angular/core';
 
 import {httpClientInMemBackendServiceFactory} from './http-client-in-memory-web-api-module';

--- a/scripts/ci/publish-build-artifacts.sh
+++ b/scripts/ci/publish-build-artifacts.sh
@@ -92,6 +92,12 @@ function publishPackages {
 
   for dir in $PKGS_DIST/*/
   do
+    if [[ ! -f "$dir/package.json" ]]; then
+      # Only publish directories that contain a `package.json` file.
+      echo "Skipping $dir, it does not contain a package to be published."
+      continue
+    fi
+
     COMPONENT="$(basename ${dir})"
 
     # Replace _ with - in component name.


### PR DESCRIPTION
Docs show deprecation notice: https://pr41393-f625e20.ngbuilds.io/api/common/http/XhrFactory
Tested against ngcc-validation: https://github.com/angular/ngcc-validation/pull/2820
Deprecation message also shows in IDE:
![Screenshot 2021-03-31 at 17 12 25](https://user-images.githubusercontent.com/15655/113176449-697a8280-9244-11eb-906c-72e38ca88eb4.png)
