### PR TITLE
fix(dev-infra): fetch 100 branches from Github instead of 30

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -885,7 +885,9 @@ function getVersionForVersionBranch(branchName) {
  */
 function getBranchesForMajorVersions(repo, majorVersions) {
     return tslib.__awaiter(this, void 0, void 0, function* () {
-        const { data: branchData } = yield repo.api.repos.listBranches({ owner: repo.owner, repo: repo.name, protected: true });
+        // TODO(alxhub): actually paginate this, since eventually the number of branches we have will run
+        // off the end of the first page of data returned by `listBranches`.
+        const { data: branchData } = yield repo.api.repos.listBranches({ owner: repo.owner, repo: repo.name, protected: true, per_page: 100 });
         const branches = [];
         for (const { name } of branchData) {
             if (!isVersionBranch(name)) {

--- a/dev-infra/release/versioning/version-branches.ts
+++ b/dev-infra/release/versioning/version-branches.ts
@@ -67,8 +67,10 @@ export function getVersionForVersionBranch(branchName: string): semver.SemVer|nu
  */
 export async function getBranchesForMajorVersions(
     repo: GithubRepoWithApi, majorVersions: number[]): Promise<VersionBranch[]> {
-  const {data: branchData} =
-      await repo.api.repos.listBranches({owner: repo.owner, repo: repo.name, protected: true});
+  // TODO(alxhub): actually paginate this, since eventually the number of branches we have will run
+  // off the end of the first page of data returned by `listBranches`.
+  const {data: branchData} = await repo.api.repos.listBranches(
+      {owner: repo.owner, repo: repo.name, protected: true, per_page: 100});
   const branches: VersionBranch[] = [];
 
   for (const {name} of branchData) {


### PR DESCRIPTION
This commit fixes an issue with the ng-dev tool, where Github's API returns
paginated branch data. Only 30 branches are returned by default, and Angular
now has more than 30 branches in its repo. This commit increases the number
of branches returned to the API limit of 100, which should buy us some time
until we can implement proper pagination.

