### PR TITLE
update supported range of nodes versions to be less restrictive.

### DIFF
--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "bin": {
     "api-extractor": "./src/api-extractor/index.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "locales": "locales",
   "dependencies": {

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -41,7 +41,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "bugs": {
     "url": "https://github.com/angular/angular/issues"

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >14.0.0"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || >14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -7,7 +7,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -10,7 +10,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/platform-browser-dynamic/package.json
+++ b/packages/platform-browser-dynamic/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "peerDependencies": {
     "@angular/animations": "0.0.0-PLACEHOLDER",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -14,7 +14,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "bugs": {
     "url": "https://github.com/angular/angular/issues"

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
     "tslib": "^2.1.0"

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.14.1 || ^14.0.0"
+    "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
     "tslib": "^2.1.0"


### PR DESCRIPTION
Update the supported range of node versions for to be less restrictive, no longer causing yarn or npm to fail engine's checks for future versions of node.

**NOTE:** While this change will no longer cause yarn or npm to fail these engine's check, this does not reflect a change in the officially supported versions of node for Angular.  Angular continues to maintain support for `Active LTS` and `Maintenance LTS` versions of node.

Closes #42076