### PR TITLE
build: test angular.io/docs examples against RxJS v7 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,6 +441,9 @@ jobs:
       - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
         # Check the bundle sizes.
       - run: yarn --cwd aio payload-size aio-local
+        # Run tests with RxJS v7.
+      - run: yarn --cwd aio add rxjs@7.1.0
+      - run: yarn --cwd aio test --progress=false --watch=false
 
   test_aio_tools:
     executor: default-executor
@@ -469,6 +472,10 @@ jobs:
         # Since the parallelism is set to "5", there will be five parallel CircleCI containers.
         # with either "0", "1", etc as node index. This can be passed to the "--shard" argument.
       - run: yarn --cwd aio example-e2e --setup --local --cliSpecsConcurrency=5 --shard=${CIRCLE_NODE_INDEX}/${CIRCLE_NODE_TOTAL}
+        # Run tests with RxJS v7.
+        # (Exclude some examples that are not yet compatible with v7.)
+      - run: yarn --cwd aio/tools/examples/shared add rxjs@7.1.0 && yarn --cwd aio boilerplate:add
+      - run: yarn --cwd aio example-e2e --cliSpecsConcurrency=5 --shard=${CIRCLE_NODE_INDEX}/${CIRCLE_NODE_TOTAL} --exclude=practical-observable-usage --exclude=upgrade-module --exclude=upgrade-phonecat
 
   # This job should only be run on PR builds, where `CI_PULL_REQUEST` is not `false`.
   aio_preview:

--- a/aio/content/examples/elements/src/app/popup.component.ts
+++ b/aio/content/examples/elements/src/app/popup.component.ts
@@ -50,5 +50,5 @@ export class PopupComponent {
   private _message = '';
 
   @Output()
-  closed = new EventEmitter();
+  closed = new EventEmitter<void>();
 }

