### PR TITLE
build(docs-infra): upgrade cli command docs sources to d965a67c6

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -18,7 +18,7 @@
     "build-local": "yarn ~~build",
     "prebuild-local-ci": "yarn setup-local-ci",
     "build-local-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 54ce436c9",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js d965a67c6",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#12.0.x](https://github.com/angular/angular/tree/12.0.x) from [cli-builds#12.0.x](https://github.com/angular/cli-builds/tree/12.0.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/54ce436c9...d965a67c6):

**Modified**
- help/add.json
- help/analytics.json
- help/deploy.json
- help/e2e.json
- help/help.json
- help/lint.json
- help/new.json
- help/run.json
- help/test.json