### PR TITLE
build(docs-infra): fixed broken stackblitz examples

### DIFF
--- a/aio/content/examples/http/specs.stackblitz.json
+++ b/aio/content/examples/http/specs.stackblitz.json
@@ -15,5 +15,6 @@
     "src/index-specs.html"
   ],
   "main": "src/index-specs.html",
-  "tags": ["http", "testing"]
+  "tags": ["http", "testing"],
+  "devDependencies": ["jasmine-core"]
 }

--- a/aio/content/examples/http/stackblitz.json
+++ b/aio/content/examples/http/stackblitz.json
@@ -8,5 +8,6 @@
     "!src/main-specs.ts"
   ],
   "file": "src/app/app.component.ts", 
-  "tags": ["http"]
+  "tags": ["http"],
+  "devDependencies": ["jasmine-core"]
 }


### PR DESCRIPTION
This commit fixes the broken stackblitz examples.

Closes #42116 .

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Some of stackblitz example were broke with PR #42001 

Issue Number: #42001 


## What is the new behavior?
With this PR broken stackblitz issue is resolved.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
