### PR TITLE
fix(platform-browser): unencapsulated styles leaking out of shadow dom host

### DIFF
--- a/aio/content/examples/view-encapsulation/src/app/shadow-dom-encapsulation.component.ts
+++ b/aio/content/examples/view-encapsulation/src/app/shadow-dom-encapsulation.component.ts
@@ -4,12 +4,12 @@ import { Component, ViewEncapsulation } from '@angular/core';
 @Component({
   selector: 'app-shadow-dom-encapsulation',
   template: `
-    <h2>ShadowDom</h2>
+    <h2 class="shadow-header">ShadowDom</h2>
     <div class="shadow-message">Shadow DOM encapsulation</div>
     <app-emulated-encapsulation></app-emulated-encapsulation>
     <app-no-encapsulation></app-no-encapsulation>
   `,
-  styles: ['h2, .shadow-message { color: blue; }'],
+  styles: ['.shadow-header, .shadow-message { color: blue; }'],
   encapsulation: ViewEncapsulation.ShadowDom,
 })
 export class ShadowDomEncapsulationComponent { }

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1170,
-        "main-es2015": 138189,
+        "main-es2015": 138881,
         "polyfills-es2015": 36964
       }
     }
@@ -30,7 +30,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1190,
-        "main-es2015": 136546,
+        "main-es2015": 137263,
         "polyfills-es2015": 37641
       }
     }

--- a/packages/platform-browser/test/dom/shared_styles_host_spec.ts
+++ b/packages/platform-browser/test/dom/shared_styles_host_spec.ts
@@ -63,5 +63,18 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       ssh.ngOnDestroy();
       expect(someHost.innerHTML).toEqual('');
     });
+
+    it('should remove style nodes when all associated hosts have been removed', () => {
+      ssh.addStyles(['a {};']);
+      ssh.addHost(someHost);
+      ssh.addHost(someHost);
+      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+
+      ssh.removeHost(someHost);
+      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+
+      ssh.removeHost(someHost);
+      expect(someHost.innerHTML).toEqual('');
+    });
   });
 }


### PR DESCRIPTION
Currently when a component with `ViewEncapsulation.None` is inserted, it always adds its styles to `document.head`. This can be problematic when the component is inside the shadow DOM, because it can cause styles to leak out of it.

These changes resolve the issue by adding some extra logic to the `SharedStylesHost` that allows for multiple "insertion nodes" to be associated with a component host node. Then we use this new functionality to associate the unencapsulated component styles with the closest shadow root.

Note that in most cases we'll have one insertion node per host node, but we have to support multiple for the case where several unencapsulated components are inserted inside a shadow DOM host.

Fixes #35039.