### PR TITLE
docs: edit strict-mode.md to remove references for opting in

### DIFF
--- a/aio/content/guide/setup-local.md
+++ b/aio/content/guide/setup-local.md
@@ -85,13 +85,6 @@ The Angular CLI installs the necessary Angular npm packages and other dependenci
 
 The CLI creates a new workspace and a simple Welcome app, ready to run.
 
-<div class="alert is-helpful">
-
-You also have the option to use Angular's strict mode, which can help you write better, more maintainable code.
-For more information, see [Strict mode](/guide/strict-mode).
-
-</div>
-
 {@a serve}
 
 ## Run the application

--- a/aio/content/guide/strict-mode.md
+++ b/aio/content/guide/strict-mode.md
@@ -1,11 +1,11 @@
 # Strict mode
 
-When you create a new workspace or an application you have an option to create them in a strict mode using the `--strict` flag.
+Angular CLI creates all new workspaces and projects with **strict mode** enabled.
 
-Enabling this flag initializes your new workspace or application with a few new settings that improve maintainability, help you catch bugs ahead of time.
-Additionally, applications that use these stricter settings are easier to statically analyze, which can help the `ng update` command refactor code more safely and precisely when you are updating to future versions of Angular.
+Strict mode improves maintainability and helps you catch bugs ahead of time.
+Additionally, strict mode applications are easier to statically analyze and can help the `ng update` command refactor code more safely and precisely when you are updating to future versions of Angular.
 
