### PR TITLE
fix(dev-infra): update outdated build-worker.js file

### DIFF
--- a/dev-infra/build-worker.js
+++ b/dev-infra/build-worker.js
@@ -77,7 +77,7 @@ var GithubClient = /** @class */ (function () {
         /** The graphql instance with authentication set during construction. */
         this._graphql = graphql.graphql.defaults({ headers: { authorization: "token " + this.token } });
         /** The Octokit instance actually performing API requests. */
-        this._octokit = new rest.Octokit({ token: this.token });
+        this._octokit = new rest.Octokit({ auth: this.token });
         this.pulls = this._octokit.pulls;
         this.repos = this._octokit.repos;
         this.issues = this._octokit.issues;


### PR DESCRIPTION
Updates the outdated build-worker.js file. This file has
been accidentally not updated when we fixed the Octokit
authentication to unblock the caretaker.

Note: Should be merged manually into `master`.