### PR TITLE
fix(common): add body as an optional property on the options parameter of HttpClient.delete request (#19438)

### DIFF
--- a/goldens/public-api/common/http/http.d.ts
+++ b/goldens/public-api/common/http/http.d.ts
@@ -18,6 +18,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<ArrayBuffer>;
     delete(url: string, options: {
         headers?: HttpHeaders | {
@@ -31,6 +32,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<Blob>;
     delete(url: string, options: {
         headers?: HttpHeaders | {
@@ -44,6 +46,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<string>;
     delete(url: string, options: {
         headers?: HttpHeaders | {
@@ -57,6 +60,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<HttpEvent<ArrayBuffer>>;
     delete(url: string, options: {
         headers?: HttpHeaders | {
@@ -70,6 +74,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<HttpEvent<Blob>>;
     delete(url: string, options: {
         headers?: HttpHeaders | {
@@ -83,6 +88,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<HttpEvent<string>>;
     delete(url: string, options: {
         headers?: HttpHeaders | {
@@ -96,6 +102,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<HttpEvent<Object>>;
     delete<T>(url: string, options: {
         headers?: HttpHeaders | {
@@ -109,6 +116,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<HttpEvent<T>>;
     delete(url: string, options: {
         headers?: HttpHeaders | {
@@ -122,6 +130,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<HttpResponse<ArrayBuffer>>;
     delete(url: string, options: {
         headers?: HttpHeaders | {
@@ -135,6 +144,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<HttpResponse<Blob>>;
     delete(url: string, options: {
         headers?: HttpHeaders | {
@@ -148,6 +158,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<HttpResponse<string>>;
     delete(url: string, options: {
         headers?: HttpHeaders | {
@@ -161,6 +172,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<HttpResponse<Object>>;
     delete<T>(url: string, options: {
         headers?: HttpHeaders | {
@@ -174,6 +186,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<HttpResponse<T>>;
     delete(url: string, options?: {
         headers?: HttpHeaders | {
@@ -187,6 +200,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<Object>;
     delete<T>(url: string, options?: {
         headers?: HttpHeaders | {
@@ -200,6 +214,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        body?: any | null;
     }): Observable<T>;
     get(url: string, options: {
         headers?: HttpHeaders | {

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -619,6 +619,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    body?: any|null,
   }): Observable<ArrayBuffer>;
 
 
@@ -639,6 +640,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    body?: any|null,
   }): Observable<Blob>;
 
   /**
@@ -658,6 +660,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    body?: any|null,
   }): Observable<string>;
 
   /**
@@ -677,6 +680,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    body?: any|null
   }): Observable<HttpEvent<ArrayBuffer>>;
 
   /**
@@ -696,6 +700,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    body?: any|null,
   }): Observable<HttpEvent<Blob>>;
 
   /**
@@ -715,6 +720,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    body?: any|null,
   }): Observable<HttpEvent<string>>;
 
   /**
@@ -735,6 +741,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    body?: any|null,
   }): Observable<HttpEvent<Object>>;
 
   /**
@@ -755,6 +762,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    body?: any|null,
   }): Observable<HttpEvent<T>>;
 
   /**
@@ -773,6 +781,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    body?: any|null,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
   /**
@@ -791,6 +800,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    body?: any|null,
   }): Observable<HttpResponse<Blob>>;
 
   /**
@@ -809,6 +819,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    body?: any|null,
   }): Observable<HttpResponse<string>>;
 
   /**
@@ -829,6 +840,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    body?: any|null,
   }): Observable<HttpResponse<Object>>;
 
   /**
@@ -848,6 +860,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    body?: any|null,
   }): Observable<HttpResponse<T>>;
 
   /**
@@ -868,6 +881,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    body?: any|null,
   }): Observable<Object>;
 
   /**
@@ -888,6 +902,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    body?: any|null,
   }): Observable<T>;
 
   /**
@@ -908,6 +923,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    body?: any|null,
   } = {}): Observable<any> {
     return this.request<any>('DELETE', url, options as any);
   }

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -177,6 +177,30 @@ import {toArray} from 'rxjs/operators';
         testReq.flush('hello world');
       });
     });
+    describe('makes a DELETE request', () => {
+      it('with body', done => {
+        const body = {data: 'json body'};
+        client.delete('/test', {observe: 'response', responseType: 'text', body: body})
+            .subscribe(res => {
+              expect(res.ok).toBeTruthy();
+              expect(res.status).toBe(200);
+              done();
+            });
+        const testReq = backend.expectOne('/test');
+        expect(testReq.request.body).toBe(body);
+        testReq.flush('hello world');
+      });
+      it('without body', done => {
+        client.delete('/test', {observe: 'response', responseType: 'text'}).subscribe(res => {
+          expect(res.ok).toBeTruthy();
+          expect(res.status).toBe(200);
+          done();
+        });
+        const testReq = backend.expectOne('/test');
+        expect(testReq.request.body).toBe(null);
+        testReq.flush('hello world');
+      });
+    });
     describe('makes a JSONP request', () => {
       it('with properly set method and callback', done => {
         client.jsonp('/test', 'myCallback').subscribe(() => done());


### PR DESCRIPTION
adding optional body for HTTP delete request options. This new param added as an optional so won't break the existing code also provide the capability the send the body when and where it required.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?


- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The HTTP DELETE request does not support the request body.

Issue Number: #19438


## What is the new behavior?
adding optional body for HTTP delete request. This new param added as an optional so won't break the existing code also provide the capability the send the body when and where it required.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



## Other information
