### PR TITLE
Fix AsyncPipe types for RxJS 6 and 7

### DIFF
--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -3,9 +3,9 @@ export declare const APP_BASE_HREF: InjectionToken<string>;
 export declare class AsyncPipe implements OnDestroy, PipeTransform {
     constructor(_ref: ChangeDetectorRef);
     ngOnDestroy(): void;
-    transform<T>(obj: Subscribable<T> | Promise<T>): T | null;
+    transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T>): T | null;
     transform<T>(obj: null | undefined): null;
-    transform<T>(obj: Subscribable<T> | Promise<T> | null | undefined): T | null;
+    transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T> | null | undefined): T | null;
 }
 
 export declare class CommonModule {

--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -7,7 +7,7 @@
  */
 
 import {ChangeDetectorRef, EventEmitter, OnDestroy, Pipe, PipeTransform, ɵisPromise, ɵisSubscribable} from '@angular/core';
-import {Subscribable, Unsubscribable} from 'rxjs';
+import {Observable, Subscribable, Unsubscribable} from 'rxjs';
 
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
@@ -95,10 +95,14 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
     }
   }
 
-  transform<T>(obj: Subscribable<T>|Promise<T>): T|null;
+  // NOTE(@benlesh): Because Observable has deprecated a few call patterns for `subscribe`,
+  // TypeScript has a hard time matching Observable to Subscribable, for more information
+  // see https://github.com/microsoft/TypeScript/issues/43643
+
+  transform<T>(obj: Observable<T>|Subscribable<T>|Promise<T>): T|null;
   transform<T>(obj: null|undefined): null;
-  transform<T>(obj: Subscribable<T>|Promise<T>|null|undefined): T|null;
-  transform<T>(obj: Subscribable<T>|Promise<T>|null|undefined): T|null {
+  transform<T>(obj: Observable<T>|Subscribable<T>|Promise<T>|null|undefined): T|null;
+  transform<T>(obj: Observable<T>|Subscribable<T>|Promise<T>|null|undefined): T|null {
     if (!this._obj) {
       if (obj) {
         this._subscribe(obj);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~ this is a non-breaking change and adding a test would require adding a development dependency to this project of `rxjs@next`, which seems like overkill. However this will get exercised extremely well in `google3`.
- [x] ~~Docs have been added / updated (for bug fixes / features)~~ unnecessary


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe:

This resolves an issue reported to me by @leggechr and escalated to @alxhub. The issue is discussed here as well: https://github.com/microsoft/TypeScript/issues/43643




## What is the current behavior?
Currently, when upgrading to RxJS 7, in many cases Angular templates are unable to infer the proper value type from RxJS observables. This is because of the TypeScript issue/quirk pointed out above.


## What is the new behavior?
The value types will be inferred properly in the Angular template.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This is affecting targets within `google3` and I recommend you work with @leggechr and escalate this as a Googler issue. 
