### PR TITLE
docs: add margin to button boilerplate CSS for examples

### DIFF
--- a/aio/tools/examples/shared/boilerplate/common/src/styles.css
+++ b/aio/tools/examples/shared/boilerplate/common/src/styles.css
@@ -40,6 +40,7 @@ button {
   padding: 1rem;
   margin-right: 1rem;
   margin-bottom: 1rem;
+  margin-top: 1rem;
 }
 button:hover {
   background-color: black;


### PR DESCRIPTION
Adds margin to button styles in example boilerplate CSS