### PR TITLE
ci: extend default timeout of karma tests for legacy saucelab tests

### DIFF
--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -8,6 +8,7 @@
 
 const browserProvidersConf = require('./browser-providers.conf');
 const {generateSeed} = require('./tools/jasmine-seed-generator');
+const {hostname} = require('os');
 
 // Karma configuration
 // Generated on Thu Sep 25 2014 11:52:02 GMT-0700 (PDT)
@@ -20,6 +21,7 @@ module.exports = function(config) {
         random: true,
         seed: generateSeed('karma-js.conf'),
       },
+      captureConsole: process.env.CI ? false : true,
     },
 
     files: [
@@ -182,6 +184,8 @@ module.exports = function(config) {
   // More context can be found in: https://github.com/angular/angular/pull/35171.
   if (process.env.SAUCE_LOCALHOST_ALIAS_DOMAIN) {
     conf.hostname = process.env.SAUCE_LOCALHOST_ALIAS_DOMAIN;
+  } else {
+    conf.hostname = hostname();
   }
 
   if (process.env.KARMA_WEB_TEST_MODE) {

--- a/test-main.js
+++ b/test-main.js
@@ -9,7 +9,7 @@
 // Tun on full stack traces in errors to help debugging
 Error.stackTraceLimit = Infinity;
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 3000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
 
 // Cancel Karma's synchronous start,
 // we will call `__karma__.start()` later, once all the specs are loaded.


### PR DESCRIPTION
After testing, it seems that the flakyness we are experiencing in our legacy
saucelabs job is caused by timeouts which happen due to the karma server being
unable to serve all of the files needed for the tests fast enough while concurrent
tests are being run.