### PR TITLE
build: remove `core-js` in favor of `core-js-bundle`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,7 +19,7 @@ filegroup(
     name = "web_test_bootstrap_scripts",
     # do not sort
     srcs = [
-        "@npm//:node_modules/core-js/client/core.js",
+        "@npm//:node_modules/core-js-bundle/index.js",
         "//packages/zone.js/bundles:zone.umd.js",
         "//packages/zone.js/bundles:zone-testing.umd.js",
         "//packages/zone.js/bundles:task-tracking.umd.js",

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -37,7 +37,7 @@ module.exports = function(config) {
       {pattern: 'node_modules/angular/angular?(.min).js', included: false, watched: false},
       {pattern: 'node_modules/angular-mocks/angular-mocks.js', included: false, watched: false},
 
-      'node_modules/core-js/client/core.js',
+      'node_modules/core-js-bundle/index.js',
       'node_modules/jasmine-ajax/lib/mock-ajax.js',
 
       // Dependencies built by Bazel. See `config.yml` for steps running before

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "chalk": "^2.3.1",
     "chokidar": "^3.5.1",
     "convert-source-map": "^1.5.1",
-    "core-js": "^2.4.1",
+    "core-js-bundle": "^3.10.2",
     "dependency-graph": "^0.11.0",
     "diff": "^5.0.0",
     "domino": "~2.1.6",

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -14,6 +14,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {ivyEnabled, onlyInIvy} from '@angular/private/testing';
 
 import {domRendererFactory3} from '../../src/render3/interfaces/renderer';
+import {global} from '../../src/util/global';
 
 
 describe('component', () => {
@@ -304,7 +305,7 @@ describe('component', () => {
      });
 
   describe('with ngDevMode', () => {
-    const _global: {ngDevMode: any} = global as any;
+    const _global: {ngDevMode: any} = global;
     let saveNgDevMode!: typeof ngDevMode;
     beforeEach(() => saveNgDevMode = ngDevMode);
     afterEach(() => _global.ngDevMode = saveNgDevMode);

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -11,6 +11,7 @@ import {fakeAsync, flushMicrotasks, waitForAsync} from '@angular/core/testing';
 import {AsyncTestCompleter, beforeEach, describe, expect, inject, it, Log, xit} from '@angular/core/testing/src/testing_internal';
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
 
+import {global} from '../../src/util/global';
 import {scheduleMicroTask} from '../../src/util/microtask';
 import {getNativeRequestAnimationFrame} from '../../src/util/raf';
 import {NoopNgZone} from '../../src/zone/ng_zone';
@@ -982,10 +983,10 @@ function commonTests() {
 
     describe('shouldCoalesceEventChangeDetection = true, shouldCoalesceRunChangeDetection = false', () => {
       let nativeRequestAnimationFrame: (fn: FrameRequestCallback) => void;
-      let nativeSetTimeout: any = (global as any)[Zone.__symbol__('setTimeout')];
-      if (!(global as any).requestAnimationFrame) {
+      let nativeSetTimeout: any = global[Zone.__symbol__('setTimeout')];
+      if (!global.requestAnimationFrame) {
         nativeRequestAnimationFrame = function(fn: Function) {
-          (global as any)[Zone.__symbol__('setTimeout')](fn, 16);
+          global[Zone.__symbol__('setTimeout')](fn, 16);
         };
       } else {
         nativeRequestAnimationFrame = getNativeRequestAnimationFrame().nativeRequestAnimationFrame;
@@ -996,7 +997,7 @@ function commonTests() {
 
       beforeEach(() => {
         patchedImmediate = setImmediate;
-        (global as any).setImmediate = (global as any)[Zone.__symbol__('setImmediate')];
+        global.setImmediate = global[Zone.__symbol__('setImmediate')];
         coalesceZone = new NgZone({shouldCoalesceEventChangeDetection: true});
         logs = [];
         coalesceZone.onMicrotaskEmpty.subscribe(() => {
@@ -1005,7 +1006,7 @@ function commonTests() {
       });
 
       afterEach(() => {
-        (global as any).setImmediate = patchedImmediate;
+        global.setImmediate = patchedImmediate;
       });
 
       it('should run in requestAnimationFrame async', (done: DoneFn) => {
@@ -1121,10 +1122,10 @@ function commonTests() {
 
     describe('shouldCoalesceRunChangeDetection = true', () => {
       let nativeRequestAnimationFrame: (fn: FrameRequestCallback) => void;
-      let nativeSetTimeout: any = (global as any)[Zone.__symbol__('setTimeout')];
-      if (!(global as any).requestAnimationFrame) {
+      let nativeSetTimeout: any = global[Zone.__symbol__('setTimeout')];
+      if (!global.requestAnimationFrame) {
         nativeRequestAnimationFrame = function(fn: Function) {
-          (global as any)[Zone.__symbol__('setTimeout')](fn, 16);
+          global[Zone.__symbol__('setTimeout')](fn, 16);
         };
       } else {
         nativeRequestAnimationFrame = getNativeRequestAnimationFrame().nativeRequestAnimationFrame;
@@ -1135,7 +1136,7 @@ function commonTests() {
 
       beforeEach(() => {
         patchedImmediate = setImmediate;
-        (global as any).setImmediate = (global as any)[Zone.__symbol__('setImmediate')];
+        global.setImmediate = global[Zone.__symbol__('setImmediate')];
         coalesceZone = new NgZone({shouldCoalesceRunChangeDetection: true});
         logs = [];
         coalesceZone.onMicrotaskEmpty.subscribe(() => {
@@ -1144,7 +1145,7 @@ function commonTests() {
       });
 
       afterEach(() => {
-        (global as any).setImmediate = patchedImmediate;
+        global.setImmediate = patchedImmediate;
       });
 
       it('should run in requestAnimationFrame async', (done: DoneFn) => {

--- a/packages/elements/test/BUILD.bazel
+++ b/packages/elements/test/BUILD.bazel
@@ -38,7 +38,7 @@ filegroup(
     testonly = True,
     # do not sort
     srcs = [
-        "@npm//:node_modules/core-js/client/core.js",
+        "@npm//:node_modules/core-js-bundle/index.js",
         # Required for browsers that do not natively support Custom Elements.
         "@npm//:node_modules/@webcomponents/custom-elements/custom-elements.min.js",
         # Required for ES5 code to work with a native Custom Elements implementation.

--- a/packages/misc/angular-in-memory-web-api/test/BUILD.bazel
+++ b/packages/misc/angular-in-memory-web-api/test/BUILD.bazel
@@ -22,7 +22,7 @@ karma_web_test_suite(
     name = "test_web",
     # do not sort
     bootstrap = [
-        "@npm//:node_modules/core-js/client/core.js",
+        "@npm//:node_modules/core-js-bundle/index.js",
         "@npm//:node_modules/reflect-metadata/Reflect.js",
         "@npm//:node_modules/jasmine-ajax/lib/mock-ajax.js",
         "//packages/zone.js/bundles:zone.umd.js",

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -91,7 +91,7 @@ import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockS
           ],
         });
 
-        const context: any = global || window;
+        const context: any = globalThis;
         const originalDescriptor = Object.getOwnPropertyDescriptor(context, 'navigator');
         const patchedDescriptor = {value: {serviceWorker: undefined}, configurable: true};
 
@@ -120,7 +120,7 @@ import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockS
              ]
            });
 
-           const context: any = global || window;
+           const context: any = globalThis;
            const originalDescriptor = Object.getOwnPropertyDescriptor(context, 'navigator');
            const patchedDescriptor = {value: {serviceWorker: mock}, configurable: true};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4117,6 +4117,11 @@ copy-webpack-plugin@8.1.1:
     schema-utils "^3.0.0"
     serialize-javascript "^5.0.1"
 
+core-js-bundle@^3.10.2:
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/core-js-bundle/-/core-js-bundle-3.10.2.tgz#16734b2674373afa40f0533b985a1c9e87bd426f"
+  integrity sha512-cU/daFGOLWwtNAdXBksUl2HNqPOaM5g6bMxJ8doMw9PkshbWSzUweog2EEJsIlgmCCAFI0NLDBl4SD2TzZEevw==
+
 core-js-compat@^3.6.2, core-js-compat@^3.8.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.10.0.tgz#3600dc72869673c110215ee7a005a8609dea0fe1"
@@ -4129,11 +4134,6 @@ core-js@3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.10.1.tgz#e683963978b6806dcc6c0a4a8bd4ab0bdaf3f21a"
   integrity sha512-pwCxEXnj27XG47mu7SXAwhLP3L5CrlvCB91ANUkIz40P27kUcvNfSdvyZJ9CLHiVoKSp+TTChMQMSKQEH/IQxA==
-
-core-js@^2.4.1:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
-  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION


**build: remove `core-js` in favor of `core-js-bundle`**
    
`core-js` is a CJS package which cannot be used directly in the browser. `core-js-bundle` is the bundled version of the package which can be used in directly in the browser.

 **test(service-worker): replace `global || window` with `globalThis`**
    
`global` property is not available in the browser, previously this was polyfilled through `core-js`. This now fails with `global is not defined`, since global cannot be accessed when not defined.

**test: use `global` util instead of `global`  property**
    
`global` property is not available in the browser, previously this was polyfilled through core-js.
    
