### PR TITLE
refactor(dev-infra): set `version` as an attribute of ReleaseAction

### DIFF
--- a/dev-infra/release/publish/index.ts
+++ b/dev-infra/release/publish/index.ts
@@ -99,6 +99,7 @@ export class ReleaseTool {
       if (await actionType.isActive(activeTrains)) {
         const action: ReleaseAction =
             new actionType(activeTrains, this._git, this._config, this._projectRoot);
+        await action.setup();
         choices.push({name: await action.getDescription(), value: action});
       }
     }

--- a/dev-infra/release/publish/test/move-next-into-feature-freeze.spec.ts
+++ b/dev-infra/release/publish/test/move-next-into-feature-freeze.spec.ts
@@ -92,6 +92,7 @@ describe('move next into feature-freeze action', () => {
     fork.expectBranchRequest(expectedStagingForkBranch, null)
         .expectBranchRequest(expectedNextUpdateBranch, null);
 
+    await instance.setup();
     await instance.perform();
 
     expect(gitClient.pushed.length).toBe(3);

--- a/dev-infra/release/publish/test/test-utils.ts
+++ b/dev-infra/release/publish/test/test-utils.ts
@@ -148,6 +148,7 @@ export async function expectStagingAndPublishWithoutCherryPick(
   // so that the PR can be created properly without collisions.
   fork.expectBranchRequest(expectedStagingForkBranch, null);
 
+  await action.instance.setup();
   await action.instance.perform();
 
   expect(gitClient.pushed.length).toBe(1);
@@ -177,6 +178,7 @@ export async function expectStagingAndPublishWithoutCherryPick(
 export async function expectStagingAndPublishWithCherryPick(
     action: TestReleaseAction, expectedBranch: string, expectedVersion: string,
     expectedNpmDistTag: string) {
+  action.instance.version = new semver.SemVer(expectedVersion);
   const {repo, fork, gitClient, releaseConfig} = action;
   const expectedStagingForkBranch = `release-stage-${expectedVersion}`;
   const expectedCherryPickForkBranch = `changelog-cherry-pick-${expectedVersion}`;
@@ -203,6 +205,7 @@ export async function expectStagingAndPublishWithCherryPick(
   fork.expectBranchRequest(expectedStagingForkBranch, null)
       .expectBranchRequest(expectedCherryPickForkBranch, null);
 
+  await action.instance.setup();
   await action.instance.perform();
 
   expect(gitClient.pushed.length).toBe(2);


### PR DESCRIPTION
Creates a `version` attribute on ReleaseAction.  This is being done in preparation for integrating the common `ReleaseNotes` generation system.