### PR TITLE
feat(docs-infra): implement popup to inform about the use of cookies

### DIFF
--- a/aio/angular.json
+++ b/aio/angular.json
@@ -11,16 +11,19 @@
   "newProjectRoot": "projects",
   "projects": {
     "site": {
-      "root": "",
-      "sourceRoot": "src",
       "projectType": "application",
-      "prefix": "aio",
       "schematics": {
+        "@schematics/angular:application": {
+          "strict": true
+        },
         "@schematics/angular:component": {
           "inlineStyle": true,
           "style": "scss"
         }
       },
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "aio",
       "architect": {
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
@@ -64,16 +67,18 @@
             "scripts": [],
             "budgets": [
               {
+                "type": "initial",
+                "maximumWarning": "850kb",
+                "maximumError": "1mb"
+              },
+              {
                 "type": "anyComponentStyle",
-                "maximumWarning": "6kb"
+                "maximumWarning": "2kb",
+                "maximumError": "4kb"
               }
             ]
           },
           "configurations": {
-            "fast": {
-              "buildOptimizer": false,
-              "optimization": false
-            },
             "next": {
               "fileReplacements": [
                 {
@@ -112,18 +117,20 @@
             },
             "ci": {
               "progress": false
+            },
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "outputHashing": "none",
+              "vendorChunk": true,
+              "extractLicenses": false
             }
-          }
+          },
+          "defaultConfiguration": "stable"
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
-          "options": {
-            "browserTarget": "site:build"
-          },
           "configurations": {
-            "fast": {
-              "browserTarget": "site:build:fast"
-            },
             "next": {
               "browserTarget": "site:build:next"
             },
@@ -138,8 +145,12 @@
             },
             "ci": {
               "browserTarget": "site:build:ci"
+            },
+            "development": {
+              "browserTarget": "site:build:development"
             }
-          }
+          },
+          "defaultConfiguration": "development"
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",

--- a/aio/angular.json
+++ b/aio/angular.json
@@ -172,7 +172,17 @@
               "src/google385281288605d160.html"
             ],
             "styles": [
-              "src/styles/main.scss"
+              "src/styles/main.scss",
+              {
+                "inject": false,
+                "input": "src/styles/custom-themes/dark-theme.scss",
+                "bundleName": "dark-theme"
+              },
+              {
+                "inject": false,
+                "input": "src/styles/custom-themes/light-theme.scss",
+                "bundleName": "light-theme"
+              }
             ],
             "scripts": []
           }

--- a/aio/package.json
+++ b/aio/package.json
@@ -11,7 +11,7 @@
     "aio-use-npm": "node tools/ng-packages-installer restore .",
     "aio-check-local": "node tools/ng-packages-installer check .",
     "ng": "yarn check-env && ng",
-    "start": "yarn check-env && ng serve --configuration=fast",
+    "start": "yarn check-env && ng serve",
     "prebuild": "yarn setup",
     "build": "yarn ~~build",
     "prebuild-local": "yarn setup-local",

--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -1,5 +1,7 @@
 <div id="top-of-page"></div>
 
+<aio-cookies-popup></aio-cookies-popup>
+
 <div *ngIf="isFetching" class="progress-bar-container">
   <mat-progress-bar mode="indeterminate" color="warn"></mat-progress-bar>
 </div>

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -7,6 +7,7 @@ import { MatSidenav } from '@angular/material/sidenav';
 import { By, Title } from '@angular/platform-browser';
 import { ElementsLoader } from 'app/custom-elements/elements-loader';
 import { DocumentService } from 'app/documents/document.service';
+import { CookiesPopupComponent } from 'app/layout/cookies-popup/cookies-popup.component';
 import { DocViewerComponent } from 'app/layout/doc-viewer/doc-viewer.component';
 import { CurrentNodes } from 'app/navigation/navigation.model';
 import { NavigationNode, NavigationService } from 'app/navigation/navigation.service';
@@ -698,6 +699,13 @@ describe('AppComponent', () => {
       it('should have version number', () => {
         const versionEl: HTMLElement = fixture.debugElement.query(By.css('aio-footer')).nativeElement;
         expect(versionEl.textContent).toContain(TestHttpClient.versionInfo.full);
+      });
+    });
+
+    describe('aio-cookies-popup', () => {
+      it('should have a cookies popup', () => {
+        const cookiesPopupDe = fixture.debugElement.query(By.directive(CookiesPopupComponent));
+        expect(cookiesPopupDe.componentInstance).toBeInstanceOf(CookiesPopupComponent);
       });
     });
 

