### PR TITLE
feat(compiler-cli): mark ability to use partial compilation mode as stable

### DIFF
--- a/aio/content/guide/angular-compiler-options.md
+++ b/aio/content/guide/angular-compiler-options.md
@@ -67,6 +67,15 @@ Modifies how Angular-specific annotations are emitted to improve tree-shaking. N
 When `true`, use [Tsickle](https://github.com/angular/tsickle) to annotate the emitted JavaScript with [JSDoc](https://jsdoc.app/) comments needed by the
 [Closure Compiler](https://github.com/google/closure-compiler). Default is `false`.
 
+### `compilationMode`
+
+Specifies the compilation mode to use. The following modes are available:
+
+- `'full'`: generates fully AOT-compiled code using Ivy instructions.
+- `'partial'`: generates code in a stable, but intermediate form suitable for publication to NPM.
+
+The default value is `'full'`.
+
 ### `disableExpressionLowering`
 
 When `true` (the default), transforms code that is or could be used in an annotation, to allow it to be imported from template factory modules. See [metadata rewriting](guide/aot-compiler#metadata-rewriting) for more information.

--- a/aio/content/guide/angular-compiler-options.md
+++ b/aio/content/guide/angular-compiler-options.md
@@ -71,8 +71,8 @@ When `true`, use [Tsickle](https://github.com/angular/tsickle) to annotate the e
 
 Specifies the compilation mode to use. The following modes are available:
 
-- `'full'`: generates fully AOT-compiled code using Ivy instructions.
-- `'partial'`: generates code in a stable, but intermediate form suitable for publication to NPM.
+- `'full'`: generates fully AOT-compiled code according to the version of Angular that is currently being used.
+- `'partial'`: generates code in a stable, but intermediate form suitable for a published library.
 
 The default value is `'full'`.
 

--- a/goldens/public-api/compiler-cli/compiler_options.d.ts
+++ b/goldens/public-api/compiler-cli/compiler_options.d.ts
@@ -43,3 +43,7 @@ export interface StrictTemplateOptions {
     strictSafeNavigationTypes?: boolean;
     strictTemplates?: boolean;
 }
+
+export interface TargetOptions {
+    compilationMode?: 'full' | 'partial';
+}

--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {BazelAndG3Options, I18nOptions, LegacyNgcOptions, MiscOptions, NgcCompatibilityOptions, StrictTemplateOptions} from './public_options';
+import {BazelAndG3Options, I18nOptions, LegacyNgcOptions, MiscOptions, NgcCompatibilityOptions, StrictTemplateOptions, TargetOptions} from './public_options';
 
 
 /**
@@ -34,22 +34,6 @@ export interface TestOnlyOptions {
    * This is currently not exposed to users as the trace format is still unstable.
    */
   tracePerformance?: string;
-}
-
-/**
- * Options that specify compilation target.
- */
-export interface TargetOptions {
-  /**
-   * Specifies the compilation mode to use. The following modes are available:
-   * - 'full': generates fully AOT compiled code using Ivy instructions.
-   * - 'partial': generates code in a stable, but intermediate form suitable to be published to NPM.
-   *
-   * To become public once the linker is ready.
-   *
-   * @internal
-   */
-  compilationMode?: 'full'|'partial';
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -341,6 +341,22 @@ export interface I18nOptions {
 }
 
 /**
+ * Options that specify compilation target.
+ *
+ * @publicApi
+ */
+export interface TargetOptions {
+  /**
+   * Specifies the compilation mode to use. The following modes are available:
+   * - 'full': generates fully AOT compiled code using Ivy instructions.
+   * - 'partial': generates code in a stable, but intermediate form suitable to be published to NPM.
+   *
+   * The default value is 'full'.
+   */
+  compilationMode?: 'full'|'partial';
+}
+
+/**
  * Miscellaneous options that don't fall into any other category
  *
  * @publicApi

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -349,7 +349,7 @@ export interface TargetOptions {
   /**
    * Specifies the compilation mode to use. The following modes are available:
    * - 'full': generates fully AOT compiled code using Ivy instructions.
-   * - 'partial': generates code in a stable, but intermediate form suitable to be published to NPM.
+   * - 'partial': generates code in a stable, but intermediate form suitable for publication to NPM.
    *
    * The default value is 'full'.
    */


### PR DESCRIPTION
This commit marks the `compilationMode` compiler option as stable, such
that libraries can be compiled in partial compilation mode.

In partial compilation mode, the compiler's output changes from fully
compiled AOT definitions to an intermediate form using partial
declarations. This form is suitable to be published to NPM, which now
allows libraries to be compiled and published using the Ivy compiler.

Please be aware that libraries that have been compiled using this mode
can only be used in Angular 12 applications and up; they cannot be used
when Ivy is disabled (i.e. when using View Engine) or in versions of
Angular prior to 12. The `compilationMode` option has no effect if
`enableIvy: false` is used.

Closes #41496