### PR TITLE
refactor(service-worker): improve typings/mocks and switch to official TypeScript typings

### DIFF
--- a/packages/localize/src/localize/src/global.ts
+++ b/packages/localize/src/localize/src/global.ts
@@ -10,7 +10,9 @@
 // This code to access the global object is mostly copied from `packages/core/src/util/global.ts`
 
 declare global {
-  var WorkerGlobalScope: any;
+  interface WorkerGlobalScope extends EventTarget, WindowOrWorkerGlobalScope {}
+
+  var WorkerGlobalScope: {prototype: WorkerGlobalScope; new (): WorkerGlobalScope;};
 }
 
 const __globalThis = typeof globalThis !== 'undefined' && globalThis;

--- a/packages/localize/src/localize/src/global.ts
+++ b/packages/localize/src/localize/src/global.ts
@@ -10,6 +10,15 @@
 // This code to access the global object is mostly copied from `packages/core/src/util/global.ts`
 
 declare global {
+  // The definition of `WorkerGlobalScope` must be compatible with the one in `lib.webworker.d.ts`,
+  // because all files under `packages/` are compiled together as part of the
+  // [legacy-unit-tests-saucelabs][1] CI job, including the `lib.webworker.d.ts` typings brought in
+  // by [service-worker/worker/src/service-worker.d.ts][2].
+  //
+  // [1]:
+  // https://github.com/angular/angular/blob/ffeea63f43e6a7fd46be4a8cd5a5d254c98dea08/.circleci/config.yml#L681
+  // [2]:
+  // https://github.com/angular/angular/blob/316dc2f12ce8931f5ff66fa5f8da21c0d251a337/packages/service-worker/worker/src/service-worker.d.ts#L9
   interface WorkerGlobalScope extends EventTarget, WindowOrWorkerGlobalScope {}
 
   var WorkerGlobalScope: {prototype: WorkerGlobalScope; new (): WorkerGlobalScope;};

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -13,6 +13,14 @@ import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {NavigationEnd, Resolve, Router, RouterModule} from '@angular/router';
 
+// This is needed, because all files under `packages/` are compiled together as part of the
+// [legacy-unit-tests-saucelabs][1] CI job, including the `lib.webworker.d.ts` typings brought in by
+// [service-worker/worker/src/service-worker.d.ts][2].
+//
+// [1]:
+// https://github.com/angular/angular/blob/ffeea63f43e6a7fd46be4a8cd5a5d254c98dea08/.circleci/config.yml#L681
+// [2]:
+// https://github.com/angular/angular/blob/316dc2f12ce8931f5ff66fa5f8da21c0d251a337/packages/service-worker/worker/src/service-worker.d.ts#L9
 declare var window: Window;
 
 describe('bootstrap', () => {

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -13,6 +13,8 @@ import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {NavigationEnd, Resolve, Router, RouterModule} from '@angular/router';
 
+declare var window: Window;
+
 describe('bootstrap', () => {
   if (isNode) return;
   let log: any[] = [];

--- a/packages/service-worker/test/integration_spec.ts
+++ b/packages/service-worker/test/integration_spec.ts
@@ -89,7 +89,7 @@ describe('ngsw + companion lib', () => {
     scope = new SwTestHarnessBuilder().withServerState(server).build();
     driver = new Driver(scope, scope, new CacheDatabase(scope));
 
-    scope.clients.add('default');
+    scope.clients.add('default', scope.registration.scope);
     scope.clients.getMock('default')!.queue.subscribe(msg => {
       mock.sendMessage(msg);
     });

--- a/packages/service-worker/test/integration_spec.ts
+++ b/packages/service-worker/test/integration_spec.ts
@@ -16,12 +16,13 @@ import {Manifest} from '@angular/service-worker/worker/src/manifest';
 import {MockRequest} from '@angular/service-worker/worker/testing/fetch';
 import {MockFileSystemBuilder, MockServerStateBuilder, tmpHashTableForFs} from '@angular/service-worker/worker/testing/mock';
 import {SwTestHarness, SwTestHarnessBuilder} from '@angular/service-worker/worker/testing/scope';
+import {envIsSupported} from '@angular/service-worker/worker/testing/utils';
 import {Observable} from 'rxjs';
 import {take} from 'rxjs/operators';
 
 (function() {
 // Skip environments that don't support the minimum APIs needed to run the SW tests.
-if (!SwTestHarness.envIsSupported()) {
+if (!envIsSupported()) {
   return;
 }
 

--- a/packages/service-worker/test/integration_spec.ts
+++ b/packages/service-worker/test/integration_spec.ts
@@ -9,7 +9,7 @@
 import {NgswCommChannel} from '@angular/service-worker/src/low_level';
 import {SwPush} from '@angular/service-worker/src/push';
 import {SwUpdate} from '@angular/service-worker/src/update';
-import {MockServiceWorkerContainer, MockServiceWorkerRegistration} from '@angular/service-worker/testing/mock';
+import {MockServiceWorkerContainer} from '@angular/service-worker/testing/mock';
 import {CacheDatabase} from '@angular/service-worker/worker/src/db-cache';
 import {Driver} from '@angular/service-worker/worker/src/driver';
 import {Manifest} from '@angular/service-worker/worker/src/manifest';
@@ -78,7 +78,6 @@ const serverUpdate =
 describe('ngsw + companion lib', () => {
   let mock: MockServiceWorkerContainer;
   let comm: NgswCommChannel;
-  let reg: MockServiceWorkerRegistration;
   let scope: SwTestHarness;
   let driver: Driver;
 
@@ -102,7 +101,6 @@ describe('ngsw + companion lib', () => {
     });
 
     mock.setupSw();
-    reg = mock.mockRegistration!;
 
     await Promise.all(scope.handleFetch(new MockRequest('/only.txt'), 'default'));
     await driver.initialized;
@@ -117,9 +115,7 @@ describe('ngsw + companion lib', () => {
     const update = new SwUpdate(comm);
     scope.updateServerState(serverUpdate);
 
-    const gotUpdateNotice = (async () => {
-      const notice = await obsToSinglePromise(update.available);
-    })();
+    const gotUpdateNotice = (async () => await obsToSinglePromise(update.available))();
 
     await update.checkForUpdate();
     await gotUpdateNotice;

--- a/packages/service-worker/worker/src/adapter.ts
+++ b/packages/service-worker/worker/src/adapter.ts
@@ -104,14 +104,3 @@ export class Adapter<T extends CacheStorage = CacheStorage> {
     });
   }
 }
-
-/**
- * An event context in which an operation is taking place, which allows
- * the delaying of Service Worker shutdown until certain triggers occur.
- */
-export interface Context {
-  /**
-   * Delay shutdown of the Service Worker until the given promise resolves.
-   */
-  waitUntil(fn: Promise<any>): void;
-}

--- a/packages/service-worker/worker/src/adapter.ts
+++ b/packages/service-worker/worker/src/adapter.ts
@@ -18,7 +18,7 @@ import {NamedCacheStorage} from './named-cache-storage';
  */
 export class Adapter<T extends CacheStorage = CacheStorage> {
   readonly caches: NamedCacheStorage<T>;
-  private readonly origin: string;
+  readonly origin: string;
 
   constructor(protected readonly scopeUrl: string, caches: T) {
     const parsedScopeUrl = this.parseUrl(this.scopeUrl);

--- a/packages/service-worker/worker/src/app-version.ts
+++ b/packages/service-worker/worker/src/app-version.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Adapter, Context} from './adapter';
+import {Adapter} from './adapter';
 import {CacheState, NormalizedUrl, UpdateCacheStatus, UpdateSource} from './api';
 import {AssetGroup, LazyAssetGroup, PrefetchAssetGroup} from './assets';
 import {DataGroup} from './data';
@@ -135,7 +135,7 @@ export class AppVersion implements UpdateSource {
     }
   }
 
-  async handleFetch(req: Request, context: Context): Promise<Response|null> {
+  async handleFetch(req: Request, event: ExtendableEvent): Promise<Response|null> {
     // Check the request against each `AssetGroup` in sequence. If an `AssetGroup` can't handle the
     // request,
     // it will return `null`. Thus, the first non-null response is the SW's answer to the request.
@@ -152,7 +152,7 @@ export class AppVersion implements UpdateSource {
       }
 
       // No response has been found yet. Maybe this group will have one.
-      return group.handleFetch(req, context);
+      return group.handleFetch(req, event);
     }, Promise.resolve<Response|null>(null));
 
     // The result of the above is the asset response, if there is any, or null otherwise. Return the
@@ -170,7 +170,7 @@ export class AppVersion implements UpdateSource {
         return resp;
       }
 
-      return group.handleFetch(req, context);
+      return group.handleFetch(req, event);
     }, Promise.resolve<Response|null>(null));
 
     // If the data caching group returned a response, go with it.
@@ -195,7 +195,7 @@ export class AppVersion implements UpdateSource {
 
       // This was a navigation request. Re-enter `handleFetch` with a request for
       // the URL.
-      return this.handleFetch(this.adapter.newRequest(this.indexUrl), context);
+      return this.handleFetch(this.adapter.newRequest(this.indexUrl), event);
     }
 
     return null;

--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Adapter, Context} from './adapter';
+import {Adapter} from './adapter';
 import {CacheState, NormalizedUrl, UpdateCacheStatus, UpdateSource, UrlMetadata} from './api';
 import {Database, Table} from './database';
 import {CacheTable} from './db-cache';
@@ -114,7 +114,7 @@ export abstract class AssetGroup {
   /**
    * Process a request for a given resource and return it, or return null if it's not available.
    */
-  async handleFetch(req: Request, ctx: Context): Promise<Response|null> {
+  async handleFetch(req: Request, _event: ExtendableEvent): Promise<Response|null> {
     const url = this.adapter.normalizeUrl(req.url);
     // Either the request matches one of the known resource URLs, one of the patterns for
     // dynamically matched URLs, or neither. Determine which is the case for this request in

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -673,7 +673,7 @@ export class Driver implements Debuggable, UpdateSource {
 
           const client = await this.scope.clients.get(clientId);
 
-          await this.updateClient(client);
+          await this.updateClient(client!);
           appVersion = this.lookupVersionByHash(this.latestHash, 'assignVersion');
         }
 
@@ -1050,7 +1050,7 @@ export class Driver implements Debuggable, UpdateSource {
 
     await Promise.all(affectedClients.map(async clientId => {
       const client = await this.scope.clients.get(clientId);
-      client.postMessage({type: 'UNRECOVERABLE_STATE', reason});
+      client!.postMessage({type: 'UNRECOVERABLE_STATE', reason});
     }));
   }
 

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -672,8 +672,10 @@ export class Driver implements Debuggable, UpdateSource {
           }
 
           const client = await this.scope.clients.get(clientId);
+          if (client) {
+            await this.updateClient(client);
+          }
 
-          await this.updateClient(client!);
           appVersion = this.lookupVersionByHash(this.latestHash, 'assignVersion');
         }
 
@@ -1050,7 +1052,9 @@ export class Driver implements Debuggable, UpdateSource {
 
     await Promise.all(affectedClients.map(async clientId => {
       const client = await this.scope.clients.get(clientId);
-      client!.postMessage({type: 'UNRECOVERABLE_STATE', reason});
+      if (client) {
+        client.postMessage({type: 'UNRECOVERABLE_STATE', reason});
+      }
     }));
   }
 

--- a/packages/service-worker/worker/src/service-worker.d.ts
+++ b/packages/service-worker/worker/src/service-worker.d.ts
@@ -1,159 +1,19 @@
-// tslint:disable:file-header
 /**
- * Copyright (c) 2016, Tiernan Cridland
+ * @license
+ * Copyright Google LLC All Rights Reserved.
  *
- * Permission to use, copy, modify, and/or distribute this software for any purpose with or without
- * fee is hereby
- * granted, provided that the above copyright notice and this permission notice appear in all
- * copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
- * SOFTWARE INCLUDING ALL
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
- * SPECIAL, DIRECT,
- * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
- * PROFITS, WHETHER
- * IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
- * WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
- *
- * Typings for Service Worker
- * @author Tiernan Cridland
- * @email tiernanc@gmail.com
- * @license: ISC
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
  */
-interface ExtendableEvent extends Event {
-  waitUntil(fn: Promise<any>): void;
-}
 
-// Client API
+/// <reference lib="webworker" />
 
-declare class Client {
-    readonly frameType: FrameType;
-    readonly id: string;
-    readonly type: ClientTypes;
-    readonly url: string;
-    postMessage(message: any): void;
-}
-
-interface Clients {
-  claim(): Promise<void>;
-  get(id: string): Promise<Client | undefined>;
-  matchAll<T extends ClientMatchOptions>(
-    options?: T
-  ): Promise<ReadonlyArray<T['type'] extends 'window' ? WindowClient : Client>>;
-  openWindow(url: string): Promise<WindowClient | null>;
-}
-
-interface ClientMatchOptions {
-  includeUncontrolled?: boolean;
-  type?: ClientTypes;
-}
-
-interface WindowClient extends Client {
-  readonly focused: boolean;
-  readonly visibilityState: VisibilityState;
-  focus(): Promise<WindowClient>;
-  navigate(url: string): Promise<WindowClient | null>;
-}
-
-type FrameType = 'auxiliary'|'top-level'|'nested'|'none';
-type ClientTypes = 'window'|'worker'|'sharedworker'|'all';
-type VisibilityState = 'hidden'|'visible';
-
-// Fetch API
-
-interface FetchEvent extends ExtendableEvent {
-  readonly clientId: string;
-  readonly preloadResponse: Promise<any>;
-  readonly request: Request;
-  readonly resultingClientId: string;
-  respondWith(r: Response|Promise<Response>): void;
-}
-
-// Notification API
-
-interface NotificationEvent extends ExtendableEvent {
-  readonly action: string;
-  readonly notification: Notification;
-}
-
-// Push API
-
-interface PushEvent extends ExtendableEvent {
-  readonly data: PushMessageData|null;
-}
-
-interface PushMessageData {
-  arrayBuffer(): ArrayBuffer;
-  blob(): Blob;
-  json(): any;
-  text(): string;
-}
-
-// Sync API
-
-interface SyncEvent extends ExtendableEvent {
-  readonly lastChance: boolean;
-  readonly tag: string;
-}
-
-interface ExtendableMessageEvent extends ExtendableEvent {
-  readonly data: any;
-  readonly lastEventId: string;
-  readonly origin: string;
-  readonly ports: ReadonlyArray<MessagePort>;
-  readonly source: Client|ServiceWorker|MessagePort|null;
-}
-
-// WorkerGlobalScope
-
-// Explicitly omit the `caches` property to disallow accessing `CacheStorage` APIs directly. All
-// interactions with `CacheStorage` should go through a `NamedCacheStorage` instance (exposed by the
-// `Adapter`).
-interface WorkerGlobalScope extends EventTarget, Omit<WindowOrWorkerGlobalScope, 'caches'> {
-  readonly location: WorkerLocation;
-  readonly navigator: WorkerNavigator;
-  readonly self: WorkerGlobalScope & typeof globalThis;
-
-  importScripts(...urls: string[]): void;
-  addEventListener<K extends keyof WorkerGlobalScopeEventMap>(type: K, listener: (this: WorkerGlobalScope, ev: WorkerGlobalScopeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-  addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-  removeEventListener<K extends keyof WorkerGlobalScopeEventMap>(type: K, listener: (this: WorkerGlobalScope, ev: WorkerGlobalScopeEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-  removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-}
-
-interface WorkerGlobalScopeEventMap {
-  error: ErrorEvent;
-  languagechange: Event;
-  offline: Event;
-  online: Event;
-  rejectionhandled: PromiseRejectionEvent;
-  unhandledrejection: PromiseRejectionEvent;
-}
-
-// ServiceWorkerGlobalScope
-
-interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
-  readonly clients: Clients;
-  readonly registration: ServiceWorkerRegistration;
-  readonly serviceWorker: ServiceWorker;
-
-  skipWaiting(): Promise<void>;
-  addEventListener<K extends keyof ServiceWorkerGlobalScopeEventMap>(type: K, listener: (this: ServiceWorkerGlobalScope, ev: ServiceWorkerGlobalScopeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-  addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-  removeEventListener<K extends keyof ServiceWorkerGlobalScopeEventMap>(type: K, listener: (this: ServiceWorkerGlobalScope, ev: ServiceWorkerGlobalScopeEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-  removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-}
-
-interface ServiceWorkerGlobalScopeEventMap extends WorkerGlobalScopeEventMap {
-  activate: ExtendableEvent;
-  fetch: FetchEvent;
-  install: ExtendableEvent;
-  message: ExtendableMessageEvent;
-  messageerror: MessageEvent;
-  notificationclick: NotificationEvent;
-  notificationclose: NotificationEvent;
-  push: PushEvent;
-  sync: SyncEvent;
+export declare global {
+  interface ServiceWorkerGlobalScope {
+    /**
+     * Disallow accessing `CacheStorage APIs directly to ensure that all accesses go through a
+     * `NamedCacheStorage` instance (exposed by the `Adapter`).
+     */
+    caches: unknown;
+  }
 }

--- a/packages/service-worker/worker/src/service-worker.d.ts
+++ b/packages/service-worker/worker/src/service-worker.d.ts
@@ -106,23 +106,54 @@ interface ExtendableMessageEvent extends ExtendableEvent {
   readonly source: Client|ServiceWorker|MessagePort|null;
 }
 
+// WorkerGlobalScope
+
+// Explicitly omit the `caches` property to disallow accessing `CacheStorage` APIs directly. All
+// interactions with `CacheStorage` should go through a `NamedCacheStorage` instance (exposed by the
+// `Adapter`).
+interface WorkerGlobalScope extends EventTarget, Omit<WindowOrWorkerGlobalScope, 'caches'> {
+  readonly location: WorkerLocation;
+  readonly navigator: WorkerNavigator;
+  readonly self: WorkerGlobalScope & typeof globalThis;
+
+  importScripts(...urls: string[]): void;
+  addEventListener<K extends keyof WorkerGlobalScopeEventMap>(type: K, listener: (this: WorkerGlobalScope, ev: WorkerGlobalScopeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+  removeEventListener<K extends keyof WorkerGlobalScopeEventMap>(type: K, listener: (this: WorkerGlobalScope, ev: WorkerGlobalScopeEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+}
+
+interface WorkerGlobalScopeEventMap {
+  error: ErrorEvent;
+  languagechange: Event;
+  offline: Event;
+  online: Event;
+  rejectionhandled: PromiseRejectionEvent;
+  unhandledrejection: PromiseRejectionEvent;
+}
+
 // ServiceWorkerGlobalScope
 
-interface ServiceWorkerGlobalScope {
-  // Intentionally does not include a `caches` property to disallow accessing `CacheStorage` APIs
-  // directly. All interactions with `CacheStorage` should go through a `NamedCacheStorage` instance
-  // (exposed by the `Adapter`).
-  clients: Clients;
-  registration: ServiceWorkerRegistration;
+interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
+  readonly clients: Clients;
+  readonly registration: ServiceWorkerRegistration;
+  readonly serviceWorker: ServiceWorker;
 
-  addEventListener(event: 'activate', fn: (event?: ExtendableEvent) => any): void;
-  addEventListener(event: 'message', fn: (event?: ExtendableMessageEvent) => any): void;
-  addEventListener(event: 'fetch', fn: (event?: FetchEvent) => any): void;
-  addEventListener(event: 'install', fn: (event?: ExtendableEvent) => any): void;
-  addEventListener(event: 'push', fn: (event?: PushEvent) => any): void;
-  addEventListener(event: 'notificationclick', fn: (event?: NotificationEvent) => any): void;
-  addEventListener(event: 'sync', fn: (event?: SyncEvent) => any): void;
-
-  fetch(request: Request|string): Promise<Response>;
   skipWaiting(): Promise<void>;
+  addEventListener<K extends keyof ServiceWorkerGlobalScopeEventMap>(type: K, listener: (this: ServiceWorkerGlobalScope, ev: ServiceWorkerGlobalScopeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+  removeEventListener<K extends keyof ServiceWorkerGlobalScopeEventMap>(type: K, listener: (this: ServiceWorkerGlobalScope, ev: ServiceWorkerGlobalScopeEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+}
+
+interface ServiceWorkerGlobalScopeEventMap extends WorkerGlobalScopeEventMap {
+  activate: ExtendableEvent;
+  fetch: FetchEvent;
+  install: ExtendableEvent;
+  message: ExtendableMessageEvent;
+  messageerror: MessageEvent;
+  notificationclick: NotificationEvent;
+  notificationclose: NotificationEvent;
+  push: PushEvent;
+  sync: SyncEvent;
 }

--- a/packages/service-worker/worker/src/service-worker.d.ts
+++ b/packages/service-worker/worker/src/service-worker.d.ts
@@ -29,15 +29,16 @@ interface ExtendableEvent extends Event {
 // Client API
 
 declare class Client {
-  frameType: ClientFrameType;
-  id: string;
-  url: string;
-  postMessage(message: any): void;
+    readonly frameType: FrameType;
+    readonly id: string;
+    readonly type: ClientTypes;
+    readonly url: string;
+    postMessage(message: any): void;
 }
 
 interface Clients {
   claim(): Promise<void>;
-  get(id: string): Promise<Client>;
+  get(id: string): Promise<Client | undefined>;
   matchAll<T extends ClientMatchOptions>(
     options?: T
   ): Promise<ReadonlyArray<T['type'] extends 'window' ? WindowClient : Client>>;
@@ -46,20 +47,19 @@ interface Clients {
 
 interface ClientMatchOptions {
   includeUncontrolled?: boolean;
-  type?: ClientMatchTypes;
+  type?: ClientTypes;
 }
 
 interface WindowClient extends Client {
-  readonly ancestorOrigins: ReadonlyArray<string>;
   readonly focused: boolean;
   readonly visibilityState: VisibilityState;
   focus(): Promise<WindowClient>;
   navigate(url: string): Promise<WindowClient | null>;
 }
 
-type ClientFrameType = 'auxiliary'|'top-level'|'nested'|'none';
-type ClientMatchTypes = 'window'|'worker'|'sharedworker'|'all';
-type WindowClientState = 'hidden'|'visible'|'prerender'|'unloaded';
+type FrameType = 'auxiliary'|'top-level'|'nested'|'none';
+type ClientTypes = 'window'|'worker'|'sharedworker'|'all';
+type VisibilityState = 'hidden'|'visible';
 
 // Fetch API
 

--- a/packages/service-worker/worker/src/service-worker.d.ts
+++ b/packages/service-worker/worker/src/service-worker.d.ts
@@ -64,29 +64,24 @@ type WindowClientState = 'hidden'|'visible'|'prerender'|'unloaded';
 // Fetch API
 
 interface FetchEvent extends ExtendableEvent {
-  request: Request;
-  clientId?: string;
-  resultingClientId?: string;
-  respondWith(response: Promise<Response>|Response): Promise<Response>;
+  readonly clientId: string;
+  readonly preloadResponse: Promise<any>;
+  readonly request: Request;
+  readonly resultingClientId: string;
+  respondWith(r: Response|Promise<Response>): void;
 }
-
-interface InstallEvent extends ExtendableEvent {
-  activeWorker: ServiceWorker;
-}
-
-interface ActivateEvent extends ExtendableEvent {}
 
 // Notification API
 
 interface NotificationEvent extends ExtendableEvent {
-  action: string;
-  notification: Notification;
+  readonly action: string;
+  readonly notification: Notification;
 }
 
 // Push API
 
 interface PushEvent extends ExtendableEvent {
-  data: PushMessageData;
+  readonly data: PushMessageData|null;
 }
 
 interface PushMessageData {
@@ -99,13 +94,16 @@ interface PushMessageData {
 // Sync API
 
 interface SyncEvent extends ExtendableEvent {
-  lastChance: boolean;
-  tag: string;
+  readonly lastChance: boolean;
+  readonly tag: string;
 }
 
 interface ExtendableMessageEvent extends ExtendableEvent {
-  data: any;
-  source: Client|Object;
+  readonly data: any;
+  readonly lastEventId: string;
+  readonly origin: string;
+  readonly ports: ReadonlyArray<MessagePort>;
+  readonly source: Client|ServiceWorker|MessagePort|null;
 }
 
 // ServiceWorkerGlobalScope

--- a/packages/service-worker/worker/test/data_spec.ts
+++ b/packages/service-worker/worker/test/data_spec.ts
@@ -13,10 +13,11 @@ import {MockCache} from '../testing/cache';
 import {MockRequest} from '../testing/fetch';
 import {MockFileSystemBuilder, MockServerStateBuilder, tmpHashTableForFs} from '../testing/mock';
 import {SwTestHarness, SwTestHarnessBuilder} from '../testing/scope';
+import {envIsSupported} from '../testing/utils';
 
 (function() {
 // Skip environments that don't support the minimum APIs needed to run the SW tests.
-if (!SwTestHarness.envIsSupported()) {
+if (!envIsSupported()) {
   return;
 }
 

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -12,9 +12,10 @@ import {Driver, DriverReadyState} from '../src/driver';
 import {AssetGroupConfig, DataGroupConfig, Manifest} from '../src/manifest';
 import {sha1} from '../src/sha1';
 import {clearAllCaches, MockCache} from '../testing/cache';
+import {WindowClientImpl} from '../testing/clients';
 import {MockRequest, MockResponse} from '../testing/fetch';
 import {MockFileSystem, MockFileSystemBuilder, MockServerState, MockServerStateBuilder, tmpHashTableForFs} from '../testing/mock';
-import {MockClient, SwTestHarness, SwTestHarnessBuilder, WindowClientImpl} from '../testing/scope';
+import {SwTestHarness, SwTestHarnessBuilder} from '../testing/scope';
 import {envIsSupported} from '../testing/utils';
 
 (function() {

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -15,10 +15,11 @@ import {clearAllCaches, MockCache} from '../testing/cache';
 import {MockRequest, MockResponse} from '../testing/fetch';
 import {MockFileSystem, MockFileSystemBuilder, MockServerState, MockServerStateBuilder, tmpHashTableForFs} from '../testing/mock';
 import {MockClient, SwTestHarness, SwTestHarnessBuilder, WindowClientImpl} from '../testing/scope';
+import {envIsSupported} from '../testing/utils';
 
 (function() {
 // Skip environments that don't support the minimum APIs needed to run the SW tests.
-if (!SwTestHarness.envIsSupported()) {
+if (!envIsSupported()) {
   return;
 }
 

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -783,7 +783,7 @@ describe('Driver', () => {
       const message: any = scope.clients.getMock('default')!.messages[0];
 
       expect(message.type).toEqual('NOTIFICATION_CLICK');
-      expect(message.data.action).toBeUndefined();
+      expect(message.data.action).toBe('');
       expect(message.data.notification.title).toEqual('This is a test without action');
       expect(message.data.notification.body).toEqual('Test body without action');
     });

--- a/packages/service-worker/worker/test/idle_spec.ts
+++ b/packages/service-worker/worker/test/idle_spec.ts
@@ -8,10 +8,11 @@
 
 import {IdleScheduler} from '../src/idle';
 import {SwTestHarness, SwTestHarnessBuilder} from '../testing/scope';
+import {envIsSupported} from '../testing/utils';
 
 (function() {
 // Skip environments that don't support the minimum APIs needed to run the SW tests.
-if (!SwTestHarness.envIsSupported()) {
+if (!envIsSupported()) {
   return;
 }
 

--- a/packages/service-worker/worker/test/prefetch_spec.ts
+++ b/packages/service-worker/worker/test/prefetch_spec.ts
@@ -10,9 +10,10 @@ import {PrefetchAssetGroup} from '../src/assets';
 import {CacheDatabase} from '../src/db-cache';
 import {IdleScheduler} from '../src/idle';
 import {MockCache} from '../testing/cache';
+import {MockExtendableEvent} from '../testing/events';
 import {MockRequest} from '../testing/fetch';
 import {MockFileSystemBuilder, MockServerStateBuilder, tmpHashTable, tmpManifestSingleAssetGroup} from '../testing/mock';
-import {MockExtendableEvent, SwTestHarnessBuilder} from '../testing/scope';
+import {SwTestHarnessBuilder} from '../testing/scope';
 import {envIsSupported} from '../testing/utils';
 
 (function() {

--- a/packages/service-worker/worker/test/prefetch_spec.ts
+++ b/packages/service-worker/worker/test/prefetch_spec.ts
@@ -12,11 +12,12 @@ import {IdleScheduler} from '../src/idle';
 import {MockCache} from '../testing/cache';
 import {MockRequest} from '../testing/fetch';
 import {MockFileSystemBuilder, MockServerStateBuilder, tmpHashTable, tmpManifestSingleAssetGroup} from '../testing/mock';
-import {MockExtendableEvent, SwTestHarness, SwTestHarnessBuilder} from '../testing/scope';
+import {MockExtendableEvent, SwTestHarnessBuilder} from '../testing/scope';
+import {envIsSupported} from '../testing/utils';
 
 (function() {
 // Skip environments that don't support the minimum APIs needed to run the SW tests.
-if (!SwTestHarness.envIsSupported()) {
+if (!envIsSupported()) {
   return;
 }
 

--- a/packages/service-worker/worker/testing/clients.ts
+++ b/packages/service-worker/worker/testing/clients.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Subject} from 'rxjs';
+
+
+export class MockClient {
+  queue = new Subject<Object>();
+
+  constructor(readonly id: string) {}
+
+  readonly messages: Object[] = [];
+
+  postMessage(message: Object): void {
+    this.messages.push(message);
+    this.queue.next(message);
+  }
+}
+
+export class WindowClientImpl extends MockClient implements WindowClient {
+  readonly ancestorOrigins: ReadonlyArray<string> = [];
+  readonly focused: boolean = false;
+  readonly visibilityState: VisibilityState = 'hidden';
+  frameType: ClientFrameType = 'top-level';
+  url = 'http://localhost/unique';
+
+  constructor(readonly id: string) {
+    super(id);
+  }
+
+  async focus(): Promise<WindowClient> {
+    return this;
+  }
+
+  async navigate(url: string): Promise<WindowClient|null> {
+    return this;
+  }
+}
+
+export class MockClients implements Clients {
+  private clients = new Map<string, MockClient>();
+
+  add(clientId: string): void {
+    if (this.clients.has(clientId)) {
+      return;
+    }
+    this.clients.set(clientId, new MockClient(clientId));
+  }
+
+  remove(clientId: string): void {
+    this.clients.delete(clientId);
+  }
+
+  async get(id: string): Promise<Client> {
+    return this.clients.get(id)! as any as Client;
+  }
+
+  getMock(id: string): MockClient|undefined {
+    return this.clients.get(id);
+  }
+
+  async matchAll<T extends ClientQueryOptions>(options?: T):
+      Promise<ReadonlyArray<T['type'] extends 'window'? WindowClient : Client>> {
+    return Array.from(this.clients.values()) as any[];
+  }
+
+  async openWindow(url: string): Promise<WindowClient|null> {
+    return null;
+  }
+
+  async claim(): Promise<any> {}
+}

--- a/packages/service-worker/worker/testing/clients.ts
+++ b/packages/service-worker/worker/testing/clients.ts
@@ -9,35 +9,39 @@
 import {Subject} from 'rxjs';
 
 
-export class MockClient {
-  queue = new Subject<Object>();
+export class MockClient implements Client {
+  readonly messages: any[] = [];
+  readonly queue = new Subject<any>();
+  lastFocusedAt = 0;
 
-  constructor(readonly id: string) {}
+  constructor(
+      readonly id: string, readonly url: string, readonly type: ClientTypes = 'all',
+      readonly frameType: FrameType = 'top-level') {}
 
-  readonly messages: Object[] = [];
-
-  postMessage(message: Object): void {
+  postMessage(message: any): void {
     this.messages.push(message);
     this.queue.next(message);
   }
 }
 
-export class WindowClientImpl extends MockClient implements WindowClient {
-  readonly ancestorOrigins: ReadonlyArray<string> = [];
+export class MockWindowClient extends MockClient implements WindowClient {
   readonly focused: boolean = false;
-  readonly visibilityState: VisibilityState = 'hidden';
-  frameType: ClientFrameType = 'top-level';
-  url = 'http://localhost/unique';
+  readonly visibilityState: VisibilityState = 'visible';
 
-  constructor(readonly id: string) {
-    super(id);
+  constructor(id: string, url: string, frameType: FrameType = 'top-level') {
+    super(id, url, 'window', frameType);
   }
 
   async focus(): Promise<WindowClient> {
+    // This is only used for relatively ordering clients based on focus order, so we don't need to
+    // use `Adapter#time`.
+    this.lastFocusedAt = Date.now();
+    (this.focused as boolean) = true;
     return this;
   }
 
   async navigate(url: string): Promise<WindowClient|null> {
+    (this.url as string) = url;
     return this;
   }
 }
@@ -45,11 +49,20 @@ export class WindowClientImpl extends MockClient implements WindowClient {
 export class MockClients implements Clients {
   private clients = new Map<string, MockClient>();
 
-  add(clientId: string): void {
+  add(clientId: string, url: string, type: ClientTypes = 'window'): void {
     if (this.clients.has(clientId)) {
-      return;
+      const existingClient = this.clients.get(clientId)!;
+      if (existingClient.url === url) {
+        return;
+      }
+      throw new Error(
+          `Trying to add mock client with same ID (${existingClient.id}) and different URL ` +
+          `(${existingClient.url} --> ${url})`);
     }
-    this.clients.set(clientId, new MockClient(clientId));
+
+    const client = (type === 'window') ? new MockWindowClient(clientId, url) :
+                                         new MockClient(clientId, url, type);
+    this.clients.set(clientId, client);
   }
 
   remove(clientId: string): void {
@@ -66,7 +79,13 @@ export class MockClients implements Clients {
 
   async matchAll<T extends ClientQueryOptions>(options?: T):
       Promise<ReadonlyArray<T['type'] extends 'window'? WindowClient : Client>> {
-    return Array.from(this.clients.values()) as any[];
+    const type = options && options.type || 'window';
+    const allClients = Array.from(this.clients.values());
+    const matchedClients =
+        (type === 'all') ? allClients : allClients.filter(client => client.type === type);
+
+    // Order clients in most recently focused order to adhere to the spec.
+    return matchedClients.reverse().sort((a, b) => b.lastFocusedAt - a.lastFocusedAt) as any;
   }
 
   async openWindow(url: string): Promise<WindowClient|null> {

--- a/packages/service-worker/worker/testing/events.ts
+++ b/packages/service-worker/worker/testing/events.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export class MockEvent implements Event {
+  readonly AT_TARGET = -1;
+  readonly BUBBLING_PHASE = -1;
+  readonly CAPTURING_PHASE = -1;
+  readonly NONE = -1;
+
+  readonly bubbles = false;
+  cancelBubble = false;
+  readonly cancelable = false;
+  readonly composed = false;
+  readonly currentTarget = null;
+  readonly defaultPrevented = false;
+  readonly eventPhase = -1;
+  readonly isTrusted = false;
+  returnValue = false;
+  readonly srcElement = null;
+  readonly target = null;
+  readonly timeStamp = Date.now();
+
+  constructor(readonly type: string) {}
+
+  composedPath(): EventTarget[] {
+    this.notImplemented();
+  }
+  initEvent(type: string, bubbles?: boolean, cancelable?: boolean): void {
+    this.notImplemented();
+  }
+  preventDefault(): void {
+    this.notImplemented();
+  }
+  stopImmediatePropagation(): void {
+    this.notImplemented();
+  }
+  stopPropagation(): void {
+    this.notImplemented();
+  }
+
+  private notImplemented(): never {
+    throw new Error('Method not implemented in `MockEvent`.');
+  }
+}
+
+export class MockExtendableEvent extends MockEvent implements ExtendableEvent {
+  private queue: Promise<void>[] = [];
+
+  get ready(): Promise<void> {
+    return (async () => {
+      while (this.queue.length > 0) {
+        await this.queue.shift();
+      }
+    })();
+  }
+
+  waitUntil(promise: Promise<void>): void {
+    this.queue.push(promise);
+  }
+}
+
+export class MockActivateEvent extends MockExtendableEvent {
+  constructor() {
+    super('activate');
+  }
+}
+
+export class MockFetchEvent extends MockExtendableEvent {
+  response: Promise<Response|undefined> = Promise.resolve(undefined);
+
+  constructor(
+      readonly request: Request, readonly clientId: string, readonly resultingClientId: string) {
+    super('fetch');
+  }
+
+  respondWith(promise: Promise<Response>): Promise<Response> {
+    this.response = promise;
+    return promise;
+  }
+}
+
+export class MockInstallEvent extends MockExtendableEvent {
+  constructor() {
+    super('install');
+  }
+}
+
+export class MockMessageEvent extends MockExtendableEvent {
+  constructor(readonly data: Object, readonly source: MockClient|null) {
+    super('message');
+  }
+}
+
+export class MockNotificationEvent extends MockExtendableEvent {
+  readonly notification = {
+    ...this._notification,
+    close: () => undefined,
+  };
+
+  constructor(private _notification: any, readonly action?: string) {
+    super('notification');
+  }
+}
+
+export class MockPushEvent extends MockExtendableEvent {
+  data = {
+    json: () => this._data,
+  };
+
+  constructor(private _data: object) {
+    super('push');
+  }
+}

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -13,6 +13,7 @@ import {AssetGroupConfig, Manifest} from '../src/manifest';
 import {sha1} from '../src/sha1';
 
 import {MockCacheStorage} from './cache';
+import {MockActivateEvent, MockFetchEvent, MockInstallEvent, MockMessageEvent, MockNotificationEvent, MockPushEvent} from './events';
 import {MockHeaders, MockRequest, MockResponse} from './fetch';
 import {MockServerState, MockServerStateBuilder} from './mock';
 import {normalizeUrl, parseUrl} from './utils';
@@ -354,111 +355,5 @@ export class ConfigBuilder {
       navigationRequestStrategy: 'performance',
       hashTable,
     };
-  }
-}
-
-class MockEvent implements Event {
-  readonly AT_TARGET = -1;
-  readonly BUBBLING_PHASE = -1;
-  readonly CAPTURING_PHASE = -1;
-  readonly NONE = -1;
-
-  readonly bubbles = false;
-  cancelBubble = false;
-  readonly cancelable = false;
-  readonly composed = false;
-  readonly currentTarget = null;
-  readonly defaultPrevented = false;
-  readonly eventPhase = -1;
-  readonly isTrusted = false;
-  returnValue = false;
-  readonly srcElement = null;
-  readonly target = null;
-  readonly timeStamp = Date.now();
-
-  constructor(readonly type: string) {}
-
-  composedPath(): EventTarget[] {
-    this.notImplemented();
-  }
-  initEvent(type: string, bubbles?: boolean, cancelable?: boolean): void {
-    this.notImplemented();
-  }
-  preventDefault(): void {
-    this.notImplemented();
-  }
-  stopImmediatePropagation(): void {
-    this.notImplemented();
-  }
-  stopPropagation(): void {
-    this.notImplemented();
-  }
-
-  private notImplemented(): never {
-    throw new Error('Method not implemented in `MockEvent`.');
-  }
-}
-
-export class MockExtendableEvent extends MockEvent implements ExtendableEvent {
-  private queue: Promise<void>[] = [];
-
-  waitUntil(promise: Promise<void>): void {
-    this.queue.push(promise);
-  }
-
-  get ready(): Promise<void> {
-    return (async () => {
-      while (this.queue.length > 0) {
-        await this.queue.shift();
-      }
-    })();
-  }
-}
-
-class MockFetchEvent extends MockExtendableEvent {
-  response: Promise<Response|undefined> = Promise.resolve(undefined);
-
-  constructor(
-      readonly request: Request, readonly clientId: string, readonly resultingClientId: string) {
-    super('fetch');
-  }
-
-  respondWith(promise: Promise<Response>): Promise<Response> {
-    this.response = promise;
-    return promise;
-  }
-}
-
-class MockMessageEvent extends MockExtendableEvent {
-  constructor(readonly data: Object, readonly source: MockClient|null) {
-    super('message');
-  }
-}
-
-class MockPushEvent extends MockExtendableEvent {
-  constructor(private _data: Object) {
-    super('push');
-  }
-  data = {
-    json: () => this._data,
-  };
-}
-
-class MockNotificationEvent extends MockExtendableEvent {
-  constructor(private _notification: any, readonly action?: string) {
-    super('notification');
-  }
-  readonly notification = {...this._notification, close: () => undefined};
-}
-
-class MockInstallEvent extends MockExtendableEvent {
-  constructor() {
-    super('install');
-  }
-}
-
-class MockActivateEvent extends MockExtendableEvent {
-  constructor() {
-    super('activate');
   }
 }

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -132,22 +132,6 @@ export class SwTestHarness extends Adapter<MockCacheStorage> implements ServiceW
         },
   } as any;
 
-  static envIsSupported(): boolean {
-    if (typeof URL === 'function') {
-      return true;
-    }
-
-    // If we're in a browser that doesn't support URL at this point, don't go any further
-    // since browser builds use requirejs which will fail on the `require` call below.
-    if (typeof window !== 'undefined' && window) {
-      return false;
-    }
-
-    // In older Node.js versions, the `URL` global does not exist. We can use `url` instead.
-    const url = (typeof require === 'function') && require('url');
-    return url && (typeof url.parse === 'function') && (typeof url.resolve === 'function');
-  }
-
   get time() {
     return this.mockTime;
   }

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -13,7 +13,7 @@ import {AssetGroupConfig, Manifest} from '../src/manifest';
 import {sha1} from '../src/sha1';
 
 import {MockCacheStorage} from './cache';
-import {MockActivateEvent, MockFetchEvent, MockInstallEvent, MockMessageEvent, MockNotificationEvent, MockPushEvent} from './events';
+import {MockActivateEvent, MockExtendableMessageEvent, MockFetchEvent, MockInstallEvent, MockNotificationEvent, MockPushEvent} from './events';
 import {MockHeaders, MockRequest, MockResponse} from './fetch';
 import {MockServerState, MockServerStateBuilder} from './mock';
 import {normalizeUrl, parseUrl} from './utils';
@@ -244,12 +244,13 @@ export class SwTestHarness extends Adapter<MockCacheStorage> implements ServiceW
     if (!this.eventHandlers.has('message')) {
       throw new Error('No message handler registered');
     }
-    let event: MockMessageEvent;
+    let event: MockExtendableMessageEvent;
     if (clientId === null) {
-      event = new MockMessageEvent(data, null);
+      event = new MockExtendableMessageEvent(data, null);
     } else {
       this.clients.add(clientId);
-      event = new MockMessageEvent(data, this.clients.getMock(clientId) || null);
+      event = new MockExtendableMessageEvent(
+          data, this.clients.getMock(clientId) as unknown as Client || null);
     }
     this.eventHandlers.get('message')!.call(this, event);
     return event.ready;

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -6,50 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Subject} from 'rxjs';
-
 import {Adapter} from '../src/adapter';
 import {AssetGroupConfig, Manifest} from '../src/manifest';
 import {sha1} from '../src/sha1';
 
 import {MockCacheStorage} from './cache';
+import {MockClient, MockClients} from './clients';
 import {MockActivateEvent, MockExtendableMessageEvent, MockFetchEvent, MockInstallEvent, MockNotificationEvent, MockPushEvent} from './events';
 import {MockHeaders, MockRequest, MockResponse} from './fetch';
 import {MockServerState, MockServerStateBuilder} from './mock';
 import {normalizeUrl, parseUrl} from './utils';
 
 const EMPTY_SERVER_STATE = new MockServerStateBuilder().build();
-
-export class MockClient {
-  queue = new Subject<Object>();
-
-  constructor(readonly id: string) {}
-
-  readonly messages: Object[] = [];
-
-  postMessage(message: Object): void {
-    this.messages.push(message);
-    this.queue.next(message);
-  }
-}
-export class WindowClientImpl extends MockClient implements WindowClient {
-  readonly ancestorOrigins: ReadonlyArray<string> = [];
-  readonly focused: boolean = false;
-  readonly visibilityState: VisibilityState = 'hidden';
-  frameType: ClientFrameType = 'top-level';
-  url = 'http://localhost/unique';
-
-  constructor(readonly id: string) {
-    super(id);
-  }
-
-  async focus(): Promise<WindowClient> {
-    return this;
-  }
-  async navigate(url: string): Promise<WindowClient|null> {
-    return this;
-  }
-}
 
 export class SwTestHarnessBuilder {
   private origin = parseUrl(this.scopeUrl).origin;
@@ -71,39 +39,6 @@ export class SwTestHarnessBuilder {
   build(): SwTestHarness {
     return new SwTestHarness(this.server, this.caches, this.scopeUrl);
   }
-}
-
-export class MockClients implements Clients {
-  private clients = new Map<string, MockClient>();
-
-  add(clientId: string): void {
-    if (this.clients.has(clientId)) {
-      return;
-    }
-    this.clients.set(clientId, new MockClient(clientId));
-  }
-
-  remove(clientId: string): void {
-    this.clients.delete(clientId);
-  }
-
-  async get(id: string): Promise<Client> {
-    return this.clients.get(id)! as any as Client;
-  }
-
-  getMock(id: string): MockClient|undefined {
-    return this.clients.get(id);
-  }
-
-  async matchAll<T extends ClientQueryOptions>(options?: T):
-      Promise<ReadonlyArray<T['type'] extends 'window'? WindowClient : Client>> {
-    return Array.from(this.clients.values()) as any[];
-  }
-  async openWindow(url: string): Promise<WindowClient|null> {
-    return null;
-  }
-
-  async claim(): Promise<any> {}
 }
 
 export class SwTestHarness extends Adapter<MockCacheStorage> implements ServiceWorkerGlobalScope {

--- a/packages/service-worker/worker/testing/utils.ts
+++ b/packages/service-worker/worker/testing/utils.ts
@@ -10,6 +10,27 @@ import {NormalizedUrl} from '../src/api';
 
 
 /**
+ * Determine whether the current environment provides all necessary APIs to run ServiceWorker tests.
+ *
+ * @return Whether ServiceWorker tests can be run in the current environment.
+ */
+export function envIsSupported(): boolean {
+  if (typeof URL === 'function') {
+    return true;
+  }
+
+  // If we're in a browser that doesn't support URL at this point, don't go any further
+  // since browser builds use requirejs which will fail on the `require` call below.
+  if (typeof window !== 'undefined' && window) {
+    return false;
+  }
+
+  // In older Node.js versions, the `URL` global does not exist. We can use `url` instead.
+  const url = (typeof require === 'function') && require('url');
+  return url && (typeof url.parse === 'function') && (typeof url.resolve === 'function');
+}
+
+/**
  * Get a normalized representation of a URL relative to a provided base URL.
  *
  * More specifically:


### PR DESCRIPTION
This PR includes several improvements to the ServiceWorker typings and mocks used in tests, bringing the typings and mock implementations closer to the actual implementations. It also switches from using custom typings for ServiceWorker APIs to using the official TypeScript ones.

See individual commits for details.

##
The PR also includes a small fix (related to notifying clients about an unrecoverable state), which was revealed by the more accurate typings.

See the last commit for more details.