### PR TITLE
feat(service-worker): add `openWindow` and `lastFocusedOrOpen` to not…

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -614,6 +614,7 @@ groups:
           'aio/content/examples/service-worker-getting-started/**',
           'aio/content/guide/app-shell.md',
           'aio/content/guide/service-worker-communications.md',
+          'aio/content/guide/service-worker-notifications.md',
           'aio/content/guide/service-worker-config.md',
           'aio/content/guide/service-worker-devops.md',
           'aio/content/guide/service-worker-intro.md',

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -614,10 +614,10 @@ groups:
           'aio/content/examples/service-worker-getting-started/**',
           'aio/content/guide/app-shell.md',
           'aio/content/guide/service-worker-communications.md',
-          'aio/content/guide/service-worker-notifications.md',
           'aio/content/guide/service-worker-config.md',
           'aio/content/guide/service-worker-devops.md',
           'aio/content/guide/service-worker-intro.md',
+          'aio/content/guide/service-worker-notifications.md',
           'aio/content/images/guide/service-worker/**'
           ])
     reviewers:

--- a/aio/content/guide/service-worker-communications.md
+++ b/aio/content/guide/service-worker-communications.md
@@ -95,4 +95,4 @@ You can subscribe to `SwUpdate#unrecoverable` to be notified and handle these er
 ## More on Angular service workers
 
 You may also be interested in the following:
-* [Service Worker in Production](guide/service-worker-devops).
+* [Service Worker Notifications](guide/service-worker-notifications).

--- a/aio/content/guide/service-worker-intro.md
+++ b/aio/content/guide/service-worker-intro.md
@@ -66,6 +66,7 @@ The rest of the articles in this section specifically address the Angular implem
 
 * [App Shell](guide/app-shell)
 * [Service Worker Communication](guide/service-worker-communications)
+* [Service Worker Notifications](guide/service-worker-notifications)
 * [Service Worker in Production](guide/service-worker-devops)
 * [Service Worker Configuration](guide/service-worker-config)
 

--- a/aio/content/guide/service-worker-notifications.md
+++ b/aio/content/guide/service-worker-notifications.md
@@ -13,7 +13,7 @@ The Angular service worker enables the display of push notifications and the han
 
 #### Prerequisites
 
-A basic understanding of the following:
+We recommend you have a basic understanding of the following:
 
 - [Getting Started with Service Workers](guide/service-worker-getting-started).
 
@@ -30,7 +30,7 @@ Invoke push notifications by pushing a message with a valid payload. See `SwPush
 
 ## Notification click handling
 
-The default behaviour for the `notificationclick` event, is to close the notification and notify `SwPush.notificationClicks`.
+The default behavior for the `notificationclick` event is to close the notification and notify `SwPush.notificationClicks`.
 
 You can specify an additional operation to be executed on `notificationclick` by adding an `onActionClick` property to the `data` object, and providing a `default` entry. This is especially useful for when there are no open clients when a notification is clicked.
 
@@ -59,7 +59,7 @@ The Angular service worker supports the following operations:
 
 <div class="alert is-important">
 
-  If an `onActionClick` item does not define a `url`, then the service worker's registration scope will be used.
+  If an `onActionClick` item does not define a `url`, then the service worker's registration scope is used.
   
 </div>
 

--- a/aio/content/guide/service-worker-notifications.md
+++ b/aio/content/guide/service-worker-notifications.md
@@ -6,20 +6,10 @@ The Angular service worker enables the display of push notifications and the han
 
 <div class="alert is-helpful">
 
-  When using the Angular service worker, push notification interactions can be handled using the `SwPush` service.
+  When using the Angular service worker, push notification interactions are handled using the `SwPush` service.
+  To learn more about the native APIs involved see [Push API](https://developer.mozilla.org/en-US/docs/Web/API/Push_API) and [Using the Notifications API](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API).
 
 </div>
-
-<div class="alert is-helpful"> 
-
-  For details about the native APIs used by the service worker, see
-
-  [Push API](https://marketfinder.thinkwithgoogle.com/intl/en_us/guide/how-to-approach-i18n/#overview).
-
-  [Using the Notifications API](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API).
-
-</div>
-
 
 #### Prerequisites
 
@@ -40,7 +30,7 @@ Invoke push notifications by pushing a message with a valid payload. See `SwPush
 
 ## Notification click handling
 
-The default behaviour for the `notificationclick` event, is to close the notification and notify `SwPush#notificationClicks`.
+The default behaviour for the `notificationclick` event, is to close the notification and notify `SwPush.notificationClicks`.
 
 This can easily be changed by adding an `onActionClick` property to the `data` object, and provide a `default` operation.
 
@@ -57,7 +47,7 @@ This can easily be changed by adding an `onActionClick` property to the `data` o
 }
 ```
 
-#### Operations
+### Operations
 
 The Angular service worker supports the following operations:
 
@@ -69,11 +59,11 @@ The Angular service worker supports the following operations:
 
 <div class="alert is-important">
 
-  If a corresponding `onActionClick` field does not have a defined `url` then the service worker's registration scope will be used with no path.
+  If an `onActionClick` item does not define a `url`, then the service worker's registration scope will be used.
   
 </div>
 
-#### Actions
+### Actions
 
 Actions offer a way to customize how the user can interact with a notification.
 
@@ -93,10 +83,10 @@ In addition, using the `onActionClick` property on the `data` object, you can ti
     ],
     "data": {
       "onActionClick": {
-        "default": {"operation": "openWindow", "url": "/foo"},
-        "foo": {"operation": "openWindow", "url": "foo"},
-        "bar": {"operation": "focusLastFocusedOrOpen", "url": "foo"},
-        "baz": {"operation": "navigateLastFocusedOrOpen", "url": "foo"}
+        "default": {"operation": "openWindow"},
+        "foo": {"operation": "openWindow", "url": "/absolute/path"},
+        "bar": {"operation": "focusLastFocusedOrOpen", "url": "relative/path"},
+        "baz": {"operation": "navigateLastFocusedOrOpen", "url": "https://other.domain.com/"}
       }
     }
   }
@@ -105,7 +95,7 @@ In addition, using the `onActionClick` property on the `data` object, you can ti
 
 <div class="alert is-important">
 
-  If an action does not have a corresponding `onActionClick` property, then the notification is closed and `SwPush#notificationClicks` is notified.
+  If an action does not have a corresponding `onActionClick` entry, then the notification is closed and `SwPush.notificationClicks` is notified on existing clients.
 
 </div>
 

