### PR TITLE
build(docs-infra): show a dist-tag when installing the CLI on non-stable versions (BACKPORT: 9.1.x)

### DIFF
--- a/aio/content/guide/setup-local.md
+++ b/aio/content/guide/setup-local.md
@@ -59,8 +59,7 @@ To install the CLI using `npm`, open a terminal/console window and enter the fol
 
 
 <code-example language="sh" class="code-shell">
-  npm install -g @angular/cli
-
+  npm install -g @angular/cli<aio-angular-dist-tag class="pln"></aio-angular-dist-tag>
 </code-example>
 
 

--- a/aio/src/app/custom-elements/dist-tag/dist-tag.component.spec.ts
+++ b/aio/src/app/custom-elements/dist-tag/dist-tag.component.spec.ts
@@ -1,0 +1,47 @@
+import { VERSION } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { environment } from 'environments/environment';
+import { DistTagComponent } from './dist-tag.component';
+
+describe('DistTagComponent', () => {
+  let actualMode: string;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ declarations: [DistTagComponent] });
+    actualMode = environment.mode;
+  });
+
+  afterEach(() => {
+    (environment.mode as any) = actualMode;
+  });
+
+  describe('rendering', () => {
+    it('should display nothing (for stable versions)', () => {
+      environment.mode = 'stable';
+      const fixture = TestBed.createComponent(DistTagComponent);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerHTML).toEqual('');
+    });
+
+    it('should display the current major version (for archive versions)', () => {
+      environment.mode = 'archive';
+      const fixture = TestBed.createComponent(DistTagComponent);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerHTML).toEqual('@' + VERSION.major);
+    });
+
+    it('should display "@next" (for rc versions)', () => {
+      environment.mode = 'rc';
+      const fixture = TestBed.createComponent(DistTagComponent);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerHTML).toEqual('@next');
+    });
+
+    it('should display "@next" (for next versions)', () => {
+      environment.mode = 'next';
+      const fixture = TestBed.createComponent(DistTagComponent);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerHTML).toEqual('@next');
+    });
+  });
+});

--- a/aio/src/app/custom-elements/dist-tag/dist-tag.component.ts
+++ b/aio/src/app/custom-elements/dist-tag/dist-tag.component.ts
@@ -1,0 +1,27 @@
+import { Component, VERSION } from '@angular/core';
+import { environment } from 'environments/environment';
+
+/**
+ * Display the dist-tag of Angular for installing from npm at the point these docs are generated.
+ */
+@Component({
+  selector: 'aio-angular-dist-tag',
+  template: '{{tag}}',
+})
+export class DistTagComponent {
+  tag: string;
+
+  constructor() {
+    switch (environment.mode) {
+      case 'stable':
+        this.tag = '';
+        break;
+      case 'next':
+      case 'rc':
+        this.tag = '@next';
+        break;
+      default:
+        this.tag = `@${VERSION.major}`;
+    }
+  }
+}

--- a/aio/src/app/custom-elements/dist-tag/dist-tag.module.ts
+++ b/aio/src/app/custom-elements/dist-tag/dist-tag.module.ts
@@ -1,0 +1,12 @@
+import { NgModule, Type } from '@angular/core';
+import { WithCustomElementComponent } from '../element-registry';
+
+import { DistTagComponent } from './dist-tag.component';
+
+@NgModule({
+  declarations: [ DistTagComponent ],
+  entryComponents: [ DistTagComponent ],
+})
+export class DistTagModule implements WithCustomElementComponent {
+  customElementComponent: Type<any> = DistTagComponent;
+}

--- a/aio/src/app/custom-elements/element-registry.ts
+++ b/aio/src/app/custom-elements/element-registry.ts
@@ -22,6 +22,10 @@ export const ELEMENT_MODULE_LOAD_CALLBACKS_AS_ROUTES = [
     loadChildren: () => import('./search/file-not-found-search.module').then(m => m.FileNotFoundSearchModule)
   },
   {
+    selector: 'aio-angular-dist-tag',
+    loadChildren: () => import('./dist-tag/dist-tag.module').then(m => m.DistTagModule)
+  },
+  {
     selector: 'aio-resource-list',
     loadChildren: () => import('./resource/resource-list.module').then(m => m.ResourceListModule)
   },

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -2,8 +2,8 @@
   "aio": {
     "master": {
       "uncompressed": {
-        "runtime-es2015": 2987,
-        "main-es2015": 454032,
+        "runtime-es2015": 3041,
+        "main-es2015": 453890,
         "polyfills-es2015": 52685
       }
     }
@@ -11,8 +11,8 @@
   "aio-local": {
     "master": {
       "uncompressed": {
-        "runtime-es2015": 2987,
-        "main-es2015": 454665,
+        "runtime-es2015": 3041,
+        "main-es2015": 454762,
         "polyfills-es2015": 52628
       }
     }
@@ -20,8 +20,8 @@
   "aio-local-viewengine": {
     "master": {
       "uncompressed": {
-        "runtime-es2015": 3097,
-        "main-es2015": 430383,
+        "runtime-es2015": 3161,
+        "main-es2015": 430354,
         "polyfills-es2015": 52628
       }
     }

--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -40,6 +40,8 @@ INTEGRATION_TESTS = {
             # everything down. Ask Bazel to allocate multiple CPUs for these tests with "cpu:n" tag.
             "cpu:3",
             "no-ivy-aot",
+            # Tagged test as manual as it is broken due to chrome driver, but is deprecated.
+            "manual",
         ],
     },
     "cli-hello-world": {"commands": "payload_size_tracking"},


### PR DESCRIPTION
It is important to use the correct major version of the Angular CLI when
following the examples in the tutorials. This commit provides a custom
element that renders an appropriate dist-tag in the setup step of
the tutorial when the docs are not in "stable" mode.

Fixes #39821
