### PR TITLE
fix(compiler-cli): change ngcc hash algorithm to be FIPS compliant

### DIFF
--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -236,10 +236,12 @@ export class NgccConfiguration {
   private projectConfig: PartiallyProcessedConfig;
   private cache = new Map<string, VersionedPackageConfig>();
   readonly hash: string;
+  readonly hashAlgorithm: string;
 
   constructor(private fs: ReadonlyFileSystem, baseDir: AbsoluteFsPath) {
     this.defaultConfig = this.processProjectConfig(DEFAULT_NGCC_CONFIG);
     this.projectConfig = this.processProjectConfig(this.loadProjectConfig(baseDir));
+    this.hashAlgorithm = this.projectConfig.hashAlgorithm;
     this.hash = this.computeHash();
   }
 
@@ -390,9 +392,7 @@ export class NgccConfiguration {
   }
 
   private computeHash(): string {
-    return createHash(this.projectConfig.hashAlgorithm)
-        .update(JSON.stringify(this.projectConfig))
-        .digest('hex');
+    return createHash(this.hashAlgorithm).update(JSON.stringify(this.projectConfig)).digest('hex');
   }
 }
 

--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -28,7 +28,7 @@ export interface NgccProjectConfig<T = RawNgccPackageConfig> {
   /**
    * Name of hash algorithm used to generate hashes of the configuration.
    *
-   * Defaults to `md5`.
+   * Defaults to `sha256`.
    */
   hashAlgorithm?: string;
 }
