### PR TITLE
ci: rename the angular devtools pullapprove name

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -763,24 +763,6 @@ groups:
       reviewed_for: required
 
   # =========================================================
-  #  DevTools
-  # =========================================================
-  devtools:
-    <<: *defaults
-    conditions:
-      - *can-be-global-approved
-      - *can-be-global-docs-approved
-      - >
-        contains_any_globs(files, [
-          'aio/content/guide/devtools.md',
-          'aio/content/images/guide/devtools/**'
-          ])
-    reviewers:
-      users:
-        - mgechev
-        - twerske
-
-  # =========================================================
   #  Bazel
   # =========================================================
   bazel:
@@ -1027,6 +1009,23 @@ groups:
         - IgorMinar
         - jelbourn
 
+  # =========================================================
+  #  Docs: Angular DevTools
+  # =========================================================
+  docs-devtools:
+    <<: *defaults
+    conditions:
+      - *can-be-global-approved
+      - *can-be-global-docs-approved
+      - >
+        contains_any_globs(files, [
+          'aio/content/guide/devtools.md',
+          'aio/content/images/guide/devtools/**'
+          ])
+    reviewers:
+      users:
+        - mgechev
+        - twerske
 
   # =========================================================
   #  Tooling: Compiler API shared with Angular CLI


### PR DESCRIPTION
Change `devtools` to `docs-devtools` to properly reflect the approval
group.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
