### PR TITLE
fix(upgrade): expose upgrade component scope to subclass

### DIFF
--- a/goldens/public-api/upgrade/static/static.d.ts
+++ b/goldens/public-api/upgrade/static/static.d.ts
@@ -22,6 +22,7 @@ export declare function setAngularJSGlobal(ng: any): void;
 export declare function setAngularLib(ng: any): void;
 
 export declare class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
+    protected $componentScope: IScope;
     constructor(name: string, elementRef: ElementRef, injector: Injector);
     ngDoCheck(): void;
     ngOnChanges(changes: SimpleChanges): void;

--- a/goldens/public-api/upgrade/static/static.d.ts
+++ b/goldens/public-api/upgrade/static/static.d.ts
@@ -22,7 +22,7 @@ export declare function setAngularJSGlobal(ng: any): void;
 export declare function setAngularLib(ng: any): void;
 
 export declare class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
-    protected $componentScope: IScope;
+    protected readonly $componentScope: IScope;
     constructor(name: string, elementRef: ElementRef, injector: Injector);
     ngDoCheck(): void;
     ngOnChanges(changes: SimpleChanges): void;

--- a/packages/upgrade/static/src/upgrade_component.ts
+++ b/packages/upgrade/static/src/upgrade_component.ts
@@ -74,7 +74,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
 
   private element: Element;
   private $element: IAugmentedJQuery;
-  private $componentScope: IScope;
+  protected $componentScope: IScope;
 
   private directive: IDirective;
   private bindings: Bindings;

--- a/packages/upgrade/static/src/upgrade_component.ts
+++ b/packages/upgrade/static/src/upgrade_component.ts
@@ -74,7 +74,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
 
   private element: Element;
   private $element: IAugmentedJQuery;
-  protected $componentScope: IScope;
+  protected readonly $componentScope: IScope;
 
   private directive: IDirective;
   private bindings: Bindings;


### PR DESCRIPTION
Expose upgrade component's scope to be accessible to subclass in order to access the scope that UpgradeComponent creates in its constructor. This is helpful if declaring other services that need the same scope as the UpgradeComponent.

Fixes #41756

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 41756


## What is the new behavior?

When extending UpgradeComponent, it creates a new scope for the upgraded component. In my case, I need to be able to access this scope to ensure any other controllers or components I create are created using this new scope.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No

