### PR TITLE
docs: move helpful alert regarding built-in directives to more logical place

### DIFF
--- a/aio/content/guide/built-in-directives.md
+++ b/aio/content/guide/built-in-directives.md
@@ -31,6 +31,13 @@ The most common attribute directives are as follows:
 * [`NgStyle`](guide/built-in-directives#ngstyle)&mdash;adds and removes a set of HTML styles.
 * [`NgModel`](guide/built-in-directives#ngModel)&mdash;adds two-way data binding to an HTML form element.
 
+<div class="alert is-helpful">
+
+Built-in directives use only public APIs.
+They do not have special access to any private APIs that other directives can't access.
+
+</div>
+
 {@a ngClass}
 ## Adding and removing classes with `NgClass`
 
@@ -267,13 +274,6 @@ In the following illustration of the `trackBy` effect, **Reset items** creates n
 
 <div class="lightbox">
   <img src="generated/images/guide/built-in-directives/ngfor-trackby.gif" alt="Animation of trackBy">
-</div>
-
-<div class="alert is-helpful">
-
-Built-in directives use only public APIs.
-They do not have special access to any private APIs that other directives can't access.
-
 </div>
 
 {@a ngcontainer}


### PR DESCRIPTION
Moving the helpful alert expressing that built-in directives use public APIs
to be under the heading about built-in directives generally makes the content
in the alert more related to its surroundings than its previous location within
the ng-for section.
