### PR TITLE
fix(docs-infra): fix `autoLinkCode` Dgeni post-processor

### DIFF
--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
@@ -55,7 +55,7 @@ module.exports = function autoLinkCode(getDocFromAlias) {
           const index = parent.children.indexOf(node);
 
           // Can we convert the whole text node into a doc link?
-          const docs = getDocFromAlias(node.value);
+          const docs = getFilteredDocsFromAlias([node.value], 0);
           if (foundValidDoc(docs, node.value, file)) {
             parent.children.splice(index, 1, createLinkNode(docs[0], node.value));
           } else {
@@ -89,14 +89,18 @@ module.exports = function autoLinkCode(getDocFromAlias) {
     return ancestors.some(ancestor => is(ancestor, 'a'));
   }
 
+  function getFilteredDocsFromAlias(words, index) {
+    // Remove docs that fail the custom filter tests.
+    return autoLinkCodeImpl.customFilters.reduce(
+        (docs, filter) => filter(docs, words, index), getDocFromAlias(words[index]));
+  }
+
   function getNodes(node, file) {
     return textContent(node)
         .split(/([A-Za-z0-9_.-]+)/)
         .filter(word => word.length)
         .map((word, index, words) => {
-          // remove docs that fail the custom filter tests
-          const filteredDocs = autoLinkCodeImpl.customFilters.reduce(
-              (docs, filter) => filter(docs, words, index), getDocFromAlias(word));
+          const filteredDocs = getFilteredDocsFromAlias(words, index);
 
           return foundValidDoc(filteredDocs, word, file) ?
               // Create a link wrapping the text node.

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
@@ -46,10 +46,6 @@ module.exports = function autoLinkCode(getDocFromAlias) {
         }
 
         visit(node, 'text', (node, ancestors) => {
-          if (node.addedByAutoLinkCode) {
-            return;
-          }
-
           const isInLink = isInsideLink(ancestors);
           if (isInLink) {
             return;
@@ -67,6 +63,8 @@ module.exports = function autoLinkCode(getDocFromAlias) {
             const nodes = getNodes(node, file);
             // Replace the text node with the links and leftover text nodes
             Array.prototype.splice.apply(parent.children, [index, 1].concat(nodes));
+            // Do not visit this node's children or the newly added nodes
+            return [visit.SKIP, index + nodes.length];
           }
         });
       });
@@ -104,7 +102,7 @@ module.exports = function autoLinkCode(getDocFromAlias) {
               // Create a link wrapping the text node.
               createLinkNode(filteredDocs[0], word) :
               // this is just text so push a new text node
-              {type: 'text', value: word, addedByAutoLinkCode: true};
+              {type: 'text', value: word};
         });
   }
 

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
@@ -46,6 +46,10 @@ module.exports = function autoLinkCode(getDocFromAlias) {
         }
 
         visit(node, 'text', (node, ancestors) => {
+          if (node.addedByAutoLinkCode) {
+            return;
+          }
+
           const isInLink = isInsideLink(ancestors);
           if (isInLink) {
             return;
@@ -100,7 +104,7 @@ module.exports = function autoLinkCode(getDocFromAlias) {
               // Create a link wrapping the text node.
               createLinkNode(filteredDocs[0], word) :
               // this is just text so push a new text node
-              {type: 'text', value: word};
+              {type: 'text', value: word, addedByAutoLinkCode: true};
         });
   }
 

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
@@ -89,7 +89,7 @@ describe('autoLinkCode post-processor', () => {
        expect(doc.renderedContent).toEqual('<code>xyz-MyClass</code>');
      });
 
-  it('should ignore code items that are filtered out by custom filters', () => {
+  it('should ignore code items that are filtered out by custom filters (multiple words)', () => {
     autoLinkCode.customFilters = [filterPipes];
     aliasMap.addDoc({
       docType: 'pipe',
@@ -113,6 +113,27 @@ describe('autoLinkCode post-processor', () => {
             'myClass ' +
             'OtherClass|<a href="a/b/myclass" class="code-anchor">MyClass</a>' +
             '</code>');
+  });
+
+  it('should ignore code items that are filtered out by custom filters (single word)', () => {
+    const filterAnchors = (docs, words, index) => (words[index].toLowerCase() === 'a') ? [] : docs;
+    autoLinkCode.customFilters = [filterAnchors];
+    autoLinkCode.docTypes = ['directive'];
+
+    aliasMap.addDoc({
+      docType: 'directive',
+      id: 'MyAnchorDirective',
+      aliases: ['MyAnchorDirective', 'a'],
+      path: 'a/b/my-anchor-directive',
+    });
+    const doc = {
+      docType: 'test-doc',
+      renderedContent: '<code>a</code>',
+    };
+
+    processor.$process([doc]);
+
+    expect(doc.renderedContent).toBe('<code>a</code>');
   });
 
   it('should ignore generated nodes', () => {

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
@@ -110,9 +110,30 @@ describe('autoLinkCode post-processor', () => {
             '{ xyz | <a href="a/b/myclass" class="code-anchor">myClass</a> } ' +
             '{ xyz|<a href="a/b/myclass" class="code-anchor">myClass</a> } ' +
             '<a href="a/b/myclass" class="code-anchor">MyClass</a> ' +
-            '<a href="a/b/myclass" class="code-anchor">myClass</a> ' +
+            'myClass ' +
             'OtherClass|<a href="a/b/myclass" class="code-anchor">MyClass</a>' +
             '</code>');
+  });
+
+  it('should ignore generated nodes', () => {
+    const filterAnchors = (docs, words, index) => (words[index].toLowerCase() === 'a') ? [] : docs;
+    autoLinkCode.customFilters = [filterAnchors];
+    autoLinkCode.docTypes = ['directive'];
+
+    aliasMap.addDoc({
+      docType: 'directive',
+      id: 'MyAnchorDirective',
+      aliases: ['MyAnchorDirective', 'a'],
+      path: 'a/b/my-anchor-directive',
+    });
+    const doc = {
+      docType: 'test-doc',
+      renderedContent: '<code>&#x3C;a></code>',
+    };
+
+    processor.$process([doc]);
+
+    expect(doc.renderedContent).toBe('<code>&#x3C;a></code>');
   });
 
   it('should ignore code items that match an internal API doc', () => {

--- a/aio/tools/transforms/angular-base-package/services/auto-link-filters/filterPipes.js
+++ b/aio/tools/transforms/angular-base-package/services/auto-link-filters/filterPipes.js
@@ -8,5 +8,6 @@ module.exports = function filterPipes() {
     docs.filter(doc =>
       doc.docType !== 'pipe' ||
       doc.pipeOptions.name !== '\'' + words[index] + '\'' ||
-      index > 0 && words[index - 1].trim() === '|');
+      index === 0 ||
+      words[index - 1].trim() === '|');
 };


### PR DESCRIPTION
A couple of fixes related to auto-linking `<code>` elements in the docs.
(See individual commits for details.)