### PR TITLE
fix(compiler-cli): do not error with prepocessing if component has no inline styles

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -302,6 +302,8 @@ export class ComponentDecoratorHandler implements
                              this.preanalyzeStylesCache.set(node, styles);
                            });
       }
+    } else {
+      this.preanalyzeStylesCache.set(node, null);
     }
 
     // Wait for both the template and all styleUrl resources to resolve.


### PR DESCRIPTION
The asynchronous preprocessing check was not accounting for components that did not have any inline styles. In that case, the cache did not have an entry which then allowed the asynchronous check to run and fail the compilation. The caching during the asynchronous analysis phase now handles components without inline styles.
