### PR TITLE
docs: provide more info on the `NO_ERRORS_SCHEMA` schema

### DIFF
--- a/aio/content/examples/testing/src/app/about/about.component.spec.ts
+++ b/aio/content/examples/testing/src/app/about/about.component.spec.ts
@@ -1,4 +1,4 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AboutComponent } from './about.component';
@@ -11,7 +11,7 @@ describe('AboutComponent (highlightDirective)', () => {
   beforeEach(() => {
     fixture = TestBed.configureTestingModule({
       declarations: [ AboutComponent, HighlightDirective ],
-      schemas:      [ NO_ERRORS_SCHEMA ]
+      schemas:      [ CUSTOM_ELEMENTS_SCHEMA ]
     })
     .createComponent(AboutComponent);
     fixture.detectChanges(); // initial binding

--- a/packages/core/src/metadata/schema.ts
+++ b/packages/core/src/metadata/schema.ts
@@ -35,6 +35,10 @@ export const CUSTOM_ELEMENTS_SCHEMA: SchemaMetadata = {
 /**
  * Defines a schema that allows any property on any element.
  *
+ * This schema allows you to ignore the errors related to any unknown elements or properties in a
+ * template. The usage of this schema is generally discouraged because it prevents useful validation
+ * and may hide real errors in your template. Consider using the `CUSTOM_ELEMENTS_SCHEMA` instead.
+ *
  * @publicApi
  */
 export const NO_ERRORS_SCHEMA: SchemaMetadata = {


### PR DESCRIPTION
The `NO_ERRORS_SCHEMA` schema can be used to ignore errors related to unknown elements or properties, but since it suppresses these errors it may also hide real problems in a template. This commit updates the `NO_ERRORS_SCHEMA` docs to mention that.

Closes #39454.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No