### PR TITLE
build: remove entities dependency from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,6 @@
     "conventional-changelog": "^3.1.24",
     "conventional-commits-parser": "^3.2.1",
     "ejs": "^3.1.6",
-    "entities": "1.1.1",
     "firebase-tools": "^7.11.0",
     "git-raw-commits": "^2.0.10",
     "glob": "7.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5025,11 +5025,6 @@ ent@~2.2.0:
   resolved "https://registry.yarnpkg.com/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d"
   integrity sha1-6WQhkyWiHQX0RGai9obtbOX13R0=
 
-entities@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
-  integrity sha1-blwtClYhtdra7O+AuQ7ftc13cvA=
-
 entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"


### PR DESCRIPTION
Remove the dependency on `entities` in the root package.json as it is unused.  `entities` is
used in aio, however the package.json in aio manages these dependencies.
