### PR TITLE
Clean up deprecated --prod flag usages

### DIFF
--- a/aio/content/examples/forms-overview/example-config.json
+++ b/aio/content/examples/forms-overview/example-config.json
@@ -1,6 +1,6 @@
 {
   "tests": [
     {"cmd": "yarn", "args": ["test", "--browsers=ChromeHeadless", "--no-watch"]},
-    {"cmd": "yarn", "args": ["e2e", "--prod", "--protractor-config=e2e/protractor-puppeteer.conf.js", "--no-webdriver-update", "--port={PORT}"]}
+    {"cmd": "yarn", "args": ["e2e", "--configuration=production", "--protractor-config=e2e/protractor-puppeteer.conf.js", "--no-webdriver-update", "--port={PORT}"]}
   ]
 }

--- a/aio/content/examples/http/example-config.json
+++ b/aio/content/examples/http/example-config.json
@@ -2,6 +2,6 @@
   "projectType": "testing",
   "tests": [
     {"cmd": "yarn", "args": ["test", "--browsers=ChromeHeadless", "--no-watch"]},
-    {"cmd": "yarn", "args": ["e2e", "--prod", "--protractor-config=e2e/protractor-puppeteer.conf.js", "--no-webdriver-update", "--port={PORT}"]}
+    {"cmd": "yarn", "args": ["e2e", "--configuration=production", "--protractor-config=e2e/protractor-puppeteer.conf.js", "--no-webdriver-update", "--port={PORT}"]}
   ]
 }

--- a/aio/content/examples/service-worker-getting-started/example-config.json
+++ b/aio/content/examples/service-worker-getting-started/example-config.json
@@ -2,7 +2,7 @@
   "projectType": "service-worker",
   "tests": [
     {"cmd": "yarn", "args": ["e2e", "--protractor-config=e2e/protractor-puppeteer.conf.js", "--no-webdriver-update", "--port={PORT}"]},
-    {"cmd": "yarn", "args": ["build", "--prod"]},
+    {"cmd": "yarn", "args": ["build", "--configuration=production"]},
     {"cmd": "node", "args": ["--eval", "assert(fs.existsSync('./dist/ngsw.json'), 'ngsw.json is missing')"]},
     {"cmd": "node", "args": ["--eval", "assert(fs.existsSync('./dist/ngsw-worker.js'), 'ngsw-worker.js is missing')"]},
     {"cmd": "node", "args": ["--eval", "assert(require('./package.json').dependencies['@angular/service-worker'], '@angular/service-worker is missing')"]}

--- a/aio/content/examples/setup/example-config.json
+++ b/aio/content/examples/setup/example-config.json
@@ -1,6 +1,6 @@
 {
   "tests": [
     {"cmd": "yarn", "args": ["test", "--browsers=ChromeHeadless", "--no-watch"]},
-    {"cmd": "yarn", "args": ["e2e", "--prod", "--protractor-config=e2e/protractor-puppeteer.conf.js", "--no-webdriver-update", "--port={PORT}"]}
+    {"cmd": "yarn", "args": ["e2e", "--configuration=production", "--protractor-config=e2e/protractor-puppeteer.conf.js", "--no-webdriver-update", "--port={PORT}"]}
   ]
 }

--- a/aio/content/examples/testing/example-config.json
+++ b/aio/content/examples/testing/example-config.json
@@ -2,6 +2,6 @@
   "projectType": "testing",
   "tests": [
     {"cmd": "yarn", "args": ["test", "--browsers=ChromeHeadless", "--no-watch"]},
-    {"cmd": "yarn", "args": ["e2e", "--prod", "--protractor-config=e2e/protractor-puppeteer.conf.js", "--no-webdriver-update", "--port={PORT}"]}
+    {"cmd": "yarn", "args": ["e2e", "--configuration=production", "--protractor-config=e2e/protractor-puppeteer.conf.js", "--no-webdriver-update", "--port={PORT}"]}
   ]
 }

--- a/aio/content/examples/toh-pt6/example-config.json
+++ b/aio/content/examples/toh-pt6/example-config.json
@@ -1,6 +1,6 @@
 {
   "tests": [
     {"cmd": "yarn", "args": ["test", "--browsers=ChromeHeadless", "--no-watch"]},
-    {"cmd": "yarn", "args": ["e2e", "--prod", "--protractor-config=e2e/protractor-puppeteer.conf.js", "--no-webdriver-update", "--port={PORT}"]}
+    {"cmd": "yarn", "args": ["e2e", "--configuration=production", "--protractor-config=e2e/protractor-puppeteer.conf.js", "--no-webdriver-update", "--port={PORT}"]}
   ]
 }

