### PR TITLE
Revert "ci: re-enable the `@angular/components` unit tests (#41816)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ var_4_win: &cache_key_win_fallback v4-angular-win-node-12-{{ checksum "month.txt
 
 # Cache key for the `components-repo-unit-tests` job. **Note** when updating the SHA in the
 # cache keys also update the SHA for the "COMPONENTS_REPO_COMMIT" environment variable.
-var_5: &components_repo_unit_tests_cache_key v1-angular-components-{{ checksum "month.txt" }}-7cc42f5d835b7971e9ff73e220b801cf7834d515
+var_5: &components_repo_unit_tests_cache_key v1-angular-components-{{ checksum "month.txt" }}-09e68db8ed5b1253f2fe38ff954ef0df019fc25a
 var_6: &components_repo_unit_tests_cache_key_fallback v1-angular-components-{{ checksum "month.txt" }}
 
 # Workspace initially persisted by the `setup` job, and then enhanced by `build-npm-packages` and
@@ -730,7 +730,11 @@ jobs:
       - run:
           # Run yarn install to fetch the Bazel binaries as used in the components repo.
           name: Installing dependencies.
-          command: yarn --cwd ${COMPONENTS_REPO_TMP_DIR} install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
+          # TODO: remove this once the repo has been updated to use NodeJS v12 and Yarn 1.19.1.
+          # We temporarily ignore the "engines" because the Angular components repository has
+          # minimum dependency on NodeJS v12 and Yarn 1.19.1, but the framework repository uses
+          # older versions.
+          command: yarn --ignore-engines --cwd ${COMPONENTS_REPO_TMP_DIR} install --frozen-lockfile --non-interactive --cache-folder ~/.cache/yarn
       - save_cache:
           key: *components_repo_unit_tests_cache_key
           paths:
@@ -740,14 +744,10 @@ jobs:
             - "/tmp/angular-components-repo"
       - run:
           # Updates the `angular/components` `package.json` file to refer to the release output
-          # inside the `packages-dist` directory.
+          # inside the `packages-dist` directory. Note that it's not necessary to perform a yarn
+          # install as Bazel runs Yarn automatically when needed.
           name: Setting up release packages.
           command: node scripts/ci/update-deps-to-dist-packages.js ${COMPONENTS_REPO_TMP_DIR}/package.json dist/packages-dist/
-      - run:
-          # Run `yarn install` again to install the Angular packages from `packages-dist/` and update the lockfile.
-          # NOTE: We cannot rely on Bazel to run `yarn install`, because it uses the `--frozen-lockfile` flag and fails.
-          name: Installing local Angular packages.
-          command: yarn --cwd ${COMPONENTS_REPO_TMP_DIR} install --non-interactive --cache-folder ~/.cache/yarn
       - run:
           name: "Running `angular/components` unit tests"
           command: ./scripts/ci/run_angular_components_unit_tests.sh
@@ -890,9 +890,16 @@ workflows:
             - build-npm-packages
             - build-ivy-npm-packages
             - legacy-unit-tests-saucelabs
-      - components-repo-unit-tests:
-          requires:
-            - build-npm-packages
+      # Temporarily disabled components-repo-unit-tests to update rules_nodejs to 2.0.0. Breaking changes in
+      # rules_nodejs create a dependency sandwich between angular/angular & angular/components that are very
+      # difficult and time consuming to resolve and involve patching @angular/bazel in components repo such
+      # as https://github.com/angular/components/commit/9e7ba251207df77164d73d66620e619bcbc4d2ad. It is simpler to
+      # 1) land angular/angular upgrade to rule_nodejs 2.0.0 which has breaking changes
+      # 2) land angular/components upgrade to rules_nodejs 2.0.0 using the @angular/bazel builds snapshot
+      # 3) update angular/angular to the landed components commit and re-enable these tests
+      # - components-repo-unit-tests:
+      #     requires:
+      #       - build-npm-packages
       - test_zonejs:
           requires:
             - setup

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -74,7 +74,7 @@ setPublicVar COMPONENTS_REPO_TMP_DIR "/tmp/angular-components-repo"
 setPublicVar COMPONENTS_REPO_URL "https://github.com/angular/components.git"
 setPublicVar COMPONENTS_REPO_BRANCH "master"
 # **NOTE**: When updating the commit SHA, also update the cache key in the CircleCI `config.yml`.
-setPublicVar COMPONENTS_REPO_COMMIT "7cc42f5d835b7971e9ff73e220b801cf7834d515"
+setPublicVar COMPONENTS_REPO_COMMIT "09e68db8ed5b1253f2fe38ff954ef0df019fc25a"
 
 
 ####################################################################################################


### PR DESCRIPTION
This PR reverts a single commit from #41816. The change breaks CI due to TypeScript version requirements for the enabled tests.

// cc @gkalpak