### PR TITLE
Circle cache improvements 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -729,7 +729,7 @@ jobs:
           # We temporarily ignore the "engines" because the Angular components repository has
           # minimum dependency on NodeJS v12 and Yarn 1.19.1, but the framework repository uses
           # older versions.
-          command: yarn --ignore-engines --cwd ${COMPONENTS_REPO_TMP_DIR} install --frozen-lockfile --non-interactive  --cache-folder ~/.cache/yarn
+          command: yarn --ignore-engines --cwd ${COMPONENTS_REPO_TMP_DIR} install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
       - save_cache:
           key: *components_repo_unit_tests_cache_key
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,11 +197,6 @@ commands:
             - *cache_key_win_fallback
       # On Windows `~/` is not resolved when using as a CLI value. `../` results in the same path.
       - run: yarn install --frozen-lockfile --non-interactive --cache-folder ../.cache/yarn
-      # Save dependencies to use on subsequent runs.
-      - save_cache:
-          key: *cache_key_win
-          paths:
-            - ~/.cache/yarn
 
   notify_webhook_on_fail:
     description: Notify a webhook about failure
@@ -798,6 +793,11 @@ jobs:
           name: Test all windows CI targets
           command: yarn bazel test --config=ivy --build_tag_filters=-no-windows --test_tag_filters="-no-ivy-aot,-no-windows,-fixme-ivy-aot,-browser:chromium-local" //packages/compiler-cli/... //tools/ts-api-guardian/... //packages/localize/...
           no_output_timeout: 15m
