### PR TITLE
fix(common): add right ContentType for boolean values with HttpClient request body(#38924)

### DIFF
--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -322,9 +322,9 @@ export class HttpRequest<T> {
     if (this.body instanceof HttpParams) {
       return 'application/x-www-form-urlencoded;charset=UTF-8';
     }
-    // Arrays, objects, and numbers will be encoded as JSON.
+    // Arrays, objects, boolean and numbers will be encoded as JSON.
     if (typeof this.body === 'object' || typeof this.body === 'number' ||
-        Array.isArray(this.body)) {
+        typeof this.body === 'boolean') {
       return 'application/json';
     }
     // No type could be inferred.

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -129,6 +129,10 @@ const TEST_STRING = `I'm a body!`;
         const req = baseReq.clone({body: {data: 'test data'}});
         expect(req.detectContentTypeHeader()).toBe('application/json');
       });
+      it('handles boolean as json', () => {
+        const req = baseReq.clone({body: true});
+        expect(req.detectContentTypeHeader()).toBe('application/json');
+      });
     });
     describe('body serialization', () => {
       const baseReq = new HttpRequest('POST', '/test', null);


### PR DESCRIPTION

We are adding application/json as ContentType for boolean as the body,  currently it is seen as text/plain, where it should be seen as application/json, since it is valid JSON, like numbers.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
currently a boolean as the body is seen as text/plain, where it should be seen as application/json, since it is valid JSON, like numbers.

Issue Number: #38924


## What is the new behavior?
currently a boolean as the body is seen as text/plain, where it should be seen as application/json, since it is valid JSON, like numbers.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
