### PR TITLE
docs: add missing import to `CartService` tutorial instructions

### DIFF
--- a/aio/content/examples/getting-started/src/app/cart.service.ts
+++ b/aio/content/examples/getting-started/src/app/cart.service.ts
@@ -1,9 +1,9 @@
-// #docplaster
 // #docregion import-http
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+// #docregion props
 import { Product } from './products';
-// #enddocregion import-http
+// #enddocregion props, import-http
 
 @Injectable({
   providedIn: 'root'

--- a/aio/content/start/start-data.md
+++ b/aio/content/start/start-data.md
@@ -30,6 +30,7 @@ This section walks you through adding a **Buy** button and setting up a cart ser
 
     <code-example header="src/app/cart.service.ts" path="getting-started/src/app/cart.service.1.ts"></code-example>
 
+1. Import the `Product` interface from `./products.js`.
 1. In the `CartService` class, define an `items` property to store the array of the current products in the cart.
 
     <code-example path="getting-started/src/app/cart.service.ts" header="src/app/cart.service.ts" region="props"></code-example>


### PR DESCRIPTION
The 'Managing Data' part of the tutorial is missing an instruction to import `Product` into `cart.service.ts`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The angular tutorial does not work as currently written. `Cannot find name 'Product'` error is thrown when creating the `cart.service.ts` file.

Issue Number: N/A


## What is the new behavior?
Include an instruction to import Product from `'./products'`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
