### PR TITLE
docs: update Node.js supported version statement

### DIFF
--- a/aio/content/guide/setup-local.md
+++ b/aio/content/guide/setup-local.md
@@ -35,7 +35,7 @@ To install Angular on your local system, you need the following:
 
   <div class="alert is-helpful">
 
-  For information about specific version requirements, see the `engines` key in the [package.json](https://unpkg.com/@angular/core/package.json) file.
+  For information about specific version requirements, see the `engines` key in the [package.json](https://unpkg.com/browse/@angular/core/package.json) file.
 
   </div>
 

--- a/aio/content/guide/setup-local.md
+++ b/aio/content/guide/setup-local.md
@@ -33,6 +33,12 @@ To install Angular on your local system, you need the following:
 
   Angular requires an [active LTS or maintenance LTS](https://nodejs.org/about/releases) version of Node.js.
 
+  <div class="alert is-helpful">
+
+  For information about specific version requirements, see the `engines` key in the [package.json](https://unpkg.com/@angular/core/package.json) file.
+
+  </div>
+
   For more information on installing Node.js, see [nodejs.org](https://nodejs.org "Nodejs.org").
   If you are unsure what version of Node.js runs on your system, run `node -v` in a terminal window.
 

--- a/aio/content/guide/setup-local.md
+++ b/aio/content/guide/setup-local.md
@@ -33,12 +33,6 @@ To install Angular on your local system, you need the following:
 
   Angular requires an [active LTS or maintenance LTS](https://nodejs.org/about/releases) version of Node.js.
 
-  <div class="alert is-helpful">
-
-  For information about specific version requirements, see the `engines` key in the [package.json](https://unpkg.com/@angular/cli/package.json) file.
-
-  </div>
-
   For more information on installing Node.js, see [nodejs.org](https://nodejs.org "Nodejs.org").
   If you are unsure what version of Node.js runs on your system, run `node -v` in a terminal window.
 

--- a/aio/content/guide/setup-local.md
+++ b/aio/content/guide/setup-local.md
@@ -30,8 +30,8 @@ To install Angular on your local system, you need the following:
 {@a nodejs}
 
 * **Node.js**
-  
-  Angular requires a [current, active LTS, or maintenance LTS](https://nodejs.org/about/releases) version of Node.js.
+
+  Angular requires an [active LTS or maintenance LTS](https://nodejs.org/about/releases) version of Node.js.
 
   <div class="alert is-helpful">
 


### PR DESCRIPTION
Update the statement expressing Angular's supported versions of Node.js. Previously, we stated
that the `current` version of Node.js was supported, however Node.js's `current` version maps
more closely to what we would term a `next` branch and is not expected meant for usage with
production applications. This intention is stated on Node.js Releases page:

> Production applications should only use Active LTS or Maintenance LTS releases.
