### PR TITLE
fix(docs-infra): move dots inside Usage Notes anchor tag

### DIFF
--- a/aio/tools/transforms/templates/api/includes/description.html
+++ b/aio/tools/transforms/templates/api/includes/description.html
@@ -2,7 +2,7 @@
 <section class="description">
   <h2>Description</h2>
   {$ doc.description | trimBlankLines | marked $}
-  {% if doc.usageNotes %}<p>Further information available in the <a href="#usage-notes">Usage Notes</a>...</p>{%
+  {% if doc.usageNotes %}<p>Further information available in the <a href="#usage-notes">Usage Notes...</a></p>{%
   endif %}
 </section>
 {% endif %}


### PR DESCRIPTION
I think that in the html generated aio docs the dots of "Usage Notes..." should be part of the anchor tag, same as it is for "See More..."

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other: docs generation change/bugfix


## What is the current behavior?
The dots of the "Usage Notes..." links are not part of the link itself, this is a bit ugly and inconsistent in respect to "See More..."
![before](https://user-images.githubusercontent.com/61631103/124033931-7ac55d80-d9f2-11eb-8d7c-c7521296d991.gif)

Issue Number: N/A


## What is the new behavior?
The dots are part of the link
![after](https://user-images.githubusercontent.com/61631103/124033961-83b62f00-d9f2-11eb-834c-204b26810880.gif)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is kind of my opinion but there is no issue or anything about this anywhere so I hope you agree with me, if not sorry for the PR :stuck_out_tongue_winking_eye: 