### PR TITLE
aio/docs - minor sidenav styles improvements

### DIFF
--- a/aio/src/styles/1-layouts/sidenav/_sidenav.scss
+++ b/aio/src/styles/1-layouts/sidenav/_sidenav.scss
@@ -80,8 +80,9 @@ aio-nav-menu {
 
       //icons _within_ nav
       .mat-icon {
-        height: 24px;
-        width: 24px;
+        flex: 0 0 2.4rem;
+        display: flex;
+        align-items: center;
       }
     }
 

--- a/aio/src/styles/1-layouts/sidenav/_sidenav.scss
+++ b/aio/src/styles/1-layouts/sidenav/_sidenav.scss
@@ -90,6 +90,7 @@ aio-nav-menu {
       background-color: transparent;
       margin: 0;
       width: 100%;
+      overflow: hidden;
     }
 
     .heading-children {

--- a/aio/src/styles/1-layouts/sidenav/_sidenav.scss
+++ b/aio/src/styles/1-layouts/sidenav/_sidenav.scss
@@ -41,7 +41,7 @@ mat-sidenav-container.sidenav-container {
 
 aio-nav-menu {
   display: block;
-  margin: 0 auto;
+  margin: 0 2px;
   max-width: 268px;
 
   &:first-of-type {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/42552

The sidenav at [angular.io/docs](https://angular.io/docs):
  - produces unwanted overflow animation around the chevron icons when opening/closing items
  - may reduce some of the chevron icons' size (creating unwanted differences between the icons' sizes)
  - crops the outlined of focused nav items

## What is the new behavior?

The sidenav:
  - no longer produces the unwanted overflow
  - keeps the icon sizes consistent at 24px
  - has a minimal margin preventing the cropping of nav items outlines 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
