### PR TITLE
docs: clarify onSameUrlNavigation behavior

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -470,8 +470,16 @@ export class Router {
 
   /**
    * How to handle a navigation request to the current URL. One of:
+   *
    * - `'ignore'` :  The router ignores the request.
    * - `'reload'` : The router reloads the URL. Use to implement a "refresh" feature.
+   *
+   * Note that this only configures whether the Route reprocesses the URL and triggers related
+   * action and events like redirects, guards, and resolvers. By default, the router re-uses a
+   * component instance when it re-navigates to the same component type without visiting a different
+   * component first. This behavior is configured by the `RouteReuseStrategy`. In order to reload
+   * routed components on same url navigation, you need to set `onSameUrlNavigation` to `'reload'`
+   * _and_ provide a `RouteReuseStrategy` which returns `false` for `shouldReuseRoute`.
    */
   onSameUrlNavigation: 'reload'|'ignore' = 'ignore';
 


### PR DESCRIPTION
`onSameUrlNavigation` only affects whether the Angular Router
processes the URL and runs it through the navigation pipeline,
retriggering redirects, guards, and resolvers. The name `reload` is a
little confusing because it does _not_ reload the component. Developers
_also_ need to implement a custom `RouteReuseStrategy` to trigger a
component reload on same URL navigation.

Fixes #21115
