### PR TITLE
refactor(dev-infra): unify the method of sorting semver branches and tags

### DIFF
--- a/dev-infra/build-worker.js
+++ b/dev-infra/build-worker.js
@@ -6,7 +6,6 @@ var path = require('path');
 var chalk = require('chalk');
 require('inquirer');
 var child_process = require('child_process');
-var semver = require('semver');
 var graphql = require('@octokit/graphql');
 var Octokit = require('@octokit/rest');
 var typedGraphqlify = require('typed-graphqlify');
@@ -352,16 +351,6 @@ var GitClient = /** @class */ (function () {
             this.runGraceful(['reset', '--hard'], { stdio: 'ignore' });
         }
         return this.runGraceful(['checkout', branchOrRevision], { stdio: 'ignore' }).status === 0;
-    };
-    /** Gets the latest git tag on the current branch that matches SemVer. */
-    GitClient.prototype.getLatestSemverTag = function () {
-        var semVerOptions = { loose: true };
-        var tags = this.runGraceful(['tag', '--sort=-committerdate', '--merged']).stdout.split('\n');
-        var latestTag = tags.find(function (tag) { return semver.parse(tag, semVerOptions); });
-        if (latestTag === undefined) {
-            throw new Error("Unable to find a SemVer matching tag on \"" + this.getCurrentBranchOrRevision() + "\"");
-        }
-        return new semver.SemVer(latestTag, semVerOptions);
     };
     /** Retrieve a list of all files in the repostitory changed since the provided shaOrRef. */
     GitClient.prototype.allChangesFilesSince = function (shaOrRef) {

--- a/dev-infra/release/publish/actions.ts
+++ b/dev-infra/release/publish/actions.ts
@@ -18,7 +18,7 @@ import {BuiltPackage, ReleaseConfig} from '../config/index';
 import {NpmDistTag} from '../versioning';
 import {ActiveReleaseTrains} from '../versioning/active-release-trains';
 import {runNpmPublish} from '../versioning/npm-publish';
-import {getLatestSemverTagFromGit} from '../versioning/version-tags';
+import {getLatestSemverTagForRepo} from '../versioning/version-tags';
 
 import {FatalReleaseActionError, UserAbortedReleaseActionError} from './actions-error';
 import {getCommitMessageForRelease, getReleaseNoteCherryPickCommitMessage} from './commit-message';
@@ -352,8 +352,9 @@ export abstract class ReleaseAction {
   protected async stageVersionForBranchAndCreatePullRequest(
       newVersion: semver.SemVer, pullRequestBaseBranch: string):
       Promise<{releaseNotes: ReleaseNotes, pullRequest: PullRequest}> {
-    const releaseNotes =
-        await ReleaseNotes.fromRange(newVersion, getLatestSemverTagFromGit().tag, 'HEAD');
+    const latestTag =
+        (await getLatestSemverTagForRepo({api: this.git.github, ...this.git.remoteConfig})).tag;
+    const releaseNotes = await ReleaseNotes.fromRange(newVersion, latestTag, 'HEAD');
     await this.updateProjectVersion(newVersion);
     await this.prependReleaseNotesToChangelog(releaseNotes);
     await this.waitForEditsAndCreateReleaseCommit(newVersion);

--- a/dev-infra/release/publish/actions.ts
+++ b/dev-infra/release/publish/actions.ts
@@ -18,6 +18,7 @@ import {BuiltPackage, ReleaseConfig} from '../config/index';
 import {NpmDistTag} from '../versioning';
 import {ActiveReleaseTrains} from '../versioning/active-release-trains';
 import {runNpmPublish} from '../versioning/npm-publish';
+import {getLatestSemverTagFromGit} from '../versioning/version-tags';
 
 import {FatalReleaseActionError, UserAbortedReleaseActionError} from './actions-error';
 import {getCommitMessageForRelease, getReleaseNoteCherryPickCommitMessage} from './commit-message';
@@ -352,7 +353,7 @@ export abstract class ReleaseAction {
       newVersion: semver.SemVer, pullRequestBaseBranch: string):
       Promise<{releaseNotes: ReleaseNotes, pullRequest: PullRequest}> {
     const releaseNotes =
-        await ReleaseNotes.fromRange(newVersion, this.git.getLatestSemverTag().format(), 'HEAD');
+        await ReleaseNotes.fromRange(newVersion, getLatestSemverTagFromGit().tag, 'HEAD');
     await this.updateProjectVersion(newVersion);
     await this.prependReleaseNotesToChangelog(releaseNotes);
     await this.waitForEditsAndCreateReleaseCommit(newVersion);

--- a/dev-infra/release/publish/test/test-utils.ts
+++ b/dev-infra/release/publish/test/test-utils.ts
@@ -71,8 +71,8 @@ export function setupReleaseActionForTesting<T extends ReleaseAction>(
     isNextPublishedToNpm = true): TestReleaseAction<T> {
   installVirtualGitClientSpies();
   installMockReleaseNotes();
-  spyOn(versionTags, 'getLatestSemverTagFromGit')
-      .and.returnValue({tag: '0.0.0', parsed: new semver.SemVer('0.0.0')});
+  spyOn(versionTags, 'getLatestSemverTagForRepo')
+      .and.resolveTo({tag: '0.0.0', parsed: new semver.SemVer('0.0.0')});
 
   // Reset existing HTTP interceptors.
   nock.cleanAll();

--- a/dev-infra/release/publish/test/test-utils.ts
+++ b/dev-infra/release/publish/test/test-utils.ts
@@ -18,6 +18,7 @@ import {ReleaseConfig} from '../../config/index';
 import {ActiveReleaseTrains} from '../../versioning/active-release-trains';
 import * as npm from '../../versioning/npm-publish';
 import {_npmPackageInfoCache, NpmDistTag, NpmPackageInfo} from '../../versioning/npm-registry';
+import * as versionTags from '../../versioning/version-tags';
 import {ReleaseAction, ReleaseActionConstructor} from '../actions';
 import * as constants from '../constants';
 import * as externalCommands from '../external-commands';
@@ -70,6 +71,8 @@ export function setupReleaseActionForTesting<T extends ReleaseAction>(
     isNextPublishedToNpm = true): TestReleaseAction<T> {
   installVirtualGitClientSpies();
   installMockReleaseNotes();
+  spyOn(versionTags, 'getLatestSemverTagFromGit')
+      .and.returnValue({tag: '0.0.0', parsed: new semver.SemVer('0.0.0')});
 
   // Reset existing HTTP interceptors.
   nock.cleanAll();

--- a/dev-infra/release/versioning/version-tags.ts
+++ b/dev-infra/release/versioning/version-tags.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as semver from 'semver';
+import {GitClient} from '../../utils/git/index';
+
+/** Type describing a version tag. */
+export interface VersionTag {
+  /** The tag in Git. e.g. `10.1.2`. */
+  tag: string;
+  /** Parsed SemVer version for the version tag. */
+  parsed: semver.SemVer;
+}
+
+
+/** Regular expression that matches version tags. */
+const versionTagRegex = /^v?(\d+)\.(\d+)\.(\d+)(\-(alpha|beta|next|rc)\.\d+)?$/;
+
+/** Whether the provided tag is a version tag. */
+function isVersionTag(tag: string): boolean {
+  return versionTagRegex.test(tag);
+}
+
+/**
+ * Get the filter and sorted list of tags from the provided list of tags foor the provided major
+ * versions.
+ */
+function filterAndSortVersionTags(tags: string[]): VersionTag[] {
+  const versionTags: VersionTag[] = [];
+
+  for (const tag of tags) {
+    if (!isVersionTag(tag)) {
+      continue;
+    }
+
+    const parsed = semver.parse(tag);
+
+    if (parsed === null) {
+      continue;
+    }
+    versionTags.push({tag, parsed});
+  }
+
+  return versionTags.sort((a, b) => semver.rcompare(a.parsed, b.parsed));
+}
+
+/** Retrieve the all semver matching tags from the current branch on git. */
+function getSemverTagsFromGit(git = GitClient.getInstance()): VersionTag[] {
+  const tagsFromGit = git.runGraceful(['tag', '--merged']).stdout.split('\n');
+  return filterAndSortVersionTags(tagsFromGit);
+}
+
+/** Retrieve the latest semver matching tag from the current branch on git. */
+export function getLatestSemverTagFromGit(): VersionTag {
+  const git = GitClient.getInstance();
+  const latestTag = getSemverTagsFromGit()[0];
+  if (latestTag === undefined) {
+    throw new Error(
+        `Unable to find a SemVer matching tag on "${git.getCurrentBranchOrRevision()}"`);
+  }
+
+  return latestTag;
+}

--- a/dev-infra/utils/git/index.ts
+++ b/dev-infra/utils/git/index.ts
@@ -248,19 +248,6 @@ export class GitClient<Authenticated extends boolean> {
     return this.runGraceful(['checkout', branchOrRevision], {stdio: 'ignore'}).status === 0;
   }
 
-  /** Gets the latest git tag on the current branch that matches SemVer. */
-  getLatestSemverTag(): SemVer {
-    const semVerOptions: SemVerOptions = {loose: true};
-    const tags = this.runGraceful(['tag', '--sort=-committerdate', '--merged']).stdout.split('\n');
-    const latestTag = tags.find((tag: string) => parse(tag, semVerOptions));
-
-    if (latestTag === undefined) {
-      throw new Error(
-          `Unable to find a SemVer matching tag on "${this.getCurrentBranchOrRevision()}"`);
-    }
-    return new SemVer(latestTag, semVerOptions);
-  }
-
   /** Retrieve a list of all files in the repostitory changed since the provided shaOrRef. */
   allChangesFilesSince(shaOrRef = 'HEAD'): string[] {
     return Array.from(new Set([

--- a/dev-infra/utils/testing/virtual-git-client.ts
+++ b/dev-infra/utils/testing/virtual-git-client.ts
@@ -83,15 +83,6 @@ export class VirtualGitClient<Authenticated extends boolean> extends GitClient<A
   /** List of pushed heads to a given remote ref. */
   pushed: {remote: RemoteRef, head: GitHead}[] = [];
 
-
-  /**
-   * Override the actual GitClient getLatestSemverTag, as an actual tag cannot be retrieved in
-   * testing.
-   */
-  getLatestSemverTag() {
-    return new SemVer('0.0.0');
-  }
-
   /** Override for the actual Git client command execution. */
   runGraceful(args: string[], options: SpawnSyncOptions = {}): SpawnSyncReturns<string> {
     const [command, ...rawArgs] = args;


### PR DESCRIPTION
Use the same logic for filtering and sorting semver branches and tags throughout
the toolset.
