### PR TITLE
test(docs-infra): correctly test URL redirects when the destination URL is also redirected

### DIFF
--- a/aio/tests/deployment/e2e/redirection.e2e-spec.ts
+++ b/aio/tests/deployment/e2e/redirection.e2e-spec.ts
@@ -34,8 +34,19 @@ describe(browser.baseUrl, () => {
       it(`should redirect '${fromUrl}' to '${toUrl}' (${i + 1}/${page.legacyUrls.length})`, async () => {
         await page.goTo(fromUrl);
 
-        const expectedUrl = stripTrailingSlash(/^https?:/.test(toUrl) ? toUrl : page.baseUrl + toUrl);
+        let expectedUrl = stripTrailingSlash(/^https?:/.test(toUrl) ? toUrl : page.baseUrl + toUrl);
         const actualUrl = await getCurrentUrl();
+
+        if (actualUrl !== expectedUrl) {
+          // If the actual URL does not match the expected URL, check whether the expected URL
+          // itself is also redirected to the actual URL.
+          await page.goTo(expectedUrl);
+          const redirectedExpectedUrl = await getCurrentUrl();
+
+          if (actualUrl === redirectedExpectedUrl) {
+            expectedUrl = redirectedExpectedUrl;
+          }
+        }
 
         expect(actualUrl).toBe(expectedUrl);
       }, 120000);


### PR DESCRIPTION
Since #41625, `/guide/updating-to-version-10` is being redirected to `https://v11.angular.io/guide/updating-to-version-11`. However, `v11.angular.io` itself is being redirected to `angular.io`, while v11 is the latest stable version. As a result, `/guide/updating-to-version-10` ends up being redirected to `https://angular.io/guide/updating-to-version-11`. Currently, this causes a CI failure in the `aio_monidoting` job ([example failure][1]).

This will change once v12 is released as the new stable version. Alternatively, we could update the config and tests to expected
`/guide/updating-to-version-10` to be redirected to `https://angular.io/guide/updating-to-version-11`, but that would end up being redirected to `https://angular.io/guide/updating-to-version-12` once v12 would be released, which is different behavior.

This commit provides a way to test for redirects when the destination URL is itself redirected to a different URL. This allows us to use the intended URL (for example, `https://v11.angular.io/...`), which will continue to work as expected regardless of what is the latest stable version without causing CI failures.

[1]: https://circleci.com/gh/angular/angular/983738
