### PR TITLE
docs: error pages alignment fix and styling changes on aio-search-results

### DIFF
--- a/aio/content/file-not-found.md
+++ b/aio/content/file-not-found.md
@@ -1,7 +1,7 @@
 <div class="center-layout-wide">
   <div class="nf-container l-flex-wrap flex-center">
     <img src="assets/images/support/angular-404.svg" width="300" height="300"/>
-    <div class="nf-response l-flex-wrap">
+    <div class="nf-response l-flex-wrap center">
       <h1 class="no-anchor no-toc">Page Not Found</h1>
       <p>We're sorry. The page you are looking for cannot be found.</p>
     </div>

--- a/aio/src/404-body.html
+++ b/aio/src/404-body.html
@@ -28,7 +28,7 @@
             <div class="content">
               <div class="nf-container l-flex-wrap flex-center">
                 <img src="assets/images/support/angular-404.svg" width="300" height="300" />
-                <div class="nf-response l-flex-wrap">
+                <div class="nf-response l-flex-wrap center">
                   <h1 class="no-toc" id="page-not-found">Resource Not Found</h1>
                   <p>We're sorry. The resource you are looking for cannot be found.</p>
                 </div>

--- a/aio/src/app/custom-elements/search/file-not-found-search.component.ts
+++ b/aio/src/app/custom-elements/search/file-not-found-search.component.ts
@@ -8,7 +8,9 @@ import { SearchService } from 'app/search/search.service';
 @Component({
   selector: 'aio-file-not-found-search',
   template:
-  `<p>Let's see if any of these search results help...</p>
+  `<div class="alert is-helpful">
+      <p>Let's see if any of these search results help...</p>
+   </div>
   <aio-search-results class="embedded" [searchResults]="searchResults | async"></aio-search-results>`
 })
 export class FileNotFoundSearchComponent implements OnInit {

--- a/aio/src/app/documents/document.service.ts
+++ b/aio/src/app/documents/document.service.ts
@@ -18,10 +18,11 @@ export const DOC_CONTENT_URL_PREFIX = CONTENT_URL_PREFIX + 'docs/';
 const FETCHING_ERROR_CONTENTS = (path: string) => `
   <div class="nf-container l-flex-wrap flex-center">
     <div class="nf-icon material-icons">error_outline</div>
-    <div class="nf-response l-flex-wrap">
-      <h1 class="no-toc">Request for document failed.</h1>
+    <div class="nf-response l-flex-wrap center">
+      <h1 class="no-toc">Request for document failed</h1>
       <p>
         We are unable to retrieve the "${path}" page at this time.
+        <br/>
         Please check your connection and try again later.
       </p>
     </div>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Alignment issues were there in the heading texts of the views of following pages -

- file-not-found.md
- 404-body.html
- file-not-found-search.component.ts

Also, some minor styling issues were there.


## What is the new behavior?
Styling is consistent and alignment is properly done on the affected pages.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Screenshots
1.  Changes in Alignment
![Issue 1](https://user-images.githubusercontent.com/61384771/123033663-c2058a00-d405-11eb-8c36-ca8d882b60f7.png)

-----------

2. Added alert-box style to the info text
![Issue 2](https://user-images.githubusercontent.com/61384771/123033705-cd58b580-d405-11eb-84e2-ae61064769ba.png)

-----------

3. Reduced font-weight, so that text doesn't look blurry.
![Issue 3](https://user-images.githubusercontent.com/61384771/123033718-d2b60000-d405-11eb-86c5-a84fce442760.png)