+      # Save dependencies to use on subsequent runs.
+      - save_cache:
+          key: *cache_key_win
+          paths:
+            - ~/.cache/yarn
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,10 @@ var_3: &cache_key v4-angular-node-12-{{ checksum ".bazelversion" }}-{{ checksum 
 # be slower due to its growing size.
 var_4: &cache_key_fallback v4-angular-node-12-{{ checksum ".bazelversion" }}
 
+# Windows needs its own cache key because binaries in node_modules are different.
+var_3_win: &cache_key_win v4-angular-win-node-12-{{ checksum ".bazelversion" }}-{{ checksum "yarn.lock" }}-{{ checksum "WORKSPACE" }}-{{ checksum "packages/bazel/package.bzl" }}-{{ checksum "aio/yarn.lock" }}
+var_4_win: &cache_key_win_fallback v4-angular-win-node-12-{{ checksum ".bazelversion" }}
+
 # Cache key for the `components-repo-unit-tests` job. **Note** when updating the SHA in the
 # cache keys also update the SHA for the "COMPONENTS_REPO_COMMIT" environment variable.
 var_5: &components_repo_unit_tests_cache_key v1-angular-components-09e68db8ed5b1253f2fe38ff954ef0df019fc25a
@@ -187,7 +191,17 @@ commands:
       - run: ./.circleci/windows-env.ps1
       - run: node --version
       - run: yarn --version
-      - run: yarn install --frozen-lockfile --non-interactive
+      - restore_cache:
+          keys:
+            - *cache_key_win
+            - *cache_key_win_fallback
+      # On Windows `~/` is not resolved when using as a CLI value. `../` results in the same path.
+      - run: yarn install --frozen-lockfile --non-interactive --cache-folder ../.cache/yarn
+      # Save dependencies to use on subsequent runs.
+      - save_cache:
+          key: *cache_key_win
+          paths:
+            - ~/.cache/yarn
 
   notify_webhook_on_fail:
     description: Notify a webhook about failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,11 @@ version: 2.1
 # **NOTE 1 **: If you change the cache key prefix, also sync the cache_key_fallback to match.
 # **NOTE 2 **: Keep the static part of the cache key as prefix to enable correct fallbacks.
 # See https://circleci.com/docs/2.0/caching/#restoring-cache for how prefixes work in CircleCI.
-var_3: &cache_key v1-angular-node-12-{{ checksum ".bazelversion" }}-{{ checksum "yarn.lock" }}-{{ checksum "WORKSPACE" }}-{{ checksum "packages/bazel/package.bzl" }}-{{ checksum "aio/yarn.lock" }}
+var_3: &cache_key v4-angular-node-12-{{ checksum ".bazelversion" }}-{{ checksum "yarn.lock" }}-{{ checksum "WORKSPACE" }}-{{ checksum "packages/bazel/package.bzl" }}-{{ checksum "aio/yarn.lock" }}
 # We invalidate the cache if the Bazel version changes because otherwise the `bazelisk` cache
 # folder will contain all previously used versions and ultimately cause the cache restoring to
 # be slower due to its growing size.
-var_4: &cache_key_fallback v1-angular-node-12-{{ checksum ".bazelversion" }}
+var_4: &cache_key_fallback v4-angular-node-12-{{ checksum ".bazelversion" }}
 
 # Cache key for the `components-repo-unit-tests` job. **Note** when updating the SHA in the
 # cache keys also update the SHA for the "COMPONENTS_REPO_COMMIT" environment variable.
@@ -232,10 +232,10 @@ jobs:
             - *cache_key_fallback
       - run:
           name: Running Yarn install
-          command: yarn install --frozen-lockfile --non-interactive
+          command: yarn install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
           # Yarn's requests sometimes take more than 10mins to complete.
           no_output_timeout: 45m
-      - run: yarn --cwd aio install --frozen-lockfile --non-interactive
+      - run: yarn --cwd aio install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
       # Make the bazel directories and add a file to them if they don't exist already so that
       # persist_to_workspace does not fail.
       - run: |
@@ -424,7 +424,7 @@ jobs:
       - custom_attach_workspace
       - init_environment
         # Install
-      - run: yarn --cwd aio install --frozen-lockfile --non-interactive
+      - run: yarn --cwd aio install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
       - run: yarn --cwd aio extract-cli-command-docs
         # Run tools tests
       - run: yarn --cwd aio tools-test
@@ -444,7 +444,7 @@ jobs:
       - init_environment
       - install_chrome_libs
         # Install aio
-      - run: yarn --cwd aio install --frozen-lockfile --non-interactive
+      - run: yarn --cwd aio install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
         # Run examples tests. The "CIRCLE_NODE_INDEX" will be set if "parallelism" is enabled.
         # Since the parallelism is set to "5", there will be five parallel CircleCI containers.
         # with either "0", "1", etc as node index. This can be passed to the "--shard" argument.
@@ -473,7 +473,7 @@ jobs:
       - custom_attach_workspace
       - init_environment
       - install_chrome_libs
-      - run: yarn --cwd aio install --frozen-lockfile --non-interactive
+      - run: yarn --cwd aio install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
       - run:
           name: Wait for preview and run tests
           command: node aio/scripts/test-preview.js $CI_PULL_REQUEST $CI_COMMIT $CI_AIO_MIN_PWA_SCORE
@@ -508,10 +508,9 @@ jobs:
       - save_cache:
           key: *cache_key
           paths:
-            - "node_modules"
-            - "aio/node_modules"
-            - "~/bazel_repository_cache"
-            - "~/.cache/bazelisk"
+            - ~/.cache/yarn
+            - ~/bazel_repository_cache
+            - ~/.cache/bazelisk
 
   # Build the ivy npm packages.
   build-ivy-npm-packages:
@@ -716,7 +715,7 @@ jobs:
           # We temporarily ignore the "engines" because the Angular components repository has
           # minimum dependency on NodeJS v12 and Yarn 1.19.1, but the framework repository uses
           # older versions.
-          command: yarn --ignore-engines --cwd ${COMPONENTS_REPO_TMP_DIR} install --frozen-lockfile --non-interactive
+          command: yarn --ignore-engines --cwd ${COMPONENTS_REPO_TMP_DIR} install --frozen-lockfile --non-interactive  --cache-folder ~/.cache/yarn
       - save_cache:
           key: *components_repo_unit_tests_cache_key
           paths:
@@ -743,7 +742,7 @@ jobs:
       - init_environment
       - install_java
         # Install
-      - run: yarn --cwd packages/zone.js install --frozen-lockfile --non-interactive
+      - run: yarn --cwd packages/zone.js install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
         # Run zone.js tools tests
       - run: yarn --cwd packages/zone.js promisetest
       - run: yarn --cwd packages/zone.js promisefinallytest
@@ -755,7 +754,7 @@ jobs:
       - run: yarn --cwd packages/zone.js jest:nodetest
       - run: yarn --cwd packages/zone.js electrontest
       - run: yarn --cwd packages/zone.js closuretest
-      - run: yarn --cwd packages/zone.js/test/typings install --frozen-lockfile --non-interactive
+      - run: yarn --cwd packages/zone.js/test/typings install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
       - run: yarn --cwd packages/zone.js/test/typings test
 
   # Windows jobs


### PR DESCRIPTION
 **ci: add cache for windows run**
Add CircleCI cache for windows runs


**ci: don't save node_modules directory**
Storing node_modules directory in cache causes a number of issues, such as increase in the laid out node_modules tree and also in some cases break module resolution. This is because modules are not hoisted correctly when running `yarn install`.
    
Example of related failures https://app.circleci.com/pipelines/github/angular/angular/30441/workflows/c1a16135-f5c9-478d-a298-d720c6657d52/jobs/952138
    
A better cache strategy would be to save yarn cache, more information can be found in https://circleci.com/docs/2.0/caching/#yarn-node.