### PR TITLE
feat(forms): add `ng-submitted` class to forms that have been submitted.

### DIFF
--- a/aio/content/guide/form-validation.md
+++ b/aio/content/guide/form-validation.md
@@ -195,6 +195,7 @@ The following classes are currently supported.
 * `.ng-dirty`
 * `.ng-untouched`
 * `.ng-touched`
+* `.ng-submitted` (enclosing form element only)
 
 In the following example, the hero form uses the `.ng-valid` and `.ng-invalid` classes to
 set the color of each form control's border.

--- a/aio/content/guide/forms.md
+++ b/aio/content/guide/forms.md
@@ -314,6 +314,8 @@ Angular sets special CSS classes on the control element to reflect the state, as
 
 </table>
 
+Additionally, Angular applies the `ng-submitted` class to `<form>` elements upon submission. This class does *not* apply to inner controls.
+
 You use these CSS classes to define the styles for your control based on its status.
 
 ### Observe control states

--- a/goldens/public-api/forms/forms.d.ts
+++ b/goldens/public-api/forms/forms.d.ts
@@ -460,7 +460,7 @@ export declare class RadioControlValueAccessor extends ɵangular_packages_forms_
     name: string;
     onChange: () => void;
     value: any;
-    constructor(renderer: Renderer2, elementRef: ElementRef, _registry: ɵangular_packages_forms_forms_q, _injector: Injector);
+    constructor(renderer: Renderer2, elementRef: ElementRef, _registry: ɵangular_packages_forms_forms_r, _injector: Injector);
     fireUncheck(value: any): void;
     ngOnDestroy(): void;
     ngOnInit(): void;

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -190,7 +190,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
       });
 
       it('should update nested form group model when UI changes', () => {
-        const fixture = initTest(NestedFormGroupComp);
+        const fixture = initTest(NestedFormGroupNameComp);
         fixture.componentInstance.form = new FormGroup(
             {'signin': new FormGroup({'login': new FormControl(), 'password': new FormControl()})});
         fixture.detectChanges();
@@ -242,7 +242,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
       });
 
       it('should pick up dir validators from nested form groups', () => {
-        const fixture = initTest(NestedFormGroupComp, LoginIsEmptyValidator);
+        const fixture = initTest(NestedFormGroupNameComp, LoginIsEmptyValidator);
         const form = new FormGroup({
           'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')})
         });
@@ -260,7 +260,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
       });
 
       it('should strip named controls that are not found', () => {
-        const fixture = initTest(NestedFormGroupComp, LoginIsEmptyValidator);
+        const fixture = initTest(NestedFormGroupNameComp, LoginIsEmptyValidator);
         const form = new FormGroup({
           'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')})
         });
