### PR TITLE
refactor(elements): support ES5 based elements using `Reflect.construct`

### DIFF
--- a/goldens/public-api/elements/elements.md
+++ b/goldens/public-api/elements/elements.md
@@ -6,7 +6,6 @@
 
 import { Injector } from '@angular/core';
 import { Observable } from 'rxjs';
-import { Subscription } from 'rxjs';
 import { Type } from '@angular/core';
 import { Version } from '@angular/core';
 
@@ -18,8 +17,6 @@ export abstract class NgElement extends HTMLElement {
     abstract attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string, namespace?: string): void;
     abstract connectedCallback(): void;
     abstract disconnectedCallback(): void;
-    protected ngElementEventsSubscription: Subscription | null;
-    protected abstract ngElementStrategy: NgElementStrategy;
 }
 
 // @public
@@ -68,7 +65,6 @@ export const VERSION: Version;
 export type WithProperties<P> = {
     [property in keyof P]: P[property];
 };
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/elements/public_api.ts
+++ b/packages/elements/public_api.ts
@@ -11,7 +11,8 @@
  * @description
  * Entry point for all public APIs of the `elements` package.
  */
-export {createCustomElement, NgElement, NgElementConfig, NgElementConstructor, WithProperties} from './src/create-custom-element';
+export {NgElement} from './src/base-html-element';
+export {createCustomElement, NgElementConfig, NgElementConstructor, WithProperties} from './src/create-custom-element';
 export {NgElementStrategy, NgElementStrategyEvent, NgElementStrategyFactory} from './src/element-strategy';
 export {VERSION} from './src/version';
 

--- a/packages/elements/src/base-html-element.ts
+++ b/packages/elements/src/base-html-element.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// The primary mechanism of creating a custom element in a modern browser is to write an ES2015
+// class that `extends HTMLElement`. Notably, this only works in ES2015 mode - if downleveled to ES5
+// using prototype-based syntax for inheritance, extending `HTMLElement` will fail at runtime. Since
+// all browsers which support custom elements naturally support ES2015, this is not much of an issue
+// in practice.
+//
+// However, there is a complex scenario in Google's repo where application tests need to be
+// downleveled (because of zone.js) and due to build system limitations, they're downleveled to ES5.
+// In this case, the browser still supports custom elements, but there is no way to retain the
+// ES2015 syntax ordinarily required to define one.
+//
+// Eventually, the zone.js issue which requires downleveling to ES5 will be addressed. Until then,
+// this file allows Angular Elements to work around this problem by enabling custom elements to be
+// defined without ES2015 syntax, using the `Reflect.construct` API also supported in modern
+// browsers. This is based on the technique outlined in the `native-shim.js` polyfill:
+// https://github.com/webcomponents/custom-elements/blob/master/src/native-shim.js
+//
+// In normal (ES2015) mode, this file simply re-exports `HTMLElement` to use as the base class for
+// `NgElement` and thus Angular custom elements. However, an ES5 mode can be enabled, where this
+// base class is replaced with a version that uses `Reflect.construct` under the hood, allowing for
+// derivation of `HTMLElement` even in ES5-compiled classes.
+//
+// Note that the main observable side effect of this workaround is that Angular Elements will no
+// longer be `instanceof NgElement` when the workaround is in effect. As this workaround is intended
+// to only be used in test code, it is expected that this will not be an issue.
+
+/**
+ * Implements the functionality needed for a custom element.
+ *
+ * @publicApi
+ */
+export abstract class NgElement extends HTMLElement {
+  /**
+   * Prototype for a handler that responds to a change in an observed attribute.
+   * @param attrName The name of the attribute that has changed.
+   * @param oldValue The previous value of the attribute.
+   * @param newValue The new value of the attribute.
+   * @param namespace The namespace in which the attribute is defined.
+   * @returns Nothing.
+   */
+  abstract attributeChangedCallback(
+      attrName: string, oldValue: string|null, newValue: string, namespace?: string): void;
+  /**
+   * Prototype for a handler that responds to the insertion of the custom element in the DOM.
+   * @returns Nothing.
+   */
+  abstract connectedCallback(): void;
+  /**
+   * Prototype for a handler that responds to the deletion of the custom element from the DOM.
+   * @returns Nothing.
+   */
+  abstract disconnectedCallback(): void;
+}
+
+let BaseCustomElement: {new (): HTMLElement} = NgElement as unknown as typeof HTMLElement;
+
+export function getBaseCustomElement(): typeof BaseCustomElement {
+  return BaseCustomElement;
+}
+
+export function useReflectionBasedElements(): void {
+  const NativeHTMLElement = HTMLElement;
+
+  // We go through the trouble of defining this function as a string literal-named field on an
+  // object here so that if this code does get minified with advanced property renaming, the
+  // `HTMLElement` name of the function is preserved.
+  const ReflectionBasedHTMLElement = {
+    'HTMLElement': function HTMLElement() {
+      // TODO(alxhub): google3 doesn't compile TS code with `Reflect.construct` typings available
+      // yet. Update this once they are.
+      return (Reflect as any).construct(NativeHTMLElement, [], this.constructor);
+    },
+  }['HTMLElement'];
+
+  // Do some prototype magic to ensure that `ReflectionBasedHTMLElement` can be extended via normal
+  // ES5 class extension.
+  ReflectionBasedHTMLElement.prototype = NativeHTMLElement.prototype;
+
+  // These operations don't seem to be strictly necessary in testing, but we err on the side of
+  // caution by ensuring that `ReflectionBasedHTMLElement`s look as much like `HTMLElement`s as
+  // possible once constructed.
+  ReflectionBasedHTMLElement.prototype.constructor = ReflectionBasedHTMLElement;
+  Object.setPrototypeOf(ReflectionBasedHTMLElement, NativeHTMLElement);
+
+  // Swap in `ReflectionBasedHTMLElement` to use as the base class for all new Angular Elements.
+  BaseCustomElement = ReflectionBasedHTMLElement as unknown as typeof HTMLElement;
+}

