### PR TITLE
build(docs-infra): disambiguate doc paths for global APIs

### DIFF
--- a/aio/tests/deployment/e2e/smoke-tests.e2e-spec.ts
+++ b/aio/tests/deployment/e2e/smoke-tests.e2e-spec.ts
@@ -68,6 +68,7 @@ describe(browser.baseUrl, () => {
         /* Directive */ 'api/common/NgIf': 'class ngif',
         /* Enum */ 'api/core/ChangeDetectionStrategy': 'enum changedetectionstrategy',
         /* Function */ 'api/animations/animate': 'animate(',
+        /* Global */ 'api/core/global/ngApplyChanges': 'ng.applychanges(',
         /* Interface */ 'api/core/OnDestroy': 'interface ondestroy',
         /* Pipe */ 'api/common/JsonPipe': '| json',
         /* Type-Alias */ 'api/common/http/HttpEvent': 'type httpevent',

--- a/aio/tools/transforms/angular-api-package/processors/updateGlobalApiPath.js
+++ b/aio/tools/transforms/angular-api-package/processors/updateGlobalApiPath.js
@@ -6,8 +6,8 @@
  */
 module.exports = function updateGlobalApiPathProcessor() {
   return {
-    $runAfter: ['computePathsProcessor'],
-    $runBefore: ['processNgModuleDocs'],
+    $runAfter: ['paths-computed'],
+    $runBefore: ['disambiguateDocPathsProcessor', 'processNgModuleDocs'],
     $process: function(docs) {
       docs.forEach(doc => {
         if (doc.global && doc.globalNamespace) {

--- a/aio/tools/transforms/angular-api-package/processors/updateGlobalApiPath.spec.js
+++ b/aio/tools/transforms/angular-api-package/processors/updateGlobalApiPath.spec.js
@@ -12,12 +12,12 @@ describe('updateGlobalApiPath processor', () => {
 
   it('should run before the correct processor', () => {
     const processor = processorFactory();
-    expect(processor.$runBefore).toEqual(['processNgModuleDocs']);
+    expect(processor.$runBefore).toEqual(['disambiguateDocPathsProcessor', 'processNgModuleDocs']);
   });
 
   it('should run after the correct processor', () => {
     const processor = processorFactory();
-    expect(processor.$runAfter).toEqual(['computePathsProcessor']);
+    expect(processor.$runAfter).toEqual(['paths-computed']);
   });
 
   it('should update the paths of namespaced global APIs', () => {


### PR DESCRIPTION
In #41788, the `disambiguateDocsPathsProcessor` was introduced to fix an issue with case-insensitively equal paths. This processor may alter the output paths of some docs. Due to its nature, the `disambiguateDocPathsProcessor` must be the last processor in the pipeline that updates a doc's output path. However, the `updateGlobalApiPathProcessor` (which also alters the output paths of some docs) was not configured to run before `disambiguateDocPathsProcessor`. As a result, the changes made by `disambiguateDocPathsProcessor` were overridden by `updateGlobalApiPathProcessor`, resulting in the app's failing to load such global API docs pages. An example of such an API page is: https://angular.io/api/core/global/ngApplyChanges

This commit fixes it by ensuring that the `updateGlobalApiPathProcessor` is explicitly run before the `disambiguateDocPathsProcessor`, so that the former does not override the changes made by the latter.

##
_**EDIT:** You can see the fix in action here: https://pr42648-1ffa225.ngbuilds.io/api/core/global/ngApplyChanges_