### PR TITLE
docs: fix `BannerComponent` unit tests

### DIFF
--- a/aio/content/examples/testing/src/app/banner/banner-external.component.spec.ts
+++ b/aio/content/examples/testing/src/app/banner/banner-external.component.spec.ts
@@ -28,11 +28,9 @@ describe('BannerComponent (external files)', () => {
   describe('Two beforeEach', () => {
     // #docregion async-before-each
     beforeEach(async () => {
-      TestBed
-          .configureTestingModule({
-            declarations: [ BannerComponent ],
-          })
-          .compileComponents();  // compile template and css
+      await TestBed.configureTestingModule({
+        declarations: [ BannerComponent ],
+      }).compileComponents();  // compile template and css
     });
     // #enddocregion async-before-each
 

--- a/aio/content/examples/testing/src/app/banner/banner-external.component.spec.ts
+++ b/aio/content/examples/testing/src/app/banner/banner-external.component.spec.ts
@@ -10,12 +10,27 @@ describe('BannerComponent (external files)', () => {
   let fixture: ComponentFixture<BannerComponent>;
   let h1: HTMLElement;
 
+  describe('setup that may fail', () => {
+    // #docregion setup-may-fail
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        declarations: [ BannerComponent ],
+      }); // missing call to compileComponents()
+      fixture = TestBed.createComponent(BannerComponent);
+    });
+    // #enddocregion setup-may-fail
+
+    it('should create', () => {
+      expect(fixture.componentInstance).toBeDefined();
+    });
+  });
+
   describe('Two beforeEach', () => {
     // #docregion async-before-each
     beforeEach(async () => {
       TestBed
           .configureTestingModule({
-            declarations: [BannerComponent],
+            declarations: [ BannerComponent ],
           })
           .compileComponents();  // compile template and css
     });
@@ -37,7 +52,7 @@ describe('BannerComponent (external files)', () => {
     // #docregion one-before-each
     beforeEach(async () => {
       await TestBed.configureTestingModule({
-        declarations: [BannerComponent],
+        declarations: [ BannerComponent ],
       }).compileComponents();
       fixture = TestBed.createComponent(BannerComponent);
       component = fixture.componentInstance;

--- a/aio/content/examples/testing/src/app/banner/banner.component.spec.ts
+++ b/aio/content/examples/testing/src/app/banner/banner.component.spec.ts
@@ -11,18 +11,15 @@ describe('BannerComponent (inline template)', () => {
   let fixture: ComponentFixture<BannerComponent>;
   let h1: HTMLElement;
 
-  // #docregion configure-and-create
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       declarations: [ BannerComponent ],
     });
     fixture = TestBed.createComponent(BannerComponent);
-    // #enddocregion configure-and-create
     component = fixture.componentInstance; // BannerComponent test instance
     h1 = fixture.nativeElement.querySelector('h1');
-    // #docregion configure-and-create
   });
-  // #enddocregion setup, configure-and-create
+  // #enddocregion setup
 
   // #docregion test-w-o-detect-changes
   it('no title in the DOM after createComponent()', () => {

--- a/aio/content/guide/testing-components-scenarios.md
+++ b/aio/content/guide/testing-components-scenarios.md
@@ -1469,9 +1469,9 @@ the following version of the `BannerComponent` does.
 The test fails when the `TestBed` tries to create the component.
 
 <code-example
-  path="testing/src/app/banner/banner.component.spec.ts"
-  region="configure-and-create"
-  header="app/banner/banner.component.spec.ts (setup that fails)"
+  path="testing/src/app/banner/banner-external.component.spec.ts"
+  region="setup-may-fail"
+  header="app/banner/banner-external.component.spec.ts (setup that fails)"
   avoid></code-example>
 
 Recall that the application hasn't been compiled.


### PR DESCRIPTION
remove `async` and `await` from `BannerComponent` test because the
component uses an inline template and styles

create new region in `banner-external.component.spec.ts` demonstrating
test setup that may fail due to a missing call to `.compileComponents()`
for a component with an external template and stylesheet

resolves #42325

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #42325


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
