### PR TITLE
fix(dev-infra): build with stamping for release builds

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -5180,15 +5180,9 @@ function buildReleaseOutput(stampForRelease = false) {
  */
 /** Yargs command builder for configuring the `ng-dev release build` command. */
 function builder$7(argv) {
-    return argv
-        .option('json', {
+    return argv.option('json', {
         type: 'boolean',
         description: 'Whether the built packages should be printed to stdout as JSON.',
-        default: false,
-    })
-        .option('stampForRelease', {
-        type: 'boolean',
-        description: 'Whether the built packages should be stamped for release.',
         default: false,
     });
 }
@@ -5196,7 +5190,7 @@ function builder$7(argv) {
 function handler$7(args) {
     return tslib.__awaiter(this, void 0, void 0, function* () {
         const { npmPackages } = getReleaseConfig();
-        let builtPackages = yield buildReleaseOutput(args.stampForRelease);
+        let builtPackages = yield buildReleaseOutput(true);
         // If package building failed, print an error and exit with an error code.
         if (builtPackages === null) {
             error(red(`  ✘   Could not build release output. Please check output above.`));

--- a/dev-infra/release/build/cli.ts
+++ b/dev-infra/release/build/cli.ts
@@ -17,28 +17,21 @@ import {buildReleaseOutput} from './index';
 /** Command line options for building a release. */
 export interface ReleaseBuildOptions {
   json: boolean;
-  stampForRelease: boolean;
 }
 
 /** Yargs command builder for configuring the `ng-dev release build` command. */
 function builder(argv: Argv): Argv<ReleaseBuildOptions> {
-  return argv
-      .option('json', {
-        type: 'boolean',
-        description: 'Whether the built packages should be printed to stdout as JSON.',
-        default: false,
-      })
-      .option('stampForRelease', {
-        type: 'boolean',
-        description: 'Whether the built packages should be stamped for release.',
-        default: false,
-      });
+  return argv.option('json', {
+    type: 'boolean',
+    description: 'Whether the built packages should be printed to stdout as JSON.',
+    default: false,
+  });
 }
 
 /** Yargs command handler for building a release. */
 async function handler(args: Arguments<ReleaseBuildOptions>) {
   const {npmPackages} = getReleaseConfig();
-  let builtPackages = await buildReleaseOutput(args.stampForRelease);
+  let builtPackages = await buildReleaseOutput(true);
 
   // If package building failed, print an error and exit with an error code.
   if (builtPackages === null) {


### PR DESCRIPTION
`ng-dev release build` should always build with version stamping rather than
snapshot stamping.
