### PR TITLE
feat(dev-infra): allow a list of additional files to include in release commits

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -6255,7 +6255,7 @@ class ReleaseAction {
             // Commit message for the release point.
             const commitMessage = getCommitMessageForRelease(newVersion);
             // Create a release staging commit including changelog and version bump.
-            yield this.createCommit(commitMessage, [packageJsonPath, changelogPath]);
+            yield this.createCommit(commitMessage, [packageJsonPath, changelogPath, ...(this.config.additionalCommitFiles || [])]);
             info(green(`  ✓   Created release commit for: "${newVersion}".`));
         });
     }

--- a/dev-infra/release/config/index.ts
+++ b/dev-infra/release/config/index.ts
@@ -28,6 +28,8 @@ export interface ReleaseConfig {
   releasePrLabels?: string[];
   /** Configuration for creating release notes during publishing. */
   releaseNotes: ReleaseNotesConfig;
+  /** List of files to include in release commits additional to CHANGELOG.md and package.json. */
+  additionalCommitFiles?: string[];
 }
 
 /** Configuration for creating release notes during publishing. */

--- a/dev-infra/release/publish/actions.ts
+++ b/dev-infra/release/publish/actions.ts
@@ -151,7 +151,9 @@ export abstract class ReleaseAction {
     // Commit message for the release point.
     const commitMessage = getCommitMessageForRelease(newVersion);
     // Create a release staging commit including changelog and version bump.
-    await this.createCommit(commitMessage, [packageJsonPath, changelogPath]);
+    await this.createCommit(
+        commitMessage,
+        [packageJsonPath, changelogPath, ...(this.config.additionalCommitFiles || [])]);
 
     info(green(`  ✓   Created release commit for: "${newVersion}".`));
   }


### PR DESCRIPTION
Providing a configuration to providing a list of additional files to be included in
release commits will allow for projects (namely angular/angular-cli) to add additional
files in the generated release commit.
