### PR TITLE
docs: JIT was Default until angular 8 added

### DIFF
--- a/aio/content/guide/glossary.md
+++ b/aio/content/guide/glossary.md
@@ -25,6 +25,7 @@ and runs that code.
 This is the best compilation mode for production environments, with decreased load time and increased performance compared to [just-in-time (JIT) compilation](#jit).
 
 By compiling your application using the `ngc` command-line tool, you can bootstrap directly to a module factory, so you don't need to include the Angular compiler in your JavaScript bundle.
+AOT is the default since Angular 9.
 
 {@a angular-element}
 
@@ -527,7 +528,7 @@ See [ECMAScript](#ecma), [TypeScript](#typescript).
 The Angular just-in-time (JIT) compiler converts your Angular HTML and TypeScript code into
 efficient JavaScript code at run time, as part of bootstrapping.
 
-JIT compilation is the default (as opposed to AOT compilation) when you run Angular's `ng build` and `ng serve` CLI commands, and is a good choice during development.
+JIT compilation was default until Angular 8 when you ran Angular's `ng build` and `ng serve` CLI commands (From Angular 9 AOT is default), and JIT is a good choice during development.
 JIT mode is strongly discouraged for production use
 because it results in large application payloads that hinder the bootstrap performance.
 


### PR DESCRIPTION
changed this line from JIT compilation is the default (as opposed to AOT compilation) when you run Angular's ng build and ng serve ==>  To JIT compilation was default until Angular 8 when you ran Angular's `ng build` and `ng serve` CLI commands (From Angular 9 AOT is default), and JIT is a good choice during development.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
