### PR TITLE
docs(forms): default cva docs

### DIFF
--- a/packages/forms/src/directives/default_value_accessor.ts
+++ b/packages/forms/src/directives/default_value_accessor.ts
@@ -35,13 +35,11 @@ function _isAndroid(): boolean {
 export const COMPOSITION_BUFFER_MODE = new InjectionToken<boolean>('CompositionEventMode');
 
 /**
- * @description
- *
- * {@searchKeywords ngDefaultControl}
- *
  * The default `ControlValueAccessor` for writing a value and listening to changes on input
  * elements. The accessor is used by the `FormControlDirective`, `FormControlName`, and
  * `NgModel` directives.
+ *
+ * {@searchKeywords ngDefaultControl}
  *
  * @usageNotes
  *


### PR DESCRIPTION
The position of the `{@searchKeywords}` inline tag was causing the short-description to be empty.

See https://pr41409-86afc01.ngbuilds.io/api/forms/DefaultValueAccessor compared to https://next.angular.io/api/forms/DefaultValueAccessor

(Something I noticed while reviewing #41225).