### PR TITLE
fix(dev-infra): make scopes for `test` and `refactor` commit types optional

### DIFF
--- a/dev-infra/commit-message/config.ts
+++ b/dev-infra/commit-message/config.ts
@@ -92,7 +92,7 @@ export const COMMIT_TYPES: {[key: string]: CommitType} = {
   refactor: {
     name: 'refactor',
     description: 'Refactor without any change in functionality or API (includes style changes)',
-    scope: ScopeRequirement.Required,
+    scope: ScopeRequirement.Optional,
     releaseNotesLevel: ReleaseNotesLevel.Hidden,
   },
   release: {
@@ -104,7 +104,7 @@ export const COMMIT_TYPES: {[key: string]: CommitType} = {
   test: {
     name: 'test',
     description: 'Improvements or corrections made to the project\'s test suite',
-    scope: ScopeRequirement.Required,
+    scope: ScopeRequirement.Optional,
     releaseNotesLevel: ReleaseNotesLevel.Hidden,
   },
 };

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -1716,7 +1716,7 @@ const COMMIT_TYPES = {
     refactor: {
         name: 'refactor',
         description: 'Refactor without any change in functionality or API (includes style changes)',
-        scope: ScopeRequirement.Required,
+        scope: ScopeRequirement.Optional,
         releaseNotesLevel: ReleaseNotesLevel.Hidden,
     },
     release: {
@@ -1728,7 +1728,7 @@ const COMMIT_TYPES = {
     test: {
         name: 'test',
         description: 'Improvements or corrections made to the project\'s test suite',
-        scope: ScopeRequirement.Required,
+        scope: ScopeRequirement.Optional,
         releaseNotesLevel: ReleaseNotesLevel.Hidden,
     },
 };


### PR DESCRIPTION
As the `test` and `refactor` commit types are not used in release notes and there
are solid use cases for having multiple scopes/scopeless uses of these types, they
are made to be optional instead of required on commits.
