### PR TITLE
refactor(docs-infra): prepare DocumentService to handle new disambiguated URLs

### DIFF
--- a/aio/src/app/documents/document.service.ts
+++ b/aio/src/app/documents/document.service.ts
@@ -70,18 +70,17 @@ export class DocumentService {
         catchError((error: HttpErrorResponse) => {
           const encodedPath = encodeToLowercase(requestPath);
           return error.status === 404 && encodedPath !== requestPath ?
-              this.http.get<DocumentContents>(encodeToLowercase(requestPath)) :
+              this.http.get<DocumentContents>(encodedPath) :
               throwError(error);
         }),
         catchError((error: HttpErrorResponse) => {
           const disambiguatedPath = convertDisambiguatedPath(requestPath);
           return error.status === 404 && disambiguatedPath !== requestPath ?
-              this.http.get<DocumentContents>(convertDisambiguatedPath(requestPath)) :
+              this.http.get<DocumentContents>(disambiguatedPath) :
               throwError(error);
         }),
         // END HACK: PREPARE FOR CHANGING TO CASE-INSENSITIVE URLS
         catchError((error: HttpErrorResponse) => {
-          console.log('3');
           return error.status === 404 ? this.getFileNotFoundDoc(id) : this.getErrorDoc(id, error);
         }),
       )

--- a/aio/src/app/documents/document.service.ts
+++ b/aio/src/app/documents/document.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 
-import { AsyncSubject, Observable, of } from 'rxjs';
+import { AsyncSubject, Observable, of, throwError } from 'rxjs';
 import { catchError, switchMap, tap } from 'rxjs/operators';
 
 import { DocumentContents } from './document-contents';
@@ -66,7 +66,22 @@ export class DocumentService {
             throw Error('Invalid data');
           }
         }),
+        // HACK: PREPARE FOR CHANGING TO CASE-INSENSITIVE URLS
         catchError((error: HttpErrorResponse) => {
+          const encodedPath = encodeToLowercase(requestPath);
+          return error.status === 404 && encodedPath !== requestPath ?
+              this.http.get<DocumentContents>(encodeToLowercase(requestPath)) :
+              throwError(error);
+        }),
+        catchError((error: HttpErrorResponse) => {
+          const disambiguatedPath = convertDisambiguatedPath(requestPath);
+          return error.status === 404 && disambiguatedPath !== requestPath ?
+              this.http.get<DocumentContents>(convertDisambiguatedPath(requestPath)) :
+              throwError(error);
+        }),
+        // END HACK: PREPARE FOR CHANGING TO CASE-INSENSITIVE URLS
+        catchError((error: HttpErrorResponse) => {
+          console.log('3');
           return error.status === 404 ? this.getFileNotFoundDoc(id) : this.getErrorDoc(id, error);
         }),
       )
@@ -96,4 +111,31 @@ export class DocumentService {
       contents: FETCHING_ERROR_CONTENTS(id),
     });
   }
+}
+
+/**
+ * Encode the path to the content in a deterministic, reversible, case-insensitive form.
+ *
+ * This avoids collisions on case-insensitive file-systems.
+ *
+ * - Escape underscores (_) to double underscores (__).
+ * - Convert all uppercase letters to lowercase followed by an underscore.
+ */
+function encodeToLowercase(str: string): string {
+  return str.replace(/[A-Z_]/g, char => char.toLowerCase() + '_');
+}
+
+/**
+ * A temporary function to deal with a future change to URL disambiguation.
+ *
+ * Currently there are disambiguated URLs such as `INJECTOR-0` and `Injector-1`, which
+ * will attempt to load their document contents from `injector-0.json` and `injector-1.json`
+ * respectively. In a future version of the AIO app, the disambiguation will be changed to
+ * escape the upper-case characters instead.
+ *
+ * This function will be called if the current AIO is trying to request documents from a
+ * server that has been updated to use the new disambiguated URLs.
+ */
+function convertDisambiguatedPath(str: string): string {
+  return encodeToLowercase(str.replace(/-\d+\.json$/, '.json'));
 }

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 4619,
-        "main-es2015": 453172,
+        "main-es2015": 453855,
         "polyfills-es2015": 55210
       }
     }
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 4619,
-        "main-es2015": 453394,
+        "main-es2015": 453981,
         "polyfills-es2015": 55291
       }
     }


### PR DESCRIPTION
A subsequent commit is going to change disambiguated URLs.
This commit prepares the AIO application to attempt the new URLs
if the old URLs fail. This will help to mitigate problems that may occur
during the period between deployment of the new version and the
service-worker not being updated.
