### PR TITLE
docs: specify correct interceptor class type

### DIFF
--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -655,7 +655,7 @@ There are many more interceptors in the complete sample code.
 
 Angular applies interceptors in the order that you provide them.
 For example, consider a situation in which you want to handle the authentication of your HTTP requests and log them before sending them to a server. To accomplish this task, you could provide an `AuthInterceptor` service and then a `LoggingInterceptor` service.
-Outgoing requests would flow from the `AuthInterceptor` to the `AuthInterceptor`.
+Outgoing requests would flow from the `AuthInterceptor` to the `LoggingInterceptor`.
 Responses from these requests would flow in the other direction, from `LoggingInterceptor` back to `AuthInterceptor`.
 The following is a visual representation of the process:
 


### PR DESCRIPTION
In the "Interceptor order" section of the HTTP guide there is a typo which incorrectly lists the same service twice when referring to two different services. The order that these services are listed is important, and this commit fixes the typo by listing the services in the correct order.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

Issue Number: N/A

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No