### PR TITLE
docs: update date pipe api reference to indicate it is a pure pipe

### DIFF
--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -16,6 +16,14 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  * @description
  *
  * Formats a date value according to locale rules.
+ * 
+ * `DatePipe` is executed only when it detects a pure change to the input value.
+ * A pure change is either a change to a primitive input value
+ * (such as `String`, `Number`, `Boolean`, or `Symbol`),
+ * or a changed object reference (such as `Date`, `Array`, `Function`, or `Object`).
+ *
+ * Note that mutating a `Date` object does not cause the pipe to be rendered again.
+ * To ensure that the pipe is executed, you must create a new `Date` object.
  *
  * Only the `en-US` locale data comes with Angular. To localize dates
  * in another language, you must import the corresponding locale data.


### PR DESCRIPTION
This note was included in #37099 but the PR was closed without being merged.

Fixes #33897
