### PR TITLE
fix(router): fix `serializeQueryParams` logic

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -497,12 +497,15 @@ function serializeMatrixParams(params: {[key: string]: string}): string {
 }
 
 function serializeQueryParams(params: {[key: string]: any}): string {
-  const strParams: string[] = Object.keys(params).map((name) => {
-    const value = params[name];
-    return Array.isArray(value) ?
-        value.map(v => `${encodeUriQuery(name)}=${encodeUriQuery(v)}`).join('&') :
-        `${encodeUriQuery(name)}=${encodeUriQuery(value)}`;
-  });
+  const strParams: string[] =
+      Object.keys(params)
+          .map((name) => {
+            const value = params[name];
+            return Array.isArray(value) ?
+                value.map(v => `${encodeUriQuery(name)}=${encodeUriQuery(v)}`).join('&') :
+                `${encodeUriQuery(name)}=${encodeUriQuery(value)}`;
+          })
+          .filter(s => !!s);
 
   return strParams.length ? `?${strParams.join('&')}` : '';
 }

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -27,6 +27,16 @@ describe('createUrlTree', () => {
       expect(serializer.serialize(t2)).toEqual('/a/c/c2?m=v1&m=v2');
     });
 
+    it('should support parameter with empty arrays as values', () => {
+      const p1 = serializer.parse('/a/c');
+      const t1 = create(p1.root.children[PRIMARY_OUTLET], 1, p1, ['c2'], {m: []});
+      expect(serializer.serialize(t1)).toEqual('/a/c/c2');
+
+      const p2 = serializer.parse('/a/c');
+      const t2 = create(p2.root.children[PRIMARY_OUTLET], 1, p2, ['c2'], {m: [], n: 1});
+      expect(serializer.serialize(t2)).toEqual('/a/c/c2?n=1');
+    });
+
     it('should set query params', () => {
       const p = serializer.parse('/');
       const t = createRoot(p, [], {a: 'hey'});


### PR DESCRIPTION
**I am currently marking this as a breaking change out of an abundance of caution, because it does make a small change to the way query params are serialized into a url. The maintainers can decide if it truly is a breaking change.**

corrects a bug that resulted in query params such as `{a: 1, b:[]}` being serialized as 'a=1&' instead of 'a=1'

resolves #42445

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

It changes the way query params are serialized into a url

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Something like `[queryParams]={a: 1, b:[]}` gets serialized as 'a=1&'

Issue Number: #42445 


## What is the new behavior?

Something like `[queryParams]={a: 1, b:[]}` gets serialized as 'a=1'


## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The url generated by the router link directive will be different if this PR is merged. It will no longer contain the extra ampersand.

## Other information
