### PR TITLE
build(docs-infra): revert `watchr` to v3.0.1 to restore `docs-watch` performance

### DIFF
--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -6660,7 +6660,12 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@*, graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3:
+graceful-fs@*, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
+  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
+graceful-fs@^4.1.0, graceful-fs@^4.1.15, graceful-fs@^4.1.9:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==


### PR DESCRIPTION
_This is a backport of #41903 to the `11.2.x` branch._

##
[`watchr` v4.0.0][1] changes the way watched directories are scanned/watched, thus causing a great increase in the consumed CPU and RAM. This affects the performance of the `docs-watch` and transitively `serve-and-sync` npm scripts.
(For reference, on my local machine it goes from 0% CPU and 275MB RAM with v3.0.1 to 50% CPU and 10GB RAM with v4+.)

This commit pins `watchr` to version 3.0.1 (which is the latest version that does not cause performance issues) and disabled automatic updates via Renovate.

[1]: https://github.com/bevry/watchr/releases/tag/v4.0.0
