### PR TITLE
fix(core): do not retain dynamically compiled components and modules

### DIFF
--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -373,12 +373,12 @@ function getAnnotation<T>(type: any, name: string): T|null {
  * NgModule the component belongs to. We keep the list of compiled components here so that the
  * TestBed can reset it later.
  */
-let ownerNgModule = new Map<Type<any>, NgModuleType<any>>();
-let verifiedNgModule = new Map<NgModuleType<any>, boolean>();
+let ownerNgModule = new WeakMap<Type<any>, NgModuleType<any>>();
+let verifiedNgModule = new WeakMap<NgModuleType<any>, boolean>();
 
 export function resetCompiledComponents(): void {
-  ownerNgModule = new Map<Type<any>, NgModuleType<any>>();
-  verifiedNgModule = new Map<NgModuleType<any>, boolean>();
+  ownerNgModule = new WeakMap<Type<any>, NgModuleType<any>>();
+  verifiedNgModule = new WeakMap<NgModuleType<any>, boolean>();
   moduleQueue.length = 0;
 }
 


### PR DESCRIPTION
The JIT compiler has a mapping from component to the owning NgModule
and tracks whether a certain NgModule class has been verified; these
maps causes any JIT compiled component and NgModule to be retained even
if they are no longer referenced from anywhere else. This commit
switches the maps to `WeakMap` to allow garbage collecting any
components and NgModules that are no longer referenced elsewhere.

Fixes #19997
