### PR TITLE
fix(common): properly cast http param values to strings

### DIFF
--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -164,7 +164,9 @@ export class HttpParams {
       this.map = new Map<string, string[]>();
       Object.keys(options.fromObject).forEach(key => {
         const value = (options.fromObject as any)[key];
-        this.map!.set(key, Array.isArray(value) ? value : [value]);
+        // convert the values to strings
+        const values = Array.isArray(value) ? value.map(valueToString) : [valueToString(value)];
+        this.map!.set(key, values);
       });
     } else {
       this.map = null;

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -195,18 +195,26 @@ import {HttpParams} from '@angular/common/http/src/params';
       it('should stringify number params', () => {
         const body = new HttpParams({fromObject: {a: '', b: 2, c: 3}});
         expect(body.toString()).toBe('a=&b=2&c=3');
+        // make sure the param value is now a string
+        expect(body.get('b')).toBe('2');
       });
       it('should stringify number array params', () => {
         const body = new HttpParams({fromObject: {a: '', b: [21, 22], c: 3}});
         expect(body.toString()).toBe('a=&b=21&b=22&c=3');
+        // make sure the param values are now strings
+        expect(body.getAll('b')).toEqual(['21', '22']);
       });
       it('should stringify boolean params', () => {
         const body = new HttpParams({fromObject: {a: '', b: true, c: 3}});
         expect(body.toString()).toBe('a=&b=true&c=3');
+        // make sure the param value is now a boolean
+        expect(body.get('b')).toBe('true');
       });
       it('should stringify boolean array params', () => {
         const body = new HttpParams({fromObject: {a: '', b: [true, false], c: 3}});
         expect(body.toString()).toBe('a=&b=true&b=false&c=3');
+        // make sure the param values are now booleans
+        expect(body.getAll('b')).toEqual(['true', 'false']);
       });
       it('should stringify array params of different types', () => {
         const body = new HttpParams({fromObject: {a: ['', false, 3] as const}});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Before this commit, when initializing `HttpParams` with:

```ts
const body = new HttpParams({fromObject: {b: 2}});
```

then `body.get('b')` returned `2` instead of `'2'` as expected.

Fixes #42641


## What is the new behavior?

This commit makes sure the values are converted to strings in such cases.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
