### PR TITLE
refactor(core): remove deprecated rxjs signature usage in event emitter and make more minifier-friendly

### DIFF
--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -651,6 +651,9 @@
     "name": "_testabilityGetter"
   },
   {
+    "name": "_wrapInTimeout"
+  },
+  {
     "name": "addComponentLogic"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -639,6 +639,9 @@
     "name": "_testabilityGetter"
   },
   {
+    "name": "_wrapInTimeout"
+  },
+  {
     "name": "addComponentLogic"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -927,6 +927,9 @@
     "name": "_testabilityGetter"
   },
   {
+    "name": "_wrapInTimeout"
+  },
+  {
     "name": "absoluteRedirect"
   },
   {


### PR DESCRIPTION
* We had a usage of `Observable.subscribe` that uses the deprecated signature with 3 arguments. These changes switch to the non-deprecated version that passes in an `Observer`.
* Avoids always creating a `complete` callback since it isn't required.
* We were repeating all of the internal callbacks twice: once for sync and once for async. These changes move them out into variables so that they're more minifier-friendly. The savings aren't huge (~100 bytes minified), but it doesn't add any maintenance effort on our end so I decided to add it.