### PR TITLE
Docs infra: ambiguous letter-casing doc filenames

### DIFF
--- a/aio/content/errors/NG2003.md
+++ b/aio/content/errors/NG2003.md
@@ -8,4 +8,4 @@ There is no injection token for a constructor parameter at compile time. [Inject
 @debugging
 Look at the parameter that throws the error and all uses of the class. This error is commonly thrown when a constructor defines parameters with primitive types like `string`, `number`, `boolean`, and `Object`.
 
-Use the [@Injectable](api/core/Injectable) method or [@Inject](api/core/Inject) decorator from `@angular/core` to ensure that the type you are injecting is reified (has a runtime representation). Make sure to add a provider to this decorator so that you do not throw [NG0201: No Provider Found](errors/NG0201).
+Use the `@Injectable` method or `@Inject` decorator from `@angular/core` to ensure that the type you are injecting is reified (has a runtime representation). Make sure to add a provider to this decorator so that you do not throw [NG0201: No Provider Found](errors/NG0201).

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -97,7 +97,7 @@ Tip: In the [API reference section](api) of this doc site, deprecated APIs are i
 | API | Replacement | Deprecation announced | Notes |
 | --- | ----------- | --------------------- | ----- |
 | [`DefaultIterableDiffer`](api/core/DefaultIterableDiffer) | n/a | v4 | Not part of public API. |
-| [`ReflectiveInjector`](api/core/ReflectiveInjector) | [`Injector.create`](api/core/Injector#create)  | v5 | See [`ReflectiveInjector`](#reflectiveinjector) |
+| [`ReflectiveInjector`](api/core/ReflectiveInjector) | `{@link Injector#create Injector.create()}` | v5 | See [`ReflectiveInjector`](#reflectiveinjector) |
 | [`ReflectiveKey`](api/core/ReflectiveKey) | none | v5 | none |
 | [`defineInjectable`](api/core/defineInjectable) | `ɵɵdefineInjectable` | v8 | Used only in generated code. No source code should depend on this API. |
 | [`entryComponents`](api/core/NgModule#entryComponents) | none | v9 | See [`entryComponents`](#entryComponents) |

--- a/aio/tests/deployment/e2e/smoke-tests.e2e-spec.ts
+++ b/aio/tests/deployment/e2e/smoke-tests.e2e-spec.ts
@@ -62,7 +62,7 @@ describe(browser.baseUrl, () => {
 
     describe('(api docs pages)', () => {
       const textPerUrl: { [key: string]: string } = {
-        /* Class */ 'api/core/Injector': 'class injector',
+        /* Class */ 'api/core/injector-0': 'class injector',
         /* Const */ 'api/forms/NG_VALIDATORS': 'const ng_validators',
         /* Decorator */ 'api/core/Component': '@component',
         /* Directive */ 'api/common/NgIf': 'class ngif',

--- a/aio/tests/deployment/e2e/smoke-tests.e2e-spec.ts
+++ b/aio/tests/deployment/e2e/smoke-tests.e2e-spec.ts
@@ -62,7 +62,7 @@ describe(browser.baseUrl, () => {
 
     describe('(api docs pages)', () => {
       const textPerUrl: { [key: string]: string } = {
-        /* Class */ 'api/core/injector-0': 'class injector',
+        /* Class */ 'api/core/Injector-0': 'class injector',
         /* Const */ 'api/forms/NG_VALIDATORS': 'const ng_validators',
         /* Decorator */ 'api/core/Component': '@component',
         /* Directive */ 'api/common/NgIf': 'class ngif',

--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -217,7 +217,7 @@ module.exports =
           convertToJsonProcessor.docTypes =
               convertToJsonProcessor.docTypes.concat(API_DOC_TYPES_TO_RENDER);
           postProcessHtml.docTypes =
-              convertToJsonProcessor.docTypes.concat(API_DOC_TYPES_TO_RENDER);
+              postProcessHtml.docTypes.concat(API_DOC_TYPES_TO_RENDER);
           autoLinkCode.docTypes = API_DOC_TYPES;
           autoLinkCode.codeElements = ['code', 'code-example', 'code-pane'];
         });

--- a/aio/tools/transforms/angular-base-package/index.js
+++ b/aio/tools/transforms/angular-base-package/index.js
@@ -67,7 +67,7 @@ module.exports = new Package('angular-base', [
     collectExamples.exampleFolders = [];
 
     generateKeywordsProcessor.ignoreWords = require(path.resolve(__dirname, 'ignore-words'))['en'];
-    generateKeywordsProcessor.docTypesToIgnore = [undefined, 'example-region', 'json-doc', 'api-list-data', 'api-list-data', 'contributors-json', 'navigation-json', 'announcements-json'];
+    generateKeywordsProcessor.docTypesToIgnore = [undefined, 'example-region', 'json-doc', 'api-list-data', 'api-list-data', 'contributors-json', 'navigation-json', 'announcements-json', 'disambiguator'];
     generateKeywordsProcessor.propertiesToIgnore = ['basePath', 'renderedContent', 'docType', 'searchTitle'];
   })
 

--- a/aio/tools/transforms/angular-base-package/index.js
+++ b/aio/tools/transforms/angular-base-package/index.js
@@ -37,6 +37,7 @@ module.exports = new Package('angular-base', [
   .processor(require('./processors/renderLinkInfo'))
   .processor(require('./processors/checkContentRules'))
   .processor(require('./processors/splitDescription'))
+  .processor(require('./processors/disambiguateDocPaths'))
 
   // overrides base packageInfo and returns the one for the 'angular/angular' repo.
   .factory('packageInfo', function() { return require(path.resolve(PROJECT_ROOT, 'package.json')); })
@@ -167,5 +168,5 @@ module.exports = new Package('angular-base', [
   })
 
   .config(function(convertToJsonProcessor) {
-    convertToJsonProcessor.docTypes = [];
+    convertToJsonProcessor.docTypes = ['disambiguator'];
   });

--- a/aio/tools/transforms/angular-base-package/processors/disambiguateDocPaths.js
+++ b/aio/tools/transforms/angular-base-package/processors/disambiguateDocPaths.js
@@ -12,7 +12,7 @@ module.exports = function disambiguateDocPathsProcessor(log) {
     $process(docs) {
       // Collect all the ambiguous docs, whose outputPath is are only different by casing.
       const ambiguousDocMap = new Map();
-      for(const doc of docs) {
+      for (const doc of docs) {
         if (!doc.outputPath) {
           continue;
         }
@@ -25,9 +25,8 @@ module.exports = function disambiguateDocPathsProcessor(log) {
       }
 
       // Create a disambiguator doc for each set of such ambiguous docs,
-      // and update the ambigous docs to have unique `path` and `outputPath` properties.
-      for(const outputPath of ambiguousDocMap.keys()) {
-        const ambiguousDocs = ambiguousDocMap.get(outputPath);
+      // and update the ambiguous docs to have unique `path` and `outputPath` properties.
+      for (const [outputPath, ambiguousDocs] of ambiguousDocMap) {
         if (ambiguousDocs.length === 1) {
           continue;
         }
@@ -43,7 +42,7 @@ module.exports = function disambiguateDocPathsProcessor(log) {
 
         // Update the paths
         let count = 0;
-        for(const doc of ambiguousDocs) {
+        for (const doc of ambiguousDocs) {
           doc.path = convertPath(doc.path, count);
           doc.outputPath = convertPath(doc.outputPath, count);
           count += 1;
@@ -53,7 +52,7 @@ module.exports = function disambiguateDocPathsProcessor(log) {
   };
 };
 
-function convertPath(outputPath, count) {
+function convertPath(path, count) {
   // Add the counter before any extension
-  return outputPath.replace(/(\.[^.]*)?$/, `-${count}$1`).toLowerCase();
+  return path.replace(/(\.[^.]*)?$/, `-${count}$1`);
 }

--- a/aio/tools/transforms/angular-base-package/processors/disambiguateDocPaths.js
+++ b/aio/tools/transforms/angular-base-package/processors/disambiguateDocPaths.js
@@ -1,0 +1,59 @@
+/**
+ * @dgProcessor disambiguateDocPathsProcessor
+ * @description
+ *
+ * Ensures that docs that have the same path, other than case changes,
+ * are disambiguated.
+ */
+module.exports = function disambiguateDocPathsProcessor(log) {
+  return {
+    $runAfter: ['paths-computed'],
+    $runBefore: ['rendering-docs'],
+    $process(docs) {
+      // Collect all the ambiguous docs, whose outputPath is are only different by casing.
+      const ambiguousDocMap = new Map();
+      for(const doc of docs) {
+        if (!doc.outputPath) {
+          continue;
+        }
+        const outputPath = doc.outputPath.toLowerCase();
+        if (!ambiguousDocMap.has(outputPath)) {
+          ambiguousDocMap.set(outputPath, []);
+        }
+        const ambiguousDocs = ambiguousDocMap.get(outputPath);
+        ambiguousDocs.push(doc);
+      }
+
+      // Create a disambiguator doc for each set of such ambiguous docs,
+      // and update the ambigous docs to have unique `path` and `outputPath` properties.
+      for(const outputPath of ambiguousDocMap.keys()) {
+        const ambiguousDocs = ambiguousDocMap.get(outputPath);
+        if (ambiguousDocs.length === 1) {
+          continue;
+        }
+
+        log.debug('Docs with ambiguous outputPath:' + ambiguousDocs.map((d, i) => `\n - ${d.id}: "${d.outputPath}" replaced with "${convertPath(d.outputPath, i)}".`));
+
+        const doc = ambiguousDocs[0];
+        const path = doc.path;
+        const id = `${doc.id.toLowerCase()}-disambiguator`;
+        const title = `${doc.id.toLowerCase()} (disambiguation)`;
+        const aliases = [id];
+        docs.push({ docType: 'disambiguator', id, title, aliases, path, outputPath, docs: ambiguousDocs });
+
+        // Update the paths
+        let count = 0;
+        for(const doc of ambiguousDocs) {
+          doc.path = convertPath(doc.path, count);
+          doc.outputPath = convertPath(doc.outputPath, count);
+          count += 1;
+        }
+      }
+    }
+  };
+};
+
+function convertPath(outputPath, count) {
+  // Add the counter before any extension
+  return outputPath.replace(/(\.[^.]*)?$/, `-${count}$1`).toLowerCase();
+}

--- a/aio/tools/transforms/angular-base-package/processors/disambiguateDocPaths.js
+++ b/aio/tools/transforms/angular-base-package/processors/disambiguateDocPaths.js
@@ -4,6 +4,16 @@
  *
  * Ensures that docs that have the same path, other than case changes,
  * are disambiguated.
+ *
+ * For example in Angular there is the `ROUTES` const and a `Routes` type.
+ * In a case-sensitive file-system these would both be stored at the paths
+ *
+ * ```
+ * aio/src/generated/router/Routes.json
+ * aio/src/generated/router/ROUTES.json
+ * ```
+ *
+ * but in a case-insensitive file-system these two paths point to the same file!
  */
 module.exports = function disambiguateDocPathsProcessor(log) {
   return {

--- a/aio/tools/transforms/angular-base-package/processors/disambiguateDocPaths.spec.js
+++ b/aio/tools/transforms/angular-base-package/processors/disambiguateDocPaths.spec.js
@@ -4,7 +4,7 @@ const Dgeni = require('dgeni');
 describe('disambiguateDocPaths processor', () => {
   let dgeni, injector, processor, docs;
 
-  beforeEach(function() {
+  beforeEach(() => {
     dgeni = new Dgeni([testPackage('angular-base-package')]);
     injector = dgeni.configureInjector();
     processor = injector.get('disambiguateDocPathsProcessor');
@@ -26,7 +26,7 @@ describe('disambiguateDocPaths processor', () => {
     const numDocs = docs.length;
     processor.$process(docs);
     expect(docs.length).toEqual(numDocs + 2);
-    expect(docs[docs.length-2]).toEqual({
+    expect(docs[docs.length - 2]).toEqual({
       docType: 'disambiguator',
       id: 'test-doc-disambiguator',
       title: 'test-doc (disambiguation)',
@@ -35,7 +35,7 @@ describe('disambiguateDocPaths processor', () => {
       outputPath: 'test/doc.json',
       docs: [docs[0], docs[1]],
     });
-    expect(docs[docs.length-1]).toEqual({
+    expect(docs[docs.length - 1]).toEqual({
       docType: 'disambiguator',
       id: 'other-doc-disambiguator',
       title: 'other-doc (disambiguation)',
@@ -50,8 +50,8 @@ describe('disambiguateDocPaths processor', () => {
     processor.$process(docs);
     expect(docs[0].path).toEqual('test/doc-0');
     expect(docs[0].outputPath).toEqual('test/doc-0.json');
-    expect(docs[1].path).toEqual('test/doc-1');
-    expect(docs[1].outputPath).toEqual('test/doc-1.json');
+    expect(docs[1].path).toEqual('TEST/DOC-1');
+    expect(docs[1].outputPath).toEqual('TEST/DOC-1.json');
 
     // The non-ambiguous docs are left alone
     expect(docs[2].outputPath).toEqual('test/Doc.xml');
@@ -59,7 +59,7 @@ describe('disambiguateDocPaths processor', () => {
 
     expect(docs[4].path).toEqual('other/doc-0');
     expect(docs[4].outputPath).toEqual('other/doc-0.json');
-    expect(docs[5].path).toEqual('other/doc-1');
-    expect(docs[5].outputPath).toEqual('other/doc-1.json');
+    expect(docs[5].path).toEqual('other/DOC-1');
+    expect(docs[5].outputPath).toEqual('other/DOC-1.json');
   });
 });

--- a/aio/tools/transforms/angular-base-package/processors/disambiguateDocPaths.spec.js
+++ b/aio/tools/transforms/angular-base-package/processors/disambiguateDocPaths.spec.js
@@ -1,0 +1,65 @@
+const testPackage = require('../../helpers/test-package');
+const Dgeni = require('dgeni');
+
+describe('disambiguateDocPaths processor', () => {
+  let dgeni, injector, processor, docs;
+
+  beforeEach(function() {
+    dgeni = new Dgeni([testPackage('angular-base-package')]);
+    injector = dgeni.configureInjector();
+    processor = injector.get('disambiguateDocPathsProcessor');
+    docs = [
+      {docType: 'test-doc', id: 'test-doc', path: 'test/doc', outputPath: 'test/doc.json'},
+      {docType: 'test-doc', id: 'TEST-DOC', path: 'TEST/DOC', outputPath: 'TEST/DOC.json'},
+      {docType: 'test-doc', id: 'test-Doc', path: 'test/Doc', outputPath: 'test/Doc.xml'},
+      {docType: 'test-doc', id: 'unique-doc', path: 'unique/doc', outputPath: 'unique/doc.json'},
+      {docType: 'test-doc', id: 'other-doc', path: 'other/doc', outputPath: 'other/doc.json'},
+      {docType: 'test-doc', id: 'other-DOC', path: 'other/DOC', outputPath: 'other/DOC.json'},
+    ];
+  });
+
+  it('should be part of the dgeni package', () => {
+    expect(processor).toBeDefined();
+  });
+
+  it('should create `disambiguator` documents for docs that have ambiguous outputPaths', () => {
+    const numDocs = docs.length;
+    processor.$process(docs);
+    expect(docs.length).toEqual(numDocs + 2);
+    expect(docs[docs.length-2]).toEqual({
+      docType: 'disambiguator',
+      id: 'test-doc-disambiguator',
+      title: 'test-doc (disambiguation)',
+      aliases: ['test-doc-disambiguator'],
+      path: 'test/doc',
+      outputPath: 'test/doc.json',
+      docs: [docs[0], docs[1]],
+    });
+    expect(docs[docs.length-1]).toEqual({
+      docType: 'disambiguator',
+      id: 'other-doc-disambiguator',
+      title: 'other-doc (disambiguation)',
+      aliases: ['other-doc-disambiguator'],
+      path: 'other/doc',
+      outputPath: 'other/doc.json',
+      docs: [docs[4], docs[5]],
+    });
+  });
+
+  it('should update the path and outputPath properties of each ambiguous doc', () => {
+    processor.$process(docs);
+    expect(docs[0].path).toEqual('test/doc-0');
+    expect(docs[0].outputPath).toEqual('test/doc-0.json');
+    expect(docs[1].path).toEqual('test/doc-1');
+    expect(docs[1].outputPath).toEqual('test/doc-1.json');
+
+    // The non-ambiguous docs are left alone
+    expect(docs[2].outputPath).toEqual('test/Doc.xml');
+    expect(docs[3].outputPath).toEqual('unique/doc.json');
+
+    expect(docs[4].path).toEqual('other/doc-0');
+    expect(docs[4].outputPath).toEqual('other/doc-0.json');
+    expect(docs[5].path).toEqual('other/doc-1');
+    expect(docs[5].outputPath).toEqual('other/doc-1.json');
+  });
+});

--- a/aio/tools/transforms/templates/disambiguator.template.html
+++ b/aio/tools/transforms/templates/disambiguator.template.html
@@ -1,0 +1,15 @@
+{% marked %}
+# {$ doc.title $}
+{% endmarked %}
+
+{% block content %}
+<div class="content">
+  There are multiple pages that match this path:
+  <ul>
+    {% for ambiguousDoc in doc.docs %}<li>
+      <a href="{$ ambiguousDoc.path $}">{$ ambiguousDoc.id $}</a>
+      {$ ambiguousDoc.shortDescription | marked $}
+    </li>{% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/packages/core/src/di/interface/provider.ts
+++ b/packages/core/src/di/interface/provider.ts
@@ -250,7 +250,7 @@ export interface FactoryProvider extends FactorySansProvider {
  * Describes how an `Injector` should be configured as static (that is, without reflection).
  * A static provider provides tokens to an injector for various types of dependencies.
  *
- * @see [Injector.create()](/api/core/Injector#create).
+ * @see `Injector.create()`.
  * @see ["Dependency Injection Guide"](guide/dependency-injection-providers).
  *
  * @publicApi


### PR DESCRIPTION
The motivation for this PR is actually to support upgrading AIO to Angular CLI v12 (and so Webpack 5).