### PR TITLE
ci: replace `matchCurrentVersion` RegExp negate with semver version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -126,7 +126,7 @@
         "minor",
         "patch"
       ],
-      "matchCurrentVersion": "!/^0\\./",
+      "matchCurrentVersion": ">=1",
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
       "schedule": [


### PR DESCRIPTION
While RegExp negation should work as per documentation https://docs.renovatebot.com/configuration-options/#matchcurrentversion it appears that in this case it is not working. See the following commit https://github.com/angular/angular/pull/41884/commits/076f13da867d2bc46b41bd49f09ccb49e00a4095, therefore we work around this by using a semver version that excludes anything which doesn't match `>= 1`.
