### PR TITLE
docs: add missing `Product` interface to example

### DIFF
--- a/aio/content/examples/getting-started-v0/src/app/products.ts
+++ b/aio/content/examples/getting-started-v0/src/app/products.ts
@@ -1,3 +1,10 @@
+export interface Product {
+  id: number;
+  name: string;
+  price: number;
+  description: string;
+}
+
 export const products = [
   {
     id: 1,


### PR DESCRIPTION
fix issue42144
Docs or angular.io Bug Report
Description

this page
https://angular.io/start#pass-data-to-a-child-component
this line

import { Product } from '../products';
cause error, there isn't exist any class of Product in products.js
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 42144


## What is the new behavior?
fixed the bug

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Fixes #42144 
