### PR TITLE
docs: align code in `product-example.component.*.ts` files

### DIFF
--- a/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.1.html
+++ b/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.1.html
@@ -1,3 +1,3 @@
-<p *ngIf="product.price > 700">
+<p *ngIf="product && product.price > 700">
   <button>Notify Me</button>
 </p>

--- a/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.html
+++ b/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.html
@@ -1,3 +1,3 @@
-<p *ngIf="product.price > 700">
+<p *ngIf="product && product.price > 700">
   <button (click)="notify.emit()">Notify Me</button>
 </p>

--- a/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.ts
+++ b/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.ts
@@ -13,6 +13,6 @@ import { Product } from '../products';
 })
 // #docregion input-output
 export class ProductAlertsComponent {
-  @Input() product!: Product;
+  @Input() product: Product|undefined;
   @Output() notify = new EventEmitter();
 }


### PR DESCRIPTION
This commit aligns the code in `product-alerts.component.ts` with [product-alerts.component.1.ts][1], since both files are supposed to represent the same component in different points in time. It also makes the necessary changes in the respective templates.

This is a follow-up to #41999.

[1]: https://github.com/angular/angular/blob/e86a1d3441b30776e28c0216f00610d6787de297/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.1.ts#L18