### PR TITLE
build: add prettier to format JSON, MD and YAML files

### DIFF
--- a/.ng-dev/format.ts
+++ b/.ng-dev/format.ts
@@ -23,5 +23,8 @@ export const format: FormatConfig = {
       '!packages/compiler-cli/test/compliance/test_cases/**/*.js',
     ]
   },
+  'prettier': {
+    'matchers': ['**/*.{json,yml,yaml,md}'],
+  },
   'buildifier': true
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,10 @@
+dist
 /bazel-out/
-/dist
 /goldens/public-api
 /integration
 third_party/
-aio/content/examples/
-aio/tools/transforms/templates/
+/aio/src/generated
+/aio/content/examples
+/aio/tools/transforms/templates
+/aio/tools/examples/shared
 /CHANGELOG.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+/bazel-out/
+/dist
+/goldens/public-api
+/integration
+third_party/
+aio/content/examples/
+aio/tools/transforms/templates/
+/CHANGELOG.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 100,
+  "quoteProps": "preserve",
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     "mutation-observer": "^1.0.3",
     "nock": "^13.0.3",
     "ora": "^5.0.0",
+    "prettier": "^2.2.1",
     "rollup-plugin-hashbang": "^2.2.2",
     "sauce-connect": "https://saucelabs.com/downloads/sc-4.6.2-linux.tar.gz",
     "semver": "^7.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10655,6 +10655,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+
 pretty-bytes@^5.3.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"


### PR DESCRIPTION
Currently there are 1419 JSON, MD and YAML files which are not formatted, with this change we add prettier to format them when a file is changed.