### PR TITLE
docs: unsubscribe from observables

### DIFF
--- a/aio/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts
+++ b/aio/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts
@@ -3,6 +3,7 @@
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { first } from 'rxjs/operators';
 
 import { addMatchers, click } from '../../testing';
 import { Hero } from '../model/hero';
@@ -18,7 +19,7 @@ describe('DashboardHeroComponent class only', () => {
     const hero: Hero = {id: 42, name: 'Test'};
     comp.hero = hero;
 
-    comp.selected.subscribe((selectedHero: Hero) => expect(selectedHero).toBe(hero));
+    comp.selected.pipe(first()).subscribe((selectedHero: Hero) => expect(selectedHero).toBe(hero));
     comp.click();
   });
   // #enddocregion class-only
@@ -69,7 +70,7 @@ describe('DashboardHeroComponent when tested directly', () => {
   // #docregion click-test
   it('should raise selected event when clicked (triggerEventHandler)', () => {
     let selectedHero: Hero | undefined;
-    comp.selected.subscribe((hero: Hero) => selectedHero = hero);
+    comp.selected.pipe(first()).subscribe((hero: Hero) => selectedHero = hero);
 
     // #docregion trigger-event-handler
     heroDe.triggerEventHandler('click', null);
@@ -81,7 +82,7 @@ describe('DashboardHeroComponent when tested directly', () => {
   // #docregion click-test-2
   it('should raise selected event when clicked (element.click)', () => {
     let selectedHero: Hero | undefined;
-    comp.selected.subscribe((hero: Hero) => selectedHero = hero);
+    comp.selected.pipe(first()).subscribe((hero: Hero) => selectedHero = hero);
 
     heroEl.click();
     expect(selectedHero).toBe(expectedHero);
@@ -89,16 +90,24 @@ describe('DashboardHeroComponent when tested directly', () => {
   // #enddocregion click-test-2
 
   // #docregion click-test-3
-  it('should raise selected event when clicked (click helper)', () => {
+  it('should raise selected event when clicked (click helper with DebugElement)', () => {
     let selectedHero: Hero | undefined;
-    comp.selected.subscribe((hero: Hero) => selectedHero = hero);
+    comp.selected.pipe(first()).subscribe((hero: Hero) => selectedHero = hero);
 
     click(heroDe);  // click helper with DebugElement
-    click(heroEl);  // click helper with native element
 
     expect(selectedHero).toBe(expectedHero);
   });
   // #enddocregion click-test-3
+
+  it('should raise selected event when clicked (click helper with native element)', () => {
+    let selectedHero: Hero | undefined;
+    comp.selected.pipe(first()).subscribe((hero: Hero) => selectedHero = hero);
+
+    click(heroEl);  // click helper with native element
+
+    expect(selectedHero).toBe(expectedHero);
+  });
 });
 
 //////////////////


### PR DESCRIPTION
Add rxjs `first` operator in `DashboardHeroComponent` unit tests to ensure unsubscription from observables

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

This PR ensures that observables in the `DashboardHeroComponent` are unsubscribed from using the `first` operator.

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Several `DashboardHeroComponent` unit tests subscribe to the component's `selected` Event Emitter, which is an observable. However, the tests do not perform adequate cleanup, so the observables never complete.

Issue Number: N/A


## What is the new behavior?

The observable completes in each unit test

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I created this [StackBlitz](https://stackblitz.com/edit/angular-6r4mde?file=src%2Fapp%2Fdashboard%2Fdashboard-hero.component.spec.ts) which contains two sample tests. The first test demonstrates how an observable is subscribe to but does not complete (`COMPLETE 1` is never logged). The second test uses the `first()` operator and logs `COMPLETE 2` to the console when the observable completes.
