### PR TITLE
docs(forms): make the reactive forms guide specify more clearly discuss mixing HTML5 native validators with Angular forms.

### DIFF
--- a/aio/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.html
+++ b/aio/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.html
@@ -4,9 +4,7 @@
 <!-- #enddocregion ng-submit -->
   <label>
     First Name:
-    <!-- #docregion required-attribute -->
     <input type="text" formControlName="firstName" required>
-    <!-- #enddocregion required-attribute -->
   </label>
 
   <label>

--- a/aio/content/guide/form-validation.md
+++ b/aio/content/guide/form-validation.md
@@ -351,3 +351,7 @@ With reactive forms, set the property in the `FormControl` instance.
 ```typescript
 new FormControl('', {updateOn: 'blur'});
 ```
+
+## Interaction with native HTML form validation
+
+By default, Angular disables [native HTML form validation](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Constraint_validation) by adding the `novalidate` attribute on the enclosing `<form>` and uses directives to match these attributes with validator functions in the framework. If you want to use native validation **in combination** with Angular-based validation, you can re-enable it with the `ngNativeValidate` directive. See the [API docs](https://angular.io/api/forms/NgForm#native-dom-validation-ui) for details.

--- a/aio/content/guide/reactive-forms.md
+++ b/aio/content/guide/reactive-forms.md
@@ -379,16 +379,6 @@ In the `ProfileEditor` component, add the `Validators.required` static method as
 
 </code-example>
 
-HTML5 has a set of built-in attributes that you can use for native validation, including `required`, `minlength`, and `maxlength`. You can take advantage of these optional attributes on your form input elements. Add the `required` attribute to the `firstName` input element.
-
-<code-example path="reactive-forms/src/app/profile-editor/profile-editor.component.html" region="required-attribute" header="src/app/profile-editor/profile-editor.component.html (required attribute)"></code-example>
-
-<div class="alert is-important">
-
-**Caution:** Use these HTML5 validation attributes *in combination with* the built-in validators provided by Angular's reactive forms. Using these in combination prevents errors when the expression is changed after the template has been checked.
-
-</div>
-
 **Display form status**
 
 When you add a required field to the form control, its initial status is invalid. This invalid status propagates to the parent form group element, making its status invalid. Access the current status of the form group instance through its `status` property.


### PR DESCRIPTION
I have added a couple lines in the appropriate spot clarifying this issue.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Reactive forms allow the use of HTML5 native validators, but there is a gotcha: `novalidate` is added to the enclosing form, disabling the native HTML5 behavior. Previously, the docs didn't say anything about that, or how to override that behavior. 

Issue Number: 39549


## What is the new behavior?

The docs now specify that `novalidate` is added to the enclosing form, and native validation can be re-enabled with the `ngNativeValidate` directive.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Closes #39549
