### PR TITLE
docs: ToH hero detail route id null

### DIFF
--- a/aio/content/examples/toh-pt5/src/app/hero-detail/hero-detail.component.ts
+++ b/aio/content/examples/toh-pt5/src/app/hero-detail/hero-detail.component.ts
@@ -33,7 +33,7 @@ export class HeroDetailComponent implements OnInit {
   }
 
   getHero(): void {
-    const id = +this.route.snapshot.paramMap.get('id');
+    const id = Number(this.route.snapshot.paramMap.get('id'));
     this.heroService.getHero(id)
       .subscribe(hero => this.hero = hero);
   }

--- a/aio/content/tutorial/toh-pt5.md
+++ b/aio/content/tutorial/toh-pt5.md
@@ -406,7 +406,7 @@ The `paramMap` is a dictionary of route parameter values extracted from the URL.
 The `"id"` key returns the `id` of the hero to fetch.
 
 Route parameters are always strings.
-The JavaScript (+) operator converts the string to a number,
+The JavaScript `Number` function converts the string to a number,
 which is what a hero `id` should be.
 
 The browser refreshes and the application crashes with a compiler error.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

When going through the tutorial with stricter type checking enforced, the (+) operator causes an unexpected error. The issue is that `this.route.snapshot.paramMap.get` could return null, as signified by its type `string | null`. To fix this, the `Number` function seems appropriate.

Issue Number: N/A


## What is the new behavior?

No unexpected error when going through the tutorial with stricter type checking enforced.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

N/A