### PR TITLE
ci: disable automatic updates of rollup

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,7 @@
     "angular-mocks-1.6",
     "angular-mocks-1.7",
     "puppeteer",
+    "rollup",
     "selenium-webdriver"
   ],
   "packageFiles": [


### PR DESCRIPTION
Rollup updates cannot be automated as these can cause golden files to be changed such as with this PR https://github.com/angular/angular/pull/41671