### PR TITLE
fix(benchpress): update the check for start and end events

### DIFF
--- a/packages/benchpress/src/metric/perflog_metric.ts
+++ b/packages/benchpress/src/metric/perflog_metric.ts
@@ -238,13 +238,25 @@ export class PerflogMetric extends Metric {
     events.forEach((event) => {
       const ph = event['ph'];
       const name = event['name'];
-      if (ph === 'B' && name === markName) {
+
+      // Here we are determining if this is the event signaling the start or end of our performance
+      // testing (this is triggered by us calling #timeBegin and #timeEnd).
+      //
+      // Previously, this was done by checking that the event name matched our mark name and that
+      // the phase was either "B" or "E" ("begin" or "end"). However, for some reason now this is
+      // showing up as "-bpstart" and "-bpend" ("benchpress start/end"), which is what one would
+      // actually expect since that is the mark name used in ChromeDriverExtension - see the
+      // #timeBegin and #timeEnd implementations in chrome_driver_extension.ts. We are not sure why
+      // the markName didn't show up with the "-bp(start/end)" suffix before.
+      const isStartEvent = (ph === 'B' && name === markName) || name === markName + '-bpstart';
+      const isEndEvent = (ph === 'E' && name === markName) || name === markName + '-bpend';
+      if (isStartEvent) {
         markStartEvent = event;
       } else if (ph === 'I' && name === 'navigationStart' && !this._ignoreNavigation) {
         // if a benchmark measures reload of a page, use the last
         // navigationStart as begin event
         markStartEvent = event;
-      } else if (ph === 'E' && name === markName) {
+      } else if (isEndEvent) {
         markEndEvent = event;
       }
     });


### PR DESCRIPTION
* recently, performance events started showing up with a -bpstart and -bpend
  suffix to indicate their being the start and end events for our performance
  testing. to fix this, we added an additional check for those suffixes in
  addition to the old checks.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
