### PR TITLE
fix(common): synchronise location mock behavior with the navigators

### DIFF
--- a/packages/router/test/computed_state_restoration.spec.ts
+++ b/packages/router/test/computed_state_restoration.spec.ts
@@ -6,168 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CommonModule, Location, LocationStrategy, PlatformLocation} from '@angular/common';
+import {CommonModule, Location} from '@angular/common';
 import {SpyLocation} from '@angular/common/testing';
-import {Component, EventEmitter, Injectable, NgModule} from '@angular/core';
+import {Component, Injectable, NgModule} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {CanActivate, CanDeactivate, Resolve, Router, RouterModule, UrlTree} from '@angular/router';
-import {EMPTY, Observable, of, SubscriptionLike} from 'rxjs';
+import {EMPTY, Observable, of} from 'rxjs';
 
 import {isUrlTree} from '../src/utils/type_guards';
 import {RouterTestingModule} from '../testing';
 
 describe('`restoredState#ɵrouterPageId`', () => {
-  // TODO: Remove RouterSpyLocation after #38884 is submitted.
-  class RouterSpyLocation implements Location {
-    urlChanges: string[] = [];
-    private _history: LocationState[] = [new LocationState('', '', null)];
-    private _historyIndex: number = 0;
-    /** @internal */
-    _subject: EventEmitter<any> = new EventEmitter();
-    /** @internal */
-    _baseHref: string = '';
-    /** @internal */
-    _platformStrategy: LocationStrategy = null!;
-    /** @internal */
-    _platformLocation: PlatformLocation = null!;
-    /** @internal */
-    _urlChangeListeners: ((url: string, state: unknown) => void)[] = [];
-    /** @internal */
-    _urlChangeSubscription?: SubscriptionLike;
-
-    setInitialPath(url: string) {
-      this._history[this._historyIndex].path = url;
-    }
-
-    setBaseHref(url: string) {
-      this._baseHref = url;
-    }
-
-    path(): string {
-      return this._history[this._historyIndex].path;
-    }
-
-    getState(): unknown {
-      return this._history[this._historyIndex].state;
-    }
-
-    isCurrentPathEqualTo(path: string, query: string = ''): boolean {
-      const givenPath = path.endsWith('/') ? path.substring(0, path.length - 1) : path;
-      const currPath = this.path().endsWith('/') ?
-          this.path().substring(0, this.path().length - 1) :
-          this.path();
-
-      return currPath == givenPath + (query.length > 0 ? ('?' + query) : '');
-    }
-
-    simulateUrlPop(pathname: string) {
-      this._subject.emit({'url': pathname, 'pop': true, 'type': 'popstate'});
-    }
-
-    simulateHashChange(pathname: string) {
-      // Because we don't prevent the native event, the browser will independently update the path
-      this.setInitialPath(pathname);
-      this.urlChanges.push('hash: ' + pathname);
-      this._subject.emit({'url': pathname, 'pop': true, 'type': 'hashchange'});
-    }
-
-    prepareExternalUrl(url: string): string {
-      if (url.length > 0 && !url.startsWith('/')) {
-        url = '/' + url;
-      }
-      return this._baseHref + url;
-    }
-
-    go(path: string, query: string = '', state: any = null) {
-      path = this.prepareExternalUrl(path);
-
-      if (this._historyIndex > 0) {
-        this._history.splice(this._historyIndex + 1);
-      }
-      this._history.push(new LocationState(path, query, state));
-      this._historyIndex = this._history.length - 1;
-
-      const locationState = this._history[this._historyIndex - 1];
-      if (locationState.path == path && locationState.query == query) {
-        return;
-      }
-
-      const url = path + (query.length > 0 ? ('?' + query) : '');
-      this.urlChanges.push(url);
-    }
-
-    replaceState(path: string, query: string = '', state: any = null) {
-      path = this.prepareExternalUrl(path);
-
-      const history = this._history[this._historyIndex];
-      if (history.path == path && history.query == query) {
-        return;
-      }
-
-      history.path = path;
-      history.query = query;
-      history.state = state;
-
-      const url = path + (query.length > 0 ? ('?' + query) : '');
-      this.urlChanges.push('replace: ' + url);
-    }
-
-    forward() {
-      if (this._historyIndex < (this._history.length - 1)) {
-        this._historyIndex++;
-        this._subject.emit(
-            {'url': this.path(), 'state': this.getState(), 'pop': true, 'type': 'popstate'});
-      }
-    }
-
-    back() {
-      if (this._historyIndex > 0) {
-        this._historyIndex--;
-        this._subject.emit(
-            {'url': this.path(), 'state': this.getState(), 'pop': true, 'type': 'popstate'});
-      }
-    }
-
-    historyGo(relativePosition: number = 0): void {
-      const nextPageIndex = this._historyIndex + relativePosition;
-      if (nextPageIndex >= 0 && nextPageIndex < this._history.length) {
-        this._historyIndex = nextPageIndex;
-        this._subject.emit(
-            {'url': this.path(), 'state': this.getState(), 'pop': true, 'type': 'popstate'});
-      }
-    }
-
-    onUrlChange(fn: (url: string, state: unknown) => void) {
-      this._urlChangeListeners.push(fn);
-
-      if (!this._urlChangeSubscription) {
-        this._urlChangeSubscription = this.subscribe(v => {
-          this._notifyUrlChangeListeners(v.url, v.state);
-        });
-      }
-    }
-
-    /** @internal */
-    _notifyUrlChangeListeners(url: string = '', state: unknown) {
-      this._urlChangeListeners.forEach(fn => fn(url, state));
-    }
-
-    subscribe(
-        onNext: (value: any) => void, onThrow?: ((error: any) => void)|null,
-        onReturn?: (() => void)|null): SubscriptionLike {
-      return this._subject.subscribe({next: onNext, error: onThrow, complete: onReturn});
-    }
-
-    normalize(url: string): string {
-      return null!;
-    }
-  }
-
-  class LocationState {
-    constructor(public path: string, public query: string, public state: any) {}
-  }
-
   @Injectable({providedIn: 'root'})
   class MyCanDeactivateGuard implements CanDeactivate<any> {
     allow: boolean = true;
@@ -227,7 +77,7 @@ describe('`restoredState#ɵrouterPageId`', () => {
       imports: [TestModule],
       providers: [
         {provide: 'alwaysFalse', useValue: (a: any) => false},
-        {provide: Location, useClass: RouterSpyLocation}
+        {provide: Location, useClass: SpyLocation}
       ]
     });
     const router = TestBed.inject(Router);

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_BASE_HREF, CommonModule, Location, LOCATION_INITIALIZED, LocationStrategy, PlatformLocation} from '@angular/common';
+import {APP_BASE_HREF, CommonModule, HashLocationStrategy, Location, LOCATION_INITIALIZED, LocationStrategy, PlatformLocation} from '@angular/common';
 import {SpyLocation} from '@angular/common/testing';
 import {ChangeDetectionStrategy, Component, EventEmitter, Injectable, NgModule, NgModuleFactoryLoader, NgModuleRef, NgZone, OnDestroy, ViewChild, ɵConsole as Console, ɵNoopNgZone as NoopNgZone} from '@angular/core';
 import {ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
@@ -1061,13 +1061,13 @@ describe('Integration', () => {
        location.back();
        advance(fixture);
        expect(location.path()).toEqual('/team/33/simple');
-       expect(event!.navigationTrigger).toEqual('hashchange');
+       expect(event!.navigationTrigger).toEqual('popstate');
        expect(event!.restoredState!.navigationId).toEqual(simpleNavStart.id);
 
        location.forward();
        advance(fixture);
        expect(location.path()).toEqual('/team/22/user/victor');
-       expect(event!.navigationTrigger).toEqual('hashchange');
+       expect(event!.navigationTrigger).toEqual('popstate');
        expect(event!.restoredState!.navigationId).toEqual(userVictorNavStart.id);
      })));
 
@@ -1226,7 +1226,6 @@ describe('Integration', () => {
          const recordedEvents = [] as Event[];
          router.events.forEach(e => onlyNavigationStartAndEnd(e) && recordedEvents.push(e));
 
-         location.simulateUrlPop('/blocked');
          location.simulateHashChange('/blocked');
 
          advance(fixture);
@@ -2634,8 +2633,11 @@ describe('Integration', () => {
          expect(router.serializeUrl(afterRedirectUrl as any)).toBe('/team/22');
        })));
 
-    it('should not break the back button when trigger by location change',
-       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+    it('should not break the back button when trigger by location change', fakeAsync(() => {
+         TestBed.configureTestingModule(
+             {providers: [{provide: LocationStrategy, useClass: HashLocationStrategy}]});
+         const router = TestBed.inject(Router);
+         const location = TestBed.inject(Location) as SpyLocation;
          const fixture = TestBed.createComponent(RootCmp);
          advance(fixture);
          router.resetConfig([
@@ -2656,8 +2658,7 @@ describe('Integration', () => {
          expect(location.path()).toEqual('/initial');
 
          // location change
-         (<any>location).go('/old/team/33');
-
+         location.simulateHashChange('/old/team/33');
 
          advance(fixture);
          expect(location.path()).toEqual('/team/33');
@@ -2665,7 +2666,7 @@ describe('Integration', () => {
          location.back();
          advance(fixture);
          expect(location.path()).toEqual('/initial');
-       })));
+       }));
   });
   describe('guards', () => {
     describe('CanActivate', () => {
@@ -2835,16 +2836,20 @@ describe('Integration', () => {
       describe('should reset the location when cancelling a navigation', () => {
         beforeEach(() => {
           TestBed.configureTestingModule({
-            providers: [{
-              provide: 'alwaysFalse',
-              useValue: (a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                return false;
-              }
-            }]
+            providers: [
+              {
+                provide: 'alwaysFalse',
+                useValue: (a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
+                  return false;
+                }
+              },
+              {provide: LocationStrategy, useClass: HashLocationStrategy}
+            ]
           });
         });
 
-        it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+        it('works',
+           fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
              const fixture = createRoot(router, RootCmp);
 
              router.resetConfig([
@@ -2856,7 +2861,7 @@ describe('Integration', () => {
              advance(fixture);
              expect(location.path()).toEqual('/one');
 
-             location.go('/two');
+             location.simulateHashChange('/two');
              advance(fixture);
              expect(location.path()).toEqual('/one');
            })));
@@ -5393,12 +5398,16 @@ describe('Integration', () => {
       }
 
       beforeEach(() => {
-        TestBed.configureTestingModule(
-            {providers: [{provide: UrlHandlingStrategy, useClass: CustomUrlHandlingStrategy}]});
+        TestBed.configureTestingModule({
+          providers: [
+            {provide: UrlHandlingStrategy, useClass: CustomUrlHandlingStrategy},
+            {provide: LocationStrategy, useClass: HashLocationStrategy}
+          ]
+        });
       });
 
       it('should work',
-         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
            const fixture = createRoot(router, RootCmp);
 
            router.resetConfig([{
@@ -5439,14 +5448,14 @@ describe('Integration', () => {
            events.splice(0);
 
            // another unsupported URL
-           location.go('/exclude/two');
+           location.simulateHashChange('/exclude/two');
            advance(fixture);
 
            expect(location.path()).toEqual('/exclude/two');
            expectEvents(events, []);
 
            // back to a supported URL
-           location.go('/include/simple');
+           location.simulateHashChange('/include/simple');
            advance(fixture);
 
            expect(location.path()).toEqual('/include/simple');
@@ -5461,7 +5470,7 @@ describe('Integration', () => {
          })));
 
       it('should handle the case when the router takes only the primary url',
-         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
            const fixture = createRoot(router, RootCmp);
 
            router.resetConfig([{
@@ -5474,7 +5483,7 @@ describe('Integration', () => {
            const events: any[] = [];
            router.events.subscribe(e => e instanceof RouterEvent && events.push(e));
 
-           location.go('/include/user/kate(aux:excluded)');
+           location.simulateHashChange('/include/user/kate(aux:excluded)');
            advance(fixture);
 
            expect(location.path()).toEqual('/include/user/kate(aux:excluded)');
@@ -5486,7 +5495,7 @@ describe('Integration', () => {
            ]);
            events.splice(0);
 
-           location.go('/include/user/kate(aux:excluded2)');
+           location.simulateHashChange('/include/user/kate(aux:excluded2)');
            advance(fixture);
            expectEvents(events, []);
 


### PR DESCRIPTION
* Do not emit url pop on Location.go
* Emit a `popstate` event before each `hashchange` to have the same
behavior of the browser.
* Track the url change in the internal history when calling `simulateHashChange`

The changes to the router tests reflect the goals of the test.
Generally when `Location.go` is used to trigger navigations, it is only
relevant for `HashLocationStrategy` and verifying that the Router picks
up changes from manual URL changes. To do this, we convert those calls
to `simulateHashChange` instead.
Manual URL bar changes to the path when not using the `HashLocationStrategy`
would otherwise trigger a full page refresh so they aren't relevant to
these test scenarios which assert correct behavior during the lifetime
of the router.

[Reference for no `popstate` on `pushState`/`replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event)
> Note that just calling history.pushState() or history.replaceState() won't
trigger a popstate event. The popstate event will be triggered by doing a browser
action such as a click on the back or forward button (or calling history.back()
or history.forward() in JavaScript).

[Reference for `popstate` before `hashChange`](https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event#when_popstate_is_sent)

>  When the transition occurs, either due to the user triggering the browser's
> "Back" button or otherwise, the popstate event is near the end of the process to transition to the new location
...
> 12. If the value of state changed, the popstate event is sent to the document.
> 13. Any persisted user state is restored, if the browser chooses to do so.
> 14. If the original and new entry's shared the same document, but had different fragments in their URLs, send the hashchange event to the window.

BREAKING CHANGE:

The behavior of the `SpyLocation` used by the `RouterTestingModule` has changed
to match the behavior of browsers. It no longer emits a 'popstate' event
when `Location.go` is called. In addition, `simulateHashChange` now
triggers _both_ a `hashchange` and a `popstate` event.
Tests which use `location.go` and expect the changes to be picked up by
the `Router` should likely change to `simulateHashChange` instead.
Each test is different in what it attempts to assert so there is no
single change that works for all tests. Each test using the `SpyLocation` to
simulate browser URL changes should be evaluated on a case-by-case basis.

fixes #27059


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
