### PR TITLE
docs: move the schematics under Angular Tools menu section

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -413,27 +413,6 @@
           ]
         },
         {
-          "title": "Schematics",
-          "tooltip": "Understanding schematics.",
-          "children": [
-            {
-              "url": "guide/schematics",
-              "title": "Schematics Overview",
-              "tooltip": "Extending CLI generation capabilities."
-            },
-            {
-              "url": "guide/schematics-authoring",
-              "title": "Authoring Schematics",
-              "tooltip": "Understand the structure of a schematic."
-            },
-            {
-              "url": "guide/schematics-for-libraries",
-              "title": "Schematics for Libraries",
-              "tooltip": "Use schematics to integrate your library with the Angular CLI."
-            }
-          ]
-        },
-        {
           "title": "Service Workers & PWA",
           "tooltip": "Angular service workers: Controlling caching of application resources.",
           "children": [
@@ -572,6 +551,27 @@
           "title": "DevTools",
           "tooltip": "DevTools",
           "url": "guide/devtools"
+        },
+        {
+          "title": "Schematics",
+          "tooltip": "Understanding schematics.",
+          "children": [
+            {
+              "url": "guide/schematics",
+              "title": "Schematics Overview",
+              "tooltip": "Extending CLI generation capabilities."
+            },
+            {
+              "url": "guide/schematics-authoring",
+              "title": "Authoring Schematics",
+              "tooltip": "Understand the structure of a schematic."
+            },
+            {
+              "url": "guide/schematics-for-libraries",
+              "title": "Schematics for Libraries",
+              "tooltip": "Use schematics to integrate your library with the Angular CLI."
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
In #39176 Alan noted that schematics is currently misplaced and should really be under the Angular Tools menu item.

In that issue, Alan also noted the "Angular Compiler" and "Angular CLI" are not refereced from here.
Since the issue was created "Angular Compiler" has already been moved under "Angular Tools".

Angular CLI is documented throughout the docs, and the "CLI Command Reference" under References is really just a reference
so it seems correctly located.

Fixes #39176