### PR TITLE
build: update node version to stop aio from breaking while g…

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -79,7 +79,7 @@
   },
   "//engines-comment": "Keep this in sync with /package.json and /aio/tools/examples/shared/package.json",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0",
+    "node": "^12.20.0 || ^14.0.0",
     "yarn": ">=1.22.4 <2",
     "npm": "Please use yarn instead of NPM to install dependencies"
   },

--- a/aio/tools/examples/shared/package.json
+++ b/aio/tools/examples/shared/package.json
@@ -12,7 +12,7 @@
   },
   "//engines-comment": "Keep this in sync with /package.json and /aio/package.json",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0",
+    "node": "^12.20.0 || ^14.0.0",
     "yarn": ">=1.21.1 <2",
     "npm": "Please use yarn instead of NPM to install dependencies"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "//engines-comment": "Keep this in sync with /aio/package.json and /aio/tools/examples/shared/package.json",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0",
+    "node": "^12.20.0 || ^14.0.0",
     "yarn": ">=1.22.4 <2",
     "npm": "Please use yarn instead of NPM to install dependencies"
   },


### PR DESCRIPTION
…enerating docs

When aio yarn docs-only command runs on v12.14.1 details given on issue #41979. Upgrading node version to v12.17.0 solves this but creates a new warning (node:467072) ExperimentalWarning: The ESM module loader is experimental.
This warning gets removed in v12.20.0. Upgrading node version to 12.20.0

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
