### PR TITLE
feat(compiler): support safe keyed read expressions

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -156,7 +156,7 @@ class AstTranslator implements AstVisitor {
   }
 
   visitKeyedRead(ast: KeyedRead): ts.Expression {
-    const receiver = wrapForDiagnostics(this.translate(ast.obj));
+    const receiver = wrapForDiagnostics(this.translate(ast.receiver));
     const key = this.translate(ast.key);
     const node = ts.createElementAccess(receiver, key);
     addParseSpanInfo(node, ast.sourceSpan);
@@ -164,7 +164,7 @@ class AstTranslator implements AstVisitor {
   }
 
   visitKeyedWrite(ast: KeyedWrite): ts.Expression {
-    const receiver = wrapForDiagnostics(this.translate(ast.obj));
+    const receiver = wrapForDiagnostics(this.translate(ast.receiver));
     const left = ts.createElementAccess(receiver, this.translate(ast.key));
     // TODO(joost): annotate `left` with the span of the element access, which is not currently
     //  available on `ast`.
@@ -332,7 +332,7 @@ class AstTranslator implements AstVisitor {
   }
 
   visitSafeKeyedRead(ast: SafeKeyedRead): ts.Expression {
-    const receiver = wrapForDiagnostics(this.translate(ast.obj));
+    const receiver = wrapForDiagnostics(this.translate(ast.receiver));
     const key = this.translate(ast.key);
     let node: ts.Expression;
 
@@ -374,7 +374,7 @@ class VeSafeLhsInferenceBugDetector implements AstVisitor {
 
   static veWillInferAnyFor(ast: SafeMethodCall|SafePropertyRead|SafeKeyedRead) {
     const visitor = VeSafeLhsInferenceBugDetector.SINGLETON;
-    return ast instanceof SafeKeyedRead ? ast.obj.visit(visitor) : ast.receiver.visit(visitor);
+    return ast instanceof SafeKeyedRead ? ast.receiver.visit(visitor) : ast.receiver.visit(visitor);
   }
 
   visitUnary(ast: Unary): boolean {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -424,6 +424,23 @@ runInEachFileSystem(() => {
 
         expect(messages).toEqual([]);
       });
+
+      it('infers a safe keyed read as undefined', () => {
+        const messages = diagnose(`<div (click)="log(person.favoriteColors?.[0])"></div>`, `
+          export class TestComponent {
+            person: {
+              favoriteColors?: string[];
+            };
+
+            log(color: string) {
+              console.log(color);
+            }
+          }`);
+
+        expect(messages).toEqual([
+          `TestComponent.html(1, 19): Argument of type 'string | undefined' is not assignable to parameter of type 'string'.`
+        ]);
+      });
     });
 
     it('computes line and column offsets', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -412,6 +412,18 @@ runInEachFileSystem(() => {
 
         expect(messages).toEqual([]);
       });
+
+      it('does not produce diagnostic for safe keyed access', () => {
+        const messages =
+            diagnose(`<div [class.red-text]="person.favoriteColors?.[0] === 'red'"></div>`, `
+              export class TestComponent {
+                person: {
+                  favoriteColors?: string[];
+                };
+              }`);
+
+        expect(messages).toEqual([]);
+      });
     });
 
     it('computes line and column offsets', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/test_utils.ts
@@ -44,6 +44,7 @@ export function typescriptLibDts(): TestFile {
         call(...args: any[]): any;
       }
       declare interface Array<T> {
+        [index: number]: T;
         length: number;
       }
       declare interface String {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -997,12 +997,13 @@ describe('type check blocks', () => {
     });
 
     describe('config.strictSafeNavigationTypes', () => {
-      const TEMPLATE = `{{a?.b}} {{a?.method()}}`;
+      const TEMPLATE = `{{a?.b}} {{a?.method()}} {{a?.[0]}}`;
 
       it('should use undefined for safe navigation operations when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
         expect(block).toContain('(null as any ? (((ctx).a))!.method() : undefined)');
         expect(block).toContain('(null as any ? (((ctx).a))!.b : undefined)');
+        expect(block).toContain('(null as any ? (((ctx).a))![0] : undefined)');
       });
       it('should use an \'any\' type for safe navigation operations when disabled', () => {
         const DISABLED_CONFIG:
@@ -1010,15 +1011,17 @@ describe('type check blocks', () => {
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
         expect(block).toContain('((((ctx).a))!.method() as any)');
         expect(block).toContain('((((ctx).a))!.b as any)');
+        expect(block).toContain('(((((ctx).a))![0] as any)');
       });
     });
 
     describe('config.strictSafeNavigationTypes (View Engine bug emulation)', () => {
-      const TEMPLATE = `{{a.method()?.b}} {{a()?.method()}}`;
+      const TEMPLATE = `{{a.method()?.b}} {{a()?.method()}} {{a.method()?.[0]}}`;
       it('should check the presence of a property/method on the receiver when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
         expect(block).toContain('(null as any ? ((((ctx).a)).method())!.b : undefined)');
         expect(block).toContain('(null as any ? ((ctx).a())!.method() : undefined)');
+        expect(block).toContain('(null as any ? ((((ctx).a)).method())![0] : undefined)');
       });
       it('should not check the presence of a property/method on the receiver when disabled', () => {
         const DISABLED_CONFIG:
@@ -1026,6 +1029,7 @@ describe('type check blocks', () => {
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
         expect(block).toContain('(((((ctx).a)).method()) as any).b');
         expect(block).toContain('(((ctx).a()) as any).method()');
+        expect(block).toContain('(((((ctx).a)).method()) as any)[0]');
       });
     });
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
@@ -1,0 +1,57 @@
+/****************************************************************************************************
+ * PARTIAL FILE: safe_keyed_read.js
+ ****************************************************************************************************/
+import { Component, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.unknownNames = null;
+        this.knownNames = [['Frodo', 'Bilbo']];
+        this.species = null;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <span [title]="'Your last name is ' + (unknownNames?.[0] || 'unknown')">
+      Hello, {{ knownNames?.[0]?.[1] }}!
+      You are a Balrog: {{ species?.[0]?.[1]?.[2]?.[3]?.[4]?.[5] || 'unknown' }}
+    </span>
+`, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <span [title]="'Your last name is ' + (unknownNames?.[0] || 'unknown')">
+      Hello, {{ knownNames?.[0]?.[1] }}!
+      You are a Balrog: {{ species?.[0]?.[1]?.[2]?.[3]?.[4]?.[5] || 'unknown' }}
+    </span>
+`
+                }]
+        }] });
+export class MyModule {
+}
+MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [MyApp] });
+MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
+            type: NgModule,
+            args: [{ declarations: [MyApp] }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: safe_keyed_read.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    unknownNames: string[] | null;
+    knownNames: string[][];
+    species: null;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never>;
+}
+export declare class MyModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof MyApp], never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
@@ -8,6 +8,8 @@ export class MyApp {
         this.unknownNames = null;
         this.knownNames = [['Frodo', 'Bilbo']];
         this.species = null;
+        this.keys = null;
+        this.speciesMap = { key: 'unknown' };
     }
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
@@ -15,6 +17,8 @@ MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "12.0.0", version: "0.0.0-
     <span [title]="'Your last name is ' + (unknownNames?.[0] || 'unknown')">
       Hello, {{ knownNames?.[0]?.[1] }}!
       You are a Balrog: {{ species?.[0]?.[1]?.[2]?.[3]?.[4]?.[5] || 'unknown' }}