--- a/aio/src/app/app.module.ts
+++ b/aio/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { ModeBannerComponent } from 'app/layout/mode-banner/mode-banner.componen
 import { GaService } from 'app/shared/ga.service';
 import { Logger } from 'app/shared/logger.service';
 import { LocationService } from 'app/shared/location.service';
+import { STORAGE_PROVIDERS } from 'app/shared/storage.service';
 import { NavigationService } from 'app/navigation/navigation.service';
 import { DocumentService } from 'app/documents/document.service';
 import { SearchService } from 'app/search/search.service';
@@ -187,6 +188,7 @@ export const svgIconProviders = [
     ScrollService,
     ScrollSpyService,
     SearchService,
+    STORAGE_PROVIDERS,
     svgIconProviders,
     TocService,
     { provide: CurrentDateToken, useFactory: currentDateProvider },

--- a/aio/src/app/app.module.ts
+++ b/aio/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { AppComponent } from 'app/app.component';
 import { CustomIconRegistry, SVG_ICONS } from 'app/shared/custom-icon-registry';
 import { Deployment } from 'app/shared/deployment.service';
+import { CookiesPopupComponent } from 'app/layout/cookies-popup/cookies-popup.component';
 import { DocViewerComponent } from 'app/layout/doc-viewer/doc-viewer.component';
 import { DtComponent } from 'app/layout/doc-viewer/dt.component';
 import { ModeBannerComponent } from 'app/layout/mode-banner/mode-banner.component';
@@ -163,6 +164,7 @@ export const svgIconProviders = [
   ],
   declarations: [
     AppComponent,
+    CookiesPopupComponent,
     DocViewerComponent,
     DtComponent,
     FooterComponent,

--- a/aio/src/app/layout/cookies-popup/cookies-popup.component.spec.ts
+++ b/aio/src/app/layout/cookies-popup/cookies-popup.component.spec.ts
@@ -1,0 +1,92 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LocalStorage } from 'app/shared/storage.service';
+import { CookiesPopupComponent, storageKey } from './cookies-popup.component';
+
+describe('CookiesPopupComponent', () => {
+  let mockLocalStorage: MockLocalStorage;
+  let fixture: ComponentFixture<CookiesPopupComponent>;
+
+  beforeEach(() => {
+    mockLocalStorage = new MockLocalStorage();
+
+    TestBed.configureTestingModule({
+      declarations: [
+        CookiesPopupComponent,
+      ],
+      providers: [
+        { provide: LocalStorage, useValue: mockLocalStorage },
+      ],
+    });
+
+    fixture = TestBed.createComponent(CookiesPopupComponent);
+  });
+
+  it('should make the popup visible by default', () => {
+    fixture.detectChanges();
+
+    expect(getCookiesPopup()).not.toBeNull();
+  });
+
+  it('should include the correct content in the popup', () => {
+    fixture.detectChanges();
+
+    const popup = getCookiesPopup() as Element;
+    const infoBtn = popup.querySelector<HTMLAnchorElement>('a[mat-button]:nth-child(1)');
+    const okBtn = popup.querySelector<HTMLButtonElement>('button[mat-button]:nth-child(2)');
+
+    expect(popup.textContent).toContain(
+        'This site uses cookies from Google to deliver its services and to analyze traffic.');
+
+    expect(infoBtn).toBeInstanceOf(HTMLElement);
+    expect(infoBtn?.href).toBe('https://policies.google.com/technologies/cookies');
+    expect(infoBtn?.textContent).toMatch(/learn more/i);
+
+    expect(okBtn).toBeInstanceOf(HTMLElement);
+    expect(okBtn?.textContent).toMatch(/ok, got it/i);
+  });
+
+  it('should hide the cookies popup if the user has already accepted cookies', () => {
+    mockLocalStorage.setItem(storageKey, 'true');
+    fixture = TestBed.createComponent(CookiesPopupComponent);
+
+    fixture.detectChanges();
+
+    expect(getCookiesPopup()).toBeNull();
+  });
+
+  describe('acceptCookies()', () => {
+    it('should hide the cookies popup', () => {
+      fixture.detectChanges();
+      expect(getCookiesPopup()).not.toBeNull();
+
+      fixture.componentInstance.acceptCookies();
+      fixture.detectChanges();
+      expect(getCookiesPopup()).toBeNull();
+    });
+
+    it('should store the user\'s confirmation', () => {
+      fixture.detectChanges();
+      expect(mockLocalStorage.getItem(storageKey)).toBeNull();
+
+      fixture.componentInstance.acceptCookies();
+      expect(mockLocalStorage.getItem(storageKey)).toBe('true');
+    });
+  });
+
+  // Helpers
+  function getCookiesPopup() {
+    return (fixture.nativeElement as HTMLElement).querySelector('.cookies-popup');
+  }
+
+  class MockLocalStorage implements Pick<Storage, 'getItem' | 'setItem'> {
+    private items = new Map<string, string>();
+
+    getItem(key: string): string | null {
+      return this.items.get(key) ?? null;
+    }
+
+    setItem(key: string, val: string): void {
+      this.items.set(key, val);
+    }
+  }
+});

--- a/aio/src/app/layout/cookies-popup/cookies-popup.component.ts
+++ b/aio/src/app/layout/cookies-popup/cookies-popup.component.ts
@@ -7,14 +7,16 @@ export const storageKey = 'aio-accepts-cookies';
   selector: 'aio-cookies-popup',
   template: `
     <div class="cookies-popup no-print" *ngIf="!hasAcceptedCookies">
+      <h2 class="visually-hidden">Cookies concent notice</h2>
+
       This site uses cookies from Google to deliver its services and to analyze traffic.
 
       <div class="actions">
         <a mat-button href="https://policies.google.com/technologies/cookies" target="_blank" rel="noopener">
-          LEARN MORE
+          Learn more
         </a>
         <button mat-button (click)="acceptCookies()">
-          OK, GOT IT
+          OK, got it
         </button>
       </div>
     </div>

--- a/aio/src/app/layout/cookies-popup/cookies-popup.component.ts
+++ b/aio/src/app/layout/cookies-popup/cookies-popup.component.ts
@@ -1,0 +1,35 @@
+import { Component, Inject } from '@angular/core';
+import { LocalStorage } from 'app/shared/storage.service';
+
+export const storageKey = 'aio-accepts-cookies';
+
+@Component({
+  selector: 'aio-cookies-popup',
+  template: `
+    <div class="cookies-popup no-print" *ngIf="!hasAcceptedCookies">
+      This site uses cookies from Google to deliver its services and to analyze traffic.
+
+      <div class="actions">
+        <a mat-button href="https://policies.google.com/technologies/cookies" target="_blank" rel="noopener">
+          LEARN MORE
+        </a>
+        <button mat-button (click)="acceptCookies()">
+          OK, GOT IT
+        </button>
+      </div>
+    </div>
+  `,
+})
+export class CookiesPopupComponent {
+  /** Whether the user has already accepted the cookies disclaimer. */
+  hasAcceptedCookies: boolean;
+
+  constructor(@Inject(LocalStorage) private storage: Storage) {
+    this.hasAcceptedCookies = this.storage.getItem(storageKey) === 'true';
+  }
+
+  acceptCookies() {
+    this.storage.setItem(storageKey, 'true');
+    this.hasAcceptedCookies = true;
+  }
+}

--- a/aio/src/app/layout/notification/notification.component.spec.ts
+++ b/aio/src/app/layout/notification/notification.component.spec.ts
@@ -3,8 +3,8 @@ import { Component, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { CurrentDateToken } from 'app/shared/current-date';
+import { LocalStorage, NoopStorage } from 'app/shared/storage.service';
 import { NotificationComponent } from './notification.component';
-import { WindowToken } from 'app/shared/window';
 
 describe('NotificationComponent', () => {
   let component: NotificationComponent;
@@ -14,7 +14,7 @@ describe('NotificationComponent', () => {
     TestBed.configureTestingModule({
       declarations: [TestComponent, NotificationComponent],
       providers: [
-        { provide: WindowToken, useClass: MockWindow },
+        { provide: LocalStorage, useValue: new NoopStorage() },
         { provide: CurrentDateToken, useValue: now },
       ],
       imports: [NoopAnimationsModule],
@@ -92,7 +92,8 @@ describe('NotificationComponent', () => {
   it('should update localStorage key when dismiss is called', () => {
     configTestingModule();
     createComponent();
-    const setItemSpy: jasmine.Spy = (TestBed.inject(WindowToken) as MockWindow).localStorage.setItem;
+    const localStorage = TestBed.inject(LocalStorage);
+    const setItemSpy = spyOn(localStorage, 'setItem');
     component.dismiss();
     expect(setItemSpy).toHaveBeenCalledWith('aio-notification/survey-january-2018', 'hide');
   });
@@ -105,26 +106,10 @@ describe('NotificationComponent', () => {
 
   it('should not show the notification if the there is a "hide" flag in localStorage', () => {
     configTestingModule();
-    const getItemSpy: jasmine.Spy = (TestBed.inject(WindowToken) as MockWindow).localStorage.getItem;
-    getItemSpy.and.returnValue('hide');
+    const localStorage = TestBed.inject(LocalStorage);
+    const getItemSpy = spyOn(localStorage, 'getItem').and.returnValue('hide');
     createComponent();
     expect(getItemSpy).toHaveBeenCalledWith('aio-notification/survey-january-2018');
-    expect(component.showNotification).toBe('hide');
-  });
-
-  it('should not break when cookies are disabled in the browser', () => {
-    configTestingModule();
-
-    // Simulate `window.localStorage` being inaccessible, when cookies are disabled.
-    const mockWindow: MockWindow = TestBed.inject(WindowToken);
-    Object.defineProperty(mockWindow, 'localStorage', {
-      get() { throw new Error('The operation is insecure'); },
-    });
-
-    expect(() => createComponent()).not.toThrow();
-    expect(component.showNotification).toBe('show');
-
-    component.dismiss();
     expect(component.showNotification).toBe('hide');
   });
 });
@@ -144,8 +129,4 @@ describe('NotificationComponent', () => {
   </aio-notification>`
 })
 class TestComponent {
-}
-
-class MockWindow {
-  localStorage = jasmine.createSpyObj('localStorage', ['getItem', 'setItem']);
 }

