### PR TITLE
fix(core): allow proper type inference when `ngFor` is used with a `trackBy` function

### DIFF
--- a/goldens/public-api/core/core.md
+++ b/goldens/public-api/core/core.md
@@ -1258,7 +1258,7 @@ export class TestabilityRegistry {
 // @public
 export interface TrackByFunction<T> {
     // (undocumented)
-    <U extends T>(index: number, item: U): any;
+    <U extends T>(index: number, item: T & U): any;
 }
 
 // @public

--- a/packages/compiler-cli/src/ngtsc/testing/fake_core/index.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/fake_core/index.ts
@@ -116,5 +116,5 @@ export interface OnDestroy {
 }
 
 export interface TrackByFunction<T> {
-  <U extends T>(index: number, item: U): any;
+  <U extends T>(index: number, item: T&U): any;
 }

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -167,7 +167,7 @@ export interface TrackByFunction<T> {
    * @param index The index of the item within the iterable.
    * @param item The item in the iterable.
    */
-  <U extends T>(index: number, item: U): any;
+  <U extends T>(index: number, item: T&U): any;
 }
 
 /**


### PR DESCRIPTION
In #41995 the type of `TrackByFunction` was changed such that the
declaration of a `trackBy` function did not cause the item type to be
widened to the `trackBy`'s item type, which may be a supertype of the
iterated type. This has introduced situations where the template type
checker is now reporting errors for cases where a `trackBy` function is
no longer assignable to `TrackByFunction`.

This commit fixes the error by also including the item type `T` in
addition to the constrained type parameter `U`, allowing TypeScript to
infer an appropriate `T`.

Fixes #42609