### PR TITLE
docs: remove ts-node and tslint form dev deps

### DIFF
--- a/aio/content/guide/npm-packages.md
+++ b/aio/content/guide/npm-packages.md
@@ -121,8 +121,6 @@ Package name                               | Description
 **@types/... ** | TypeScript definition files for 3rd party libraries such as Jasmine and Node.js.
 **jasmine/... ** | Packages to support the [Jasmine](https://jasmine.github.io/) test library.
 **karma/... ** | Packages to support the [karma](https://www.npmjs.com/package/karma) test runner.
-[**ts-node**](https://www.npmjs.com/package/ts-node) | TypeScript execution environment and REPL for Node.js.
-[**tslint**](https://www.npmjs.com/package/tslint) | A static analysis tool that checks TypeScript code for readability, maintainability, and functionality errors.
 [**typescript**](https://www.npmjs.com/package/typescript) | The TypeScript language server, including the *tsc* TypeScript compiler.
 
 


### PR DESCRIPTION
A recent commit 3b589030a80e956509c787f6e4c07bb78b529c91 reintroduced these dev deps.
They were previously removed by #41826 and #41873

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

A recent commit 3b589030a80e956509c787f6e4c07bb78b529c91 reintroduced these dev deps probably not on purpose.
They were previously removed by #41826 and #41873

## What is the new behavior?

Removes the dev deps again.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
