### PR TITLE
docs(router): make getCurrentNavigation() jsdoc more explicit

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1027,7 +1027,10 @@ export class Router {
     return this.serializeUrl(this.currentUrlTree);
   }
 
-  /** The current Navigation object if one exists */
+  /**
+   * Returns the current `Navigation` object when the router is navigating,
+   * and `null` when idle.
+   */
   getCurrentNavigation(): Navigation|null {
     return this.currentNavigation;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The current docs for this method does not specify that the return value is null whenever the router is idle. 

## What is the new behavior?
The docs now are explicit that the method returns null when the router is idle.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
