### PR TITLE
build: fix linting against jasmine focus functions

### DIFF
--- a/packages/examples/testing/ts/testing.ts
+++ b/packages/examples/testing/ts/testing.ts
@@ -18,7 +18,7 @@ describe('some component', () => {
      });
 });
 
-/* tslint:disable-next-line:no-jasmine-focus */
+// tslint:disable-next-line:ban
 fdescribe('some component', () => {
   it('has a test',
      () => {
@@ -44,7 +44,7 @@ describe('another component', () => {
 });
 
 describe('some component', () => {
-  /* tslint:disable-next-line:no-jasmine-focus */
+  // tslint:disable-next-line:ban
   fit('has a test',
       () => {
           // This test will run.

--- a/tslint.json
+++ b/tslint.json
@@ -20,7 +20,6 @@
     "no-construct": true,
     "no-duplicate-imports": true,
     "no-duplicate-variable": true,
-    "no-jasmine-focus": true,
     "no-var-keyword": true,
     "prefer-literal": [
       true,
@@ -49,7 +48,12 @@
       true,
       "function"
     ],
-    "no-debugger": true
+    "no-debugger": true,
+    "ban": [
+      true,
+      {"name": "fdescribe", "message": "Don't keep jasmine focus methods."},
+      {"name": "fit", "message": "Don't keep jasmine focus methods."}
+    ]
   },
   "jsRules": {
     "file-header": [
@@ -65,7 +69,6 @@
     ],
     "no-duplicate-imports": true,
     "no-duplicate-variable": true,
-    "no-jasmine-focus": true,
     "require-internal-with-underscore": true,
     "semicolon": [
       true
@@ -77,6 +80,11 @@
     "no-inner-declarations": [
       true,
       "function"
+    ],
+    "ban": [
+      true,
+      {"name": "fdescribe", "message": "Don't keep jasmine focus methods."},
+      {"name": "fit", "message": "Don't keep jasmine focus methods."}
     ]
   },
   "linterOptions": {


### PR DESCRIPTION
We were linting against usages of `fdescribe` and `fit` by referencing the `no-jasmine-focus` rule which isn't installed, causing tslint to log the following:

```
Could not find implementations for the following rules specified in the configuration:
    no-jasmine-focus
Try upgrading TSLint and/or ensuring that you have all necessary custom rules installed.
If TSLint was recently upgraded, you may have old rules configured which need to be cleaned
```

These changes switch to using the built-in `ban` rule.