### PR TITLE
fix(dev-infra): correctly detect prettier config

### DIFF
--- a/dev-infra/bazel/remote-execution/BUILD.bazel
+++ b/dev-infra/bazel/remote-execution/BUILD.bazel
@@ -14,7 +14,7 @@ platform(
     # frequently. There are rare cases where it needs to be updated. e.g. for a more recent Bash
     # version, or new system settings that are required for launching browsers. In order to do that,
     # we need to either see if the `rbe-ubuntu16-04-webtest` image can be updated, or if we need to
-    # build and publish our own image to the Google cloud image registry. Additionally, we set th
+    # build and publish our own image to the Google cloud image registry. Additionally, we set the
     # `SYS_ADMIN` capability so that browsers can be launched with sandbox mode enabled. Related
     # information: https://developers.google.com/web/tools/puppeteer/troubleshooting#running_puppeteer_in_docker
     remote_execution_properties = """

--- a/dev-infra/format/formatters/prettier.ts
+++ b/dev-infra/format/formatters/prettier.ts
@@ -24,11 +24,11 @@ export class Prettier extends Formatter {
   defaultFileMatcher = ['**/*.{t,j}s'];
 
   /**
-   * The configuration path of the pretter config, obtained during construction to prevent needing
+   * The configuration path of the prettier config, obtained during construction to prevent needing
    * to discover it repeatedly for each execution.
    */
   private configPath =
-      this.config['pretter'] ? exec(`${this.binaryFilePath} --find-config-path .`).trim() : '';
+      this.config['prettier'] ? exec(`${this.binaryFilePath} --find-config-path .`).trim() : '';
 
   actions = {
     check: {

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -2480,10 +2480,10 @@ class Prettier extends Formatter {
         this.binaryFilePath = path.join(this.git.baseDir, 'node_modules/.bin/prettier');
         this.defaultFileMatcher = ['**/*.{t,j}s'];
         /**
-         * The configuration path of the pretter config, obtained during construction to prevent needing
+         * The configuration path of the prettier config, obtained during construction to prevent needing
          * to discover it repeatedly for each execution.
          */
-        this.configPath = this.config['pretter'] ? shelljs.exec(`${this.binaryFilePath} --find-config-path .`).trim() : '';
+        this.configPath = this.config['prettier'] ? shelljs.exec(`${this.binaryFilePath} --find-config-path .`).trim() : '';
         this.actions = {
             check: {
                 commandFlags: `--config ${this.configPath} --check`,

--- a/dev-infra/release/publish/index.ts
+++ b/dev-infra/release/publish/index.ts
@@ -7,8 +7,8 @@
  */
 
 import {ListChoiceOptions, prompt} from 'inquirer';
-import {spawnWithDebugOutput} from '../../utils/child-process';
 
+import {spawnWithDebugOutput} from '../../utils/child-process';
 import {GithubConfig} from '../../utils/config';
 import {debug, error, info, log, promptConfirm, red, yellow} from '../../utils/console';
 import {GitClient} from '../../utils/git/index';


### PR DESCRIPTION
This PR uses the correct property name (`prettier` vs `pretter`) to check whether prettier is enabled via the config.

(It also fixes some typos in `dev-infra`.)
