### PR TITLE
fix(dev-infra): only create authenticated github instance once in yargs

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -805,7 +805,12 @@ function addGithubTokenOption(yargs) {
                 error(yellow("You can generate a token here: " + GITHUB_TOKEN_GENERATE_URL));
                 process.exit(1);
             }
-            GitClient.authenticateWithToken(githubToken);
+            try {
+                GitClient.getAuthenticatedInstance();
+            }
+            catch (_a) {
+                GitClient.authenticateWithToken(githubToken);
+            }
             return githubToken;
         },
     })

--- a/dev-infra/utils/git/github-yargs.ts
+++ b/dev-infra/utils/git/github-yargs.ts
@@ -32,7 +32,11 @@ export function addGithubTokenOption(yargs: Argv): ArgvWithGithubToken {
             error(yellow(`You can generate a token here: ${GITHUB_TOKEN_GENERATE_URL}`));
             process.exit(1);
           }
-          GitClient.authenticateWithToken(githubToken);
+          try {
+            GitClient.getAuthenticatedInstance();
+          } catch {
+            GitClient.authenticateWithToken(githubToken);
+          }
           return githubToken;
         },
       })


### PR DESCRIPTION
Fix github token option for yargs to only create an authenticated token one time.