### PR TITLE
fix(dev-infra): require npm login for all publishes via wombat proxy

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -6485,9 +6485,21 @@ class ReleaseTool {
      * @returns a boolean indicating whether the user is logged into NPM.
      */
     _verifyNpmLoginState() {
-        var _a;
+        var _a, _b;
         return tslib.__awaiter(this, void 0, void 0, function* () {
             const registry = `NPM at the ${(_a = this._config.publishRegistry) !== null && _a !== void 0 ? _a : 'default NPM'} registry`;
+            // TODO(josephperrott): remove wombat specific block once wombot allows `npm whoami` check to
+            // check the status of the local token in the .npmrc file.
+            if ((_b = this._config.publishRegistry) === null || _b === void 0 ? void 0 : _b.includes('wombat-dressing-room.appspot.com')) {
+                info('Unable to determine NPM login state for wombat proxy, requiring login now.');
+                try {
+                    yield npmLogin(this._config.publishRegistry);
+                }
+                catch (_c) {
+                    return false;
+                }
+                return true;
+            }
             if (yield npmIsLoggedIn(this._config.publishRegistry)) {
                 debug(`Already logged into ${registry}.`);
                 return true;
@@ -6499,7 +6511,7 @@ class ReleaseTool {
                 try {
                     yield npmLogin(this._config.publishRegistry);
                 }
-                catch (_b) {
+                catch (_d) {
                     return false;
                 }
                 return true;

--- a/dev-infra/release/publish/index.ts
+++ b/dev-infra/release/publish/index.ts
@@ -150,6 +150,17 @@ export class ReleaseTool {
    */
   private async _verifyNpmLoginState(): Promise<boolean> {
     const registry = `NPM at the ${this._config.publishRegistry ?? 'default NPM'} registry`;
+    // TODO(josephperrott): remove wombat specific block once wombot allows `npm whoami` check to
+    // check the status of the local token in the .npmrc file.
+    if (this._config.publishRegistry?.includes('wombat-dressing-room.appspot.com')) {
+      info('Unable to determine NPM login state for wombat proxy, requiring login now.');
+      try {
+        await npmLogin(this._config.publishRegistry);
+      } catch {
+        return false;
+      }
+      return true;
+    }
     if (await npmIsLoggedIn(this._config.publishRegistry)) {
       debug(`Already logged into ${registry}.`);
       return true;


### PR DESCRIPTION
Due to an issue with wombat proxy returning the login state of the generated tokens,
we will need to require a login for all `ng-dev release publish` runs to ensure npm
login has occured.
