### PR TITLE
fix(dev-infra): spawned child processes messing with tty output

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -5210,6 +5210,21 @@ const ReleaseBuildCommandModule = {
  * found in the LICENSE file at https://angular.io/license
  */
 /**
+ * Spawns a given command with the specified arguments inside an interactive shell. All process
+ * stdin, stdout and stderr output is printed to the current console.
+ *
+ * @returns a Promise resolving on success, and rejecting on command failure with the status code.
+ */
+function spawnInteractiveCommand(command, args, options) {
+    if (options === void 0) { options = {}; }
+    return new Promise(function (resolve, reject) {
+        var commandText = command + " " + args.join(' ');
+        debug("Executing command: " + commandText);
+        var childProcess = child_process.spawn(command, args, tslib.__assign(tslib.__assign({}, options), { shell: true, stdio: 'inherit' }));
+        childProcess.on('exit', function (status) { return status === 0 ? resolve() : reject(status); });
+    });
+}
+/**
  * Spawns a given command with the specified arguments inside a shell. All process stdout
  * output is captured and returned as resolution on completion. Depending on the chosen
  * output mode, stdout/stderr output is also printed to the console, or only on error.
@@ -5223,7 +5238,7 @@ function spawnWithDebugOutput(command, args, options) {
         var commandText = command + " " + args.join(' ');
         var outputMode = options.mode;
         debug("Executing command: " + commandText);
-        var childProcess = child_process.spawn(command, args, tslib.__assign(tslib.__assign({}, options), { shell: true, stdio: ['inherit', 'pipe', 'pipe'] }));
+        var childProcess = child_process.spawn(command, args, tslib.__assign(tslib.__assign({}, options), { shell: true, stdio: 'pipe' }));
         var logOutput = '';
         var stdout = '';
         var stderr = '';
@@ -5321,7 +5336,7 @@ function npmIsLoggedIn(registryUrl) {
 }
 /**
  * Log into NPM at a provided registry.
- * @throws With the process log output if the login fails.
+ * @throws With the `npm login` status code if the login failed.
  */
 function npmLogin(registryUrl) {
     return tslib.__awaiter(this, void 0, void 0, function* () {
@@ -5332,7 +5347,9 @@ function npmLogin(registryUrl) {
         if (registryUrl !== undefined) {
             args.splice(1, 0, '--registry', registryUrl);
         }
-        yield spawnWithDebugOutput('npm', args);
+        // The login command prompts for username, password and other profile information. Hence
+        // the process needs to be interactive (i.e. respecting current TTYs stdin).
+        yield spawnInteractiveCommand('npm', args);
     });
 }
 /**

--- a/dev-infra/release/publish/index.ts
+++ b/dev-infra/release/publish/index.ts
@@ -12,7 +12,6 @@ import {spawnWithDebugOutput} from '../../utils/child-process';
 import {GithubConfig} from '../../utils/config';
 import {debug, error, info, log, promptConfirm, red, yellow} from '../../utils/console';
 import {GitClient} from '../../utils/git/index';
-import {exec} from '../../utils/shelljs';
 import {ReleaseConfig} from '../config/index';
 import {ActiveReleaseTrains, fetchActiveReleaseTrains, nextBranchName} from '../versioning/active-release-trains';
 import {npmIsLoggedIn, npmLogin, npmLogout} from '../versioning/npm-publish';

--- a/dev-infra/release/versioning/npm-publish.ts
+++ b/dev-infra/release/versioning/npm-publish.ts
@@ -7,7 +7,7 @@
  */
 
 import * as semver from 'semver';
-import {spawnWithDebugOutput} from '../../utils/child-process';
+import {spawnInteractiveCommand, spawnWithDebugOutput} from '../../utils/child-process';
 
 /**
  * Runs NPM publish within a specified package directory.
@@ -57,7 +57,7 @@ export async function npmIsLoggedIn(registryUrl: string|undefined): Promise<bool
 
 /**
  * Log into NPM at a provided registry.
- * @throws With the process log output if the login fails.
+ * @throws With the `npm login` status code if the login failed.
  */
 export async function npmLogin(registryUrl: string|undefined) {
   const args = ['login', '--no-browser'];
@@ -67,7 +67,9 @@ export async function npmLogin(registryUrl: string|undefined) {
   if (registryUrl !== undefined) {
     args.splice(1, 0, '--registry', registryUrl);
   }
-  await spawnWithDebugOutput('npm', args);
+  // The login command prompts for username, password and other profile information. Hence
+  // the process needs to be interactive (i.e. respecting current TTYs stdin).
+  await spawnInteractiveCommand('npm', args);
 }
 
 /**


### PR DESCRIPTION
Currently we have a common utility method for running commands
in a child process. This method pipes all stdout and stderr, but sets
the `stdin` to `inherited`. This seemed to work as expected in terms of
allowing interactive commands being executed, but it messes with the
TTY in Windows (and potentially other platforms) so that colors and
prompts no longer work properly. It's unclear how this causes the TTY
to no longer support colors; but I guess it's the mix of inherit and pipe.

See attached screenshot. ![image](https://user-images.githubusercontent.com/4987015/117051174-88be7100-ad16-11eb-90b9-0ab5b5599abb.png)


We fix this by not inheriting the stdin by default; but exposing
a dedicated method for interactive commands. This results in more
readable and obvious code too, so it's worth making this change
regardless of the TTY issues.