### PR TITLE
Revert "refactor(core): optimize calls to `split` and `slice` while c…

### DIFF
--- a/packages/animations/src/version.ts
+++ b/packages/animations/src/version.ts
@@ -23,10 +23,10 @@ export class Version {
   public readonly patch: string;
 
   constructor(public full: string) {
-    const [major, minor, ...rest] = full.split('.');
-    this.major = major;
-    this.minor = minor;
-    this.patch = rest.join('.');
+    const splits = full.split('.');
+    this.major = splits[0];
+    this.minor = splits[1];
+    this.patch = splits.slice(2).join('.');
   }
 }
 

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -236,10 +236,10 @@ export class Version {
   public readonly patch: string;
 
   constructor(public full: string) {
-    const [major, minor, ...rest] = full.split('.');
-    this.major = major;
-    this.minor = minor;
-    this.patch = rest.join('.');
+    const splits = full.split('.');
+    this.major = splits[0];
+    this.minor = splits[1];
+    this.patch = splits.slice(2).join('.');
   }
 }
 

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -17,10 +17,9 @@ export class Version {
   public readonly patch: string;
 
   constructor(public full: string) {
-    const [major, minor, ...rest] = full.split('.');
-    this.major = major;
-    this.minor = minor;
-    this.patch = rest.join('.');
+    this.major = full.split('.')[0];
+    this.minor = full.split('.')[1];
+    this.patch = full.split('.').slice(2).join('.');
   }
 }
 


### PR DESCRIPTION
…omputing version parts (#41208)"

This reverts commit 744bd2b64f6dd2e7b25cbc0bedd03abc3f59d264.
Caused issues in safari in production internally.
