### PR TITLE
refactor(docs-infra): use Renderer2 to render codeContainer html content

### DIFF
--- a/aio/src/app/custom-elements/code/code.component.ts
+++ b/aio/src/app/custom-elements/code/code.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Input, OnChanges, Output, ViewChild } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnChanges, Output, Renderer2, ViewChild } from '@angular/core';
 import { Clipboard } from '@angular/cdk/clipboard';
 import { Logger } from 'app/shared/logger.service';
 import { PrettyPrinter } from './pretty-printer.service';
@@ -97,6 +97,7 @@ export class CodeComponent implements OnChanges {
   constructor(
     private snackbar: MatSnackBar,
     private pretty: PrettyPrinter,
+    private renderer: Renderer2,
     private clipboard: Clipboard,
     private logger: Logger) {}
 
@@ -138,7 +139,7 @@ export class CodeComponent implements OnChanges {
   private setCodeHtml(formattedCode: string) {
     // **Security:** Code example content is provided by docs authors and as such its considered to
     // be safe for innerHTML purposes.
-    this.codeContainer.nativeElement.innerHTML = formattedCode;
+    this.renderer.setProperty(this.codeContainer.nativeElement, 'innerHTML', formattedCode);
   }
 
   /** Gets the textContent of the displayed code element. */


### PR DESCRIPTION
use Renderer2 api to render codeContainer html content instead of using dom api

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
