### PR TITLE
fix(forms): add dataType and resolved minMax validator issue

### DIFF
--- a/goldens/public-api/forms/forms.d.ts
+++ b/goldens/public-api/forms/forms.d.ts
@@ -336,26 +336,26 @@ export declare class FormsModule {
 }
 
 export declare class MaxLengthValidator implements Validator, OnChanges {
-    maxlength: string | number;
+    maxlength: string | number | null;
     ngOnChanges(changes: SimpleChanges): void;
     registerOnValidatorChange(fn: () => void): void;
     validate(control: AbstractControl): ValidationErrors | null;
 }
 
 export declare class MaxValidator extends AbstractValidatorDirective implements OnChanges {
-    max: string | number;
+    max: string | number | null;
     ngOnChanges(changes: SimpleChanges): void;
 }
 
 export declare class MinLengthValidator implements Validator, OnChanges {
-    minlength: string | number;
+    minlength: string | number | null;
     ngOnChanges(changes: SimpleChanges): void;
     registerOnValidatorChange(fn: () => void): void;
     validate(control: AbstractControl): ValidationErrors | null;
 }
 
 export declare class MinValidator extends AbstractValidatorDirective implements OnChanges {
-    min: string | number;
+    min: string | number | null;
     ngOnChanges(changes: SimpleChanges): void;
 }
 