--- a/packages/elements/test/create-custom-element_spec.ts
+++ b/packages/elements/test/create-custom-element_spec.ts
@@ -12,6 +12,7 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
 import {Subject} from 'rxjs';
 
+import {useReflectionBasedElements} from '../src/base-html-element';
 import {createCustomElement, NgElementConstructor} from '../src/create-custom-element';
 import {NgElementStrategy, NgElementStrategyEvent, NgElementStrategyFactory} from '../src/element-strategy';
 
@@ -21,8 +22,20 @@ type WithFooBar = {
 };
 
 if (browserDetection.supportsCustomElements) {
-  describe('createCustomElement', () => {
-    let selectorUid = 0;
+  // Run the tests using the default ES2015 classes.
+  runTests('ES2015');
+
+  // Run the tests again, this time using `Reflect.construct` based custom elements.
+  useReflectionBasedElements();
+  runTests('Reflect.construct');
+}
+
+// This must be defined outside `runTests`, so that the tests will use unique selectors even when
+// repeated in both custom element modes.
+let selectorUid = 0;
+
+function runTests(mode: string): void {
+  describe(`createCustomElement (${mode})`, () => {
     let testContainer: HTMLDivElement;
     let NgElementCtor: NgElementConstructor<WithFooBar>;
     let strategy: TestStrategy;

--- a/packages/elements/test/slots_spec.ts
+++ b/packages/elements/test/slots_spec.ts
@@ -11,7 +11,8 @@ import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
 
-import {createCustomElement, NgElement} from '../src/create-custom-element';
+import {NgElement} from '../src/base-html-element';
+import {createCustomElement} from '../src/create-custom-element';
 
 
 // we only run these tests in browsers that support Shadom DOM slots natively


### PR DESCRIPTION
There is a particular case in Google's repo where tests for an application
that use Angular Elements must be run in a downleveled ES5 mode. This
ordinarily would not work, since custom element classes must extend
HTMLElement and HTMLElement does not support being extended via the
normal downleveling of such ES2015 class declarations.

This commit implements a workaround, by allowing the structure of custom
element classes to be switched if needed. In the default mode, custom
elements are created using ES2015 class extension of HTMLElement, as
before. However, by calling a private helper function, custom elements can
instead be created extending from a constructor function that uses the
`Reflect.construct` API, which works even in downleveled ES5 code.