@@ -308,7 +308,7 @@ export class NgccConfiguration {
 
   private processProjectConfig(projectConfig: NgccProjectConfig): PartiallyProcessedConfig {
     const processedConfig:
-        PartiallyProcessedConfig = {packages: {}, locking: {}, hashAlgorithm: 'md5'};
+        PartiallyProcessedConfig = {packages: {}, locking: {}, hashAlgorithm: 'sha256'};
 
     // locking configuration
     if (projectConfig.locking !== undefined) {

--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -25,6 +25,12 @@ export interface NgccProjectConfig<T = RawNgccPackageConfig> {
    * Options that control how locking the process is handled.
    */
   locking?: ProcessLockingConfiguration;
+  /**
+   * Name of hash algorithm used to generate hashes of the configuration.
+   *
+   * Defaults to `md5`.
+   */
+  hashAlgorithm?: string;
 }
 
 /**
@@ -299,7 +305,8 @@ export class NgccConfiguration {
   }
 
   private processProjectConfig(projectConfig: NgccProjectConfig): PartiallyProcessedConfig {
-    const processedConfig: PartiallyProcessedConfig = {packages: {}, locking: {}};
+    const processedConfig:
+        PartiallyProcessedConfig = {packages: {}, locking: {}, hashAlgorithm: 'md5'};
 
     // locking configuration
     if (projectConfig.locking !== undefined) {
@@ -315,6 +322,11 @@ export class NgccConfiguration {
             processedConfig.packages[packageName] || (processedConfig.packages[packageName] = []);
         packageConfigs!.push({...packageConfig, versionRange});
       }
+    }
+
+    // hash algorithm config
+    if (projectConfig.hashAlgorithm !== undefined) {
+      processedConfig.hashAlgorithm = projectConfig.hashAlgorithm;
     }
 
     return processedConfig;
@@ -378,7 +390,9 @@ export class NgccConfiguration {
   }
 
   private computeHash(): string {
-    return createHash('md5').update(JSON.stringify(this.projectConfig)).digest('hex');
+    return createHash(this.projectConfig.hashAlgorithm)
+        .update(JSON.stringify(this.projectConfig))
+        .digest('hex');
   }
 }
 

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
@@ -159,7 +159,7 @@ export class EntryPointManifest {
       const lockFilePath = this.fs.resolve(directory, lockFileName);
       if (this.fs.exists(lockFilePath)) {
         const lockFileContents = this.fs.readFile(lockFilePath);
-        return createHash('md5').update(lockFileContents).digest('hex');
+        return createHash(this.config.hashAlgorithm).update(lockFileContents).digest('hex');
       }
     }
     return null;

--- a/packages/compiler-cli/ngcc/test/packages/configuration_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/configuration_spec.ts
@@ -48,7 +48,7 @@ runInEachFileSystem(() => {
         }]);
         const project1Conf = new NgccConfiguration(fs, project1);
         const expectedProject1Config =
-            `{"packages":{"package-1":[{"entryPoints":{"./entry-point-1":{}},"versionRange":"*"}]},"locking":{}}`;
+            `{"packages":{"package-1":[{"entryPoints":{"./entry-point-1":{}},"versionRange":"*"}]},"locking":{},"hashAlgorithm":"md5"}`;
         expect(project1Conf.hash)
             .toEqual(createHash('md5').update(expectedProject1Config).digest('hex'));
 
@@ -66,7 +66,7 @@ runInEachFileSystem(() => {
         }]);
         const project2Conf = new NgccConfiguration(fs, project2);
         const expectedProject2Config =
-            `{"packages":{"package-1":[{"entryPoints":{"./entry-point-1":{"ignore":true}},"versionRange":"*"}]},"locking":{}}`;
+            `{"packages":{"package-1":[{"entryPoints":{"./entry-point-1":{"ignore":true}},"versionRange":"*"}]},"locking":{},"hashAlgorithm":"md5"}`;
         expect(project2Conf.hash)
             .toEqual(createHash('md5').update(expectedProject2Config).digest('hex'));
       });
@@ -76,8 +76,30 @@ runInEachFileSystem(() => {
         const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
         expect(configuration.hash)
             .toEqual(createHash('md5')
-                         .update(JSON.stringify({packages: {}, locking: {}}))
+                         .update(JSON.stringify({packages: {}, locking: {}, hashAlgorithm: 'md5'}))
                          .digest('hex'));
+      });
+
+      it('should use a custom hash algorithm if specified in the config', () => {
+        const project1 = _Abs('/project-1');
+        const project1Config = fs.resolve(project1, 'ngcc.config.js');
+
+        loadTestFiles([{
+          name: project1Config,
+          contents: `
+            module.exports = {
+              packages: {
+                'package-1': {entryPoints: {'./entry-point-1': {}}},
+              },
+              hashAlgorithm: 'sha256',
+            };`
+        }]);
+        const project1Conf = new NgccConfiguration(fs, project1);
+        const expectedProject1Config =
+            `{"packages":{"package-1":[{"entryPoints":{"./entry-point-1":{}},"versionRange":"*"}]},"locking":{},"hashAlgorithm":"sha256"}`;
+        expect(JSON.stringify((project1Conf as any).projectConfig)).toEqual(expectedProject1Config);
+        expect(project1Conf.hash)
+            .toEqual(createHash('sha256').update(expectedProject1Config).digest('hex'));
       });
     });
 

--- a/packages/compiler-cli/ngcc/test/packages/configuration_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/configuration_spec.ts
@@ -48,9 +48,9 @@ runInEachFileSystem(() => {
         }]);
         const project1Conf = new NgccConfiguration(fs, project1);
         const expectedProject1Config =
-            `{"packages":{"package-1":[{"entryPoints":{"./entry-point-1":{}},"versionRange":"*"}]},"locking":{},"hashAlgorithm":"md5"}`;
+            `{"packages":{"package-1":[{"entryPoints":{"./entry-point-1":{}},"versionRange":"*"}]},"locking":{},"hashAlgorithm":"sha256"}`;
         expect(project1Conf.hash)
-            .toEqual(createHash('md5').update(expectedProject1Config).digest('hex'));
+            .toEqual(createHash('sha256').update(expectedProject1Config).digest('hex'));
 
         const project2 = _Abs('/project-2');
         const project2Config = fs.resolve(project2, 'ngcc.config.js');
@@ -66,18 +66,19 @@ runInEachFileSystem(() => {
         }]);
         const project2Conf = new NgccConfiguration(fs, project2);
         const expectedProject2Config =
-            `{"packages":{"package-1":[{"entryPoints":{"./entry-point-1":{"ignore":true}},"versionRange":"*"}]},"locking":{},"hashAlgorithm":"md5"}`;
+            `{"packages":{"package-1":[{"entryPoints":{"./entry-point-1":{"ignore":true}},"versionRange":"*"}]},"locking":{},"hashAlgorithm":"sha256"}`;
         expect(project2Conf.hash)
-            .toEqual(createHash('md5').update(expectedProject2Config).digest('hex'));
+            .toEqual(createHash('sha256').update(expectedProject2Config).digest('hex'));
       });
 
       it('should compute a hash even if there is no project configuration', () => {
         loadTestFiles([{name: _Abs('/project-1/empty.js'), contents: ``}]);
         const configuration = new NgccConfiguration(fs, _Abs('/project-1'));
         expect(configuration.hash)
-            .toEqual(createHash('md5')
-                         .update(JSON.stringify({packages: {}, locking: {}, hashAlgorithm: 'md5'}))
-                         .digest('hex'));
+            .toEqual(
+                createHash('sha256')
+                    .update(JSON.stringify({packages: {}, locking: {}, hashAlgorithm: 'sha256'}))
+                    .digest('hex'));
       });
 
       it('should use a custom hash algorithm if specified in the config', () => {
@@ -91,15 +92,15 @@ runInEachFileSystem(() => {
               packages: {
                 'package-1': {entryPoints: {'./entry-point-1': {}}},
               },
-              hashAlgorithm: 'sha256',
+              hashAlgorithm: 'md5',
             };`
         }]);
         const project1Conf = new NgccConfiguration(fs, project1);
         const expectedProject1Config =
-            `{"packages":{"package-1":[{"entryPoints":{"./entry-point-1":{}},"versionRange":"*"}]},"locking":{},"hashAlgorithm":"sha256"}`;
+            `{"packages":{"package-1":[{"entryPoints":{"./entry-point-1":{}},"versionRange":"*"}]},"locking":{},"hashAlgorithm":"md5"}`;
         expect(JSON.stringify((project1Conf as any).projectConfig)).toEqual(expectedProject1Config);
         expect(project1Conf.hash)
-            .toEqual(createHash('sha256').update(expectedProject1Config).digest('hex'));
+            .toEqual(createHash('md5').update(expectedProject1Config).digest('hex'));
       });
     });
 

--- a/packages/compiler-cli/ngcc/test/packages/entry_point_manifest_spec.ts
+++ b/packages/compiler-cli/ngcc/test/packages/entry_point_manifest_spec.ts
@@ -40,7 +40,7 @@ runInEachFileSystem(() => {
       beforeEach(() => {
         manifestFile = {
           ngccVersion: NGCC_VERSION,
-          lockFileHash: createHash('md5').update('LOCK FILE CONTENTS').digest('hex'),
+          lockFileHash: createHash('sha256').update('LOCK FILE CONTENTS').digest('hex'),
           configFileHash: config.hash,
           entryPointPaths: []
         };
@@ -278,7 +278,7 @@ runInEachFileSystem(() => {
             JSON.parse(fs.readFile(_Abs('/project/node_modules/__ngcc_entry_points__.json'))) as
             EntryPointManifestFile;
         expect(file.lockFileHash)
-            .toEqual(createHash('md5').update('LOCK FILE CONTENTS').digest('hex'));
+            .toEqual(createHash('sha256').update('LOCK FILE CONTENTS').digest('hex'));
       });
 
       it('should write a hash of the package-lock.json file', () => {
@@ -288,7 +288,7 @@ runInEachFileSystem(() => {
             JSON.parse(fs.readFile(_Abs('/project/node_modules/__ngcc_entry_points__.json'))) as
             EntryPointManifestFile;
         expect(file.lockFileHash)
-            .toEqual(createHash('md5').update('LOCK FILE CONTENTS').digest('hex'));
+            .toEqual(createHash('sha256').update('LOCK FILE CONTENTS').digest('hex'));
       });
 
       it('should write a hash of the project config', () => {


### PR DESCRIPTION
Fixes #42577

NOTE: This is not a breaking change, since the hashes are only used locally and are recreated when installing a new version of ngcc.