### PR TITLE
ci: update to latest feature request triage bot commit

### DIFF
--- a/.github/workflows/feature-requests.yml
+++ b/.github/workflows/feature-requests.yml
@@ -7,7 +7,7 @@ jobs:
     if: github.repository == 'angular/angular'
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/feature-request@34dd2e86e50f548643797ebeb198784c1a15e276
+      - uses: angular/dev-infra/github-actions/feature-request@29796774d2f41de529a88d99afeb22520f1ba091
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}
           limit: 50


### PR DESCRIPTION
Update to the latest feature request triage bot commit to use
the correct implemntation of obtaining an installation token.
