### PR TITLE
build(docs-infra): add correct types to tuples

### DIFF
--- a/aio/tests/deployment/unit/test.js
+++ b/aio/tests/deployment/unit/test.js
@@ -18,4 +18,8 @@ register({project: join(__dirname, 'tsconfig.json')});
 
 const runner = new Jasmine({projectBaseDir: __dirname});
 runner.loadConfig({spec_files: ['**/*.spec.ts']});
-runner.execute();
+runner.execute().catch((error) => {
+  // Something broke so non-zero exit to prevent the process from succeeding.
+  console.error(error);
+  process.exit(1);
+});

--- a/aio/tools/examples/test.js
+++ b/aio/tools/examples/test.js
@@ -14,4 +14,8 @@
 const Jasmine = require('jasmine');
 const jasmine = new Jasmine({ projectBaseDir: __dirname });
 jasmine.loadConfig({ spec_files: ['*.spec.js'] });
-jasmine.execute();
+jasmine.execute().catch((error) => {
+  // Something broke so non-zero exit to prevent the process from succeeding.
+  console.error(error);
+  process.exit(1);
+});

--- a/aio/tools/firebase-test-utils/FirebaseGlob.ts
+++ b/aio/tools/firebase-test-utils/FirebaseGlob.ts
@@ -60,7 +60,7 @@ export class FirebaseGlob {
 
     const result: { [key: string]: string } = {};
     const names = this.regex.xregexp.captureNames || [];
-    names.forEach(name => result[name] = (match[name]));
+    names.forEach(name => result[name] = match.groups![name]);
     return result;
   }
 }

--- a/aio/tools/firebase-test-utils/FirebaseRedirect.ts
+++ b/aio/tools/firebase-test-utils/FirebaseRedirect.ts
@@ -12,8 +12,9 @@ export class FirebaseRedirect {
       return undefined;
     }
 
-    const paramReplacers = Object.keys(this.glob.namedParams).map(name => [ XRegExp(`:${name}`, 'g'), match[name] ]);
-    const restReplacers = Object.keys(this.glob.restParams).map(name => [ XRegExp(`:${name}\\*`, 'g'), match[name] ]);
+    XRegExp.uninstall('namespacing');
+    const paramReplacers = Object.keys(this.glob.namedParams).map<[RegExp, string]>(name => [ XRegExp(`:${name}`, 'g'), match[name] ]);
+    const restReplacers = Object.keys(this.glob.restParams).map<[RegExp, string]>(name => [ XRegExp(`:${name}\\*`, 'g'), match[name] ]);
     return XRegExp.replaceEach(this.destination, [...paramReplacers, ...restReplacers]);
   }
 }

--- a/aio/tools/firebase-test-utils/FirebaseRedirect.ts
+++ b/aio/tools/firebase-test-utils/FirebaseRedirect.ts
@@ -12,7 +12,6 @@ export class FirebaseRedirect {
       return undefined;
     }
 
-    XRegExp.uninstall('namespacing');
     const paramReplacers = Object.keys(this.glob.namedParams).map<[RegExp, string]>(name => [ XRegExp(`:${name}`, 'g'), match[name] ]);
     const restReplacers = Object.keys(this.glob.restParams).map<[RegExp, string]>(name => [ XRegExp(`:${name}\\*`, 'g'), match[name] ]);
     return XRegExp.replaceEach(this.destination, [...paramReplacers, ...restReplacers]);

--- a/aio/tools/firebase-test-utils/test.js
+++ b/aio/tools/firebase-test-utils/test.js
@@ -18,4 +18,8 @@ register({project: join(__dirname, 'tsconfig.json')});
 
 const runner = new Jasmine({projectBaseDir: __dirname});
 runner.loadConfig({spec_files: ['**/*.spec.ts']});
-runner.execute();
+runner.execute().catch((error) => {
+  // Something broke so non-zero exit to prevent the process from succeeding.
+  console.error(error);
+  process.exit(1);
+});

--- a/aio/tools/transforms/test.js
+++ b/aio/tools/transforms/test.js
@@ -14,4 +14,8 @@
 const Jasmine = require('jasmine');
 const jasmine = new Jasmine({ projectBaseDir: __dirname });
 jasmine.loadConfig({ random: true, spec_files: ['**/*.spec.js'] });
-jasmine.execute();
+jasmine.execute().catch((error) => {
+  // Something broke so non-zero exit to prevent the process from succeeding.
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
This is to fix the below error:
```
tools/firebase-test-utils/FirebaseRedirect.ts:17:50 - error TS2345: Argument of type '(string | RegExp)[][]' is not assignable to parameter of type 'ReplacementDetail[]'.
  Type '(string | RegExp)[]' is missing the following properties from type 'ReplacementDetail': 0, 1

17     return XRegExp.replaceEach(this.destination, [...paramReplacers, ...restReplacers]);
```

https://app.circleci.com/pipelines/github/angular/angular/31076/workflows/5fd3851e-ae9e-4d77-b0ef-366ba38a9088/jobs/961795
