### PR TITLE
test: fix `Function#name` shim used in IE11

### DIFF
--- a/third_party/shims_for_IE.js
+++ b/third_party/shims_for_IE.js
@@ -6,11 +6,7 @@ if (!Object.hasOwnProperty('name')) {
   Object.defineProperty(Function.prototype, 'name', {
     get: function() {
       var matches = this.toString().match(/^\s*function\s*((?![0-9])[a-zA-Z0-9_$]*)\s*\(/);
-      var name = matches && matches.length > 1 ? matches[1] : "";
-      // For better performance only parse once, and then cache the
-      // result through a new accessor for repeated access.
-      Object.defineProperty(this, 'name', {value: name});
-      return name;
+      return matches && matches.length > 1 ? matches[1] : '';
     }
   });
 }


### PR DESCRIPTION
Since IE11 does not support `Function#name`, we use a shim in tests that parses the stringified function to extract the name. Previously, that shim would cache the computed name on the function to speed up future invocations. However, this resulted in incorrect values for functions that "extended" other functions (such as the code generated by TypeScript when downleveling ES2015 classes that extended other classes).

To avoid issues such as #41416 (see also [internal discussion][1]), this commit removes the caching of names. This is not expected to noticeably affect performance, since (a) it is only used in tests, (b) it is only used on browsers that do not natively support `Function#name` (i.e. IE11) and (c) accessing function names is rare and inexpensive compared to other operations that happen during testing.

[1]: https://angular-team.slack.com/archives/CB4UC1932/p1617285258058000
