### PR TITLE
docs: add a note about the ngc command and command line options

### DIFF
--- a/aio/content/guide/angular-compiler-options.md
+++ b/aio/content/guide/angular-compiler-options.md
@@ -221,3 +221,14 @@ When you use the CLI command `ng new --strict`, it is set to `true` in the gener
 ### `trace`
 
 When `true`, prints extra information while compiling templates. Default is `false`.
+
+
+{@a cli-options}
+## Command Line Options
+
+While most of the time you interact with the Angular Compiler indirectly using Angular CLI, when debugging certain issues, you might find it useful to invoke the Angular Compiler directly.
+You can use the `ngc` command provided by the `@angular/compiler-cli` npm package to call the compiler from the command line.
+
+The `ngc` command is just a wrapper around TypeScript's `tsc` compiler command and is primarily configured via the `tsconfig.json` configuration options documented in [the previous sections](#angular-compiler-options).
+
+In addition to the configuration file, you can also use [`tsc` command line options](https://www.typescriptlang.org/docs/handbook/compiler-options.html) to configure `ngc`.


### PR DESCRIPTION
It turns out that we don't document anywhere how ngc works and what options we support.
I added a brief section, without going too much into details because most users should not need to use ngc directly.

I also came across some bug in `ngc` and filed #42372.

Fixes #29623

