### PR TITLE
fix(core): handle multiple i18n attributes with expression bindings

### DIFF
--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -1624,17 +1624,23 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
     });
 
     it('multiple attributes', () => {
-      loadTranslations({[computeMsgId('hello {$INTERPOLATION}')]: 'bonjour {$INTERPOLATION}'});
+      loadTranslations({
+        [computeMsgId('hello {$INTERPOLATION} - {$INTERPOLATION_1}')]:
+            'bonjour {$INTERPOLATION} - {$INTERPOLATION_1}',
+        [computeMsgId('bye {$INTERPOLATION} - {$INTERPOLATION_1}')]:
+            'au revoir {$INTERPOLATION} - {$INTERPOLATION_1}',
+      });
       const fixture = initWithTemplate(
           AppComp,
-          `<input i18n i18n-title title="hello {{name}}" i18n-placeholder placeholder="hello {{name}}">`);
+          `<input i18n i18n-title title="hello {{name}} - {{count}}" i18n-placeholder placeholder="bye {{count}} - {{name}}">`);
       expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<input title="bonjour Angular" placeholder="bonjour Angular">`);
+          .toEqual(`<input title="bonjour Angular - 0" placeholder="au revoir 0 - Angular">`);
 
       fixture.componentRef.instance.name = 'John';
+      fixture.componentRef.instance.count = 5;
       fixture.detectChanges();
       expect(fixture.nativeElement.innerHTML)
-          .toEqual(`<input title="bonjour John" placeholder="bonjour John">`);
+          .toEqual(`<input title="bonjour John - 5" placeholder="au revoir 5 - John">`);
     });
 
     it('on removed elements', () => {

--- a/packages/core/test/render3/i18n/i18n_spec.ts
+++ b/packages/core/test/render3/i18n/i18n_spec.ts
@@ -458,9 +458,10 @@ describe('Runtime i18n', () => {
     });
 
     it('for multiple attributes', () => {
-      const message = `Hello �0�!`;
-      const attrs = ['title', message, 'aria-label', message];
-      const nbConsts = 2;
+      const message1 = `Hello �0� - �1�!`;
+      const message2 = `Bye �0� - �1�!`;
+      const attrs = ['title', message1, 'aria-label', message2];
+      const nbConsts = 4;
       const index = 1;
       const opCodes = getOpCodes(attrs, () => {
         ɵɵelementStart(0, 'div');
@@ -469,11 +470,10 @@ describe('Runtime i18n', () => {
       }, undefined, nbConsts, HEADER_OFFSET + index);
 
       expect(opCodes).toEqual(matchDebug([
-        `if (mask & 0b1) { (lView[${
-            HEADER_OFFSET + 0}] as Element).setAttribute('title', \`Hello \$\{lView[i-1]}!\`); }`,
-        `if (mask & 0b1) { (lView[${
-            HEADER_OFFSET +
-            0}] as Element).setAttribute('aria-label', \`Hello \$\{lView[i-1]}!\`); }`,
+        `if (mask & 0b11) { (lView[${HEADER_OFFSET + 0}] as Element).` +
+            'setAttribute(\'title\', `Hello ${lView[i-1]} - ${lView[i-2]}!`); }',
+        `if (mask & 0b1100) { (lView[${HEADER_OFFSET + 0}] as Element).` +
+            'setAttribute(\'aria-label\', `Bye ${lView[i-3]} - ${lView[i-4]}!`); }',
       ]));
     });
   });


### PR DESCRIPTION
When there are multiple attributes that are marked for i18n translation,
which contain expression bindings, we were generating i18n update op-codes
that did not accurately map to the correct value to be bound in the lView.
Each attribute's bindings were relative to the start of the lView first
attributes values rather than to their own.

This fix passes the current binding index to `generateBindingUpdateOpCodes()`
when processing i18n attributes to account for this.

Fixes #41869