@@ -449,7 +449,7 @@ export declare class NumberValueAccessor extends ɵangular_packages_forms_forms_
 }
 
 export declare class PatternValidator implements Validator, OnChanges {
-    pattern: string | RegExp;
+    pattern: string | RegExp | null;
     ngOnChanges(changes: SimpleChanges): void;
     registerOnValidatorChange(fn: () => void): void;
     validate(control: AbstractControl): ValidationErrors | null;

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -167,14 +167,19 @@ export const MAX_VALIDATOR: StaticProvider = {
   selector:
       'input[type=number][max][formControlName],input[type=number][max][formControl],input[type=number][max][ngModel]',
   providers: [MAX_VALIDATOR],
-  host: {'[attr.max]': 'max ?? null'}
+  host: {
+    '[attr.max]': 'max ?? null'
+  }  // if `this.max` is falsy (including "", 0 and null) this attribute is not added to the DOM
+     // element
 })
 export class MaxValidator extends AbstractValidatorDirective implements OnChanges {
   /**
    * @description
    * Tracks changes to the max bound to this directive.
    */
-  @Input() max!: string|number;
+  @Input()
+  max!: string|number|
+      null;  // This input is always defined (but may be `null`), since the name matches selector.
   /** @internal */
   inputName = 'max';
   /** @internal */
@@ -227,14 +232,19 @@ export const MIN_VALIDATOR: StaticProvider = {
   selector:
       'input[type=number][min][formControlName],input[type=number][min][formControl],input[type=number][min][ngModel]',
   providers: [MIN_VALIDATOR],
-  host: {'[attr.min]': 'min ?? null'}
+  host: {
+    '[attr.min]': 'min ?? null'
+  }  // if `this.min` is falsy (including "", 0 and null) this attribute is not added to the DOM
+     // element
 })
 export class MinValidator extends AbstractValidatorDirective implements OnChanges {
   /**
    * @description
    * Tracks changes to the min bound to this directive.
    */
-  @Input() min!: string|number;
+  @Input()
+  min!: string|number|
+      null;  // This input is always defined (but may be `null`), since the name matches selector.
   /** @internal */
   inputName = 'min';
   /** @internal */
@@ -338,7 +348,10 @@ export const CHECKBOX_REQUIRED_VALIDATOR: StaticProvider = {
   selector:
       ':not([type=checkbox])[required][formControlName],:not([type=checkbox])[required][formControl],:not([type=checkbox])[required][ngModel]',
   providers: [REQUIRED_VALIDATOR],
-  host: {'[attr.required]': 'required ? "" : null'}
+  host: {
+    '[attr.required]': 'required ? "" : null'
+  }  // if `this.required` is falsy (including "", 0 and null) this attribute is not added to the
+     // DOM element
 })
 export class RequiredValidator implements Validator {
   private _required = false;
@@ -402,7 +415,10 @@ export class RequiredValidator implements Validator {
   selector:
       'input[type=checkbox][required][formControlName],input[type=checkbox][required][formControl],input[type=checkbox][required][ngModel]',
   providers: [CHECKBOX_REQUIRED_VALIDATOR],
-  host: {'[attr.required]': 'required ? "" : null'}
+  host: {
+    '[attr.required]': 'required ? "" : null'
+  }  // if `this.required` is falsy (including "", 0 and null) this attribute is not added to the
+     // DOM element
 })
 export class CheckboxRequiredValidator extends RequiredValidator {
   /**
@@ -540,7 +556,10 @@ export const MIN_LENGTH_VALIDATOR: any = {
 @Directive({
   selector: '[minlength][formControlName],[minlength][formControl],[minlength][ngModel]',
   providers: [MIN_LENGTH_VALIDATOR],
-  host: {'[attr.minlength]': 'minlength ? minlength : null'}
+  host: {
+    '[attr.minlength]': 'minlength ? minlength : null'
+  }  // if `this.minlength` is falsy (including "", 0 and null) this attribute is not added to the
+     // DOM element
 })
 export class MinLengthValidator implements Validator, OnChanges {
   private _validator: ValidatorFn = nullValidator;
@@ -551,7 +570,8 @@ export class MinLengthValidator implements Validator, OnChanges {
    * Tracks changes to the minimum length bound to this directive.
    */
   @Input()
-  minlength!: string|number;  // This input is always defined, since the name matches selector.
+  minlength!: string|number|
+      null;  // This input is always defined (but may be `null`), since the name matches selector.
 
   /** @nodoc */
   ngOnChanges(changes: SimpleChanges): void {
@@ -579,8 +599,14 @@ export class MinLengthValidator implements Validator, OnChanges {
   }
 
   private _createValidator(): void {
-    this._validator = minLengthValidator(
-        typeof this.minlength === 'number' ? this.minlength : parseInt(this.minlength, 10));
+    // Enable validation only for truthy values.
+    // Note that `0` will result in no validation.
+    if (this.minlength) {
+      this._validator = minLengthValidator(
+          typeof this.minlength === 'number' ? this.minlength : parseInt(this.minlength, 10));
+    } else {
+      this._validator = nullValidator;
+    }
   }
 }
 
@@ -618,7 +644,10 @@ export const MAX_LENGTH_VALIDATOR: any = {
 @Directive({
   selector: '[maxlength][formControlName],[maxlength][formControl],[maxlength][ngModel]',
   providers: [MAX_LENGTH_VALIDATOR],
-  host: {'[attr.maxlength]': 'maxlength ? maxlength : null'}
+  host: {
+    '[attr.maxlength]': 'maxlength ? maxlength : null'
+  }  // if `this.maxlength` is falsy (including "", 0 and null) this attribute is not added to the
+     // DOM element
 })
 export class MaxLengthValidator implements Validator, OnChanges {
   private _validator: ValidatorFn = nullValidator;
@@ -629,7 +658,8 @@ export class MaxLengthValidator implements Validator, OnChanges {
    * Tracks changes to the maximum length bound to this directive.
    */
   @Input()
-  maxlength!: string|number;  // This input is always defined, since the name matches selector.
+  maxlength!: string|number|
+      null;  // This input is always defined (but may be `null`), since the name matches selector.
 
   /** @nodoc */
   ngOnChanges(changes: SimpleChanges): void {
@@ -656,8 +686,14 @@ export class MaxLengthValidator implements Validator, OnChanges {
   }
 
   private _createValidator(): void {
-    this._validator = maxLengthValidator(
-        typeof this.maxlength === 'number' ? this.maxlength : parseInt(this.maxlength, 10));
+    // Enable validation only for truthy values.
+    // Note that `0` will result in no validation.
+    if (this.maxlength) {
+      this._validator = maxLengthValidator(
+          typeof this.maxlength === 'number' ? this.maxlength : parseInt(this.maxlength, 10));
+    } else {
+      this._validator = nullValidator;
+    }
   }
 }
 
@@ -698,7 +734,10 @@ export const PATTERN_VALIDATOR: any = {
 @Directive({
   selector: '[pattern][formControlName],[pattern][formControl],[pattern][ngModel]',
   providers: [PATTERN_VALIDATOR],
-  host: {'[attr.pattern]': 'pattern ? pattern : null'}
+  host: {
+    '[attr.pattern]': 'pattern ? pattern : null'
+  }  // if `this.pattern` is falsy (including "", 0 and null) this attribute is not added to the DOM
+     // element
 })
 export class PatternValidator implements Validator, OnChanges {
   private _validator: ValidatorFn = nullValidator;
@@ -709,7 +748,8 @@ export class PatternValidator implements Validator, OnChanges {
    * Tracks changes to the pattern bound to this directive.
    */
   @Input()
-  pattern!: string|RegExp;  // This input is always defined, since the name matches selector.
+  pattern!: string|RegExp|
+      null;  // This input is always defined (but may be `null`), since the name matches selector.
 
   /** @nodoc */
   ngOnChanges(changes: SimpleChanges): void {
@@ -736,6 +776,12 @@ export class PatternValidator implements Validator, OnChanges {
   }
 
   private _createValidator(): void {
-    this._validator = patternValidator(this.pattern);
+    // Enable validation only for truthy values.
+    // Note that `0` will result in no validation.
+    if (this.pattern) {
+      this._validator = patternValidator(this.pattern);
+    } else {
+      this._validator = nullValidator;
+    }
   }
 }

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -2529,6 +2529,83 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
                .toEqual(2, `Expected original observable to be canceled on the next value change.`);
          }));
 
+      describe('null validation', () => {
+        it('should remove attribute min and max if value is null', () => {
+          const control = new FormControl();
+          @Component({
+            selector: 'min-max-null',
+            template: `
+              <form [formGroup]="form">
+                <input formControlName="control" [min]="null" [max]="null" randomAttribute="randomValue">
+              </form>
+            `
+          })
+          class MinMaxComponent {
+              form = new FormGroup({control: new FormControl()});
+          }
+
+          const fixture = initTest(MinMaxComponent);
+
+          const minAttribute = fixture.debugElement.query(By.css('[min]'));
+          expect(minAttribute).toBeNull();
+
+          const maxAttribute = fixture.debugElement.query(By.css('[max]'));
+          expect(maxAttribute).toBeNull();
+
+          const randomAttribute = fixture.debugElement.query(By.css('[randomAttribute]'));
+          expect(randomAttribute).toBeDefined();
+        });
+
+        it('should remove attribute pattern if value is null', () => {
+          const control = new FormControl();
+          @Component({
+            selector: 'pattern-null',
+            template: `
+              <form [formGroup]="form">
+                <input formControlName="control" [pattern]="null" randomAttribute="randomValue">
+              </form>
+            `
+          })
+          class PatternComponent {
+              form = new FormGroup({control: new FormControl()});
+          }
+
+          const fixture = initTest(PatternComponent);
+
+          const patternAttribute = fixture.debugElement.query(By.css('[pattern]'));
+          expect(patternAttribute).toBeNull();
+
+          const randomAttribute = fixture.debugElement.query(By.css('[randomAttribute]'));
+          expect(randomAttribute).toBeDefined();
+        });
+
+        it('should remove attribute minLength and maxLength if value is null', () => {
+          const control = new FormControl();
+          @Component({
+            selector: 'min-max-length-null',
+            template: `
+              <form [formGroup]="form">
+                <input formControlName="control" randomAttribute="randomValue" [minLength]="null" [maxLength]="null">
+              </form>
+            `
+          })
+          class MinMaxLengthComponent {
+            form = new FormGroup({control: new FormControl()});
+          }
+
+          const fixture = initTest(MinMaxLengthComponent);
+
+          const randomAttribute = fixture.debugElement.query(By.css('[randomAttribute]'));
+          expect(randomAttribute).toBeDefined();
+
+          const minLengthAttribute = fixture.debugElement.query(By.css('[minlength]'));
+          expect(minLengthAttribute).toBeNull();
+
+          const maxLenghtAttribute = fixture.debugElement.query(By.css('[maxlength]'));
+          expect(maxLenghtAttribute).toBeNull();
+        });
+      });
+
       describe('min and max validators', () => {
         function getComponent(dir: string): Type<MinMaxFormControlComp|MinMaxFormControlNameComp> {
           return dir === 'formControl' ? MinMaxFormControlComp : MinMaxFormControlNameComp;

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -9,10 +9,11 @@
 import {ɵgetDOM as getDOM} from '@angular/common';
 import {Component, Directive, forwardRef, Input, Type, ViewChild} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from '@angular/core/testing';
-import {AbstractControl, AsyncValidator, COMPOSITION_BUFFER_MODE, ControlValueAccessor, FormControl, FormsModule, MaxValidator, MinValidator, NG_ASYNC_VALIDATORS, NG_VALIDATORS, NG_VALUE_ACCESSOR, NgForm, NgModel, Validator} from '@angular/forms';
+import {AbstractControl, AsyncValidator, COMPOSITION_BUFFER_MODE, ControlValueAccessor, FormControl, FormsModule, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, NG_ASYNC_VALIDATORS, NG_VALIDATORS, NG_VALUE_ACCESSOR, NgForm, NgModel, Validator} from '@angular/forms';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {dispatchEvent, sortedClassList} from '@angular/platform-browser/testing/src/browser_util';
 import {merge} from 'rxjs';
+import {PatternValidator} from '../src/forms';
 
 import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integration_spec';
 
@@ -1858,6 +1859,73 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            expect(maxValidateFnSpy).not.toHaveBeenCalled();
            expect(minValidateFnSpy).not.toHaveBeenCalled();
          }));
+
+      describe('null validation', () => {
+        it('should not include the min and max validators for null', fakeAsync(() => {
+             @Component({template: '<input type="input" [min]="null" [max]="null">'})
+             class AppComponent {
+             }
+
+             const fixture = initTest(AppComponent);
+             const maxValidateFnSpy = spyOn(MaxValidator.prototype, 'validate');
+             const minValidateFnSpy = spyOn(MinValidator.prototype, 'validate');
+
+             fixture.detectChanges();
+             tick();
+
+             const maxValidator = fixture.debugElement.query(By.directive(MaxValidator));
+             expect(maxValidator).toBeNull();
+
+             const minValidator = fixture.debugElement.query(By.directive(MinValidator));
+             expect(minValidator).toBeNull();
+
+             expect(maxValidateFnSpy).not.toHaveBeenCalled();
+             expect(minValidateFnSpy).not.toHaveBeenCalled();
+                
+           }));
+
+        it('should not include the pattern validators for null', fakeAsync(() => {
+             @Component({template: '<input type="input" [pattern]="null">'})
+             class AppComponent {
+             }
+
+             const fixture = initTest(AppComponent);
+             const patternValidateFnSpy = spyOn(PatternValidator.prototype, 'validate');
+
+             fixture.detectChanges();
+             tick();
+
+             const patternValidator = fixture.debugElement.query(By.directive(PatternValidator));
+             expect(patternValidator).toBeNull();
+
+             expect(patternValidateFnSpy).not.toHaveBeenCalled();
+           }));
+
+        it('should not include the minLength and maxLength validators for null', fakeAsync(() => {
+             @Component({template: '<input type="input" [minLength]="null" [maxLength]="null">'})
+             class AppComponent {
+             }
+
+             const fixture = initTest(AppComponent);
+             const maxLengthValidateFnSpy = spyOn(MaxLengthValidator.prototype, 'validate');
+             const minLenghtValidateFnSpy = spyOn(MinLengthValidator.prototype, 'validate');
+
+             fixture.detectChanges();
+             tick();
+
+             const maxLengthValidator =
+                 fixture.debugElement.query(By.directive(MinLengthValidator));
+             expect(maxLengthValidator).toBeNull();
+
+             const minLengthValidator =
+                 fixture.debugElement.query(By.directive(MaxLengthValidator));
+             expect(minLengthValidator).toBeNull();
+
+             expect(maxLengthValidateFnSpy).not.toHaveBeenCalled();
+             expect(minLenghtValidateFnSpy).not.toHaveBeenCalled();
+                    
+           }));
+      });
 
       ['number', 'string'].forEach((inputType: string) => {
         it(`should validate min and max when constraints are represented using a ${inputType}`,


### PR DESCRIPTION
Added data type of null and undefined for validators and resolved issue where min and max validator wasn't working when value was

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Right now angular app isn't working in strict mode when any validator value is set to null also when min and max validator value is set to 0 it's misbheaving

Issue Number: #42267 


## What is the new behavior?
Added data type of null and undefined in validator where it was required and now min and max validator is working for 0 as well

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
