### PR TITLE
docs: replace hair space with regular space in `creating-libraries.md`

### DIFF
--- a/aio/content/guide/creating-libraries.md
+++ b/aio/content/guide/creating-libraries.md
@@ -112,7 +112,7 @@ If that form will need additional customization by the developer who is using yo
 However, if the form will always be the same and not need much customization by developers, then you could create a dynamic component that takes the configuration and generates the form.
 In general, the more complex the customization, the more useful the schematic approach.
 
-To learn more, see [Schematics Overview](guide/schematics) and [Schematics for Libraries](guide/schematics-for-libraries).
+To learn more, see [Schematics Overview](guide/schematics) and [Schematics for Libraries](guide/schematics-for-libraries).
 
 ## Publishing your library
 


### PR DESCRIPTION
This commit replaces a [hair space][1] with a regular space in `creating-libraries.md`.
(You can see the hair space "in action" in the "Schematics for Libraries" link right above the [Publishing your library][2] section.

[1]: https://en.wikipedia.org/wiki/Template:Hair_space
[2]: https://v10.angular.io/guide/creating-libraries#publishing-your-library
