### PR TITLE
fix(dev-infra): publish script python check not working on windows

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -6751,16 +6751,16 @@ class ReleaseTool {
         });
     }
     /**
-     * Verifies the current environment contains /usr/bin/python which points to the Python3
-     * interpreter.  python is required by our tooling in bazel as it contains scripts setting
-     * `#! /usr/bin/env python`.
-     *
+     * Verifies that Python can be resolved within scripts and points to a compatible version. Python
+     * is required in Bazel actions as there can be tools (such as `skydoc`) that rely on it.
      * @returns a boolean indicating success or failure.
      */
     _verifyEnvironmentHasPython3Symlink() {
         return tslib.__awaiter(this, void 0, void 0, function* () {
             try {
-                const pyVersion = yield spawnWithDebugOutput('/usr/bin/python', ['--version'], { mode: 'silent' });
+                // Note: We do not rely on `/usr/bin/env` but rather access the `env` binary directly as it
+                // should be part of the shell's `$PATH`. This is necessary for compatibility with Windows.
+                const pyVersion = yield spawnWithDebugOutput('env', ['python', '--version'], { mode: 'silent' });
                 const version = pyVersion.stdout.trim() || pyVersion.stderr.trim();
                 if (version.startsWith('Python 3.')) {
                     debug(`Local python version: ${version}`);

--- a/dev-infra/release/publish/index.ts
+++ b/dev-infra/release/publish/index.ts
@@ -131,16 +131,16 @@ export class ReleaseTool {
   }
 
   /**
-   * Verifies the current environment contains /usr/bin/python which points to the Python3
-   * interpreter.  python is required by our tooling in bazel as it contains scripts setting
-   * `#! /usr/bin/env python`.
-   *
+   * Verifies that Python can be resolved within scripts and points to a compatible version. Python
+   * is required in Bazel actions as there can be tools (such as `skydoc`) that rely on it.
    * @returns a boolean indicating success or failure.
    */
   private async _verifyEnvironmentHasPython3Symlink(): Promise<boolean> {
     try {
+      // Note: We do not rely on `/usr/bin/env` but rather access the `env` binary directly as it
+      // should be part of the shell's `$PATH`. This is necessary for compatibility with Windows.
       const pyVersion =
-          await spawnWithDebugOutput('/usr/bin/python', ['--version'], {mode: 'silent'});
+          await spawnWithDebugOutput('env', ['python', '--version'], {mode: 'silent'});
       const version = pyVersion.stdout.trim() || pyVersion.stderr.trim();
       if (version.startsWith('Python 3.')) {
         debug(`Local python version: ${version}`);


### PR DESCRIPTION
We recently added a sanity check that ensures that `python` is
available for Bazel. The check relies on `/usr/bin/python` to check
if python is available w/ the correct version. The problem is
that on Windows there is no guarantee that the `/usr/bin` folder
exists, so the `ng-dev release publish` command always fails.

We fix this by just accessing the `env` binary that is also consulted
by scripts executed within Bazel actions. The `env` binary can be
assumed exist in the shell's `$PATH` and can point us to Python
as if it would be executed within Bazel.

@josephperrott As we discussed in the past, the check might be useful in general. Especially
since the release tooling could be used in other repositories that might rely on Skydoc. We
could also re-consider removing the check; I don't feel strongly about this.
