### PR TITLE
docs(core): tighten up PipeTransform example types

### DIFF
--- a/packages/examples/core/ts/pipes/simple_truncate.ts
+++ b/packages/examples/core/ts/pipes/simple_truncate.ts
@@ -5,12 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
+// #docregion
 import {Pipe, PipeTransform} from '@angular/core';
 
 @Pipe({name: 'truncate'})
 export class TruncatePipe implements PipeTransform {
-  transform(value: any) {
+  transform(value: string) {
     return value.split(' ').slice(0, 2).join(' ') + '...';
   }
 }

--- a/packages/examples/core/ts/pipes/truncate.ts
+++ b/packages/examples/core/ts/pipes/truncate.ts
@@ -5,12 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
+// #docregion
 import {Pipe, PipeTransform} from '@angular/core';
 
 @Pipe({name: 'truncate'})
 export class TruncatePipe implements PipeTransform {
-  transform(value: any, length: number, symbol: string) {
+  transform(value: string, length: number, symbol: string) {
     return value.split(' ').slice(0, length).join(' ') + symbol;
   }
 }


### PR DESCRIPTION
The example was using `any` type but then assuming that the value was a string.

Fixes #42239