### PR TITLE
build: use wombat-dressing-room proxy for publishing releases

### DIFF
--- a/scripts/release/publish-latest
+++ b/scripts/release/publish-latest
@@ -20,5 +20,5 @@ $BAZEL build --config=release $NPM_PACKAGE_LABELS
 # publish all packages in sequence to make it easier to spot any errors or warnings
 for packageLabel in $NPM_PACKAGE_LABELS; do
   echo "publishing $packageLabel"
-  $BAZEL run --config=release -- ${packageLabel}.publish --access public --tag latest
+  $BAZEL run --config=release -- ${packageLabel}.publish --access public --tag latest --registry https://wombat-dressing-room.appspot.com
 done

--- a/scripts/release/publish-next
+++ b/scripts/release/publish-next
@@ -20,5 +20,5 @@ $BAZEL build --config=release $NPM_PACKAGE_LABELS
 # publish all packages in sequence to make it easier to spot any errors or warnings
 for packageLabel in $NPM_PACKAGE_LABELS; do
   echo "publishing $packageLabel"
-  $BAZEL run --config=release -- ${packageLabel}.publish --access public --tag next
+  $BAZEL run --config=release -- ${packageLabel}.publish --access public --tag next --registry https://wombat-dressing-room.appspot.com
 done


### PR DESCRIPTION
In the scripts to release latest and next, use the npm proxy for publishing the
release.
