### PR TITLE
docs: add selector documentation for `ViewChildren`, `ContentChildren`, and `ContentChild`

### DIFF
--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -154,6 +154,20 @@ export interface ContentChildrenDecorator {
    *   removed in future versions of Angular.
    * * **read** - Used to read a different token from the queried elements.
    *
+   * The following selectors are supported.
+   *   * Any class with the `@Component` or `@Directive` decorator
+   *   * A template reference variable as a string (e.g. query `<my-component #cmp></my-component>`
+   * with `@ContentChildren('cmp')`)
+   *   * Any provider defined in the child component tree of the current component (e.g.
+   * `@ContentChildren(SomeService) someService: SomeService`)
+   *   * Any provider defined through a string token (e.g. `@ContentChildren('someToken')
+   * someTokenVal: any`)
+   *   * A `TemplateRef` (e.g. query `<ng-template></ng-template>` with
+   * `@ContentChildren(TemplateRef) template;`)
+   *
+   * In addition, multiple string selectors can be separated with a comma (e.g.
+   * `@ContentChildren('cmp1,cmp2')`)
+   *
    * The following values are supported by `read`:
    *   * Any class with the `@Component` or `@Directive` decorator
    *   * Any provider defined on the injector of the component that is matched by the `selector` of
@@ -237,6 +251,17 @@ export interface ContentChildDecorator {
    * * **static** - True to resolve query results before change detection runs,
    * false to resolve after change detection. Defaults to false.
    *
+   * The following selectors are supported.
+   *   * Any class with the `@Component` or `@Directive` decorator
+   *   * A template reference variable as a string (e.g. query `<my-component #cmp></my-component>`
+   * with `@ContentChild('cmp')`)
+   *   * Any provider defined in the child component tree of the current component (e.g.
+   * `@ContentChild(SomeService) someService: SomeService`)
+   *   * Any provider defined through a string token (e.g. `@ContentChild('someToken') someTokenVal:
+   * any`)
+   *   * A `TemplateRef` (e.g. query `<ng-template></ng-template>` with `@ContentChild(TemplateRef)
+   * template;`)
+   *
    * The following values are supported by `read`:
    *   * Any class with the `@Component` or `@Directive` decorator
    *   * Any provider defined on the injector of the component that is matched by the `selector` of
@@ -306,6 +331,20 @@ export interface ViewChildrenDecorator {
    *   if the QueryList has not changed.
    *   ** Note: *** This config option is **deprecated**, it will be permanently set to `true` and
    * removed in future versions of Angular.
+   *
+   * The following selectors are supported.
+   *   * Any class with the `@Component` or `@Directive` decorator
+   *   * A template reference variable as a string (e.g. query `<my-component #cmp></my-component>`
+   * with `@ViewChildren('cmp')`)
+   *   * Any provider defined in the child component tree of the current component (e.g.
+   * `@ViewChildren(SomeService) someService: SomeService`)
+   *   * Any provider defined through a string token (e.g. `@ViewChildren('someToken') someTokenVal:
+   * any`)
+   *   * A `TemplateRef` (e.g. query `<ng-template></ng-template>` with `@ViewChildren(TemplateRef)
+   * template;`)
+   *
+   * In addition, multiple string selectors can be separated with a comma (e.g.
+   * `@ViewChildren('cmp1,cmp2')`)
    *
    * The following values are supported by `read`:
    *   * Any class with the `@Component` or `@Directive` decorator


### PR DESCRIPTION


These notes are copied from `ViewChild`. In addition, `ContentChildren` and `ViewChildren`
can specify multiple string selectors by separating each selector by a
comma.

fixes #21734
