### PR TITLE
build(docs-infra): show a dist-tag when installing the CLI on non-stable versions (BACKPORT: 10.2.x)

### DIFF
--- a/aio/content/guide/setup-local.md
+++ b/aio/content/guide/setup-local.md
@@ -30,7 +30,7 @@ To install Angular on your local system, you need the following:
 {@a nodejs}
 
 * **Node.js**
-  
+
   Angular requires a [current, active LTS, or maintenance LTS](https://nodejs.org/about/releases) version of Node.js.
 
   <div class="alert is-helpful">
@@ -61,7 +61,7 @@ You use the Angular CLI to create projects, generate application and library cod
 To install the Angular CLI, open a terminal window and run the following command:
 
 <code-example language="sh" class="code-shell">
-  npm install -g @angular/cli
+  npm install -g @angular/cli<aio-angular-dist-tag class="pln"></aio-angular-dist-tag>
 </code-example>
 
 {@a create-proj}

--- a/aio/src/app/custom-elements/dist-tag/dist-tag.component.spec.ts
+++ b/aio/src/app/custom-elements/dist-tag/dist-tag.component.spec.ts
@@ -1,0 +1,47 @@
+import { VERSION } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { environment } from 'environments/environment';
+import { DistTagComponent } from './dist-tag.component';
+
+describe('DistTagComponent', () => {
+  let actualMode: string;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ declarations: [DistTagComponent] });
+    actualMode = environment.mode;
+  });
+
+  afterEach(() => {
+    (environment.mode as any) = actualMode;
+  });
+
+  describe('rendering', () => {
+    it('should display nothing (for stable versions)', () => {
+      environment.mode = 'stable';
+      const fixture = TestBed.createComponent(DistTagComponent);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerHTML).toEqual('');
+    });
+
+    it('should display the current major version (for archive versions)', () => {
+      environment.mode = 'archive';
+      const fixture = TestBed.createComponent(DistTagComponent);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerHTML).toEqual('@' + VERSION.major);
+    });
+
+    it('should display "@next" (for rc versions)', () => {
+      environment.mode = 'rc';
+      const fixture = TestBed.createComponent(DistTagComponent);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerHTML).toEqual('@next');
+    });
+
+    it('should display "@next" (for next versions)', () => {
+      environment.mode = 'next';
+      const fixture = TestBed.createComponent(DistTagComponent);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerHTML).toEqual('@next');
+    });
+  });
+});

--- a/aio/src/app/custom-elements/dist-tag/dist-tag.component.ts
+++ b/aio/src/app/custom-elements/dist-tag/dist-tag.component.ts
@@ -1,0 +1,27 @@
+import { Component, VERSION } from '@angular/core';
+import { environment } from 'environments/environment';
+
+/**
+ * Display the dist-tag of Angular for installing from npm at the point these docs are generated.
+ */
+@Component({
+  selector: 'aio-angular-dist-tag',
+  template: '{{tag}}',
+})
+export class DistTagComponent {
+  tag: string;
+
+  constructor() {
+    switch (environment.mode) {
+      case 'stable':
+        this.tag = '';
+        break;
+      case 'next':
+      case 'rc':
+        this.tag = '@next';
+        break;
+      default:
+        this.tag = `@${VERSION.major}`;
+    }
+  }
+}

--- a/aio/src/app/custom-elements/dist-tag/dist-tag.module.ts
+++ b/aio/src/app/custom-elements/dist-tag/dist-tag.module.ts
@@ -1,0 +1,12 @@
+import { NgModule, Type } from '@angular/core';
+import { WithCustomElementComponent } from '../element-registry';
+
+import { DistTagComponent } from './dist-tag.component';
+
+@NgModule({
+  declarations: [ DistTagComponent ],
+  entryComponents: [ DistTagComponent ],
+})
+export class DistTagModule implements WithCustomElementComponent {
+  customElementComponent: Type<any> = DistTagComponent;
+}

--- a/aio/src/app/custom-elements/element-registry.ts
+++ b/aio/src/app/custom-elements/element-registry.ts
@@ -22,6 +22,10 @@ export const ELEMENT_MODULE_LOAD_CALLBACKS_AS_ROUTES = [
     loadChildren: () => import('./search/file-not-found-search.module').then(m => m.FileNotFoundSearchModule)
   },
   {
+    selector: 'aio-angular-dist-tag',
+    loadChildren: () => import('./dist-tag/dist-tag.module').then(m => m.DistTagModule)
+  },
+  {
     selector: 'aio-resource-list',
     loadChildren: () => import('./resource/resource-list.module').then(m => m.ResourceListModule)
   },

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -2,27 +2,27 @@
   "aio": {
     "master": {
       "uncompressed": {
-        "runtime-es2015": 3037,
-        "main-es2015": 448243,
-        "polyfills-es2015": 52685
+        "runtime-es2015": 3093,
+        "main-es2015": 448431,
+        "polyfills-es2015": 52686
       }
     }
   },
   "aio-local": {
     "master": {
       "uncompressed": {
-        "runtime-es2015": 3037,
-        "main-es2015": 447742,
-        "polyfills-es2015": 52415
+        "runtime-es2015": 3093,
+        "main-es2015": 447782,
+        "polyfills-es2015": 52509
       }
     }
   },
   "aio-local-viewengine": {
     "master": {
       "uncompressed": {
-        "runtime-es2015": 3157,
-        "main-es2015": 431750,
-        "polyfills-es2015": 52415
+        "runtime-es2015": 3223,
+        "main-es2015": 432042,
+        "polyfills-es2015": 52509
       }
     }
   }


### PR DESCRIPTION
It is important to use the correct major version of the Angular CLI when
following the examples in the tutorials. This commit provides a custom
element that renders an appropriate dist-tag in the setup step of
the tutorial when the docs are not in "stable" mode.

Fixes #39821
