### PR TITLE
Introduce debugging APIs for structural inspection of an application

### DIFF
--- a/goldens/public-api/core/global_utils.d.ts
+++ b/goldens/public-api/core/global_utils.d.ts
@@ -1,10 +1,22 @@
 export declare function applyChanges(component: {}): void;
 
+export interface ComponentDebugMetadata extends DirectiveDebugMetadata {
+    changeDetection: ChangeDetectionStrategy;
+    encapsulation: ViewEncapsulation;
+}
+
+export interface DirectiveDebugMetadata {
+    inputs: Record<string, string>;
+    outputs: Record<string, string>;
+}
+
 export declare function getComponent<T>(element: Element): T | null;
 
 export declare function getContext<T>(element: Element): T | null;
 
-export declare function getDirectives(element: Element): {}[];
+export declare function getDirectiveMetadata(directiveOrComponentInstance: any): ComponentDebugMetadata | DirectiveDebugMetadata | null;
+
+export declare function getDirectives(node: Node): {}[];
 
 export declare function getHostElement(componentOrDirective: {}): Element;
 

--- a/packages/core/src/render3/global_utils_api.ts
+++ b/packages/core/src/render3/global_utils_api.ts
@@ -16,4 +16,4 @@
  */
 
 export {applyChanges} from './util/change_detection_utils';
-export {getComponent, getContext, getDirectives, getHostElement, getInjector, getListeners, getOwningComponent, getRootComponents, Listener} from './util/discovery_utils';
+export {ComponentDebugMetadata, DirectiveDebugMetadata, getComponent, getContext, getDirectiveMetadata, getDirectives, getHostElement, getInjector, getListeners, getOwningComponent, getRootComponents, Listener} from './util/discovery_utils';

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -13,7 +13,7 @@ import {ɵɵNgOnChangesFeature} from './features/ng_onchanges_feature';
 import {ɵɵProvidersFeature} from './features/providers_feature';
 import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveType, PipeDef} from './interfaces/definition';
 import {ɵɵComponentDeclaration, ɵɵDirectiveDeclaration, ɵɵFactoryDeclaration, ɵɵInjectorDeclaration, ɵɵNgModuleDeclaration, ɵɵPipeDeclaration} from './interfaces/public_definitions';
-import {getComponent, getDirectives, getHostElement, getRenderedText} from './util/discovery_utils';
+import {ComponentDebugMetadata, DirectiveDebugMetadata, getComponent, getDirectiveMetadata, getDirectives, getHostElement, getRenderedText} from './util/discovery_utils';
 
 export {NgModuleType} from '../metadata/ng_module_def';
 export {ComponentFactory, ComponentFactoryResolver, ComponentRef, injectComponentFactoryResolver} from './component_ref';
