### PR TITLE
docs: remove `entryComponent` from deprecated list

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -454,7 +454,6 @@ This section contains a complete list all of the currently deprecated CLI flags.
 
 | API/Option                      | May be removed in | Notes                                                                           |
 | ------------------------------- | ----------------- |-------------------------------------------------------------------------------- |
-| `entryComponent`                | <!--v9--> v12     | No longer needed with Ivy.                                                      |
 | `lintFix`                       | <!--v11--> v12    | Deprecated as part of TSLint deprecation.                                      |
 
 {@a removed}


### PR DESCRIPTION
This has been removed in https://github.com/angular/angular-cli/pull/20402