--- a/aio/content/guide/service-worker-notifications.md
+++ b/aio/content/guide/service-worker-notifications.md
@@ -1,0 +1,121 @@
+# Service worker notifications
+
+Push notifications are a compelling way to engage users. Through the power of service workers, notifications can be delivered to a device even when your application is not in focus.
+
+The Angular service worker enables the display of push notifications and the handling of notification click events.
+
+#### Prerequisites
+
+A basic understanding of the following:
+
+- [Getting Started with Service Workers](guide/service-worker-getting-started).
+
+### Notification Payload
+
+Invoke Push Notifications by pushing a message with the following payload.
+
+```json
+ {
+   "notification": {
+     "actions": NotificationAction[],
+     "badge": USVString
+     "body": DOMString,
+     "data": any,
+     "dir": "auto"|"ltr"|"rtl",
+     "icon": USVString,
+     "image": USVString,
+     "lang": DOMString,
+     "renotify": boolean,
+     "requireInteraction": boolean,
+     "silent": boolean,
+     "tag": DOMString,
+     "timestamp": DOMTimeStamp,
+     "title": DOMString,
+     "vibrate": number[]
+   }
+ }
+```
+
+Only `title` is required. See `Notification` [instance properties](https://developer.mozilla.org/en-US/docs/Web/API/Notification#Instance_properties).
+
+<div class="alert is-helpful">
+
+  In chrome you can push a notification without a backend.
+  Open chrome devtools -> Application -> Service Workers -> Use the `Push` input to send a valid json notification payload
+
+</div>
+
+### Notification Behaviour
+
+The default behaviour for the `notificationclick` event, is to close the notification.
+
+This can easily be changed by adding a `onActionClick` field to the data object, and provide a `default` operation.
+
+```json
+{
+  "notification": {
+    "title": "New Notification!",
+    "data": {
+      "onActionClick": {
+        "default": {"operation": "openWindow", "url": "/foo"}
+      }
+    }
+  }
+}
+```
+
+### Operations
+
+Angular service worker supports the following operations:
+
+- `openWindow`: will open a new client at the given url relative to the service worker scope
+
+- `focusLastFocusedOrOpen`: will focus the last focussed client. If there is no client open, then will open a new client at the given url relative to the service worker scope
+
+- `navigateLastFocusedOrOpen`: will focus the last focussed client and navigate that client to the given url relative to the service worker scope. If there is no client open, then will open a new client at the given url relative to the service worker scope
+
+### Actions
+
+Actions are a good way to expand how the end user interacts with the notification.
+
+Using the `onActionClick` field, each action can be tied to an `operation`:
+
+```ts
+{
+  "notification": {
+    "title": "New Notification!",
+    "actions": [
+      {"action": "foo", "title": "Open new tab"},
+      {"action": "bar", "title": "Focus last"},
+      {"action": "baz", "title": "Navigate last"},
+      {"action": "bazza", "title": "default openWindow"}
+    ],
+    "data": {
+      "onActionClick": {
+        "default": {"operation": "openWindow", "url": "/foo"},
+        "foo": {"operation": "openWindow", "url": "/foo"},
+        "bar": {"operation": "focusLastFocusedOrOpen", "url": "/foo"},
+        "baz": {"operation": "navigateLastFocusedOrOpen", "url": "/foo"}
+      }
+    }
+  }
+}
+```
+
+<div class="alert is-important">
+
+  If an action does not have a corresponding `onActionClick` field, then it will use the configured `default` `onActionClick`.
+
+</div>
+
+<div class="alert is-important">
+
+  If a corresponding `onActionClick` field does not have a defined `url` then the service worker's registration scope will be used with no path.
+  
+</div>
+
+## More on Angular service workers
+
+You may also be interested in the following:
+
+- [Service Worker in Production](guide/service-worker-devops).

--- a/aio/content/guide/service-worker-notifications.md
+++ b/aio/content/guide/service-worker-notifications.md
@@ -4,52 +4,45 @@ Push notifications are a compelling way to engage users. Through the power of se
 
 The Angular service worker enables the display of push notifications and the handling of notification click events.
 
+<div class="alert is-helpful">
+
+  When using the Angular service worker, push notification interactions can be handled using the `SwPush` service.
+
+</div>
+
+<div class="alert is-helpful"> 
+
+  For details about the native APIs used by the service worker, see
+
+  [Push API](https://marketfinder.thinkwithgoogle.com/intl/en_us/guide/how-to-approach-i18n/#overview).
+
+  [Using the Notifications API](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API).
+
+</div>
+
+
 #### Prerequisites
 
 A basic understanding of the following:
 
 - [Getting Started with Service Workers](guide/service-worker-getting-started).
 
-### Notification Payload
+## Notification payload
 
-Invoke Push Notifications by pushing a message with the following payload.
-
-```json
- {
-   "notification": {
-     "actions": NotificationAction[],
-     "badge": USVString
-     "body": DOMString,
-     "data": any,
-     "dir": "auto"|"ltr"|"rtl",
-     "icon": USVString,
-     "image": USVString,
-     "lang": DOMString,
-     "renotify": boolean,
-     "requireInteraction": boolean,
-     "silent": boolean,
-     "tag": DOMString,
-     "timestamp": DOMTimeStamp,
-     "title": DOMString,
-     "vibrate": number[]
-   }
- }
-```
-
-Only `title` is required. See `Notification` [instance properties](https://developer.mozilla.org/en-US/docs/Web/API/Notification#Instance_properties).
+Invoke push notifications by pushing a message with a valid payload. See `SwPush` for guidance.
 
 <div class="alert is-helpful">
 
-  In chrome you can push a notification without a backend.
-  Open chrome devtools -> Application -> Service Workers -> Use the `Push` input to send a valid json notification payload
+  In Chrome, you can test push notifications without a backend.
+  Open Devtools -> Application -> Service Workers and use the `Push` input to send a JSON notification payload.
 
 </div>
 
-### Notification Behaviour
+## Notification click handling
 
-The default behaviour for the `notificationclick` event, is to close the notification.
+The default behaviour for the `notificationclick` event, is to close the notification and notify `SwPush#notificationClicks`.
 
-This can easily be changed by adding a `onActionClick` field to the data object, and provide a `default` operation.
+This can easily be changed by adding an `onActionClick` property to the `data` object, and provide a `default` operation.
 
 ```json
 {
@@ -57,28 +50,36 @@ This can easily be changed by adding a `onActionClick` field to the data object,
     "title": "New Notification!",
     "data": {
       "onActionClick": {
-        "default": {"operation": "openWindow", "url": "/foo"}
+        "default": {"operation": "openWindow", "url": "foo"}
       }
     }
   }
 }
 ```
 
-### Operations
+#### Operations
 
-Angular service worker supports the following operations:
+The Angular service worker supports the following operations:
 
-- `openWindow`: will open a new client at the given url relative to the service worker scope
+- `openWindow`: Opens a new tab at the specified URL, which is resolved relative to the service worker scope.
 
-- `focusLastFocusedOrOpen`: will focus the last focussed client. If there is no client open, then will open a new client at the given url relative to the service worker scope
+- `focusLastFocusedOrOpen`: Focuses the last focused client. If there is no client open, then it opens a new tab at the specified URL, which is resolved relative to the service worker scope.
 
-- `navigateLastFocusedOrOpen`: will focus the last focussed client and navigate that client to the given url relative to the service worker scope. If there is no client open, then will open a new client at the given url relative to the service worker scope
+- `navigateLastFocusedOrOpen`: Focuses the last focused client and navigates it to the specified URL, which is resolved relative to the service worker scope. If there is no client open, then it opens a new tab at the specified URL.
 
-### Actions
+<div class="alert is-important">
 
-Actions are a good way to expand how the end user interacts with the notification.
+  If a corresponding `onActionClick` field does not have a defined `url` then the service worker's registration scope will be used with no path.
+  
+</div>
 
-Using the `onActionClick` field, each action can be tied to an `operation`:
+#### Actions
+
+Actions offer a way to customize how the user can interact with a notification.
+
+Using the `actions` property, you can define a set of available actions. Each action is represented as an action button that the user can click to interact with the notification.
+
+In addition, using the `onActionClick` property on the `data` object, you can tie each action to an operation to be performed when the corresponding action button is clicked:
 
 ```ts
 {
@@ -88,14 +89,14 @@ Using the `onActionClick` field, each action can be tied to an `operation`:
       {"action": "foo", "title": "Open new tab"},
       {"action": "bar", "title": "Focus last"},
       {"action": "baz", "title": "Navigate last"},
-      {"action": "bazza", "title": "default openWindow"}
+      {"action": "qux", "title": "Just notify existing clients"}
     ],
     "data": {
       "onActionClick": {
         "default": {"operation": "openWindow", "url": "/foo"},
-        "foo": {"operation": "openWindow", "url": "/foo"},
-        "bar": {"operation": "focusLastFocusedOrOpen", "url": "/foo"},
-        "baz": {"operation": "navigateLastFocusedOrOpen", "url": "/foo"}
+        "foo": {"operation": "openWindow", "url": "foo"},
+        "bar": {"operation": "focusLastFocusedOrOpen", "url": "foo"},
+        "baz": {"operation": "navigateLastFocusedOrOpen", "url": "foo"}
       }
     }
   }
@@ -104,14 +105,8 @@ Using the `onActionClick` field, each action can be tied to an `operation`:
 
 <div class="alert is-important">
 
-  If an action does not have a corresponding `onActionClick` field, then it will use the configured `default` `onActionClick`.
+  If an action does not have a corresponding `onActionClick` property, then the notification is closed and `SwPush#notificationClicks` is notified.
 
-</div>
-
-<div class="alert is-important">
-
-  If a corresponding `onActionClick` field does not have a defined `url` then the service worker's registration scope will be used with no path.
-  
 </div>
 
 ## More on Angular service workers

--- a/aio/content/guide/service-worker-notifications.md
+++ b/aio/content/guide/service-worker-notifications.md
@@ -32,7 +32,7 @@ Invoke push notifications by pushing a message with a valid payload. See `SwPush
 
 The default behaviour for the `notificationclick` event, is to close the notification and notify `SwPush.notificationClicks`.
 
-This can easily be changed by adding an `onActionClick` property to the `data` object, and provide a `default` operation.
+You can specify an additional operation to be executed on `notificationclick` by adding an `onActionClick` property to the `data` object, and providing a `default` entry. This is especially useful for when there are no open clients when a notification is clicked.
 
 ```json
 {

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -437,7 +437,7 @@
             },
             {
               "url": "guide/service-worker-notifications",
-              "title": "Service Notifications",
+              "title": "Service Worker Notifications",
               "tooltip": "Configuring service worker notification behavior."
             },
             {

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -436,6 +436,11 @@
               "tooltip": "Services that enable you to interact with an Angular service worker."
             },
             {
+              "url": "guide/service-worker-notifications",
+              "title": "Service Notifications",
+              "tooltip": "Configuring service worker notification behavior."
+            },
+            {
               "url": "guide/service-worker-devops",
               "title": "Service Worker in Production",
               "tooltip": "Running apps with service workers, managing app update, debugging, and killing apps."

--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -81,6 +81,7 @@ import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, PushEvent} from './low_level';
  * <code-example path="service-worker/push/module.ts" region="subscribe-to-notification-clicks"
  * header="app.component.ts"></code-example>
  *
+ * @see {@link guide/service-worker-notifications Service worker notifications guide}
  * @see [Push Notifications](https://developers.google.com/web/fundamentals/codelabs/push-notifications/)
  * @see [Angular Push Notifications](https://blog.angular-university.io/angular-push-notifications/)
  * @see [MDN: Push API](https://developer.mozilla.org/en-US/docs/Web/API/Push_API)

--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -81,7 +81,8 @@ import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, PushEvent} from './low_level';
  * <code-example path="service-worker/push/module.ts" region="subscribe-to-notification-clicks"
  * header="app.component.ts"></code-example>
  *
- * @see {@link guide/service-worker-notifications Service worker notifications guide}
+ * You can read more on handling notification clicks in the [Service worker notifications guide](guide/service-worker-notifications).
+ *
  * @see [Push Notifications](https://developers.google.com/web/fundamentals/codelabs/push-notifications/)
  * @see [Angular Push Notifications](https://blog.angular-university.io/angular-push-notifications/)
  * @see [MDN: Push API](https://developer.mozilla.org/en-US/docs/Web/API/Push_API)

--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -81,7 +81,8 @@ import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, PushEvent} from './low_level';
  * <code-example path="service-worker/push/module.ts" region="subscribe-to-notification-clicks"
  * header="app.component.ts"></code-example>
  *
- * You can read more on handling notification clicks in the [Service worker notifications guide](guide/service-worker-notifications).
+ * You can read more on handling notification clicks in the [Service worker notifications
+ * guide](guide/service-worker-notifications).
  *
  * @see [Push Notifications](https://developers.google.com/web/fundamentals/codelabs/push-notifications/)
  * @see [Angular Push Notifications](https://blog.angular-university.io/angular-push-notifications/)

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -348,12 +348,52 @@ export class Driver implements Debuggable, UpdateSource {
     NOTIFICATION_OPTION_NAMES.filter(name => name in notification)
         .forEach(name => options[name] = notification[name]);
 
+    const notificationAction = action === '' || action === undefined ? 'default' : action;
+
+    const onActionClick = notification?.data?.onActionClick[notificationAction];
+
+    const urlToOpen = new URL(onActionClick?.url ?? '/', this.scope.registration.scope).href;
+
+    switch (onActionClick?.operation) {
+      case 'openWindow':
+        await this.scope.clients.openWindow(urlToOpen);
+        break;
+      case 'focusLastFocusedOrOpen': {
+        let matchingClient = await this.getLastFocusedMatchingClient(this.scope);
+        if (matchingClient) {
+          await matchingClient?.focus();
+        } else {
+          await this.scope.clients.openWindow(urlToOpen);
+        }
+        break;
+      }
+      case 'navigateLastFocusedOrOpen': {
+        let matchingClient = await this.getLastFocusedMatchingClient(this.scope);
+        if (matchingClient) {
+          matchingClient = await matchingClient.navigate(urlToOpen);
+          await matchingClient?.focus();
+        } else {
+          await this.scope.clients.openWindow(urlToOpen);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
     await this.broadcast({
       type: 'NOTIFICATION_CLICK',
       data: {action, notification: options},
     });
   }
 
+  private async getLastFocusedMatchingClient(scope: ServiceWorkerGlobalScope):
+      Promise<WindowClient|null> {
+    const windowClients = await scope.clients.matchAll({type: 'window'});
+
+    // As per the spec windowClients are `sorted in the most recently focused order`
+    return windowClients[0];
+  }
   private async reportStatus(client: Client, promise: Promise<void>, nonce: number): Promise<void> {
     const response = {type: 'STATUS', nonce, status: true};
     try {

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -352,7 +352,7 @@ export class Driver implements Debuggable, UpdateSource {
 
     const onActionClick = notification?.data?.onActionClick[notificationAction];
 
-    const urlToOpen = new URL(onActionClick?.url ?? '/', this.scope.registration.scope).href;
+    const urlToOpen = new URL(onActionClick?.url ?? '', this.scope.registration.scope).href;
 
     switch (onActionClick?.operation) {
       case 'openWindow':

--- a/packages/service-worker/worker/src/service-worker.d.ts
+++ b/packages/service-worker/worker/src/service-worker.d.ts
@@ -38,7 +38,7 @@ declare class Client {
 interface Clients {
   claim(): Promise<void>;
   get(id: string): Promise<Client>;
-  matchAll<T extends ClientQueryOptions>(
+  matchAll<T extends ClientMatchOptions>(
     options?: T
   ): Promise<ReadonlyArray<T['type'] extends 'window' ? WindowClient : Client>>;
   openWindow(url: string): Promise<WindowClient | null>;

--- a/packages/service-worker/worker/src/service-worker.d.ts
+++ b/packages/service-worker/worker/src/service-worker.d.ts
@@ -36,9 +36,12 @@ declare class Client {
 }
 
 interface Clients {
-  claim(): Promise<any>;
+  claim(): Promise<void>;
   get(id: string): Promise<Client>;
-  matchAll(options?: ClientMatchOptions): Promise<Array<Client>>;
+  matchAll<T extends ClientQueryOptions>(
+    options?: T
+  ): Promise<ReadonlyArray<T['type'] extends 'window' ? WindowClient : Client>>;
+  openWindow(url: string): Promise<WindowClient | null>;
 }
 
 interface ClientMatchOptions {
@@ -46,11 +49,12 @@ interface ClientMatchOptions {
   type?: ClientMatchTypes;
 }
 
-interface WindowClient {
-  focused: boolean;
-  visibilityState: WindowClientState;
+interface WindowClient extends Client {
+  readonly ancestorOrigins: ReadonlyArray<string>;
+  readonly focused: boolean;
+  readonly visibilityState: VisibilityState;
   focus(): Promise<WindowClient>;
-  navigate(url: string): Promise<WindowClient>;
+  navigate(url: string): Promise<WindowClient | null>;
 }
 
 type ClientFrameType = 'auxiliary'|'top-level'|'nested'|'none';

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -1026,7 +1026,7 @@ describe('Driver', () => {
                 body: 'Test body with a relative url',
                 data: {
                   onActionClick: {
-                    foo: {operation: 'openWindow', url:'baz/qux'},
+                    foo: {operation: 'openWindow', url: 'baz/qux'},
                   },
                 },
               },
@@ -1048,7 +1048,7 @@ describe('Driver', () => {
                 body: 'Test body with an absolute path url',
                 data: {
                   onActionClick: {
-                    foo: {operation: 'openWindow', url:'/baz/qux'},
+                    foo: {operation: 'openWindow', url: '/baz/qux'},
                   },
                 },
               },
@@ -1070,7 +1070,7 @@ describe('Driver', () => {
                 body: 'Test body with external origin',
                 data: {
                   onActionClick: {
-                    foo: {operation: 'openWindow', url:'http://other.host/baz/qux'},
+                    foo: {operation: 'openWindow', url: 'http://other.host/baz/qux'},
                   },
                 },
               },

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -66,7 +66,9 @@ const brokenManifest: Manifest = {
     name: 'assets',
     installMode: 'prefetch',
     updateMode: 'prefetch',
-    urls: ['/foo.txt'],
+    urls: [
+      '/foo.txt',
+    ],
     patterns: [],
     cacheQueryOptions: {ignoreVary: true},
   }],
@@ -85,7 +87,9 @@ const brokenLazyManifest: Manifest = {
       name: 'assets',
       installMode: 'prefetch',
       updateMode: 'prefetch',
-      urls: ['/foo.txt'],
+      urls: [
+        '/foo.txt',
+      ],
       patterns: [],
       cacheQueryOptions: {ignoreVary: true},
     },
@@ -93,7 +97,9 @@ const brokenLazyManifest: Manifest = {
       name: 'lazy-assets',
       installMode: 'lazy',
       updateMode: 'lazy',
-      urls: ['/bar.txt'],
+      urls: [
+        '/bar.txt',
+      ],
       patterns: [],
       cacheQueryOptions: {ignoreVary: true},
     },
@@ -134,15 +140,24 @@ const manifest: Manifest = {
       name: 'assets',
       installMode: 'prefetch',
       updateMode: 'prefetch',
-      urls: ['/foo.txt', '/bar.txt', '/redirected.txt'],
-      patterns: ['/unhashed/.*'],
+      urls: [
+        '/foo.txt',
+        '/bar.txt',
+        '/redirected.txt',
+      ],
+      patterns: [
+        '/unhashed/.*',
+      ],
       cacheQueryOptions: {ignoreVary: true},
     },
     {
       name: 'other',
       installMode: 'lazy',
       updateMode: 'lazy',
-      urls: ['/baz.txt', '/qux.txt'],
+      urls: [
+        '/baz.txt',
+        '/qux.txt',
+      ],
       patterns: [],
       cacheQueryOptions: {ignoreVary: true},
     },
@@ -150,7 +165,12 @@ const manifest: Manifest = {
       name: 'lazy_prefetch',
       installMode: 'lazy',
       updateMode: 'prefetch',
-      urls: ['/quux.txt', '/quuux.txt', '/lazy/unchanged1.txt', '/lazy/unchanged2.txt'],
+      urls: [
+        '/quux.txt',
+        '/quuux.txt',
+        '/lazy/unchanged1.txt',
+        '/lazy/unchanged2.txt',
+      ],
       patterns: [],
       cacheQueryOptions: {ignoreVary: true},
     }
@@ -162,7 +182,9 @@ const manifest: Manifest = {
       maxAge: 3600000,
       maxSize: 100,
       strategy: 'freshness',
-      patterns: ['/api/.*'],
+      patterns: [
+        '/api/.*',
+      ],
       cacheQueryOptions: {ignoreVary: true},
     },
     {
@@ -171,7 +193,9 @@ const manifest: Manifest = {
       maxAge: 3600000,
       maxSize: 100,
       strategy: 'performance',
-      patterns: ['/api-static/.*'],
+      patterns: [
+        '/api-static/.*',
+      ],
       cacheQueryOptions: {ignoreVary: true},
     },
   ],
@@ -192,15 +216,24 @@ const manifestUpdate: Manifest = {
       name: 'assets',
       installMode: 'prefetch',
       updateMode: 'prefetch',
-      urls: ['/foo.txt', '/bar.txt', '/redirected.txt'],
-      patterns: ['/unhashed/.*'],
+      urls: [
+        '/foo.txt',
+        '/bar.txt',
+        '/redirected.txt',
+      ],
+      patterns: [
+        '/unhashed/.*',
+      ],
       cacheQueryOptions: {ignoreVary: true},
     },
     {
       name: 'other',
       installMode: 'lazy',
       updateMode: 'lazy',
-      urls: ['/baz.txt', '/qux.txt'],
+      urls: [
+        '/baz.txt',
+        '/qux.txt',
+      ],
       patterns: [],
       cacheQueryOptions: {ignoreVary: true},
     },
@@ -208,7 +241,12 @@ const manifestUpdate: Manifest = {
       name: 'lazy_prefetch',
       installMode: 'lazy',
       updateMode: 'prefetch',
-      urls: ['/quux.txt', '/quuux.txt', '/lazy/unchanged1.txt', '/lazy/unchanged2.txt'],
+      urls: [
+        '/quux.txt',
+        '/quuux.txt',
+        '/lazy/unchanged1.txt',
+        '/lazy/unchanged2.txt',
+      ],
       patterns: [],
       cacheQueryOptions: {ignoreVary: true},
     }
@@ -253,6 +291,7 @@ const server404 = new MockServerStateBuilder().withStaticFiles(dist).build();
 
 const manifestHash = sha1(JSON.stringify(manifest));
 const manifestUpdateHash = sha1(JSON.stringify(manifestUpdate));
+
 
 describe('Driver', () => {
   let scope: SwTestHarness;
@@ -717,6 +756,7 @@ describe('Driver', () => {
           expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
 
           spyOn(scope.clients, 'openWindow');
+          const url = `foo`;
 
           await driver.initialized;
           await scope.handleClick(
@@ -725,12 +765,12 @@ describe('Driver', () => {
                 body: 'Test body with url',
                 data: {
                   onActionClick: {
-                    foo: {operation: 'openWindow', url: '/foo'},
+                    foo: {operation: 'openWindow', url},
                   },
                 },
               },
               'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith('http://localhost/foo');
+          expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
         });
 
         it('opens a new client window with `/` when no `url`', async () => {
@@ -750,7 +790,7 @@ describe('Driver', () => {
                 },
               },
               'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith('http://localhost/');
+          expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}`);
         });
       });
 
@@ -761,6 +801,7 @@ describe('Driver', () => {
           spyOn(scope.clients, 'matchAll').and.returnValue(Promise.resolve([mockClient]));
           spyOn(mockClient, 'focus');
           spyOn(mockClient, 'navigate');
+          const url = `foo`;
 
           await driver.initialized;
           await scope.handleClick(
@@ -769,7 +810,7 @@ describe('Driver', () => {
                 body: 'Test body with operation focusLastFocusedOrOpen',
                 data: {
                   onActionClick: {
-                    foo: {operation: 'focusLastFocusedOrOpen', url: '/foo'},
+                    foo: {operation: 'focusLastFocusedOrOpen', url},
                   },
                 },
               },
@@ -783,6 +824,7 @@ describe('Driver', () => {
           expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
           spyOn(scope.clients, 'openWindow');
           spyOn(scope.clients, 'matchAll').and.returnValue(Promise.resolve([]));
+          const url = `foo`;
 
           await driver.initialized;
           await scope.handleClick(
@@ -791,12 +833,12 @@ describe('Driver', () => {
                 body: 'Test body with operation focusLastFocusedOrOpen',
                 data: {
                   onActionClick: {
-                    foo: {operation: 'focusLastFocusedOrOpen', url: '/foo'},
+                    foo: {operation: 'focusLastFocusedOrOpen', url},
                   },
                 },
               },
               'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith('http://localhost/foo');
+          expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
         });
 
         it('falls back to openWindow at `/` when no last client and no `url`', async () => {
@@ -816,17 +858,18 @@ describe('Driver', () => {
                 },
               },
               'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith('http://localhost/');
+          expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}`);
         });
       });
 
       describe('`navigateLastFocusedOrOpen` operation', () => {
-        it('focuses last client with `url`', async () => {
+        it('navigates last client to `url`', async () => {
           expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
           const mockClient = new WindowClientImpl('fooBar');
           spyOn(scope.clients, 'matchAll').and.returnValue(Promise.resolve([mockClient]));
           spyOn(mockClient, 'focus');
           spyOn(mockClient, 'navigate').and.returnValue(Promise.resolve(mockClient));
+          const url = 'foo';
 
           await driver.initialized;
           await scope.handleClick(
@@ -835,16 +878,16 @@ describe('Driver', () => {
                 body: 'Test body with operation navigateLastFocusedOrOpen',
                 data: {
                   onActionClick: {
-                    foo: {operation: 'navigateLastFocusedOrOpen', url: '/foo'},
+                    foo: {operation: 'navigateLastFocusedOrOpen', url},
                   },
                 },
               },
               'foo');
-          expect(mockClient.navigate).toHaveBeenCalledWith('http://localhost/foo');
+          expect(mockClient.navigate).toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
           expect(mockClient.focus).toHaveBeenCalled();
         });
 
-        it('focuses last client with `/` if no `url', async () => {
+        it('navigates last client to `/` if no `url', async () => {
           expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
           const mockClient = new WindowClientImpl('fooBar');
           spyOn(scope.clients, 'matchAll').and.returnValue(Promise.resolve([mockClient]));
@@ -863,7 +906,7 @@ describe('Driver', () => {
                 },
               },
               'foo');
-          expect(mockClient.navigate).toHaveBeenCalledWith('http://localhost/');
+          expect(mockClient.navigate).toHaveBeenCalledWith(`${scope.registration.scope}`);
           expect(mockClient.focus).toHaveBeenCalled();
         });
 
@@ -871,6 +914,7 @@ describe('Driver', () => {
           expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
           spyOn(scope.clients, 'openWindow');
           spyOn(scope.clients, 'matchAll').and.returnValue(Promise.resolve([]));
+          const url = 'foo';
 
           await driver.initialized;
           await scope.handleClick(
@@ -879,12 +923,12 @@ describe('Driver', () => {
                 body: 'Test body with operation navigateLastFocusedOrOpen',
                 data: {
                   onActionClick: {
-                    foo: {operation: 'navigateLastFocusedOrOpen', url: '/foo'},
+                    foo: {operation: 'navigateLastFocusedOrOpen', url},
                   },
                 },
               },
               'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith('http://localhost/foo');
+          expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
         });
 
         it('falls back to openWindow at `/` when no last client and no `url`', async () => {
@@ -904,7 +948,7 @@ describe('Driver', () => {
                 },
               },
               'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith('http://localhost/');
+          expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}`);
         });
       });
 
@@ -933,6 +977,7 @@ describe('Driver', () => {
         it('uses onActionClick default when no specific action is clicked', async () => {
           expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
           spyOn(scope.clients, 'openWindow');
+          const url = 'fooz';
 
           await driver.initialized;
           await scope.handleClick(
@@ -941,12 +986,12 @@ describe('Driver', () => {
                 body: 'Test body without action',
                 data: {
                   onActionClick: {
-                    default: {operation: 'openWindow', url: 'fooz'},
+                    default: {operation: 'openWindow', url},
                   },
                 },
               },
               '');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith('http://localhost/fooz');
+          expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
         });
 
         describe('no onActionClick default', () => {
@@ -1169,7 +1214,10 @@ describe('Driver', () => {
           name: 'eager',
           installMode: 'prefetch',
           updateMode: 'prefetch',
-          urls: [`${baseHref}foo.txt`, `${baseHref}bar.txt`],
+          urls: [
+            `${baseHref}foo.txt`,
+            `${baseHref}bar.txt`,
+          ],
           patterns: [],
           cacheQueryOptions: {ignoreVary: true},
         },
@@ -1177,7 +1225,10 @@ describe('Driver', () => {
           name: 'lazy',
           installMode: 'lazy',
           updateMode: 'lazy',
-          urls: [`${baseHref}baz.txt`, `${baseHref}qux.txt`],
+          urls: [
+            `${baseHref}baz.txt`,
+            `${baseHref}qux.txt`,
+          ],
           patterns: [],
           cacheQueryOptions: {ignoreVary: true},
         },
@@ -1189,7 +1240,9 @@ describe('Driver', () => {
           maxAge: 3600000,
           maxSize: 100,
           strategy: 'freshness',
-          patterns: ['/api/.*'],
+          patterns: [
+            '/api/.*',
+          ],
           cacheQueryOptions: {ignoreVary: true},
         },
       ],
@@ -1528,8 +1581,14 @@ describe('Driver', () => {
           name: 'eager',
           installMode: 'prefetch',
           updateMode: 'prefetch',
-          urls: ['./index.html', './main.js', './styles.css'],
-          patterns: ['/unhashed/.*'],
+          urls: [
+            './index.html',
+            './main.js',
+            './styles.css',
+          ],
+          patterns: [
+            '/unhashed/.*',
+          ],
           cacheQueryOptions: {ignoreVary: true},
         },
         {
@@ -1542,7 +1601,9 @@ describe('Driver', () => {
             './unchanged/chunk-3.js',
             './unchanged/chunk-4.js',
           ],
-          patterns: ['/lazy/unhashed/.*'],
+          patterns: [
+            '/lazy/unhashed/.*',
+          ],
           cacheQueryOptions: {ignoreVary: true},
         }
       ],
@@ -1813,7 +1874,7 @@ describe('Driver', () => {
          spyOn(MockCache.prototype, 'put').and.throwError('Can\'t touch this');
          spyOn(driver.debugger, 'log');
          expect(await makeRequest(scope, '/api/foo', 'default', {
-           method: 'post',
+           method: 'post'
          })).toEqual('this is api foo');
          expect(driver.state).toBe(DriverReadyState.NORMAL);
          // Since we are swallowing an error here, make sure it is at least properly logged

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -1034,8 +1034,7 @@ describe('Driver', () => {
                 },
               },
               'foo');
-          expect(scope.clients.openWindow)
-              .toHaveBeenCalledWith('http://localhost/foo/bar/baz/qux');
+          expect(scope.clients.openWindow).toHaveBeenCalledWith('http://localhost/foo/bar/baz/qux');
         });
 
         it('should resolve with an absolute path', async () => {
@@ -1060,8 +1059,7 @@ describe('Driver', () => {
                 },
               },
               'foo');
-          expect(scope.clients.openWindow)
-              .toHaveBeenCalledWith('http://localhost/baz/qux');
+          expect(scope.clients.openWindow).toHaveBeenCalledWith('http://localhost/baz/qux');
         });
 
         it('should resolve other origins', async () => {
@@ -1086,8 +1084,7 @@ describe('Driver', () => {
                 },
               },
               'foo');
-          expect(scope.clients.openWindow)
-              .toHaveBeenCalledWith('http://other.host/baz/qux');
+          expect(scope.clients.openWindow).toHaveBeenCalledWith('http://other.host/baz/qux');
         });
       });
     });

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -1013,14 +1013,11 @@ describe('Driver', () => {
 
       describe('URL resolution', () => {
         it('should resolve relative to service worker scope', async () => {
-          scope = new SwTestHarnessBuilder().withServerState(server).build();
           (scope.registration.scope as string) = 'http://localhost/foo/bar/';
-          driver = new Driver(scope, scope, new CacheDatabase(scope, scope));
 
           expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
 
           spyOn(scope.clients, 'openWindow');
-          const url = 'baz/qux';
 
           await driver.initialized;
           await scope.handleClick(
@@ -1029,7 +1026,7 @@ describe('Driver', () => {
                 body: 'Test body with a relative url',
                 data: {
                   onActionClick: {
-                    foo: {operation: 'openWindow', url},
+                    foo: {operation: 'openWindow', url:'baz/qux'},
                   },
                 },
               },
@@ -1038,14 +1035,11 @@ describe('Driver', () => {
         });
 
         it('should resolve with an absolute path', async () => {
-          scope = new SwTestHarnessBuilder().withServerState(server).build();
           (scope.registration.scope as string) = 'http://localhost/foo/bar/';
-          driver = new Driver(scope, scope, new CacheDatabase(scope, scope));
 
           expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
 
           spyOn(scope.clients, 'openWindow');
-          const url = '/baz/qux';
 
           await driver.initialized;
           await scope.handleClick(
@@ -1054,7 +1048,7 @@ describe('Driver', () => {
                 body: 'Test body with an absolute path url',
                 data: {
                   onActionClick: {
-                    foo: {operation: 'openWindow', url},
+                    foo: {operation: 'openWindow', url:'/baz/qux'},
                   },
                 },
               },
@@ -1063,14 +1057,11 @@ describe('Driver', () => {
         });
 
         it('should resolve other origins', async () => {
-          scope = new SwTestHarnessBuilder().withServerState(server).build();
           (scope.registration.scope as string) = 'http://localhost/foo/bar/';
-          driver = new Driver(scope, scope, new CacheDatabase(scope, scope));
 
           expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
 
           spyOn(scope.clients, 'openWindow');
-          const url = 'http://other.host/baz/qux';
 
           await driver.initialized;
           await scope.handleClick(
@@ -1079,7 +1070,7 @@ describe('Driver', () => {
                 body: 'Test body with external origin',
                 data: {
                   onActionClick: {
-                    foo: {operation: 'openWindow', url},
+                    foo: {operation: 'openWindow', url:'http://other.host/baz/qux'},
                   },
                 },
               },

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -770,7 +770,8 @@ describe('Driver', () => {
                 },
               },
               'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
+          expect(scope.clients.openWindow)
+              .toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
         });
 
         it('opens a new client window with `/` when no `url`', async () => {
@@ -838,7 +839,8 @@ describe('Driver', () => {
                 },
               },
               'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
+          expect(scope.clients.openWindow)
+              .toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
         });
 
         it('falls back to openWindow at `/` when no last client and no `url`', async () => {
@@ -928,7 +930,8 @@ describe('Driver', () => {
                 },
               },
               'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
+          expect(scope.clients.openWindow)
+              .toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
         });
 
         it('falls back to openWindow at `/` when no last client and no `url`', async () => {
@@ -991,7 +994,8 @@ describe('Driver', () => {
                 },
               },
               '');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
+          expect(scope.clients.openWindow)
+              .toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
         });
 
         describe('no onActionClick default', () => {

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -31,6 +31,24 @@ export class MockClient {
     this.queue.next(message);
   }
 }
+export class WindowClientImpl extends MockClient implements WindowClient {
+  readonly ancestorOrigins: ReadonlyArray<string> = [];
+  readonly focused: boolean = false;
+  readonly visibilityState: VisibilityState = 'hidden';
+  frameType: ClientFrameType = 'top-level';
+  url = 'http://localhost/unique';
+
+  constructor(readonly id: string) {
+    super(id);
+  }
+
+  async focus(): Promise<WindowClient> {
+    return this;
+  }
+  async navigate(url: string): Promise<WindowClient|null> {
+    return this;
+  }
+}
 
 export class SwTestHarnessBuilder {
   private origin = parseUrl(this.scopeUrl).origin;
@@ -76,8 +94,12 @@ export class MockClients implements Clients {
     return this.clients.get(id);
   }
 
-  async matchAll(): Promise<Client[]> {
-    return Array.from(this.clients.values()) as any[] as Client[];
+  async matchAll<T extends ClientQueryOptions>(options?: T):
+      Promise<ReadonlyArray<T['type'] extends 'window'? WindowClient : Client>> {
+    return Array.from(this.clients.values()) as any[];
+  }
+  async openWindow(url: string): Promise<WindowClient|null> {
+    return null;
   }
 
   async claim(): Promise<any> {}
@@ -132,12 +154,7 @@ export class SwTestHarness extends Adapter implements ServiceWorkerGlobalScope, 
 
   private mockTime = Date.now();
 
-  private timers: {
-    at: number,
-    duration: number,
-    fn: Function,
-    fired: boolean,
-  }[] = [];
+  private timers: {at: number, duration: number, fn: Function, fired: boolean}[] = [];
 
   parseUrl = parseUrl;
 

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -154,7 +154,12 @@ export class SwTestHarness extends Adapter implements ServiceWorkerGlobalScope, 
 
   private mockTime = Date.now();
 
-  private timers: {at: number, duration: number, fn: Function, fired: boolean}[] = [];
+  private timers: {
+    at: number,
+    duration: number,
+    fn: Function,
+    fired: boolean,
+  }[] = [];
 
   parseUrl = parseUrl;
 


### PR DESCRIPTION
…ificationClick

Add `openWindow` and `lastFocusedOrOpen` abilty to the notificationClick handler such that when either a notification or notification action is clicked the service-worker can act accordingly without the need for the app to be open

PR Close #26907





## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #26907 #29368

Currently the `notificationClick` handler in the service worker only broadcasts the event if the app is open.

The following enriched functionality is not present: 

Opening a new window on notification click
Focusing an already open window on click
Focusing an already open window on click and navigating to a new route

## What is the new behavior?

The notification now accepts a new data field `onActionClick`

```
notification: NotificationOptions = {
    "notification": {
        "title": "Now Fancy",       
		"actions": [
			{"action": "foo", "title": "Open new tab"},
			{"action": "bar", "title": "Focus last and Nav"},
			{"action": "baz", "title": "Focus last NO Nav"}
		],
        "data": {
			"onActionClick": {
			    "default": {"operation": "openWindow", "url": "/foo"},
				"foo": {"operation": "openWindow", "url": "/foo"},
				"bar": {"operation": "lastFocusedOrOpen", "navigate": true, "url": "/bar"},
				"baz": {"operation": "lastFocusedOrOpen", "navigate": false, "url": "/baz"}
			}
		},
        "body": "New notification"
    }
} 
```
The action will trigger the corresponding `onActionClick` based on a name match.


This PR handles the following operations:

`openWindow`: this will open a new window at the given `url` or at `/` if not provided

`lastFocusedOrOpen`:

1. If navigation true, will either open a new client or focus the latest client at the given url, depending on if there is a client to be focused
2. If navigation false, will focus the latest client but cause no navigation change. If no client, will open a new window at the provided url or default to `/`

If no action is clicked, but rather the notification itself, the default behavior is to open a new window at `/`, however this can be overwritten with a `default` option.


***Advice needed***

1. Advice on maybe where in the docs needs an update would be great.
~~2. I was unsure how to add test cases.  I can see there was ones that tested the swPush receiving the notification, but was struggling to think how to test browser tab opening etc~~



***Other***

~~I have also removed the custom types as ServiceWorker types are now provided by '--lib dom'~~

~~This caused a change required in other handlers to check if a client exists first as `this.scope.clients.get(clientId)` can now return a client or undefined~~

**EDIT**
Descoping type change as not part of scope of PR

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
