### PR TITLE
fix(language-service): Correct rename info for pipe name expressions

### DIFF
--- a/packages/language-service/ivy/test/references_and_rename_spec.ts
+++ b/packages/language-service/ivy/test/references_and_rename_spec.ts
@@ -809,20 +809,23 @@ describe('find references and rename locations', () => {
           birthday = '';
         }
       `,
-          'prefix-pipe.ts': prefixPipe
+          'prefix_pipe.ts': prefixPipe
         };
         env = LanguageServiceTestEnv.setup();
         const project = createModuleAndProjectWithDeclarations(env, 'test', files);
-        const file = project.openFile('app.ts');
-        file.moveCursorToText('prefi¦xPipe:');
+        const file = project.openFile('prefix_pipe.ts');
+        file.moveCursorToText(`'prefi¦xPipe'`);
         const renameLocations = getRenameLocationsAtPosition(file)!;
         expect(renameLocations.length).toBe(2);
-        assertFileNames(renameLocations, ['prefix-pipe.ts', 'app.ts']);
+        assertFileNames(renameLocations, ['prefix_pipe.ts', 'app.ts']);
         assertTextSpans(renameLocations, ['prefixPipe']);
 
         const result = file.getRenameInfo() as ts.RenameInfoSuccess;
         expect(result.canRename).toEqual(true);
         expect(result.displayName).toEqual('prefixPipe');
+        expect(file.contents.substring(
+                   result.triggerSpan.start, result.triggerSpan.start + result.triggerSpan.length))
+            .toBe('prefixPipe');
       });
 
       it('finds rename locations in base class', () => {


### PR DESCRIPTION
Prior to this PR, attempting to get rename info for pipe name expressions would defer to the
typescript language service, which would return no rename info. This was not caught because
the test was written incorrectly.

This PR corrects the test behavior and adjusts the logic in getting rename info to account
for indirect renames (like pipe names).
