### PR TITLE
fix(dev-infra): correct `FormatConfig` interface

### DIFF
--- a/dev-infra/format/config.ts
+++ b/dev-infra/format/config.ts
@@ -13,7 +13,7 @@ interface Formatter {
 }
 
 export interface FormatConfig {
-  [keyof: string]: boolean|Formatter;
+  [key: string]: boolean|Formatter;
 }
 
 /** Retrieve and validate the config as `FormatConfig`. */


### PR DESCRIPTION
Correct the `FormatConfig` interface to use `[key: string]` instead of the incorrect `[keyof: string]`.
