### PR TITLE
fix(compiler): do not allow unterminated interpolation to leak into later tokens

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -713,6 +713,10 @@ class _Tokenizer {
       }
     } while (!this._isTextEnd());
 
+    // It is possible that an interpolation was started but not ended inside this text token.
+    // Make sure that we reset the state of the lexer correctly.
+    this._inInterpolation = false;
+
     this._endToken([this._processCarriageReturns(parts.join(''))]);
   }
 

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -721,7 +721,7 @@ class _Tokenizer {
   }
 
   private _isTextEnd(): boolean {
-    if (this._cursor.peek() === chars.$LT || this._cursor.peek() === chars.$EOF) {
+    if (this._isTagStart() || this._cursor.peek() === chars.$EOF) {
       return true;
     }
 
@@ -737,6 +737,25 @@ class _Tokenizer {
       }
     }
 
+    return false;
+  }
+
+  /**
+   * Returns true if the current cursor is pointing to the start of a tag
+   * (opening/closing/comments/cdata/etc).
+   */
+  private _isTagStart(): boolean {
+    if (this._cursor.peek() === chars.$LT) {
+      // We assume that `<` followed by whitespace is not the start of an HTML element.
+      const tmp = this._cursor.clone();
+      tmp.advance();
+      // If the next character is alphabetic, ! nor / then it is a tag start
+      const code = tmp.peek();
+      if ((chars.$a <= code && code <= chars.$z) || (chars.$A <= code && code <= chars.$Z) ||
+          code === chars.$SLASH || code === chars.$BANG) {
+        return true;
+      }
+    }
     return false;
   }
 

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -1208,6 +1208,18 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
             ]]);
       });
 
+      it('should report unescaped "{" as an error, even after a prematurely terminated interpolation',
+         () => {
+           expect(tokenizeAndHumanizeErrors(
+                      `<code>{{b}<!---->}</code><pre>import {a} from 'a';</pre>`,
+                      {tokenizeExpansionForms: true}))
+               .toEqual([[
+                 lex.TokenType.RAW_TEXT,
+                 `Unexpected character "EOF" (Do you have an unescaped "{" in your template? Use "{{ '{' }}") to escape it.)`,
+                 '0:56',
+               ]]);
+         });
+
       it('should include 2 lines of context in message', () => {
         const src = '111\n222\n333\nE\n444\n555\n666\n';
         const file = new ParseSourceFile(src, 'file://');

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -612,7 +612,7 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
         ]);
       });
 
-      it('should parse valid start tag in interpolation', () => {
+      it('should break out of interpolation in text token on valid start tag', () => {
         expect(tokenizeAndHumanizeParts('{{ a <b && c > d }}')).toEqual([
           [lex.TokenType.TEXT, '{{ a '],
           [lex.TokenType.TAG_OPEN_START, '', 'b'],
@@ -623,6 +623,42 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
           [lex.TokenType.EOF],
         ]);
       });
+
+      it('should break out of interpolation in text token on valid comment', () => {
+        expect(tokenizeAndHumanizeParts('{{ a }<!---->}')).toEqual([
+          [lex.TokenType.TEXT, '{{ a }'],
+          [lex.TokenType.COMMENT_START],
+          [lex.TokenType.RAW_TEXT, ''],
+          [lex.TokenType.COMMENT_END],
+          [lex.TokenType.TEXT, '}'],
+          [lex.TokenType.EOF],
+        ]);
+      });
+
+      it('should break out of interpolation in text token on valid CDATA', () => {
+        expect(tokenizeAndHumanizeParts('{{ a }<![CDATA[]]>}')).toEqual([
+          [lex.TokenType.TEXT, '{{ a }'],
+          [lex.TokenType.CDATA_START],
+          [lex.TokenType.RAW_TEXT, ''],
+          [lex.TokenType.CDATA_END],
+          [lex.TokenType.TEXT, '}'],
+          [lex.TokenType.EOF],
+        ]);
+      });
+
+      it('should ignore invalid start tag in interpolation', () => {
+        // Note that if the `<=` is considered an "end of text" then the following `{` would
+        // incorrectly be considered part of an ICU.
+        expect(tokenizeAndHumanizeParts(`<code>{{'<={'}}</code>`, {tokenizeExpansionForms: true}))
+            .toEqual([
+              [lex.TokenType.TAG_OPEN_START, '', 'code'],
+              [lex.TokenType.TAG_OPEN_END],
+              [lex.TokenType.TEXT, '{{\'<={\'}}'],
+              [lex.TokenType.TAG_CLOSE, '', 'code'],
+              [lex.TokenType.EOF],
+            ]);
+      });
+
 
       it('should parse start tags quotes in place of an attribute name as text', () => {
         expect(tokenizeAndHumanizeParts('<t ">')).toEqual([


### PR DESCRIPTION
The lexer tracks whether it is reading characters from inside an interpolation
when consuming a text token, so that it can identify invalid ICU expressions.
Inside an interpolation there will be no ICU expression so it is safe to
have unmatched `{` characters, but outside this is an error.

Previously, if an interpolation was started, by an opening marker (e.g. `{{`)
in the text, but the text came to an end before the closing marker (e.g. `}}`)
then the lexer was not clearing its internal state that tracked that it was
inside an interpolation. So if when a new text token was being consumed,
the lexer, incorrectly thought it was already within an interpolation.
This resulted in invalid ICU expression errors not being reported.

There are instances of this error being hidden inside G3, and so these will
need to be fixed in order to land this change.

