### PR TITLE
feat(core): add support for Types in ViewContainerRef.createComponent

### DIFF
--- a/goldens/public-api/core/core.d.ts
+++ b/goldens/public-api/core/core.d.ts
@@ -1020,7 +1020,7 @@ export declare abstract class ViewContainerRef {
     abstract get length(): number;
     /** @deprecated */ abstract get parentInjector(): Injector;
     abstract clear(): void;
-    abstract createComponent<C>(componentFactory: ComponentFactory<C>, index?: number, injector?: Injector, projectableNodes?: any[][], ngModule?: NgModuleRef<any>): ComponentRef<C>;
+    abstract createComponent<C>(componentFactoryOrType: ComponentFactory<C> | Type<C>, index?: number, injector?: Injector, projectableNodes?: any[][], ngModule?: NgModuleRef<any>): ComponentRef<C>;
     abstract createEmbeddedView<C>(templateRef: TemplateRef<C>, context?: C, index?: number): EmbeddedViewRef<C>;
     abstract detach(index?: number): ViewRef | null;
     abstract get(index: number): ViewRef | null;

--- a/packages/core/src/render3/view_engine_compatibility_prebound.ts
+++ b/packages/core/src/render3/view_engine_compatibility_prebound.ts
@@ -7,10 +7,7 @@
  */
 
 
-import {ChangeDetectorRef, injectChangeDetectorRef} from '../change_detection/change_detector_ref';
-import {InjectFlags} from '../di/interface/injector';
 import {createTemplateRef, TemplateRef} from '../linker/template_ref';
-import {throwProviderNotFoundError} from './errors_di';
 import {TNode} from './interfaces/node';
 import {LView} from './interfaces/view';
 

--- a/packages/core/src/view/refs.ts
+++ b/packages/core/src/view/refs.ts
@@ -17,6 +17,7 @@ import {InternalNgModuleRef, NgModuleRef} from '../linker/ng_module_factory';
 import {TemplateRef} from '../linker/template_ref';
 import {ViewContainerRef} from '../linker/view_container_ref';
 import {EmbeddedViewRef, InternalViewRef, ViewRef, ViewRefTracker} from '../linker/view_ref';
+import {assertEqual} from '../util/assert';
 import {stringify} from '../util/stringify';
 import {VERSION} from '../version';
 
@@ -191,9 +192,15 @@ class ViewContainerRef_ implements ViewContainerData {
   }
 
   createComponent<C>(
-      componentFactory: ComponentFactory<C>, index?: number, injector?: Injector,
+      componentFactoryOrType: ComponentFactory<C>|Type<C>, index?: number, injector?: Injector,
       projectableNodes?: any[][], ngModuleRef?: NgModuleRef<any>): ComponentRef<C> {
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      assertEqual(
+          typeof componentFactoryOrType !== 'function', true,
+          'ViewEngine does not support Type as an argument for \'componentFactoryOrType\'');
+    }
     const contextInjector = injector || this.parentInjector;
+    const componentFactory = componentFactoryOrType as ComponentFactory<C>;
     if (!ngModuleRef && !(componentFactory instanceof ComponentFactoryBoundToModule)) {
       ngModuleRef = contextInjector.get(NgModuleRef);
     }

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -1495,6 +1495,38 @@ describe('ViewContainerRef', () => {
 
          expect(fixture.debugElement.nativeElement.innerHTML).toContain('Child Component');
        });
+
+    it('should be able to create a component using Type', () => {
+      @Component({
+        selector: 'child',
+        template: `Child Component`,
+      })
+      class Child {
+      }
+
+      @Component({
+        selector: 'comp',
+        template: '',
+      })
+      class Comp {
+        constructor(private viewContainerRef: ViewContainerRef) {}
+
+        ngOnInit() {
+          this.viewContainerRef!.createComponent(Child);
+        }
+      }
+
+      TestBed.configureTestingModule({declarations: [Comp, Child]});
+
+      const fixture = TestBed.createComponent(Comp);
+      if (ivyEnabled) {
+        fixture.detectChanges();
+        const native = fixture.debugElement.nativeElement as Element;
+        expect((native.parentNode as Element).textContent).toContain('Child Component');
+      } else {
+        expect(() => fixture.detectChanges()).toThrowError(/ViewEngine does not support Type/);
+      }
+    });
   });
 
   describe('insertion points and declaration points', () => {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -6,6 +6,12 @@
     "name": "ChangeDetectionStrategy"
   },
   {
+    "name": "ComponentFactory"
+  },
+  {
+    "name": "ComponentRef"
+  },
+  {
     "name": "DefaultIterableDiffer"
   },
   {
@@ -33,6 +39,9 @@
     "name": "IterableDiffers"
   },
   {
+    "name": "LifecycleHooksFeature"
+  },
+  {
     "name": "NG_COMP_DEF"
   },
   {
@@ -55,6 +64,9 @@
   },
   {
     "name": "NOT_FOUND"
+  },
+  {
+    "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
   },
   {
     "name": "NO_CHANGE"
@@ -93,6 +105,12 @@
     "name": "RecordViewTuple"
   },
   {
+    "name": "RendererFactory2"
+  },
+  {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -103,6 +121,9 @@
   },
   {
     "name": "SWITCH_VIEW_CONTAINER_REF_FACTORY"
+  },
+  {
+    "name": "Sanitizer"
   },
   {
     "name": "SimpleChange"
@@ -138,7 +159,13 @@
     "name": "TodoStore"
   },
   {
+    "name": "VERSION"
+  },
+  {
     "name": "VE_ViewContainerRef"
+  },
+  {
+    "name": "Version"
   },
   {
     "name": "ViewContainerRef"
@@ -261,6 +288,9 @@
     "name": "createDirectivesInstances"
   },
   {
+    "name": "createElementNode"
+  },
+  {
     "name": "createElementRef"
   },
   {
@@ -274,6 +304,15 @@
   },
   {
     "name": "createNodeInjector"
+  },
+  {
+    "name": "createRootComponent"
+  },
+  {
+    "name": "createRootComponentView"
+  },
+  {
+    "name": "createRootContext"
   },
   {
     "name": "createTView"
@@ -295,6 +334,9 @@
   },
   {
     "name": "detachView"
+  },
+  {
+    "name": "detectChangesInRootView"
   },
   {
     "name": "detectChangesInternal"
@@ -447,6 +489,9 @@
     "name": "getSymbolIterator"
   },
   {
+    "name": "getTNode"
+  },
+  {
     "name": "getTStylingRangeNext"
   },
   {
@@ -567,6 +612,9 @@
     "name": "leaveViewLight"
   },
   {
+    "name": "locateHostElement"
+  },
+  {
     "name": "lookupTokenUsingModuleInjector"
   },
   {
@@ -583,6 +631,9 @@
   },
   {
     "name": "markViewDirty"
+  },
+  {
+    "name": "maybeWrapInNotSelector"
   },
   {
     "name": "mergeHostAttribute"
@@ -729,10 +780,19 @@
     "name": "stringify"
   },
   {
+    "name": "stringifyCSSSelector"
+  },
+  {
     "name": "stringifyForError"
   },
   {
     "name": "throwProviderNotFoundError"
+  },
+  {
+    "name": "tickRootContext"
+  },
+  {
+    "name": "toRefArray"
   },
   {
     "name": "toTStylingRange"


### PR DESCRIPTION
With Ivy it's possible to create a `ComponentFactory` instance based on the generated Component def, thus the `ViewContainerRef.createComponent` can accept a Component instance and create a factory inside, rather than requiring additional complexity of creating a ComponentFactory outside (by invoking `ComponentFactoryResolver`).

This should simplify the API that is used for creating components dynamically.

Current version:

```
@Directive({ ... })
export class MyDirective {
  constructor(
    private viewContainerRef: ViewContainerRef,
    private componentFactoryResolver: ComponentFactoryResolver
  ) {}

  createMyComponent() {
    const componentFactory = this.componentFactoryResolver.resolveComponentFactory(MyComponent);
    this.viewContainerRef.createComponent(componentFactory);
  }
}
```

New version:

```
@Directive({ ... })
export class MyDirective {
  constructor(private viewContainerRef: ViewContainerRef) {}

  createMyComponent() {
    this.viewContainerRef.createComponent(MyComponent);
  }
}
```

Note: this work is based on @mhevery's PR #32742.


## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No