--- a/aio/src/app/layout/notification/notification.component.ts
+++ b/aio/src/app/layout/notification/notification.component.ts
@@ -1,7 +1,7 @@
 import { animate, state, style, trigger, transition } from '@angular/animations';
 import { Component, EventEmitter, HostBinding, Inject, Input, OnInit, Output } from '@angular/core';
 import { CurrentDateToken } from 'app/shared/current-date';
-import { WindowToken } from 'app/shared/window';
+import { LocalStorage } from 'app/shared/storage.service';
 
 const LOCAL_STORAGE_NAMESPACE = 'aio-notification/';
 
@@ -20,8 +20,6 @@ const LOCAL_STORAGE_NAMESPACE = 'aio-notification/';
   ]
 })
 export class NotificationComponent implements OnInit {
-  private storage: Storage;
-
   @Input() dismissOnContentClick: boolean;
   @Input() notificationId: string;
   @Input() expirationDate: string;
@@ -30,25 +28,7 @@ export class NotificationComponent implements OnInit {
   @HostBinding('@hideAnimation')
   showNotification: 'show'|'hide';
 
-  constructor(
-    @Inject(WindowToken) window: Window,
-    @Inject(CurrentDateToken) private currentDate: Date
-  ) {
-    try {
-      this.storage = window.localStorage;
-    } catch {
-      // When cookies are disabled in the browser, even trying to access
-      // `window.localStorage` throws an error. Use a no-op storage.
-      this.storage = {
-        length: 0,
-        clear: () => undefined,
-        getItem: () => null,
-        key: () => null,
-        removeItem: () => undefined,
-        setItem: () => undefined
-      };
-    }
-  }
+  constructor(@Inject(LocalStorage) private storage: Storage, @Inject(CurrentDateToken) private currentDate: Date) {}
 
   ngOnInit() {
     const previouslyHidden = this.storage.getItem(LOCAL_STORAGE_NAMESPACE + this.notificationId) === 'hide';

--- a/aio/src/app/shared/scroll.service.ts
+++ b/aio/src/app/shared/scroll.service.ts
@@ -2,6 +2,7 @@ import {DOCUMENT, Location, PlatformLocation, PopStateEvent, ViewportScroller} f
 import {Inject, Injectable, OnDestroy} from '@angular/core';
 import {fromEvent, Subject} from 'rxjs';
 import {debounceTime, takeUntil} from 'rxjs/operators';
+import {SessionStorage} from './storage.service';
 
 type ScrollPosition = [number, number];
 interface ScrollPositionPopStateEvent extends PopStateEvent {
@@ -18,7 +19,6 @@ export class ScrollService implements OnDestroy {
   private _topOffset: number|null;
   private _topOfPageElement: Element;
   private onDestroy = new Subject<void>();
-  private storage: Storage;
 
   // The scroll position which has to be restored, after a `popstate` event.
   poppedStateScrollPosition: ScrollPosition|null = null;
@@ -45,22 +45,8 @@ export class ScrollService implements OnDestroy {
 
   constructor(
       @Inject(DOCUMENT) private document: any, private platformLocation: PlatformLocation,
-      private viewportScroller: ViewportScroller, private location: Location) {
-    try {
-      this.storage = window.sessionStorage;
-    } catch {
-      // When cookies are disabled in the browser, even trying to access
-      // `window.sessionStorage` throws an error. Use a no-op storage.
-      this.storage = {
-        length: 0,
-        clear: () => undefined,
-        getItem: () => null,
-        key: () => null,
-        removeItem: () => undefined,
-        setItem: () => undefined
-      };
-    }
-
+      private viewportScroller: ViewportScroller, private location: Location,
+      @Inject(SessionStorage) private storage: Storage) {
     // On resize, the toolbar might change height, so "invalidate" the top offset.
     fromEvent(window, 'resize')
         .pipe(takeUntil(this.onDestroy))

--- a/aio/src/app/shared/storage.service.spec.ts
+++ b/aio/src/app/shared/storage.service.spec.ts
@@ -1,0 +1,37 @@
+import { Injector } from '@angular/core';
+import { LocalStorage, NoopStorage, SessionStorage, STORAGE_PROVIDERS } from './storage.service';
+import { WindowToken } from './window';
+
+[
+  ['localStorage', LocalStorage] as const,
+  ['sessionStorage', SessionStorage] as const,
+].forEach(([storagePropName, storageToken]) => {
+  let getStorageSpy: jasmine.Spy;
+  let injector: Injector;
+
+  beforeEach(() => {
+    getStorageSpy = jasmine.createSpy(`get ${storagePropName}`);
+    injector = Injector.create({
+      providers: [
+        STORAGE_PROVIDERS,
+        {
+          provide: WindowToken,
+          useValue: Object.defineProperty({}, storagePropName, { get: getStorageSpy }),
+        },
+      ],
+    });
+  });
+
+  it('should return the storage from `window`', () => {
+    const mockStorage = { mock: true } as unknown as Storage;
+    getStorageSpy.and.returnValue(mockStorage);
+
+    expect(injector.get(storageToken)).toBe(mockStorage);
+  });
+
+  it('should return a no-op storage if accessing the storage on `window` errors', () => {
+    getStorageSpy.and.throwError('Can\'t touch this!');
+
+    expect(injector.get(storageToken)).toBeInstanceOf(NoopStorage);
+  });
+});

--- a/aio/src/app/shared/storage.service.ts
+++ b/aio/src/app/shared/storage.service.ts
@@ -1,0 +1,29 @@
+import { InjectionToken, StaticProvider } from '@angular/core';
+import { WindowToken } from './window';
+
+export const LocalStorage = new InjectionToken<Storage>('LocalStorage');
+export const SessionStorage = new InjectionToken<Storage>('SessionStorage');
+
+export const STORAGE_PROVIDERS: StaticProvider[] = [
+  { provide: LocalStorage, useFactory: (win: Window) => getStorage(win, 'localStorage'), deps: [WindowToken] },
+  { provide: SessionStorage, useFactory: (win: Window) => getStorage(win, 'sessionStorage'), deps: [WindowToken] },
+];
+
+export class NoopStorage implements Storage {
+  length = 0;
+  clear() {}
+  getItem() { return null; }
+  key() { return null; }
+  removeItem() {}
+  setItem() {}
+}
+
+function getStorage(win: Window, storageType: 'localStorage' | 'sessionStorage'): Storage {
+  // When cookies are disabled in the browser, even trying to access `window[storageType]` throws an
+  // error. If so, return a no-op storage.
+  try {
+    return win[storageType];
+  } catch {
+    return new NoopStorage();
+  }
+}

--- a/aio/src/app/shared/theme-picker/theme-toggle.component.spec.ts
+++ b/aio/src/app/shared/theme-picker/theme-toggle.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconModule } from '@angular/material/icon';
 import { By } from '@angular/platform-browser';
 import { ThemeStorage, ThemeToggleComponent } from './theme-toggle.component';
 
@@ -45,7 +46,7 @@ describe('ThemeToggleComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ ThemeToggleComponent ],
-      providers: [ { provide: ThemeStorage, useClass: FakeThemeStorage } ],
+      imports: [ MatIconModule ],
     });
 
     fixture = TestBed.createComponent(ThemeToggleComponent);

--- a/aio/src/app/shared/theme-picker/theme-toggle.component.ts
+++ b/aio/src/app/shared/theme-picker/theme-toggle.component.ts
@@ -1,27 +1,8 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, Inject, Injectable } from '@angular/core';
+import { Component, Inject } from '@angular/core';
+import { LocalStorage } from 'app/shared/storage.service';
 
-/** Injectable facade around localStorage for theme preference to make testing easier. */
-@Injectable({ providedIn: 'root' })
-export class ThemeStorage {
-  getThemePreference(): string | null {
-    // Wrap localStorage access in try/catch because user agents can block localStorage. If it is
-    // blocked, we treat it as if no preference was previously stored.
-    try {
-      return localStorage.getItem('aio-theme');
-    } catch {
-      return null;
-    }
-  }
-
-  setThemePreference(isDark: boolean): void {
-    // Wrap localStorage access in try/catch because user agents can block localStorage. If it
-    // fails, we persist nothing.
-    try {
-      localStorage.setItem('aio-theme', String(isDark));
-    } catch { }
-  }
-}
+export const storageKey = 'aio-theme';
 
 @Component({
   selector: 'aio-theme-toggle',
@@ -37,7 +18,7 @@ export class ThemeStorage {
 export class ThemeToggleComponent {
   isDark = false;
 
-  constructor(@Inject(DOCUMENT) private document: Document, private readonly themeStorage: ThemeStorage) {
+  constructor(@Inject(DOCUMENT) private document: Document, @Inject(LocalStorage) private storage: Storage) {
     this.initializeThemeFromPreferences();
   }
 
@@ -48,7 +29,7 @@ export class ThemeToggleComponent {
 
   private initializeThemeFromPreferences(): void {
     // Check whether there's an explicit preference in localStorage.
-    const storedPreference = this.themeStorage.getThemePreference();
+    const storedPreference = this.storage.getItem(storageKey);
 
     // If we do have a preference in localStorage, use that. Otherwise,
     // initialize based on the prefers-color-scheme media query.
@@ -86,6 +67,6 @@ export class ThemeToggleComponent {
       customLinkElement.href = `${this.getThemeName()}-theme.css`;
     }
 
-    this.themeStorage.setThemePreference(this.isDark);
+    this.storage.setItem(storageKey, String(this.isDark));
   }
 }

--- a/aio/src/environments/environment.ts
+++ b/aio/src/environments/environment.ts
@@ -1,7 +1,7 @@
 // The file contents for the current environment will overwrite these during build.
-// The build system defaults to the dev environment which uses `environment.ts`, but if you do
+// The build system defaults to using `environment.ts`, but if you do
 // `ng build --configuration=<foo>` then `environment.<foo>.ts` will be used instead.
-// The list of which configurations maps to which file can be found in `angular.json`.
+// The list of which configuration maps to which file can be found in `angular.json`.
 
 
 export const environment = {

--- a/aio/src/styles/2-modules/_index.scss
+++ b/aio/src/styles/2-modules/_index.scss
@@ -12,6 +12,7 @@
 @forward 'cli-pages/cli-pages';
 @forward 'code/code';
 @forward 'contribute/contribute';
+@forward 'cookies-popup/cookies-popup';
 @forward 'contributor/contributor';
 @forward 'deploy-theme/deploy-theme';
 @forward 'details/details';

--- a/aio/src/styles/2-modules/_theme.scss
+++ b/aio/src/styles/2-modules/_theme.scss
@@ -7,6 +7,7 @@
 @use 'card/card-theme';
 @use 'code/code-theme';
 @use 'contributor/contributor-theme';
+@use 'cookies-popup/cookies-popup-theme';
 @use 'deploy-theme/deploy-theme';
 @use 'details/details-theme';
 @use 'errors/errors-theme';
@@ -33,6 +34,7 @@
   @include card-theme.theme($theme);
   @include code-theme.theme($theme);
   @include contributor-theme.theme($theme);
+  @include cookies-popup-theme.theme($theme);
   @include deploy-theme.theme($theme);
   @include details-theme.theme($theme);
   @include errors-theme.theme($theme);

--- a/aio/src/styles/2-modules/cookies-popup/_cookies-popup-theme.scss
+++ b/aio/src/styles/2-modules/cookies-popup/_cookies-popup-theme.scss
@@ -1,0 +1,23 @@
+@use 'sass:map';
+@use '../../constants' as c;
+@use '~@angular/material' as mat;
+
+@mixin theme($theme) {
+  $is-dark-theme: map.get($theme, is-dark);
+
+  aio-cookies-popup {
+    .cookies-popup {
+      background: if($is-dark-theme, map.get(mat.$grey-palette, 50), #252525);
+      color: if($is-dark-theme,
+        map.get(map.get(mat.$grey-palette, contrast), 50),
+        map.get(mat.$dark-theme-foreground-palette, secondary-text)
+      );
+
+      .actions {
+        .mat-button {
+          color: if($is-dark-theme, c.$blue, c.$lightblue);
+        }
+      }
+    }
+  }
+}

--- a/aio/src/styles/2-modules/cookies-popup/_cookies-popup-theme.scss
+++ b/aio/src/styles/2-modules/cookies-popup/_cookies-popup-theme.scss
@@ -16,6 +16,10 @@
       .actions {
         .mat-button {
           color: if($is-dark-theme, c.$blue, c.$lightblue);
+
+          .mat-button-focus-overlay {
+            background: if($is-dark-theme, c.$black, c.$white);
+          }
         }
       }
     }

--- a/aio/src/styles/2-modules/cookies-popup/_cookies-popup.scss
+++ b/aio/src/styles/2-modules/cookies-popup/_cookies-popup.scss
@@ -19,6 +19,10 @@ aio-cookies-popup {
       display: flex;
       justify-content: flex-end;
       margin: $inner-spacing $inner-spacing / -2 0 0;
+
+      .mat-button {
+        text-transform: uppercase;
+      }
     }
   }
 }

--- a/aio/src/styles/2-modules/cookies-popup/_cookies-popup.scss
+++ b/aio/src/styles/2-modules/cookies-popup/_cookies-popup.scss
@@ -1,0 +1,24 @@
+@use '~@angular/cdk' as cdk;
+@use '~@angular/material' as mat;
+
+$inner-spacing: 16px;
+
+aio-cookies-popup {
+  .cookies-popup {
+    @include mat.elevation(6);
+    border-radius: 4px;
+    bottom: 0;
+    left: 0;
+    position: fixed;
+    margin: 24px;
+    max-width: 430px;
+    padding: $inner-spacing $inner-spacing $inner-spacing / 2;
+    z-index: cdk.$overlay-container-z-index + 1;
+
+    .actions {
+      display: flex;
+      justify-content: flex-end;
+      margin: $inner-spacing $inner-spacing / -2 0 0;
+    }
+  }
+}

--- a/aio/tests/e2e/src/app.po.ts
+++ b/aio/tests/e2e/src/app.po.ts
@@ -9,6 +9,7 @@ export class SitePage {
   docsMenuLink = element(by.cssContainingText('aio-top-menu a', 'Docs'));
   sidenav = element(by.css('mat-sidenav'));
   docViewer = element(by.css('aio-doc-viewer'));
+  cookiesPopup = element(by.css('.cookies-popup'));
   codeExample = element.all(by.css('aio-doc-viewer pre > code'));
   ghLinks = this.docViewer
     .all(by.css('a'))
@@ -39,10 +40,15 @@ export class SitePage {
   ga() { return browser.executeScript<any[][]>('return window["ga"].q'); }
   locationPath() { return browser.executeScript<string>('return document.location.pathname'); }
 
-  async navigateTo(pageUrl: string) {
-    // Navigate to the page, disable animations, and wait for Angular.
+  async navigateTo(pageUrl: string, keepCookiesPopup = false) {
+    // Navigate to the page, disable animations, potentially hide the cookies popup, and wait for
+    // Angular.
     await browser.get(`/${pageUrl.replace(/^\//, '')}`);
     await browser.executeScript('document.body.classList.add(\'no-animations\')');
+    if (!keepCookiesPopup) {
+      // Hide the cookies popup to prevent it from obscuring other elements.
+      await browser.executeScript('arguments[0].remove()', this.cookiesPopup);
+    }
     await browser.waitForAngular();
   }
 

--- a/aio/tests/e2e/src/cookies-popup.e2e-spec.ts
+++ b/aio/tests/e2e/src/cookies-popup.e2e-spec.ts
@@ -1,0 +1,53 @@
+import { browser, by } from 'protractor';
+import { SitePage } from './app.po';
+
+describe('cookies popup', () => {
+  const getButton = (idx: number) => page.cookiesPopup.all(by.css('.actions .mat-button')).get(idx);
+  let page: SitePage;
+
+  beforeEach(async () => {
+    page = new SitePage();
+    await page.navigateTo('', true);
+  });
+
+  afterEach(() => browser.executeScript('localStorage.clear()'));
+
+  it('should be shown by default', async () => {
+    expect(await page.cookiesPopup.isDisplayed()).toBe(true);
+  });
+
+  it('should open a new tab with more info when clicking the first button', async () => {
+    // Click the "Learn more" button.
+    await page.click(getButton(0));
+
+    // Switch to the newly opened tab.
+    const originalWindowHandle = await browser.getWindowHandle();
+    const openedWindowHandle = (await browser.getAllWindowHandles()).pop() as string;
+    await browser.switchTo().window(openedWindowHandle);
+    await browser.waitForAngularEnabled(false);
+
+    // Verify the tab's URL.
+    expect(await browser.getCurrentUrl()).toBe('https://policies.google.com/technologies/cookies');
+
+    // Close the tab and switch back to the original tab.
+    await browser.waitForAngularEnabled(true);
+    await browser.close();
+    await browser.switchTo().window(originalWindowHandle);
+  });
+
+  it('should not hide the popup when clicking the first button', async () => {
+    await page.click(getButton(0));
+
+    expect(await page.cookiesPopup.isDisplayed()).toBe(true);
+  });
+
+  it('should hide the popup when clicking the second button', async () => {
+    expect(await page.cookiesPopup.isDisplayed()).toBe(true);
+
+    await page.click(getButton(1));
+    expect(await page.cookiesPopup.isPresent()).toBe(false);
+
+    await page.navigateTo('', true);
+    expect(await page.cookiesPopup.isPresent()).toBe(false);
+  });
+});

--- a/aio/tsconfig.json
+++ b/aio/tsconfig.json
@@ -16,7 +16,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2017",
     "module": "es2020",
     "lib": [
       "es2018",

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -2,18 +2,18 @@
   "aio": {
     "master": {
       "uncompressed": {
-        "runtime-es2015": 4619,
-        "main-es2015": 453855,
-        "polyfills-es2015": 55210
+        "runtime-es2017": 4619,
+        "main-es2017": 454043,
+        "polyfills-es2017": 55210
       }
     }
   },
   "aio-local": {
     "master": {
       "uncompressed": {
-        "runtime-es2015": 4619,
-        "main-es2015": 453981,
-        "polyfills-es2015": 55291
+        "runtime-es2017": 4619,
+        "main-es2017": 454178,
+        "polyfills-es2017": 55348
       }
     }
   }

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2017": 4619,
-        "main-es2017": 454043,
+        "main-es2017": 454003,
         "polyfills-es2017": 55210
       }
     }
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2017": 4619,
-        "main-es2017": 454178,
+        "main-es2017": 454138,
         "polyfills-es2017": 55348
       }
     }

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2017": 4619,
-        "main-es2017": 454003,
+        "main-es2017": 456795,
         "polyfills-es2017": 55210
       }
     }
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2017": 4619,
-        "main-es2017": 454138,
+        "main-es2017": 456930,
         "polyfills-es2017": 55348
       }
     }


### PR DESCRIPTION
This commit adds a popup to angular.io to inform the user about the use of cookies. Once the user confirms having read the info, the popup will not be shown on subsequent visits.

This commit is partly based on angular/material.angular.io#988.

Fixes #42209.