### PR TITLE
ci: disable dependency updates of Angular JS packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,10 @@
     "@types/node",
     "@types/selenium-webdriver",
     "@microsoft/api-extractor",
+    "angular",
+    "angular-1.5",
+    "angular-1.6",
+    "angular-1.7",
     "puppeteer",
     "selenium-webdriver"
   ],


### PR DESCRIPTION


With this change we configure Renote Bot to ignore Angular JS packages.

Example of unwanted PR: https://github.com/angular/angular/pull/41639/files