### PR TITLE
docs: clarify how type-only imports can be used to avoid NG3003

### DIFF
--- a/aio/content/errors/NG3003.md
+++ b/aio/content/errors/NG3003.md
@@ -53,3 +53,5 @@ component being compiled. Here are some ideas for fixing the problem:
 that is stored in an independent file that can be imported to both dependent files without
 causing an import cycle.
 * Move the classes that reference each other into the same file, to avoid any imports between them.
+* Convert import statements to type-only imports (using `import type` syntax) if the imported declarations
+are only used as types, as type-only imports do not contribute to cycles.


### PR DESCRIPTION
Since #42453, type-only imports are not considered for cyclic imports.
This commit adds a note to the NG3003 error documentation to mention
using type-only imports to avoid the error.