### PR TITLE
build(docs-infra): fix e2e testing SystemJS-based docs examples

### DIFF
--- a/aio/tools/examples/shared/boilerplate/systemjs/package.json
+++ b/aio/tools/examples/shared/boilerplate/systemjs/package.json
@@ -10,6 +10,7 @@
     "serve:e2e": "lite-server -c=bs-config.e2e.json",
     "prestart": "npm run build",
     "start": "concurrently \"npm run build:watch\" \"npm run serve\"",
+    "pree2e": "webdriver-manager update",
     "e2e": "concurrently \"npm run serve:e2e\" \"npm run protractor\" --kill-others --success first",
     "protractor": "protractor protractor.config.js --specs=e2e-spec.ts",
     "pretest": "npm run build",

--- a/aio/tools/examples/shared/boilerplate/systemjs/tsconfig.json
+++ b/aio/tools/examples/shared/boilerplate/systemjs/tsconfig.json
@@ -14,8 +14,8 @@
   },
   "compileOnSave": true,
   "exclude": [
-    "node_modules/*",
     "**/*-aot.ts",
-    "universal/*"
+    "node_modules/",
+    "universal/"
   ]
 }


### PR DESCRIPTION
This commits makes the SystemJS-based docs examples more self-contained by ensuring the necessary WebDrivers are fetched before running the e2e tests.
This is a follow-up to #41689. (See there for more discussion.)