### PR TITLE
build: update the recommended `Dockerfile` for VSCode remote development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ var_10: &only_on_master
 # **NOTE 1**: Pin to exact images using an ID (SHA). See https://circleci.com/docs/2.0/circleci-images/#using-a-docker-image-id-to-pin-an-image-to-a-fixed-version.
 #             (Using the tag in not necessary when pinning by ID, but include it anyway for documentation purposes.)
 # **NOTE 2**: If you change the version of the docker images, also change the `cache_key` suffix.
+# **NOTE 3**: If you change the version of Node.js provided by the docker images, also update `.devcontainer/recommended-Dockerfile` to match the new version.
 executors:
   default-executor:
     parameters:

--- a/.devcontainer/recommended-Dockerfile
+++ b/.devcontainer/recommended-Dockerfile
@@ -1,8 +1,8 @@
 # Image metadata and config.
-# Ideally, the image version should be what we use on CI.
-# See `executors > browsers-executor` in `.circleci/config.yml`.
-FROM circleci/node:10-browsers  
-                                
+# Ideally, the Node.js version should match what we use on CI.
+# See `executors > default-executor` in `.circleci/config.yml`.
+FROM circleci/node:12-browsers
+
 
 LABEL name="Angular dev environment" \
       description="This image can be used to create a dev environment for building Angular." \
@@ -16,12 +16,8 @@ EXPOSE 4000 4200 4433 5000 8080 9876
 USER root
 
 
-# Configure `Node.js`/`npm` and install utilities.
+# Configure `Node.js`/`npm`.
 RUN npm config --global set user root
-
-# Ideally, the version should be what we use on CI.
-# See `commands > overwrite_yarn` in `.circleci/config.yml`.
-RUN npm install --global yarn@latest
 
 
 # Go! (And keep going.)


### PR DESCRIPTION
This PR updates the recommended `Dockerfile` for VSCode remote development to take into account recent changes in our dev workflow (updated Node.js version, vendored yarn, modified CircleCI config).

It also adds a note in the CircleCI config to keep the recommended `Dockerfile` up-to-date with the Node.js version used on CI.