### PR TITLE
fix(dev-infra): use template strings for release note templates

### DIFF
--- a/dev-infra/BUILD.bazel
+++ b/dev-infra/BUILD.bazel
@@ -44,7 +44,6 @@ pkg_npm(
         "index.bzl",
         "//dev-infra/bazel:files",
         "//dev-infra/benchmark:files",
-        "//dev-infra/release/publish/release-notes/templates",
     ],
     substitutions = {
         # angular/angular should not consume it's own packages, so we use

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -5857,6 +5857,180 @@ function buildDateStamp(date = new Date()) {
     return [year, month, day].join('-');
 }
 
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+var changelogTemplate = `
+<a name="<%- version %>"></a>
+# <%- version %><% if (title) { %> "<%- title %>"<% } %> (<%- dateStamp %>)
+
+<%_
+const commitsInChangelog = commits.filter(includeInReleaseNotes());
+for (const group of asCommitGroups(commitsInChangelog)) {
+_%>
+
+### <%- group.title %>
+| Commit | Description |
+| -- | -- |
+<%_
+  for (const commit of group.commits) {
+_%>
+| <%- commit.shortHash %> | <%- commit.header %> |
+<%_
+  }
+}
+_%>
+
+<%_
+const breakingChanges = commits.filter(contains('breakingChanges'));
+if (breakingChanges.length) {
+_%>
+## Breaking Changes
+
+<%_
+  for (const group of asCommitGroups(breakingChanges)) {
+_%>
+### <%- group.title %>
+
+<%_
+    for (const commit of group.commits) {
+_%>
+<%- commit.breakingChanges[0].text %>
+
+<%_
+    }
+  }
+}
+_%>
+
+<%_
+const deprecations = commits.filter(contains('deprecations'));
+if (deprecations.length) {
+_%>
+## Deprecations
+<%_
+  for (const group of asCommitGroups(deprecations)) {
+_%>
+### <%- group.title %>
+
+<%_
+    for (const commit of group.commits) {
+_%>
+<%- commit.deprecations[0].text %>
+<%_
+    }
+  }
+}
+_%>
+
+<%_
+const authors = commits.filter(unique('author')).map(c => c.author).sort();
+if (authors.length === 1) {
+_%>
+## Special Thanks:
+<%- authors[0]%>
+<%_
+}
+if (authors.length > 1) {
+_%>
+## Special Thanks:
+<%- authors.slice(0, -1).join(', ') %> and <%- authors.slice(-1)[0] %>
+<%_
+}
+_%>
+`;
+
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+var githubReleaseTemplate = `
+<a name="<%- version %>"></a>
+# <%- version %><% if (title) { %> "<%- title %>"<% } %> (<%- dateStamp %>)
+
+<%_
+const commitsInChangelog = commits.filter(includeInReleaseNotes());
+for (const group of asCommitGroups(commitsInChangelog)) {
+_%>
+
+### <%- group.title %>
+| Commit | Description |
+| -- | -- |
+<%_
+  for (const commit of group.commits) {
+_%>
+| <%- commit.shortHash %> | <%- commit.header %> |
+<%_
+  }
+}
+_%>
+
+<%_
+const breakingChanges = commits.filter(contains('breakingChanges'));
+if (breakingChanges.length) {
+_%>
+## Breaking Changes
+
+<%_
+  for (const group of asCommitGroups(breakingChanges)) {
+_%>
+### <%- group.title %>
+
+<%_
+    for (const commit of group.commits) {
+_%>
+<%- commit.breakingChanges[0].text %>
+
+<%_
+    }
+  }
+}
+_%>
+
+<%_
+const deprecations = commits.filter(contains('deprecations'));
+if (deprecations.length) {
+_%>
+## Deprecations
+<%_
+  for (const group of asCommitGroups(deprecations)) {
+_%>
+### <%- group.title %>
+
+<%_
+    for (const commit of group.commits) {
+_%>
+<%- commit.deprecations[0].text %>
+<%_
+    }
+  }
+}
+_%>
+
+<%_
+const authors = commits.filter(unique('author')).map(c => c.author).sort();
+if (authors.length === 1) {
+_%>
+## Special Thanks:
+<%- authors[0]%>
+<%_
+}
+if (authors.length > 1) {
+_%>
+## Special Thanks:
+<%- authors.slice(0, -1).join(', ') %> and <%- authors.slice(-1)[0] %>
+<%_
+}
+_%>
+`;
+
 /** Gets the path for the changelog file in a given project. */
 function getLocalChangelogFilePath(projectDir) {
     return path.join(projectDir, changelogPath);
@@ -5882,13 +6056,13 @@ class ReleaseNotes {
     /** Retrieve the release note generated for a Github Release. */
     getGithubReleaseEntry() {
         return tslib.__awaiter(this, void 0, void 0, function* () {
-            return ejs.renderFile(path.join(__dirname, 'templates/github-release.ejs'), yield this.generateRenderContext(), { rmWhitespace: true });
+            return ejs.render(githubReleaseTemplate, yield this.generateRenderContext(), { rmWhitespace: true });
         });
     }
     /** Retrieve the release note generated for a CHANGELOG entry. */
     getChangelogEntry() {
         return tslib.__awaiter(this, void 0, void 0, function* () {
-            return ejs.renderFile(path.join(__dirname, 'templates/changelog.ejs'), yield this.generateRenderContext(), { rmWhitespace: true });
+            return ejs.render(changelogTemplate, yield this.generateRenderContext(), { rmWhitespace: true });
         });
     }
     /**

--- a/dev-infra/release/publish/release-notes/release-notes.ts
+++ b/dev-infra/release/publish/release-notes/release-notes.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {renderFile} from 'ejs';
+import {render} from 'ejs';
 import {join} from 'path';
 import * as semver from 'semver';
 import {CommitFromGitLog} from '../../../commit-message/parse';
@@ -16,6 +16,9 @@ import {GitClient} from '../../../utils/git/index';
 import {DevInfraReleaseConfig, getReleaseConfig, ReleaseNotesConfig} from '../../config/index';
 import {changelogPath} from '../constants';
 import {RenderContext} from './context';
+
+import changelogTemplate from './templates/changelog';
+import githubReleaseTemplate from './templates/github-release';
 
 /** Gets the path for the changelog file in a given project. */
 export function getLocalChangelogFilePath(projectDir: string): string {
@@ -45,16 +48,12 @@ export class ReleaseNotes {
 
   /** Retrieve the release note generated for a Github Release. */
   async getGithubReleaseEntry(): Promise<string> {
-    return renderFile(
-        join(__dirname, 'templates/github-release.ejs'), await this.generateRenderContext(),
-        {rmWhitespace: true});
+    return render(githubReleaseTemplate, await this.generateRenderContext(), {rmWhitespace: true});
   }
 
   /** Retrieve the release note generated for a CHANGELOG entry. */
   async getChangelogEntry() {
-    return renderFile(
-        join(__dirname, 'templates/changelog.ejs'), await this.generateRenderContext(),
-        {rmWhitespace: true});
+    return render(changelogTemplate, await this.generateRenderContext(), {rmWhitespace: true});
   }
 
   /**

--- a/dev-infra/release/publish/release-notes/templates/BUILD.bazel
+++ b/dev-infra/release/publish/release-notes/templates/BUILD.bazel
@@ -1,6 +1,0 @@
-package(default_visibility = ["//dev-infra:__subpackages__"])
-
-filegroup(
-    name = "templates",
-    srcs = glob(["*.ejs"]),
-)

--- a/dev-infra/release/publish/release-notes/templates/changelog.ts
+++ b/dev-infra/release/publish/release-notes/templates/changelog.ts
@@ -1,3 +1,12 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export default `
 <a name="<%- version %>"></a>
 # <%- version %><% if (title) { %> "<%- title %>"<% } %> (<%- dateStamp %>)
 
@@ -75,3 +84,4 @@ _%>
 <%_
 }
 _%>
+`;

--- a/dev-infra/release/publish/release-notes/templates/github-release.ts
+++ b/dev-infra/release/publish/release-notes/templates/github-release.ts
@@ -1,3 +1,12 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export default `
 <a name="<%- version %>"></a>
 # <%- version %><% if (title) { %> "<%- title %>"<% } %> (<%- dateStamp %>)
 
@@ -75,3 +84,4 @@ _%>
 <%_
 }
 _%>
+`;

--- a/dev-infra/release/publish/test/BUILD.bazel
+++ b/dev-infra/release/publish/test/BUILD.bazel
@@ -33,8 +33,5 @@ jasmine_node_test(
     # enabled in NodeJS. TODO: Remove this with rules_nodejs 3.x where patching is optional.
     # https://github.com/bazelbuild/rules_nodejs/commit/7d070ffadf9c3b41711382a4737b995f987c14fa.
     args = ["--nobazel_patch_module_resolver"],
-    data = [
-        "//dev-infra/release/publish/release-notes/templates",
-    ],
     deps = [":test_lib"],
 )


### PR DESCRIPTION
Use template strings for release note templates rather than loading `ejs` files at runtime.
