### PR TITLE
docs: fix ng-for link in structural-directives.md

### DIFF
--- a/aio/content/guide/structural-directives.md
+++ b/aio/content/guide/structural-directives.md
@@ -8,7 +8,7 @@ For the example application that this page describes, see the <live-example></li
 
 </div>
 
-For more information on Angular's built-in structural directives, such as `NgIf`, `NgFor`, and `NgSwitch`, see [Built-in directives](guide/built-in-directives).
+For more information on Angular's built-in structural directives, such as `NgIf`, `NgForOf`, and `NgSwitch`, see [Built-in directives](guide/built-in-directives).
 
 {@a unless}
 


### PR DESCRIPTION
Correctly the reference to ng-for as `NgForOf` so that we get the word linked to the API page.

`NgFor` is not a JavaScript symbol so the docs infra doesn't autolink to the API page unless
we use the correct symbol name - `NgForOf`.

Before:

<img width="873" alt="Screen Shot 2021-05-24 at 3 36 35 PM" src="https://user-images.githubusercontent.com/216296/119415149-e3a81000-bca5-11eb-8683-8240f1f84d41.png">
