### PR TITLE
docs: clarify the definition of the bundle bundget defaults with strict mode

### DIFF
--- a/aio/content/guide/build.md
+++ b/aio/content/guide/build.md
@@ -215,10 +215,10 @@ Each budget entry is a JSON object with the following properties:
     The type of budget. One of:
 
 * `bundle` - The size of a specific bundle.
-* `initial` - The initial size of the app.
+* `initial` - The size of JavaScript needed for bootstrapping the application. Defaults to warning @ 500kb and erroring @ 1mb.
 * `allScript` - The size of all scripts.
 * `all` - The size of the entire app.
-* `anyComponentStyle` - This size of any one component stylesheet.
+* `anyComponentStyle` - This size of any one component stylesheet. Defaults to warning @ 2kb and erroring at 4kb.
 * `anyScript` - The size of any one script.
 * `any` - The size of any file.
 

--- a/aio/content/guide/build.md
+++ b/aio/content/guide/build.md
@@ -215,10 +215,10 @@ Each budget entry is a JSON object with the following properties:
     The type of budget. One of:
 
 * `bundle` - The size of a specific bundle.
-* `initial` - The size of JavaScript needed for bootstrapping the application. Defaults to warning @ 500kb and erroring @ 1mb.
+* `initial` - The size of JavaScript needed for bootstrapping the application. Defaults to warning @ 500kb and erroring at 1mb.
 * `allScript` - The size of all scripts.
 * `all` - The size of the entire app.
-* `anyComponentStyle` - This size of any one component stylesheet. Defaults to warning @ 2kb and erroring at 4kb.
+* `anyComponentStyle` - This size of any one component stylesheet. Defaults to warning at 2kb and erroring at 4kb.
 * `anyScript` - The size of any one script.
 * `any` - The size of any file.
 

--- a/aio/content/guide/strict-mode.md
+++ b/aio/content/guide/strict-mode.md
@@ -5,11 +5,11 @@ Angular CLI creates all new workspaces and projects with **strict mode** enabled
 Strict mode improves maintainability and helps you catch bugs ahead of time.
 Additionally, strict mode applications are easier to statically analyze and can help the `ng update` command refactor code more safely and precisely when you are updating to future versions of Angular.
 
-Specifically, strict mode does the following:
+Specifically, strict mode affects newly generated applications in the following way:
 
 * Enables [`strict` mode in TypeScript](https://www.typescriptlang.org/tsconfig#strict), as well as other strictness flags recommended by the TypeScript team. Specifically, `forceConsistentCasingInFileNames`, `noImplicitReturns`,  `noFallthroughCasesInSwitch`.
 * Turns on strict Angular compiler flags [`strictTemplates`](guide/angular-compiler-options#stricttemplates), [`strictInjectionParameters`](guide/angular-compiler-options#strictinjectionparameters) and [`strictInputAccessModifiers`](guide/template-typecheck#troubleshooting-template-errors).
-* [Bundle size budgets](guide/build#configuring-size-budgets) have been reduced by ~75%.
+* Reduces the [bundle size budgets](guide/build#configuring-size-budgets) for the `initial` and `anyComponentStyle` budget types by 75% compared to the previous defaults.
 
 You can apply these settings at the workspace and project level.
 


### PR DESCRIPTION
Previously we didn't clarify that the stricter defaults have no impact on existing
projects, and we also didn't define the default values for bundle budgets.

Fixes #41966