### PR TITLE
test(core): fix JIT factory declaration test for IE11

### DIFF
--- a/packages/core/test/render3/jit/declare_factory_spec.ts
+++ b/packages/core/test/render3/jit/declare_factory_spec.ts
@@ -32,7 +32,6 @@ describe('Factory declaration jit compilation', () => {
 
   it('should compile a factory declaration that has inheritance', () => {
     const factory = ChildClass.ɵfac as Function;
-    expect(factory.name).toEqual('ChildClass_Factory');
     const instance = factory();
     expect(instance).toBeInstanceOf(ChildClass);
     expect(instance.testClass).toBeInstanceOf(TestClass);


### PR DESCRIPTION
This commit removes a check for the name of the generated factory
function, which is unimportant to test the behaviour of the code.

The name of these functions is generated from the name of the class
being instantiated. In IE11, there is no `function.name` property available
and so there is a shim for it in `third_party/shims_for_IE.js`, which patches
the `Function.property.name` property.

For performance reasons this shim writes the result of the computation
to the prototype of the function. Unfortunately, this means that any class
that extends the patched class will have the same value for `name`.
