### PR TITLE
docs: asynchronous test spy method

### DIFF
--- a/aio/content/examples/testing/src/app/model/hero.service.spec.ts
+++ b/aio/content/examples/testing/src/app/model/hero.service.spec.ts
@@ -20,20 +20,23 @@ describe ('HeroesService (with spies)', () => {
     heroService = new HeroService(httpClientSpy as any);
   });
 
-  it('should return expected heroes (HttpClient called once)', () => {
+  it('should return expected heroes (HttpClient called once)', (done: DoneFn) => {
     const expectedHeroes: Hero[] =
       [{ id: 1, name: 'A' }, { id: 2, name: 'B' }];
 
     httpClientSpy.get.and.returnValue(asyncData(expectedHeroes));
 
     heroService.getHeroes().subscribe(
-      heroes => expect(heroes).toEqual(expectedHeroes, 'expected heroes'),
-      fail
+      heroes => {
+        expect(heroes).toEqual(expectedHeroes, 'expected heroes');
+        done();
+      },
+      done.fail
     );
     expect(httpClientSpy.get.calls.count()).toBe(1, 'one call');
   });
 
-  it('should return an error when the server returns a 404', () => {
+  it('should return an error when the server returns a 404', (done: DoneFn) => {
     const errorResponse = new HttpErrorResponse({
       error: 'test 404 error',
       status: 404, statusText: 'Not Found'
@@ -42,8 +45,11 @@ describe ('HeroesService (with spies)', () => {
     httpClientSpy.get.and.returnValue(asyncError(errorResponse));
 
     heroService.getHeroes().subscribe(
-      heroes => fail('expected an error, not heroes'),
-      error  => expect(error.message).toContain('test 404 error')
+      heroes => done.fail('expected an error, not heroes'),
+      error  => {
+        expect(error.message).toContain('test 404 error');
+        done();
+      }
     );
   });
   // #enddocregion test-with-spies


### PR DESCRIPTION
fixes two `HeroService` tests that were synchronously testing an asynchronous spy method

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

It fixes two unit tests

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Two of the unit tests for `HeroService` use the `asyncData` and `asyncError` unit testing utility functions. These functions return observables that emit asynchronously.

```ts
// async-observable-helpers.ts (exerpt)

export function asyncData<T>(data: T) {
  return defer(() => Promise.resolve(data));
}

export function asyncError<T>(errorObject: any) {
  return defer(() => Promise.reject(errorObject));
}
```

However, the unit tests treat the observables as though they emit synchronously.

To illustrate the behavior I created a [StackBlitz](https://stackblitz.com/edit/spec-has-no-expectations?file=src/app/model/hero.service.spec.ts) that isolates the two tests. The result of running the two tests is:

![image](https://user-images.githubusercontent.com/18009315/119374121-33c3aa00-bc87-11eb-849f-106dd4fd9104.png)

Issue Number: N/A

## What is the new behavior?

The tests work correctly and account for the asynchronous nature of the observable.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
