### PR TITLE
feat(router): add `navigationSucceeded` output to `routerLink` directive

### DIFF
--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -385,6 +385,7 @@ export declare class RouterEvent {
 
 export declare class RouterLink implements OnChanges {
     fragment?: string;
+    navigationSucceeded: EventEmitter<boolean>;
     preserveFragment: boolean;
     queryParams?: Params | null;
     queryParamsHandling?: QueryParamsHandling | null;
@@ -418,6 +419,7 @@ export declare class RouterLinkActive implements OnChanges, OnDestroy, AfterCont
 export declare class RouterLinkWithHref implements OnChanges, OnDestroy {
     fragment?: string;
     href: string;
+    navigationSucceeded: EventEmitter<boolean>;
     preserveFragment: boolean;
     queryParams?: Params | null;
     queryParamsHandling?: QueryParamsHandling | null;

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -7,7 +7,7 @@
  */
 
 import {LocationStrategy} from '@angular/common';
-import {Attribute, Directive, ElementRef, HostBinding, HostListener, Input, OnChanges, OnDestroy, Renderer2, SimpleChanges} from '@angular/core';
+import {Attribute, Directive, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnChanges, OnDestroy, Output, Renderer2, SimpleChanges} from '@angular/core';
 import {Subject, Subscription} from 'rxjs';
 
 import {QueryParamsHandling} from '../config';
@@ -180,6 +180,11 @@ export class RouterLink implements OnChanges {
    */
   @Input() relativeTo?: ActivatedRoute|null;
 
+  /**
+   * Emits `true` when navigation succeeded and `false` when navigation failed.
+   */
+  @Output() navigationSucceeded = new EventEmitter<boolean>();
+
   private commands: any[] = [];
   private preserve!: boolean;
 
@@ -225,7 +230,9 @@ export class RouterLink implements OnChanges {
       replaceUrl: attrBoolValue(this.replaceUrl),
       state: this.state,
     };
-    this.router.navigateByUrl(this.urlTree, extras);
+    this.router.navigateByUrl(this.urlTree, extras)
+        .then(
+            () => this.navigationSucceeded.emit(true), () => this.navigationSucceeded.emit(false));
     return true;
   }
 
@@ -320,6 +327,11 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
    */
   @Input() relativeTo?: ActivatedRoute|null;
 
+  /**
+   * Emits `true` when navigation succeeded and `false` when navigation failed.
+   */
+  @Output() navigationSucceeded = new EventEmitter<boolean>();
+
   private commands: any[] = [];
   private subscription: Subscription;
   // TODO(issue/24571): remove '!'.
@@ -387,7 +399,9 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
       replaceUrl: attrBoolValue(this.replaceUrl),
       state: this.state
     };
-    this.router.navigateByUrl(this.urlTree, extras);
+    this.router.navigateByUrl(this.urlTree, extras)
+        .then(
+            () => this.navigationSucceeded.emit(true), () => this.navigationSucceeded.emit(false));
     return false;
   }
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2512,6 +2512,58 @@ describe('Integration', () => {
          const native = fixture.nativeElement.querySelector('area');
          expect(native.getAttribute('href')).toEqual('/home');
        }));
+
+    it('should emit `true` of `navigationSucceeded` output that indicates succeeded navigation',
+       fakeAsync(() => {
+         @Component({
+           selector: 'someRoot',
+           template:
+               `<a routerLink="/home" (navigationSucceeded)="navigationSucceededSpy($event)"></a>`
+         })
+         class RootCmpWithArea {
+           navigationSucceededSpy:
+               (succeeded: boolean) => void = jasmine.createSpy('navigationSucceededFn');
+         }
+
+         TestBed.configureTestingModule({declarations: [RootCmpWithArea]});
+         const router: Router = TestBed.inject(Router);
+
+         const fixture = createRoot(router, RootCmpWithArea);
+
+         router.resetConfig([{path: 'home', component: SimpleCmp}]);
+
+         const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
+         anchor.click();
+         advance(fixture);
+
+         expect(fixture.componentInstance.navigationSucceededSpy).toHaveBeenCalledWith(true);
+       }));
+
+    it('should emit `false` of `navigationSucceeded` output that indicates failed navigation',
+       fakeAsync(() => {
+         @Component({
+           selector: 'someRoot',
+           template:
+               `<a routerLink="/home" (navigationSucceeded)="navigationSucceededSpy($event)"></a>`
+         })
+         class RootCmpWithArea {
+           navigationSucceededSpy:
+               (succeeded: boolean) => void = jasmine.createSpy('navigationSucceededFn');
+         }
+
+         TestBed.configureTestingModule({declarations: [RootCmpWithArea]});
+         const router: Router = TestBed.inject(Router);
+
+         const fixture = createRoot(router, RootCmpWithArea);
+
+         router.resetConfig([{path: 'foo', component: SimpleCmp}]);
+
+         const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
+         anchor.click();
+         advance(fixture);
+
+         expect(fixture.componentInstance.navigationSucceededSpy).toHaveBeenCalledWith(false);
+       }));
   });
 
   describe('redirects', () => {


### PR DESCRIPTION
For now it's not possible to get an event from `routerLink` directive
when navigation succeeded or failed. `navigationSucceeded` output
emits `true` when navigation succeeded and `false` when navigation failed.