### PR TITLE
feat(dev-infra): validate deprecation notes in commit messages

### DIFF
--- a/dev-infra/commit-message/parse.spec.ts
+++ b/dev-infra/commit-message/parse.spec.ts
@@ -135,6 +135,15 @@ describe('commit message parsing:', () => {
       expect(parsedMessage.breakingChanges[0].text).toBe(`${summary}\n\n${description}`);
       expect(parsedMessage.breakingChanges.length).toBe(1);
     });
+
+    it('only when keyword is at the beginning of a line', () => {
+      const message = buildCommitMessage({
+        body: 'This changes how the `BREAKING CHANGE: ` commit message note\n' +
+            'keyword is detected for the changelog.',
+      });
+      const parsedMessage = parseCommitMessage(message);
+      expect(parsedMessage.breakingChanges.length).toBe(0);
+    });
   });
 
   describe('parses deprecation notes', () => {
@@ -167,6 +176,15 @@ describe('commit message parsing:', () => {
       const parsedMessage = parseCommitMessage(message);
       expect(parsedMessage.deprecations[0].text).toBe(`${summary}\n\n${description}`);
       expect(parsedMessage.deprecations.length).toBe(1);
+    });
+
+    it('only when keyword is at the beginning of a line', () => {
+      const message = buildCommitMessage({
+        body: 'This changes how the `DEPRECATED: ` commit message note\n' +
+            'keyword is detected for the changelog.',
+      });
+      const parsedMessage = parseCommitMessage(message);
+      expect(parsedMessage.deprecations.length).toBe(0);
     });
   });
 });

--- a/dev-infra/commit-message/parse.ts
+++ b/dev-infra/commit-message/parse.ts
@@ -111,7 +111,7 @@ const parseOptions: Options&{notesPattern: (keywords: string) => RegExp} = {
   headerPattern,
   headerCorrespondence,
   noteKeywords: [NoteSections.BREAKING_CHANGE, NoteSections.DEPRECATED],
-  notesPattern: (keywords: string) => new RegExp(`(${keywords})(?:: ?)(.*)`),
+  notesPattern: (keywords: string) => new RegExp(`(${keywords}): ?(.*)`),
 };
 
 /** Parse a commit message into its composite parts. */

--- a/dev-infra/commit-message/parse.ts
+++ b/dev-infra/commit-message/parse.ts
@@ -111,7 +111,7 @@ const parseOptions: Options&{notesPattern: (keywords: string) => RegExp} = {
   headerPattern,
   headerCorrespondence,
   noteKeywords: [NoteSections.BREAKING_CHANGE, NoteSections.DEPRECATED],
-  notesPattern: (keywords: string) => new RegExp(`(${keywords}): ?(.*)`),
+  notesPattern: (keywords: string) => new RegExp(`^\s*(${keywords}): ?(.*)`),
 };
 
 /** Parse a commit message into its composite parts. */

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -1843,7 +1843,7 @@ const parseOptions = {
     headerPattern,
     headerCorrespondence,
     noteKeywords: [NoteSections.BREAKING_CHANGE, NoteSections.DEPRECATED],
-    notesPattern: (keywords) => new RegExp(`(${keywords}): ?(.*)`),
+    notesPattern: (keywords) => new RegExp(`^\s*(${keywords}): ?(.*)`),
 };
 /** Parse a commit message into its composite parts. */
 const parseCommitMessage = parseInternal;

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -1843,7 +1843,7 @@ const parseOptions = {
     headerPattern,
     headerCorrespondence,
     noteKeywords: [NoteSections.BREAKING_CHANGE, NoteSections.DEPRECATED],
-    notesPattern: (keywords) => new RegExp(`(${keywords})(?:: ?)(.*)`),
+    notesPattern: (keywords) => new RegExp(`(${keywords}): ?(.*)`),
 };
 /** Parse a commit message into its composite parts. */
 const parseCommitMessage = parseInternal;
