### PR TITLE
fix(service-worker): avoid storing redundant metadata for hashed assets

### DIFF
--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -45,7 +45,7 @@ import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, PushEvent} from './low_level';
  * {
  *   "notification": {
  *     "actions": NotificationAction[],
- *     "badge": USVString
+ *     "badge": USVString,
  *     "body": DOMString,
  *     "data": any,
  *     "dir": "auto"|"ltr"|"rtl",

--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -454,7 +454,6 @@ export abstract class AssetGroup {
   protected async maybeUpdate(updateFrom: UpdateSource, req: Request, cache: Cache):
       Promise<boolean> {
     const url = this.adapter.normalizeUrl(req.url);
-    const meta = await this.metadata;
     // Check if this resource is hashed and already exists in the cache of a prior version.
     if (this.hashes.has(url)) {
       const hash = this.hashes.get(url)!;
@@ -467,7 +466,6 @@ export abstract class AssetGroup {
       if (res !== null) {
         // Copy to this cache.
         await cache.put(req, res);
-        await meta.write(req.url, {ts: this.adapter.time, used: false} as UrlMetadata);
 
         // No need to do anything further with this resource, it's now cached properly.
         return true;


### PR DESCRIPTION
The ServiceWorker needs to keep track of some metadata for unhashed asset resources to know if/when they might need to be revalidated. This applies to resources that do not exist on the filesystem at build-time (and thus can be hashed), such as fonts or images loaded from external sources. For hashed resources, this metadata is irrelevant, because the hash is enough to verify that the content hasn't changed and no revalidation is necessary.

Previously, the ServiceWorker would store such metadata for hashed resources as well, even though it would never be used (thus taking up space unnecessarily).

This commit fixes it by not storing metadata for hased resources, i.e. those that are included in an asset-group's `hashes` array.