### PR TITLE
build(docs-infra): fixed broken stackblitz example of i18n module

### DIFF
--- a/aio/content/examples/i18n/stackblitz.json
+++ b/aio/content/examples/i18n/stackblitz.json
@@ -8,5 +8,6 @@
       "**/*.xlf"
     ],
     "file": "src/app/app.component.ts", 
-    "tags": ["Angular", "i18n", "internationalization"]
+    "tags": ["Angular", "i18n", "internationalization"],
+    "devDependencies": ["@angular/compiler-cli", "typescript"]
 }

--- a/aio/content/examples/testing/specs.stackblitz.json
+++ b/aio/content/examples/testing/specs.stackblitz.json
@@ -19,5 +19,6 @@
     "src/**/*.spec.ts"
   ],
   "main": "src/index-specs.html",
-  "tags": ["testing"]
+  "tags": ["testing"],
+  "devDependencies": ["jasmine-core", "jasmine-marbles"]
 }

--- a/aio/content/examples/testing/stackblitz.json
+++ b/aio/content/examples/testing/stackblitz.json
@@ -14,5 +14,6 @@
 
     "!src/**/*.spec.ts"
   ],
-  "tags": ["testing"]
+  "tags": ["testing"],
+  "devDependencies": ["jasmine-core", "jasmine-marbles"]
 }

--- a/aio/tools/stackblitz-builder/builder.js
+++ b/aio/tools/stackblitz-builder/builder.js
@@ -48,7 +48,7 @@ class StackblitzBuilder {
 
     // Add unit test packages from devDependencies for unit test examples
     const devDependencies = packageJson.devDependencies;
-    ['jasmine-core', 'jasmine-marbles'].forEach(dep => exampleDependencies[dep] = devDependencies[dep]);
+    (config.devDependencies || []).forEach(dep => exampleDependencies[dep] = devDependencies[dep]);
 
     postData.dependencies = JSON.stringify(exampleDependencies);
   }


### PR DESCRIPTION
This commit fixes the broken stackblitz example of animation.

Closes 41838.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
angular.io/guide/i18n live example is  broken

Issue Number: [https://github.com/angular/angular/issues/41838](https://github.com/angular/angular/issues/41838)


## What is the new behavior?
angular.io/guide/i18n live example issue if fixed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
