### PR TITLE
fix(docs-infra): avoid auto-linking generic word `state`

### DIFF
--- a/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.js
+++ b/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.js
@@ -5,6 +5,6 @@
  */
 
 module.exports = function ignoreGenericWords() {
-  const ignoredWords = new Set(['a', 'classes', 'create', 'error', 'group', 'request', 'target', 'value', '_']);
+  const ignoredWords = new Set(['a', 'classes', 'create', 'error', 'group', 'request', 'state', 'target', 'value', '_']);
   return (docs, words, index) => ignoredWords.has(words[index].toLowerCase()) ? [] : docs;
 };


### PR DESCRIPTION
Since `state` is a generic word, this commit adds it to the list of ignored words for auto-linking to avoid incorrectly auto-linking to the [state()][1] animation helper. For example, see `/ngsw/state` in the [ServiceWorker in production][2] guide.

[1]: https://v10.angular.io/api/animations/state
[2]: https://v10.angular.io/guide/service-worker-devops#locating-and-analyzing-debugging-information
