### PR TITLE
preserve default imports in incremental compilations

### DIFF
--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -14,7 +14,7 @@ import {ComponentDecoratorHandler, DirectiveDecoratorHandler, InjectableDecorato
 import {CycleAnalyzer, CycleHandlingStrategy, ImportGraph} from '../../../src/ngtsc/cycles';
 import {isFatalDiagnosticError} from '../../../src/ngtsc/diagnostics';
 import {absoluteFromSourceFile, LogicalFileSystem, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
-import {AbsoluteModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, NOOP_DEFAULT_IMPORT_RECORDER, PrivateExportAliasingHost, Reexport, ReferenceEmitter} from '../../../src/ngtsc/imports';
+import {AbsoluteModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, PrivateExportAliasingHost, Reexport, ReferenceEmitter} from '../../../src/ngtsc/imports';
 import {SemanticSymbol} from '../../../src/ngtsc/incremental/semantic_graph';
 import {CompoundMetadataReader, CompoundMetadataRegistry, DtsMetadataReader, InjectableClassRegistry, LocalMetadataRegistry, ResourceRegistry} from '../../../src/ngtsc/metadata';
 import {PartialEvaluator} from '../../../src/ngtsc/partial_evaluator';
@@ -107,8 +107,8 @@ export class DecorationAnalyzer {
         /* i18nUseExternalIds */ true, this.bundle.enableI18nLegacyMessageIdFormat,
         /* usePoisonedData */ false,
         /* i18nNormalizeLineEndingsInICUs */ false, this.moduleResolver, this.cycleAnalyzer,
-        CycleHandlingStrategy.UseRemoteScoping, this.refEmitter, NOOP_DEFAULT_IMPORT_RECORDER,
-        NOOP_DEPENDENCY_TRACKER, this.injectableRegistry,
+        CycleHandlingStrategy.UseRemoteScoping, this.refEmitter, NOOP_DEPENDENCY_TRACKER,
+        this.injectableRegistry,
         /* semanticDepGraphUpdater */ null, !!this.compilerOptions.annotateForClosureCompiler,
         NOOP_PERF_RECORDER),
 
@@ -116,7 +116,7 @@ export class DecorationAnalyzer {
     // clang-format off
     new DirectiveDecoratorHandler(
         this.reflectionHost, this.evaluator, this.fullRegistry, this.scopeRegistry,
-        this.fullMetaReader, NOOP_DEFAULT_IMPORT_RECORDER, this.injectableRegistry, this.isCore,
+        this.fullMetaReader, this.injectableRegistry, this.isCore,
         /* semanticDepGraphUpdater */ null,
         !!this.compilerOptions.annotateForClosureCompiler,
         // In ngcc we want to compile undecorated classes with Angular features. As of
@@ -131,18 +131,17 @@ export class DecorationAnalyzer {
     // before injectable factories (so injectable factories can delegate to them)
     new PipeDecoratorHandler(
         this.reflectionHost, this.evaluator, this.metaRegistry, this.scopeRegistry,
-        NOOP_DEFAULT_IMPORT_RECORDER, this.injectableRegistry, this.isCore, NOOP_PERF_RECORDER),
+        this.injectableRegistry, this.isCore, NOOP_PERF_RECORDER),
     new InjectableDecoratorHandler(
-        this.reflectionHost, NOOP_DEFAULT_IMPORT_RECORDER, this.isCore,
+        this.reflectionHost, this.isCore,
         /* strictCtorDeps */ false, this.injectableRegistry, NOOP_PERF_RECORDER,
         /* errorOnDuplicateProv */ false),
     new NgModuleDecoratorHandler(
         this.reflectionHost, this.evaluator, this.fullMetaReader, this.fullRegistry,
         this.scopeRegistry, this.referencesRegistry, this.isCore, /* routeAnalyzer */ null,
         this.refEmitter,
-        /* factoryTracker */ null, NOOP_DEFAULT_IMPORT_RECORDER,
-        !!this.compilerOptions.annotateForClosureCompiler, this.injectableRegistry,
-        NOOP_PERF_RECORDER),
+        /* factoryTracker */ null, !!this.compilerOptions.annotateForClosureCompiler,
+        this.injectableRegistry, NOOP_PERF_RECORDER),
   ];
   compiler = new NgccTraitCompiler(this.handlers, this.reflectionHost);
   migrations: Migration[] = [

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
 import {Cycle, CycleAnalyzer, CycleHandlingStrategy} from '../../cycles';
 import {ErrorCode, FatalDiagnosticError, makeDiagnostic, makeRelatedInformation} from '../../diagnostics';
 import {absoluteFrom, relative} from '../../file_system';
-import {DefaultImportRecorder, ImportedFile, ModuleResolver, Reference, ReferenceEmitter} from '../../imports';
+import {ImportedFile, ModuleResolver, Reference, ReferenceEmitter} from '../../imports';
 import {DependencyTracker} from '../../incremental/api';
 import {extractSemanticTypeParameters, isArrayEqual, isReferenceEqual, SemanticDepGraphUpdater, SemanticReference, SemanticSymbol} from '../../incremental/semantic_graph';
 import {IndexingContext} from '../../indexer';
@@ -205,7 +205,6 @@ export class ComponentDecoratorHandler implements
       private i18nNormalizeLineEndingsInICUs: boolean|undefined,
       private moduleResolver: ModuleResolver, private cycleAnalyzer: CycleAnalyzer,
       private cycleHandlingStrategy: CycleHandlingStrategy, private refEmitter: ReferenceEmitter,
-      private defaultImportRecorder: DefaultImportRecorder,
       private depTracker: DependencyTracker|null,
       private injectableRegistry: InjectableClassRegistry,
       private semanticDepGraphUpdater: SemanticDepGraphUpdater|null,
@@ -326,8 +325,8 @@ export class ComponentDecoratorHandler implements
     // @Component inherits @Directive, so begin by extracting the @Directive metadata and building
     // on it.
     const directiveResult = extractDirectiveMetadata(
-        node, decorator, this.reflector, this.evaluator, this.defaultImportRecorder, this.isCore,
-        flags, this.annotateForClosureCompiler,
+        node, decorator, this.reflector, this.evaluator, this.isCore, flags,
+        this.annotateForClosureCompiler,
         this.elementSchemaRegistry.getDefaultComponentElementName());
     if (directiveResult === undefined) {
       // `extractDirectiveMetadata` returns undefined when the @Directive has `jit: true`. In this
@@ -490,8 +489,7 @@ export class ComponentDecoratorHandler implements
         },
         typeCheckMeta: extractDirectiveTypeCheckMeta(node, inputs, this.reflector),
         classMetadata: extractClassMetadata(
-            node, this.reflector, this.defaultImportRecorder, this.isCore,
-            this.annotateForClosureCompiler),
+            node, this.reflector, this.isCore, this.annotateForClosureCompiler),
         template,
         providersRequiringFactory,
         viewProvidersRequiringFactory,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/metadata.ts
@@ -9,7 +9,6 @@
 import {Expression, FunctionExpr, LiteralArrayExpr, LiteralExpr, literalMap, R3ClassMetadata, ReturnStatement, WrappedNodeExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {DefaultImportRecorder} from '../../imports';
 import {CtorParameter, DeclarationNode, Decorator, ReflectionHost, TypeValueReferenceKind} from '../../reflection';
 
 import {valueReferenceToExpression, wrapFunctionExpressionsInParens} from './util';
@@ -23,8 +22,7 @@ import {valueReferenceToExpression, wrapFunctionExpressionsInParens} from './uti
  * as a `Statement` for inclusion along with the class.
  */
 export function extractClassMetadata(
-    clazz: DeclarationNode, reflection: ReflectionHost,
-    defaultImportRecorder: DefaultImportRecorder, isCore: boolean,
+    clazz: DeclarationNode, reflection: ReflectionHost, isCore: boolean,
     annotateForClosureCompiler?: boolean): R3ClassMetadata|null {
   if (!reflection.isClass(clazz)) {
     return null;
@@ -55,8 +53,7 @@ export function extractClassMetadata(
   let metaCtorParameters: Expression|null = null;
   const classCtorParameters = reflection.getConstructorParameters(clazz);
   if (classCtorParameters !== null) {
-    const ctorParameters = classCtorParameters.map(
-        param => ctorParameterToMetadata(param, defaultImportRecorder, isCore));
+    const ctorParameters = classCtorParameters.map(param => ctorParameterToMetadata(param, isCore));
     metaCtorParameters = new FunctionExpr([], [
       new ReturnStatement(new LiteralArrayExpr(ctorParameters)),
     ]);
@@ -93,13 +90,11 @@ export function extractClassMetadata(
 /**
  * Convert a reflected constructor parameter to metadata.
  */
-function ctorParameterToMetadata(
-    param: CtorParameter, defaultImportRecorder: DefaultImportRecorder,
-    isCore: boolean): Expression {
+function ctorParameterToMetadata(param: CtorParameter, isCore: boolean): Expression {
   // Parameters sometimes have a type that can be referenced. If so, then use it, otherwise
   // its type is undefined.
   const type = param.typeValueReference.kind !== TypeValueReferenceKind.UNAVAILABLE ?
-      valueReferenceToExpression(param.typeValueReference, defaultImportRecorder) :
+      valueReferenceToExpression(param.typeValueReference) :
       new LiteralExpr(undefined);
 
   const mapEntries: {key: string, value: Expression, quoted: false}[] = [

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -10,7 +10,7 @@ import {compileClassMetadata, compileDeclareClassMetadata, compileDeclareInjecto
 import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError, makeDiagnostic, makeRelatedInformation} from '../../diagnostics';
-import {DefaultImportRecorder, Reference, ReferenceEmitter} from '../../imports';
+import {Reference, ReferenceEmitter} from '../../imports';
 import {isArrayEqual, isReferenceEqual, isSymbolEqual, SemanticReference, SemanticSymbol} from '../../incremental/semantic_graph';
 import {InjectableClassRegistry, MetadataReader, MetadataRegistry} from '../../metadata';
 import {PartialEvaluator, ResolvedValue} from '../../partial_evaluator';
@@ -130,9 +130,7 @@ export class NgModuleDecoratorHandler implements
       private scopeRegistry: LocalModuleScopeRegistry,
       private referencesRegistry: ReferencesRegistry, private isCore: boolean,
       private routeAnalyzer: NgModuleRouteAnalyzer|null, private refEmitter: ReferenceEmitter,
-      private factoryTracker: FactoryTracker|null,
-      private defaultImportRecorder: DefaultImportRecorder,
-      private annotateForClosureCompiler: boolean,
+      private factoryTracker: FactoryTracker|null, private annotateForClosureCompiler: boolean,
       private injectableRegistry: InjectableClassRegistry, private perf: PerfRecorder,
       private localeId?: string) {}
 
@@ -350,8 +348,7 @@ export class NgModuleDecoratorHandler implements
       type,
       internalType,
       typeArgumentCount: 0,
-      deps: getValidConstructorDependencies(
-          node, this.reflector, this.defaultImportRecorder, this.isCore),
+      deps: getValidConstructorDependencies(node, this.reflector, this.isCore),
       target: FactoryTarget.NgModule,
     };
 
@@ -371,8 +368,7 @@ export class NgModuleDecoratorHandler implements
             resolveProvidersRequiringFactory(rawProviders, this.reflector, this.evaluator) :
             null,
         classMetadata: extractClassMetadata(
-            node, this.reflector, this.defaultImportRecorder, this.isCore,
-            this.annotateForClosureCompiler),
+            node, this.reflector, this.isCore, this.annotateForClosureCompiler),
         factorySymbolName: node.name.text,
       },
     };

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -10,7 +10,7 @@ import {compileClassMetadata, compileDeclareClassMetadata, compileDeclarePipeFro
 import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
-import {DefaultImportRecorder, Reference} from '../../imports';
+import {Reference} from '../../imports';
 import {SemanticSymbol} from '../../incremental/semantic_graph';
 import {InjectableClassRegistry, MetadataRegistry} from '../../metadata';
 import {PartialEvaluator} from '../../partial_evaluator';
@@ -55,7 +55,6 @@ export class PipeDecoratorHandler implements
   constructor(
       private reflector: ReflectionHost, private evaluator: PartialEvaluator,
       private metaRegistry: MetadataRegistry, private scopeRegistry: LocalModuleScopeRegistry,
-      private defaultImportRecorder: DefaultImportRecorder,
       private injectableRegistry: InjectableClassRegistry, private isCore: boolean,
       private perf: PerfRecorder) {}
 
@@ -131,12 +130,10 @@ export class PipeDecoratorHandler implements
           internalType,
           typeArgumentCount: this.reflector.getGenericArityOfClass(clazz) || 0,
           pipeName,
-          deps: getValidConstructorDependencies(
-              clazz, this.reflector, this.defaultImportRecorder, this.isCore),
+          deps: getValidConstructorDependencies(clazz, this.reflector, this.isCore),
           pure,
         },
-        classMetadata:
-            extractClassMetadata(clazz, this.reflector, this.defaultImportRecorder, this.isCore),
+        classMetadata: extractClassMetadata(clazz, this.reflector, this.isCore),
       },
     };
   }

--- a/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
@@ -13,7 +13,7 @@ import {CycleAnalyzer, CycleHandlingStrategy, ImportGraph} from '../../cycles';
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
 import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
-import {ModuleResolver, NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../imports';
+import {ModuleResolver, ReferenceEmitter} from '../../imports';
 import {CompoundMetadataReader, DtsMetadataReader, InjectableClassRegistry, LocalMetadataRegistry, ResourceRegistry} from '../../metadata';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {NOOP_PERF_RECORDER} from '../../perf';
@@ -81,7 +81,6 @@ function setup(program: ts.Program, options: ts.CompilerOptions, host: ts.Compil
       cycleAnalyzer,
       CycleHandlingStrategy.UseRemoteScoping,
       refEmitter,
-      NOOP_DEFAULT_IMPORT_RECORDER,
       /* depTracker */ null,
       injectableRegistry,
       /* semanticDepGraphUpdater */ null,

--- a/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 
 import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
-import {NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../imports';
+import {ReferenceEmitter} from '../../imports';
 import {DtsMetadataReader, InjectableClassRegistry, LocalMetadataRegistry} from '../../metadata';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {NOOP_PERF_RECORDER} from '../../perf';
@@ -168,8 +168,8 @@ runInEachFileSystem(() => {
         null);
     const injectableRegistry = new InjectableClassRegistry(reflectionHost);
     const handler = new DirectiveDecoratorHandler(
-        reflectionHost, evaluator, scopeRegistry, scopeRegistry, metaReader,
-        NOOP_DEFAULT_IMPORT_RECORDER, injectableRegistry, /*isCore*/ false,
+        reflectionHost, evaluator, scopeRegistry, scopeRegistry, metaReader, injectableRegistry,
+        /*isCore*/ false,
         /*semanticDepGraphUpdater*/ null,
         /*annotateForClosureCompiler*/ false,
         /*detectUndecoratedClassesWithAngularFeatures*/ false, NOOP_PERF_RECORDER);

--- a/packages/compiler-cli/src/ngtsc/annotations/test/injectable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/injectable_spec.ts
@@ -8,7 +8,6 @@
 import {ErrorCode, FatalDiagnosticError, ngErrorCode} from '../../diagnostics';
 import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
-import {NOOP_DEFAULT_IMPORT_RECORDER} from '../../imports';
 import {InjectableClassRegistry} from '../../metadata';
 import {NOOP_PERF_RECORDER} from '../../perf';
 import {isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
@@ -70,7 +69,7 @@ function setupHandler(errorOnDuplicateProv: boolean) {
   const reflectionHost = new TypeScriptReflectionHost(checker);
   const injectableRegistry = new InjectableClassRegistry(reflectionHost);
   const handler = new InjectableDecoratorHandler(
-      reflectionHost, NOOP_DEFAULT_IMPORT_RECORDER, /* isCore */ false,
+      reflectionHost, /* isCore */ false,
       /* strictCtorDeps */ false, injectableRegistry, NOOP_PERF_RECORDER, errorOnDuplicateProv);
   const TestClass = getDeclaration(program, ENTRY_FILE, 'TestClass', isNamedClassDeclaration);
   const ɵprov = reflectionHost.getMembersOfClass(TestClass).find(member => member.name === 'ɵprov');

--- a/packages/compiler-cli/src/ngtsc/annotations/test/metadata_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/metadata_spec.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 
 import {absoluteFrom, getSourceFileOrError} from '../../file_system';
 import {runInEachFileSystem, TestFile} from '../../file_system/testing';
-import {NOOP_DEFAULT_IMPORT_RECORDER, NoopImportRewriter} from '../../imports';
+import {NoopImportRewriter} from '../../imports';
 import {TypeScriptReflectionHost} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';
 import {ImportManager, translateStatement} from '../../translator';
@@ -128,7 +128,7 @@ runInEachFileSystem(() => {
         {target: ts.ScriptTarget.ES2015});
     const host = new TypeScriptReflectionHost(program.getTypeChecker());
     const target = getDeclaration(program, _('/index.ts'), 'Target', ts.isClassDeclaration);
-    const call = extractClassMetadata(target, host, NOOP_DEFAULT_IMPORT_RECORDER, false);
+    const call = extractClassMetadata(target, host, false);
     if (call === null) {
       return '';
     }

--- a/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 
 import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
-import {LocalIdentifierStrategy, NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../imports';
+import {LocalIdentifierStrategy, ReferenceEmitter} from '../../imports';
 import {CompoundMetadataReader, DtsMetadataReader, InjectableClassRegistry, LocalMetadataRegistry} from '../../metadata';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {NOOP_PERF_RECORDER} from '../../perf';
@@ -72,8 +72,7 @@ runInEachFileSystem(() => {
       const handler = new NgModuleDecoratorHandler(
           reflectionHost, evaluator, metaReader, metaRegistry, scopeRegistry, referencesRegistry,
           /* isCore */ false, /* routeAnalyzer */ null, refEmitter, /* factoryTracker */ null,
-          NOOP_DEFAULT_IMPORT_RECORDER, /* annotateForClosureCompiler */ false, injectableRegistry,
-          NOOP_PERF_RECORDER);
+          /* annotateForClosureCompiler */ false, injectableRegistry, NOOP_PERF_RECORDER);
       const TestModule =
           getDeclaration(program, _('/entry.ts'), 'TestModule', isNamedClassDeclaration);
       const detected =

--- a/packages/compiler-cli/src/ngtsc/imports/README.md
+++ b/packages/compiler-cli/src/ngtsc/imports/README.md
@@ -167,8 +167,6 @@ It consists of two mechanisms:
 
 1. A `DefaultImportTracker`, which records information about both default imports encountered in the program as well as usages of those imports added during compilation.
 
-A `DefaultImportRecorder` interface is used to allow for a noop implementation in cases (like ngcc) where this tracking isn't necessary.
-
 2. A TypeScript transformer which processes default import statements and can preserve those which are actually used.
 
 This is accessed via `DefaultImportTracker.importPreservingTransformer`.

--- a/packages/compiler-cli/src/ngtsc/imports/index.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/index.ts
@@ -8,7 +8,7 @@
 
 export {AliasingHost, AliasStrategy, PrivateExportAliasingHost, UnifiedModulesAliasingHost} from './src/alias';
 export {ImportRewriter, NoopImportRewriter, R3SymbolsImportRewriter, validateAndRewriteCoreSymbol} from './src/core';
-export {DefaultImportRecorder, DefaultImportTracker, NOOP_DEFAULT_IMPORT_RECORDER} from './src/default';
+export {DefaultImportTracker} from './src/default';
 export {AbsoluteModuleStrategy, EmittedReference, ImportedFile, ImportFlags, LocalIdentifierStrategy, LogicalProjectStrategy, ReferenceEmitStrategy, ReferenceEmitter, RelativePathStrategy, UnifiedModulesStrategy} from './src/emitter';
 export {Reexport} from './src/reexport';
 export {OwningModule, Reference} from './src/references';

--- a/packages/compiler-cli/src/ngtsc/imports/test/default_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/test/default_spec.ts
@@ -39,12 +39,10 @@ runInEachFileSystem(() => {
             module: ts.ModuleKind.ES2015,
           });
       const fooClause = getDeclaration(program, _('/test.ts'), 'Foo', ts.isImportClause);
-      const fooId = fooClause.name!;
       const fooDecl = fooClause.parent;
 
       const tracker = new DefaultImportTracker();
-      tracker.recordImportedIdentifier(fooId, fooDecl);
-      tracker.recordUsedIdentifier(fooId);
+      tracker.recordUsedImport(fooDecl);
       program.emit(undefined, undefined, undefined, undefined, {
         before: [tracker.importPreservingTransformer()],
       });
@@ -73,8 +71,7 @@ runInEachFileSystem(() => {
       const fooDecl = fooClause.parent;
 
       const tracker = new DefaultImportTracker();
-      tracker.recordImportedIdentifier(fooId, fooDecl);
-      tracker.recordUsedIdentifier(fooId);
+      tracker.recordUsedImport(fooDecl);
       program.emit(undefined, undefined, undefined, undefined, {
         before: [
           addReferenceTransformer(fooId),

--- a/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
@@ -9,10 +9,11 @@
 import {ConstantPool} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {DefaultImportRecorder, ImportRewriter} from '../../imports';
+import {DefaultImportTracker, ImportRewriter} from '../../imports';
+import {getDefaultImportDeclaration} from '../../imports/src/default';
 import {PerfPhase, PerfRecorder} from '../../perf';
 import {Decorator, ReflectionHost} from '../../reflection';
-import {ImportManager, RecordWrappedNodeExprFn, translateExpression, translateStatement, TranslatorOptions} from '../../translator';
+import {ImportManager, RecordWrappedNodeFn, translateExpression, translateStatement, TranslatorOptions} from '../../translator';
 import {visit, VisitListEntryResult, Visitor} from '../../util/src/visitor';
 
 import {CompileResult} from './api';
@@ -34,16 +35,16 @@ interface FileOverviewMeta {
 
 export function ivyTransformFactory(
     compilation: TraitCompiler, reflector: ReflectionHost, importRewriter: ImportRewriter,
-    defaultImportRecorder: DefaultImportRecorder, perf: PerfRecorder, isCore: boolean,
+    defaultImportTracker: DefaultImportTracker, perf: PerfRecorder, isCore: boolean,
     isClosureCompilerEnabled: boolean): ts.TransformerFactory<ts.SourceFile> {
-  const recordWrappedNodeExpr = createRecorderFn(defaultImportRecorder);
+  const recordWrappedNode = createRecorderFn(defaultImportTracker);
   return (context: ts.TransformationContext): ts.Transformer<ts.SourceFile> => {
     return (file: ts.SourceFile): ts.SourceFile => {
       return perf.inPhase(
           PerfPhase.Compile,
           () => transformIvySourceFile(
               compilation, context, reflector, importRewriter, file, isCore,
-              isClosureCompilerEnabled, recordWrappedNodeExpr));
+              isClosureCompilerEnabled, recordWrappedNode));
     };
   };
 }
@@ -81,7 +82,7 @@ class IvyTransformationVisitor extends Visitor {
       private compilation: TraitCompiler,
       private classCompilationMap: Map<ts.ClassDeclaration, CompileResult[]>,
       private reflector: ReflectionHost, private importManager: ImportManager,
-      private recordWrappedNodeExpr: RecordWrappedNodeExprFn<ts.Expression>,
+      private recordWrappedNodeExpr: RecordWrappedNodeFn<ts.Expression>,
       private isClosureCompilerEnabled: boolean, private isCore: boolean) {
     super();
   }
@@ -95,7 +96,7 @@ class IvyTransformationVisitor extends Visitor {
     }
 
     const translateOptions: TranslatorOptions<ts.Expression> = {
-      recordWrappedNodeExpr: this.recordWrappedNodeExpr,
+      recordWrappedNode: this.recordWrappedNodeExpr,
       annotateForClosureCompiler: this.isClosureCompilerEnabled,
     };
 
@@ -252,7 +253,7 @@ function transformIvySourceFile(
     compilation: TraitCompiler, context: ts.TransformationContext, reflector: ReflectionHost,
     importRewriter: ImportRewriter, file: ts.SourceFile, isCore: boolean,
     isClosureCompilerEnabled: boolean,
-    recordWrappedNodeExpr: RecordWrappedNodeExprFn<ts.Expression>): ts.SourceFile {
+    recordWrappedNode: RecordWrappedNodeFn<ts.Expression>): ts.SourceFile {
   const constantPool = new ConstantPool(isClosureCompilerEnabled);
   const importManager = new ImportManager(importRewriter);
 
@@ -274,7 +275,7 @@ function transformIvySourceFile(
   // results obtained at Step 1.
   const transformationVisitor = new IvyTransformationVisitor(
       compilation, compilationVisitor.classCompilationMap, reflector, importManager,
-      recordWrappedNodeExpr, isClosureCompilerEnabled, isCore);
+      recordWrappedNode, isClosureCompilerEnabled, isCore);
   let sf = visit(file, transformationVisitor, context);
 
   // Generate the constant statements first, as they may involve adding additional imports
@@ -282,7 +283,7 @@ function transformIvySourceFile(
   const downlevelTranslatedCode = getLocalizeCompileTarget(context) < ts.ScriptTarget.ES2015;
   const constants =
       constantPool.statements.map(stmt => translateStatement(stmt, importManager, {
-                                    recordWrappedNodeExpr,
+                                    recordWrappedNode,
                                     downlevelTaggedTemplates: downlevelTranslatedCode,
                                     downlevelVariableDeclarations: downlevelTranslatedCode,
                                     annotateForClosureCompiler: isClosureCompilerEnabled,
@@ -370,11 +371,12 @@ function isFromAngularCore(decorator: Decorator): boolean {
   return decorator.import !== null && decorator.import.from === '@angular/core';
 }
 
-function createRecorderFn(defaultImportRecorder: DefaultImportRecorder):
-    RecordWrappedNodeExprFn<ts.Expression> {
-  return expr => {
-    if (ts.isIdentifier(expr)) {
-      defaultImportRecorder.recordUsedIdentifier(expr);
+function createRecorderFn(defaultImportTracker: DefaultImportTracker):
+    RecordWrappedNodeFn<ts.Expression> {
+  return node => {
+    const importDecl = getDefaultImportDeclaration(node);
+    if (importDecl !== null) {
+      defaultImportTracker.recordUsedImport(importDecl);
     }
   };
 }

--- a/packages/compiler-cli/src/ngtsc/translator/index.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/index.ts
@@ -10,7 +10,7 @@ export {AstFactory, BinaryOperator, LeadingComment, ObjectLiteralProperty, Sourc
 export {ImportGenerator, NamedImport} from './src/api/import_generator';
 export {Context} from './src/context';
 export {Import, ImportManager} from './src/import_manager';
-export {ExpressionTranslatorVisitor, RecordWrappedNodeExprFn, TranslatorOptions} from './src/translator';
+export {ExpressionTranslatorVisitor, RecordWrappedNodeFn, TranslatorOptions} from './src/translator';
 export {translateType} from './src/type_translator';
 export {attachComments, createTemplateMiddle, createTemplateTail, TypeScriptAstFactory} from './src/typescript_ast_factory';
 export {translateExpression, translateStatement} from './src/typescript_translator';

--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -37,12 +37,12 @@ const BINARY_OPERATORS = new Map<o.BinaryOperator, BinaryOperator>([
   [o.BinaryOperator.NullishCoalesce, '??'],
 ]);
 
-export type RecordWrappedNodeExprFn<TExpression> = (expr: TExpression) => void;
+export type RecordWrappedNodeFn<TExpression> = (node: o.WrappedNodeExpr<TExpression>) => void;
 
 export interface TranslatorOptions<TExpression> {
   downlevelTaggedTemplates?: boolean;
   downlevelVariableDeclarations?: boolean;
-  recordWrappedNodeExpr?: RecordWrappedNodeExprFn<TExpression>;
+  recordWrappedNode?: RecordWrappedNodeFn<TExpression>;
   annotateForClosureCompiler?: boolean;
 }
 
@@ -50,14 +50,14 @@ export class ExpressionTranslatorVisitor<TStatement, TExpression> implements o.E
                                                                              o.StatementVisitor {
   private downlevelTaggedTemplates: boolean;
   private downlevelVariableDeclarations: boolean;
-  private recordWrappedNodeExpr: RecordWrappedNodeExprFn<TExpression>;
+  private recordWrappedNode: RecordWrappedNodeFn<TExpression>;
 
   constructor(
       private factory: AstFactory<TStatement, TExpression>,
       private imports: ImportGenerator<TExpression>, options: TranslatorOptions<TExpression>) {
     this.downlevelTaggedTemplates = options.downlevelTaggedTemplates === true;
     this.downlevelVariableDeclarations = options.downlevelVariableDeclarations === true;
-    this.recordWrappedNodeExpr = options.recordWrappedNodeExpr || (() => {});
+    this.recordWrappedNode = options.recordWrappedNode || (() => {});
   }
 
   visitDeclareVarStmt(stmt: o.DeclareVarStmt, context: Context): TStatement {
@@ -382,7 +382,7 @@ export class ExpressionTranslatorVisitor<TStatement, TExpression> implements o.E
   }
 
   visitWrappedNodeExpr(ast: o.WrappedNodeExpr<any>, _context: Context): any {
-    this.recordWrappedNodeExpr(ast.node);
+    this.recordWrappedNode(ast);
     return ast.node;
   }
 

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -53,7 +53,7 @@ export class NgtscTestEnvironment {
 
     env.write(absoluteFrom('/tsconfig-base.json'), `{
       "compilerOptions": {
-        "emitDecoratorMetadata": true,
+        "emitDecoratorMetadata": false,
         "experimentalDecorators": true,
         "skipLibCheck": true,
         "noImplicitAny": true,

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -4648,7 +4648,7 @@ function allTests(os: string) {
 
       env.driveMain();
       const jsContents = trim(env.getContents('test.js'));
-      expect(jsContents).toContain(`import { KeyCodes } from './keycodes';`);
+      expect(jsContents).toContain(`import * as i1 from "./keycodes";`);
       expect(jsContents).toMatch(setClassMetadataRegExp('type: i1.KeyCodes'));
     });
 


### PR DESCRIPTION
See individual commits. The second commit is sufficient to fix the bug, but it has been completely refactored in the third commit as there was a conceptual mismatch in how this used to work.