### PR TITLE
build: remove unnecessary polyfills from tests

### DIFF
--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -59,7 +59,6 @@ module.exports = function(config) {
         included: false,
         watched: false
       },
-      {pattern: 'node_modules/mutation-observer/index.js', included: false, watched: false},
 
       {pattern: 'node_modules/rxjs/**', included: false, watched: false, served: true},
       'node_modules/reflect-metadata/Reflect.js',

--- a/package.json
+++ b/package.json
@@ -191,7 +191,6 @@
     "karma-sauce-launcher": "^2.0.2",
     "madge": "^4.0.2",
     "multimatch": "^5.0.0",
-    "mutation-observer": "^1.0.3",
     "nock": "^13.0.3",
     "ora": "^5.0.0",
     "prettier": "^2.3.0",

--- a/test-main.js
+++ b/test-main.js
@@ -134,42 +134,6 @@ Promise
 
 
 function loadCustomElementsPolyfills() {
-  var loadedPromise = Promise.resolve();
-
-  // The custom elements polyfill relies on `MutationObserver`.
-  if (!window.MutationObserver) {
-    loadedPromise = loadedPromise
-                        .then(function() {
-                          return System.import('node_modules/mutation-observer/index.js');
-                        })
-                        .then(function(MutationObserver) {
-                          window.MutationObserver = MutationObserver;
-                        });
-  }
-
-  // The custom elements polyfill relies on `Object.setPrototypeOf()`.
-  if (!Object.setPrototypeOf) {
-    var getDescriptor = function getDescriptor(obj, prop) {
-      var descriptor;
-      while (obj && !descriptor) {
-        descriptor = Object.getOwnPropertyDescriptor(obj, prop);
-        obj = Object.getPrototypeOf(obj);
-      }
-      return descriptor || {};
-    };
-    var setPrototypeOf = function setPrototypeOf(obj, proto) {
-      for (var prop in proto) {
-        if (!obj.hasOwnProperty(prop)) {
-          Object.defineProperty(obj, prop, getDescriptor(proto, prop));
-        }
-      }
-      return obj;
-    };
-
-    Object.defineProperty(setPrototypeOf, '$$shimmed', {value: true});
-    Object.setPrototypeOf = setPrototypeOf;
-  }
-
   // The custom elements polyfill will patch properties and methods on `(HTML)Element` and `Node`
   // (among others), including `(HTML)Element#innerHTML` and `Node#removeChild()`:
   // https://github.com/webcomponents/custom-elements/blob/4f7072c0dbda4beb505d16967acfffd33337b325/src/Patch/Element.js#L28-L73
@@ -209,46 +173,39 @@ function loadCustomElementsPolyfills() {
       // Allow ES5 functions as custom element constructors.
       'node_modules/@webcomponents/custom-elements/src/native-shim.js';
 
-  loadedPromise = loadedPromise
-                      .then(function() {
-                        return System.import(polyfillPath);
-                      })
-                      .then(function() {
-                        // `packages/compiler/test/schema/schema_extractor.ts` relies on
-                        // `HTMLElement.name`, but custom element polyfills will replace
-                        // `HTMLElement` with an anonymous function.
-                        Object.defineProperty(HTMLElement, 'name', {value: 'HTMLElement'});
+  return System.import(polyfillPath).then(function() {
+    // `packages/compiler/test/schema/schema_extractor.ts` relies on
+    // `HTMLElement.name`, but custom element polyfills will replace
+    // `HTMLElement` with an anonymous function.
+    Object.defineProperty(HTMLElement, 'name', {value: 'HTMLElement'});
 
-                        // Create helper functions on `window` for patching/restoring
-                        // properties/methods.
-                        Object.keys(patchConfig).forEach(function(prop) {
-                          var patchMethod = '$$patch_' + prop;
-                          var restoreMethod = '$$restore_' + prop;
+    // Create helper functions on `window` for patching/restoring
+    // properties/methods.
+    Object.keys(patchConfig).forEach(function(prop) {
+      var patchMethod = '$$patch_' + prop;
+      var restoreMethod = '$$restore_' + prop;
 
-                          if (!patchTargets[prop]) {
-                            // No patching detected. Create no-op functions.
-                            window[patchMethod] = window[restoreMethod] = function() {};
-                          } else {
-                            var patchTarget = patchTargets[prop];
-                            var originalDescriptor = originalDescriptors[prop];
-                            var patchedDescriptor =
-                                Object.getOwnPropertyDescriptor(patchTarget, prop);
+      if (!patchTargets[prop]) {
+        // No patching detected. Create no-op functions.
+        window[patchMethod] = window[restoreMethod] = function() {};
+      } else {
+        var patchTarget = patchTargets[prop];
+        var originalDescriptor = originalDescriptors[prop];
+        var patchedDescriptor = Object.getOwnPropertyDescriptor(patchTarget, prop);
 
-                            window[patchMethod] = function() {
-                              Object.defineProperty(patchTarget, prop, patchedDescriptor);
-                            };
-                            window[restoreMethod] = function() {
-                              Object.defineProperty(patchTarget, prop, originalDescriptor);
-                            };
+        window[patchMethod] = function() {
+          Object.defineProperty(patchTarget, prop, patchedDescriptor);
+        };
+        window[restoreMethod] = function() {
+          Object.defineProperty(patchTarget, prop, originalDescriptor);
+        };
 
-                            // Restore `prop`. The patch will be manually applied only during the
-                            // `@angular/elements` tests that need it.
-                            window[restoreMethod]();
-                          }
-                        });
-                      });
-
-  return loadedPromise;
+        // Restore `prop`. The patch will be manually applied only during the
+        // `@angular/elements` tests that need it.
+        window[restoreMethod]();
+      }
+    });
+  });
 }
 
 function onlySpecFiles(path) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9236,11 +9236,6 @@ multimatch@*, multimatch@^5.0.0:
     arrify "^2.0.1"
     minimatch "^3.0.4"
 
-mutation-observer@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/mutation-observer/-/mutation-observer-1.0.3.tgz#42e9222b101bca82e5ba9d5a7acf4a14c0f263d0"
-  integrity sha512-M/O/4rF2h776hV7qGMZUH3utZLO/jK7p8rnNgGkjKUw8zCGjRQPxB8z6+5l8+VjRUQ3dNYu4vjqXYLr+U8ZVNA==
-
 mute-stdout@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mute-stdout/-/mute-stdout-1.0.1.tgz#acb0300eb4de23a7ddeec014e3e96044b3472331"
@@ -12018,7 +12013,6 @@ sauce-connect-launcher@^1.2.4:
 
 "sauce-connect@https://saucelabs.com/downloads/sc-4.6.2-linux.tar.gz":
   version "0.0.0"
-  uid "7b7f35433af9c3380758e048894d7b9aecf3754e"
   resolved "https://saucelabs.com/downloads/sc-4.6.2-linux.tar.gz#7b7f35433af9c3380758e048894d7b9aecf3754e"
 
 saucelabs@^1.5.0:


### PR DESCRIPTION
Removes the polyfills for `MutationObserver` and `setPrototypeOf` from our testing setup, because none of the browsers that we support require them. This results in slightly less code and the removal of an external dependency.