--- a/aio/src/app/custom-elements/api/api.service.ts
+++ b/aio/src/app/custom-elements/api/api.service.ts
@@ -30,7 +30,7 @@ export class ApiService implements OnDestroy {
   private apiBase = DOC_CONTENT_URL_PREFIX + 'api/';
   private apiListJsonDefault = 'api-list.json';
   private firstTime = true;
-  private onDestroy = new Subject();
+  private onDestroy = new Subject<void>();
   private sectionsSubject = new ReplaySubject<ApiSection[]>(1);
   private _sections = this.sectionsSubject.pipe(takeUntil(this.onDestroy));
 

--- a/aio/src/app/custom-elements/toc/toc.component.ts
+++ b/aio/src/app/custom-elements/toc/toc.component.ts
@@ -19,7 +19,7 @@ export class TocComponent implements OnInit, AfterViewInit, OnDestroy {
   isCollapsed = true;
   isEmbedded = false;
   @ViewChildren('tocItem') private items: QueryList<ElementRef>;
-  private onDestroy = new Subject();
+  private onDestroy = new Subject<void>();
   primaryMax = 4;
   tocList: TocItem[];
 

--- a/aio/src/app/layout/notification/notification.component.ts
+++ b/aio/src/app/layout/notification/notification.component.ts
@@ -23,7 +23,7 @@ export class NotificationComponent implements OnInit {
   @Input() dismissOnContentClick: boolean;
   @Input() notificationId: string;
   @Input() expirationDate: string;
-  @Output() dismissed = new EventEmitter();
+  @Output() dismissed = new EventEmitter<void>();
 
   @HostBinding('@hideAnimation')
   showNotification: 'show'|'hide';

--- a/aio/src/app/shared/scroll-spy.service.ts
+++ b/aio/src/app/shared/scroll-spy.service.ts
@@ -118,7 +118,7 @@ export class ScrollSpiedElementGroup {
 @Injectable()
 export class ScrollSpyService {
   private spiedElementGroups: ScrollSpiedElementGroup[] = [];
-  private onStopListening = new Subject();
+  private onStopListening = new Subject<void>();
   private resizeEvents = fromEvent(window, 'resize').pipe(auditTime(300), takeUntil(this.onStopListening));
   private scrollEvents = fromEvent(window, 'scroll').pipe(auditTime(10), takeUntil(this.onStopListening));
   private lastContentHeight: number;

--- a/aio/tools/examples/run-example-e2e.js
+++ b/aio/tools/examples/run-example-e2e.js
@@ -398,6 +398,9 @@ function getE2eSpecsFor(basePath, specFile, filter) {
 }
 
 function filterToGlob(filter) {
+  // `filter` can be either a string (if there is one occurrence of the corresponding option) or an
+  // array (if there are two or more occurrences of the corresponding option). In other words, if
+  // `filter` is an array, it will have more than one element.
   return Array.isArray(filter) ? `*{${filter.join(',')}}*` : `*${filter}*`;
 }
 

--- a/aio/tools/examples/run-example-e2e.js
+++ b/aio/tools/examples/run-example-e2e.js
@@ -25,8 +25,14 @@ const IGNORED_EXAMPLES = [];
  * Run Protractor End-to-End Tests for Doc Samples
  *
  * Flags
- *  --filter to filter/select _example app subdir names
+ *  --filter to filter/select example app subdir names
+ *    Can be used multiple times to include multiple patterns.
  *    e.g. --filter=foo  // all example apps with 'foo' in their folder names.
+ *
+ *  --exclude to exclude example app subdir names
+ *    Can be used multiple times to exclude multiple patterns.
+ *    NOTE: `--exclude` is always cosidered after `--filter`.
+ *    e.g. --exclude=bar  // Exclude all example apps with 'bar' in their folder names.
  *
  *  --setup to run yarn install, copy boilerplate and update webdriver
  *    e.g. --setup
@@ -60,7 +66,7 @@ function runE2e() {
   return Promise.resolve()
       .then(
           () => findAndRunE2eTests(
-              argv.filter, outputFile, argv.shard,
+              argv.filter, argv.exclude, outputFile, argv.shard,
               argv.cliSpecsConcurrency || DEFAULT_CLI_SPECS_CONCURRENCY, argv.retry || 1))
       .then((status) => {
         reportStatus(status, outputFile);
@@ -76,7 +82,9 @@ function runE2e() {
 
 // Finds all of the *e2e-spec.tests under the examples folder along with the corresponding apps
 // that they should run under. Then run each app/spec collection sequentially.
-function findAndRunE2eTests(filter, outputFile, shard, cliSpecsConcurrency, maxAttempts) {
+function findAndRunE2eTests(
+    includeFilter, excludeFilter, outputFile, shard, cliSpecsConcurrency, maxAttempts) {
+  const filter = {include: includeFilter, exclude: excludeFilter};
   const shardParts = shard ? shard.split('/') : [0, 1];
   const shardModulo = parseInt(shardParts[0], 10);
   const shardDivider = parseInt(shardParts[1], 10);
@@ -84,7 +92,8 @@ function findAndRunE2eTests(filter, outputFile, shard, cliSpecsConcurrency, maxA
   // create an output file with header.
   const startTime = new Date().getTime();
   let header = `Doc Sample Protractor Results on ${new Date().toLocaleString()}\n`;
-  header += `  Filter: ${filter ? filter : 'All tests'}\n\n`;
+  header += `  Include: ${filter.include || 'All tests'}\n`;
+  header += `  Exclude: ${filter.exclude || 'No tests'}\n\n`;
   fs.writeFileSync(outputFile, header);
 
   const status = {passed: [], failed: []};
@@ -378,14 +387,18 @@ function getE2eSpecs(basePath, filter) {
 // Find all e2e specs in a given example folder.
 function getE2eSpecsFor(basePath, specFile, filter) {
   // Only get spec file at the example root.
-  // The formatter doesn't understand nested template string expressions (honestly, neither do I).
-  // clang-format off
-  const e2eSpecGlob = `${filter ? `*${filter}*` : '*'}/${specFile}`;
-  // clang-format on
+  const e2eSpecGlob = [
+    `${filter.include ? filterToGlob(filter.include) : '*'}/${specFile}`,
+    `!${filter.exclude ? filterToGlob(filter.exclude) : ''}/${specFile}`,
+  ];
   return globby(e2eSpecGlob, {cwd: basePath, nodir: true})
       .then(
           paths => paths.filter(file => !IGNORED_EXAMPLES.some(ignored => file.startsWith(ignored)))
                        .map(file => path.join(basePath, file)));
+}
+
+function filterToGlob(filter) {
+  return Array.isArray(filter) ? `*{${filter.join(',')}}*` : `*${filter}*`;
 }
 
 // Load configuration for an example. Used for SystemJS


### PR DESCRIPTION
Extend PR #41793 to run angular.io and docs-examples tests against RxJS v7 on CI (as a quick way to guard against potential regressions).