### PR TITLE
build(docs-infra): align code with new CLI v12 apps

### DIFF
--- a/aio/angular.json
+++ b/aio/angular.json
@@ -11,16 +11,19 @@
   "newProjectRoot": "projects",
   "projects": {
     "site": {
-      "root": "",
-      "sourceRoot": "src",
       "projectType": "application",
-      "prefix": "aio",
       "schematics": {
+        "@schematics/angular:application": {
+          "strict": true
+        },
         "@schematics/angular:component": {
           "inlineStyle": true,
           "style": "scss"
         }
       },
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "aio",
       "architect": {
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
@@ -64,16 +67,18 @@
             "scripts": [],
             "budgets": [
               {
+                "type": "initial",
+                "maximumWarning": "850kb",
+                "maximumError": "1mb"
+              },
+              {
                 "type": "anyComponentStyle",
-                "maximumWarning": "6kb"
+                "maximumWarning": "2kb",
+                "maximumError": "4kb"
               }
             ]
           },
           "configurations": {
-            "fast": {
-              "buildOptimizer": false,
-              "optimization": false
-            },
             "next": {
               "fileReplacements": [
                 {
@@ -112,18 +117,20 @@
             },
             "ci": {
               "progress": false
+            },
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "outputHashing": "none",
+              "vendorChunk": true,
+              "extractLicenses": false
             }
-          }
+          },
+          "defaultConfiguration": "stable"
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
-          "options": {
-            "browserTarget": "site:build"
-          },
           "configurations": {
-            "fast": {
-              "browserTarget": "site:build:fast"
-            },
             "next": {
               "browserTarget": "site:build:next"
             },
@@ -138,8 +145,12 @@
             },
             "ci": {
               "browserTarget": "site:build:ci"
+            },
+            "development": {
+              "browserTarget": "site:build:development"
             }
-          }
+          },
+          "defaultConfiguration": "development"
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",

--- a/aio/package.json
+++ b/aio/package.json
@@ -11,7 +11,7 @@
     "aio-use-npm": "node tools/ng-packages-installer restore .",
     "aio-check-local": "node tools/ng-packages-installer check .",
     "ng": "yarn check-env && ng",
-    "start": "yarn check-env && ng serve --configuration=fast",
+    "start": "yarn check-env && ng serve",
     "prebuild": "yarn setup",
     "build": "yarn ~~build",
     "prebuild-local": "yarn setup-local",

--- a/aio/src/environments/environment.ts
+++ b/aio/src/environments/environment.ts
@@ -1,7 +1,7 @@
 // The file contents for the current environment will overwrite these during build.
-// The build system defaults to the dev environment which uses `environment.ts`, but if you do
+// The build system defaults to using `environment.ts`, but if you do
 // `ng build --configuration=<foo>` then `environment.<foo>.ts` will be used instead.
-// The list of which configurations maps to which file can be found in `angular.json`.
+// The list of which configuration maps to which file can be found in `angular.json`.
 
 
 export const environment = {

--- a/aio/tsconfig.json
+++ b/aio/tsconfig.json
@@ -16,7 +16,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2017",
     "module": "es2020",
     "lib": [
       "es2018",

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -2,18 +2,18 @@
   "aio": {
     "master": {
       "uncompressed": {
-        "runtime-es2015": 4619,
-        "main-es2015": 453855,
-        "polyfills-es2015": 55210
+        "runtime-es2017": 4619,
+        "main-es2017": 454043,
+        "polyfills-es2017": 55210
       }
     }
   },
   "aio-local": {
     "master": {
       "uncompressed": {
-        "runtime-es2015": 4619,
-        "main-es2015": 453981,
-        "polyfills-es2015": 55291
+        "runtime-es2017": 4619,
+        "main-es2017": 454178,
+        "polyfills-es2017": 55348
       }
     }
   }


### PR DESCRIPTION
This PR aligns the angular.io config files more closely to how a newly generated CLI v12 app would look like. This helps validate the setup and makes it easier to apply new chages in the future (by preventing the angular.io layout from deviating too much from the default new app layout).
