### PR TITLE
refactor(dev-infra): always use en-US locale for printing date in merge tool

### DIFF
--- a/dev-infra/pr/merge/defaults/lts-branch.ts
+++ b/dev-infra/pr/merge/defaults/lts-branch.ts
@@ -53,7 +53,7 @@ export async function assertActiveLtsBranch(
   // allow the merge as per our LTS guarantees. Can be forcibly overridden if desired.
   // See: https://angular.io/guide/releases#support-policy-and-schedule.
   if (today > ltsEndDate) {
-    const ltsEndDateText = ltsEndDate.toLocaleDateString();
+    const ltsEndDateText = ltsEndDate.toLocaleDateString('en-US');
     warn(red(`Long-term support ended for v${version.major} on ${ltsEndDateText}.`));
     warn(yellow(
         `Merging of pull requests for this major is generally not ` +


### PR DESCRIPTION
In the dev-infra merge tool, a test fails locally if it runs on
a system with a different system locale. We can either make the
test more flexible, or update the merge tool to always print the date
in `en-US` format. The latter is more reasonable given our console
messages being in English anyway.