### PR TITLE
revert: "build(docs-infra): fix `StackblitzBuilder` after `jsdom` update"

### DIFF
--- a/aio/tools/stackblitz-builder/builder.js
+++ b/aio/tools/stackblitz-builder/builder.js
@@ -254,7 +254,7 @@ class StackblitzBuilder {
 
   _createStackblitzHtml(config, postData) {
     const baseHtml = this._createBaseStackblitzHtml(config);
-    const doc = new jsdom.JSDOM(baseHtml).window.document;
+    const doc = jsdom.jsdom(baseHtml);
     const form = doc.querySelector('form');
 
     for(const [key, value] of Object.entries(postData)) {


### PR DESCRIPTION
This PR reverts a single commit from #41725. The change caused aio builds to fail for 11.2.x.

// cc @gkalpak 
