### PR TITLE
docs: clarify location.subscribe behavior

### DIFF
--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -30,7 +30,7 @@ export interface PopStateEvent {
  *
  * @usageNotes
  *
- * It's better to use the `Router#navigate` service to trigger route changes. Use
+ * It's better to use the `Router.navigate()` service to trigger route changes. Use
  * `Location` only if you need to interact with or create normalized URLs outside of
  * routing.
  *
@@ -228,8 +228,13 @@ export class Location {
   /**
    * Subscribes to the platform's `popState` events.
    *
+   * Note: `Location.go()` does not trigger the `popState` event in the browser. Use
+   * `Location.onUrlChange()` to subscribe to URL changes instead.
+   *
    * @param value Event that is triggered when the state history changes.
    * @param exception The exception to throw.
+   *
+   * @see [onpopstate](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onpopstate)
    *
    * @returns Subscribed events.
    */


### PR DESCRIPTION
`Location.go` does not trigger the browser's `popstate` event because
the Angular Router uses `pushState` and `replaceState`. This can be
confusing when calling `Location.go` and using `Location.subscribe`.
This commit clarifies the behavior of `Location.subscribe` and points
developers to the `onUrlChanges` subscription instead.

Fixes #12691