### PR TITLE
docs: clarify providedIn options

### DIFF
--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -64,9 +64,15 @@ export interface InjectableDecorator {
  */
 export interface Injectable {
   /**
-   * Determines which injectors will provide the injectable,
-   * by either associating it with an `@NgModule` or other `InjectorType`,
-   * or by specifying that this injectable should be provided in one of the following injectors:
+   * Determines which injectors will provide the injectable.
+   *
+   * - `Type<any>` - associates the injectable with an `@NgModule` or other `InjectorType`,
+   * - 'null' : Equivalent to `undefined`. The injectable is not provided in any scope automatically
+   * and must be added to a `providers` array of an [@NgModule](api/core/NgModule#providers),
+   * [@Component](api/core/Directive#providers) or [@Directive](api/core/Directive#providers).
+   *
+   * The following options specify that this injectable should be provided in one of the following
+   * injectors:
    * - 'root' : The application-level injector in most apps.
    * - 'platform' : A special singleton platform injector shared by all
    * applications on the page.


### PR DESCRIPTION
The list for the possible options of providedIn was not totally clear. This commit ensures each possible value is included explicitly in the docs.

fixes #29330
