### PR TITLE
docs: correct literal string example

### DIFF
--- a/aio/content/guide/aot-compiler.md
+++ b/aio/content/guide/aot-compiler.md
@@ -173,7 +173,7 @@ Define metadata objects with the following limited syntax:
     <td><code>`pie is ${multiplier} times better than cake`</code></td>
    <tr>
     <td>Literal string</td>
-    <td><code>pi</code></td>
+    <td><code>'pi'</code></td>
   </tr>
    <tr>
     <td>Literal number</td>


### PR DESCRIPTION
Change literal string example `pi` to `'pi'`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A string literal example value is missing quotes.

Issue Number: N/A


## What is the new behavior?
A string literal example value is quoted using single quotes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
![image](https://user-images.githubusercontent.com/6364586/123002385-2a2a8080-d3b2-11eb-8e13-caef8df5a1da.png)
See https://angular.io/guide/aot-compiler#expression-syntax