### PR TITLE
fix(core): ensure that autoRegisterModuleById registration in ɵɵdefineNgModule is not DCE-ed by closure

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -410,22 +410,22 @@ export function ɵɵdefineNgModule<T>(def: {
   /** Unique ID for the module that is used with `getModuleFactory`. */
   id?: string | null;
 }): unknown {
-  const res: NgModuleDef<T> = {
-    type: def.type,
-    bootstrap: def.bootstrap || EMPTY_ARRAY,
-    declarations: def.declarations || EMPTY_ARRAY,
-    imports: def.imports || EMPTY_ARRAY,
-    exports: def.exports || EMPTY_ARRAY,
-    transitiveCompileScopes: null,
-    schemas: def.schemas || null,
-    id: def.id || null,
-  };
-  if (def.id != null) {
-    noSideEffects(() => {
+  return noSideEffects(() => {
+    const res: NgModuleDef<T> = {
+      type: def.type,
+      bootstrap: def.bootstrap || EMPTY_ARRAY,
+      declarations: def.declarations || EMPTY_ARRAY,
+      imports: def.imports || EMPTY_ARRAY,
+      exports: def.exports || EMPTY_ARRAY,
+      transitiveCompileScopes: null,
+      schemas: def.schemas || null,
+      id: def.id || null,
+    };
+    if (def.id != null) {
       autoRegisterModuleById[def.id!] = def.type as unknown as NgModuleType;
-    });
-  }
-  return res;
+    }
+    return res;
+  });
 }
 
 /**


### PR DESCRIPTION
Previously the autoRegisterModuleById registration was marked with noSideEffects wrapper to ensure that we don't end up retaining all NgModules.

However the return value was not referenced by anything, so closure compiler removed it because it determined that this code has no side effects and is not referenced by anyone.

This issue affects apps that use Closure Compiler and also rely on https://angular.io/api/core/getModuleFactory to retrieve factories by ID. This combination is used heavily in google3, especially in Pantheon.