### PR TITLE
docs: remove `entryComponents` references from the custom elements guide

### DIFF
--- a/aio/content/examples/elements/src/app/app.module.ts
+++ b/aio/content/examples/elements/src/app/app.module.ts
@@ -6,16 +6,11 @@ import { AppComponent } from './app.component';
 import { PopupComponent } from './popup.component';
 import { PopupService } from './popup.service';
 
-// Include the `PopupService` provider,
-// but exclude `PopupComponent` from compilation,
-// because it will be added dynamically.
-
 @NgModule({
   imports: [BrowserModule, BrowserAnimationsModule],
   providers: [PopupService],
   declarations: [AppComponent, PopupComponent],
   bootstrap: [AppComponent],
-  entryComponents: [PopupComponent],
 })
 export class AppModule {
 }

--- a/aio/content/guide/elements.md
+++ b/aio/content/guide/elements.md
@@ -147,9 +147,9 @@ Using an Angular custom element makes the process much simpler and more transpar
 The Popup Service example application (shown below) defines a component that you can either load dynamically or convert to a custom element.
 
 - `popup.component.ts` defines a simple pop-up element that displays an input message, with some animation and styling.
-- `popup.service.ts` creates an injectable service that provides two different ways to invoke the PopupComponent; as a dynamic component, or as a custom element. Notice how much more setup is required for the dynamic-loading method.
-- `app.module.ts` adds the PopupComponent in the module's `entryComponents` list, to exclude it from compilation and avoid startup warnings or errors.
-- `app.component.ts` defines the application's root component, which uses the PopupService to add the pop-up to the DOM at run time. When the application runs, the root component's constructor converts PopupComponent to a custom element.
+- `popup.service.ts` creates an injectable service that provides two different ways to invoke the `PopupComponent`; as a dynamic component, or as a custom element. Notice how much more setup is required for the dynamic-loading method.
+- `app.module.ts` adds the `PopupComponent` in the module's `declarations` list.
+- `app.component.ts` defines the application's root component, which uses the `PopupService` to add the pop-up to the DOM at run time. When the application runs, the root component's constructor converts `PopupComponent` to a custom element.
 
 For comparison, the demo shows both methods. One button adds the popup using the dynamic-loading method, and the other uses the custom element. You can see that the result is the same; only the preparation is different.
 


### PR DESCRIPTION
Since the `entryComponents` field is deprecated and no longer used in Ivy, this commit removes `entryComponents` references from the custom elements guide.

Closes #40341.


## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No