### PR TITLE
docs(docs-infra): allow for download of testing guide application

### DIFF
--- a/aio/content/examples/testing/stackblitz.json
+++ b/aio/content/examples/testing/stackblitz.json
@@ -10,9 +10,7 @@
 
     "src/app/**/*.css",
     "src/app/**/*.html",
-    "src/app/**/*.ts",
-
-    "!src/**/*.spec.ts"
+    "src/app/**/*.ts"
   ],
   "tags": ["testing"],
   "devDependencies": ["jasmine-core", "jasmine-marbles"]

--- a/aio/content/guide/test-debugging.md
+++ b/aio/content/guide/test-debugging.md
@@ -4,9 +4,10 @@ If your tests aren't working as you expect them to, you can inspect and debug th
 
 <div class="alert is-helpful">
 
-  For the sample application that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
-
-  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
+  See the <live-example name="testing" noDownload>sample app</live-example> / <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>
+  for a working example containing the code snippets in this guide.
+  
+  Download the sample app and tests <live-example name="testing" downloadOnly>here</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-attribute-directives.md
+++ b/aio/content/guide/testing-attribute-directives.md
@@ -8,9 +8,10 @@ Its name reflects the way the directive is applied: as an attribute on a host el
 
 <div class="alert is-helpful">
 
-  For the sample app that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
-
-  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
+  See the <live-example name="testing" noDownload>sample app</live-example> / <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>
+  for a working example containing the code snippets in this guide.
+  
+  Download the sample app and tests <live-example name="testing" downloadOnly>here</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-code-coverage.md
+++ b/aio/content/guide/testing-code-coverage.md
@@ -7,9 +7,10 @@ Code coverage reports show you any parts of your code base that may not be prope
 
 <div class="alert is-helpful">
 
-For the sample app that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
-
-For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
+  See the <live-example name="testing" noDownload>sample app</live-example> / <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>
+  for a working example containing the code snippets in this guide.
+  
+  Download the sample app and tests <live-example name="testing" downloadOnly>here</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-components-basics.md
+++ b/aio/content/guide/testing-components-basics.md
@@ -15,9 +15,10 @@ can validate much of the component's behavior in an easier, more obvious way.
 
 <div class="alert is-helpful">
 
-  For the sample application that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
-
-  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
+  See the <live-example name="testing" noDownload>sample app</live-example> / <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>
+  for a working example containing the code snippets in this guide.
+  
+  Download the sample app and tests <live-example name="testing" downloadOnly>here</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-components-scenarios.md
+++ b/aio/content/guide/testing-components-scenarios.md
@@ -4,9 +4,10 @@ This guide explores common component testing use cases.
 
 <div class="alert is-helpful">
 
-  For the sample application that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
-
-  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
+  See the <live-example name="testing" noDownload>sample app</live-example> / <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>
+  for a working example containing the code snippets in this guide.
+  
+  Download the sample app and tests <live-example name="testing" downloadOnly>here</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-pipes.md
+++ b/aio/content/guide/testing-pipes.md
@@ -4,9 +4,10 @@ You can test [pipes](guide/pipes) without the Angular testing utilities.
 
 <div class="alert is-helpful">
 
-  For the sample application that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
-
-  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
+  See the <live-example name="testing" noDownload>sample app</live-example> / <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>
+  for a working example containing the code snippets in this guide.
+  
+  Download the sample app and tests <live-example name="testing" downloadOnly>here</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing-services.md
+++ b/aio/content/guide/testing-services.md
@@ -5,9 +5,10 @@ To check that your services are working as you intend, you can write tests speci
 
 <div class="alert is-helpful">
 
-  For the sample application that the testing guides describe, see the <live-example name="testing" embedded-style noDownload>sample app</live-example>.
-
-  For the tests features in the testing guides, see <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>.
+  See the <live-example name="testing" noDownload>sample app</live-example> / <live-example name="testing" stackblitz="specs" noDownload>tests</live-example>
+  for a working example containing the code snippets in this guide.
+  
+  Download the sample app and tests <live-example name="testing" downloadOnly>here</live-example>.
 
 </div>
 

--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -21,9 +21,10 @@ This sample application is much like the one in the [_Tour of Heroes_ tutorial](
 
 <div class="alert is-helpful">
 
-  For the sample application that the testing guides describe, see the <live-example noDownload>sample app</live-example>.
-
-  For the tests features in the testing guides, see <live-example stackblitz="specs" noDownload>tests</live-example>.
+  See the <live-example noDownload>sample app</live-example> / <live-example stackblitz="specs" noDownload>tests</live-example>
+  for a working example containing the code snippets in this guide.
+  
+  Download the sample app and tests <live-example downloadOnly>here</live-example>.
 
 </div>
 


### PR DESCRIPTION
add feature to download the testing guide application and its associated tests. I can confirm that after downloading the app `ng serve` and `ng test` perform with no issues.

resolves #42389, #38535

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Gives the user the option to download the testing guide application and then run `ng serve` or `ng test`. Users are currently limited to seeing the application and its tests in StackBlitz

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #42389 


## What is the new behavior?

The StackBlitz link for the application and the StackBlitz link for the tests are next to each other. User can optionally download the application.

![image](https://user-images.githubusercontent.com/18009315/120023807-5540d080-bfbc-11eb-8e51-1e958cae50af.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
