### PR TITLE
feat(dev-infra): create shared platform for remote execution 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -114,15 +114,11 @@ build:remote --cpu=k8
 build:remote --host_cpu=k8
 
 # Toolchain and platform related flags
-build:remote --host_javabase=@rbe_ubuntu1604_angular//java:jdk
-build:remote --javabase=@rbe_ubuntu1604_angular//java:jdk
-build:remote --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:remote --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:remote --crosstool_top=@rbe_ubuntu1604_angular//cc:toolchain
-build:remote --extra_toolchains=@rbe_ubuntu1604_angular//config:cc-toolchain
-build:remote --extra_execution_platforms=//tools:rbe_ubuntu1604-angular
-build:remote --host_platform=//tools:rbe_ubuntu1604-angular
-build:remote --platforms=//tools:rbe_ubuntu1604-angular
+build:remote --crosstool_top=//dev-infra/bazel/remote-execution/cpp:cc_toolchain_suite
+build:remote --extra_toolchains=//dev-infra/bazel/remote-execution/cpp:cc_toolchain
+build:remote --extra_execution_platforms=//dev-infra/bazel/remote-execution:platform
+build:remote --host_platform=//dev-infra/bazel/remote-execution:platform
+build:remote --platforms=//dev-infra/bazel/remote-execution:platform
 
 # Remote instance and caching
 build:remote --remote_instance_name=projects/internal-200822/instances/default_instance

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,27 +62,3 @@ sass_repositories()
 load("@io_bazel_skydoc//skylark:skylark.bzl", "skydoc_repositories")
 
 skydoc_repositories()
-
-load("@bazel_toolchains//rules:environments.bzl", "clang_env")
-load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
-
-rbe_autoconfig(
-    name = "rbe_ubuntu1604_angular",
-    # Need to specify a base container digest in order to ensure that we can use the checked-in
-    # platform configurations for the "ubuntu16_04" image. Otherwise the autoconfig rule would
-    # need to pull the image and run it in order determine the toolchain configuration. See:
-    # https://github.com/bazelbuild/bazel-toolchains/blob/4.0.0/configs/ubuntu16_04_clang/versions.bzl
-    base_container_digest = "sha256:f6568d8168b14aafd1b707019927a63c2d37113a03bcee188218f99bd0327ea1",
-    # Note that if you change the `digest`, you might also need to update the
-    # `base_container_digest` to make sure marketplace.gcr.io/google/rbe-ubuntu16-04-webtest:<digest>
-    # and marketplace.gcr.io/google/rbe-ubuntu16-04:<base_container_digest> have
-    # the same Clang and JDK installed. Clang is needed because of the dependency on
-    # @com_google_protobuf. Java is needed for the Bazel's test executor Java tool.
-    digest = "sha256:dddaaddbe07a61c2517f9b08c4977fc23c4968fcb6c0b8b5971e955d2de7a961",
-    env = clang_env(),
-    registry = "marketplace.gcr.io",
-    # We can't use the default "ubuntu16_04" RBE image provided by the autoconfig because we need
-    # a specific Linux kernel that comes with "libx11" in order to run headless browser tests.
-    repository = "google/rbe-ubuntu16-04-webtest",
-    use_checked_in_confs = "Force",
-)

--- a/dev-infra/bazel/BUILD.bazel
+++ b/dev-infra/bazel/BUILD.bazel
@@ -5,5 +5,6 @@ filegroup(
     srcs = [
         "BUILD.bazel",
         "expand_template.bzl",
+        "//dev-infra/bazel/remote-execution:files",
     ],
 )

--- a/dev-infra/bazel/remote-execution/BUILD.bazel
+++ b/dev-infra/bazel/remote-execution/BUILD.bazel
@@ -9,9 +9,14 @@ platform(
     ],
     # We use a basic docker image from the Google Cloud container registry that supports
     # browser tests. Note that we usually do not use any of the local browsers, but the image
