### PR TITLE
ci: configure Renovate to disable updates for  dependencies versioned `0.0.0-PLACEHOLDER`     

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -101,6 +101,10 @@
           "major"
         ],
         "enabled": false
+      },
+      {
+        "matchCurrentVersion": "0.0.0-PLACEHOLDER",
+        "enabled": false
       }
     ]
   }

--- a/renovate.json
+++ b/renovate.json
@@ -1,110 +1,110 @@
 {
-    "pinVersions": false,
-    "semanticCommits": true,
-    "semanticPrefix": "build",
-    "commitMessage": "{{semanticPrefix}} update {{#if groupName}}{{{groupName}}} packages{{else}}{{{depName}}} to version {{{newVersion}}}{{/if}}",
-    "separateMajorMinor": false,
-    "prHourlyLimit": 2,
-    "labels": [
-      "target: minor",
-      "comp: build & ci",
-      "action: merge"
-    ],
-    "timezone": "America/Tijuana",
-    "lockFileMaintenance": {
-      "enabled": true
+  "pinVersions": false,
+  "semanticCommits": true,
+  "semanticPrefix": "build",
+  "commitMessage": "{{semanticPrefix}} update {{#if groupName}}{{{groupName}}} packages{{else}}{{{depName}}} to version {{{newVersion}}}{{/if}}",
+  "separateMajorMinor": false,
+  "prHourlyLimit": 2,
+  "labels": [
+    "target: minor",
+    "comp: build & ci",
+    "action: merge"
+  ],
+  "timezone": "America/Tijuana",
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "schedule": [
+    "after 10pm every weekday",
+    "before 4am every weekday",
+    "every weekend"
+  ],
+  "baseBranches": [
+    "master"
+  ],
+  "ignoreDeps": [
+    "@babel/core",
+    "@babel/generator",
+    "@babel/parser",
+    "@babel/preset-env",
+    "@babel/template",
+    "@babel/traverse",
+    "@babel/types",
+    "@types/babel__core",
+    "@types/babel__generator",
+    "@types/babel__template",
+    "@types/babel__traverse",
+    "@types/node",
+    "@types/selenium-webdriver",
+    "@microsoft/api-extractor",
+    "puppeteer",
+    "selenium-webdriver"
+  ],
+  "packageFiles": [
+    "WORKSPACE",
+    "integration/bazel/WORKSPACE",
+    "package.json",
+    "packages/**/package.json",
+    "tools/ts-api-guardian/package.json",
+    "aio/package.json"
+  ],
+  "packageRules": [
+    {
+      "packagePatterns": [
+        "^@angular/.*",
+        "^@angular-devkit/.*",
+        "^@schematics/.*"
+      ],
+      "groupName": "angular",
+      "pinVersions": false
     },
-    "schedule": [
-      "after 10pm every weekday",
-      "before 4am every weekday",
-      "every weekend"
-    ],
-    "baseBranches": [
-      "master"
-    ],
-    "ignoreDeps": [
-      "@babel/core",
-      "@babel/generator",
-      "@babel/parser",
-      "@babel/preset-env",
-      "@babel/template",
-      "@babel/traverse",
-      "@babel/types",
-      "@types/babel__core",
-      "@types/babel__generator",
-      "@types/babel__template",
-      "@types/babel__traverse",
-      "@types/node",
-      "@types/selenium-webdriver",
-      "@microsoft/api-extractor",
-      "puppeteer",
-      "selenium-webdriver"
-    ],
-    "packageFiles": [
-      "WORKSPACE",
-      "integration/bazel/WORKSPACE",
-      "package.json",
-      "packages/**/package.json",
-      "tools/ts-api-guardian/package.json",
-      "aio/package.json"
-    ],
-    "packageRules": [
-      {
-        "packagePatterns": [
-          "^@angular/.*",
-          "^@angular-devkit/.*",
-          "^@schematics/.*"
-        ],
-        "groupName": "angular",
-        "pinVersions": false
-      },
-     {
-        "packagePatterns": [
-          "^@babel/.*"
-        ],
-        "groupName": "babel",
-        "pinVersions": false
-      },
-      {
-        "packagePatterns": [
-          "^@bazel/.*",
-          "^build_bazel.*",
-          "bazel_toolchains"
-        ],
-        "groupName": "bazel",
-        "pinVersions": false
-      },
-      {
-        "packagePatterns": [
-          "^remark-.*",
-          "remark"
-        ],
-        "groupName": "remark",
-        "pinVersions": false
-      },
-      {
-        "packageNames": [
-          "typescript",
-          "rxjs",
-          "tslib"
-        ],
-        "separateMinorPatch": true
-      },
-      {
-        "packageNames": [
-          "typescript",
-          "rxjs",
-          "tslib"
-        ],
-        "updateTypes": [
-          "minor",
-          "major"
-        ],
-        "enabled": false
-      },
-      {
-        "matchCurrentVersion": "0.0.0-PLACEHOLDER",
-        "enabled": false
-      }
-    ]
-  }
+    {
+      "packagePatterns": [
+        "^@babel/.*"
+      ],
+      "groupName": "babel",
+      "pinVersions": false
+    },
+    {
+      "packagePatterns": [
+        "^@bazel/.*",
+        "^build_bazel.*",
+        "bazel_toolchains"
+      ],
+      "groupName": "bazel",
+      "pinVersions": false
+    },
+    {
+      "packagePatterns": [
+        "^remark-.*",
+        "remark"
+      ],
+      "groupName": "remark",
+      "pinVersions": false
+    },
+    {
+      "packageNames": [
+        "typescript",
+        "rxjs",
+        "tslib"
+      ],
+      "separateMinorPatch": true
+    },
+    {
+      "packageNames": [
+        "typescript",
+        "rxjs",
+        "tslib"
+      ],
+      "updateTypes": [
+        "minor",
+        "major"
+      ],
+      "enabled": false
+    },
+    {
+      "matchCurrentVersion": "0.0.0-PLACEHOLDER",
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
ci: configure Renovate to disable updates for  dependencies versioned `0.0.0-PLACEHOLDER`
    
With this change we disable Renovate from updating `@angular/*` peerDependencies which are versioned `0.0.0-PLACEHOLDER`.
    
Example PR: https://github.com/angular/angular/pull/41615