+      You are an Elf: {{ speciesMap?.[keys?.[0] ?? 'key'] }}
+      You are an Orc: {{ speciesMap?.['key'] }}
     </span>
 `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -24,6 +28,8 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
     <span [title]="'Your last name is ' + (unknownNames?.[0] || 'unknown')">
       Hello, {{ knownNames?.[0]?.[1] }}!
       You are a Balrog: {{ species?.[0]?.[1]?.[2]?.[3]?.[4]?.[5] || 'unknown' }}
+      You are an Elf: {{ speciesMap?.[keys?.[0] ?? 'key'] }}
+      You are an Orc: {{ speciesMap?.['key'] }}
     </span>
 `
                 }]
@@ -46,6 +52,8 @@ export declare class MyApp {
     unknownNames: string[] | null;
     knownNames: string[][];
     species: null;
+    keys: null;
+    speciesMap: Record<string, string>;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never>;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../test_case_schema.json",
+  "cases": [
+    {
+      "description": "should handle safe keyed reads inside templates",
+      "inputFiles": [
+        "safe_keyed_read.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "safe_keyed_read_template.js",
+              "generated": "safe_keyed_read.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_keyed_read.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_keyed_read.ts
@@ -1,0 +1,19 @@
+import {Component, NgModule} from '@angular/core';
+
+@Component({
+  template: `
+    <span [title]="'Your last name is ' + (unknownNames?.[0] || 'unknown')">
+      Hello, {{ knownNames?.[0]?.[1] }}!
+      You are a Balrog: {{ species?.[0]?.[1]?.[2]?.[3]?.[4]?.[5] || 'unknown' }}
+    </span>
+`
+})
+export class MyApp {
+  unknownNames: string[]|null = null;
+  knownNames: string[][] = [['Frodo', 'Bilbo']];
+  species = null;
+}
+
+@NgModule({declarations: [MyApp]})
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_keyed_read.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_keyed_read.ts
@@ -5,6 +5,8 @@ import {Component, NgModule} from '@angular/core';
     <span [title]="'Your last name is ' + (unknownNames?.[0] || 'unknown')">
       Hello, {{ knownNames?.[0]?.[1] }}!
       You are a Balrog: {{ species?.[0]?.[1]?.[2]?.[3]?.[4]?.[5] || 'unknown' }}
+      You are an Elf: {{ speciesMap?.[keys?.[0] ?? 'key'] }}
+      You are an Orc: {{ speciesMap?.['key'] }}
     </span>
 `
 })
@@ -12,6 +14,8 @@ export class MyApp {
   unknownNames: string[]|null = null;
   knownNames: string[][] = [['Frodo', 'Bilbo']];
   species = null;
+  keys = null;
+  speciesMap: Record<string, string> = {key: 'unknown'};
 }
 
 @NgModule({declarations: [MyApp]})

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_keyed_read_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_keyed_read_template.js
@@ -1,0 +1,12 @@
+template: function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵelementStart(0, "span", 0);
+    i0.ɵɵtext(1);
+    i0.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    i0.ɵɵproperty("title", "Your last name is " + ((ctx.unknownNames == null ? null : ctx.unknownNames[0]) || "unknown"));
+    i0.ɵɵadvance(1);
+    i0.ɵɵtextInterpolate2(" Hello, ", ctx.knownNames == null ? null : ctx.knownNames[0] == null ? null : ctx.knownNames[0][1], "! You are a Balrog: ", (ctx.species == null ? null : ctx.species[0] == null ? null : ctx.species[0][1] == null ? null : ctx.species[0][1][2] == null ? null : ctx.species[0][1][2][3] == null ? null : ctx.species[0][1][2][3][4] == null ? null : ctx.species[0][1][2][3][4][5]) || "unknown", " ");
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_keyed_read_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_keyed_read_template.js
@@ -5,8 +5,9 @@ template: function MyApp_Template(rf, ctx) {
     i0.ɵɵelementEnd();
   }
   if (rf & 2) {
+    let $tmp_0_0$;
     i0.ɵɵproperty("title", "Your last name is " + ((ctx.unknownNames == null ? null : ctx.unknownNames[0]) || "unknown"));
     i0.ɵɵadvance(1);
-    i0.ɵɵtextInterpolate2(" Hello, ", ctx.knownNames == null ? null : ctx.knownNames[0] == null ? null : ctx.knownNames[0][1], "! You are a Balrog: ", (ctx.species == null ? null : ctx.species[0] == null ? null : ctx.species[0][1] == null ? null : ctx.species[0][1][2] == null ? null : ctx.species[0][1][2][3] == null ? null : ctx.species[0][1][2][3][4] == null ? null : ctx.species[0][1][2][3][4][5]) || "unknown", " ");
+    i0.ɵɵtextInterpolate4(" Hello, ", ctx.knownNames == null ? null : ctx.knownNames[0] == null ? null : ctx.knownNames[0][1], "! You are a Balrog: ", (ctx.species == null ? null : ctx.species[0] == null ? null : ctx.species[0][1] == null ? null : ctx.species[0][1][2] == null ? null : ctx.species[0][1][2][3] == null ? null : ctx.species[0][1][2][3][4] == null ? null : ctx.species[0][1][2][3][4][5]) || "unknown", " You are an Elf: ", ctx.speciesMap == null ? null : ctx.speciesMap[($tmp_0_0$ = ctx.keys == null ? null : ctx.keys[0]) !== null && $tmp_0_0$ !== undefined ? $tmp_0_0$ : "key"], " You are an Orc: ", ctx.speciesMap == null ? null : ctx.speciesMap["key"], " ");
   }
 }

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -9,7 +9,7 @@
 import * as chars from '../chars';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../ml_parser/interpolation_config';
 
-import {AbsoluteSourceSpan, AST, AstVisitor, ASTWithSource, Binary, BindingPipe, Chain, Conditional, EmptyExpr, ExpressionBinding, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralMapKey, LiteralPrimitive, MethodCall, NonNullAssert, ParserError, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeMethodCall, SafePropertyRead, TemplateBinding, TemplateBindingIdentifier, ThisReceiver, Unary, VariableBinding} from './ast';
+import {AbsoluteSourceSpan, AST, AstVisitor, ASTWithSource, Binary, BindingPipe, Chain, Conditional, EmptyExpr, ExpressionBinding, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralMapKey, LiteralPrimitive, MethodCall, NonNullAssert, ParserError, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeKeyedRead, SafeMethodCall, SafePropertyRead, TemplateBinding, TemplateBindingIdentifier, ThisReceiver, Unary, VariableBinding} from './ast';
 import {EOF, isIdentifier, isQuote, Lexer, Token, TokenType} from './lexer';
 
 export interface InterpolationPiece {
@@ -822,24 +822,11 @@ export class _ParseAST {
         result = this.parseAccessMemberOrMethodCall(result, start, false);
 
       } else if (this.consumeOptionalOperator('?.')) {
-        result = this.parseAccessMemberOrMethodCall(result, start, true);
-
+        result = this.consumeOptionalCharacter(chars.$LBRACKET) ?
+            this.parseKeyedReadOrWrite(result, start, true) :
+            this.parseAccessMemberOrMethodCall(result, start, true);
       } else if (this.consumeOptionalCharacter(chars.$LBRACKET)) {
-        this.withContext(ParseContextFlags.Writable, () => {
-          this.rbracketsExpected++;
-          const key = this.parsePipe();
-          if (key instanceof EmptyExpr) {
-            this.error(`Key access cannot be empty`);
-          }
-          this.rbracketsExpected--;
-          this.expectCharacter(chars.$RBRACKET);
-          if (this.consumeOptionalOperator('=')) {
-            const value = this.parseConditional();
-            result = new KeyedWrite(this.span(start), this.sourceSpan(start), result, key, value);
-          } else {
-            result = new KeyedRead(this.span(start), this.sourceSpan(start), result, key);
-          }
-        });
+        result = this.parseKeyedReadOrWrite(result, start, false);
       } else if (this.consumeOptionalCharacter(chars.$LPAREN)) {
         this.rparensExpected++;
         const args = this.parseCallArguments();
@@ -954,7 +941,7 @@ export class _ParseAST {
     return new LiteralMap(this.span(start), this.sourceSpan(start), keys, values);
   }
 
-  parseAccessMemberOrMethodCall(receiver: AST, start: number, isSafe: boolean = false): AST {
+  parseAccessMemberOrMethodCall(receiver: AST, start: number, isSafe: boolean): AST {
     const nameStart = this.inputIndex;
     const id = this.withContext(ParseContextFlags.Writable, () => {
       const id = this.expectIdentifierOrKeyword() ?? '';
@@ -1093,6 +1080,34 @@ export class _ParseAST {
     }
 
     return new TemplateBindingParseResult(bindings, [] /* warnings */, this.errors);
+  }
+
+  parseKeyedReadOrWrite(receiver: AST, start: number, isSafe: boolean) {
+    let result: AST|undefined;
+
+    this.withContext(ParseContextFlags.Writable, () => {
+      this.rbracketsExpected++;
+      const key = this.parsePipe();
+      if (key instanceof EmptyExpr) {
+        this.error(`Key access cannot be empty`);
+      }
+      this.rbracketsExpected--;
+      this.expectCharacter(chars.$RBRACKET);
+      if (this.consumeOptionalOperator('=')) {
+        if (isSafe) {
+          this.error('The \'?.\' operator cannot be used in the assignment');
+        } else {
+          const value = this.parseConditional();
+          result = new KeyedWrite(this.span(start), this.sourceSpan(start), receiver, key, value);
+        }
+      } else {
+        result = isSafe ?
+            new SafeKeyedRead(this.span(start), this.sourceSpan(start), receiver, key) :
+            new KeyedRead(this.span(start), this.sourceSpan(start), receiver, key);
+      }
+    });
+
+    return result || new EmptyExpr(this.span(start), this.sourceSpan(start));
   }
 
   /**
@@ -1333,6 +1348,8 @@ class SimpleExpressionChecker implements AstVisitor {
   visitChain(ast: Chain, context: any) {}
 
   visitQuote(ast: Quote, context: any) {}
+
+  visitSafeKeyedRead(ast: SafeKeyedRead, context: any) {}
 }
 
 /**

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -1082,10 +1082,8 @@ export class _ParseAST {
     return new TemplateBindingParseResult(bindings, [] /* warnings */, this.errors);
   }
 
-  parseKeyedReadOrWrite(receiver: AST, start: number, isSafe: boolean) {
-    let result: AST|undefined;
-
-    this.withContext(ParseContextFlags.Writable, () => {
+  parseKeyedReadOrWrite(receiver: AST, start: number, isSafe: boolean): AST {
+    return this.withContext(ParseContextFlags.Writable, () => {
       this.rbracketsExpected++;
       const key = this.parsePipe();
       if (key instanceof EmptyExpr) {
@@ -1098,16 +1096,15 @@ export class _ParseAST {
           this.error('The \'?.\' operator cannot be used in the assignment');
         } else {
           const value = this.parseConditional();
-          result = new KeyedWrite(this.span(start), this.sourceSpan(start), receiver, key, value);
+          return new KeyedWrite(this.span(start), this.sourceSpan(start), receiver, key, value);
         }
       } else {
-        result = isSafe ?
-            new SafeKeyedRead(this.span(start), this.sourceSpan(start), receiver, key) :
-            new KeyedRead(this.span(start), this.sourceSpan(start), receiver, key);
+        return isSafe ? new SafeKeyedRead(this.span(start), this.sourceSpan(start), receiver, key) :
+                        new KeyedRead(this.span(start), this.sourceSpan(start), receiver, key);
       }
-    });
 
-    return result || new EmptyExpr(this.span(start), this.sourceSpan(start));
+      return new EmptyExpr(this.span(start), this.sourceSpan(start));
+    });
   }
 
   /**

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -127,6 +127,14 @@ function expectErrorToken(token: Token, index: any, end: number, message: string
         expectCharacterToken(tokens[3], 3, 4, ']');
       });
 
+      it('should tokenize a safe indexed operator', () => {
+        const tokens: number[] = lex('j?.[k]');
+        expect(tokens.length).toBe(5);
+        expectOperatorToken(tokens[1], 1, 3, '?.');
+        expectCharacterToken(tokens[2], 3, 4, '[');
+        expectCharacterToken(tokens[4], 5, 6, ']');
+      });
+
       it('should tokenize numbers', () => {
         const tokens: number[] = lex('88');
         expect(tokens.length).toEqual(1);

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -224,6 +224,7 @@ describe('parser', () => {
         checkAction('a?.["a"]');
         checkAction('this.a?.["a"]', 'a?.["a"]');
         checkAction('a.a?.["a"]');
+        checkAction('this.a?.[this.b?.["a"] ?? "a"]', 'a?.[b?.["a"] ?? "a"]');
       });
 
       describe('malformed keyed reads', () => {

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -215,16 +215,16 @@ describe('parser', () => {
 
     describe('keyed read', () => {
       it('should parse keyed reads', () => {
-        checkAction('a["a"]');
-        checkAction('this.a["a"]', 'a["a"]');
-        checkAction('a.a["a"]');
+        checkBinding('a["a"]');
+        checkBinding('this.a["a"]', 'a["a"]');
+        checkBinding('a.a["a"]');
       });
 
       it('should parse safe keyed reads', () => {
-        checkAction('a?.["a"]');
-        checkAction('this.a?.["a"]', 'a?.["a"]');
-        checkAction('a.a?.["a"]');
-        checkAction('this.a?.[this.b?.["a"] ?? "a"]', 'a?.[b?.["a"] ?? "a"]');
+        checkBinding('a?.["a"]');
+        checkBinding('this.a?.["a"]', 'a?.["a"]');
+        checkBinding('a.a?.["a"]');
+        checkBinding('a.a?.["a" | foo]', 'a.a?.[("a" | foo)]');
       });
 
       describe('malformed keyed reads', () => {

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -220,6 +220,12 @@ describe('parser', () => {
         checkAction('a.a["a"]');
       });
 
+      it('should parse safe keyed reads', () => {
+        checkAction('a?.["a"]');
+        checkAction('this.a?.["a"]', 'a?.["a"]');
+        checkAction('a.a?.["a"]');
+      });
+
       describe('malformed keyed reads', () => {
         it('should recover on missing keys', () => {
           checkActionWithError('a[]', 'a[]', 'Key access cannot be empty');
@@ -246,6 +252,10 @@ describe('parser', () => {
         checkAction('a["a"] = 1 + 2');
         checkAction('this.a["a"] = 1 + 2', 'a["a"] = 1 + 2');
         checkAction('a.a["a"] = 1 + 2');
+      });
+
+      it('should report on safe keyed writes', () => {
+        expectActionError('a?.["a"] = 123', 'cannot be used in the assignment');
       });
 
       describe('malformed keyed writes', () => {

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -101,14 +101,14 @@ class Unparser implements AstVisitor {
   }
 
   visitKeyedRead(ast: KeyedRead, context: any) {
-    this._visit(ast.obj);
+    this._visit(ast.receiver);
     this._expression += '[';
     this._visit(ast.key);
     this._expression += ']';
   }
 
   visitKeyedWrite(ast: KeyedWrite, context: any) {
-    this._visit(ast.obj);
+    this._visit(ast.receiver);
     this._expression += '[';
     this._visit(ast.key);
     this._expression += '] = ';
@@ -194,7 +194,7 @@ class Unparser implements AstVisitor {
   }
 
   visitSafeKeyedRead(ast: SafeKeyedRead, context: any) {
-    this._visit(ast.obj);
+    this._visit(ast.receiver);
     this._expression += '?.[';
     this._visit(ast.key);
     this._expression += ']';

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, AstVisitor, ASTWithSource, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, NonNullAssert, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeMethodCall, SafePropertyRead, ThisReceiver, Unary} from '../../../src/expression_parser/ast';
+import {AST, AstVisitor, ASTWithSource, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, NonNullAssert, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeKeyedRead, SafeMethodCall, SafePropertyRead, ThisReceiver, Unary} from '../../../src/expression_parser/ast';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../../src/ml_parser/interpolation_config';
 
 class Unparser implements AstVisitor {
@@ -191,6 +191,13 @@ class Unparser implements AstVisitor {
 
   visitQuote(ast: Quote, context: any) {
     this._expression += `${ast.prefix}:${ast.uninterpretedExpression}`;
+  }
+
+  visitSafeKeyedRead(ast: SafeKeyedRead, context: any) {
+    this._visit(ast.obj);
+    this._expression += '?.[';
+    this._visit(ast.key);
+    this._expression += ']';
   }
 
   private _visit(ast: AST) {

--- a/packages/compiler/test/expression_parser/utils/validator.ts
+++ b/packages/compiler/test/expression_parser/utils/validator.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeMethodCall, SafePropertyRead, Unary} from '../../../src/expression_parser/ast';
+import {AST, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeKeyedRead, SafeMethodCall, SafePropertyRead, Unary} from '../../../src/expression_parser/ast';
 
 import {unparse} from './unparser';
 
@@ -112,6 +112,10 @@ class ASTValidator extends RecursiveAstVisitor {
 
   visitSafePropertyRead(ast: SafePropertyRead, context: any): any {
     this.validate(ast, () => super.visitSafePropertyRead(ast, context));
+  }
+
+  visitSafeKeyedRead(ast: SafeKeyedRead, context: any): any {
+    this.validate(ast, () => super.visitSafeKeyedRead(ast, context));
   }
 }
 

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -114,6 +114,10 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     this.recordAst(ast);
     super.visitQuote(ast, null);
   }
+  visitSafeKeyedRead(ast: e.SafeKeyedRead) {
+    this.recordAst(ast);
+    super.visitSafeKeyedRead(ast, null);
+  }
 
   visitTemplate(ast: t.Template) {
     t.visitAll(this, ast.children);

--- a/packages/compiler/test/template_parser/util/expression.ts
+++ b/packages/compiler/test/template_parser/util/expression.ts
@@ -114,6 +114,10 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Templ
     this.recordAst(ast);
     super.visitQuote(ast, null);
   }
+  visitSafeKeyedRead(ast: e.SafeKeyedRead) {
+    this.recordAst(ast);
+    super.visitSafeKeyedRead(ast, null);
+  }
 
   visitNgContent(ast: t.NgContentAst) {}
   visitEmbeddedTemplate(ast: t.EmbeddedTemplateAst) {

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -1955,6 +1955,31 @@ describe('acceptance integration tests', () => {
     expect(content).toContain(`<span title="Your last name is Baggins">`);
   });
 
+  it('should handle safe keyed reads inside templates', () => {
+    @Component({
+      template: `
+      <span [title]="'Your last name is ' + (unknownNames?.[0] || 'unknown')">
+        Hello, {{ knownNames?.[0]?.[1] }}!
+        You are a Balrog: {{ species?.[0]?.[1]?.[2]?.[3]?.[4]?.[5] || 'unknown' }}
+      </span>
+    `
+    })
+    class App {
+      unknownNames: string[]|null = null;
+      knownNames: string[][] = [['Frodo', 'Bilbo']];
+      species = null;
+    }
+
+    TestBed.configureTestingModule({declarations: [App]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    const content = fixture.nativeElement.innerHTML;
+
+    expect(content).toContain('Hello, Bilbo!');
+    expect(content).toContain('You are a Balrog: unknown');
+    expect(content).toContain(`<span title="Your last name is unknown">`);
+  });
+
   it('should handle nullish coalescing inside host bindings', () => {
     const logs: string[] = [];
 

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -1961,6 +1961,8 @@ describe('acceptance integration tests', () => {
       <span [title]="'Your last name is ' + (unknownNames?.[0] || 'unknown')">
         Hello, {{ knownNames?.[0]?.[1] }}!
         You are a Balrog: {{ species?.[0]?.[1]?.[2]?.[3]?.[4]?.[5] || 'unknown' }}
+        You are an Elf: {{ speciesMap?.[keys?.[0] ?? 'key'] }}
+        You are an Orc: {{ speciesMap?.['key'] }}
       </span>
     `
     })
@@ -1968,6 +1970,8 @@ describe('acceptance integration tests', () => {
       unknownNames: string[]|null = null;
       knownNames: string[][] = [['Frodo', 'Bilbo']];
       species = null;
+      keys = null;
+      speciesMap: Record<string, string> = {key: 'unknown'};
     }
 
     TestBed.configureTestingModule({declarations: [App]});
@@ -1977,6 +1981,7 @@ describe('acceptance integration tests', () => {
 
     expect(content).toContain('Hello, Bilbo!');
     expect(content).toContain('You are a Balrog: unknown');
+    expect(content).toContain('You are an Elf: unknown');
     expect(content).toContain(`<span title="Your last name is unknown">`);
   });
 

--- a/packages/language-service/ivy/test/legacy/template_target_spec.ts
+++ b/packages/language-service/ivy/test/legacy/template_target_spec.ts
@@ -471,6 +471,15 @@ describe('getTargetAtPosition for expression AST', () => {
     expect(node).toBeInstanceOf(e.KeyedRead);
   });
 
+  it('should locate safe keyed read', () => {
+    const {errors, nodes, position} = parse(`{{ foo?.['bar']¦ }}`);
+    expect(errors).toBe(null);
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
+    expect(isExpressionNode(node!)).toBe(true);
+    expect(node).toBeInstanceOf(e.SafeKeyedRead);
+  });
+
   it('should locate property write', () => {
     const {errors, nodes, position} = parse(`<div (foo)="b¦ar=$event"></div>`);
     expect(errors).toBe(null);

--- a/packages/language-service/src/expression_type.ts
+++ b/packages/language-service/src/expression_type.ts
@@ -271,7 +271,7 @@ export class AstType implements AstVisitor {
   }
 
   visitKeyedRead(ast: KeyedRead): Symbol {
-    const targetType = this.getType(ast.obj);
+    const targetType = this.getType(ast.receiver);
     const keyType = this.getType(ast.key);
     const result = targetType.indexed(
         keyType, ast.key instanceof LiteralPrimitive ? ast.key.value : undefined);
@@ -380,7 +380,7 @@ export class AstType implements AstVisitor {
   }
 
   visitSafeKeyedRead(ast: SafeKeyedRead): Symbol {
-    const targetType = this.query.getNonNullableType(this.getType(ast.obj));
+    const targetType = this.query.getNonNullableType(this.getType(ast.receiver));
     const keyType = this.getType(ast.key);
     const result = targetType.indexed(
         keyType, ast.key instanceof LiteralPrimitive ? ast.key.value : undefined);

--- a/packages/language-service/src/expression_type.ts
+++ b/packages/language-service/src/expression_type.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, AstVisitor, ASTWithName, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead, ThisReceiver, Unary} from '@angular/compiler';
+import {AST, AstVisitor, ASTWithName, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeKeyedRead, SafeMethodCall, SafePropertyRead, ThisReceiver, Unary} from '@angular/compiler';
 
 import {createDiagnostic, Diagnostic} from './diagnostic_messages';
 import {BuiltinType, Signature, Symbol, SymbolQuery, SymbolTable} from './symbols';
@@ -377,6 +377,14 @@ export class AstType implements AstVisitor {
 
   visitSafePropertyRead(ast: SafePropertyRead) {
     return this.resolvePropertyRead(this.query.getNonNullableType(this.getType(ast.receiver)), ast);
+  }
+
+  visitSafeKeyedRead(ast: SafeKeyedRead): Symbol {
+    const targetType = this.query.getNonNullableType(this.getType(ast.obj));
+    const keyType = this.getType(ast.key);
+    const result = targetType.indexed(
+        keyType, ast.key instanceof LiteralPrimitive ? ast.key.value : undefined);
+    return result || this.anyType;
   }
 
   /**

--- a/packages/language-service/src/expressions.ts
+++ b/packages/language-service/src/expressions.ts
@@ -74,6 +74,7 @@ export function getExpressionCompletions(
       result = undefined;
     },
     visitKeyedRead(_ast) {},
+    visitSafeKeyedRead(_ast) {},
     visitKeyedWrite(_ast) {},
     visitLiteralArray(_ast) {},
     visitLiteralMap(_ast) {},
@@ -168,6 +169,7 @@ export function getExpressionSymbol(
     visitThisReceiver(_ast) {},
     visitInterpolation(_ast) {},
     visitKeyedRead(_ast) {},
+    visitSafeKeyedRead(_ast) {},
     visitKeyedWrite(_ast) {},
     visitLiteralArray(_ast) {},
     visitLiteralMap(_ast) {},


### PR DESCRIPTION
Currently we support safe property (`a?.b`) and method (`a?.b()`) accesses, but we don't handle safe keyed reads (`a?.[0]`) which is inconsistent. These changes expand the compiler in order to support safe key read expressions as well.
