### PR TITLE
docs: fix documentation of guard execution order

### DIFF
--- a/aio/content/guide/router-tutorial-toh.md
+++ b/aio/content/guide/router-tutorial-toh.md
@@ -1942,8 +1942,8 @@ The router supports multiple guard interfaces:
 
 
 You can have multiple guards at every level of a routing hierarchy.
-The router checks the `CanDeactivate` and `CanActivateChild` guards first, from the deepest child route to the top.
-Then it checks the `CanActivate` guards from the top down to the deepest child route.
+The router checks the `CanDeactivate` guards first, from the deepest child route to the top.
+Then it checks the `CanActivate` and `CanActivateChild` guards from the top down to the deepest child route.
 If the feature module is loaded asynchronously, the `CanLoad` guard is checked before the module is loaded.
 If _any_ guard returns false, pending guards that have not completed will be canceled, and the entire navigation is canceled.
 


### PR DESCRIPTION
The current documentation of the `CanDeactivate`, `CanActivate`, and
`CanActivateChild` guard execution order is incorrect. This commit
corrects the documentation. For reference, see https://stackblitz.com/edit/angular-canactivatechild-nqp1f7

Fixes #28082
