### PR TITLE
docs: Fix reference to SwUpdate.isEnabled boolean

### DIFF
--- a/aio/content/guide/service-worker-intro.md
+++ b/aio/content/guide/service-worker-intro.md
@@ -55,7 +55,7 @@ More specifically:
 It is highly recommended that you ensure that your application works even without service worker support in the browser.
 Although an unsupported browser ignores service worker caching, it will still report errors if the application attempts to interact with the service worker.
 For example, calling `SwUpdate.checkForUpdate()` will return rejected promises.
-To avoid such an error, you can check whether the Angular service worker is enabled using `SwUpdate.isEnabled()`.
+To avoid such an error, you can check whether the Angular service worker is enabled using `SwUpdate.isEnabled`.
 
 To learn more about other browsers that are service worker ready, see the [Can I Use](https://caniuse.com/#feat=serviceworkers) page and [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API).
 


### PR DESCRIPTION
SwUpdate has an `isEnabled` boolean rather than an `isEnabled()` method. Removed parentheses for accuracy.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Service Worker documentation refers to a method `SwUpdate.isEnabled()` that doesn't exist.

Issue Number: N/A


## What is the new behavior?
Service Worker documentation refers to the correct boolean property `SwUpdate.isEnabled`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is a tiny change and it's my first ever pull request! 🎉 Hopefully I did it right. 🤞🏻 