### PR TITLE
docs: clarify pathMatch strategy prefix

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -396,8 +396,12 @@ export interface Route {
    * Default is 'prefix'.
    *
    * By default, the router checks URL elements from the left to see if the URL
-   * matches a given  path, and stops when there is a match. For example,
-   * '/team/11/user' matches 'team/:id'.
+   * matches a given path and stops when there is a config match. Importantly there must still be a
+   * config match for each segment of the URL. For example, '/team/11/user' matches the prefix
+   * 'team/:id' if one of the route's children matches the segment 'user'. That is, the URL
+   * '/team/11/user` matches the config
+   * `{path: 'team/:id', children: [{path: ':user', component: User}]}`
+   * but does not match when there are no children as in `{path: 'team/:id', component: Team}`.
    *
    * The path-match strategy 'full' matches against the entire URL.
    * It is important to do this when redirecting empty-path routes.


### PR DESCRIPTION
This commit clarifies the description of the default `pathMatch`
strategy (prefix) to indicate that the path segments must each match to
a config.

fixes #39737
