### PR TITLE
fix(core): error in TestBed if module is reset mid-compilation in ViewEngine

### DIFF
--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -307,6 +307,28 @@ describe('TestBed', () => {
     expect(SimpleService.ngOnDestroyCalls).toBe(0);
   });
 
+  it('should be able to create a fixture if a test module is reset mid-compilation', async () => {
+    @Component({template: 'hello'})
+    class TestComponent {
+    }
+
+    TestBed.resetTestingModule();  // Reset the state from `beforeEach`.
+
+    function compile() {
+      return TestBed
+          .configureTestingModule(
+              {declarations: [TestComponent], teardown: {destroyAfterEach: true}})
+          .compileComponents();
+    }
+
+    const initialCompilation = compile();
+    TestBed.resetTestingModule();
+    await initialCompilation;
+    await compile();
+    const fixture = TestBed.createComponent(TestComponent);
+    expect(fixture.nativeElement).toHaveText('hello');
+  });
+
   describe('module overrides using TestBed.overrideModule', () => {
     @Component({
       selector: 'test-cmp',

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -308,25 +308,32 @@ describe('TestBed', () => {
   });
 
   it('should be able to create a fixture if a test module is reset mid-compilation', async () => {
-    @Component({template: 'hello'})
+    const token = new InjectionToken<number>('value');
+
+    @Component({template: 'hello {{_token}}'})
     class TestComponent {
+      constructor(@Inject(token) public _token: number) {}
     }
 
     TestBed.resetTestingModule();  // Reset the state from `beforeEach`.
 
-    function compile() {
+    function compile(tokenValue: number) {
       return TestBed
-          .configureTestingModule(
-              {declarations: [TestComponent], teardown: {destroyAfterEach: true}})
+          .configureTestingModule({
+            declarations: [TestComponent],
+            providers: [{provide: token, useValue: tokenValue}],
+            teardown: {destroyAfterEach: true}
+          })
           .compileComponents();
     }
 
-    const initialCompilation = compile();
+    const initialCompilation = compile(1);
     TestBed.resetTestingModule();
     await initialCompilation;
-    await compile();
+    await compile(2);
     const fixture = TestBed.createComponent(TestComponent);
-    expect(fixture.nativeElement).toHaveText('hello');
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveText('hello 2');
   });
 
   describe('module overrides using TestBed.overrideModule', () => {


### PR DESCRIPTION
When `TestBed.compileComponents` is called under ViewEngine, we kick off a compilation and return a promise that resolves once the compilation is done. In most cases the consumer doesn't _have_ to await the returned promise, unless their components have external resources.

The problem is that the test could be over by the time the promise has resolved, in which case we still cache the factory of the test module. This becomes a problem if another compilation is triggered right afterwards, because it'll see that we still have a `_moduleFactory` and it won't recreate the factory.

These changes resolve the issue by saving a reference to the module type that is being compiled and checking against it when the promise resolves.

Note that even though this problem was discovered while trying to roll out the new test module teardown behavior in the Components repo (https://github.com/angular/components/pull/23070), it has been there for a long time. The new test behavior made it more apparent.