### PR TITLE
refactor(compiler-cli): remove i18n options from `LinkerOptions`

### DIFF
--- a/packages/compiler-cli/linker/src/file_linker/linker_environment.ts
+++ b/packages/compiler-cli/linker/src/file_linker/linker_environment.ts
@@ -29,11 +29,6 @@ export class LinkerEnvironment<TStatement, TExpression> {
       factory: AstFactory<TStatement, TExpression>,
       options: Partial<LinkerOptions>): LinkerEnvironment<TStatement, TExpression> {
     return new LinkerEnvironment(fileSystem, logger, host, factory, {
-      enableI18nLegacyMessageIdFormat: options.enableI18nLegacyMessageIdFormat ??
-          DEFAULT_LINKER_OPTIONS.enableI18nLegacyMessageIdFormat,
-      i18nNormalizeLineEndingsInICUs: options.i18nNormalizeLineEndingsInICUs ??
-          DEFAULT_LINKER_OPTIONS.i18nNormalizeLineEndingsInICUs,
-      i18nUseExternalIds: options.i18nUseExternalIds ?? DEFAULT_LINKER_OPTIONS.i18nUseExternalIds,
       sourceMapping: options.sourceMapping ?? DEFAULT_LINKER_OPTIONS.sourceMapping,
       linkerJitMode: options.linkerJitMode ?? DEFAULT_LINKER_OPTIONS.linkerJitMode,
     });

--- a/packages/compiler-cli/linker/src/file_linker/linker_options.ts
+++ b/packages/compiler-cli/linker/src/file_linker/linker_options.ts
@@ -11,24 +11,6 @@
  */
 export interface LinkerOptions {
   /**
-   * Whether to generate legacy i18n message ids.
-   * The default is `true`.
-   */
-  enableI18nLegacyMessageIdFormat: boolean;
-  /**
-   * Whether to convert all line-endings in ICU expressions to `\n` characters.
-   * The default is `false`.
-   */
-  i18nNormalizeLineEndingsInICUs: boolean;
-
-  /**
-   * Whether translation variable name should contain external message id
-   * (used by Closure Compiler's output of `goog.getMsg` for transition period)
-   * The default is `false`.
-   */
-  i18nUseExternalIds: boolean;
-
-  /**
    * Whether to use source-mapping to compute the original source for external templates.
    * The default is `true`.
    */
@@ -47,9 +29,6 @@ export interface LinkerOptions {
  * The default linker options to use if properties are not provided.
  */
 export const DEFAULT_LINKER_OPTIONS: LinkerOptions = {
-  enableI18nLegacyMessageIdFormat: true,
-  i18nNormalizeLineEndingsInICUs: false,
-  i18nUseExternalIds: false,
   sourceMapping: true,
   linkerJitMode: false,
 };

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
@@ -14,7 +14,6 @@ import {Range} from '../../ast/ast_host';
 import {AstObject, AstValue} from '../../ast/ast_value';
 import {FatalLinkerError} from '../../fatal_linker_error';
 import {GetSourceFileFn} from '../get_source_file';
-import {LinkerEnvironment} from '../linker_environment';
 
 import {toR3DirectiveMeta} from './partial_directive_linker_1';
 import {PartialLinker} from './partial_linker';
@@ -25,14 +24,7 @@ import {extractForwardRef} from './util';
  */
 export class PartialComponentLinkerVersion1<TStatement, TExpression> implements
     PartialLinker<TExpression> {
-  private readonly i18nNormalizeLineEndingsInICUs =
-      this.environment.options.i18nNormalizeLineEndingsInICUs;
-  private readonly enableI18nLegacyMessageIdFormat =
-      this.environment.options.enableI18nLegacyMessageIdFormat;
-  private readonly i18nUseExternalIds = this.environment.options.i18nUseExternalIds;
-
   constructor(
-      private readonly environment: LinkerEnvironment<TStatement, TExpression>,
       private readonly getSourceFile: GetSourceFileFn, private sourceUrl: AbsoluteFsPath,
       private code: string) {}
 
@@ -54,17 +46,15 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression> implements
     const isInline = metaObj.has('isInline') ? metaObj.getBoolean('isInline') : false;
     const templateInfo = this.getTemplateInfo(templateSource, isInline);
 
-    // We always normalize line endings if the template is inline.
-    const i18nNormalizeLineEndingsInICUs = isInline || this.i18nNormalizeLineEndingsInICUs;
-
     const template = parseTemplate(templateInfo.code, templateInfo.sourceUrl, {
       escapedString: templateInfo.isEscaped,
       interpolationConfig: interpolation,
       range: templateInfo.range,
-      enableI18nLegacyMessageIdFormat: this.enableI18nLegacyMessageIdFormat,
+      enableI18nLegacyMessageIdFormat: false,
       preserveWhitespaces:
           metaObj.has('preserveWhitespaces') ? metaObj.getBoolean('preserveWhitespaces') : false,
-      i18nNormalizeLineEndingsInICUs,
+      // We normalize line endings if the template is was inline.
+      i18nNormalizeLineEndingsInICUs: isInline,
       isInline,
     });
     if (template.errors !== null) {
@@ -141,7 +131,7 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression> implements
           ChangeDetectionStrategy.Default,
       animations: metaObj.has('animations') ? metaObj.getOpaque('animations') : null,
       relativeContextFilePath: this.sourceUrl,
-      i18nUseExternalIds: this.i18nUseExternalIds,
+      i18nUseExternalIds: false,
       pipes,
       directives,
     };

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_linker_selector.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_linker_selector.ts
@@ -95,8 +95,7 @@ export class PartialLinkerSelector<TStatement, TExpression> {
     const partialDirectiveLinkerVersion1 = new PartialDirectiveLinkerVersion1(sourceUrl, code);
     const partialClassMetadataLinkerVersion1 = new PartialClassMetadataLinkerVersion1();
     const partialComponentLinkerVersion1 = new PartialComponentLinkerVersion1(
-        environment, createGetSourceFile(sourceUrl, code, environment.sourceFileLoader), sourceUrl,
-        code);
+        createGetSourceFile(sourceUrl, code, environment.sourceFileLoader), sourceUrl, code);
     const partialFactoryLinkerVersion1 = new PartialFactoryLinkerVersion1();
     const partialInjectableLinkerVersion1 = new PartialInjectableLinkerVersion1();
     const partialInjectorLinkerVersion1 = new PartialInjectorLinkerVersion1();

--- a/packages/compiler-cli/test/compliance/linked/linked_compile_spec.ts
+++ b/packages/compiler-cli/test/compliance/linked/linked_compile_spec.ts
@@ -32,8 +32,6 @@ function linkPartials(fileSystem: FileSystem, test: ComplianceTest): CompileResu
   const linkerPlugin = createEs2015LinkerPlugin({
     fileSystem,
     logger,
-    // By default we don't render legacy message ids in compliance tests.
-    enableI18nLegacyMessageIdFormat: false,
     sourceMapping: test.compilerOptions?.sourceMap === true,
     ...test.angularCompilerOptions
   });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/line_ending_normalization/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/line_ending_normalization/TEST_CASES.json
@@ -106,6 +106,9 @@
         "i18nNormalizeLineEndingsInICUs": true,
         "enableI18nLegacyMessageIdFormat": true
       },
+      "compilationModeFilter": [
+        "full compile"
+      ],
       "expectations": [
         {
           "files": [
@@ -130,6 +133,9 @@
         "i18nNormalizeLineEndingsInICUs": false,
         "enableI18nLegacyMessageIdFormat": true
       },
+      "compilationModeFilter": [
+        "full compile"
+      ],
       "expectations": [
         {
           "files": [
@@ -154,6 +160,9 @@
         "i18nNormalizeLineEndingsInICUs": true,
         "enableI18nLegacyMessageIdFormat": true
       },
+      "compilationModeFilter": [
+        "full compile"
+      ],
       "expectations": [
         {
           "extraChecks": [
@@ -172,6 +181,9 @@
         "i18nNormalizeLineEndingsInICUs": false,
         "enableI18nLegacyMessageIdFormat": true
       },
+      "compilationModeFilter": [
+        "full compile"
+      ],
       "expectations": [
         {
           "extraChecks": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/localize_legacy_message_ids/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/localize_legacy_message_ids/TEST_CASES.json
@@ -9,6 +9,9 @@
       "angularCompilerOptions": {
         "enableI18nLegacyMessageIdFormat": true
       },
+      "compilationModeFilter": [
+        "full compile"
+      ],
       "expectations": [
         {
           "extraChecks": [


### PR DESCRIPTION
There were three options being made available to users of the linker:

- ` enableI18nLegacyMessageIdFormat`
-  `i18nNormalizeLineEndingsInICUs`
- ` i18nUseExternalIds`

None of these should actually be configurable at linking time
because partially-linked libraries have tighter restrictions on
what i18n options can be used.

This commit removes those options from the `LinkerOptions` interface.
It was considered to add a check for backwards compatibilty to ensure
that if these options were being passed, and were different to the expected
defaults, we would throw an informative error. But from looking at the
Angular CLI (the only known client of the linker) it has never been setting
these options so they have already always been set to the defaults.

BREAKING CHANGE:

Linked libraries no longer generate legacy i18n message ids. Any downstream
application that provides translations for these messages, will need to
migrate their message ids using the `localize-migrate` command line tool.

Closes #40673
