### PR TITLE
docs: clarify the wording around live examples for all testing guides

### DIFF
--- a/aio/content/examples/testing/stackblitz.json
+++ b/aio/content/examples/testing/stackblitz.json
@@ -10,9 +10,7 @@
 
     "src/app/**/*.css",
     "src/app/**/*.html",
-    "src/app/**/*.ts",
-
-    "!src/**/*.spec.ts"
+    "src/app/**/*.ts"
   ],
   "tags": ["testing"],
   "devDependencies": ["jasmine-core", "jasmine-marbles"]

--- a/aio/content/guide/test-debugging.md
+++ b/aio/content/guide/test-debugging.md
@@ -2,15 +2,6 @@
 
 If your tests aren't working as you expect them to, you can inspect and debug them in the browser.
 
-<div class="alert is-helpful">
-
-  For the sample application that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
-
-  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
-
-</div>
-
-
 Debug specs in the browser in the same way that you debug an application.
 
 1. Reveal the Karma browser window. See [Set up testing](guide/testing#set-up-testing) if you need help with this step.

--- a/aio/content/guide/testing-attribute-directives.md
+++ b/aio/content/guide/testing-attribute-directives.md
@@ -10,7 +10,7 @@ Its name reflects the way the directive is applied: as an attribute on a host el
 
   For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  Similarly, you can also <live-example name="testing" embedded-style noDownload>run and explore the application</live-example> that this testing guides describes.
+  Similarly, you can also <live-example name="testing" noDownload>run and explore the application</live-example> that this testing guides describes.
 
 </div>
 

--- a/aio/content/guide/testing-attribute-directives.md
+++ b/aio/content/guide/testing-attribute-directives.md
@@ -10,7 +10,7 @@ Its name reflects the way the directive is applied: as an attribute on a host el
 
   For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  Similarly, you can also <live-example name="testing" noDownload>run and explore the application</live-example> that this testing guides describes.
+  If you'd like to experiment with the application that this guide describes, you can <live-example name="testing" noDownload>run it in your browser</live-example> or <live-example name="testing" downloadOnly>download and run it locally</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-attribute-directives.md
+++ b/aio/content/guide/testing-attribute-directives.md
@@ -8,9 +8,9 @@ Its name reflects the way the directive is applied: as an attribute on a host el
 
 <div class="alert is-helpful">
 
-  For the sample app that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
+  For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
+  Similarly, you can also <live-example name="testing" embedded-style noDownload>run and explore the application</live-example> that this testing guides describes.
 
 </div>
 

--- a/aio/content/guide/testing-code-coverage.md
+++ b/aio/content/guide/testing-code-coverage.md
@@ -7,9 +7,9 @@ Code coverage reports show you any parts of your code base that may not be prope
 
 <div class="alert is-helpful">
 
-For the sample app that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
+  For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
+  Similarly, you can also <live-example name="testing" embedded-style noDownload>run and explore the application</live-example> that this testing guides describes.
 
 </div>
 

--- a/aio/content/guide/testing-code-coverage.md
+++ b/aio/content/guide/testing-code-coverage.md
@@ -9,7 +9,7 @@ Code coverage reports show you any parts of your code base that may not be prope
 
   For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  Similarly, you can also <live-example name="testing" noDownload>run and explore the application</live-example> that this testing guides describes.
+  If you'd like to experiment with the application that this guide describes, you can <live-example name="testing" noDownload>run it in your browser</live-example> or <live-example name="testing" downloadOnly>download and run it locally</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-code-coverage.md
+++ b/aio/content/guide/testing-code-coverage.md
@@ -9,7 +9,7 @@ Code coverage reports show you any parts of your code base that may not be prope
 
   For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  Similarly, you can also <live-example name="testing" embedded-style noDownload>run and explore the application</live-example> that this testing guides describes.
+  Similarly, you can also <live-example name="testing" noDownload>run and explore the application</live-example> that this testing guides describes.
 
 </div>
 

--- a/aio/content/guide/testing-components-basics.md
+++ b/aio/content/guide/testing-components-basics.md
@@ -17,7 +17,7 @@ can validate much of the component's behavior in an easier, more obvious way.
 
   For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  Similarly, you can also <live-example name="testing" embedded-style noDownload>run and explore the application</live-example> that this testing guides describes.
+  Similarly, you can also <live-example name="testing" noDownload>run and explore the application</live-example> that this testing guides describes.
 
 </div>
 

--- a/aio/content/guide/testing-components-basics.md
+++ b/aio/content/guide/testing-components-basics.md
@@ -17,7 +17,7 @@ can validate much of the component's behavior in an easier, more obvious way.
 
   For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  Similarly, you can also <live-example name="testing" noDownload>run and explore the application</live-example> that this testing guides describes.
+  If you'd like to experiment with the application that this guide describes, you can <live-example name="testing" noDownload>run it in your browser</live-example> or <live-example name="testing" downloadOnly>download and run it locally</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-components-basics.md
+++ b/aio/content/guide/testing-components-basics.md
@@ -15,9 +15,9 @@ can validate much of the component's behavior in an easier, more obvious way.
 
 <div class="alert is-helpful">
 
-  For the sample application that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
+  For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
+  Similarly, you can also <live-example name="testing" embedded-style noDownload>run and explore the application</live-example> that this testing guides describes.
 
 </div>
 

--- a/aio/content/guide/testing-components-scenarios.md
+++ b/aio/content/guide/testing-components-scenarios.md
@@ -6,7 +6,7 @@ This guide explores common component testing use cases.
 
   For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  Similarly, you can also <live-example name="testing" embedded-style noDownload>run and explore the application</live-example> that this testing guides describes.
+  Similarly, you can also <live-example name="testing" noDownload>run and explore the application</live-example> that this testing guides describes.
 
 </div>
 

--- a/aio/content/guide/testing-components-scenarios.md
+++ b/aio/content/guide/testing-components-scenarios.md
@@ -6,7 +6,7 @@ This guide explores common component testing use cases.
 
   For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  Similarly, you can also <live-example name="testing" noDownload>run and explore the application</live-example> that this testing guides describes.
+  If you'd like to experiment with the application that this guide describes, you can <live-example name="testing" noDownload>run it in your browser</live-example> or <live-example name="testing" downloadOnly>download and run it locally</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-components-scenarios.md
+++ b/aio/content/guide/testing-components-scenarios.md
@@ -4,9 +4,9 @@ This guide explores common component testing use cases.
 
 <div class="alert is-helpful">
 
-  For the sample application that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
+  For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
+  Similarly, you can also <live-example name="testing" embedded-style noDownload>run and explore the application</live-example> that this testing guides describes.
 
 </div>
 

--- a/aio/content/guide/testing-pipes.md
+++ b/aio/content/guide/testing-pipes.md
@@ -4,9 +4,9 @@ You can test [pipes](guide/pipes) without the Angular testing utilities.
 
 <div class="alert is-helpful">
 
-  For the sample application that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
+  For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
+  Similarly, you can also <live-example name="testing" embedded-style noDownload>run and explore the application</live-example> that this testing guides describes.
 
 </div>
 

--- a/aio/content/guide/testing-pipes.md
+++ b/aio/content/guide/testing-pipes.md
@@ -6,7 +6,7 @@ You can test [pipes](guide/pipes) without the Angular testing utilities.
 
   For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  Similarly, you can also <live-example name="testing" noDownload>run and explore the application</live-example> that this testing guides describes.
+  If you'd like to experiment with the application that this guide describes, you can <live-example name="testing" noDownload>run it in your browser</live-example> or <live-example name="testing" downloadOnly>download and run it locally</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-pipes.md
+++ b/aio/content/guide/testing-pipes.md
@@ -6,7 +6,7 @@ You can test [pipes](guide/pipes) without the Angular testing utilities.
 
   For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  Similarly, you can also <live-example name="testing" embedded-style noDownload>run and explore the application</live-example> that this testing guides describes.
+  Similarly, you can also <live-example name="testing" noDownload>run and explore the application</live-example> that this testing guides describes.
 
 </div>
 

--- a/aio/content/guide/testing-services.md
+++ b/aio/content/guide/testing-services.md
@@ -7,7 +7,7 @@ To check that your services are working as you intend, you can write tests speci
 
   For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  Similarly, you can also <live-example name="testing" embedded-style noDownload>run and explore the application</live-example> that this testing guides describes.
+  Similarly, you can also <live-example name="testing" noDownload>run and explore the application</live-example> that this testing guides describes.
 
 </div>
 

--- a/aio/content/guide/testing-services.md
+++ b/aio/content/guide/testing-services.md
@@ -5,9 +5,9 @@ To check that your services are working as you intend, you can write tests speci
 
 <div class="alert is-helpful">
 
-  For the sample application that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
+  For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
+  Similarly, you can also <live-example name="testing" embedded-style noDownload>run and explore the application</live-example> that this testing guides describes.
 
 </div>
 

--- a/aio/content/guide/testing-services.md
+++ b/aio/content/guide/testing-services.md
@@ -7,7 +7,7 @@ To check that your services are working as you intend, you can write tests speci
 
   For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  Similarly, you can also <live-example name="testing" noDownload>run and explore the application</live-example> that this testing guides describes.
+  If you'd like to experiment with the application that this guide describes, you can <live-example name="testing" noDownload>run it in your browser</live-example> or <live-example name="testing" downloadOnly>download and run it locally</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -21,9 +21,9 @@ This sample application is much like the one in the [_Tour of Heroes_ tutorial](
 
 <div class="alert is-helpful">
 
-  For the sample application that the testing guides describe, see the <live-example noDownload>sample app</live-example>.
+  For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  For the tests features in the testing guides, see <live-example stackblitz="specs" noDownload>tests</live-example>.
+  Similarly, you can also <live-example name="testing" embedded-style noDownload>run and explore the application</live-example> that this testing guides describes.
 
 </div>
 

--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -23,7 +23,7 @@ This sample application is much like the one in the [_Tour of Heroes_ tutorial](
 
   For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  Similarly, you can also <live-example name="testing" noDownload>run and explore the application</live-example> that this testing guides describes.
+  If you'd like to experiment with the application that this guide describes, you can <live-example name="testing" noDownload>run it in your browser</live-example> or <live-example name="testing" downloadOnly>download and run it locally</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -23,7 +23,7 @@ This sample application is much like the one in the [_Tour of Heroes_ tutorial](
 
   For a hands-on experience you can <live-example name="testing" stackblitz="specs" noDownload>run tests and explore the test code</live-example> in your browser as your read this guide.
 
-  Similarly, you can also <live-example name="testing" embedded-style noDownload>run and explore the application</live-example> that this testing guides describes.
+  Similarly, you can also <live-example name="testing" noDownload>run and explore the application</live-example> that this testing guides describes.
 
 </div>
 


### PR DESCRIPTION
We should primarily point readers to the stackblitz that contains the spec files and runs them.

The application stackblitz is secondary (and doesn't actually contain the spec files, which is confusing).

Fixes #38535