### PR TITLE
docs: update wording for angular libraries mapping peer dependencies

### DIFF
--- a/aio/content/guide/creating-libraries.md
+++ b/aio/content/guide/creating-libraries.md
@@ -157,7 +157,7 @@ For example, `main` should point at a JavaScript file, not a TypeScript file.
 
 ### Use TypeScript path mapping for peer dependencies
 
-Angular libraries should list all `@angular/*` dependencies as peer dependencies.
+Angular libraries should list any `@angular/*` dependencies the library depends on as peer dependencies.
 This ensures that when modules ask for Angular, they all get the exact same module.
 If a library lists `@angular/core` in `dependencies` instead of `peerDependencies`, it might get a different Angular module instead, which would cause your application to break.
 


### PR DESCRIPTION
Update the wording for Angular Libraries mapping of peer dependencies to make
it clearer that only the parts of @angular/* that the library depends on
should be marked as peer dependencies.

Closes #37304
