### PR TITLE
docs: decorate input properties with @Input

### DIFF
--- a/aio/content/guide/template-typecheck.md
+++ b/aio/content/guide/template-typecheck.md
@@ -228,6 +228,7 @@ Consider the following directive:
 class SubmitButton {
   private _disabled: boolean;
 
+  @Input()
   get disabled(): boolean {
     return this._disabled;
   }
@@ -269,6 +270,7 @@ As a workaround for this problem, Angular supports checking a wider, more permis
 class SubmitButton {
   private _disabled: boolean;
 
+  @Input()
   get disabled(): boolean {
     return this._disabled;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `disabled` input property for the `SubmitButton` example in the *Input setter coercion* section is not marked as an input property although it is described as one.

Issue Number: N/A


## What is the new behavior?
`SubmitButton#disabled` is decorated with `@Input()`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
