### PR TITLE
fix(docs-infra): fix code inside anchor elements with external URLs

### DIFF
--- a/aio/src/styles/0-base/_typography.scss
+++ b/aio/src/styles/0-base/_typography.scss
@@ -87,7 +87,6 @@ h6 {
 p,
 ol,
 ul,
-ol,
 li,
 input,
 a {

--- a/aio/src/styles/0-base/_typography.scss
+++ b/aio/src/styles/0-base/_typography.scss
@@ -210,7 +210,6 @@ code {
       > a {
         &[href^="http:"],
         &[href^="https:"] {
-          display: inline-flex;
           padding-right: calc(1em + 0.25rem);
           position: relative;
 

--- a/aio/src/styles/2-modules/_presskit.scss
+++ b/aio/src/styles/2-modules/_presskit.scss
@@ -50,7 +50,6 @@
           padding: 0;
 
           a {
-            display: inline-flex;
             padding-right: 3rem;
             position: relative;
 


### PR DESCRIPTION
Previously, due to the `inline-flex` display style of anchor elements with external URLs, `<code>` elements nested inside such anchor elements would cause extra spacing between lines. An occurrence of this can be seen in the [Angular workspace configuration][1] guide.

This commit fixes the problem by removing the `inline-flex` display style (allowing anchor elements to fall back to the default `inline` style).

For reference, the `inline-flex` style was introduced in commit 7944ee2 in order to avoid underlining link icons. This style seems to no longer be necessary (either it was never necessary or the underlying browser bug that made it necessary was fixed).

Before: ![code links before][2]
After: ![code links after][3]

[1]: https://next.angular.io/guide/workspace-config#generation-schematics
[2]: https://user-images.githubusercontent.com/8604205/115149753-34589780-a06e-11eb-8d4e-825b5e94282d.png
[3]: https://user-images.githubusercontent.com/8604205/115149755-3589c480-a06e-11eb-9b15-825d75c74878.png