### PR TITLE
refactor(language-service): stop tracking `lastKnownProgram` in `CompilerFactory`

### DIFF
--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -266,7 +266,6 @@ export class LanguageService {
         return undefined;
       }
       const result = builder.getCompletionEntrySymbol(entryName);
-      this.compilerFactory.registerLastKnownProgram();
       return result;
     });
   }
@@ -360,8 +359,6 @@ export class LanguageService {
   private withCompilerAndPerfTracing<T>(phase: PerfPhase, p: (compiler: NgCompiler) => T): T {
     const compiler = this.compilerFactory.getOrCreate();
     const result = compiler.perfRecorder.inPhase(phase, () => p(compiler));
-    this.compilerFactory.registerLastKnownProgram();
-
     const logger = this.project.projectService.logger;
     if (logger.hasLevel(ts.server.LogLevel.verbose)) {
       logger.perftrc(`LanguageService#${PerfPhase[phase]}: ${

--- a/packages/language-service/ivy/test/legacy/language_service_spec.ts
+++ b/packages/language-service/ivy/test/legacy/language_service_spec.ts
@@ -207,7 +207,7 @@ describe('language service adapter', () => {
 });
 
 function getLastKnownProgram(ngLS: LanguageService): ts.Program {
-  const program = ngLS['compilerFactory']['lastKnownProgram'];
+  const program = ngLS['compilerFactory']['compiler']?.getCurrentProgram();
   expect(program).toBeDefined();
   return program!;
 }

--- a/packages/language-service/ivy/testing/src/project.ts
+++ b/packages/language-service/ivy/testing/src/project.ts
@@ -158,8 +158,6 @@ export class Project {
       const ngDiagnostics = ngCompiler.getDiagnosticsForFile(sf, OptimizeFor.WholeProgram);
       expect(ngDiagnostics.map(diag => diag.messageText)).toEqual([]);
     }
-
-    this.ngLS.compilerFactory.registerLastKnownProgram();
   }
 
   expectNoTemplateDiagnostics(projectFileName: string, className: string): void {
@@ -172,7 +170,6 @@ export class Project {
     const component = getClassOrError(sf, className);
 
     const diags = this.getTemplateTypeChecker().getDiagnosticsForComponent(component);
-    this.ngLS.compilerFactory.registerLastKnownProgram();
     expect(diags.map(diag => diag.messageText)).toEqual([]);
   }
 


### PR DESCRIPTION
With the work done in #41291, the compiler always tracks the last known
program, so there's no need to track the program in the compiler factory
anymore.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
