### PR TITLE
docs: include source code styling section in docs style guide

### DIFF
--- a/aio/content/guide/docs-style-guide.md
+++ b/aio/content/guide/docs-style-guide.md
@@ -727,6 +727,13 @@ Remember to exclude these files from StackBlitz by listing them in the `stackbli
 
 <code-example path="docs-style-guide/stackblitz.json" header="stackblitz.json"></code-example>
 
+### Source code styling
+
+Source code should follow [Angular's style guide](guide/styleguide) where possible.
+
+#### Hexadecimals
+
+Hexadecimal should use the shorthand where possible, and use only lowercase letters.
 
 {@a live-examples}
 


### PR DESCRIPTION
Include a source code styling section in the style guide for docs,
indicating to follow the Angular style guide where possible and
defining hexadecimal style guidance.

Closes #23691