### PR TITLE
fix(router): add missing outlet events to RouterOutletContract

### DIFF
--- a/goldens/public-api/router/router.md
+++ b/goldens/public-api/router/router.md
@@ -182,7 +182,6 @@ export type DetachedRouteHandle = {};
 
 // @public
 type Event_2 = RouterEvent | RouteConfigLoadStart | RouteConfigLoadEnd | ChildActivationStart | ChildActivationEnd | ActivationStart | ActivationEnd | Scroll;
-
 export { Event_2 as Event }
 
 // @public
@@ -565,7 +564,7 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
     routerLinkActiveOptions: {
         exact: boolean;
     } | IsActiveMatchOptions;
-    }
+}
 
 // @public
 export class RouterLinkWithHref implements OnChanges, OnDestroy {
@@ -627,16 +626,18 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
-    }
+}
 
 // @public
 export interface RouterOutletContract {
     activatedRoute: ActivatedRoute | null;
     activatedRouteData: Data;
+    activateEvents?: EventEmitter<unknown>;
     activateWith(activatedRoute: ActivatedRoute, resolver: ComponentFactoryResolver | null): void;
     attach(ref: ComponentRef<unknown>, activatedRoute: ActivatedRoute): void;
     component: Object | null;
     deactivate(): void;
+    deactivateEvents?: EventEmitter<unknown>;
     detach(): ComponentRef<unknown>;
     isActivated: boolean;
 }
@@ -650,7 +651,7 @@ export class RouterPreloader implements OnDestroy {
     preload(): Observable<any>;
     // (undocumented)
     setUpPreloading(): void;
-    }
+}
 
 // @public
 export class RouterState extends ɵangular_packages_router_router_m<ActivatedRoute> {
@@ -787,7 +788,6 @@ export class UrlTree {
 
 // @public (undocumented)
 export const VERSION: Version;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Attribute, ChangeDetectorRef, ComponentFactoryResolver, ComponentRef, Directive, EventEmitter, Injector, OnDestroy, OnInit, Output, ViewContainerRef} from '@angular/core';
-
+import {Attribute, ChangeDetectorRef, ComponentFactoryResolver, ComponentRef, Directive, EventEmitter, Injector, OnDestroy, OnInit, Output, ViewContainerRef,} from '@angular/core';
 import {Data} from '../config';
 import {ChildrenOutletContexts} from '../router_outlet_context';
 import {ActivatedRoute} from '../router_state';
@@ -72,6 +71,16 @@ export interface RouterOutletContract {
    * Called when the `RouteReuseStrategy` instructs to re-attach a previously detached subtree.
    */
   attach(ref: ComponentRef<unknown>, activatedRoute: ActivatedRoute): void;
+
+  /**
+   * Emits an activate event when a new component is instantiated
+   **/
+  activateEvents?: EventEmitter<unknown>;
+
+  /**
+   * Emits a deactivate event when a component is destroyed.
+   */
+  deactivateEvents?: EventEmitter<unknown>;
 }
 
 /**


### PR DESCRIPTION
PR adds `activateEvents` and `deactivateEvents` to the `RouterOutletContract`.

This is needed in our case where we dynamically render components via the Module Federation at some point in the future. Without this the `active` component is always `ɵEmptyOutletComponent` and not the actual component which is eventually created by an external route, hence why these events are needed so that we can capture all components rendered at any given time.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe:

Simply updating the public api interface which now causes type errors in angular 12 but is technically still available.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
