### PR TITLE
fix(dev-infra): github oauth token not picked up by Octokit

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -240,7 +240,7 @@ var GithubClient = /** @class */ (function () {
         /** The graphql instance with authentication set during construction. */
         this._graphql = graphql.graphql.defaults({ headers: { authorization: "token " + this.token } });
         /** The Octokit instance actually performing API requests. */
-        this._octokit = new rest.Octokit({ token: this.token });
+        this._octokit = new rest.Octokit({ auth: this.token });
         this.pulls = this._octokit.pulls;
         this.repos = this._octokit.repos;
         this.issues = this._octokit.issues;

--- a/dev-infra/utils/git/github.ts
+++ b/dev-infra/utils/git/github.ts
@@ -45,7 +45,7 @@ export class GithubClient {
   /** The graphql instance with authentication set during construction. */
   private _graphql = graphql.defaults({headers: {authorization: `token ${this.token}`}});
   /** The Octokit instance actually performing API requests. */
-  private _octokit = new Octokit({token: this.token});
+  private _octokit = new Octokit({auth: this.token});
 
   /**
    * @param token The github authentication token for Github Rest and Graphql API requests.


### PR DESCRIPTION
We recently [updated `@octokit/rest`](https://github.com/angular/angular/commit/aeb407296b535c453fa08017a82b3de0e7902f2b) to a more recent version. For this
the Github client had to be refactored to account for new types of
Octokit. With the refactorings the authentication of the Github
client broke as we used an incorrect option for setting the OAuth
token. The TS transpilation did not fail because the Octokit types
support arbitrary options in the constructor. This is not solvable
on our side, so we cannot prevent similar issues in the future
unfortunately. Adding tests for authentication is not a reasonable
option either.