### PR TITLE
fix(dev-infra): format command incorrectly prints outdated files

### DIFF
--- a/dev-infra/format/format.ts
+++ b/dev-infra/format/format.ts
@@ -70,7 +70,7 @@ export async function checkFiles(files: string[]) {
       // Inform user how to format files in the future.
       info();
       info(`To format the failing file run the following command:`);
-      info(`  yarn ng-dev format files ${failures.join(' ')}`);
+      info(`  yarn ng-dev format files ${failures.map(f => f.filePath).join(' ')}`);
       process.exit(1);
     }
   } else {

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -2683,7 +2683,7 @@ function checkFiles(files) {
                 // Inform user how to format files in the future.
                 info();
                 info(`To format the failing file run the following command:`);
-                info(`  yarn ng-dev format files ${failures.join(' ')}`);
+                info(`  yarn ng-dev format files ${failures.map(f => f.filePath).join(' ')}`);
                 process.exit(1);
             }
         }


### PR DESCRIPTION
When `ng-dev format --check` is run, the ng-dev tool prints out
all files that are out-of-date. We recently updated the format
tool to also capture `stderr` for failed files. This broke the
console message as we did not unwrap the `FormatFailure` to
their file path when printing the "ng-dev format" fix command.