### PR TITLE
fix(docs-infra): fix margin of social icon on small screens

### DIFF
--- a/aio/src/styles/1-layouts/top-menu/_top-menu.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu.scss
@@ -200,11 +200,7 @@ mat-toolbar.app-toolbar {
   .toolbar-external-icons-container {
     a {
       @media screen and (max-width: 480px) {
-        margin: 0;
-
-        &:not(:first-child) {
-          margin-left: -8px;
-        }
+        margin: 0 -8px 0 0;
       }
 
       @media screen and (max-width: 420px) {


### PR DESCRIPTION
This commit fixes the margin of the social icons on small screens. This mainly affects screens between 420px and 480px, where only one social icon is show (due to limited space) but not necessarily the first one (in DOM order).

**Before:**
![social icon before][1]

**After:**
![social icon after][2]

[1]: https://user-images.githubusercontent.com/8604205/124788616-2f5f0200-df52-11eb-9ec2-9e46b90cd286.png
[2]: https://user-images.githubusercontent.com/8604205/124788623-2ff79880-df52-11eb-90ec-31b04973de68.png
