### PR TITLE
aio/docs - inherit line-height to list item anchors

### DIFF
--- a/aio/src/styles/0-base/_typography.scss
+++ b/aio/src/styles/0-base/_typography.scss
@@ -129,6 +129,10 @@ li {
   p {
     margin: 0;
   }
+
+  a {
+    line-height: inherit;
+  }
 }
 
 a {


### PR DESCRIPTION
in order to have a consistent line-height between list items containing text and list items containing links the anchors should inherit the list item's line-height

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

List items comprised of a single link get an inconsistent line-height


As you can for example see here: https://angular.io/guide/template-syntax
![Screenshot at 2021-06-14 18-09-44](https://user-images.githubusercontent.com/61631103/121931778-f610e900-cd3b-11eb-8052-afbc4c649706.png)
and here: https://angular.io/guide/template-syntax#prerequisites
![Screenshot at 2021-06-14 18-09-18](https://user-images.githubusercontent.com/61631103/121931757-ef827180-cd3b-11eb-904f-04837dc7ddf2.png)

(note that the list items with the links are slightly more distanciated)

## What is the new behavior?

The anchors inherit the list item's line-height and all list items are then spaced consistently

as for example:
![Screenshot at 2021-06-14 18-13-55](https://user-images.githubusercontent.com/61631103/121932893-4d638900-cd3d-11eb-850c-f93fede1192e.png)

![Screenshot at 2021-06-14 18-14-16](https://user-images.githubusercontent.com/61631103/121932898-4f2d4c80-cd3d-11eb-8fb1-657f739c53fc.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
