### PR TITLE
fix(dev-infra): set the default LogLevel of GitClient logging to DEBUG

### DIFF
--- a/dev-infra/build-worker.js
+++ b/dev-infra/build-worker.js
@@ -205,8 +205,6 @@ var GitClient = /** @class */ (function () {
      */
     function GitClient(githubToken, config, baseDir) {
         this.githubToken = githubToken;
-        /** Whether verbose logging of Git actions should be used. */
-        this.verboseLogging = true;
         /** The OAuth scopes available for the provided Github token. */
         this._cachedOauthScopes = null;
         /**
@@ -254,9 +252,16 @@ var GitClient = /** @class */ (function () {
         }
         GitClient.authenticated = new GitClient(token);
     };
-    /** Set the verbose logging state of the GitClient instance. */
-    GitClient.prototype.setVerboseLoggingState = function (verbose) {
+    /** Set the verbose logging state of the GitClient class. */
+    GitClient.setVerboseLoggingStae = function (verbose) {
         this.verboseLogging = verbose;
+    };
+    /**
+     * Set the verbose logging state of the GitClient class and get back the specific GitClient
+     * instance the verbose state was set via.
+     */
+    GitClient.prototype.setVerboseLoggingState = function (verbose) {
+        GitClient.setVerboseLoggingStae(verbose);
         return this;
     };
     /** Executes the given git command. Throws if the command fails. */
@@ -283,9 +288,10 @@ var GitClient = /** @class */ (function () {
             throw new DryRunError();
         }
         // To improve the debugging experience in case something fails, we print all executed Git
-        // commands to better understand the git actions occuring. Depending on the command being
-        // executed, this debugging information should be logged at different logging levels.
-        var printFn = (!this.verboseLogging || options.stdio === 'ignore') ? debug : info;
+        // commands at the DEBUG level to better understand the git actions occuring. Verbose logging,
+        // always logging at the INFO level, can be enabled either by setting the verboseLogging
+        // property on the GitClient class or the options object provided to the method.
+        var printFn = (GitClient.verboseLogging || options.verboseLogging) ? info : debug;
         // Note that we do not want to print the token if it is contained in the command. It's common
         // to share errors with others if the tool failed, and we do not want to leak tokens.
         printFn('Executing: git', this.omitGithubTokenFromMessage(args.join(' ')));
@@ -424,16 +430,16 @@ var GitClient = /** @class */ (function () {
         });
     };
     GitClient.prototype.determineBaseDir = function () {
-        this.setVerboseLoggingState(false);
         var _a = this.runGraceful(['rev-parse', '--show-toplevel']), stdout = _a.stdout, stderr = _a.stderr, status = _a.status;
         if (status !== 0) {
             throw Error("Unable to find the path to the base directory of the repository.\n" +
                 "Was the command run from inside of the repo?\n\n" +
                 ("ERROR:\n " + stderr));
         }
-        this.setVerboseLoggingState(true);
         return stdout.trim();
     };
+    /** Whether verbose logging of Git actions should be used. */
+    GitClient.verboseLogging = false;
     return GitClient;
 }());
 /**

--- a/dev-infra/build-worker.js
+++ b/dev-infra/build-worker.js
@@ -253,16 +253,8 @@ var GitClient = /** @class */ (function () {
         GitClient.authenticated = new GitClient(token);
     };
     /** Set the verbose logging state of the GitClient class. */
-    GitClient.setVerboseLoggingStae = function (verbose) {
+    GitClient.setVerboseLoggingState = function (verbose) {
         this.verboseLogging = verbose;
-    };
-    /**
-     * Set the verbose logging state of the GitClient class and get back the specific GitClient
-     * instance the verbose state was set via.
-     */
-    GitClient.prototype.setVerboseLoggingState = function (verbose) {
-        GitClient.setVerboseLoggingStae(verbose);
-        return this;
     };
     /** Executes the given git command. Throws if the command fails. */
     GitClient.prototype.run = function (args, options) {

--- a/dev-infra/caretaker/check/check.ts
+++ b/dev-infra/caretaker/check/check.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {GitClient} from '../../utils/git/index';
 import {getCaretakerConfig} from '../config';
 
 import {CiModule} from './ci';
@@ -24,8 +23,6 @@ const moduleList = [
 
 /** Check the status of services which Angular caretakers need to monitor. */
 export async function checkServiceStatuses() {
-  // Set the verbose logging state of the GitClient.
-  GitClient.getAuthenticatedInstance().setVerboseLoggingState(false);
   /** The configuration for the caretaker commands. */
   const config = getCaretakerConfig();
   /** List of instances of Caretaker Check modules */

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -421,16 +421,8 @@ var GitClient = /** @class */ (function () {
         GitClient.authenticated = new GitClient(token);
     };
     /** Set the verbose logging state of the GitClient class. */
-    GitClient.setVerboseLoggingStae = function (verbose) {
+    GitClient.setVerboseLoggingState = function (verbose) {
         this.verboseLogging = verbose;
-    };
-    /**
-     * Set the verbose logging state of the GitClient class and get back the specific GitClient
-     * instance the verbose state was set via.
-     */
-    GitClient.prototype.setVerboseLoggingState = function (verbose) {
-        GitClient.setVerboseLoggingStae(verbose);
-        return this;
     };
     /** Executes the given git command. Throws if the command fails. */
     GitClient.prototype.run = function (args, options) {

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -373,8 +373,6 @@ var GitClient = /** @class */ (function () {
      */
     function GitClient(githubToken, config, baseDir) {
         this.githubToken = githubToken;
-        /** Whether verbose logging of Git actions should be used. */
-        this.verboseLogging = true;
         /** The OAuth scopes available for the provided Github token. */
         this._cachedOauthScopes = null;
         /**
@@ -422,9 +420,16 @@ var GitClient = /** @class */ (function () {
         }
         GitClient.authenticated = new GitClient(token);
     };
-    /** Set the verbose logging state of the GitClient instance. */
-    GitClient.prototype.setVerboseLoggingState = function (verbose) {
+    /** Set the verbose logging state of the GitClient class. */
+    GitClient.setVerboseLoggingStae = function (verbose) {
         this.verboseLogging = verbose;
+    };
+    /**
+     * Set the verbose logging state of the GitClient class and get back the specific GitClient
+     * instance the verbose state was set via.
+     */
+    GitClient.prototype.setVerboseLoggingState = function (verbose) {
+        GitClient.setVerboseLoggingStae(verbose);
         return this;
     };
     /** Executes the given git command. Throws if the command fails. */
@@ -451,9 +456,10 @@ var GitClient = /** @class */ (function () {
             throw new DryRunError();
         }
         // To improve the debugging experience in case something fails, we print all executed Git
-        // commands to better understand the git actions occuring. Depending on the command being
-        // executed, this debugging information should be logged at different logging levels.
-        var printFn = (!this.verboseLogging || options.stdio === 'ignore') ? debug : info;
+        // commands at the DEBUG level to better understand the git actions occuring. Verbose logging,
+        // always logging at the INFO level, can be enabled either by setting the verboseLogging
+        // property on the GitClient class or the options object provided to the method.
+        var printFn = (GitClient.verboseLogging || options.verboseLogging) ? info : debug;
         // Note that we do not want to print the token if it is contained in the command. It's common
         // to share errors with others if the tool failed, and we do not want to leak tokens.
         printFn('Executing: git', this.omitGithubTokenFromMessage(args.join(' ')));
@@ -592,16 +598,16 @@ var GitClient = /** @class */ (function () {
         });
     };
     GitClient.prototype.determineBaseDir = function () {
-        this.setVerboseLoggingState(false);
         var _a = this.runGraceful(['rev-parse', '--show-toplevel']), stdout = _a.stdout, stderr = _a.stderr, status = _a.status;
         if (status !== 0) {
             throw Error("Unable to find the path to the base directory of the repository.\n" +
                 "Was the command run from inside of the repo?\n\n" +
                 ("ERROR:\n " + stderr));
         }
-        this.setVerboseLoggingState(true);
         return stdout.trim();
     };
+    /** Whether verbose logging of Git actions should be used. */
+    GitClient.verboseLogging = false;
     return GitClient;
 }());
 /**
@@ -1530,8 +1536,6 @@ const moduleList = [
 /** Check the status of services which Angular caretakers need to monitor. */
 function checkServiceStatuses() {
     return tslib.__awaiter(this, void 0, void 0, function* () {
-        // Set the verbose logging state of the GitClient.
-        GitClient.getAuthenticatedInstance().setVerboseLoggingState(false);
         /** The configuration for the caretaker commands. */
         const config = getCaretakerConfig();
         /** List of instances of Caretaker Check modules */

--- a/dev-infra/utils/git/index.ts
+++ b/dev-infra/utils/git/index.ts
@@ -89,7 +89,7 @@ export class GitClient<Authenticated extends boolean> {
   }
 
   /** Set the verbose logging state of the GitClient class. */
-  static setVerboseLoggingStae(verbose: boolean) {
+  static setVerboseLoggingState(verbose: boolean) {
     this.verboseLogging = verbose;
   }
 
@@ -132,15 +132,6 @@ export class GitClient<Authenticated extends boolean> {
     if (typeof githubToken === 'string') {
       this._githubTokenRegex = new RegExp(githubToken, 'g');
     }
-  }
-
-  /**
-   * Set the verbose logging state of the GitClient class and get back the specific GitClient
-   * instance the verbose state was set via.
-   */
-  setVerboseLoggingState(verbose: boolean): this {
-    GitClient.setVerboseLoggingStae(verbose);
-    return this;
   }
 
   /** Executes the given git command. Throws if the command fails. */


### PR DESCRIPTION
Previously by default GitClient would log the commands it was executing at the
INFO level.  This change moves the default level of this logging to DEBUG, while
still allowing callers of the methods to set the log leval back to INFO.
