### PR TITLE
docs(router): Update documentation to not state that guards and resol…

### DIFF
--- a/aio/content/examples/router/src/app/crisis-center/crisis-detail-resolver.service.ts
+++ b/aio/content/examples/router/src/app/crisis-center/crisis-detail-resolver.service.ts
@@ -7,7 +7,7 @@ import {
   ActivatedRouteSnapshot
 } from '@angular/router';
 import { Observable, of, EMPTY } from 'rxjs';
-import { mergeMap, take } from 'rxjs/operators';
+import { mergeMap } from 'rxjs/operators';
 
 import { CrisisService } from './crisis.service';
 import { Crisis } from './crisis';
@@ -22,7 +22,6 @@ export class CrisisDetailResolverService implements Resolve<Crisis> {
     const id = route.paramMap.get('id')!;
 
     return this.cs.getCrisis(id).pipe(
-      take(1),
       mergeMap(crisis => {
         if (crisis) {
           return of(crisis);

--- a/aio/content/guide/router-tutorial-toh.md
+++ b/aio/content/guide/router-tutorial-toh.md
@@ -2415,9 +2415,7 @@ Inject the `CrisisService` and `Router` and implement the `resolve()` method.
 That method could return a `Promise`, an `Observable`, or a synchronous return value.
 
 The `CrisisService.getCrisis()` method returns an observable in order to prevent the route from loading until the data is fetched.
-The `Router` guards require an observable to `complete`, which means it has emitted all
-of its values.
-You use the `take` operator with an argument of `1` to ensure that the `Observable` completes after retrieving the first value from the Observable returned by the `getCrisis()` method.
+The `Router` guards and resolvers do not require an observable to `complete`. Instead, the Router takes the first value emitted from the `Observable` returned by guards and resolvers.
 
 If it doesn't return a valid `Crisis`, then return an empty `Observable`, cancel the previous in-progress navigation to the `CrisisDetailComponent`, and navigate the user back to the `CrisisListComponent`.
 The updated resolver service looks like this:

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -382,6 +382,8 @@ export type CanDeactivateFn<T> =
  * ```
  * The order of execution is: BaseGuard, ChildGuard, BaseDataResolver, ChildDataResolver.
  *
+ * @see [Pre-fetching component data](guide/router-tutorial-toh#resolve-pre-fetching-component-data)
+ *
  * @publicApi
  */
 export interface Resolve<T> {


### PR DESCRIPTION
…vers must complete

Internally, the Router code uses `first` on all `Observable` return
values from guards and resolvers. There is no need for user code to have
additional `take(1)` and the documentation should no longer state that
the `Observable` must `complete`.

Resolves #21537 by clarifying in the tutorial what the behavior is for
`Observable` return values. The tutorial also explains through example how this
result is read from `data`.
