### PR TITLE
refactor(dev-infra): remove duplicate method that checks for uncommitted changes

### DIFF
--- a/dev-infra/build-worker.js
+++ b/dev-infra/build-worker.js
@@ -200,7 +200,7 @@ var GitCommandError = /** @class */ (function (_super) {
 var GitClient = /** @class */ (function () {
     /**
      * @param githubToken The github token used for authentication, if provided.
-     * @param _config The configuration, containing the github specific configuration.
+     * @param config The configuration, containing the github specific configuration.
      * @param baseDir The full path to the root of the repository base.
      */
     function GitClient(githubToken, config, baseDir) {
@@ -320,10 +320,6 @@ var GitClient = /** @class */ (function () {
     };
     /** Gets whether the current Git repository has uncommitted changes. */
     GitClient.prototype.hasUncommittedChanges = function () {
-        return this.runGraceful(['diff-index', '--quiet', 'HEAD']).status !== 0;
-    };
-    /** Whether the repo has any local changes. */
-    GitClient.prototype.hasLocalChanges = function () {
         return this.runGraceful(['diff-index', '--quiet', 'HEAD']).status !== 0;
     };
     /** Sanitizes a given message by omitting the provided Github token if present. */

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -368,7 +368,7 @@ var GitCommandError = /** @class */ (function (_super) {
 var GitClient = /** @class */ (function () {
     /**
      * @param githubToken The github token used for authentication, if provided.
-     * @param _config The configuration, containing the github specific configuration.
+     * @param config The configuration, containing the github specific configuration.
      * @param baseDir The full path to the root of the repository base.
      */
     function GitClient(githubToken, config, baseDir) {
@@ -488,10 +488,6 @@ var GitClient = /** @class */ (function () {
     };
     /** Gets whether the current Git repository has uncommitted changes. */
     GitClient.prototype.hasUncommittedChanges = function () {
-        return this.runGraceful(['diff-index', '--quiet', 'HEAD']).status !== 0;
-    };
-    /** Whether the repo has any local changes. */
-    GitClient.prototype.hasLocalChanges = function () {
         return this.runGraceful(['diff-index', '--quiet', 'HEAD']).status !== 0;
     };
     /** Sanitizes a given message by omitting the provided Github token if present. */
@@ -3128,7 +3124,7 @@ function checkOutPullRequestLocally(prNumber, githubToken, opts = {}) {
         const git = GitClient.getAuthenticatedInstance();
         // In order to preserve local changes, checkouts cannot occur if local changes are present in the
         // git environment. Checked before retrieving the PR to fail fast.
-        if (git.hasLocalChanges()) {
+        if (git.hasUncommittedChanges()) {
             throw new UnexpectedLocalChangesError('Unable to checkout PR due to uncommitted changes.');
         }
         /**
@@ -3268,7 +3264,7 @@ function discoverNewConflictsForPr(newPrNumber, updatedAfter) {
         const git = GitClient.getAuthenticatedInstance();
         // If there are any local changes in the current repository state, the
         // check cannot run as it needs to move between branches.
-        if (git.hasLocalChanges()) {
+        if (git.hasUncommittedChanges()) {
             error('Cannot run with local changes. Please make sure there are no local changes.');
             process.exit(1);
         }
@@ -4584,8 +4580,7 @@ function rebasePr(prNumber, githubToken, config = getConfig()) {
     return tslib.__awaiter(this, void 0, void 0, function* () {
         /** The singleton instance of the GitClient. */
         const git = GitClient.getAuthenticatedInstance();
-        // TODO: Rely on a common assertNoLocalChanges function.
-        if (git.hasLocalChanges()) {
+        if (git.hasUncommittedChanges()) {
             error('Cannot perform rebase of PR with local changes.');
             process.exit(1);
         }

--- a/dev-infra/pr/common/checkout-pr.ts
+++ b/dev-infra/pr/common/checkout-pr.ts
@@ -67,7 +67,7 @@ export async function checkOutPullRequestLocally(
 
   // In order to preserve local changes, checkouts cannot occur if local changes are present in the
   // git environment. Checked before retrieving the PR to fail fast.
-  if (git.hasLocalChanges()) {
+  if (git.hasUncommittedChanges()) {
     throw new UnexpectedLocalChangesError('Unable to checkout PR due to uncommitted changes.');
   }
 

--- a/dev-infra/pr/discover-new-conflicts/index.ts
+++ b/dev-infra/pr/discover-new-conflicts/index.ts
@@ -57,7 +57,7 @@ export async function discoverNewConflictsForPr(newPrNumber: number, updatedAfte
   const git = GitClient.getAuthenticatedInstance();
   // If there are any local changes in the current repository state, the
   // check cannot run as it needs to move between branches.
-  if (git.hasLocalChanges()) {
+  if (git.hasUncommittedChanges()) {
     error('Cannot run with local changes. Please make sure there are no local changes.');
     process.exit(1);
   }

--- a/dev-infra/pr/rebase/index.ts
+++ b/dev-infra/pr/rebase/index.ts
@@ -46,8 +46,7 @@ export async function rebasePr(
     prNumber: number, githubToken: string, config: Pick<NgDevConfig, 'github'> = getConfig()) {
   /** The singleton instance of the GitClient. */
   const git = GitClient.getAuthenticatedInstance();
-  // TODO: Rely on a common assertNoLocalChanges function.
-  if (git.hasLocalChanges()) {
+  if (git.hasUncommittedChanges()) {
     error('Cannot perform rebase of PR with local changes.');
     process.exit(1);
   }

--- a/dev-infra/utils/git/index.ts
+++ b/dev-infra/utils/git/index.ts
@@ -115,7 +115,7 @@ export class GitClient<Authenticated extends boolean> {
 
   /**
    * @param githubToken The github token used for authentication, if provided.
-   * @param _config The configuration, containing the github specific configuration.
+   * @param config The configuration, containing the github specific configuration.
    * @param baseDir The full path to the root of the repository base.
    */
   protected constructor(public githubToken: Authenticated extends true? string: undefined,
@@ -211,11 +211,6 @@ export class GitClient<Authenticated extends boolean> {
 
   /** Gets whether the current Git repository has uncommitted changes. */
   hasUncommittedChanges(): boolean {
-    return this.runGraceful(['diff-index', '--quiet', 'HEAD']).status !== 0;
-  }
-
-  /** Whether the repo has any local changes. */
-  hasLocalChanges(): boolean {
     return this.runGraceful(['diff-index', '--quiet', 'HEAD']).status !== 0;
   }
 


### PR DESCRIPTION
Removes the duplicate `hasLocalChanges` method from the Git client. We
already have `hasUncommittedChanges`. Also removes a TODO for adding
`assertNoLocalChanges` as it seems more flexible to manually check
(i.e. better messaging with context on the current tool; e.g. "cannot
perform rebase")