### PR TITLE
docs: change `updating-to-version-*` redirects to point to the respective versions

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -32,8 +32,8 @@
       {"type": 301, "source": "/getting-started", "destination": "/start"},
       {"type": 301, "source": "/getting-started/:rest*", "destination": "/start/:rest*"},
       {"type": 301, "source": "/guide/displaying-data", "destination": "/start#template-syntax"},
-      {"type": 301, "source": "/guide/updating-to-version-10", "destination": "https://v11.angular.io/guide/updating-to-version-11"},
-      {"type": 301, "source": "/guide/updating-to-version-11", "destination": "/guide/updating-to-version-12"},
+      {"type": 301, "source": "/guide/updating-to-version-10", "destination": "https://v10.angular.io/guide/updating-to-version-10"},
+      {"type": 301, "source": "/guide/updating-to-version-11", "destination": "https://v11.angular.io/guide/updating-to-version-11"},
 
       // Renaming of Getting Started topics
       {"type": 301, "source": "/start/data", "destination": "/start/start-data"},

--- a/aio/tests/deployment/shared/URLS_TO_REDIRECT.txt
+++ b/aio/tests/deployment/shared/URLS_TO_REDIRECT.txt
@@ -185,8 +185,8 @@
 /guide/service-worker-getstart --> /guide/service-worker-getting-started
 /guide/service-worker-comm --> /guide/service-worker-communications
 /guide/service-worker-configref --> /guide/service-worker-config
-/guide/updating-to-version-10 --> https://v11.angular.io/guide/updating-to-version-11
-/guide/updating-to-version-11 --> /guide/updating-to-version-12
+/guide/updating-to-version-10 --> https://v10.angular.io/guide/updating-to-version-10
+/guide/updating-to-version-11 --> https://v11.angular.io/guide/updating-to-version-11
 /guide/webpack --> https://v5.angular.io/guide/webpack
 /news --> https://blog.angular.io/
 /news.html --> https://blog.angular.io/


### PR DESCRIPTION
Previously, the `updating-to-version-*` URLs would redirect to the next version update guide. More specifically:
- `/guide/updating-to-version-10` --> `https://v11.angular.io/guide/updating-to-version-11`
- `/guide/updating-to-version-11` --> `/guide/updating-to-version-12`

This seems confusing and inconsistent. Either all URLs should redirect to the latest update guide (currently `/guide/updating-to-version-12`) or each URL should redirect to the corresponding version.

This commit implements the second approach:
- `/guide/updating-to-version-10` --> `https://v10.angular.io/guide/updating-to-version-10`
- `/guide/updating-to-version-11` --> `https://v11.angular.io/guide/updating-to-version-11`
