### PR TITLE
fix(dev-infra): use base ref name rather than sha for the githubTargetBranch

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -3437,7 +3437,7 @@ function loadAndValidatePullRequest(_a, prNumber, ignoreNonFatalFailures) {
                     if (state === 'PENDING' && !ignoreNonFatalFailures) {
                         return [2 /*return*/, PullRequestFailure.pendingCiJobs()];
                     }
-                    githubTargetBranch = prData.baseRefOid;
+                    githubTargetBranch = prData.baseRefName;
                     requiredBaseSha = config.requiredBaseCommits && config.requiredBaseCommits[githubTargetBranch];
                     needsCommitMessageFixup = !!config.commitMessageFixupLabel &&
                         labels.some(function (name) { return matchesPattern(name, config.commitMessageFixupLabel); });
@@ -3489,7 +3489,7 @@ var PR_SCHEMA$2 = {
                 },
             }],
     }),
-    baseRefOid: typedGraphqlify.types.string,
+    baseRefName: typedGraphqlify.types.string,
     title: typedGraphqlify.types.string,
     labels: typedGraphqlify.params({ first: 100 }, {
         nodes: [{

--- a/dev-infra/pr/merge/pull-request.ts
+++ b/dev-infra/pr/merge/pull-request.ts
@@ -92,7 +92,7 @@ export async function loadAndValidatePullRequest(
     return PullRequestFailure.pendingCiJobs();
   }
 
-  const githubTargetBranch = prData.baseRefOid;
+  const githubTargetBranch = prData.baseRefName;
   const requiredBaseSha =
       config.requiredBaseCommits && config.requiredBaseCommits[githubTargetBranch];
   const needsCommitMessageFixup = !!config.commitMessageFixupLabel &&
@@ -145,7 +145,7 @@ const PR_SCHEMA = {
       },
     }],
   }),
-  baseRefOid: graphQLTypes.string,
+  baseRefName: graphQLTypes.string,
   title: graphQLTypes.string,
   labels: params({first: 100}, {
     nodes: [{


### PR DESCRIPTION
After updating to use the v4 graphql api in the merge tooling, the githubTargetBranch
was set to be the sha of the latest commit rather than the branch name of the target
branch.  This caused our tooling to mismatch which branches were actually being targeted
with the effect that if a PR targeted only the patch branch (i.e. labeled `target: patch`
and targeting `11.2.x` in github)it would still expect to merge into both `11.2.x` and
`master`.  This is now corrected to once again use the branch name, restoring to the
previous functionality.
