### PR TITLE
feat(forms): allow minLength/maxLength validator to be bound to `null`

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -384,7 +384,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
     resetForm(value?: any): void;
     readonly submitted: boolean;
     updateModel(dir: FormControlName, value: any): void;
-    }
+}
 
 // @public
 export class FormGroupName extends AbstractFormGroupDirective implements OnInit, OnDestroy {
@@ -398,12 +398,14 @@ export class FormsModule {
 
 // @public
 export class MaxLengthValidator implements Validator, OnChanges {
-    maxlength: string | number;
+    // (undocumented)
+    enabled(): boolean;
+    maxlength: string | number | null;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     registerOnValidatorChange(fn: () => void): void;
     validate(control: AbstractControl): ValidationErrors | null;
-    }
+}
 
 // @public
 export class MaxValidator extends AbstractValidatorDirective implements OnChanges {
@@ -413,12 +415,14 @@ export class MaxValidator extends AbstractValidatorDirective implements OnChange
 
 // @public
 export class MinLengthValidator implements Validator, OnChanges {
-    minlength: string | number;
+    // (undocumented)
+    enabled(): boolean;
+    minlength: string | number | null;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     registerOnValidatorChange(fn: () => void): void;
     validate(control: AbstractControl): ValidationErrors | null;
-    }
+}
 
 // @public
 export class MinValidator extends AbstractValidatorDirective implements OnChanges {
@@ -539,7 +543,7 @@ export class PatternValidator implements Validator, OnChanges {
     pattern: string | RegExp;
     registerOnValidatorChange(fn: () => void): void;
     validate(control: AbstractControl): ValidationErrors | null;
-    }
+}
 
 // @public
 export class RadioControlValueAccessor extends ɵangular_packages_forms_forms_g implements ControlValueAccessor, OnDestroy, OnInit {
@@ -631,7 +635,6 @@ export class Validators {
 
 // @public (undocumented)
 export const VERSION: Version;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/examples/forms/ts/ngModelGroup/e2e_test/ng_model_group_spec.ts
+++ b/packages/examples/forms/ts/ngModelGroup/e2e_test/ng_model_group_spec.ts
@@ -23,7 +23,8 @@ describe('ngModelGroup example', () => {
 
   it('should populate the UI with initial values', () => {
     expect(inputs.get(0).getAttribute('value')).toEqual('Nancy');
-    expect(inputs.get(1).getAttribute('value')).toEqual('Drew');
+    expect(inputs.get(1).getAttribute('value')).toEqual('J');
+    expect(inputs.get(2).getAttribute('value')).toEqual('Drew');
   });
 
   it('should show the error when name is invalid', () => {
@@ -37,6 +38,7 @@ describe('ngModelGroup example', () => {
   it('should set the value when changing the domain model', () => {
     buttons.get(1).click();
     expect(inputs.get(0).getAttribute('value')).toEqual('Bess');
-    expect(inputs.get(1).getAttribute('value')).toEqual('Marvin');
+    expect(inputs.get(1).getAttribute('value')).toEqual('S');
+    expect(inputs.get(2).getAttribute('value')).toEqual('Marvin');
   });
 });

--- a/packages/examples/forms/ts/ngModelGroup/ng_model_group_example.ts
+++ b/packages/examples/forms/ts/ngModelGroup/ng_model_group_example.ts
@@ -19,6 +19,7 @@ import {NgForm} from '@angular/forms';
 
       <div ngModelGroup="name" #nameCtrl="ngModelGroup">
         <input name="first" [ngModel]="name.first" minlength="2">
+        <input name="middle" [ngModel]="name.middle" maxlength="2">
         <input name="last" [ngModel]="name.last" required>
       </div>
 
@@ -30,15 +31,15 @@ import {NgForm} from '@angular/forms';
   `,
 })
 export class NgModelGroupComp {
-  name = {first: 'Nancy', last: 'Drew'};
+  name = {first: 'Nancy', middle: 'J', last: 'Drew'};
 
   onSubmit(f: NgForm) {
-    console.log(f.value);  // {name: {first: 'Nancy', last: 'Drew'}, email: ''}
+    console.log(f.value);  // {name: {first: 'Nancy', middle: 'J', last: 'Drew'}, email: ''}
     console.log(f.valid);  // true
   }
 
   setValue() {
-    this.name = {first: 'Bess', last: 'Marvin'};
+    this.name = {first: 'Bess', middle: 'S', last: 'Marvin'};
   }
 }
 // #enddocregion

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -12,6 +12,16 @@ import {Observable} from 'rxjs';
 import {AbstractControl} from '../model';
 import {emailValidator, maxLengthValidator, maxValidator, minLengthValidator, minValidator, NG_VALIDATORS, nullValidator, patternValidator, requiredTrueValidator, requiredValidator} from '../validators';
 
+/**
+ * @description
+ * Method that updates string to integer if not alread a number
+ *
+ * @param value The value to convert to integer
+ * @returns value of parameter in number or integer.
+ */
+function toNumber(value: string|number): number {
+  return typeof value === 'number' ? value : parseInt(value, 10);
+}
 
 /**
  * @description
@@ -540,7 +550,7 @@ export const MIN_LENGTH_VALIDATOR: any = {
 @Directive({
   selector: '[minlength][formControlName],[minlength][formControl],[minlength][ngModel]',
   providers: [MIN_LENGTH_VALIDATOR],
-  host: {'[attr.minlength]': 'minlength ? minlength : null'}
+  host: {'[attr.minlength]': 'enabled() ? minlength : null'}
 })
 export class MinLengthValidator implements Validator, OnChanges {
   private _validator: ValidatorFn = nullValidator;
@@ -551,7 +561,7 @@ export class MinLengthValidator implements Validator, OnChanges {
    * Tracks changes to the minimum length bound to this directive.
    */
   @Input()
-  minlength!: string|number;  // This input is always defined, since the name matches selector.
+  minlength!: string|number|null;  // This input is always defined, since the name matches selector.
 
   /** @nodoc */
   ngOnChanges(changes: SimpleChanges): void {
@@ -567,7 +577,7 @@ export class MinLengthValidator implements Validator, OnChanges {
    * @nodoc
    */
   validate(control: AbstractControl): ValidationErrors|null {
-    return this.minlength == null ? null : this._validator(control);
+    return this.enabled() ? this._validator(control) : null;
   }
 
   /**
@@ -579,8 +589,13 @@ export class MinLengthValidator implements Validator, OnChanges {
   }
 
   private _createValidator(): void {
-    this._validator = minLengthValidator(
-        typeof this.minlength === 'number' ? this.minlength : parseInt(this.minlength, 10));
+    this._validator =
+        this.enabled() ? minLengthValidator(toNumber(this.minlength!)) : nullValidator;
+  }
+
+  /** @nodoc */
+  enabled(): boolean {
+    return this.minlength != null /* both `null` and `undefined` */;
   }
 }
 
@@ -618,7 +633,7 @@ export const MAX_LENGTH_VALIDATOR: any = {
 @Directive({
   selector: '[maxlength][formControlName],[maxlength][formControl],[maxlength][ngModel]',
   providers: [MAX_LENGTH_VALIDATOR],
-  host: {'[attr.maxlength]': 'maxlength ? maxlength : null'}
+  host: {'[attr.maxlength]': 'enabled() ? maxlength : null'}
 })
 export class MaxLengthValidator implements Validator, OnChanges {
   private _validator: ValidatorFn = nullValidator;
@@ -629,7 +644,7 @@ export class MaxLengthValidator implements Validator, OnChanges {
    * Tracks changes to the maximum length bound to this directive.
    */
   @Input()
-  maxlength!: string|number;  // This input is always defined, since the name matches selector.
+  maxlength!: string|number|null;  // This input is always defined, since the name matches selector.
 
   /** @nodoc */
   ngOnChanges(changes: SimpleChanges): void {
@@ -644,7 +659,7 @@ export class MaxLengthValidator implements Validator, OnChanges {
    * @nodoc
    */
   validate(control: AbstractControl): ValidationErrors|null {
-    return this.maxlength != null ? this._validator(control) : null;
+    return this.enabled() ? this._validator(control) : null;
   }
 
   /**
@@ -656,8 +671,13 @@ export class MaxLengthValidator implements Validator, OnChanges {
   }
 
   private _createValidator(): void {
-    this._validator = maxLengthValidator(
-        typeof this.maxlength === 'number' ? this.maxlength : parseInt(this.maxlength, 10));
+    this._validator =
+        this.enabled() ? maxLengthValidator(toNumber(this.maxlength!)) : nullValidator;
+  }
+
+  /** @nodoc */
+  enabled(): boolean {
+    return this.maxlength != null /* both `null` and `undefined` */;
   }
 }
 


### PR DESCRIPTION
If the validator is bound to be `null` then no validation occurs and
attribute is not added to DOM.

For every validator type different PR will be raised as discussed in
https://github.com/angular/angular/pull/42378.

Closes #42267.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Null data type is not supported

Issue Number: #42267.


## What is the new behavior?
Added support for null data type

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is one of many PR which is going to be  raised for adding support of null validation. One can go through  conversation  here
[https://github.com/angular/angular/pull/42378#issuecomment-858864123](https://github.com/angular/angular/pull/42378#issuecomment-858864123)