### PR TITLE
fix(dev-infra): merge tool should ensure that token has `workflow` oauth scope

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -4208,6 +4208,14 @@ var PullRequestMergeTask = /** @class */ (function () {
                                     missing.push('public_repo');
                                 }
                             }
+                            // Pull requests can modify Github action workflow files. In such cases Github requires us to
+                            // push with a token that has the `workflow` oauth scope set. To avoid errors when the
+                            // caretaker intends to merge such PRs, we ensure the scope is always set on the token before
+                            // the merge process starts.
+                            // https://docs.github.com/en/developers/apps/scopes-for-oauth-apps#available-scopes
+                            if (!scopes.includes('workflow')) {
+                                missing.push('workflow');
+                            }
                         })];
                     case 1:
                         hasOauthScopes = _c.sent();

--- a/dev-infra/pr/merge/task.ts
+++ b/dev-infra/pr/merge/task.ts
@@ -74,6 +74,15 @@ export class PullRequestMergeTask {
           missing.push('public_repo');
         }
       }
+
+      // Pull requests can modify Github action workflow files. In such cases Github requires us to
+      // push with a token that has the `workflow` oauth scope set. To avoid errors when the
+      // caretaker intends to merge such PRs, we ensure the scope is always set on the token before
+      // the merge process starts.
+      // https://docs.github.com/en/developers/apps/scopes-for-oauth-apps#available-scopes
+      if (!scopes.includes('workflow')) {
+        missing.push('workflow');
+      }
     });
 
     if (hasOauthScopes !== true) {


### PR DESCRIPTION
Currently if a PR modifies any file that configures a Github action
(e.g. a workflow file), the caretaker might face an error when merging
such PR:

```
! [remote rejected]       merge_pr_target_11.2.x -> 11.2.x
(refusing to allow a Personal Access Token to create or update workflow
```

This happens because Github requires the token being used for the
push operation to have the `workflow` scope set. This is a special
scope added by Github to ensure that no changes can be made on
upstream branches that might expose the `GITHUB_TOKEN` environment
variable, which is available for push builds and could cause the
token being leaked.

With this commit we enforce that the caretaker adds the workflow
scope to their github token. Since PRs can only be merged if reviewed
thoroughly, it's acceptable to allow workflow file changes being
merged through the merge tool by the caretaker (especially since we
also allow CircleCI config files being merged with the default
`repo`/`public_repo` scope).