### PR TITLE
fix(docs-infra): improve docs card layout (font-sizes related)

### DIFF
--- a/aio/src/styles/1-layouts/marketing-layout/_marketing-layout.scss
+++ b/aio/src/styles/1-layouts/marketing-layout/_marketing-layout.scss
@@ -173,12 +173,11 @@ section#intro {
 // ANGULAR LINE
 
 .home-row .card {
-  @include mixins.card(70%, auto);
+  @include mixins.card(70%);
   display: flex;
   flex-direction: row;
   align-items: center;
   position: relative;
-  width: 70%;
   min-width: 350px;
   height: auto;
   margin: auto;

--- a/aio/src/styles/2-modules/card/_card.scss
+++ b/aio/src/styles/2-modules/card/_card.scss
@@ -9,13 +9,14 @@
   margin: 16px 0;
 
   .docs-card {
-    @include mixins.card(194px, 35%);
+    @include mixins.card(35%);
 
     max-width: 340px;
     min-width: 300px;
     margin: 24px 16px;
-    padding-bottom: 48px;
-    position: relative;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
 
     @media screen and (max-width: 600px) {
       width: 100%;
@@ -27,7 +28,7 @@
       @include mixins.font-size(20);
       @include mixins.line-height(24);
       margin: 0;
-      padding: 32px 0 24px;
+      padding: 2.7rem 0 2.1rem;
       text-transform: none;
       text-align: center;
     }
@@ -37,16 +38,15 @@
       @include mixins.line-height(24);
       padding: 0 16px;
       margin: 0;
+      margin-bottom: 1.6rem;
       text-align: center;
     }
 
     .card-footer {
-      bottom: 0;
+      margin-bottom: 0;
       box-sizing: border-box;
-      @include mixins.line-height(48);
-      left: 0;
-      position: absolute;
-      right: 0;
+      @include mixins.line-height(24);
+      padding: 1.3rem 15px;
       text-align: right;
 
       a {

--- a/aio/src/styles/_mixins.scss
+++ b/aio/src/styles/_mixins.scss
@@ -47,8 +47,7 @@
 }
 
 // INFO CARD SKELETON
-@mixin card($height, $width) {
-  height: $height;
+@mixin card($width) {
   width: $width;
   border-radius: 4px;
   box-shadow: 0 2px 2px rgba(constants.$black, 0.24), 0 0 2px rgba(constants.$black, 0.12);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/38439

The Angular.io cards don't handle well the change of browser's font-size, they either create too much white space of overlap the card

## What is the new behavior?

The cards have a dynamic height and adapt well on all types of font-size

Here you can see the behaviour of the docs cards before (left) and after(right):
![before-and-after](https://user-images.githubusercontent.com/61631103/121405404-ed43a000-c954-11eb-854b-02ba7ca121ec.gif)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - All the unit tests pass:
![unit-tests](https://user-images.githubusercontent.com/61631103/121405532-0ea48c00-c955-11eb-847f-e3942ea040a4.png)

- The card-footer can sometime break line, this may create slightly ugly results:
![Screenshot at 2021-06-09 19-02-32](https://user-images.githubusercontent.com/61631103/121405914-7e1a7b80-c955-11eb-94fa-d158df5a937f.png)
 but this happens only on large font-sizes on just some screen widths, it is also an understandable issue which I don't think can cause real concerns, but I still wanted to mention it here, if someone has any suggestion on how to change this please let me know
 (
    it is still much better then the current version:
    ![Screenshot at 2021-06-09 19-03-11](https://user-images.githubusercontent.com/61631103/121406143-b9b54580-c955-11eb-877f-e46cc3dc75a1.png)
)