--- a/aio/content/examples/universal/example-config.json
+++ b/aio/content/examples/universal/example-config.json
@@ -1,7 +1,7 @@
 {
   "projectType": "universal",
   "e2e": [
-    {"cmd": "yarn", "args": ["e2e", "--prod", "--protractor-config=e2e/protractor-puppeteer.conf.js", "--no-webdriver-update", "--port={PORT}"]},
+    {"cmd": "yarn", "args": ["e2e", "--configuration=production", "--protractor-config=e2e/protractor-puppeteer.conf.js", "--no-webdriver-update", "--port={PORT}"]},
     {"cmd": "yarn", "args": ["run", "build:ssr"]}
   ]
 }

--- a/aio/tools/examples/README.md
+++ b/aio/tools/examples/README.md
@@ -86,7 +86,7 @@ The file is expected to contain a JSON object with zero or more of the following
       "cmd": "yarn",
       "args": [
         "e2e",
-        "--prod",
+        "--configuration=production",
         "--protractor-config=e2e/protractor-puppeteer.conf.js",
         "--no-webdriver-update",
         "--port={PORT}"

--- a/aio/tools/examples/run-example-e2e.js
+++ b/aio/tools/examples/run-example-e2e.js
@@ -251,7 +251,7 @@ function runE2eTestsCLI(appDir, outputFile, bufferOutput, port) {
                          cmd: 'yarn',
                          args: [
                            'e2e',
-                           '--prod',
+                           '--configuration=production',
                            '--protractor-config=e2e/protractor-puppeteer.conf.js',
                            '--no-webdriver-update',
                            '--port={PORT}',

--- a/aio/tools/examples/shared/boilerplate/cli/src/environments/environment.ts
+++ b/aio/tools/examples/shared/boilerplate/cli/src/environments/environment.ts
@@ -1,5 +1,5 @@
 // This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
+// `ng build --configuration=production` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {

--- a/aio/tools/examples/shared/boilerplate/universal/package.json
+++ b/aio/tools/examples/shared/boilerplate/universal/package.json
@@ -12,7 +12,7 @@
     "e2e": "ng e2e",
     "dev:ssr": "ng run angular.io-example:serve-ssr",
     "serve:ssr": "node dist/server/main.js",
-    "build:ssr": "ng build --prod && ng run angular.io-example:server:production",
+    "build:ssr": "ng build --configuration=production && ng run angular.io-example:server:production",
     "prerender": "ng run angular.io-example:prerender"
   },
   "private": true,

--- a/integration/README.md
+++ b/integration/README.md
@@ -146,7 +146,7 @@ If size regression occurs, one way to debug is to get a build which shows the co
 
 1. Check out both the `master` branch as well as the your change (let's refer to it as `change` branch) into two different working locations. (A suggested way to do this is using `git worktree`.)
 2. In both `master` and `change` locations update the failing tests `package.json` with `NG_BUILD_DEBUG_OPTIMIZE=minify` environment variable so that the resulting build would contain a human readable but optimized output. As an example:
-   - Open `integration/cli-hello-world/package.json` and prefix `NG_BUILD_DEBUG_OPTIMIZE=minify` into the `build` rule. Resulting in something like: `"build": "NG_BUILD_DEBUG_OPTIMIZE=minify ng build --prod",`
+   - Open `integration/cli-hello-world/package.json` and prefix `NG_BUILD_DEBUG_OPTIMIZE=minify` into the `build` rule. Resulting in something like: `"build": "NG_BUILD_DEBUG_OPTIMIZE=minify ng build --configuration=production",`
    - Run `bazel run //integration:cli-hello-world_test.debug` to build the output. (optionally just run `yarn build` in the directory if you want to do a quick rebuild which will only pick up changes to the test application (not framework).)
    - Diff the `master` vs `change` to see the differences. `myDiffTool change/integration/cli-hello-world/dist/main-es2015.*.js master/integration/cli-hello-world/dist/main-es2015.*.js`
    - The above should give you a better understanding as to what has changed and what is causing the regression.

--- a/integration/cli-elements-universal/package.json
+++ b/integration/cli-elements-universal/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "pretest": "ng version",
-    "test": "ng test && yarn e2e --prod && yarn test-ssr",
+    "test": "ng test && yarn e2e --configuration=production && yarn test-ssr",
     "lint": "ng lint",
     "e2e": "ng e2e --port 0",
     "pretest-ssr": "yarn ng run cli-elements-universal:app-shell:production",

--- a/integration/cli-elements-universal/src/environments/environment.ts
+++ b/integration/cli-elements-universal/src/environments/environment.ts
@@ -1,5 +1,5 @@
 // This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
+// `ng build --configuration=production` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {

--- a/integration/cli-hello-world-ivy-compat/README.md
+++ b/integration/cli-hello-world-ivy-compat/README.md
@@ -12,7 +12,7 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--configuration=production` flag for a production build.
 
 ## Running unit tests
 

--- a/integration/cli-hello-world-ivy-compat/package.json
+++ b/integration/cli-hello-world-ivy-compat/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "build": "ng build --prod",
+    "build": "ng build --configuration=production",
     "e2e": "ng e2e --port 0",
     "lint": "ng lint",
     "ng": "ng",

--- a/integration/cli-hello-world-ivy-compat/src/app/app.component.html
+++ b/integration/cli-hello-world-ivy-compat/src/app/app.component.html
@@ -418,7 +418,7 @@
       <pre *ngSwitchCase="'pwa'">ng add @angular/pwa</pre>
       <pre *ngSwitchCase="'dependency'">ng add _____</pre>
       <pre *ngSwitchCase="'test'">ng test</pre>
-      <pre *ngSwitchCase="'build'">ng build --prod</pre>
+      <pre *ngSwitchCase="'build'">ng build --configuration=production</pre>
   </div>
 
   <!-- Links -->

--- a/integration/cli-hello-world-ivy-compat/src/environments/environment.ts
+++ b/integration/cli-hello-world-ivy-compat/src/environments/environment.ts
@@ -1,5 +1,5 @@
 // This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
+// `ng build --configuration=production` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {

--- a/integration/cli-hello-world-ivy-i18n/package.json
+++ b/integration/cli-hello-world-ivy-i18n/package.json
@@ -3,14 +3,14 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "build": "ng build --prod",
+    "build": "ng build --configuration=production",
     "e2e": "ng e2e --port 0",
     "lint": "ng lint",
     "ng": "ng",
     "postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points",
     "start": "ng serve",
     "pretest": "ng version",
-    "test": "ng e2e --port 0 --prod && ng xi18n && yarn translate && ng e2e --port 0 --configuration fr && ng e2e --port 0 --configuration de",
+    "test": "ng e2e --port 0 --configuration=production && ng xi18n && yarn translate && ng e2e --port 0 --configuration fr && ng e2e --port 0 --configuration de",
     "translate": "cp src/locale/messages.xlf src/locale/messages.fr.xlf && cp src/locale/messages.xlf src/locale/messages.de.xlf && sed -i.bak -e 's/source>/target>/g' -e 's/Hello/Bonjour/' src/locale/messages.fr.xlf && sed -i.bak -e 's/source>/target>/g' -e 's/Hello/Hallo/' src/locale/messages.de.xlf",
     "serve": "serve --no-clipboard --listen 4200"
   },

--- a/integration/cli-hello-world-ivy-i18n/src/environments/environment.ts
+++ b/integration/cli-hello-world-ivy-i18n/src/environments/environment.ts
@@ -1,5 +1,5 @@
 // This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
+// `ng build --configuration=production` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {

--- a/integration/cli-hello-world-ivy-minimal/README.md
+++ b/integration/cli-hello-world-ivy-minimal/README.md
@@ -12,7 +12,7 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--configuration=production` flag for a production build.
 
 ## Running unit tests
 

--- a/integration/cli-hello-world-ivy-minimal/package.json
+++ b/integration/cli-hello-world-ivy-minimal/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "build": "ng build --prod",
+    "build": "ng build --configuration=production",
     "e2e": "ng e2e --port 0",
     "lint": "ng lint",
     "ng": "ng",

--- a/integration/cli-hello-world-lazy/package.json
+++ b/integration/cli-hello-world-lazy/package.json
@@ -2,8 +2,8 @@
   "name": "cli-hello-world-lazy",
   "version": "0.0.0",
   "scripts": {
-    "build": "ng build --prod",
-    "e2e": "ng e2e --port 0 --prod",
+    "build": "ng build --configuration=production",
+    "e2e": "ng e2e --port 0 --configuration=production",
     "test": "yarn e2e && yarn build && node check-output-for-ngdevmode.js",
     "postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points"
   },

--- a/integration/cli-hello-world-lazy/src/app/app.component.html
+++ b/integration/cli-hello-world-lazy/src/app/app.component.html
@@ -416,7 +416,7 @@
       <pre *ngSwitchCase="'pwa'">ng add @angular/pwa</pre>
       <pre *ngSwitchCase="'dependency'">ng add _____</pre>
       <pre *ngSwitchCase="'test'">ng test</pre>
-      <pre *ngSwitchCase="'build'">ng build --prod</pre>
+      <pre *ngSwitchCase="'build'">ng build --configuration=production</pre>
   </div>
 
   <!-- Links -->

--- a/integration/cli-hello-world-lazy/src/environments/environment.ts
+++ b/integration/cli-hello-world-lazy/src/environments/environment.ts
@@ -1,5 +1,5 @@
 // This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
+// `ng build --configuration=production` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {

--- a/integration/cli-hello-world/README.md
+++ b/integration/cli-hello-world/README.md
@@ -12,7 +12,7 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--configuration=production` flag for a production build.
 
 ## Running unit tests
 

--- a/integration/cli-hello-world/package.json
+++ b/integration/cli-hello-world/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod",
+    "build": "ng build --configuration=production",
     "pretest": "ng version",
     "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production",
     "lint": "ng lint",

--- a/integration/cli-hello-world/src/app/app.component.html
+++ b/integration/cli-hello-world/src/app/app.component.html
@@ -416,7 +416,7 @@
       <pre *ngSwitchCase="'pwa'">ng add @angular/pwa</pre>
       <pre *ngSwitchCase="'dependency'">ng add _____</pre>
       <pre *ngSwitchCase="'test'">ng test</pre>
-      <pre *ngSwitchCase="'build'">ng build --prod</pre>
+      <pre *ngSwitchCase="'build'">ng build --configuration=production</pre>
   </div>
 
   <!-- Links -->

--- a/integration/cli-hello-world/src/environments/environment.ts
+++ b/integration/cli-hello-world/src/environments/environment.ts
@@ -1,5 +1,5 @@
 // This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
+// `ng build --configuration=production` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {

--- a/integration/forms/README.md
+++ b/integration/forms/README.md
@@ -12,7 +12,7 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--configuration=production` flag for a production build.
 
 ## Running unit tests
 

--- a/integration/forms/package.json
+++ b/integration/forms/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod",
+    "build": "ng build --configuration=production",
     "pretest": "ng version",
     "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production",
     "lint": "ng lint",

--- a/integration/forms/src/environments/environment.ts
+++ b/integration/forms/src/environments/environment.ts
@@ -1,5 +1,5 @@
 // This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
+// `ng build --configuration=production` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {

--- a/integration/ivy-i18n/README.md
+++ b/integration/ivy-i18n/README.md
@@ -12,7 +12,7 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--configuration=production` flag for a production build.
 
 ## Running unit tests
 

--- a/integration/ivy-i18n/package.json
+++ b/integration/ivy-i18n/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "build": "ng build --prod",
+    "build": "ng build --configuration=production",
     "e2e": "ng e2e --port 0",
     "lint": "ng lint",
     "ng": "ng",

--- a/integration/ivy-i18n/src/environments/environment.ts
+++ b/integration/ivy-i18n/src/environments/environment.ts
@@ -1,5 +1,5 @@
 // This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
+// `ng build --configuration=production` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {

--- a/integration/ng_update_migrations/README.md
+++ b/integration/ng_update_migrations/README.md
@@ -12,7 +12,7 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--configuration=production` flag for a production build.
 
 ## Running unit tests
 

--- a/integration/ng_update_migrations/src/environments/environment.ts
+++ b/integration/ng_update_migrations/src/environments/environment.ts
@@ -1,5 +1,5 @@
 // This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
+// `ng build --configuration=production` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {

--- a/integration/trusted-types/README.md
+++ b/integration/trusted-types/README.md
@@ -12,7 +12,7 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--configuration=production` flag for a production build.
 
 ## Running unit tests
 

--- a/integration/trusted-types/package.json
+++ b/integration/trusted-types/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod",
+    "build": "ng build --configuration=production",
     "pretest": "ng version",
     "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production",
     "lint": "ng lint",

--- a/integration/trusted-types/src/app/app.component.html
+++ b/integration/trusted-types/src/app/app.component.html
@@ -419,7 +419,7 @@
       <pre *ngSwitchCase="'pwa'">ng add @angular/pwa</pre>
       <pre *ngSwitchCase="'dependency'">ng add _____</pre>
       <pre *ngSwitchCase="'test'">ng test</pre>
-      <pre *ngSwitchCase="'build'">ng build --prod</pre>
+      <pre *ngSwitchCase="'build'">ng build --configuration=production</pre>
   </div>
 
   <!-- Links -->

--- a/integration/trusted-types/src/environments/environment.ts
+++ b/integration/trusted-types/src/environments/environment.ts
@@ -1,5 +1,5 @@
 // This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
+// `ng build --configuration=production` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {


### PR DESCRIPTION
Version 12 of the CLI prints a warning if the `--prod` flag is used instead of `--configuration=production`. These changes update the docs and the integration tests to the new flag.