### PR TITLE
fix(zone.js): only one listener should also throw an error

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -13,7 +13,7 @@
       "uncompressed": {
         "runtime-es2015": 1205,
         "main-es2015": 17597,
-        "polyfills-es2015": 36709
+        "polyfills-es2015": 37127
       }
     }
   },


### PR DESCRIPTION
Close #41867

In the previous commit https://github.com/angular/angular/pull/41562#issuecomment-822696973,
the error thrown in the event listener will be caught and re-thrown, but there is a bug
in the commit, if there is only one listener for the specified event name, the error
will not be re-thrown, so this commit fixes the issue and make sure the error is re-thrown.
