### PR TITLE
fix(language-service): use 'any' instead of failing for inline TCBs

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
@@ -16,7 +16,7 @@ import {TypeCheckBlockMetadata, TypeCheckingConfig} from '../api';
 import {DomSchemaChecker} from './dom';
 import {Environment} from './environment';
 import {OutOfBandDiagnosticRecorder} from './oob';
-import {generateTypeCheckBlock} from './type_check_block';
+import {generateTypeCheckBlock, TcbGenericContextBehavior} from './type_check_block';
 
 
 
@@ -43,9 +43,11 @@ export class TypeCheckFile extends Environment {
 
   addTypeCheckBlock(
       ref: Reference<ClassDeclaration<ts.ClassDeclaration>>, meta: TypeCheckBlockMetadata,
-      domSchemaChecker: DomSchemaChecker, oobRecorder: OutOfBandDiagnosticRecorder): void {
+      domSchemaChecker: DomSchemaChecker, oobRecorder: OutOfBandDiagnosticRecorder,
+      genericContextBehavior: TcbGenericContextBehavior): void {
     const fnId = ts.createIdentifier(`_tcb${this.nextTcbId++}`);
-    const fn = generateTypeCheckBlock(this, ref, fnId, meta, domSchemaChecker, oobRecorder);
+    const fn = generateTypeCheckBlock(
+        this, ref, fnId, meta, domSchemaChecker, oobRecorder, genericContextBehavior);
     this.tcbStatements.push(fn);
   }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
@@ -10,9 +10,9 @@ import * as ts from 'typescript';
 
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
 import {TypeCtorMetadata} from '../api';
+import {checkIfGenericTypeBoundsAreContextFree} from './tcb_util';
 
 import {tsCreateTypeQueryForCoercedInput} from './ts_util';
-import {TypeParameterEmitter} from './type_parameter_emitter';
 
 export function generateTypeCtorDeclarationFn(
     node: ClassDeclaration<ts.ClassDeclaration>, meta: TypeCtorMetadata, nodeTypeRef: ts.EntityName,
@@ -194,12 +194,6 @@ export function requiresInlineTypeCtor(
   // The class requires an inline type constructor if it has generic type bounds that can not be
   // emitted into a different context.
   return !checkIfGenericTypeBoundsAreContextFree(node, host);
-}
-
-function checkIfGenericTypeBoundsAreContextFree(
-    node: ClassDeclaration<ts.ClassDeclaration>, reflector: ReflectionHost): boolean {
-  // Generic type parameters are considered context free if they can be emitted into any context.
-  return new TypeParameterEmitter(node.typeParameters, reflector).canEmit();
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -28,7 +28,7 @@ import {DomSchemaChecker} from '../src/dom';
 import {Environment} from '../src/environment';
 import {OutOfBandDiagnosticRecorder} from '../src/oob';
 import {TypeCheckShimGenerator} from '../src/shim';
-import {generateTypeCheckBlock} from '../src/type_check_block';
+import {generateTypeCheckBlock, TcbGenericContextBehavior} from '../src/type_check_block';
 import {TypeCheckFile} from '../src/type_check_file';
 
 export function typescriptLibDts(): TestFile {
@@ -290,13 +290,9 @@ export function tcb(
 
   const env = new TypeCheckFile(fileName, fullConfig, refEmmiter, reflectionHost, host);
 
-  const ref = new Reference(clazz);
-
-  const tcb = generateTypeCheckBlock(
-      env, ref, ts.createIdentifier('Test_TCB'), meta, new NoopSchemaChecker(),
-      new NoopOobRecorder());
-
-  env.addTypeCheckBlock(ref, meta, new NoopSchemaChecker(), new NoopOobRecorder());
+  env.addTypeCheckBlock(
+      new Reference(clazz), meta, new NoopSchemaChecker(), new NoopOobRecorder(),
+      TcbGenericContextBehavior.UseEmitter);
 
   const rendered = env.render(!options.emitSpans /* removeComments */);
   return rendered.replace(/\s+/g, ' ');

--- a/packages/language-service/ivy/test/diagnostic_spec.ts
+++ b/packages/language-service/ivy/test/diagnostic_spec.ts
@@ -276,6 +276,26 @@ describe('getSemanticDiagnostics', () => {
     expect(getTextOfDiagnostic(diag)).toBe('user');
   });
 
+  it('should process a component that would otherwise require an inline TCB', () => {
+    const files = {
+      'app.ts': `
+        import {Component, NgModule} from '@angular/core';
+        import {CommonModule} from '@angular/common';
+
+        interface PrivateInterface {}
+
+        @Component({
+          template: 'Simple template',
+        })
+        export class MyComponent<T extends PrivateInterface> {}
+      `
+    };
+
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    const diags = project.getDiagnosticsForFile('app.ts');
+    expect(diags.length).toBe(0);
+  });
+
   it('logs perf tracing', () => {
     const files = {
       'app.ts': `

--- a/packages/language-service/ivy/testing/src/util.ts
+++ b/packages/language-service/ivy/testing/src/util.ts
@@ -38,7 +38,7 @@ export function isNgSpecificDiagnostic(diag: ts.Diagnostic): boolean {
 }
 
 function getFirstClassDeclaration(declaration: string) {
-  const matches = declaration.match(/(?:export class )(\w+)(?:\s|\{)/);
+  const matches = declaration.match(/(?:export class )(\w+)(?:\s|\{|<)/);
   if (matches === null || matches.length !== 2) {
     throw new Error(`Did not find exactly one exported class in: ${declaration}`);
   }


### PR DESCRIPTION
In environments such as the Language Service where inline type-checking code
is not supported, the compiler would previously produce a diagnostic when a
template would require inlining to check. This happened whenever its
component class had generic parameters with bounds that could not be safely
reproduced in an external TCB. However, this created a bad user experience
for the Language Service, as its features would then not function with such
templates.

Instead, this commit changes the compiler to use the same strategy for
inline TCBs as it does for inline type constructors - falling back to `any`
for generic types when inlining isn't available. This allows the LS to
support such templates with slightly weaker type-checking semantics, which
a test verifies.