### PR TITLE
build: allow Node.js v15 and above for local development

### DIFF
--- a/aio/tools/examples/shared/package.json
+++ b/aio/tools/examples/shared/package.json
@@ -12,7 +12,7 @@
   },
   "//engines-comment": "Keep this in sync with /package.json and /aio/package.json",
   "engines": {
-    "node": "^12.20.0 || ^14.0.0",
+    "node": "^12.20.0 || >=14.0.0",
     "yarn": ">=1.21.1 <2",
     "npm": "Please use yarn instead of NPM to install dependencies"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "//engines-comment": "Keep this in sync with /aio/package.json and /aio/tools/examples/shared/package.json",
   "engines": {
-    "node": "^12.20.0 || ^14.0.0",
+    "node": "^12.20.0 || >=14.0.0",
     "yarn": ">=1.22.4 <2",
     "npm": "Please use yarn instead of NPM to install dependencies"
   },


### PR DESCRIPTION
Changes the `engines` rule in `package.json` to also accept Node.js version greater than v14. This allows Node.js v15 and v16 (current) to work for local development in the `angular/angular` repo.

Related to #42367.
