### PR TITLE
docs: updated collaborators and add angular dev's link

### DIFF
--- a/aio/content/marketing/README.md
+++ b/aio/content/marketing/README.md
@@ -1,6 +1,6 @@
 # Contributors page
 
-We have an official accounting of who is on the Angular Team, who are "trusted collaborators" (see https://team.angular.io/collaborators), and so on.
+We have an official accounting of who is on the Angular Team (see https://angular.io/about?group=Angular), who are "trusted collaborators" (see https://angular.io/about?group=Collaborators), and so on.
 
 The `contributors.json` should be maintained to keep our "org chart" in a single consistent place.
 


### PR DESCRIPTION
Existing trusted collaborators link is not working and now link is updated to one angular.io page for better management also current page was missing angular dev's link so added it

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Existing trusted collaborators link is not working and also it's missing angular dev's link.

Issue Number: #42513 


## What is the new behavior?
Existing trusted collaborators link is updated and added missing angular dev's link.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