@@ -176,12 +176,15 @@ export { ɵɵtemplateRefExtractor} from './view_engine_compatibility_prebound';
 // clang-format on
 
 export {
+  ComponentDebugMetadata,
   ComponentDef,
   ComponentTemplate,
   ComponentType,
+  DirectiveDebugMetadata,
   DirectiveDef,
   DirectiveType,
   getComponent,
+  getDirectiveMetadata,
   getDirectives,
   getHostElement,
   getRenderedText,

--- a/packages/core/src/render3/util/discovery_utils.ts
+++ b/packages/core/src/render3/util/discovery_utils.ts
@@ -172,7 +172,7 @@ export function getInjectionTokens(element: Element): any[] {
 }
 
 /**
- * Retrieves directive instances associated with a given DOM element. Does not include
+ * Retrieves directive instances associated with a given DOM node. Does not include
  * component instances.
  *
  * @usageNotes
@@ -184,21 +184,35 @@ export function getInjectionTokens(element: Element): any[] {
  * </my-app>
  * ```
  * Calling `getDirectives` on `<button>` will return an array with an instance of the `MyButton`
- * directive that is associated with the DOM element.
+ * directive that is associated with the DOM node.
  *
  * Calling `getDirectives` on `<my-comp>` will return an empty array.
  *
- * @param element DOM element for which to get the directives.
- * @returns Array of directives associated with the element.
+ * @param node DOM node for which to get the directives.
+ * @returns Array of directives associated with the node.
  *
  * @publicApi
  * @globalApi ng
  */
-export function getDirectives(element: Element): {}[] {
-  const context = loadLContext(element)!;
+export function getDirectives(node: Node): {}[] {
+  // Skip text nodes because we can't have directives associated with them.
+  if (node instanceof Text) {
+    return [];
+  }
 
+  const context = loadLContext(node, false);
+  if (context === null) {
+    return [];
+  }
+
+  const lView = context.lView;
+  const tView = lView[TVIEW];
+  const nodeIndex = context.nodeIndex;
+  if (!tView?.data[nodeIndex]) {
+    return [];
+  }
   if (context.directives === undefined) {
-    context.directives = getDirectivesAtNodeIndex(context.nodeIndex, context.lView, false);
+    context.directives = getDirectivesAtNodeIndex(nodeIndex, lView, false);
   }
 
   // The `directives` in this case are a named array called `LComponentView`. Clone the

--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -9,7 +9,7 @@ import {assertDefined} from '../../util/assert';
 import {global} from '../../util/global';
 import {setProfiler} from '../profiler';
 import {applyChanges} from './change_detection_utils';
-import {getComponent, getContext, getDirectives, getHostElement, getInjector, getListeners, getOwningComponent, getRootComponents} from './discovery_utils';
+import {getComponent, getContext, getDirectiveMetadata, getDirectives, getHostElement, getInjector, getListeners, getOwningComponent, getRootComponents} from './discovery_utils';
 
 
 
@@ -48,6 +48,7 @@ export function publishDefaultGlobalUtils() {
      * removed completely.
      */
     publishGlobalUtil('ɵsetProfiler', setProfiler);
+    publishGlobalUtil('getDirectiveMetadata', getDirectiveMetadata);
     publishGlobalUtil('getComponent', getComponent);
     publishGlobalUtil('getContext', getContext);
     publishGlobalUtil('getListeners', getListeners);

--- a/packages/core/test/acceptance/discover_utils_spec.ts
+++ b/packages/core/test/acceptance/discover_utils_spec.ts
@@ -7,6 +7,9 @@
  */
 import {CommonModule} from '@angular/common';
 import {Component, Directive, HostBinding, InjectionToken, ViewChild} from '@angular/core';
+import {ChangeDetectionStrategy} from '@angular/core/src/change_detection';
+import {EventEmitter} from '@angular/core/src/event_emitter';
+import {Input, Output, ViewEncapsulation} from '@angular/core/src/metadata';
 import {isLView} from '@angular/core/src/render3/interfaces/type_checks';
 import {CONTEXT} from '@angular/core/src/render3/interfaces/view';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -15,13 +18,13 @@ import {expect} from '@angular/core/testing/src/testing_internal';
 import {onlyInIvy} from '@angular/private/testing';
 
 import {getHostElement, markDirty} from '../../src/render3/index';
-import {getComponent, getComponentLView, getContext, getDebugNode, getDirectives, getInjectionTokens, getInjector, getListeners, getLocalRefs, getOwningComponent, getRootComponents, loadLContext} from '../../src/render3/util/discovery_utils';
+import {ComponentDebugMetadata, getComponent, getComponentLView, getContext, getDebugNode, getDirectiveMetadata, getDirectives, getInjectionTokens, getInjector, getListeners, getLocalRefs, getOwningComponent, getRootComponents, loadLContext} from '../../src/render3/util/discovery_utils';
 
 onlyInIvy('Ivy-specific utilities').describe('discovery utils', () => {
   let fixture: ComponentFixture<MyApp>;
   let myApp: MyApp;
   let dirA: DirectiveA[];
-  let childComponent: DirectiveA[];
+  let childComponent: (DirectiveA|Child)[];
   let child: NodeListOf<Element>;
   let span: NodeListOf<Element>;
   let div: NodeListOf<Element>;
@@ -55,6 +58,8 @@ onlyInIvy('Ivy-specific utilities').describe('discovery utils', () => {
 
   @Directive({selector: '[dirA]', exportAs: 'dirA'})
   class DirectiveA {
+    @Input('a') b = 2;
+    @Output('c') d = new EventEmitter();
     constructor() {
       dirA.push(this);
     }
@@ -73,6 +78,8 @@ onlyInIvy('Ivy-specific utilities').describe('discovery utils', () => {
   })
   class MyApp {
     text: string = 'INIT';
+    @Input('a') b = 2;
+    @Output('c') d = new EventEmitter();
     constructor() {
       myApp = this;
     }
@@ -288,6 +295,23 @@ onlyInIvy('Ivy-specific utilities').describe('discovery utils', () => {
       expect(lContext.native as any).toBe(ngContainerComment);
     });
   });
+
+  describe('getDirectiveMetadata', () => {
+    it('should work with components', () => {
+      const metadata = getDirectiveMetadata(myApp);
+      expect(metadata!.inputs).toEqual({a: 'b'});
+      expect(metadata!.outputs).toEqual({c: 'd'});
+      expect((metadata as ComponentDebugMetadata).changeDetection)
+          .toBe(ChangeDetectionStrategy.Default);
+      expect((metadata as ComponentDebugMetadata).encapsulation).toBe(ViewEncapsulation.None);
+    });
+
+    it('should work with directives', () => {
+      const metadata = getDirectiveMetadata(getDirectives(div[0])[0]);
+      expect(metadata!.inputs).toEqual({a: 'b'});
+      expect(metadata!.outputs).toEqual({c: 'd'});
+    });
+  });
 });
 
 onlyInIvy('Ivy-specific utilities').describe('discovery utils deprecated', () => {
@@ -358,6 +382,14 @@ onlyInIvy('Ivy-specific utilities').describe('discovery utils deprecated', () =>
       const elm2 = elements[1];
       const elm2Dirs = getDirectives(elm2);
       expect(elm2Dirs).toContain(fixture.componentInstance.myDir3Instance!);
+    });
+
+    it('should not throw if it cannot find LContext', () => {
+      let result: any;
+      expect(() => {
+        result = getDirectives(document.createElement('div'));
+      }).not.toThrow();
+      expect(result).toEqual([]);
     });
   });
 

--- a/packages/core/test/acceptance/discover_utils_spec.ts
+++ b/packages/core/test/acceptance/discover_utils_spec.ts
@@ -386,9 +386,11 @@ onlyInIvy('Ivy-specific utilities').describe('discovery utils deprecated', () =>
 
     it('should not throw if it cannot find LContext', () => {
       let result: any;
+
       expect(() => {
         result = getDirectives(document.createElement('div'));
       }).not.toThrow();
+
       expect(result).toEqual([]);
     });
   });

--- a/packages/core/test/render3/global_utils_spec.ts
+++ b/packages/core/test/render3/global_utils_spec.ts
@@ -8,7 +8,7 @@
 
 import {setProfiler} from '@angular/core/src/render3/profiler';
 import {applyChanges} from '../../src/render3/util/change_detection_utils';
-import {getComponent, getContext, getDirectives, getHostElement, getInjector, getListeners, getOwningComponent, getRootComponents} from '../../src/render3/util/discovery_utils';
+import {getComponent, getContext, getDirectiveMetadata, getDirectives, getHostElement, getInjector, getListeners, getOwningComponent, getRootComponents} from '../../src/render3/util/discovery_utils';
 import {GLOBAL_PUBLISH_EXPANDO_KEY, GlobalDevModeContainer, publishDefaultGlobalUtils, publishGlobalUtil} from '../../src/render3/util/global_utils';
 import {global} from '../../src/util/global';
 
@@ -60,6 +60,10 @@ describe('global utils', () => {
 
     it('should publish applyChanges', () => {
       assertPublished('applyChanges', applyChanges);
+    });
+
+    it('should publish getDirectiveMetadata', () => {
+      assertPublished('getDirectiveMetadata', getDirectiveMetadata);
     });
 
     it('should publish ɵsetProfiler', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Feature

## What is the new behavior?

Introduces new debugging utilities for structural inspection of an application. The PR expands the `ng` namespace and adds a new `getDirectiveMetadata` method that returns the metadata for a specified directive or component instance.

Additionally, the PR optimizes the `getDirectives` function by:

- Returning an empty array if it's called with a text node
- It invokes `loadLContext` with second argument `false` so it doesn't throw an error

## Does this PR introduce a breaking change?

- [x] Yes, no longer throw an error (when `ng.getDirectives` is called) in case there are no directives on the element 
- [ ] No