### PR TITLE
build(docs-infra): temporarily serve the DevTools guide at `/devtools` too

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -136,7 +136,11 @@
       {"type": 301, "source": "/strict", "destination": "/guide/strict-mode"},
 
       // Use discoverable link for Angular DevTools and redirect to the guide page
-      {"type": 301, "source": "/devtools", "destination": "/guide/devtools"}
+      {"type": 301, "source": "/devtools", "destination": "/guide/devtools"},
+
+      // Temporarily serve the guide at `/devtools` as well as `/guide/devtools` until users have
+      // their SW updated to a version that knows about the `/devtools` redirect.
+      {"type": 302, "source": "/generated/docs/devtools.json", "destination": "/generated/docs/guide/devtools.json"}
     ],
     "rewrites": [
       {


### PR DESCRIPTION
The latest SW app version knows that `/devtools` should be redirected to `/guide/devtools`. However, if a user has an older app version installed (and until the SW downloads the latest version) they will get a 404 when navigating to `/devtools`.

The reason is that the SW will see `/devtools` as a regular navigation URL and serve `index.html` instead. The Angular app will then try to get the content for `/devtools` by fetching `/generated/docs/devtools.json` (which does not exist).

This commit fixes the issue by redirecting `/generated/docs/devtools.json` to `/geenrated/docs/guide/devtools.json`. When a user visits `/devtools` for the first time, they will still be able to see the guide content (while the SW updates in the background). On subsequent visits (once the SW has downloaded the latest app version), they will be redirected to `/guide/devtools`).

At a later time, once we are confident that the majority of users will have updated to a newer app version, we can remove this temporary redirect.