@@ -335,7 +335,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         });
 
         it('should attach dirs to all child controls when group control changes', () => {
-          const fixture = initTest(NestedFormGroupComp, LoginIsEmptyValidator);
+          const fixture = initTest(NestedFormGroupNameComp, LoginIsEmptyValidator);
           const form = new FormGroup({
             signin: new FormGroup(
                 {login: new FormControl('oldLogin'), password: new FormControl('oldPassword')})
@@ -1087,6 +1087,8 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.detectChanges();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+
         expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
         dispatchEvent(input, 'blur');
@@ -1099,6 +1101,19 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.detectChanges();
 
         expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+
+        dispatchEvent(formEl, 'submit');
+        fixture.detectChanges();
+
+        expect(sortedClassList(input)).not.toContain('ng-submitted');
+        expect(sortedClassList(formEl)).toContain('ng-submitted');
+
+        dispatchEvent(formEl, 'reset');
+        fixture.detectChanges();
+
+        expect(sortedClassList(input)).not.toContain('ng-submitted');
+        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
       });
 
       it('should work with formGroup', () => {
@@ -1122,6 +1137,126 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.detectChanges();
 
         expect(sortedClassList(formEl)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+
+        dispatchEvent(formEl, 'submit');
+        fixture.detectChanges();
+
+        expect(sortedClassList(formEl)).toContain('ng-submitted');
+
+        dispatchEvent(formEl, 'reset');
+        fixture.detectChanges();
+
+        expect(sortedClassList(input)).not.toContain('ng-submitted');
+        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+      });
+
+      it('should not assign `ng-submitted` class to elements with `formArrayName`', () => {
+        // Since element with the `formArrayName` can not represent top-level forms (can only be
+        // inside other elements), this test verifies that these elements never receive
+        // `ng-submitted` CSS class even when they are located inside submitted form.
+        const fixture = initTest(FormArrayComp);
+        const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
+        const form = new FormGroup({cities: cityArray});
+        fixture.componentInstance.form = form;
+        fixture.componentInstance.cityArray = cityArray;
+        fixture.detectChanges();
+
+        const [loginInput, passwordInput] =
+            fixture.debugElement.queryAll(By.css('input')).map(el => el.nativeElement);
+        const arrEl = fixture.debugElement.query(By.css('div')).nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+
+        expect(passwordInput).toBeDefined();
+        expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
+        expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
+        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+
+        dispatchEvent(formEl, 'submit');
+        fixture.detectChanges();
+
+        expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
+        expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
+        expect(sortedClassList(formEl)).toContain('ng-submitted');
+
+        dispatchEvent(formEl, 'reset');
+        fixture.detectChanges();
+
+        expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
+        expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
+        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+      });
+
+      it('should apply submitted status with nested formArrayName', () => {
+        const fixture = initTest(NestedFormArrayNameComp);
+        const ic = new FormControl('foo');
+        const arr = new FormArray([ic]);
+        const form = new FormGroup({arr});
+        fixture.componentInstance.form = form;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        const arrEl = fixture.debugElement.query(By.css('div')).nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+
+        expect(sortedClassList(input)).not.toContain('ng-submitted');
+        expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
+        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+
+        dispatchEvent(formEl, 'submit');
+        fixture.detectChanges();
+
+        expect(sortedClassList(input)).not.toContain('ng-submitted');
+        expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
+        expect(sortedClassList(formEl)).toContain('ng-submitted');
+
+        dispatchEvent(formEl, 'reset');
+        fixture.detectChanges();
+
+        expect(sortedClassList(input)).not.toContain('ng-submitted');
+        expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
+        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+      });
+
+      it('should apply submitted status with nested formGroupName', () => {
+        const fixture = initTest(NestedFormGroupNameComp);
+        const loginControl =
+            new FormControl('', {validators: Validators.required, updateOn: 'change'});
+        const passwordControl = new FormControl('', Validators.required);
+        const formGroup = new FormGroup(
+            {signin: new FormGroup({login: loginControl, password: passwordControl})},
+            {updateOn: 'blur'});
+        fixture.componentInstance.form = formGroup;
+        fixture.detectChanges();
+
+        const [loginInput, passwordInput] =
+            fixture.debugElement.queryAll(By.css('input')).map(el => el.nativeElement);
+
+        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        const groupEl = fixture.debugElement.query(By.css('div')).nativeElement;
+        loginInput.value = 'Nancy';
+        // Input and blur events, as in a real interaction, cause the form to be touched and
+        // dirtied.
+        dispatchEvent(loginInput, 'input');
+        dispatchEvent(loginInput, 'blur');
+        fixture.detectChanges();
+
+        expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
+        expect(sortedClassList(groupEl)).not.toContain('ng-submitted');
+        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+
+        dispatchEvent(formEl, 'submit');
+        fixture.detectChanges();
+
+        expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
+        expect(sortedClassList(groupEl)).not.toContain('ng-submitted');
+        expect(sortedClassList(formEl)).toContain('ng-submitted');
+
+        dispatchEvent(formEl, 'reset');
+        fixture.detectChanges();
+
+        expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
+        expect(sortedClassList(groupEl)).not.toContain('ng-submitted');
+        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
       });
     });
 
@@ -1501,7 +1636,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
 
         it('should allow child control updateOn blur to override group updateOn', () => {
-          const fixture = initTest(NestedFormGroupComp);
+          const fixture = initTest(NestedFormGroupNameComp);
           const loginControl =
               new FormControl('', {validators: Validators.required, updateOn: 'change'});
           const passwordControl = new FormControl('', Validators.required);
@@ -1810,7 +1945,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           const validatorSpy = jasmine.createSpy('validator');
           const groupValidatorSpy = jasmine.createSpy('groupValidatorSpy');
 
-          const fixture = initTest(NestedFormGroupComp);
+          const fixture = initTest(NestedFormGroupNameComp);
           const formGroup = new FormGroup({
             signin: new FormGroup({login: new FormControl(), password: new FormControl()}),
             email: new FormControl('', {updateOn: 'submit'})
@@ -1907,7 +2042,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         });
 
         it('should allow child control updateOn submit to override group updateOn', () => {
-          const fixture = initTest(NestedFormGroupComp);
+          const fixture = initTest(NestedFormGroupNameComp);
           const loginControl =
               new FormControl('', {validators: Validators.required, updateOn: 'change'});
           const passwordControl = new FormControl('', Validators.required);
@@ -4807,7 +4942,7 @@ class FormGroupComp {
 }
 
 @Component({
-  selector: 'nested-form-group-comp',
+  selector: 'nested-form-group-name-comp',
   template: `
     <form [formGroup]="form">
       <div formGroupName="signin" login-is-empty-validator>
@@ -4817,7 +4952,7 @@ class FormGroupComp {
       <input *ngIf="form.contains('email')" formControlName="email">
     </form>`
 })
-class NestedFormGroupComp {
+class NestedFormGroupNameComp {
   // TODO(issue/24571): remove '!'.
   form!: FormGroup;
 }
@@ -4838,6 +4973,20 @@ class FormArrayComp {
   form!: FormGroup;
   // TODO(issue/24571): remove '!'.
   cityArray!: FormArray;
+}
+
+@Component({
+  selector: 'nested-form-array-name-comp',
+  template: `
+    <form [formGroup]="form">
+      <div formArrayName="arr">
+        <input formControlName="0">
+      </div>
+    </form>
+  `
+})
+class NestedFormArrayNameComp {
+  form!: FormGroup;
 }
 
 @Component({

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -187,6 +187,21 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              dispatchEvent(input, 'input');
              fixture.detectChanges();
              expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+
+             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             dispatchEvent(formEl, 'submit');
+             fixture.detectChanges();
+
+             expect(sortedClassList(formEl)).toEqual([
+               'ng-dirty', 'ng-submitted', 'ng-touched', 'ng-valid'
+             ]);
+             expect(sortedClassList(input)).not.toContain('ng-submitted');
+
+             dispatchEvent(formEl, 'reset');
+             fixture.detectChanges();
+
+             expect(sortedClassList(formEl)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
+             expect(sortedClassList(input)).not.toContain('ng-submitted');
            });
          }));
 
@@ -244,8 +259,51 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
 
              expect(sortedClassList(modelGroup)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
              expect(sortedClassList(form)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+
+             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             dispatchEvent(formEl, 'submit');
+             fixture.detectChanges();
+
+             expect(sortedClassList(formEl)).toEqual([
+               'ng-dirty', 'ng-submitted', 'ng-touched', 'ng-valid'
+             ]);
            });
          }));
+
+      it('should set status classes involving nested FormGroups', () => {
+        const fixture = initTest(NgModelNestedForm);
+        fixture.componentInstance.first = '';
+        fixture.componentInstance.other = '';
+        fixture.detectChanges();
+
+        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        const modelGroup = fixture.debugElement.query(By.css('[ngModelGroup]')).nativeElement;
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          expect(sortedClassList(modelGroup)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
+
+          expect(sortedClassList(form)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
+
+          const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+          dispatchEvent(formEl, 'submit');
+          fixture.detectChanges();
+
+          expect(sortedClassList(modelGroup)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
+          expect(sortedClassList(form)).toEqual([
+            'ng-pristine', 'ng-submitted', 'ng-untouched', 'ng-valid'
+          ]);
+          expect(sortedClassList(input)).not.toContain('ng-submitted');
+
+          dispatchEvent(formEl, 'reset');
+          fixture.detectChanges();
+
+          expect(sortedClassList(modelGroup)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
+          expect(sortedClassList(form)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
+          expect(sortedClassList(input)).not.toContain('ng-submitted');
+        });
+      });
 
       it('should not create a template-driven form when ngNoForm is used', () => {
         const fixture = initTest(NgNoFormComp);
@@ -2365,6 +2423,24 @@ class NgModelNgIfForm {
   emailShowing = true;
   // TODO(issue/24571): remove '!'.
   email!: string;
+}
+
+@Component({
+  selector: 'ng-model-nested',
+  template: `
+    <form>
+      <div ngModelGroup="contact-info">
+        <input name="first" [(ngModel)]="first">
+        <div ngModelGroup="other-names">
+          <input name="other-names" [(ngModel)]="other">
+        </div>
+      </div>
+    </form>
+  `
+})
+class NgModelNestedForm {
+  first!: string;
+  other!: string;
 }
 
 @Component({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 30486

Currently, no status class is set on a form to show that it has been submitted. As previously discussed in pull/31070 and issues/30486, this would be useful because it is often desirable to apply styles to fields that are both `ng-invalid` and `ng-pristine` after the first attempt at form submission, but Angular does not currently provide any simple way to do this (although evidently Angularjs did).

## What is the new behavior?

A new `ng-submitted` class is set on submitted forms. It will now be possible to select untouched but invalid fields in a submitted form (for example, with a selector such as`.ng-submitted .ng-invalid`).

In this implementation, the directive that sets control status classes on forms and formGroups has its set of statuses widened to include `ng-submitted`. Then, in the event that `is('submitted')` is invoked, the `submitted` property of the control container is returned iff it exists. This is preferred over checking whether the container is a `Form` or `FormGroup` directly to avoid reflecting on those classes.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


Closes #30486.
Closes #31070.
