### PR TITLE
docs: change field name from id to $id in schema.json file

### DIFF
--- a/aio/content/examples/schematics-for-libraries/projects/my-lib/schematics/my-service/schema.json
+++ b/aio/content/examples/schematics-for-libraries/projects/my-lib/schematics/my-service/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsMyService",
+  "$id": "SchematicsMyService",
   "title": "My Service Schema",
   "type": "object",
   "properties": {


### PR DESCRIPTION
fix error "SchematicsMyService" schema is using the keyword "id" which its support is deprecated. Use "$id" for schema ID.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
