### PR TITLE
ci: remove trailing comma from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -77,7 +77,7 @@
     {
       "packagePatterns": [
         "^@bazel/.*",
-        "^build_bazel.*",
+        "^build_bazel.*"
       ],
       "groupName": "bazel",
       "pinVersions": false


### PR DESCRIPTION
Renovate configuration is strict JSON which doesn’t allow trailing commas or comments.

Closes #41789