### PR TITLE
build: update to CLDR version 39

### DIFF
--- a/tools/gulp-tasks/cldr/cldr-urls.json
+++ b/tools/gulp-tasks/cldr/cldr-urls.json
@@ -1,22 +1,5 @@
 {
   "core": [
-    "https://github.com/unicode-cldr/cldr-core/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-segments-modern/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-dates-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-cal-buddhist-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-cal-chinese-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-cal-coptic-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-cal-dangi-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-cal-ethiopic-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-cal-hebrew-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-cal-indian-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-cal-islamic-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-cal-japanese-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-cal-persian-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-cal-roc-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-localenames-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-misc-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-numbers-full/archive/37.0.0.zip",
-    "https://github.com/unicode-cldr/cldr-units-full/archive/37.0.0.zip"
+    "https://github.com/unicode-org/cldr-json/releases/download/39.0.0/cldr-39.0.0-json-full.zip"
   ]
 }


### PR DESCRIPTION
Update to the latest version of CLDR data (version 39), which includes
many fixes.

Also switch to the new official CLDR-JSON repo [1], since the previous
one [2] has been archived by the CLDR organization.

\[1]: https://github.com/unicode-org/cldr-json
\[2]: https://github.com/unicode-cldr/cldr-core