### PR TITLE
fix(compiler-cli): properly emit literal types when recreating type parameters in a different file

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_parameter_emitter_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_parameter_emitter_spec.ts
@@ -86,6 +86,28 @@ runInEachFileSystem(() => {
           .toEqual('<T extends {\n    [key: string]: boolean;\n}>');
     });
 
+    it('can emit literal types', () => {
+      expect(emit(createEmitter(`export class TestClass<T extends 'a"a'> {}`)))
+          .toEqual(`<T extends "a\\"a">`);
+      expect(emit(createEmitter(`export class TestClass<T extends "b\\\"b"> {}`)))
+          .toEqual(`<T extends "b\\"b">`);
+      expect(emit(createEmitter(`export class TestClass<T extends \`c\\\`c\`> {}`)))
+          .toEqual(`<T extends \`c\\\`c\`>`);
+      expect(emit(createEmitter(`export class TestClass<T extends -1> {}`)))
+          .toEqual(`<T extends -1>`);
+      expect(emit(createEmitter(`export class TestClass<T extends 1> {}`)))
+          .toEqual(`<T extends 1>`);
+      expect(emit(createEmitter(`export class TestClass<T extends 1n> {}`)))
+          .toEqual(`<T extends 1n>`);
+    });
+
+    it('cannot emit import types', () => {
+      const emitter = createEmitter(`export class TestClass<T extends import('module')> {}`);
+
+      expect(emitter.canEmit()).toBe(false);
+      expect(() => emit(emitter)).toThrowError('Unable to emit import type');
+    });
+
     it('can emit references into external modules', () => {
       const emitter = createEmitter(`
           import {NgIterable} from '@angular/core';


### PR DESCRIPTION
In #42492 the template type checker became capable of replicating a
wider range of generic type parameters for use in template type-check
files. Any literal types within a type parameter would however emit
invalid code, as TypeScript was emitting the literals using the text as
extracted from the template type-check file instead of the original
source file where the type node was taken from.

This commit works around the issue by cloning any literal types and
marking them as synthetic, signalling to TypeScript that the literal
text has to be extracted from the node itself instead from the source
file.

This commit also excludes `import()` type nodes from being supported,
as their module specifier may potentially need to be rewritten.

Fixes #42667