### PR TITLE
docs(core): reflect current ng-cli result

### DIFF
--- a/packages/core/src/change_detection/pipe_transform.ts
+++ b/packages/core/src/change_detection/pipe_transform.ts
@@ -30,5 +30,5 @@
  * @publicApi
  */
 export interface PipeTransform {
-  transform(value: any, ...args: any[]): any;
+  transform(value: unknown, ...args: unknown[]): unknown;
 }


### PR DESCRIPTION
Changed signature, since `ng` generates pipe with `unknown` type, not `any`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Pipe `transform` method signature, has type `any`

Issue Number: N/A


## What is the new behavior?
Pipe `transform` method signature, has type `unknown`

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
