### PR TITLE
ci: changes to `packages/common/http` should not require `fw-common` approval

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -444,7 +444,7 @@ groups:
       - *can-be-global-approved
       - *can-be-global-docs-approved
       - >
-        contains_any_globs(files.exclude("packages/core/schematics/**"), [
+        contains_any_globs(files.exclude("packages/core/schematics/**").exclude("packages/common/http/**"), [
           'packages/common/**',
           'packages/examples/common/**',
           ])


### PR DESCRIPTION
Currently when the change is made to the code inside the `packages/common/http` folder, both `fw-http` and `fw-common` group members are assigned for review. However only `fw-http` is required and should be sufficient. This commit updates the PullApprove config to exclude `packages/common/http` path from the list of folders that `fw-common` "owns".

Example PR with extra `fw-common` request: https://github.com/angular/angular/pull/41885.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No