### PR TITLE
fix(common):  change return value for the HttpRequest with 204 status to undefined instead of null (#41148)

### DIFF
--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -258,20 +258,20 @@ export class HttpResponse<T> extends HttpResponseBase {
   /**
    * The response body, or `null` if one was not returned.
    */
-  readonly body: T|null;
+  readonly body: T|null|undefined;
 
   /**
    * Construct a new `HttpResponse`.
    */
   constructor(init: {
-    body?: T|null,
+    body?: T|null|undefined,
     headers?: HttpHeaders;
     status?: number;
     statusText?: string;
     url?: string;
   } = {}) {
     super(init);
-    this.body = init.body !== undefined ? init.body : null;
+    this.body = init.body !== undefined ? init.body : init.status === 204 ? undefined : null;
   }
 
   readonly type: HttpEventType.Response = HttpEventType.Response;

--- a/packages/common/http/test/response_spec.ts
+++ b/packages/common/http/test/response_spec.ts
@@ -43,6 +43,21 @@ import {describe, it} from '@angular/core/testing/src/testing_internal';
         expect(new HttpResponse({body: false}).body).toEqual(false);
         expect(new HttpResponse({body: 0}).body).toEqual(0);
       });
+      it('return undefined for 204 status code', () => {
+        const resp = new HttpResponse({
+          headers: new HttpHeaders({
+            'Test': 'Test header',
+          }),
+          status: HttpStatusCode.NoContent,
+          url: '/test',
+        });
+        expect(resp.body).toBe(undefined);
+        expect(resp.headers instanceof HttpHeaders).toBeTruthy();
+        expect(resp.headers.get('Test')).toBe('Test header');
+        expect(resp.status).toBe(HttpStatusCode.NoContent);
+        expect(resp.statusText).toBe('OK');
+        expect(resp.url).toBe('/test');
+      });
     });
     it('.ok is determined by status', () => {
       const good = new HttpResponse({status: 200});


### PR DESCRIPTION
…to undefined instead of null (#41148)

changing the return value for the HttpRequest with 204 status code to undefined instead of null.  this new change won't affect the other status code response except 204.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
An HTTP response with status code 204 returning null as a response would be semantically wrong. 

Issue Number: #41148


## What is the new behavior?
An HTTP response with status code 204 returning undefined instead of null as a response and no change in the other status codes. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

In the worst case, it will break if there is a check with response body === null when the status code is 204 but I don't think it's a best practice to add a null check especially when the status code is 204.

## Other information
