### PR TITLE
docs(core): clarify deprecation of `entryComponents`

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -380,7 +380,11 @@ All of the `wtf*` APIs are deprecated and will be removed in a future version.
 
 {@a entryComponents}
 ### `entryComponents` and `ANALYZE_FOR_ENTRY_COMPONENTS` no longer required
-Previously, the `entryComponents` array in the `NgModule` definition was used to tell the compiler which components would be created and inserted dynamically. With Ivy, this isn't a requirement anymore and the `entryComponents` array can be removed from existing module declarations. The same applies to the `ANALYZE_FOR_ENTRY_COMPONENTS` injection token.
+Previously, the `entryComponents` array in the `NgModule` definition was used to tell the compiler which components would be created and inserted dynamically.
+With Ivy, this isn't a requirement anymore and the `entryComponents` array can be removed from existing module declarations.
+The same applies to the `ANALYZE_FOR_ENTRY_COMPONENTS` injection token.
+
+Note: You may still need to keep these if building a library that will be consumed by a View Engine application.
 
 {@a moduleWithProviders}
 ### `ModuleWithProviders` type without a generic

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -199,7 +199,9 @@ export interface NgModule {
    * using one of the imperative techniques, such as `ViewContainerRef.createComponent()`.
    *
    * @see [Entry Components](guide/entry-components)
-   * @deprecated Since 9.0.0. With Ivy, this property is no longer necessary.
+   * @deprecated
+   * Since 9.0.0. With Ivy, this property is no longer necessary.
+   * (You may need to keep these if building a library in View Engine mode.)
    */
   entryComponents?: Array<Type<any>|any[]>;
 

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -201,7 +201,8 @@ export interface NgModule {
    * @see [Entry Components](guide/entry-components)
    * @deprecated
    * Since 9.0.0. With Ivy, this property is no longer necessary.
-   * (You may need to keep these if building a library in View Engine mode.)
+   * (You may need to keep these if building a library that will be consumed by a View Engine
+   * application.)
    */
   entryComponents?: Array<Type<any>|any[]>;
 


### PR DESCRIPTION
These may still be needed in View Engine libraries.

Closes #39958