### PR TITLE
docs: remove mention of scheduleTick in markForCheck

### DIFF
--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -98,9 +98,6 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
   /**
    * Marks a view and all of its ancestors dirty.
    *
-   * It also triggers change detection by calling `scheduleTick` internally, which coalesces
-   * multiple `markForCheck` calls to into one change detection run.
-   *
    * This can be used to ensure an {@link ChangeDetectionStrategy#OnPush OnPush} component is
    * checked when it needs to be re-rendered but the two normal triggers haven't marked it
    * dirty (i.e. inputs haven't changed and events haven't fired in the view).


### PR DESCRIPTION
markForCheck doesn't call scheduleTick, thus I removed the comment which mentioned this.

I see this comment is also available in older version, even as old as 10.0.x: https://github.com/angular/angular/blob/10.0.x/packages/core/src/render3/view_ref.ts
Should this PR also be merged in older branches?

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: https://github.com/angular/angular/issues/41810


## What is the new behavior?
Simply removed the misleading comment

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
