### PR TITLE
docs: add instructions for opting into latest Language Service

### DIFF
--- a/aio/content/guide/language-service.md
+++ b/aio/content/guide/language-service.md
@@ -4,6 +4,20 @@ The Angular Language Service provides code editors with a way to get completions
 hints, and navigation inside Angular templates.
 It works with external templates in separate HTML files, and also with in-line templates.
 
+## Configuring compiler options for the Angular Language Service
+
+To enable the latest Language Service features, set the `strictTemplates` option in `tsconfig.json` by setting `strictTemplates` to `true,` as shown in the following example:
+
+<code-example language="json">
+
+  "angularCompilerOptions": {
+    "strictTemplates": true
+  }
+
+</code-example>
+
+For more information, see the [Angular compiler options](guide/angular-compiler-options) guide.
+
 ## Features
 
 Your editor autodetects that you are opening an Angular file.


### PR DESCRIPTION
In light of https://github.com/angular/vscode-ng-language-service/pull/1279 we're adding info on using Ivy LS.