### PR TITLE
build: update stemmer to version 2.0.0

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -162,7 +162,7 @@
     "rimraf": "^3.0.2",
     "semver": "^7.3.5",
     "shelljs": "^0.8.4",
-    "stemmer": "^1.0.5",
+    "stemmer": "^2.0.0",
     "timezone-mock": "^1.1.3",
     "tree-kill": "^1.1.0",
     "ts-node": "^9.1.1",

--- a/aio/tools/transforms/.eslintrc.js
+++ b/aio/tools/transforms/.eslintrc.js
@@ -8,6 +8,9 @@ module.exports = {
     'eslint:recommended',
     'plugin:jasmine/recommended'
   ],
+  'parserOptions': {
+    'ecmaVersion': 2020,
+  },
   'plugins': [
     'jasmine'
   ],

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -11955,10 +11955,10 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
-stemmer@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/stemmer/-/stemmer-1.0.5.tgz#fd89beaf8bff5d04b6643bfffcaed0fc420deec0"
-  integrity sha512-SLq7annzSKRDStasOJJoftCSCzBCKmBmH38jC4fDtCunAqOzpTpIm9zmaHmwNJiZ8gLe9qpVdBVbEG2DC5dE2A==
+stemmer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stemmer/-/stemmer-2.0.0.tgz#05fcaf174c423b0fec85e660759ebd4867d811c9"
+  integrity sha512-0YS2oMdTZ/wAWUHMMpf7AAJ8Gm6dHXyHddJ0zCu2DIfOfIbdwqAm1bbk4+Vti6gxNIcOrnm5jAP7vYTzQDvc5A==
 
 stream-browserify@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
NOTE:
`stemmer` v2.0.0 switched to ES modules (see words/stemmer@03519229c84555a38d3256409d1871edfd43528f), which means that the only way to consume it in our CommonJS  setup (for example, in [generateKeywords][1]) is via an async `import()`.

This commit makes the `generateKeywords` processor asynchronous in order to be able to dynamically import and use `stemmer`.

[1]: https://github.com/angular/angular/blob/251bec159af1e8f90c3af9820695c645800207e4/aio/tools/transforms/angular-base-package/processors/generateKeywords.js
