### PR TITLE
refactor: update `$schema` and `id` keywords

### DIFF
--- a/packages/elements/schematics/ng-add/schema.json
+++ b/packages/elements/schematics/ng-add/schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsAngularElementsNgAdd",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "SchematicsAngularElementsNgAdd",
   "title": "Angular Elements Ng Add Schema",
   "type": "object",
   "properties": {

--- a/packages/localize/schematics/ng-add/schema.json
+++ b/packages/localize/schematics/ng-add/schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsAngularLocalizeNgAdd",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "SchematicsAngularLocalizeNgAdd",
   "title": "Angular Localize Ng Add Schema",
   "type": "object",
   "properties": {


### PR DESCRIPTION
In Angular CLI version 12, JSON Schema `draft-04` will no longer be supported. Therefore `id` will need to be updated to `$id`.

- We replace id with $id, this no longer valid in draft-07.
- Replace all $schemas to http://json-schema.org/draft-07/schema, this is needed to "pin" the schema to draft-07.

More information about this draft can be found https://json-schema.org/draft-07/json-schema-release-notes.html

Note: This change is backwards compatible.