### PR TITLE
fix(bazel): enable dts bundling for Ivy packages

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -140,11 +140,7 @@ def _should_produce_dts_bundle(ctx):
     Returns:
       true when we should produce bundled dts.
     """
-
-    # At the moment we cannot use this with ngtsc compiler since it emits
-    # import * as ___ from local modules which is not supported
-    # see: https://github.com/Microsoft/web-build-tools/issues/1029
-    return _is_view_engine_enabled(ctx) and getattr(ctx.attr, "bundle_dts", False)
+    return getattr(ctx.attr, "bundle_dts", False)
 
 def _should_produce_r3_symbols_bundle(ctx):
     """Should we produce r3_symbols bundle.

--- a/packages/bazel/test/ng_package/core_package.spec.ts
+++ b/packages/bazel/test/ng_package/core_package.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ivyEnabled, obsoleteInIvy} from '@angular/private/testing';
+import {obsoleteInIvy} from '@angular/private/testing';
 import {runfiles} from '@bazel/runfiles';
 import * as path from 'path';
 import * as shx from 'shelljs';
@@ -69,22 +69,16 @@ describe('@angular/core ng_package', () => {
     });
 
     describe('typescript support', () => {
-      if (ivyEnabled) {
-        it('should have an index d.ts file', () => {
-          expect(shx.cat('core.d.ts')).toContain(`export *`);
-        });
-
-        it('should not have amd module names', () => {
-          expect(shx.cat('public_api.d.ts')).not.toContain('<amd-module name');
-        });
-      } else {
-        it('should have an index d.ts file', () => {
-          expect(shx.cat('core.d.ts')).toContain('export declare');
-        });
-        it('should have an r3_symbols d.ts file', () => {
-          expect(shx.cat('src/r3_symbols.d.ts')).toContain('export declare');
-        });
-      }
+      it('should not have amd module names', () => {
+        expect(shx.cat('core.d.ts')).not.toContain('<amd-module name');
+      });
+      it('should have an index d.ts file', () => {
+        expect(shx.cat('core.d.ts')).toContain('export declare');
+      });
+      obsoleteInIvy('we no longer need to export r3_symbols')
+          .it('should have an r3_symbols d.ts file', () => {
+            expect(shx.cat('src/r3_symbols.d.ts')).toContain('export declare');
+          });
     });
 
     obsoleteInIvy('metadata files are no longer needed or produced in Ivy')
@@ -174,17 +168,10 @@ describe('@angular/core ng_package', () => {
     });
 
     describe('typings', () => {
-      if (ivyEnabled) {
-        const typingsFile = p`testing/index.d.ts`;
-        it('should have a typings file', () => {
-          expect(shx.cat(typingsFile)).toContain(`export * from './public_api';`);
-        });
-      } else {
-        const typingsFile = p`testing/testing.d.ts`;
-        it('should have a typings file', () => {
-          expect(shx.cat(typingsFile)).toContain('export declare');
-        });
-      }
+      const typingsFile = p`testing/testing.d.ts`;
+      it('should have a typings file', () => {
+        expect(shx.cat(typingsFile)).toContain('export declare');
+      });
 
       obsoleteInIvy(
           'now that we don\'t need metadata files, we don\'t need these redirects to help resolve paths to them')

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -548,6 +548,8 @@ export function reflectTypeEntityToDeclaration(
         throw new Error(`Module specifier is not a string`);
       }
       return {node, from: importDecl.moduleSpecifier.text};
+    } else if (ts.isModuleDeclaration(decl)) {
+      return {node, from: null};
     } else {
       throw new Error(`Unknown import type?`);
     }

--- a/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
@@ -153,6 +153,30 @@ runInEachFileSystem(() => {
         expectParameter(args[0], 'bar', {moduleName: './bar', name: 'Bar'});
       });
 
+      it('should reflect an argument from a namespace declarations', () => {
+        const {program} = makeProgram([{
+          name: _('/entry.ts'),
+          contents: `
+            export declare class Bar {}
+            declare namespace i1 {
+              export {
+                Bar,
+              }
+            }
+
+            class Foo {
+              constructor(bar: i1.Bar) {}
+            }
+        `
+        }]);
+        const clazz = getDeclaration(program, _('/entry.ts'), 'Foo', isNamedClassDeclaration);
+        const checker = program.getTypeChecker();
+        const host = new TypeScriptReflectionHost(checker);
+        const args = host.getConstructorParameters(clazz)!;
+        expect(args.length).toBe(1);
+        expectParameter(args[0], 'bar', 'i1.Bar');
+      });
+
       it('should reflect an argument from a default import', () => {
         const {program} = makeProgram([
           {

--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,6 @@
     "@types/babel__traverse",
     "@types/node",
     "@types/selenium-webdriver",
-    "@microsoft/api-extractor",
     "angular",
     "angular-1.5",
     "angular-1.6",


### PR DESCRIPTION
It is now possible to bundle DTS files of Ivy libraries since the blocker https://github.com/microsoft/rushstack/issues/1029 has been addressed upstream.
