### PR TITLE
feat(router): add aria-current="page" on active routerLinkActive

### DIFF
--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -35,6 +35,9 @@ import {RouterLink, RouterLinkWithHref} from './router_link';
  *
  * Whenever the URL is either '/user' or '/user/bob', the "active-link" class is
  * added to the anchor tag. If the URL changes, the class is removed.
+ * This directive also supports the
+ * {@link https://www.w3.org/TR/wai-aria-1.1/#aria-current aria-current attribute}
+ * and sets it to 'page' on active links.
  *
  * You can set more than one class using a space-separated string or an array.
  * For example:
@@ -78,6 +81,7 @@ import {RouterLink, RouterLinkWithHref} from './router_link';
  */
 @Directive({
   selector: '[routerLinkActive]',
+  host: {'[attr.aria-current]': 'isActive ? "page" : null'},
   exportAs: 'routerLinkActive',
 })
 export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -4678,6 +4678,34 @@ describe('Integration', () => {
          expect(native.className).toEqual('active');
        })));
 
+    it('should set the aria-current attribute when the link is active',
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = createRoot(router, RootCmp);
+
+         router.resetConfig([{
+           path: 'team/:id',
+           component: TeamCmp,
+           children: [{
+             path: 'link',
+             component: DummyLinkCmp,
+             children: [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
+           }]
+         }]);
+
+         router.navigateByUrl('/team/22/link');
+         advance(fixture);
+         advance(fixture);
+         expect(location.path()).toEqual('/team/22/link');
+
+         const native = fixture.nativeElement.querySelector('a');
+         expect(native.getAttribute('aria-current')).toEqual('page');
+
+         router.navigateByUrl('/team/22/link/simple');
+         advance(fixture);
+         expect(location.path()).toEqual('/team/22/link/simple');
+         expect(native.getAttribute('aria-current')).toEqual('page');
+       })));
+
     it('should expose an isActive property', fakeAsync(() => {
          @Component({
            template: `<a routerLink="/team" routerLinkActive #rla="routerLinkActive"></a>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #35051


## What is the new behavior?

The `aria-current` attribute is set to `page` on tags having an active routerLinkActive directive


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
