### PR TITLE
fix(compiler-cli): exclude type-only imports from cycle analysis

### DIFF
--- a/packages/compiler-cli/src/ngtsc/cycles/src/imports.ts
+++ b/packages/compiler-cli/src/ngtsc/cycles/src/imports.ts
@@ -110,6 +110,13 @@ export class ImportGraph {
           continue;
         }
 
+        if (ts.isImportDeclaration(stmt) && stmt.importClause !== undefined &&
+            stmt.importClause.isTypeOnly) {
+          // Exclude type-only imports as they are always elided, so they don't contribute to
+          // cycles.
+          continue;
+        }
+
         const symbol = this.checker.getSymbolAtLocation(stmt.moduleSpecifier);
         if (symbol === undefined || symbol.valueDeclaration === undefined) {
           // No symbol could be found to skip over this import/export.

--- a/packages/compiler-cli/src/ngtsc/cycles/test/analyzer_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/cycles/test/analyzer_spec.ts
@@ -70,6 +70,17 @@ runInEachFileSystem(() => {
       expect(cycle).toBeInstanceOf(Cycle);
       expect(importPath(cycle!.getPath())).toEqual('b,c,b');
     });
+
+    it('should not consider type-only imports', () => {
+      const {program, analyzer} = makeAnalyzer('a:b,c!;b;c');
+      const a = getSourceFileOrError(program, (_('/a.ts')));
+      const b = getSourceFileOrError(program, (_('/b.ts')));
+      const c = getSourceFileOrError(program, (_('/c.ts')));
+      expect(analyzer.wouldCreateCycle(c, a)).toBe(null);
+      const cycle = analyzer.wouldCreateCycle(b, a);
+      expect(cycle).toBeInstanceOf(Cycle);
+      expect(importPath(cycle!.getPath())).toEqual('b,a,b');
+    });
   });
 
   function makeAnalyzer(graph: string): {program: ts.Program, analyzer: CycleAnalyzer} {

--- a/packages/compiler-cli/src/ngtsc/cycles/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/cycles/test/util.ts
@@ -30,6 +30,8 @@ import {makeProgram} from '../../testing';
  * "a:*b,c;b;c"
  *
  * represents a program where a.ts exports from b.ts and imports from c.ts.
+ *
+ * An import can be suffixed with ! to make it a type-only import.
  */
 export function makeProgramFromGraph(fs: PathManipulation, graph: string): {
   program: ts.Program,
@@ -43,6 +45,9 @@ export function makeProgramFromGraph(fs: PathManipulation, graph: string): {
                            if (i.startsWith('*')) {
                              const sym = i.substr(1);
                              return `export {${sym}} from './${sym}';`;
+                           } else if (i.endsWith('!')) {
+                             const sym = i.substr(0, i.length - 1);
+                             return `import type {${sym}} from './${sym}';`;
                            } else {
                              return `import {${i}} from './${i}';`;
                            }


### PR DESCRIPTION
Type-only imports are known to be elided by TypeScript, so the compiler
can be certain that such imports do not contribute to potential import
cycles. As such, type-only imports are no longer considered during cycle
analysis.

Regular import statements that would eventually be fully elided by
TypeScript during emit if none of the imported symbols are used in a
value position continue to be included in the cycle analysis, as the
cycle analyzer is unaware of these elision opportunities. Only explicit
`import type` statements are excluded.