### PR TITLE
fix(compiler-cli): Allow analysis to continue with invalid style url

### DIFF
--- a/packages/language-service/ivy/test/quick_info_spec.ts
+++ b/packages/language-service/ivy/test/quick_info_spec.ts
@@ -553,8 +553,40 @@ describe('quick info', () => {
       expectQuickInfo(
           {templateOverride, expectedSpanText: 'date', expectedDisplayString: '(pipe) DatePipe'});
     });
-  });
 
+    it('should still get quick info if there is an invalid css resource', () => {
+      project = env.addProject('test', {
+        'app.ts': `
+         import {Component, NgModule} from '@angular/core';
+
+         @Component({
+           selector: 'some-cmp',
+           templateUrl: './app.html',
+           styleUrls: ['./does_not_exist'],
+         })
+         export class SomeCmp {
+           myValue!: string;
+         }
+
+         @NgModule({
+           declarations: [SomeCmp],
+         })
+         export class AppModule{
+         }
+       `,
+        'app.html': `{{myValue}}`,
+      });
+      const diagnostics = project.getDiagnosticsForFile('app.ts');
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0].messageText)
+          .toEqual(`Could not find stylesheet file './does_not_exist'.`);
+
+      const template = project.openFile('app.html');
+      template.moveCursorToText('{{myVa¦lue}}');
+      const quickInfo = template.getQuickInfoAtPosition();
+      expect(toText(quickInfo!.displayParts)).toEqual('(property) SomeCmp.myValue: string');
+    });
+  });
 
   function expectQuickInfo(
       {templateOverride, expectedSpanText, expectedDisplayString}:


### PR DESCRIPTION
Currently, we throw a FatalDiagnosticError when we fail to load a resource
(`templateUrl` or `styleUrl`) at various stages in the compiler. This prevents
analysis of the component from completing. This will result in in users not being
able to get any information in the component template when there is a missing
`styleUrl`, for example.

This commit simply tracks the diagnostic, marks the component as poisoned, and
continues merrily along. Environments configured to use poisoned data
(like the language service) will then be able to use other information from the analysis.

Fixes https://github.com/angular/vscode-ng-language-service/issues/1241
