### PR TITLE
docs: add small clarity around navigationCancel

### DIFF
--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -134,7 +134,7 @@ export class NavigationEnd extends RouterEvent {
 
 /**
  * An event triggered when a navigation is canceled, directly or indirectly.
- * This can happen when a route guard
+ * This can happen for several reasons including when a route guard
  * returns `false` or initiates a redirect by returning a `UrlTree`.
  *
  * @see `NavigationStart`


### PR DESCRIPTION
Add small clarity to sentence in documentation for navigation cancel event
to indicate that router guards returning false or urlTree is only one of
several reasons a NavigationCancel event happens.

fixes #26613
