### PR TITLE
fix(upgrade): expose upgrade component scope to subclass

### DIFF
--- a/packages/upgrade/static/src/upgrade_component.ts
+++ b/packages/upgrade/static/src/upgrade_component.ts
@@ -74,7 +74,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
 
   private element: Element;
   private $element: IAugmentedJQuery;
-  private $componentScope: IScope;
+  protected $componentScope: IScope;
 
   private directive: IDirective;
   private bindings: Bindings;


### PR DESCRIPTION
Expose upgrade component's scope to be accessible to subclass in order to access the scope that UpgradeComponent creates in its constructor. This is helpful if declaring other services that need the same scope as the UpgradeComponent.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 41756


## What is the new behavior?
When extending UpgradeComponent, it creates a new scope for the upgraded component. In my case, I need to be able to access this scope to ensure any other controllers or components I create are created using this new scope.


## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
