### PR TITLE
Edited body message to show actual message

### DIFF
--- a/aio/content/examples/http/src/app/config/config.service.ts
+++ b/aio/content/examples/http/src/app/config/config.service.ts
@@ -79,8 +79,7 @@ export class ConfigService {
       // The backend returned an unsuccessful response code.
       // The response body may contain clues as to what went wrong.
       console.error(
-        `Backend returned code ${error.status}, ` +
-        `body was: ${error.error}`);
+        `Backend returned code ${error.status}, body was: `, error.error);
     }
     // Return an observable with a user-facing error message.
     return throwError(


### PR DESCRIPTION
Perviously, the error message in the console would print `[object Object]` and not the actual error message. 
With this change, the error message is printed in the console.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Error message in the console looks like this:
`Backend returned code 500, body was: [object Object]`

Issue Number: N/A


## What is the new behavior?
New message will look like this:
`Backend returned code 500, body was:  `
`{status: 500, message: "actual error message here"}`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
