### PR TITLE
fix(docs-infra): increase the opacity of background-color for inline `code` blocks

### DIFF
--- a/aio/src/styles/2-modules/_code.scss
+++ b/aio/src/styles/2-modules/_code.scss
@@ -171,7 +171,7 @@ aio-code {
 
   :not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(pre) {
     > code {
-      background-color: rgba($lightgray, 0.5);
+      background-color: rgba($lightgray, 0.3);
       border-radius: 4px;
       color: $deepgray;
       padding: 0 4px;


### PR DESCRIPTION
Fixes #41196

I intentionally kept the font size as is, because it's already about the same size between regular text and code-formatted text.

before:
<img width="847" alt="Screen Shot 2021-05-24 at 3 51 38 PM" src="https://user-images.githubusercontent.com/216296/119419935-20790480-bcb0-11eb-9f29-66b1ab4305c2.png">


after:
<img width="850" alt="Screen Shot 2021-05-24 at 4 48 47 PM" src="https://user-images.githubusercontent.com/216296/119419948-24a52200-bcb0-11eb-8374-31d88c423313.png">
