### PR TITLE
ci: configure renovate to ignore `@microsoft/api-extractor`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,7 @@
     "@babel/template",
     "@babel/traverse",
     "@babel/types",
+    "@microsoft/api-extractor",
     "@types/babel__core",
     "@types/babel__generator",
     "@types/babel__template",


### PR DESCRIPTION
This is an interm solution until https://github.com/microsoft/rushstack/issues/2797 is fixed.

Related failures in the Angular repo https://app.circleci.com/jobs/github/angular/angular/1018749?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
