### PR TITLE
build(docs-infra): upgrade cli command docs sources to ac6fc449e

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -18,7 +18,7 @@
     "build-local": "yarn ~~build",
     "prebuild-local-ci": "yarn setup-local-ci",
     "build-local-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 2310e277b",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js ac6fc449e",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#master](https://github.com/angular/angular/tree/master) from [cli-builds#master](https://github.com/angular/cli-builds/tree/master).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/2310e277b...ac6fc449e):

**Modified**
- help/add.json
- help/analytics.json
- help/deploy.json
- help/e2e.json
- help/help.json
- help/lint.json
- help/new.json
- help/run.json
- help/test.json