### PR TITLE
build(docs-infra): disable critical CSS inlining

### DIFF
--- a/aio/angular.json
+++ b/aio/angular.json
@@ -31,6 +31,14 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "webWorkerTsConfig": "tsconfig.worker.json",
+            "optimization": {
+              "fonts": true,
+              "scripts": true,
+              "styles": {
+                "inlineCritical": false,
+                "minify": true
+              }
+            },
             "outputHashing": "all",
             "sourceMap": true,
             "namedChunks": true,


### PR DESCRIPTION
Previously, the critical CSS inlining optimization (which is turned on by default in CLI v12+) was causing a Flash Of Unstyled Content (FOUC). This was caused by the combination of the following facts:
- The way CSS inlining is implemented in the CLI makes loading the full styles asynchronous and non-render-blocking (so the app can bootstrap before the styles are fully downloaded).
- Angular.io does not employ the [app shell][1] pattern in order to render pages at build time, resulting in very minimal CSS rules being recognized as critical (for the purpose of inlining).

This commit fixes the FOUC by disabling the critical CSS inlining, while we consider a better way to approach this (in order to be able to rip the benefits of inlining without the FOUC).

Fixes #42365.

[1]: https://angular.io/guide/app-shell