### PR TITLE
fix(platform-browser): update started state on reset

### DIFF
--- a/goldens/public-api/animations/browser/testing/testing.d.ts
+++ b/goldens/public-api/animations/browser/testing/testing.d.ts
@@ -31,4 +31,5 @@ export declare class MockAnimationPlayer extends NoopAnimationPlayer {
     finish(): void;
     hasStarted(): boolean;
     play(): void;
+    reset(): void;
 }

--- a/packages/animations/browser/src/render/css_keyframes/css_keyframes_player.ts
+++ b/packages/animations/browser/src/render/css_keyframes/css_keyframes_player.ts
@@ -15,6 +15,7 @@ const DEFAULT_FILL_MODE = 'forwards';
 const DEFAULT_EASING = 'linear';
 
 export const enum AnimatorControlState {
+  RESET = 0,
   INITIALIZED = 1,
   STARTED = 2,
   FINISHED = 3,
@@ -26,7 +27,6 @@ export class CssKeyframesPlayer implements AnimationPlayer {
   private _onStartFns: Function[] = [];
   private _onDestroyFns: Function[] = [];
 
-  private _started = false;
   // TODO(issue/24571): remove '!'.
   private _styler!: ElementAnimationStyleHandler;
 
@@ -139,6 +139,7 @@ export class CssKeyframesPlayer implements AnimationPlayer {
     this.play();
   }
   reset(): void {
+    this._state = AnimatorControlState.RESET;
     this._styler.destroy();
     this._buildStyler();
     this._styler.apply();

--- a/packages/animations/browser/testing/src/mock_animation_driver.ts
+++ b/packages/animations/browser/testing/src/mock_animation_driver.ts
@@ -83,6 +83,11 @@ export class MockAnimationPlayer extends NoopAnimationPlayer {
     this._onInitFns = [];
   }
 
+  reset() {
+    super.reset();
+    this.__started = false;
+  }
+
   finish(): void {
     super.finish();
     this.__finished = true;

--- a/packages/animations/src/players/animation_player.ts
+++ b/packages/animations/src/players/animation_player.ts
@@ -184,7 +184,9 @@ export class NoopAnimationPlayer implements AnimationPlayer {
       this._onDestroyFns = [];
     }
   }
-  reset(): void {}
+  reset(): void {
+    this._started = false;
+  }
   setPosition(position: number): void {
     this._position = this.totalTime ? position * this.totalTime : 1;
   }

--- a/packages/platform-browser/animations/src/animation_builder.ts
+++ b/packages/platform-browser/animations/src/animation_builder.ts
@@ -104,6 +104,7 @@ export class RendererAnimationPlayer implements AnimationPlayer {
 
   reset(): void {
     this._command('reset');
+    this._started = false;
   }
 
   setPosition(p: number): void {

--- a/packages/platform-browser/animations/test/browser_animation_builder_spec.ts
+++ b/packages/platform-browser/animations/test/browser_animation_builder_spec.ts
@@ -104,5 +104,43 @@ import {el} from '../../testing/src/browser_util';
          expect(finished).toBeTruthy();
          expect(destroyed).toBeTruthy();
        }));
+
+    it('should update `hasStarted()` on `play()` and `reset()`', fakeAsync(() => {
+         @Component({
+           selector: 'ani-another-cmp',
+           template: '...',
+         })
+         class CmpAnother {
+           @ViewChild('target') public target: any;
+
+           constructor(public builder: AnimationBuilder) {}
+
+           build() {
+             const definition =
+                 this.builder.build([style({opacity: 0}), animate(1000, style({opacity: 1}))]);
+
+             return definition.create(this.target);
+           }
+         }
+
+         TestBed.configureTestingModule({declarations: [CmpAnother]});
+
+         const fixture = TestBed.createComponent(CmpAnother);
+         const cmp = fixture.componentInstance;
+         fixture.detectChanges();
+
+         const player = cmp.build();
+
+         expect(player.hasStarted()).toBeFalsy();
+         flushMicrotasks();
+
+         player.play();
+         flushMicrotasks();
+         expect(player.hasStarted()).toBeTruthy();
+
+         player.reset();
+         flushMicrotasks();
+         expect(player.hasStarted()).toBeFalsy();
+       }));
   });
 }


### PR DESCRIPTION
This commit fixes the state of variable _started on call of reset method.

Resolves #18140

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
on call of hasStarted method after reset method is returning true.

Issue Number: #18140 


## What is the new behavior?
After calling reset method, hasstarted method will return false.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
