### PR TITLE
perf(core): minor improvements to listener instructions

### DIFF
--- a/goldens/public-api/platform-browser/platform-browser.d.ts
+++ b/goldens/public-api/platform-browser/platform-browser.d.ts
@@ -32,7 +32,7 @@ export declare const EVENT_MANAGER_PLUGINS: InjectionToken<ɵangular_packages_pl
 export declare class EventManager {
     constructor(plugins: ɵangular_packages_platform_browser_platform_browser_g[], _zone: NgZone);
     addEventListener(element: HTMLElement, eventName: string, handler: Function): Function;
-    addGlobalEventListener(target: string, eventName: string, handler: Function): Function;
+    /** @deprecated */ addGlobalEventListener(target: string, eventName: string, handler: Function): Function;
     getZone(): NgZone;
 }
 

--- a/packages/core/src/render3/interfaces/renderer.ts
+++ b/packages/core/src/render3/interfaces/renderer.ts
@@ -30,9 +30,7 @@ export type Renderer3 = ObjectOrientedRenderer3|ProceduralRenderer3;
 
 export type GlobalTargetName = 'document'|'window'|'body';
 
-export type GlobalTargetResolver = (element: any) => {
-  name: GlobalTargetName, target: EventTarget
-};
+export type GlobalTargetResolver = (element: any) => EventTarget;
 
 /**
  * Object Oriented style of API needed to create elements and text nodes.

--- a/packages/core/src/render3/util/misc_utils.ts
+++ b/packages/core/src/render3/util/misc_utils.ts
@@ -23,7 +23,7 @@ export const defaultScheduler =
  * @codeGenApi
  */
 export function ɵɵresolveWindow(element: RElement&{ownerDocument: Document}) {
-  return {name: 'window', target: element.ownerDocument.defaultView};
+  return element.ownerDocument.defaultView;
 }
 
 /**
@@ -31,7 +31,7 @@ export function ɵɵresolveWindow(element: RElement&{ownerDocument: Document}) {
  * @codeGenApi
  */
 export function ɵɵresolveDocument(element: RElement&{ownerDocument: Document}) {
-  return {name: 'document', target: element.ownerDocument};
+  return element.ownerDocument;
 }
 
 /**
@@ -39,7 +39,7 @@ export function ɵɵresolveDocument(element: RElement&{ownerDocument: Document})
  * @codeGenApi
  */
 export function ɵɵresolveBody(element: RElement&{ownerDocument: Document}) {
-  return {name: 'body', target: element.ownerDocument.body};
+  return element.ownerDocument.body;
 }
 
 /**

--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -57,7 +57,7 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     return node instanceof DocumentFragment;
   }
 
-  /** @deprecated No longer being used in Ivy code. To be removed in a future version. */
+  /** @deprecated No longer being used in Ivy code. To be removed in version 14. */
   getGlobalEventTarget(doc: Document, target: string): EventTarget|null {
     if (target === 'window') {
       return window;

--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -57,6 +57,7 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     return node instanceof DocumentFragment;
   }
 
+  /** @deprecated No longer being used in Ivy code. To be removed in a future version. */
   getGlobalEventTarget(doc: Document, target: string): EventTarget|null {
     if (target === 'window') {
       return window;

--- a/packages/platform-browser/src/dom/events/event_manager.ts
+++ b/packages/platform-browser/src/dom/events/event_manager.ts
@@ -58,7 +58,7 @@ export class EventManager {
    * @param handler A function to call when the notification occurs. Receives the
    * event object as an argument.
    * @returns A callback function that can be used to remove the handler.
-   * @deprecated No longer being used in Ivy code. To be removed in a future version.
+   * @deprecated No longer being used in Ivy code. To be removed in version 14.
    */
   addGlobalEventListener(target: string, eventName: string, handler: Function): Function {
     const plugin = this._findPluginFor(eventName);

--- a/packages/platform-browser/src/dom/events/event_manager.ts
+++ b/packages/platform-browser/src/dom/events/event_manager.ts
@@ -58,6 +58,7 @@ export class EventManager {
    * @param handler A function to call when the notification occurs. Receives the
    * event object as an argument.
    * @returns A callback function that can be used to remove the handler.
+   * @deprecated No longer being used in Ivy code. To be removed in a future version.
    */
   addGlobalEventListener(target: string, eventName: string, handler: Function): Function {
     const plugin = this._findPluginFor(eventName);

--- a/packages/platform-server/src/domino_adapter.ts
+++ b/packages/platform-server/src/domino_adapter.ts
@@ -62,7 +62,7 @@ export class DominoAdapter extends BrowserDomAdapter {
     return node.shadowRoot == node;
   }
 
-  /** @deprecated No longer being used in Ivy code. To be removed in a future version. */
+  /** @deprecated No longer being used in Ivy code. To be removed in version 14. */
   getGlobalEventTarget(doc: Document, target: string): EventTarget|null {
     if (target === 'window') {
       return doc.defaultView;

--- a/packages/platform-server/src/domino_adapter.ts
+++ b/packages/platform-server/src/domino_adapter.ts
@@ -62,6 +62,7 @@ export class DominoAdapter extends BrowserDomAdapter {
     return node.shadowRoot == node;
   }
 
+  /** @deprecated No longer being used in Ivy code. To be removed in a future version. */
   getGlobalEventTarget(doc: Document, target: string): EventTarget|null {
     if (target === 'window') {
       return doc.defaultView;

--- a/packages/platform-server/src/server_events.ts
+++ b/packages/platform-server/src/server_events.ts
@@ -22,7 +22,7 @@ export class ServerEventManagerPlugin /* extends EventManagerPlugin which is pri
     return getDOM().onAndCancel(element, eventName, handler);
   }
 
-  /** @deprecated No longer being used in Ivy code. To be removed in a future version. */
+  /** @deprecated No longer being used in Ivy code. To be removed in version 14. */
   addGlobalEventListener(element: string, eventName: string, handler: Function): Function {
     const target: HTMLElement = getDOM().getGlobalEventTarget(this.doc, element);
     if (!target) {

--- a/packages/platform-server/src/server_events.ts
+++ b/packages/platform-server/src/server_events.ts
@@ -22,6 +22,7 @@ export class ServerEventManagerPlugin /* extends EventManagerPlugin which is pri
     return getDOM().onAndCancel(element, eventName, handler);
   }
 
+  /** @deprecated No longer being used in Ivy code. To be removed in a future version. */
   addGlobalEventListener(element: string, eventName: string, handler: Function): Function {
     const target: HTMLElement = getDOM().getGlobalEventTarget(this.doc, element);
     if (!target) {


### PR DESCRIPTION
Makes the following improvements to the listener instructions to make them slightly smaller and more memory-efficient.

1. Removes the default value from the `useCapture` parameter since it generates more code than just castint to `false`.
2. Removes the `useCapture` and `eventTargetResolver` parameters from `ɵɵsyntheticHostListener` since they won't be generated by the compiler, as far as I can tell.
3. Makes it so that we don't have to return a target name from a `GlobalTargetResolver`. This allows us to save on some memory, because we can return a reference to the target without having to wrap it in an object literal.

DEPRECATIONS:
`EventManagerPlugin.getGlobalEventTarget` is now deprecated and won't be called from Ivy code anymore. Global events will go through `addEventListener`.