### PR TITLE
docs: in toh-pt5, navigate back to home page after going to `/heroes`

### DIFF
--- a/aio/content/tutorial/toh-pt5.md
+++ b/aio/content/tutorial/toh-pt5.md
@@ -133,6 +133,9 @@ The route path to `HeroesComponent` is `/heroes`.
 Append `/heroes` to the URL in the browser address bar.
 You should see the familiar heroes master/detail view.
 
+Remove `/heroes` from the URL in the browser address bar.
+The browser should refresh and display the application title but not the list of heroes.
+
 {@a routerlink}
 
 ## Add a navigation link (`routerLink`)


### PR DESCRIPTION
This fixes an issue in part 5 of the Tour of Heroes tutorial on
angular.io. At the end of the `Add RouterOutlet` section, the reader navigates to
`"/heroes"`. The next section, `Add a navigation link`, instructs the user to click ona link on the dashboard page to navigate to the heroes page. This is problematic because the previous section instructed the reader to navigate to the heroes page, not the dashboard. It assumes, the reader is on the dashboard page.

Fixes issue by instructing the reader to navigate back to the dashboard
after navigating to `"/heroes"` in the `Add RouterOutlet` section.

resolves #41212