@@ -1902,15 +1902,25 @@ function parseInternal(fullText) {
 /** Regex matching a URL for an entire commit body line. */
 const COMMIT_BODY_URL_LINE_RE = /^https?:\/\/.*$/;
 /**
- * Regex matching a breaking change.
+ * Regular expression matching potential misuse of the `BREAKING CHANGE:` marker in a
+ * commit message. Commit messages containing one of the following snippets will fail:
  *
- * - Starts with BREAKING CHANGE
- * - Followed by a colon
- * - Followed by a single space or two consecutive new lines
- *
- * NB: Anything after `BREAKING CHANGE` is optional to facilitate the validation.
+ *   - `BREAKING CHANGE <some-content>` | Here we assume the colon is missing by accident.
+ *   - `BREAKING-CHANGE: <some-content>` | The wrong keyword is used here.
+ *   - `BREAKING CHANGES: <some-content>` | The wrong keyword is used here.
+ *   - `BREAKING-CHANGES: <some-content>` | The wrong keyword is used here.
  */
-const COMMIT_BODY_BREAKING_CHANGE_RE = /^BREAKING CHANGE(:( |\n{2}))?/m;
+const INCORRECT_BREAKING_CHANGE_BODY_RE = /^(BREAKING CHANGE[^:]|BREAKING-CHANGE|BREAKING[ -]CHANGES)/m;
+/**
+ * Regular expression matching potential misuse of the `DEPRECATED:` marker in a commit
+ * message. Commit messages containing one of the following snippets will fail:
+ *
+ *   - `DEPRECATED <some-content>` | Here we assume the colon is missing by accident.
+ *   - `DEPRECATIONS: <some-content>` | The wrong keyword is used here.
+ *   - `DEPRECATE: <some-content>` | The wrong keyword is used here.
+ *   - `DEPRECATES: <some-content>` | The wrong keyword is used here.
+ */
+const INCORRECT_DEPRECATION_BODY_RE = /^(DEPRECATED[^:]|DEPRECATIONS|DEPRECATE:|DEPRECATES)/m;
 /** Validate a commit message against using the local repo's config. */
 function validateCommitMessage(commitMsg, options = {}) {
     const config = getCommitMessageConfig().commitMessage;
@@ -2008,14 +2018,13 @@ function validateCommitMessage(commitMsg, options = {}) {
         // Breaking change
         // Check if the commit message contains a valid break change description.
         // https://github.com/angular/angular/blob/88fbc066775ab1a2f6a8c75f933375b46d8fa9a4/CONTRIBUTING.md#commit-message-footer
-        const hasBreakingChange = COMMIT_BODY_BREAKING_CHANGE_RE.exec(commit.fullText);
-        if (hasBreakingChange !== null) {
-            const [, breakingChangeDescription] = hasBreakingChange;
-            if (!breakingChangeDescription) {
-                // Not followed by :, space or two consecutive new lines,
-                errors.push(`The commit message body contains an invalid breaking change description.`);
-                return false;
-            }
+        if (INCORRECT_BREAKING_CHANGE_BODY_RE.test(commit.fullText)) {
+            errors.push(`The commit message body contains an invalid breaking change note.`);
+            return false;
+        }
+        if (INCORRECT_DEPRECATION_BODY_RE.test(commit.fullText)) {
+            errors.push(`The commit message body contains an invalid deprecation note.`);
+            return false;
         }
         return true;
     }


### PR DESCRIPTION
Currently the commit message validation tool from `ng-dev` validates
the `BREAKING CHANGE:` commit message notes. This commit adds a similar
check for `DEPRECATED:` commit message notes.

Additionally, the check for breaking changes is reworked slightly to
be more tolerant (i.e. if there is only a single line break after the
summary; this is acceptable as per the parser and commonly done in the
COMP repo). The checks have been updated to capture wrong keywords that
are commonly used instead of the correct one. e.g. if a commit message
uses `DEPRECATIONS:` instead of `DEPRECATED:`, the validation will fail.

This prevents changelog generation issues where breaking change notes,
or deprecations are missing. This happened in the COMP repo where
the `DEPRECATED:` keyword was used incorrectly. See:

https://github.com/angular/components/commit/99391e79391d20c6ef2f95a3ea4fd6901dcb631d