### PR TITLE
fix(compiler): strip scoped selectors from `@font-face` rules

### DIFF
--- a/packages/compiler/test/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css_spec.ts
@@ -369,6 +369,18 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
       expect(s(css, 'contenta', 'h')).toEqual('[h] > > .x {}');
     });
 
+    it('should strip ::ng-deep and :host from within @font-face', () => {
+      expect(s('@font-face { font-family {} }', 'contenta', 'h'))
+          .toEqual('@font-face { font-family {}}');
+      expect(s('@font-face { ::ng-deep font-family{} }', 'contenta', 'h'))
+          .toEqual('@font-face { font-family{}}');
+      expect(s('@font-face { :host ::ng-deep font-family{} }', 'contenta', 'h'))
+          .toEqual('@font-face { font-family{}}');
+      expect(s('@supports (display: flex) { @font-face { :host ::ng-deep font-family{} } }',
+               'contenta', 'h'))
+          .toEqual('@supports (display:flex) { @font-face { font-family{}}}');
+    });
+
     it('should pass through @import directives', () => {
       const styleStr = '@import url("https://fonts.googleapis.com/css?family=Roboto");';
       const css = s(styleStr, 'contenta');


### PR DESCRIPTION
`@font-face` rules cannot contain nested selectors. Nor can they be
nested under a selector. Normally this would be a syntax error by the
author of the styles. But in some rare cases, such as importing styles
from a library, and applying `:host ::ng-deep` to the imported styles,
we can end up with broken css if the imported styles happen to contain
`@font-face` rules.

This commit works around this problem by sanitizing such cases (erasing
any scoping selectors) during emulated ShadowDOM encapsulation style
processing.

Fixes #41751
