### PR TITLE
ci: exclude `service-worker/` sub-directories from `fw-testing` PullApprove group

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -665,7 +665,7 @@ groups:
       - *can-be-global-approved
       - *can-be-global-docs-approved
       - >
-        contains_any_globs(files.exclude('packages/compiler-cli/**').exclude('packages/language-service/**'), [
+        contains_any_globs(files.exclude('packages/compiler-cli/**').exclude('packages/language-service/**').exclude('packages/service-worker/**'), [
           'packages/**/testing/**',
           'aio/content/guide/testing.md',
           'aio/content/guide/test-debugging.md',


### PR DESCRIPTION
The `fw-testing` PullApprove group, which by default owns all `testing/` sub-directories, is supposed to own resources related to testing Angular applications (from an end-user's perspective). The `service-worker` package source code includes some `testing/` sub-directories which are intended for internal use only (i.e. to test the `service-worker` package itself) and are not distributed to end-users of the package.

Previously, changes in these `testing/` sub-directories would incorrectly require approval from the `fw-testing` group.

This commit fixes this by excluding the `service-worker` package sub-directories from the files owned by the `fw-testing` group.