-    # guarantees that necessary dependencies for launching browsers are installed.
-    # Additionally, we set the `SYS_ADMIN` capability so that browsers can be launched with
-    # sandbox mode enabled. Related information: https://developers.google.com/web/tools/puppeteer/troubleshooting#running_puppeteer_in_docker
+    # guarantees that necessary dependencies for launching browsers are installed. Since we
+    # do not rely on many binaries/tools from the image, the image doesn't need to be updated
+    # frequently. There are rare cases where it needs to be updated. e.g. for a more recent Bash
+    # version, or new system settings that are required for launching browsers. In order to do that,
+    # we need to either see if the `rbe-ubuntu16-04-webtest` image can be updated, or if we need to
+    # build and publish our own image to the Google cloud image registry. Additionally, we set th
+    # `SYS_ADMIN` capability so that browsers can be launched with sandbox mode enabled. Related
+    # information: https://developers.google.com/web/tools/puppeteer/troubleshooting#running_puppeteer_in_docker
     remote_execution_properties = """
         properties: {
           name: "container-image"

--- a/dev-infra/bazel/remote-execution/BUILD.bazel
+++ b/dev-infra/bazel/remote-execution/BUILD.bazel
@@ -1,0 +1,28 @@
+package(default_visibility = ["//visibility:public"])
+
+platform(
+    name = "platform",
+    constraint_values = [
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//tools/cpp:clang",
+    ],
+    remote_execution_properties = """
+        properties: {
+          name: "container-image"
+          value:"docker://gcr.io/cloud-marketplace/google/rbe-ubuntu16-04-webtest@sha256:886a12dc4726f5b991b46386292afa8d943b6703a5496c8a1e07cfde778d9044"
+        }
+        properties: {
+          name: "dockerAddCapabilities"
+          value: "SYS_ADMIN"
+        }
+        """,
+)
+
+filegroup(
+    name = "files",
+    srcs = [
+        "BUILD.bazel",
+        "//dev-infra/bazel/remote-execution/cpp:files",
+    ],
+)

--- a/dev-infra/bazel/remote-execution/BUILD.bazel
+++ b/dev-infra/bazel/remote-execution/BUILD.bazel
@@ -7,6 +7,11 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//tools/cpp:clang",
     ],
+    # We use a basic docker image from the Google Cloud container registry that supports
+    # browser tests. Note that we usually do not use any of the local browsers, but the image
+    # guarantees that necessary dependencies for launching browsers are installed.
+    # Additionally, we set the `SYS_ADMIN` capability so that browsers can be launched with
+    # sandbox mode enabled. Related information: https://developers.google.com/web/tools/puppeteer/troubleshooting#running_puppeteer_in_docker
     remote_execution_properties = """
         properties: {
           name: "container-image"

--- a/dev-infra/bazel/remote-execution/cpp/BUILD.bazel
+++ b/dev-infra/bazel/remote-execution/cpp/BUILD.bazel
@@ -1,0 +1,57 @@
+load("@bazel_tools//tools/cpp:cc_toolchain_config.bzl", "cc_toolchain_config")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "files",
+    srcs = ["BUILD.bazel"],
+)
+
+cc_toolchain_suite(
+    name = "cc_toolchain_suite",
+    toolchains = {
+        "k8": ":cc_compiler_k8",
+    },
+)
+
+toolchain(
+    name = "cc_toolchain",
+    exec_compatible_with = [
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//tools/cpp:clang",
+    ],
+    target_compatible_with = [
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//platforms:x86_64",
+    ],
+    toolchain = ":cc_compiler_k8",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+# Basic CC toolchain for k8 remote containers. Based on the default k8
+# toolchain provided in Bazel (but unfortunately internal).
+# https://github.com/bazelbuild/bazel/blob/c951753097b45cfb9be512c02199aa891b9646b8/tools/cpp/BUILD.tools#L298-L311
+cc_toolchain(
+    name = "cc_compiler_k8",
+    all_files = ":empty",
+    ar_files = ":empty",
+    as_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 1,
+    toolchain_config = ":k8_toolchain_config",
+    toolchain_identifier = "cc-k8-compiler",
+)
+
+cc_toolchain_config(
+    name = "k8_toolchain_config",
+    compiler = "compiler",
+    cpu = "local",
+)
+
+# Empty filegroup used for defining the CC toolchain.
+filegroup(name = "empty")

--- a/dev-infra/release/publish/test/common.spec.ts
+++ b/dev-infra/release/publish/test/common.spec.ts
@@ -19,7 +19,7 @@ import {ReleaseAction} from '../actions';
 import {actions} from '../actions/index';
 import {changelogPath} from '../constants';
 
-import {getChangelogForVersion, getTestingMocksForReleaseAction, parse, setupReleaseActionForTesting, testTmpDir} from './test-utils';
+import {fakeNpmPackageQueryRequest, getChangelogForVersion, getTestingMocksForReleaseAction, parse, setupReleaseActionForTesting, testTmpDir} from './test-utils';
 
 describe('common release action logic', () => {
   const baseReleaseTrains: ActiveReleaseTrains = {
@@ -36,15 +36,11 @@ describe('common release action logic', () => {
     };
 
     it('should not modify release train versions and cause invalid other actions', async () => {
-      // The cached npm package information needs to be deleted as depending on the test order
-      // their may or may not be packages in the cache, causing the number of active LTS branches
-      // in this test to be 2 instead of 0.
-      for (const packageName in _npmPackageInfoCache) {
-        delete _npmPackageInfoCache[packageName];
-      }
-
       const {releaseConfig, gitClient} = getTestingMocksForReleaseAction();
       const descriptions: string[] = [];
+
+      // Fake the NPM package request as otherwise the test would rely on `npmjs.org`.
+      fakeNpmPackageQueryRequest(releaseConfig.npmPackages[0], {'dist-tags': {}});
 
       for (const actionCtor of actions) {
         if (await actionCtor.isActive(testReleaseTrain)) {

--- a/packages/bazel/package.bzl
+++ b/packages/bazel/package.bzl
@@ -24,19 +24,6 @@ def rules_angular_dev_dependencies():
     shorter.
     """
 
-    # Needed for Remote Execution
-    # https://github.com/bazelbuild/bazel-toolchains/releases
-    _maybe(
-        http_archive,
-        name = "bazel_toolchains",
-        sha256 = "1adf5db506a7e3c465a26988514cfc3971af6d5b3c2218925cd6e71ee443fc3f",
-        strip_prefix = "bazel-toolchains-4.0.0",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/4.0.0/bazel-toolchains-4.0.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-toolchains/releases/download/4.0.0/bazel-toolchains-4.0.0.tar.gz",
-        ],
-    )
-
     #############################################
     # Dependencies for generating documentation #
     #############################################

--- a/renovate.json
+++ b/renovate.json
@@ -78,7 +78,6 @@
       "packagePatterns": [
         "^@bazel/.*",
         "^build_bazel.*",
-        "bazel_toolchains"
       ],
       "groupName": "bazel",
       "pinVersions": false


### PR DESCRIPTION
Introduces a shared Bazel platform for remote execution builds
using Google cloud. Previously we used `bazel_toolchains` for
providing the platform w/ additional CPP and Java toolchains

`bazel_toolchains` no longer provides default toolchains with the
latest version, but provides a tool (linux and windows only) for
generating toolchain/platforms, which then need to be checked
into the repository. This is quite inconvenient and cumbersome
(especially with no macOS support), so we just provide our own
platform and CPP toolchain within `//dev-infra`. This is more
simple than all the effort we'd need to make the toolchain
generation tool work (while it would also increase the amount
of checked-in sources significantly; with more unused toolchains
for CPP or Java)