### PR TITLE
fix(dev-infra): remove getBaseDir method from GitClient

### DIFF
--- a/dev-infra/build-worker.js
+++ b/dev-infra/build-worker.js
@@ -365,19 +365,6 @@ var GitClient = /** @class */ (function () {
         }
         return new semver.SemVer(latestTag, semVerOptions);
     };
-    /** Gets the path of the directory for the repository base. */
-    GitClient.prototype.getBaseDir = function () {
-        var previousVerboseLoggingState = this.verboseLogging;
-        this.setVerboseLoggingState(false);
-        var _a = this.runGraceful(['rev-parse', '--show-toplevel']), stdout = _a.stdout, stderr = _a.stderr, status = _a.status;
-        this.setVerboseLoggingState(previousVerboseLoggingState);
-        if (status !== 0) {
-            throw Error("Unable to find the path to the base directory of the repository.\n" +
-                "Was the command run from inside of the repo?\n\n" +
-                ("ERROR:\n " + stderr));
-        }
-        return stdout.trim();
-    };
     /** Retrieve a list of all files in the repostitory changed since the provided shaOrRef. */
     GitClient.prototype.allChangesFilesSince = function (shaOrRef) {
         if (shaOrRef === void 0) { shaOrRef = 'HEAD'; }
@@ -599,7 +586,7 @@ var cachedConfig = null;
 function getConfig(baseDir) {
     // If the global config is not defined, load it from the file system.
     if (cachedConfig === null) {
-        baseDir = baseDir || GitClient.getInstance().getBaseDir();
+        baseDir = baseDir || GitClient.getInstance().baseDir;
         // The full path to the configuration file.
         var configPath = path.join(baseDir, CONFIG_FILE_PATH);
         // Read the configuration and validate it before caching it for the future.

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -71,7 +71,7 @@ var userConfig = null;
 function getConfig(baseDir) {
     // If the global config is not defined, load it from the file system.
     if (cachedConfig === null) {
-        baseDir = baseDir || GitClient.getInstance().getBaseDir();
+        baseDir = baseDir || GitClient.getInstance().baseDir;
         // The full path to the configuration file.
         var configPath = path.join(baseDir, CONFIG_FILE_PATH);
         // Read the configuration and validate it before caching it for the future.
@@ -532,19 +532,6 @@ var GitClient = /** @class */ (function () {
             throw new Error("Unable to find a SemVer matching tag on \"" + this.getCurrentBranchOrRevision() + "\"");
         }
         return new semver.SemVer(latestTag, semVerOptions);
-    };
-    /** Gets the path of the directory for the repository base. */
-    GitClient.prototype.getBaseDir = function () {
-        var previousVerboseLoggingState = this.verboseLogging;
-        this.setVerboseLoggingState(false);
-        var _a = this.runGraceful(['rev-parse', '--show-toplevel']), stdout = _a.stdout, stderr = _a.stderr, status = _a.status;
-        this.setVerboseLoggingState(previousVerboseLoggingState);
-        if (status !== 0) {
-            throw Error("Unable to find the path to the base directory of the repository.\n" +
-                "Was the command run from inside of the repo?\n\n" +
-                ("ERROR:\n " + stderr));
-        }
-        return stdout.trim();
     };
     /** Retrieve a list of all files in the repostitory changed since the provided shaOrRef. */
     GitClient.prototype.allChangesFilesSince = function (shaOrRef) {

--- a/dev-infra/utils/config.ts
+++ b/dev-infra/utils/config.ts
@@ -69,7 +69,7 @@ export function getConfig(baseDir?: string): NgDevConfig;
 export function getConfig(baseDir?: string): NgDevConfig {
   // If the global config is not defined, load it from the file system.
   if (cachedConfig === null) {
-    baseDir = baseDir || GitClient.getInstance().getBaseDir();
+    baseDir = baseDir || GitClient.getInstance().baseDir;
     // The full path to the configuration file.
     const configPath = join(baseDir, CONFIG_FILE_PATH);
     // Read the configuration and validate it before caching it for the future.

--- a/dev-infra/utils/git/index.ts
+++ b/dev-infra/utils/git/index.ts
@@ -256,21 +256,6 @@ export class GitClient<Authenticated extends boolean> {
     return new SemVer(latestTag, semVerOptions);
   }
 
-  /** Gets the path of the directory for the repository base. */
-  getBaseDir(): string {
-    const previousVerboseLoggingState = this.verboseLogging;
-    this.setVerboseLoggingState(false);
-    const {stdout, stderr, status} = this.runGraceful(['rev-parse', '--show-toplevel']);
-    this.setVerboseLoggingState(previousVerboseLoggingState);
-    if (status !== 0) {
-      throw Error(
-          `Unable to find the path to the base directory of the repository.\n` +
-          `Was the command run from inside of the repo?\n\n` +
-          `ERROR:\n ${stderr}`);
-    }
-    return stdout.trim();
-  }
-
   /** Retrieve a list of all files in the repostitory changed since the provided shaOrRef. */
   allChangesFilesSince(shaOrRef = 'HEAD'): string[] {
     return Array.from(new Set([


### PR DESCRIPTION
Remove the getBaseDir method from GitClient as the baseDir is determined
once during construction and does not need to be rediscovered.  The property
access should always be used.
