### PR TITLE
fix(docs-infra): fix search results font color

### DIFF
--- a/aio/src/styles/2-modules/search-results/_search-results-theme.scss
+++ b/aio/src/styles/2-modules/search-results/_search-results-theme.scss
@@ -29,7 +29,7 @@
       }
 
       .no-results {
-        color: mat.get-color-from-palette($foreground, text);
+        color: #fff;
       }
 
       a {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In light theme text for "No results found" is dark but it is on the dark background.


## What is the new behavior?
Font color for "No results found" is white in both dark and light themes.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No