### PR TITLE
fix(docs-infra): fix stackblitz builder

### DIFF
--- a/aio/tools/stackblitz-builder/builder.js
+++ b/aio/tools/stackblitz-builder/builder.js
@@ -4,7 +4,7 @@
 const path = require('canonical-path');
 const fs = require('fs-extra');
 const globby = require('globby');
-const jsdom = require('jsdom');
+const { JSDOM } = require('jsdom');
 const json5 = require('json5');
 
 const regionExtractor = require('../transforms/examples-package/services/region-parser');
@@ -30,7 +30,8 @@ class StackblitzBuilder {
         // console.log('***'+configFileName)
         this._buildStackblitzFrom(configFileName);
       } catch (e) {
-        console.log(e);
+        console.error(e);
+        process.exit(1);
       }
     });
   }
@@ -249,7 +250,8 @@ class StackblitzBuilder {
 
   _createStackblitzHtml(config, postData) {
     const baseHtml = this._createBaseStackblitzHtml(config);
-    const doc = jsdom.jsdom(baseHtml);
+    const dom = new JSDOM(baseHtml);
+    const doc = dom.window.document;
     const form = doc.querySelector('form');
 
     for(const [key, value] of Object.entries(postData)) {


### PR DESCRIPTION
Currently, the stackblitz builder is broken and CI is not failing.

```
TypeError: jsdom.jsdom is not a function
    at StackblitzBuilder._createStackblitzHtml (/home/circleci/ng/aio/tools/stackblitz-builder/builder.js:252:23)
    at StackblitzBuilder._buildStackblitzFrom (/home/circleci/ng/aio/tools/stackblitz-builder/builder.js:99:25)
    at /home/circleci/ng/aio/tools/stackblitz-builder/builder.js:31:14
    at Array.forEach (<anonymous>)
    at StackblitzBuilder.build (/home/circleci/ng/aio/tools/stackblitz-builder/builder.js:28:15)
    at Object.<anonymous> (/home/circleci/ng/aio/tools/stackblitz-builder/generateStackblitz.js:7:58)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
```

With this change we fix the errors and also fix the builder to exit process with a non zero error code when there is an error.
