### PR TITLE
docs(common): add reference to digits info in currency and percent pipe

### DIFF
--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -121,6 +121,8 @@ export class DecimalPipe implements PipeTransform {
  * into text strings, according to various format specifications,
  * where the caller's default locale is `en-US`.
  *
+ * See [DecimalPipe](/api/common/DecimalPipe#digitsinfo) for information about the format of the digitsInfo parameter.
+ *
  * <code-example path="common/pipes/ts/percent_pipe.ts" region='PercentPipe'></code-example>
  *
  * @publicApi
@@ -196,6 +198,8 @@ export class PercentPipe implements PipeTransform {
  * The following code shows how the pipe transforms numbers
  * into text strings, according to various format specifications,
  * where the caller's default locale is `en-US`.
+ * 
+ * See [DecimalPipe](/api/common/DecimalPipe#digitsinfo) for information about the format of the digitsInfo parameter.
  *
  * <code-example path="common/pipes/ts/currency_pipe.ts" region='CurrencyPipe'></code-example>
  *


### PR DESCRIPTION
As discussed in [Angular's Discord Server](https://discord.com/channels/748677963142135818/762717176142495814/835118360206245938), the documentation on how to use the `digitsInfo` argument in both `CurrencyPipe` and `PercentPipe` was quite lacking. Currently, it's not clear how one should use this argument. Hence, I added references to `DecimalPipe`, where `digitsInfo` usage is explained in greater depth.