### PR TITLE
fix(forms): toggle disabled attribute when replacing control

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -123,8 +123,8 @@ export class FormControlDirective extends NgControl implements OnChanges, OnDest
         cleanUpControl(previousForm, this, /* validateControlPresenceOnChange */ false);
       }
       setUpControl(this.form, this);
-      if (this.control.disabled && this.valueAccessor!.setDisabledState) {
-        this.valueAccessor!.setDisabledState!(true);
+      if (this.valueAccessor!.setDisabledState) {
+        this.valueAccessor!.setDisabledState!(this.control.disabled);
       }
       this.form.updateValueAndValidity({emitEvent: false});
     }

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -631,6 +631,23 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
              expect(input.nativeElement.disabled).toBe(false);
            });
 
+        it('should remove disabled attribute when control is replaced with enabled one', () => {
+          const fixture = initTest(FormControlComp);
+          const enabledControl = new FormControl('enabled');
+          const disabledControl = new FormControl('disabled');
+          disabledControl.disable();
+          fixture.componentInstance.control = disabledControl;
+          fixture.detectChanges();
+
+          const input = fixture.debugElement.query(By.css('input'));
+          expect(input.nativeElement.disabled).toBe(true);
+
+          fixture.componentInstance.control = enabledControl;
+          fixture.detectChanges();
+
+          expect(input.nativeElement.disabled).toBe(false);
+        });
+
         it('should add disabled attribute to child controls when disable() is called on group',
            () => {
              const fixture = initTest(FormGroupComp);


### PR DESCRIPTION
## PR Checklist
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)

## PR Type
- [X] Bugfix

## What is the current behavior?
When having a [formControl] directive with a disabled control and replacing it with an enabled one, the disabled flag of the corresponding DOM element is not removed. Technically ngOnChanges will only ever set the disabled state of its DOM element to true if the control is disabled instead of also removing the disabled flag if the control is enabled.

Issue Number: N/A

## What is the new behavior?
When setting an enabled control as input of [formControl] the disabled attribute of its DOM element will be removed.

## Does this PR introduce a breaking change?

- [X] No