### PR TITLE
build: suppress errors in git hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -5,7 +5,7 @@ set +e
 
 yarn -s ng-dev commit-message pre-commit-validate --file $1 2>/dev/null
 if [ $? -ne 0 ]; then
-  echo "WARNING: failed to run commit-msg hook"
+  echo "WARNING: failed to run commit message validation (ng-dev commit-mesage pre-commit-validate)"
 fi
 
 exit 0;

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,11 @@
 #!/bin/sh
 . "$(dirname $0)/_/husky.sh"
 
-yarn -s ng-dev commit-message pre-commit-validate --file $1;
+set +e
+
+yarn -s ng-dev commit-message pre-commit-validate --file $1 2>/dev/null
+if [ $? -ne 0 ]; then
+  echo "WARNING: failed to run commit-msg hook"
+fi
+
+exit 0;

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,7 +4,7 @@
 set +e
 yarn -s ng-dev format staged 2>/dev/null
 if [ $? -ne 0 ]; then
-  echo "WARNING: failed to run pre-commit hook"
+  echo "WARNING: failed to run file formatting (ng-dev format staged)"
 fi
 
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,11 @@
 #!/bin/sh
 . "$(dirname $0)/_/husky.sh"
 
-yarn -s ng-dev format staged;
+set +e
+yarn -s ng-dev format staged 2>/dev/null
+if [ $? -ne 0 ]; then
+  echo "WARNING: failed to run pre-commit hook"
+fi
+
+
+exit 0;

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -5,7 +5,7 @@ set +e
 
 yarn -s ng-dev commit-message restore-commit-message-draft $1 $2 2>/dev/null
 if [ $? -ne 0 ]; then
-  echo "WARNING: failed to run prepare-commit-msg hook"
+  echo "WARNING: failed to attempt to restore commit message draft (ng-dev commit-message restore-commit-message-draft)"
 fi
 
 exit 0;

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,4 +1,11 @@
 #!/bin/sh
 . "$(dirname $0)/_/husky.sh"
 
-yarn -s ng-dev commit-message restore-commit-message-draft $1 $2;
+set +e
+
+yarn -s ng-dev commit-message restore-commit-message-draft $1 $2 2>/dev/null
+if [ $? -ne 0 ]; then
+  echo "WARNING: failed to run prepare-commit-msg hook"
+fi
+
+exit 0;


### PR DESCRIPTION
When errors occur in git hooks, we can safely supress them as they are validated on CI.

This is primarily coming up as an issue related to needing to reinstall node_modules
