### PR TITLE
docs(core): add context jsdoc param to createEmbeddedView

### DIFF
--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -98,6 +98,8 @@ export abstract class ViewContainerRef {
    * Instantiates an embedded view and inserts it
    * into this container.
    * @param templateRef The HTML template that defines the view.
+   * @param context The data-binding context of the embedded view, as declared
+   * in the `<ng-template>` usage.
    * @param index The 0-based index at which to insert the new view into this container.
    * If not specified, appends the new view as the last entry.
    *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The ViewContainerRef's createEmbeddedView is missing it's context param jsdoc

As you can see in anglar.io:
![Screenshot at 2021-06-27 16-46-17](https://user-images.githubusercontent.com/61631103/123550950-923ce600-d767-11eb-85c8-66ba144f8bcc.png)
([link](https://angular.io/api/core/ViewContainerRef#createembeddedview))

The context is naturally also missing with intellisense:
![Screenshot at 2021-06-27 13-14-50](https://user-images.githubusercontent.com/61631103/123551021-e5af3400-d767-11eb-9e4e-1d8084f207e2.png)




<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The jsdoc is added so that both aio and intellisense give some information to the user

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I just copied and pasted the jsdoc for the parameter from the templateRef:

![Screenshot at 2021-06-27 16-46-29](https://user-images.githubusercontent.com/61631103/123551057-12fbe200-d768-11eb-8d06-a1a89b1d44fa.png)
([link](https://angular.io/api/core/TemplateRef#createembeddedview))

![Screenshot at 2021-06-27 16-57-29](https://user-images.githubusercontent.com/61631103/123551269-f1e7c100-d768-11eb-98b5-7d6da5e7a621.png)


I think it is still applicable because the viewContainerRef's createEmbeddedView calls the templateRef's createdEmbeddedView:
![Screenshot at 2021-06-27 17-02-43](https://user-images.githubusercontent.com/61631103/123551412-894d1400-d769-11eb-95c4-d7e46c5cedbc.png)
(If I'm wrong please let me know)

One last thing that I'd like to mention is that actually there is no documentation for it's usage in the `ng-template`, actually the docs are very scarce there I opened an issue for that (https://github.com/angular/angular/issues/42678)