### PR TITLE
fix(language-service): Do not override TS LS methods not supported by…

### DIFF
--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -119,30 +119,6 @@ export function create(info: tss.server.PluginCreateInfo): NgLanguageService {
     return ngLS.getDefinitionAndBoundSpan(fileName, position);
   }
 
-  function getTypeDefinitionAtPosition(fileName: string, position: number) {
-    // Not implemented in VE Language Service
-    return undefined;
-  }
-
-  function getReferencesAtPosition(fileName: string, position: number) {
-    // Not implemented in VE Language Service
-    return undefined;
-  }
-
-  function findRenameLocations(
-      fileName: string, position: number, findInStrings: boolean, findInComments: boolean,
-      providePrefixAndSuffixTextForRename?: boolean): readonly ts.RenameLocation[]|undefined {
-    // not implemented in VE Language Service
-    return undefined;
-  }
-
-  function getSignatureHelpItems(
-      fileName: string, position: number,
-      options: ts.SignatureHelpItemsOptions|undefined): ts.SignatureHelpItems|undefined {
-    // not implemented in VE Language Service
-    return undefined;
-  }
-
   function getTcb(fileName: string, position: number) {
     // Not implemented in VE Language Service
     return undefined;
@@ -162,10 +138,6 @@ export function create(info: tss.server.PluginCreateInfo): NgLanguageService {
     getSemanticDiagnostics,
     getDefinitionAtPosition,
     getDefinitionAndBoundSpan,
-    getTypeDefinitionAtPosition,
-    getReferencesAtPosition,
-    getSignatureHelpItems,
-    findRenameLocations,
     getTcb,
     getComponentLocationsForTemplate,
   };


### PR DESCRIPTION
… VE NgLS

Historically, our Language Service was built with the potential to be a
drop-in replacement for the TypeScript Language Service with the added
benefit of being able to provide Angular-specific information as well.
While our VSCode extension does not use the Language Service in this
way, it appears that other community-contributed plugins do. We don't
really officially support this use-case but there's not real reason for
us to override the TypeScript Language Service's
implementation in the VE Angular Language Service so that it returns
`undefined`. As with other non-implemented methods, we can just allow
this to be deferred to TSLS.

fixes #42715
