### PR TITLE
fix(compiler-cli): autocomplete literal types in templates

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -105,8 +105,9 @@ export interface TemplateTypeChecker {
    * include completions from the template's context component, as well as any local references or
    * template variables which are in scope for that expression.
    */
-  getGlobalCompletions(context: TmplAstTemplate|null, component: ts.ClassDeclaration):
-      GlobalCompletion|null;
+  getGlobalCompletions(
+      context: TmplAstTemplate|null, component: ts.ClassDeclaration,
+      node: AST|TmplAstNode): GlobalCompletion|null;
 
 
   /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/completion.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/completion.ts
@@ -71,4 +71,10 @@ export interface GlobalCompletion {
    * the same name (from the `componentContext` completions).
    */
   templateContext: Map<string, ReferenceCompletion|VariableCompletion>;
+
+  /**
+   * A location within the type-checking shim where TypeScript's completion APIs can be used to
+   * access completions for the AST node of the cursor position (primitive constants).
+   */
+  nodeContext: ShimLocation|null;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -257,14 +257,15 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     return this.getLatestComponentState(component).tcb;
   }
 
-  getGlobalCompletions(context: TmplAstTemplate|null, component: ts.ClassDeclaration):
-      GlobalCompletion|null {
+  getGlobalCompletions(
+      context: TmplAstTemplate|null, component: ts.ClassDeclaration,
+      node: AST|TmplAstNode): GlobalCompletion|null {
     const engine = this.getOrCreateCompletionEngine(component);
     if (engine === null) {
       return null;
     }
     return this.perf.inPhase(
-        PerfPhase.TtcAutocompletion, () => engine.getGlobalCompletions(context));
+        PerfPhase.TtcAutocompletion, () => engine.getGlobalCompletions(context, node));
   }
 
   getExpressionCompletionLocation(

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/completion.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/completion.ts
@@ -7,7 +7,7 @@
  */
 
 import {TmplAstReference, TmplAstTemplate} from '@angular/compiler';
-import {MethodCall, PropertyRead, PropertyWrite, SafeMethodCall, SafePropertyRead} from '@angular/compiler/src/compiler';
+import {AST, EmptyExpr, MethodCall, PropertyRead, PropertyWrite, SafeMethodCall, SafePropertyRead, TmplAstNode} from '@angular/compiler/src/compiler';
 import * as ts from 'typescript';
 
 import {AbsoluteFsPath} from '../../file_system';
@@ -23,65 +23,77 @@ import {TemplateData} from './context';
  * surrounding TS program have changed.
  */
 export class CompletionEngine {
+  private componentContext: ShimLocation|null;
+
   /**
-   * Cache of `GlobalCompletion`s for various levels of the template, including the root template
-   * (`null`).
+   * Cache of completions for various levels of the template, including the root template (`null`).
+   * Memoizes `getTemplateContextCompletions`.
    */
-  private globalCompletionCache = new Map<TmplAstTemplate|null, GlobalCompletion>();
+  private templateContextCache =
+      new Map<TmplAstTemplate|null, Map<string, ReferenceCompletion|VariableCompletion>>();
 
   private expressionCompletionCache =
       new Map<PropertyRead|SafePropertyRead|MethodCall|SafeMethodCall, ShimLocation>();
 
-  constructor(private tcb: ts.Node, private data: TemplateData, private shimPath: AbsoluteFsPath) {}
 
-  /**
-   * Get global completions within the given template context - either a `TmplAstTemplate` embedded
-   * view, or `null` for the root template context.
-   */
-  getGlobalCompletions(context: TmplAstTemplate|null): GlobalCompletion|null {
-    if (this.globalCompletionCache.has(context)) {
-      return this.globalCompletionCache.get(context)!;
-    }
-
+  constructor(private tcb: ts.Node, private data: TemplateData, private shimPath: AbsoluteFsPath) {
     // Find the component completion expression within the TCB. This looks like: `ctx. /* ... */;`
     const globalRead = findFirstMatchingNode(this.tcb, {
       filter: ts.isPropertyAccessExpression,
       withExpressionIdentifier: ExpressionIdentifier.COMPONENT_COMPLETION
     });
 
-    if (globalRead === null) {
-      return null;
-    }
-
-    const completion: GlobalCompletion = {
-      componentContext: {
+    if (globalRead !== null) {
+      this.componentContext = {
         shimPath: this.shimPath,
         // `globalRead.name` is an empty `ts.Identifier`, so its start position immediately follows
         // the `.` in `ctx.`. TS autocompletion APIs can then be used to access completion results
         // for the component context.
         positionInShimFile: globalRead.name.getStart(),
-      },
-      templateContext: new Map<string, ReferenceCompletion|VariableCompletion>(),
-    };
+      };
+    } else {
+      this.componentContext = null;
+    }
+  }
 
-    // The bound template already has details about the references and variables in scope in the
-    // `context` template - they just need to be converted to `Completion`s.
-    for (const node of this.data.boundTarget.getEntitiesInTemplateScope(context)) {
-      if (node instanceof TmplAstReference) {
-        completion.templateContext.set(node.name, {
-          kind: CompletionKind.Reference,
-          node,
-        });
-      } else {
-        completion.templateContext.set(node.name, {
-          kind: CompletionKind.Variable,
-          node,
-        });
+  /**
+   * Get global completions within the given template context and AST node.
+   *
+   * @param context the given template context - either a `TmplAstTemplate` embedded view, or `null`
+   *     for the root
+   * template context.
+   * @param node the given AST node
+   */
+  getGlobalCompletions(context: TmplAstTemplate|null, node: AST|TmplAstNode): GlobalCompletion
+      |null {
+    if (this.componentContext === null) {
+      return null;
+    }
+
+    const templateContext = this.getTemplateContextCompletions(context);
+    if (templateContext === null) {
+      return null;
+    }
+
+    let nodeContext: ShimLocation|null = null;
+    if (node instanceof EmptyExpr) {
+      const nodeLocation = findFirstMatchingNode(this.tcb, {
+        filter: ts.isIdentifier,
+        withSpan: node.sourceSpan,
+      });
+      if (nodeLocation !== null) {
+        nodeContext = {
+          shimPath: this.shimPath,
+          positionInShimFile: nodeLocation.getStart(),
+        };
       }
     }
 
-    this.globalCompletionCache.set(context, completion);
-    return completion;
+    return {
+      componentContext: this.componentContext,
+      templateContext,
+      nodeContext,
+    };
   }
 
   getExpressionCompletionLocation(expr: PropertyRead|PropertyWrite|MethodCall|
@@ -130,5 +142,37 @@ export class CompletionEngine {
     };
     this.expressionCompletionCache.set(expr, res);
     return res;
+  }
+
+  /**
+   * Get global completions within the given template context - either a `TmplAstTemplate` embedded
+   * view, or `null` for the root context.
+   */
+  private getTemplateContextCompletions(context: TmplAstTemplate|null):
+      Map<string, ReferenceCompletion|VariableCompletion>|null {
+    if (this.templateContextCache.has(context)) {
+      return this.templateContextCache.get(context)!;
+    }
+
+    const templateContext = new Map<string, ReferenceCompletion|VariableCompletion>();
+
+    // The bound template already has details about the references and variables in scope in the
+    // `context` template - they just need to be converted to `Completion`s.
+    for (const node of this.data.boundTarget.getEntitiesInTemplateScope(context)) {
+      if (node instanceof TmplAstReference) {
+        templateContext.set(node.name, {
+          kind: CompletionKind.Reference,
+          node,
+        });
+      } else {
+        templateContext.set(node.name, {
+          kind: CompletionKind.Variable,
+          node,
+        });
+      }
+    }
+
+    this.templateContextCache.set(context, templateContext);
+    return templateContext;
   }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__completion_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__completion_spec.ts
@@ -141,7 +141,7 @@ function setupCompletions(
     context = tmpl;
   }
 
-  const completions = templateTypeChecker.getGlobalCompletions(context, SomeCmp)!;
+  const completions = templateTypeChecker.getGlobalCompletions(context, SomeCmp, null!)!;
   expect(completions).toBeDefined();
   return {
     completions,

--- a/packages/language-service/ivy/test/completions_spec.ts
+++ b/packages/language-service/ivy/test/completions_spec.ts
@@ -24,6 +24,18 @@ const DIR_WITH_INPUT = {
   `
 };
 
+const DIR_WITH_UNION_TYPE_INPUT = {
+  'Dir': `
+    @Directive({
+      selector: '[dir]',
+      inputs: ['myInput']
+    })
+    export class Dir {
+      myInput!: 'foo'|42|null|undefined
+    }
+  `
+};
+
 const DIR_WITH_OUTPUT = {
   'Dir': `
     @Directive({
@@ -203,6 +215,18 @@ describe('completions', () => {
       const completions = templateFile.getCompletionsAtPosition();
       expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
     });
+
+    it('should return completions of string literals, number literals, `true`, `false`, `null` and `undefined`',
+       () => {
+         const {templateFile} = setup(`<input dir [myInput]="">`, '', DIR_WITH_UNION_TYPE_INPUT);
+         templateFile.moveCursorToText('dir [myInput]="¦">');
+
+         const completions = templateFile.getCompletionsAtPosition();
+         expectContain(completions, ts.ScriptElementKind.string, [`'foo'`, '42']);
+         expectContain(completions, ts.ScriptElementKind.keyword, ['null']);
+         expectContain(completions, ts.ScriptElementKind.variableElement, ['undefined']);
+         expectDoesNotContain(completions, ts.ScriptElementKind.parameterElement, ['ctx']);
+       });
   });
 
   describe('in an expression scope', () => {
@@ -789,7 +813,7 @@ function setup(
         export class AppCmp {
           ${classContents}
         }
-        
+
         ${otherDirectiveClassDecls}
 
         @NgModule({
@@ -822,7 +846,7 @@ function setupInlineTemplate(
         export class AppCmp {
           ${classContents}
         }
-        
+
         ${otherDirectiveClassDecls}
 
         @NgModule({


### PR DESCRIPTION
…lates. (#41456)""

This reverts commit 75f881e078150b0d095f2c54a916fc67a10444f6.

This is the second attempt at #41623 . The first time it worked fine on master, but caused test failures on patch.

That's because autocompletion of literals only works when `EmptyExpression` has parse span info on it. This was already implemented in master in @alxhub 's previous work with the help context, but it was not implemented in patch.

https://github.com/angular/angular/blob/master/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts#L72

See also the path-only version of this PR #41646 