### PR TITLE
perf(compiler-cli): allow incremental compilation in the presence of redirected source files

### DIFF
--- a/packages/compiler-cli/src/ngtsc/program_driver/src/ts_create_program_driver.ts
+++ b/packages/compiler-cli/src/ngtsc/program_driver/src/ts_create_program_driver.ts
@@ -8,17 +8,9 @@
 
 import * as ts from 'typescript';
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
-
 import {AbsoluteFsPath} from '../../file_system';
 import {copyFileShimData, retagAllTsFiles, ShimReferenceTagger, untagAllTsFiles} from '../../shims';
-import {RequiredDelegations} from '../../util/src/typescript';
+import {RequiredDelegations, toUnredirectedSourceFile} from '../../util/src/typescript';
 
 import {ProgramDriver, UpdateMode} from './api';
 
@@ -114,12 +106,9 @@ class UpdatedProgramHost extends DelegatingCompilerHost {
     } else {
       sf = delegateSf;
     }
-    // TypeScript doesn't allow returning redirect source files. To avoid unforseen errors we
+    // TypeScript doesn't allow returning redirect source files. To avoid unforeseen errors we
     // return the original source file instead of the redirect target.
-    const redirectInfo = (sf as any).redirectInfo;
-    if (redirectInfo !== undefined) {
-      sf = redirectInfo.unredirected;
-    }
+    sf = toUnredirectedSourceFile(sf);
 
     this.shimTagger.tag(sf);
     return sf;

--- a/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
@@ -161,3 +161,23 @@ export type SubsetOfKeys<T, K extends keyof T> = K;
 export type RequiredDelegations<T> = {
   [M in keyof Required<T>]: T[M];
 };
+
+/**
+ * Source files may become redirects to other source files when their package name and version are
+ * identical. TypeScript creates a proxy source file for such source files which has an internal
+ * `redirectInfo` property that refers to the original source file.
+ */
+interface RedirectedSourceFile extends ts.SourceFile {
+  redirectInfo?: {unredirected: ts.SourceFile;};
+}
+
+/**
+ * Obtains the non-redirected source file for `sf`.
+ */
+export function toUnredirectedSourceFile(sf: ts.SourceFile): ts.SourceFile {
+  const redirectInfo = (sf as RedirectedSourceFile).redirectInfo;
+  if (redirectInfo === undefined) {
+    return sf;
+  }
+  return redirectInfo.unredirected;
+}


### PR DESCRIPTION
When multiple occurrences of the same package exist within a single
TypeScript compilation unit, TypeScript deduplicates the source files
by introducing redirected source file proxies. Such proxies are
recreated during an incremental compilation even if the original
declaration file did not change, which caused the compiler not to reuse
any work from the prior compilation.

This commit changes the incremental driver to recognize a redirected
source file and treat them as their unredirected source file.