-Specifically, the `strict` flag does the following:
+Specifically, strict mode does the following:
 
 * Enables [`strict` mode in TypeScript](https://www.typescriptlang.org/tsconfig#strict), as well as other strictness flags recommended by the TypeScript team. Specifically, `forceConsistentCasingInFileNames`, `noImplicitReturns`,  `noFallthroughCasesInSwitch`.
 * Turns on strict Angular compiler flags [`strictTemplates`](guide/angular-compiler-options#stricttemplates), [`strictInjectionParameters`](guide/angular-compiler-options#strictinjectionparameters) and [`strictInputAccessModifiers`](guide/template-typecheck#troubleshooting-template-errors).
@@ -13,11 +13,11 @@ Specifically, the `strict` flag does the following:
 
 You can apply these settings at the workspace and project level.
 
-To create a new workspace and application using the strict mode, run the following command:
+Using the basic `ng new` command to create a new workspace and application automatically uses strict mode, as in the following command:
 
 <code-example language="sh" class="code-shell">
 
-ng new [project-name] --strict
+ng new [project-name]
 
 </code-example>
 

--- a/aio/content/guide/template-typecheck.md
+++ b/aio/content/guide/template-typecheck.md
@@ -41,16 +41,17 @@ The following still have type `any`.
 * The `$event` object.
 * Safe navigation expressions.
 
+
 {@a strict-mode}
 
 ### Strict mode
 
-Angular version 9 maintains the behavior of the `fullTemplateTypeCheck` flag, and introduces a third "strict mode".
+Angular maintains the behavior of the `fullTemplateTypeCheck` flag, and introduces a third "strict mode".
 Strict mode is a superset of full mode, and is accessed by setting the `strictTemplates` flag to true. This flag supersedes the `fullTemplateTypeCheck` flag.
-In strict mode, Angular version 9 adds checks that go beyond the version 8 type-checker.
+In strict mode, Angular uses checks that go beyond the version 8 type-checker.
 Note that strict mode is only available if using Ivy.
 
-In addition to the full mode behavior, Angular version 9:
+In addition to the full mode behavior, Angular does the following:
 
 * Verifies that component/directive bindings are assignable to their `@Input()`s.
 * Obeys TypeScript's `strictNullChecks` flag when validating the above.
@@ -94,7 +95,7 @@ In strict mode, Angular knows that the `user` in the `<span>` has a type of `Use
 
 ## Troubleshooting template errors
 
-When enabling the new strict mode in version 9, you might encounter template errors that didn't arise in either of the previous modes.
+With strict mode, you might encounter template errors that didn't arise in either of the previous modes.
 These errors often represent genuine type mismatches in the templates that were not caught by the previous tooling.
 If this is the case, the error message should make it clear where in the template the problem occurs.
 
@@ -124,10 +125,9 @@ In case of a false positive like these, there are a few options:
 |`strictContextGenerics`|Whether the type parameters of generic components will be inferred correctly (including any generic bounds). If disabled, any type parameters will be `any`.|
 |`strictLiteralTypes`|Whether object and array literals declared in the template will have their type inferred. If disabled, the type of such literals will be `any`.|
 
-
 If you still have issues after troubleshooting with these flags, you can fall back to full mode by disabling `strictTemplates`.
 
-If that doesn't work, an option of last resort is to turn off full mode entirely with `fullTemplateTypeCheck: false`, as we've made a special effort to make Angular version 9 backwards compatible in this case.
+If that doesn't work, an option of last resort is to turn off full mode entirely with `fullTemplateTypeCheck: false`.
 
 A type-checking error that you cannot resolve with any of the recommended methods can be the result of a bug in the template type-checker itself.
 If you get errors that require falling back to basic mode, it is likely to be such a bug.
@@ -135,7 +135,7 @@ If this happens, please [file an issue](https://github.com/angular/angular/issue
 
 ## Inputs and type-checking
 
-In Angular version 9, the template type checker checks whether a binding expression's type is compatible with that of the corresponding directive input.
+The template type checker checks whether a binding expression's type is compatible with that of the corresponding directive input.
 As an example, consider the following component:
 
 ```typescript

--- a/aio/content/guide/typescript-configuration.md
+++ b/aio/content/guide/typescript-configuration.md
@@ -60,10 +60,6 @@ The initial `tsconfig.json` for an Angular workspace typically looks like the fo
 }
 </code-example>
 
-### Strict mode
-
-When you create new workspaces and projects, you have the option to use Angular's strict mode, which can help you write better, more maintainable code.
-For more information, see [Strict mode](/guide/strict-mode).
 
 {@a noImplicitAny}
 

--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -40,11 +40,6 @@ When you create a library project with `ng generate library`, the library projec
 
 </div>
 
-## Strict mode
-
-When you create new workspaces and projects, you have the option to use Angular's strict mode, which can help you write better, more maintainable code.
-For more information, see [Strict mode](/guide/strict-mode).
-
 ## Project configuration options
 
 The following top-level configuration properties are available for each project, under `projects:<project_name>`.
@@ -278,11 +273,11 @@ The following example uses the `ignore` field to exclude certain files in the as
 <code-example language="json">
 
 "assets": [
- { 
+ {
    "glob": "**/*",
    "input": "src/assets/",
    "ignore": ["**/*.svg"],
-   "output": "/assets/" 
+   "output": "/assets/"
  }
 ]
 
@@ -309,7 +304,7 @@ For example, the following object values create and name a bundle that contains 
      }
    ],
    "scripts": [
-     { 
+     {
        "input": "src/external-module/main.js",
        "inject": false,
        "bundleName": "external-module"
@@ -456,7 +451,7 @@ You can supply a value such as the following to apply optimization to one or the
 
 <code-example language="json">
 
-  "optimization": { 
+  "optimization": {
     "scripts": true,
     "styles": {
       "minify": true,

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -790,7 +790,8 @@
                 {
                   "url": "guide/strict-mode",
                   "title": "Strict mode",
-                  "tooltip": "Reference documentation for Angular's strict mode."
+                  "tooltip": "Reference documentation for Angular's strict mode.",
+                  "hidden": true
                 }
               ]
             },


### PR DESCRIPTION
For @aikidave's consideration. 


@aikidave, do we need to rewrite `template-typecheck.md`?