### PR TITLE
fix(dev-infra): formatting errors not reported with failure message

### DIFF
--- a/dev-infra/format/format.ts
+++ b/dev-infra/format/format.ts
@@ -27,7 +27,7 @@ export async function formatFiles(files: string[]) {
     error(red(`The following files could not be formatted:`));
     failures.forEach(({filePath, message}) => {
       info(`  • ${filePath}: ${message}`);
-    })
+    });
     error(red(`Formatting failed, see errors above for more information.`));
     process.exit(1);
   }
@@ -50,8 +50,8 @@ export async function checkFiles(files: string[]) {
   if (failures.length) {
     // Provide output expressing which files are failing formatting.
     info.group('\nThe following files are out of format:');
-    for (const file of failures) {
-      info(`  • ${file}`);
+    for (const {filePath} of failures) {
+      info(`  • ${filePath}`);
     }
     info.groupEnd();
     info();

--- a/dev-infra/format/format.ts
+++ b/dev-infra/format/format.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {error, info, promptConfirm} from '../utils/console';
+import {error, info, promptConfirm, red} from '../utils/console';
 
 import {runFormatterInParallel} from './run-commands-parallel';
 
@@ -24,7 +24,11 @@ export async function formatFiles(files: string[]) {
 
   // The process should exit as a failure if any of the files failed to format.
   if (failures.length !== 0) {
-    error(`Formatting failed, see errors above for more information.`);
+    error(red(`The following files could not be formatted:`));
+    failures.forEach(({filePath, message}) => {
+      info(`  • ${filePath}: ${message}`);
+    })
+    error(red(`Formatting failed, see errors above for more information.`));
     process.exit(1);
   }
   info(`√  Formatting complete.`);
@@ -47,7 +51,7 @@ export async function checkFiles(files: string[]) {
     // Provide output expressing which files are failing formatting.
     info.group('\nThe following files are out of format:');
     for (const file of failures) {
-      info(`  - ${file}`);
+      info(`  • ${file}`);
     }
     info.groupEnd();
     info();
@@ -60,7 +64,7 @@ export async function checkFiles(files: string[]) {
 
     if (runFormatter) {
       // Format the failing files as requested.
-      await formatFiles(failures);
+      await formatFiles(failures.map(f => f.filePath));
       process.exit(0);
     } else {
       // Inform user how to format files in the future.

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -2664,8 +2664,8 @@ function checkFiles(files) {
         if (failures.length) {
             // Provide output expressing which files are failing formatting.
             info.group('\nThe following files are out of format:');
-            for (const file of failures) {
-                info(`  • ${file}`);
+            for (const { filePath } of failures) {
+                info(`  • ${filePath}`);
             }
             info.groupEnd();
             info();

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -2591,7 +2591,7 @@ function runFormatterInParallel(allFiles, action) {
                 // Run the provided callback function.
                 const failed = formatter.callbackFor(action)(file, code, stdout, stderr);
                 if (failed) {
-                    failures.push(file);
+                    failures.push({ filePath: file, message: stderr });
                 }
                 // Note in the progress bar another file being completed.
                 progressBar.increment(1);
@@ -2639,7 +2639,11 @@ function formatFiles(files) {
         }
         // The process should exit as a failure if any of the files failed to format.
         if (failures.length !== 0) {
-            error(`Formatting failed, see errors above for more information.`);
+            error(red(`The following files could not be formatted:`));
+            failures.forEach(({ filePath, message }) => {
+                info(`  • ${filePath}: ${message}`);
+            });
+            error(red(`Formatting failed, see errors above for more information.`));
             process.exit(1);
         }
         info(`√  Formatting complete.`);
@@ -2661,7 +2665,7 @@ function checkFiles(files) {
             // Provide output expressing which files are failing formatting.
             info.group('\nThe following files are out of format:');
             for (const file of failures) {
-                info(`  - ${file}`);
+                info(`  • ${file}`);
             }
             info.groupEnd();
             info();
@@ -2672,7 +2676,7 @@ function checkFiles(files) {
             }
             if (runFormatter) {
                 // Format the failing files as requested.
-                yield formatFiles(failures);
+                yield formatFiles(failures.map(f => f.filePath));
                 process.exit(0);
             }
             else {


### PR DESCRIPTION
Currently if formatting for a file fails due a formatter error,
the `ng-dev` tool reports that formatting failed, but no actual
error (or involved file) is printed out. This commit prints out
the failed files with their error message.


Example error before this change:

```
$ yarn ng-dev format changed
yarn run v1.22.10
$ node dev-infra/ng-dev format changed
Formatting 1 file(s)
Formatting failed, see errors above for more information.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```