### PR TITLE
ci: disable dependency updates of `angular-mocks` packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,10 @@
     "angular-1.5",
     "angular-1.6",
     "angular-1.7",
+    "angular-mocks",
+    "angular-mocks-1.5",
+    "angular-mocks-1.6",
+    "angular-mocks-1.7",
     "puppeteer",
     "selenium-webdriver"
   ],


### PR DESCRIPTION
With this change we configure Renote Bot to ignore angular-mocks packages.

Similar to #41642 but for `angular-mocks` packages.
