### PR TITLE
refactor(docs-infra): clean up AIO Sass files

### DIFF
--- a/aio/src/styles/0-base/_typography-theme.scss
+++ b/aio/src/styles/0-base/_typography-theme.scss
@@ -1,7 +1,8 @@
+@use 'sass:map';
 @use '../constants';
 
 @mixin theme($theme) {
-  $is-dark-theme: map-get($theme, is-dark);
+  $is-dark-theme: map.get($theme, is-dark);
 
   body {
     color: if($is-dark-theme, constants.$offwhite, constants.$darkgray);

--- a/aio/src/styles/1-layouts/footer/_footer-theme.scss
+++ b/aio/src/styles/1-layouts/footer/_footer-theme.scss
@@ -1,13 +1,14 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
 @mixin theme($theme) {
-  $primary: map-get($theme, primary);
-  $is-dark-theme: map-get($theme, is-dark);
+  $primary: map.get($theme, primary);
+  $is-dark-theme: map.get($theme, is-dark);
 
   footer {
     // Because the footer background is always the same color in both light and dark mode, there is no need to specify a foreground color
-    background-color: mat-color($primary, if($is-dark-theme, 900, 700));
+    background-color: mat.get-color-from-palette($primary, if($is-dark-theme, 900, 700));
 
     aio-footer {
       & > * {

--- a/aio/src/styles/1-layouts/layout-global/_layout-global-theme.scss
+++ b/aio/src/styles/1-layouts/layout-global/_layout-global-theme.scss
@@ -1,13 +1,14 @@
+@use 'sass:map';
 @use '../../constants' ;
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
 @mixin theme($theme) {
-  $background: map-get($theme, background);
-  $is-dark-theme: map-get($theme, is-dark);
+  $background: map.get($theme, background);
+  $is-dark-theme: map.get($theme, is-dark);
 
   html,
   body,
   .content {
-    background: if($is-dark-theme, mat-color($background, background), constants.$white);
+    background: if($is-dark-theme, mat.get-color-from-palette($background, background), constants.$white);
   }
 }

--- a/aio/src/styles/1-layouts/marketing-layout/_marketing-layout-theme.scss
+++ b/aio/src/styles/1-layouts/marketing-layout/_marketing-layout-theme.scss
@@ -1,14 +1,15 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
 @mixin theme($theme) {
-  $primary: map-get($theme, primary);
-  $foreground: map-get($theme, foreground);
-  $is-dark-theme: map-get($theme, is-dark);
+  $primary: map.get($theme, primary);
+  $foreground: map.get($theme, foreground);
+  $is-dark-theme: map.get($theme, is-dark);
 
   .background-sky {
-    background: linear-gradient(145deg, mat-color($primary, 900), if($is-dark-theme, mat-color($primary, 700), #42a5f5));
-    color: mat-color($foreground, text);
+    background: linear-gradient(145deg, mat.get-color-from-palette($primary, 900), if($is-dark-theme, mat.get-color-from-palette($primary, 700), #42a5f5));
+    color: mat.get-color-from-palette($foreground, text);
   }
 
   section#intro {
@@ -59,7 +60,7 @@
   }
 
   .marketing-banner {
-    background-color: if($is-dark-theme, mat-color($primary, 800), mat-color($primary, 600));
+    background-color: if($is-dark-theme, mat.get-color-from-palette($primary, 800), mat.get-color-from-palette($primary, 600));
 
     .banner-headline {
       color: constants.$white;

--- a/aio/src/styles/1-layouts/not-found/_not-found-theme.scss
+++ b/aio/src/styles/1-layouts/not-found/_not-found-theme.scss
@@ -1,8 +1,8 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
-  $is-dark-theme: map-get($theme, is-dark);
+  $is-dark-theme: map.get($theme, is-dark);
 
   .nf-response {
     h1 {

--- a/aio/src/styles/1-layouts/sidenav/_sidenav-theme.scss
+++ b/aio/src/styles/1-layouts/sidenav/_sidenav-theme.scss
@@ -1,12 +1,13 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
 @mixin theme($theme) {
-  $background: map-get($theme, background);
-  $is-dark-theme: map-get($theme, is-dark);
+  $background: map.get($theme, background);
+  $is-dark-theme: map.get($theme, is-dark);
 
   mat-sidenav-container.sidenav-container {
-    background-color: if($is-dark-theme, mat-color($background, background), constants.$white);
+    background-color: if($is-dark-theme, mat.get-color-from-palette($background, background), constants.$white);
 
     mat-sidenav.sidenav {
       background-color: if($is-dark-theme, constants.$deepgray, constants.$superlightgray);

--- a/aio/src/styles/1-layouts/top-menu/_top-menu-theme.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu-theme.scss
@@ -1,21 +1,22 @@
+@use 'sass:map';
 @use '../../constants';
 @use '../../mixins';
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
 @mixin theme($theme) {
-  $primary: map-get($theme, primary);
-  $is-dark-theme: map-get($theme, is-dark);
+  $primary: map.get($theme, primary);
+  $is-dark-theme: map.get($theme, is-dark);
 
   mat-toolbar.app-toolbar {
     @if $is-dark-theme {
       &.mat-primary {
-        background: mat-color($primary, darker)
+        background: mat.get-color-from-palette($primary, darker)
       }
     }
 
     // HOME PAGE OVERRIDE: TOPNAV TOOLBAR
     .page-home & {
-      background: if($is-dark-theme, mat-color($primary, darker), constants.$blue);
+      background: if($is-dark-theme, mat.get-color-from-palette($primary, darker), constants.$blue);
     }
 
     mat-icon {

--- a/aio/src/styles/2-modules/_code.scss
+++ b/aio/src/styles/2-modules/_code.scss
@@ -1,8 +1,6 @@
 @use 'sass:color';
 @use '../mixins';
-
-@use '../constants' as *;
-@use '../mixins' as *;
+@use '../constants';
 
 code-example,
 code-tabs {

--- a/aio/src/styles/2-modules/_code.scss
+++ b/aio/src/styles/2-modules/_code.scss
@@ -1,3 +1,6 @@
+@use 'sass:color';
+@use '../mixins';
+
 @use '../constants' as *;
 @use '../mixins' as *;
 
@@ -52,7 +55,7 @@ code-example {
     background-color: $accentblue;
     border-radius: 5px 5px 0 0;
     color: $offwhite;
-    @include font-size(16);
+    @include mixins.font-size(16);
     padding: 8px 16px;
   }
 }
@@ -110,21 +113,21 @@ aio-code {
       }
 
       span {
-        @include line-height(24);
+        @include mixins.line-height(24);
       }
 
       ol.linenums {
         margin: 0;
-        color: lighten($mediumgray, 25%);
+        color: color.adjust($mediumgray, $lightness: 25%);
 
         li {
           margin: 0;
           font-family: $code-font;
           font-size: 90%;
-          @include line-height(24);
+          @include mixins.line-height(24);
 
           &::marker {
-            color: lighten($mediumgray, 25%);
+            color: color.adjust($mediumgray, $lightness: 25%);
           }
         }
       }

--- a/aio/src/styles/2-modules/_code.scss
+++ b/aio/src/styles/2-modules/_code.scss
@@ -1,6 +1,6 @@
 @use 'sass:color';
-@use '../mixins';
 @use '../constants';
+@use '../mixins';
 
 code-example,
 code-tabs {

--- a/aio/src/styles/2-modules/alert/_alert-theme.scss
+++ b/aio/src/styles/2-modules/alert/_alert-theme.scss
@@ -1,8 +1,8 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
-  $is-dark-theme: map-get($theme, is-dark);
+  $is-dark-theme: map.get($theme, is-dark);
 
   .alert {
     color: if($is-dark-theme, constants.$offwhite, constants.$darkgray);

--- a/aio/src/styles/2-modules/api-list/_api-list-theme.scss
+++ b/aio/src/styles/2-modules/api-list/_api-list-theme.scss
@@ -1,9 +1,9 @@
+@use 'sass:map';
 @use '../../constants';
 @use '../../mixins';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
-  $is-dark-theme: map-get($theme, is-dark);
+  $is-dark-theme: map.get($theme, is-dark);
 
   aio-api-list {
     .api-filter {

--- a/aio/src/styles/2-modules/api-pages/_api-pages-theme.scss
+++ b/aio/src/styles/2-modules/api-pages/_api-pages-theme.scss
@@ -1,5 +1,4 @@
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin api-pages-theme($theme) {
   .api-body {

--- a/aio/src/styles/2-modules/api-symbols/_api-symbols-theme.scss
+++ b/aio/src/styles/2-modules/api-symbols/_api-symbols-theme.scss
@@ -1,5 +1,5 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
   .symbol {
@@ -10,10 +10,10 @@
     // Symbol mapping variables in *constants*
     @each $name, $symbol in constants.$api-symbols {
       &.#{$name} {
-        background: map-get($symbol, background);
+        background: map.get($symbol, background);
 
         &:before {
-          content: map-get($symbol, content);
+          content: map.get($symbol, content);
         }
       }
     }

--- a/aio/src/styles/2-modules/buttons/_buttons-theme.scss
+++ b/aio/src/styles/2-modules/buttons/_buttons-theme.scss
@@ -1,5 +1,5 @@
+@use 'sass:color';
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
   // This rule overrides some Angular Material styles defined for `.mat-button`
@@ -20,7 +20,7 @@
 
     &.button-subtle {
       background: constants.$mediumgray;
-      color: darken(constants.$offwhite, 10%);
+      color: color.adjust(constants.$offwhite, $lightness: -10%);
 
       &:hover {
         color: rgba(constants.$white, 0.7);

--- a/aio/src/styles/2-modules/callout/_callout-theme.scss
+++ b/aio/src/styles/2-modules/callout/_callout-theme.scss
@@ -1,40 +1,39 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
-    $is-dark-theme: map-get($theme, is-dark);
+  $is-dark-theme: map.get($theme, is-dark);
 
+  .callout {
+    header {
+      color: constants.$white;
+    }
 
-    .callout {      
-        header {
-          color: constants.$white;
-        }
-      
-        &.is-critical {
-          border-color: constants.$brightred;
-          background: rgba(constants.$brightred, if($is-dark-theme, 0.1, 0.05));
-      
-          header {
-            background: constants.$brightred;
-          }
-        }
-      
-        &.is-important {
-          border-color: constants.$orange;
-          background: rgba(constants.$orange,if($is-dark-theme, 0.1, 0.05));
-      
-          header {
-            background: constants.$amber-700;
-          }
-        }
-      
-        &.is-helpful {
-          border-color: constants.$blue;
-          background: rgba(constants.$blue, if($is-dark-theme, 0.1, 0.05));
-      
-          header {
-            background: constants.$blue;
-          }
-        }
+    &.is-critical {
+      border-color: constants.$brightred;
+      background: rgba(constants.$brightred, if($is-dark-theme, 0.1, 0.05));
+
+      header {
+        background: constants.$brightred;
       }
+    }
+
+    &.is-important {
+      border-color: constants.$orange;
+      background: rgba(constants.$orange,if($is-dark-theme, 0.1, 0.05));
+
+      header {
+        background: constants.$amber-700;
+      }
+    }
+
+    &.is-helpful {
+      border-color: constants.$blue;
+      background: rgba(constants.$blue, if($is-dark-theme, 0.1, 0.05));
+
+      header {
+        background: constants.$blue;
+      }
+    }
+  }
 }

--- a/aio/src/styles/2-modules/card/_card-theme.scss
+++ b/aio/src/styles/2-modules/card/_card-theme.scss
@@ -1,8 +1,8 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
 
-@mixin theme($theme) { 
-  $is-dark-theme: map-get($theme, is-dark);
+@mixin theme($theme) {
+  $is-dark-theme: map.get($theme, is-dark);
 
   .card-container {
     .docs-card {

--- a/aio/src/styles/2-modules/code/_code-theme.scss
+++ b/aio/src/styles/2-modules/code/_code-theme.scss
@@ -1,8 +1,9 @@
+@use 'sass:color';
+@use 'sass:map';
 @use '../../constants';
-@import "~@angular/material/theming";
 
 @mixin theme($theme) {
-  $is-dark-theme: map-get($theme, is-dark);
+  $is-dark-theme: map.get($theme, is-dark);
 
   code-example {
     &:not(.no-box) {
@@ -51,11 +52,11 @@
     pre.prettyprint {
       code {
         ol.linenums {
-          color: lighten(constants.$mediumgray, 25%);
+          color: color.adjust(constants.$mediumgray, $lightness: 25%);
 
           li {
             &::marker {
-              color: lighten(constants.$mediumgray, 25%);
+              color: color.adjust(constants.$mediumgray, $lightness: 25%);
             }
           }
         }

--- a/aio/src/styles/2-modules/contributor/_contributor-theme.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor-theme.scss
@@ -1,11 +1,12 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
 @mixin theme($theme) {
-  $background: map-get($theme, background);
+  $background: map.get($theme, background);
 
   aio-contributor {
-    background: mat-color($background, background);
+    background: mat.get-color-from-palette($background, background);
 
     .contributor-info {
       background: rgba(constants.$darkgray, 0.5);

--- a/aio/src/styles/2-modules/deploy-theme/_deploy-theme.scss
+++ b/aio/src/styles/2-modules/deploy-theme/_deploy-theme.scss
@@ -1,17 +1,18 @@
+@use 'sass:map';
 @use '../../constants';
 @use '../../mixins';
 
 @mixin theme($theme) {
-  $is-dark-theme: map-get($theme, is-dark);
+  $is-dark-theme: map.get($theme, is-dark);
 
   aio-shell.mode-archive {
     @include mixins.deploy-theme(constants.$blue-grey-900, constants.$blue-grey-400, if($is-dark-theme, constants.$powderblue, constants.$blue-grey-900));
   }
-  
+
   aio-shell.mode-next {
     @include mixins.deploy-theme(constants.$brightred, constants.$darkred, if($is-dark-theme, constants.$powderblue, constants.$brightred));
   }
-  
+
   aio-shell.mode-rc {
     @include mixins.deploy-theme(constants.$tangerine, constants.$darkgoldenrod, if($is-dark-theme, constants.$powderblue, constants.$tangerine));
   }

--- a/aio/src/styles/2-modules/details/_details-theme.scss
+++ b/aio/src/styles/2-modules/details/_details-theme.scss
@@ -1,5 +1,4 @@
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
   details {

--- a/aio/src/styles/2-modules/details/_details.scss
+++ b/aio/src/styles/2-modules/details/_details.scss
@@ -1,3 +1,4 @@
+@use 'sass:selector';
 @use '../../constants';
 @use '../../mixins';
 
@@ -33,7 +34,7 @@ details {
     i.material-icons.expand {
       @include mixins.rotate(0deg);
 
-      @at-root #{selector-replace(&, 'details', 'details[open]')} {
+      @at-root #{selector.replace(&, 'details', 'details[open]')} {
         @include mixins.rotate(180deg);
       }
     }

--- a/aio/src/styles/2-modules/errors/_errors-theme.scss
+++ b/aio/src/styles/2-modules/errors/_errors-theme.scss
@@ -1,5 +1,4 @@
 @use '../../constants';
-@import "~@angular/material/theming";
 
 @mixin theme($theme) {
   .error-list {

--- a/aio/src/styles/2-modules/filetree/_filetree-theme.scss
+++ b/aio/src/styles/2-modules/filetree/_filetree-theme.scss
@@ -1,5 +1,4 @@
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
   .filetree {

--- a/aio/src/styles/2-modules/guides/_guides-theme.scss
+++ b/aio/src/styles/2-modules/guides/_guides-theme.scss
@@ -1,10 +1,11 @@
+@use 'sass:color';
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
-    $is-dark-theme: map-get($theme, is-dark);
+  $is-dark-theme: map.get($theme, is-dark);
 
-    .reviewed {
-        color: if($is-dark-theme, constants.$offwhite, lighten(constants.$darkgray, 10));
-      }
+  .reviewed {
+    color: if($is-dark-theme, constants.$offwhite, color.adjust(constants.$darkgray, $lightness: 10));
+  }
 }

--- a/aio/src/styles/2-modules/guides/_guides-theme.scss
+++ b/aio/src/styles/2-modules/guides/_guides-theme.scss
@@ -6,6 +6,6 @@
   $is-dark-theme: map.get($theme, is-dark);
 
   .reviewed {
-    color: if($is-dark-theme, constants.$offwhite, color.adjust(constants.$darkgray, $lightness: 10));
+    color: if($is-dark-theme, constants.$offwhite, color.adjust(constants.$darkgray, $lightness: 10%));
   }
 }

--- a/aio/src/styles/2-modules/heading-anchors/_heading-anchors-theme.scss
+++ b/aio/src/styles/2-modules/heading-anchors/_heading-anchors-theme.scss
@@ -1,5 +1,4 @@
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
   .sidenav-content {

--- a/aio/src/styles/2-modules/hr/_hr-theme.scss
+++ b/aio/src/styles/2-modules/hr/_hr-theme.scss
@@ -1,8 +1,8 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
-  $is-dark-theme: map-get($theme, is-dark);
+  $is-dark-theme: map.get($theme, is-dark);
 
   hr {
     background: if($is-dark-theme, constants.$mediumgray, constants.$lightgray);

--- a/aio/src/styles/2-modules/images/_images-theme.scss
+++ b/aio/src/styles/2-modules/images/_images-theme.scss
@@ -1,8 +1,8 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
-  $is-dark-theme: map-get($theme, is-dark);
+  $is-dark-theme: map.get($theme, is-dark);
 
   .content {
     .lightbox {

--- a/aio/src/styles/2-modules/label/_label-theme.scss
+++ b/aio/src/styles/2-modules/label/_label-theme.scss
@@ -1,36 +1,36 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
-    .api-header label {
-        color: constants.$white;
+  .api-header label {
+    color: constants.$white;
 
-        &.api-status-label {
-          background-color: constants.$mediumgray;
-      
-          &.deprecated, &.security, &.impure-pipe {
-            background-color: constants.$brightred;
-          }
-        }
-      
-        &.api-type-label {
-          background-color: constants.$accentblue;
-      
-          @each $name, $symbol in constants.$api-symbols {
-            &.#{$name} {
-              background: map-get($symbol, background);
-            }
-          }
-        }
-      
-        &.page-label {
-          background-color: constants.$mist;
-          color: constants.$mediumgray;
-        }
-      
-        &.property-type-label {
-          background-color: constants.$darkgray;
-          color: constants.$white;
+    &.api-status-label {
+      background-color: constants.$mediumgray;
+
+      &.deprecated, &.security, &.impure-pipe {
+        background-color: constants.$brightred;
+      }
+    }
+
+    &.api-type-label {
+      background-color: constants.$accentblue;
+
+      @each $name, $symbol in constants.$api-symbols {
+        &.#{$name} {
+          background: map.get($symbol, background);
         }
       }
+    }
+
+    &.page-label {
+      background-color: constants.$mist;
+      color: constants.$mediumgray;
+    }
+
+    &.property-type-label {
+      background-color: constants.$darkgray;
+      color: constants.$white;
+    }
+  }
 }

--- a/aio/src/styles/2-modules/notification/_notification-theme.scss
+++ b/aio/src/styles/2-modules/notification/_notification-theme.scss
@@ -1,5 +1,4 @@
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
   aio-notification {

--- a/aio/src/styles/2-modules/presskit/_presskit-theme.scss
+++ b/aio/src/styles/2-modules/presskit/_presskit-theme.scss
@@ -1,9 +1,10 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
 @mixin theme($theme) {
-  $background: map-get($theme, background);
-  $is-dark-theme: map-get($theme, is-dark);
+  $background: map.get($theme, background);
+  $is-dark-theme: map.get($theme, is-dark);
 
   .presskit-container {
     .presskit-section {
@@ -18,7 +19,7 @@
               background-color: constants.$white;
 
               &-inverse {
-                background-color: if($is-dark-theme, mat-color($background, background), constants.$deepgray);
+                background-color: if($is-dark-theme, mat.get-color-from-palette($background, background), constants.$deepgray);
               }
             }
           }

--- a/aio/src/styles/2-modules/resources/_resources-theme.scss
+++ b/aio/src/styles/2-modules/resources/_resources-theme.scss
@@ -1,8 +1,8 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
 
 @mixin theme($theme) {
-  $is-dark-theme: map-get($theme, is-dark);
+  $is-dark-theme: map.get($theme, is-dark);
 
   aio-resource-list {
     .subcategory-title {

--- a/aio/src/styles/2-modules/search-results/_search-results-theme.scss
+++ b/aio/src/styles/2-modules/search-results/_search-results-theme.scss
@@ -1,9 +1,11 @@
+@use 'sass:color';
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
 @mixin theme($theme) {
-  $foreground: map-get($theme, foreground);
-  $is-dark-theme: map-get($theme, is-dark);
+  $foreground: map.get($theme, foreground);
+  $is-dark-theme: map.get($theme, is-dark);
 
   aio-search-results {
     .search-results {
@@ -27,11 +29,11 @@
       }
 
       .no-results {
-        color: mat-color($foreground, text);
+        color: mat.get-color-from-palette($foreground, text);
       }
 
       a {
-        color: mat-color($foreground, text);
+        color: mat.get-color-from-palette($foreground, text);
       }
     }
 
@@ -43,7 +45,7 @@
           }
 
           .search-result-item {
-            color: if($is-dark-theme, constants.$offwhite ,lighten(constants.$darkgray, 10));
+            color: if($is-dark-theme, constants.$offwhite ,color.adjust(constants.$darkgray, $lightness: 10));
 
             &:hover {
               color: constants.$accentblue;
@@ -52,7 +54,7 @@
         }
 
         .no-results {
-          color: mat-color($foreground, text);
+          color: mat.get-color-from-palette($foreground, text);
         }
 
         a {

--- a/aio/src/styles/2-modules/search-results/_search-results-theme.scss
+++ b/aio/src/styles/2-modules/search-results/_search-results-theme.scss
@@ -19,7 +19,7 @@
 
         ul {
           .search-result-item {
-            color: if($is-dark-theme, constants.$offwhite , constants.$lightgray);
+            color: if($is-dark-theme, constants.$offwhite, constants.$lightgray);
 
             &:hover {
               color: constants.$white;
@@ -45,7 +45,7 @@
           }
 
           .search-result-item {
-            color: if($is-dark-theme, constants.$offwhite ,color.adjust(constants.$darkgray, $lightness: 10));
+            color: if($is-dark-theme, constants.$offwhite, color.adjust(constants.$darkgray, $lightness: 10%));
 
             &:hover {
               color: constants.$accentblue;

--- a/aio/src/styles/2-modules/select-menu/_select-menu-theme.scss
+++ b/aio/src/styles/2-modules/select-menu/_select-menu-theme.scss
@@ -1,9 +1,10 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
 @mixin theme($theme) {
-  $background: map-get($theme, background);
-  $is-dark-theme: map-get($theme, is-dark);
+  $background: map.get($theme, background);
+  $is-dark-theme: map.get($theme, is-dark);
 
   aio-select {
     .form-select-button {
@@ -23,7 +24,7 @@
     }
 
     .form-select-dropdown {
-      background: mat-color($background, background);
+      background: mat.get-color-from-palette($background, background);
       box-shadow: 0 16px 16px rgba(constants.$black, 0.24), 0 0 16px rgba(constants.$black, 0.12);
 
       li {

--- a/aio/src/styles/2-modules/table/_table-theme.scss
+++ b/aio/src/styles/2-modules/table/_table-theme.scss
@@ -1,13 +1,14 @@
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
 @mixin theme($theme) {
-  $background: map-get($theme, background);
-  $is-dark-theme: map-get($theme, is-dark);
+  $background: map.get($theme, background);
+  $is-dark-theme: map.get($theme, is-dark);
 
   table {
     box-shadow: 0 2px 2px rgba(constants.$mediumgray, 0.24), 0 0 2px rgba(if($is-dark-theme, constants.$white, constants.$black), 0.12);
-    background-color: if($is-dark-theme, mat-color($background, background), constants.$white);
+    background-color: if($is-dark-theme, mat.get-color-from-palette($background, background), constants.$white);
 
     thead > {
       tr > th {

--- a/aio/src/styles/2-modules/toc/_toc-theme.scss
+++ b/aio/src/styles/2-modules/toc/_toc-theme.scss
@@ -48,7 +48,7 @@
           }
 
           a {
-            color: if($is-dark-theme, constants.$white, color.adjust(constants.$darkgray, $lightness: 10));
+            color: if($is-dark-theme, constants.$white, color.adjust(constants.$darkgray, $lightness: 10%));
           }
 
           &:hover {

--- a/aio/src/styles/2-modules/toc/_toc-theme.scss
+++ b/aio/src/styles/2-modules/toc/_toc-theme.scss
@@ -1,9 +1,11 @@
+@use 'sass:color';
+@use 'sass:map';
 @use '../../constants';
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
 @mixin theme($theme) {
-  $foreground: map-get($theme, foreground);
-  $is-dark-theme: map-get($theme, is-dark);
+  $foreground: map.get($theme, foreground);
+  $is-dark-theme: map.get($theme, is-dark);
 
   aio-toc {
     .toc-inner {
@@ -46,7 +48,7 @@
           }
 
           a {
-            color: if($is-dark-theme, constants.$white, lighten(constants.$darkgray, 10));
+            color: if($is-dark-theme, constants.$white, color.adjust(constants.$darkgray, $lightness: 10));
           }
 
           &:hover {
@@ -84,7 +86,7 @@
       .toc-inner {
         .toc-heading {
           &.secondary {
-            color: mat-color($foreground, text);
+            color: mat.get-color-from-palette($foreground, text);
           }
         }
       }

--- a/aio/src/styles/_mixins.scss
+++ b/aio/src/styles/_mixins.scss
@@ -1,3 +1,5 @@
+@use 'sass:list';
+@use 'sass:selector';
 @use './constants';
 
 // REM Font Adjustments
@@ -127,7 +129,7 @@
   );
 
   @if $nestParentSelector and & {
-    @at-root #{selector-nest(#{$selectors}, &)} {
+    @at-root #{selector.nest(#{$selectors}, &)} {
       @content;
     }
   } @else {
@@ -179,10 +181,10 @@
     '.page-presskit',
     '.page-resources',
   );
-  $selectors: join($marketingPagesSelectors, $extraSelectors, $separator: comma);
+  $selectors: list.join($marketingPagesSelectors, $extraSelectors, $separator: comma);
 
   @if $nestParentSelector and & {
-    @at-root #{selector-nest(#{$selectors}, &)} {
+    @at-root #{selector.nest(#{$selectors}, &)} {
       @content;
     }
   } @else {

--- a/aio/src/styles/custom-themes/dark-theme.scss
+++ b/aio/src/styles/custom-themes/dark-theme.scss
@@ -1,10 +1,10 @@
 @use '../app-theme';
-@import "~@angular/material/theming";
+@use '~@angular/material' as mat;
 
-$ng-io-primary: mat-palette($mat-blue, 700, 600, 900);
-$ng-io-accent: mat-palette($mat-red, 700, 600, 800);
-$ng-io-warn: mat-palette($mat-red);
-$ng-io-theme: mat-dark-theme($ng-io-primary, $ng-io-accent, $ng-io-warn);
+$ng-io-primary: mat.define-palette(mat.$blue-palette, 700, 600, 900);
+$ng-io-accent: mat.define-palette(mat.$red-palette, 700, 600, 800);
+$ng-io-warn: mat.define-palette(mat.$red-palette);
+$ng-io-theme: mat.define-dark-theme($ng-io-primary, $ng-io-accent, $ng-io-warn);
 
-@include angular-material-theme($ng-io-theme);
+@include mat.all-component-themes($ng-io-theme);
 @include app-theme.theme($ng-io-theme);

--- a/aio/src/styles/custom-themes/light-theme.scss
+++ b/aio/src/styles/custom-themes/light-theme.scss
@@ -1,10 +1,10 @@
 @use '../app-theme';
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
-$ng-io-primary: mat-palette($mat-blue, 700, 600, 800);
-$ng-io-accent: mat-palette($mat-red, 700, 600, 800);
-$ng-io-warn: mat-palette($mat-red);
-$ng-io-theme: mat-light-theme($ng-io-primary, $ng-io-accent, $ng-io-warn);
+$ng-io-primary: mat.define-palette(mat.$blue-palette, 700, 600, 800);
+$ng-io-accent: mat.define-palette(mat.$red-palette, 700, 600, 800);
+$ng-io-warn: mat.define-palette(mat.$red-palette);
+$ng-io-theme: mat.define-light-theme($ng-io-primary, $ng-io-accent, $ng-io-warn);
 
-@include angular-material-theme($ng-io-theme);
+@include mat.all-component-themes($ng-io-theme);
 @include app-theme.theme($ng-io-theme);

--- a/aio/src/styles/main.scss
+++ b/aio/src/styles/main.scss
@@ -6,8 +6,8 @@
 // import print styles
 @use './print';
 
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
 // Include the base styles for Angular Material core. We include this here so that you only
 // have to load a single css file for Angular Material in your app.
-@include mat-core();
+@include mat.core();


### PR DESCRIPTION
Cleans up AIO's Sass files by:
* Switching them all over to the `@use`-based API from Angular Material.
* Removing the import of the Material theming API in a bunch of places that weren't using it.
* Migrating the new usages of Sass utility functions to the new syntax (e.g. `map.get` vs `map-get`).
* Fixing a few files that were using 4 spaces for indentation instead of 2.