### PR TITLE
fix(platform-browser): in `Meta.addTag()` do not add duplicate meta tags

### DIFF
--- a/packages/platform-browser/src/browser/meta.ts
+++ b/packages/platform-browser/src/browser/meta.ts
@@ -166,11 +166,11 @@ export class Meta {
       HTMLMetaElement {
     if (!forceCreation) {
       const selector: string = this._parseSelector(meta);
-      const elem: HTMLMetaElement = this.getTag(selector)!;
       // It's allowed to have multiple elements with the same name so it's not enough to
       // just check that element with the same name already present on the page. We also need to
       // check if element has tag attributes
-      if (elem && this._containsAttributes(meta, elem)) return elem;
+      const elem = this.getTags(selector).filter(elem => this._containsAttributes(meta, elem))[0];
+      if (elem !== undefined) return elem;
     }
     const element: HTMLMetaElement = this._dom.createElement('meta') as HTMLMetaElement;
     this._setMetaElementAttributes(meta, element);

--- a/packages/platform-browser/test/browser/meta_spec.ts
+++ b/packages/platform-browser/test/browser/meta_spec.ts
@@ -167,6 +167,16 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       expect(metaService.getTags(selector).length).toEqual(1);
     });
 
+    it('should not add meta tag if it is already present on the page, even if the first tag with the same name has different other attributes',
+       () => {
+         metaService.addTag({name: 'description', content: 'aaa'});
+         metaService.addTag({name: 'description', content: 'bbb'});
+         metaService.addTag({name: 'description', content: 'aaa'});
+         metaService.addTag({name: 'description', content: 'bbb'});
+
+         expect(metaService.getTags('name="description"').length).toEqual(2);
+       });
+
     it('should add meta tag if it is already present on the page and but has different attr',
        () => {
          const selector = 'property="fb:app_id"';


### PR DESCRIPTION
Previously, if there were two tags with the same "name" or "property" attribute selector,
then only the first was checked for duplicates when deciding whether to add a new meta
tag.

Fixes #42700
Fixes #19606
