### PR TITLE
build: remove publishConfig entry from package.json entries

### DIFF
--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -21,8 +21,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -50,8 +50,5 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  },
-  "publishConfig": {
-    "registry": "https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -26,8 +26,5 @@
   "sideEffects": [
     "**/global/*.js",
     "**/closure-locale.*"
-  ],
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  ]
 }

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -49,8 +49,5 @@
   "homepage": "https://github.com/angular/angular/tree/master/packages/compiler-cli",
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  },
-  "publishConfig": {
-    "registry": "https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -18,8 +18,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": true,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": true
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,8 +23,5 @@
     "migrations": "./schematics/migrations.json",
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig": {
-    "registry": "https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -24,8 +24,5 @@
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
   "sideEffects": false,
-  "schematics": "./schematics/collection.json",
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "schematics": "./schematics/collection.json"
 }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -24,8 +24,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -16,8 +16,5 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  },
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -36,8 +36,5 @@
   "peerDependencies": {
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "@angular/compiler-cli": "0.0.0-PLACEHOLDER"
-  },
-  "publishConfig": {
-    "registry": "https://wombat-dressing-room.appspot.com"
   }
 }

--- a/packages/platform-browser-dynamic/package.json
+++ b/packages/platform-browser-dynamic/package.json
@@ -24,8 +24,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -28,8 +28,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -36,8 +36,5 @@
     "./__ivy_ngcc__/bundles/platform-server-init.umd.js",
     "./__ivy_ngcc__/esm2015/init/src/init.js",
     "./__ivy_ngcc__/fesm2015/init.js"
-  ],
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  ]
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -32,8 +32,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -25,8 +25,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -24,8 +24,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "publishConfig":{
-    "registry":"https://wombat-dressing-room.appspot.com"
-  }
+  "sideEffects": false
 }


### PR DESCRIPTION
Remove publishConfig property from the package.json entry for each of the entries in the publish configuration.  Using the wombat proxy is now ensured/managed by the ng-dev release tooling.
