### PR TITLE
fix(dev-infra): add github token requirement for discover-new-conflicts

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -3313,7 +3313,7 @@ function cleanUpGitState(previousBranchOrRevision) {
  */
 /** Builds the discover-new-conflicts pull request command. */
 function buildDiscoverNewConflictsCommand(yargs) {
-    return yargs
+    return addGithubTokenOption(yargs)
         .option('date', {
         description: 'Only consider PRs updated since provided date',
         defaultDescription: '30 days ago',

--- a/dev-infra/pr/discover-new-conflicts/cli.ts
+++ b/dev-infra/pr/discover-new-conflicts/cli.ts
@@ -9,6 +9,7 @@
 import {Arguments, Argv} from 'yargs';
 
 import {error} from '../../utils/console';
+import {addGithubTokenOption} from '../../utils/git/github-yargs';
 
 import {discoverNewConflictsForPr} from './index';
 
@@ -21,7 +22,7 @@ export interface DiscoverNewConflictsCommandOptions {
 /** Builds the discover-new-conflicts pull request command. */
 export function buildDiscoverNewConflictsCommand(yargs: Argv):
     Argv<DiscoverNewConflictsCommandOptions> {
-  return yargs
+  return addGithubTokenOption(yargs)
       .option('date', {
         description: 'Only consider PRs updated since provided date',
         defaultDescription: '30 days ago',


### PR DESCRIPTION
Add the github token option/requirement for the pr discover-new-conflicts
command.
