### PR TITLE
fix(zone.js): update several flaky cases

### DIFF
--- a/packages/zone.js/test/browser/browser.spec.ts
+++ b/packages/zone.js/test/browser/browser.spec.ts
@@ -395,16 +395,22 @@ describe('Zone', function() {
 
           it('get window onerror should not throw error',
              ifEnvSupports(canPatchOnProperty(window, 'onerror'), function() {
+               const oriOnError = window.onerror;
                const testFn = function() {
-                 let onerror = window.onerror;
-                 window.onerror = function() {};
-                 onerror = window.onerror;
+                 try {
+                   let onerror = window.onerror;
+                   window.onerror = function() {};
+                   onerror = window.onerror;
+                 } finally {
+                   window.onerror = oriOnError;
+                 }
                };
                expect(testFn).not.toThrow();
              }));
 
           it('window.onerror callback signiture should be (message, source, lineno, colno, error)',
              ifEnvSupportsWithDone(canPatchOnProperty(window, 'onerror'), function(done: DoneFn) {
+               const oriOnError = window.onerror;
                let testError = new Error('testError');
                window.onerror = function(
                    message: any, source?: string, lineno?: number, colno?: number, error?: any) {
@@ -413,7 +419,7 @@ describe('Zone', function() {
                    // Edge 14, error will be undefined.
                    expect(error).toBe(testError);
                  }
-                 (window as any).onerror = null;
+                 (window as any).onerror = oriOnError;
                  setTimeout(done);
                  return true;
                };

--- a/packages/zone.js/test/common/zone.spec.ts
+++ b/packages/zone.js/test/common/zone.spec.ts
@@ -334,23 +334,23 @@ describe('Zone', function() {
         Zone.assertZonePatched();
       });
 
-      // xit('should throw error if ZoneAwarePromise has been overwritten', () => {
-      //   class WrongPromise {
-      //     static resolve(value: any) {}
+      it('should throw error if ZoneAwarePromise has been overwritten', () => {
+        class WrongPromise {
+          static resolve(value: any) {}
 
-      //     then() {}
-      //   }
+          then() {}
+        }
 
-      //   const ZoneAwarePromise = global.Promise;
-      //   try {
-      //     global.Promise = WrongPromise;
-      //     expect(Zone.assertZonePatched()).toThrow();
-      //   } finally {
-      //     // restore it.
-      //     global.Promise = ZoneAwarePromise;
-      //   }
-      //   Zone.assertZonePatched();
-      // });
+        const ZoneAwarePromise = global.Promise;
+        try {
+          (global as any).Promise = WrongPromise;
+          expect(() => Zone.assertZonePatched()).toThrow();
+        } finally {
+          // restore it.
+          global.Promise = ZoneAwarePromise;
+        }
+        Zone.assertZonePatched();
+      });
     });
   });
 


### PR DESCRIPTION
Related to #41434

Fix several flaky cases.

1. should restore `window.onerror` in test cases.
2. expect().toThrow() should pass a function.
