### PR TITLE
docs(core): fix `ViewChildren` code examples to avoid TS error

### DIFF
--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -337,8 +337,8 @@ export interface ViewChildrenDecorator {
    *   * A template reference variable as a string (e.g. query `<my-component #cmp></my-component>`
    * with `@ViewChildren('cmp')`)
    *   * Any provider defined in the child component tree of the current component (e.g.
-   * `@ViewChildren(SomeService) someService: SomeService`)
-   *   * Any provider defined through a string token (e.g. `@ViewChildren('someToken') someTokenVal:
+   * `@ViewChildren(SomeService) someService!: SomeService`)
+   *   * Any provider defined through a string token (e.g. `@ViewChildren('someToken') someTokenVal!:
    * any`)
    *   * A `TemplateRef` (e.g. query `<ng-template></ng-template>` with `@ViewChildren(TemplateRef)
    * template;`)

--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -338,8 +338,8 @@ export interface ViewChildrenDecorator {
    * with `@ViewChildren('cmp')`)
    *   * Any provider defined in the child component tree of the current component (e.g.
    * `@ViewChildren(SomeService) someService!: SomeService`)
-   *   * Any provider defined through a string token (e.g. `@ViewChildren('someToken') someTokenVal!:
-   * any`)
+   *   * Any provider defined through a string token (e.g. `@ViewChildren('someToken')
+   * someTokenVal!: any`)
    *   * A `TemplateRef` (e.g. query `<ng-template></ng-template>` with `@ViewChildren(TemplateRef)
    * template;`)
    *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
found ts2564 error when use your code in description
this
```Any provider defined through a string token (e.g. @ViewChild('someToken') someTokenVal: any)```

Issue Number: https://github.com/angular/angular/issues/42811


## What is the new behavior?
add ! to fix ts2564 error

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
