### PR TITLE
build: update to new remote instance name for RBE

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -121,7 +121,7 @@ build:remote --host_platform=//dev-infra/bazel/remote-execution:platform
 build:remote --platforms=//dev-infra/bazel/remote-execution:platform
 
 # Remote instance and caching
-build:remote --remote_instance_name=projects/internal-200822/instances/default_instance
+build:remote --remote_instance_name=projects/internal-200822/instances/primary_instance
 build:remote --project_id=internal-200822
 build:remote --remote_cache=remotebuildexecution.googleapis.com
 build:remote --remote_executor=remotebuildexecution.googleapis.com

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -735,6 +735,10 @@ jobs:
             # not supported.
             - '/tmp/angular-components-repo'
       - run:
+          # TODO(devversion): remove once https://github.com/angular/components/pull/23056 is available.
+          name: Replace RBE container instance name
+          command: sed -i "s#default_instance#primary_instance#g" ${COMPONENTS_REPO_TMP_DIR}/.bazelrc
+      - run:
           # Updates the `angular/components` `package.json` file to refer to the release output
           # inside the `packages-dist` directory.
           name: Setting up framework release packages.


### PR DESCRIPTION
Update to use remote instance name, primary_instance, for RBE
