### PR TITLE
fix(bazel): add missing dependency on `tslib`

### DIFF
--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@microsoft/api-extractor": "7.7.11",
     "shelljs": "0.8.2",
-    "tsickle": "^0.38.0"
+    "tsickle": "^0.38.0",
+    "tslib": "^2.1.0"
   },
   "peerDependencies": {
     "@angular/compiler-cli": "0.0.0-PLACEHOLDER",


### PR DESCRIPTION
`@angular/bazel` depends on `tslib` https://unpkg.com/browse/@angular/bazel@11.2.8/src/api-extractor/index.js#L20

Related failure https://github.com/angular/universal/pull/2040
