### PR TITLE
fix(dev-infra): allow npm like scopes as commit message scopes

### DIFF
--- a/dev-infra/commit-message/validate.spec.ts
+++ b/dev-infra/commit-message/validate.spec.ts
@@ -23,6 +23,7 @@ const config: {commitMessage: CommitMessageConfig} = {
       'compiler',
       'core',
       'packaging',
+      '@angular-devkit/build-angular',
     ]
   }
 };
@@ -85,6 +86,11 @@ describe('validate-commit-message.js', () => {
       expectValidationResult(
           validateCommitMessage(msg), INVALID,
           [`'weird' is not an allowed type.\n => TYPES: ${TYPES}`]);
+    });
+
+    it('should pass when scope is contains NPM scope', () => {
+      expectValidationResult(
+          validateCommitMessage('fix(@angular-devkit/build-angular): something'), true);
     });
 
     it('should fail when scope is invalid', () => {

--- a/dev-infra/commit-message/validate.spec.ts
+++ b/dev-infra/commit-message/validate.spec.ts
@@ -88,7 +88,7 @@ describe('validate-commit-message.js', () => {
           [`'weird' is not an allowed type.\n => TYPES: ${TYPES}`]);
     });
 
-    it('should pass when scope is contains NPM scope', () => {
+    it('should pass when scope contains NPM scope', () => {
       expectValidationResult(
           validateCommitMessage('fix(@angular-devkit/build-angular): something'), true);
     });

--- a/dev-infra/commit-message/validate.ts
+++ b/dev-infra/commit-message/validate.ts
@@ -116,9 +116,10 @@ export function validateCommitMessage(
       return false;
     }
 
-    if (commit.scope && !config.scopes.includes(commit.scope)) {
+    const fullScope = commit.npmScope ? `${commit.npmScope}/${commit.scope}` : commit.scope;
+    if (fullScope && !config.scopes.includes(fullScope)) {
       errors.push(
-          `'${commit.scope}' is not an allowed scope.\n => SCOPES: ${config.scopes.join(', ')}`);
+          `'${fullScope}' is not an allowed scope.\n => SCOPES: ${config.scopes.join(', ')}`);
       return false;
     }
 

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -1871,8 +1871,9 @@ function validateCommitMessage(commitMsg, options = {}) {
             errors.push(`Scopes are required for commits with type '${commit.type}', but no scope was provided.`);
             return false;
         }
-        if (commit.scope && !config.scopes.includes(commit.scope)) {
-            errors.push(`'${commit.scope}' is not an allowed scope.\n => SCOPES: ${config.scopes.join(', ')}`);
+        const fullScope = commit.npmScope ? `${commit.npmScope}/${commit.scope}` : commit.scope;
+        if (fullScope && !config.scopes.includes(fullScope)) {
+            errors.push(`'${fullScope}' is not an allowed scope.\n => SCOPES: ${config.scopes.join(', ')}`);
             return false;
         }
         // Commits with the type of `release` do not require a commit body.


### PR DESCRIPTION


In the CLI and Universal, we use the package name as commit message scope. The recent changes that introduced `conventional-commits-parser` in https://github.com/angular/angular/pull/41286 breaks the parsing of such commit scopes and caused commit validations to fail.

Example: https://app.circleci.com/pipelines/github/angular/angular-cli/14420/workflows/85feb5c9-184f-4088-b924-6b9e6c91f062/jobs/238446/parallel-runs/0/steps/0-102