### PR TITLE
fix(docs): setting context value inside an interceptor

### DIFF
--- a/aio/content/examples/http/src/app/http-interceptors/index.ts
+++ b/aio/content/examples/http/src/app/http-interceptors/index.ts
@@ -14,7 +14,7 @@ import { NoopInterceptor } from './noop-interceptor';
 // #enddocregion interceptor-providers
 import { TrimNameInterceptor } from './trim-name-interceptor';
 import { UploadInterceptor } from './upload-interceptor';
-
+import { RetryInterceptor } from './retry-interceptor';
 // #docregion interceptor-providers
 
 /** Http interceptor providers in outside-in order */

--- a/aio/content/examples/http/src/app/http-interceptors/retry-interceptor.ts
+++ b/aio/content/examples/http/src/app/http-interceptors/retry-interceptor.ts
@@ -39,7 +39,7 @@ export class RetryInterceptor implements HttpInterceptor {
         tap(null,
             () => {
               // An error has occurred, so increment this request's ERROR_COUNT.
-              req.set(ERROR_COUNT, req.get(ERROR_COUNT) + 1);
+              req.context.set(ERROR_COUNT, req.context.get(ERROR_COUNT) + 1);
             }),
         // #docregion reading-context
         // Retry the request a configurable number of times.


### PR DESCRIPTION
Usage of `get`/`set` methods should be done on a context object instead of a `HttpRequest` instance.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Correct use instance to set a new context value

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
