### PR TITLE
feat(dev-infra): update pullapprove verification to ensure all groups have reviewers

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -4922,10 +4922,8 @@ class PullApproveGroup {
         this.precedingGroups = precedingGroups;
         /** List of conditions for the group. */
         this.conditions = [];
-        /** List of conditions for the group. */
-        this.reviewers = {};
         this._captureConditions(config);
-        this.reviewers = (_a = config.reviewers) !== null && _a !== void 0 ? _a : {};
+        this.reviewers = (_a = config.reviewers) !== null && _a !== void 0 ? _a : { users: [], teams: [] };
     }
     _captureConditions(config) {
         if (config.conditions && this.groupName !== FALLBACK_GROUP_NAME) {

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -4917,11 +4917,15 @@ const FALLBACK_GROUP_NAME = 'fallback';
 /** A PullApprove group to be able to test files against. */
 class PullApproveGroup {
     constructor(groupName, config, precedingGroups = []) {
+        var _a;
         this.groupName = groupName;
         this.precedingGroups = precedingGroups;
         /** List of conditions for the group. */
         this.conditions = [];
+        /** List of conditions for the group. */
+        this.reviewers = {};
         this._captureConditions(config);
+        this.reviewers = (_a = config.reviewers) !== null && _a !== void 0 ? _a : {};
     }
     _captureConditions(config) {
         if (config.conditions && this.groupName !== FALLBACK_GROUP_NAME) {
@@ -5063,12 +5067,16 @@ function verify$1() {
      * Whether all group condition lines match at least one file and all files
      * are matched by at least one group.
      */
-    const verificationSucceeded = resultsByGroup.every(r => !r.unmatchedCount) && !unmatchedFiles.length;
+    const allGroupConditionsValid = resultsByGroup.every(r => !r.unmatchedCount) && !unmatchedFiles.length;
+    /** Whether all groups have at least one reviewer user or team defined.  */
+    const groupsWithoutReviewers = groups.filter(group => Object.keys(group.reviewers).length === 0);
+    /** The overall result of the verifcation. */
+    const overallResult = allGroupConditionsValid && groupsWithoutReviewers.length === 0;
     /**
      * Overall result
      */
     logHeader('Overall Result');
-    if (verificationSucceeded) {
+    if (overallResult) {
         info('PullApprove verification succeeded!');
     }
     else {
@@ -5077,6 +5085,16 @@ function verify$1() {
         info(`Please update '.pullapprove.yml' to ensure that all necessary`);
         info(`files/directories have owners and all patterns that appear in`);
         info(`the file correspond to actual files/directories in the repo.`);
+    }
+    /** Reviewers check */
+    logHeader(`Group Reviewers Check`);
+    if (groupsWithoutReviewers.length === 0) {
+        info('All group contain at least one reviewer user or team.');
+    }
+    else {
+        info.group(`Discovered ${groupsWithoutReviewers.length} group(s) without a reviewer defined`);
+        groupsWithoutReviewers.forEach(g => info(g.groupName));
+        info.groupEnd();
     }
     /**
      * File by file Summary
@@ -5108,7 +5126,7 @@ function verify$1() {
     unverifiableConditionsInGroups.forEach(group => logGroup(group, 'unverifiableConditions'));
     info.groupEnd();
     // Provide correct exit code based on verification success.
-    process.exit(verificationSucceeded ? 0 : 1);
+    process.exit(overallResult ? 0 : 1);
 }
 
 /** Build the parser for the pullapprove commands. */

--- a/dev-infra/pullapprove/group.ts
+++ b/dev-infra/pullapprove/group.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {config} from 'yargs';
 import {error} from '../utils/console';
 import {convertConditionToFunction} from './condition_evaluator';
 import {PullApproveGroupConfig} from './parse-yaml';
@@ -47,14 +46,14 @@ const FALLBACK_GROUP_NAME = 'fallback';
 export class PullApproveGroup {
   /** List of conditions for the group. */
   readonly conditions: GroupCondition[] = [];
-  /** List of conditions for the group. */
-  readonly reviewers: GroupReviewers = {};
+  /** List of reviewers for the group. */
+  readonly reviewers: GroupReviewers;
 
   constructor(
       public groupName: string, config: PullApproveGroupConfig,
       readonly precedingGroups: PullApproveGroup[] = []) {
     this._captureConditions(config);
-    this.reviewers = config.reviewers ?? {};
+    this.reviewers = config.reviewers ?? {users: [], teams: []};
   }
 
   private _captureConditions(config: PullApproveGroupConfig) {

--- a/dev-infra/pullapprove/group.ts
+++ b/dev-infra/pullapprove/group.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {config} from 'yargs';
 import {error} from '../utils/console';
 import {convertConditionToFunction} from './condition_evaluator';
 import {PullApproveGroupConfig} from './parse-yaml';
@@ -17,6 +18,11 @@ interface GroupCondition {
   checkFn: (files: string[], groups: PullApproveGroup[]) => boolean;
   matchedFiles: Set<string>;
   unverifiable: boolean;
+}
+
+interface GroupReviewers {
+  users?: string[];
+  teams?: string[];
 }
 
 /** Result of testing files against the group. */
@@ -40,12 +46,15 @@ const FALLBACK_GROUP_NAME = 'fallback';
 /** A PullApprove group to be able to test files against. */
 export class PullApproveGroup {
   /** List of conditions for the group. */
-  conditions: GroupCondition[] = [];
+  readonly conditions: GroupCondition[] = [];
+  /** List of conditions for the group. */
+  readonly reviewers: GroupReviewers = {};
 
   constructor(
       public groupName: string, config: PullApproveGroupConfig,
       readonly precedingGroups: PullApproveGroup[] = []) {
     this._captureConditions(config);
+    this.reviewers = config.reviewers ?? {};
   }
 
   private _captureConditions(config: PullApproveGroupConfig) {

--- a/dev-infra/pullapprove/verify.ts
+++ b/dev-infra/pullapprove/verify.ts
@@ -49,14 +49,18 @@ export function verify() {
    * Whether all group condition lines match at least one file and all files
    * are matched by at least one group.
    */
-  const verificationSucceeded =
+  const allGroupConditionsValid =
       resultsByGroup.every(r => !r.unmatchedCount) && !unmatchedFiles.length;
+  /** Whether all groups have at least one reviewer user or team defined.  */
+  const groupsWithoutReviewers = groups.filter(group => Object.keys(group.reviewers).length === 0);
+  /** The overall result of the verifcation. */
+  const overallResult = allGroupConditionsValid && groupsWithoutReviewers.length === 0;
 
   /**
    * Overall result
    */
   logHeader('Overall Result');
-  if (verificationSucceeded) {
+  if (overallResult) {
     info('PullApprove verification succeeded!');
   } else {
     info(`PullApprove verification failed.`);
@@ -64,6 +68,15 @@ export function verify() {
     info(`Please update '.pullapprove.yml' to ensure that all necessary`);
     info(`files/directories have owners and all patterns that appear in`);
     info(`the file correspond to actual files/directories in the repo.`);
+  }
+  /** Reviewers check */
+  logHeader(`Group Reviewers Check`);
+  if (groupsWithoutReviewers.length === 0) {
+    info('All group contain at least one reviewer user or team.');
+  } else {
+    info.group(`Discovered ${groupsWithoutReviewers.length} group(s) without a reviewer defined`);
+    groupsWithoutReviewers.forEach(g => info(g.groupName));
+    info.groupEnd();
   }
   /**
    * File by file Summary
@@ -97,5 +110,5 @@ export function verify() {
   info.groupEnd();
 
   // Provide correct exit code based on verification success.
-  process.exit(verificationSucceeded ? 0 : 1);
+  process.exit(overallResult ? 0 : 1);
 }


### PR DESCRIPTION
Update the pullapprove verification tooling to ensure a reviewer is defined for
each group. This is being done in preparation for the upcoming change to how
pullapprove billing works. The new billing will work on a seats based approach
rather than flat usage.