### PR TITLE
fix(core): associate the NgModule scope for an overridden component

### DIFF
--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -248,6 +248,22 @@ describe('TestBed', () => {
     expect(hello.nativeElement).toHaveText('Hello World!');
   });
 
+  // https://github.com/angular/angular/issues/42734
+  it('should override a component which is declared in an NgModule which is imported as a `ModuleWithProviders`',
+     () => {
+       // This test verifies that an overridden component that is declared in an NgModule that has
+       // been imported as a `ModuleWithProviders` continues to have access to the declaration scope
+       // of the NgModule.
+       TestBed.resetTestingModule();
+       TestBed.configureTestingModule({imports: [{ngModule: HelloWorldModule}]});
+       TestBed.overrideComponent(
+           HelloWorld, {set: {template: 'Overridden <greeting-cmp></greeting-cmp>'}});
+
+       const hello = TestBed.createComponent(HelloWorld);
+       hello.detectChanges();
+       expect(hello.nativeElement).toHaveText('Overridden Hello World!');
+     });
+
   it('should run `APP_INITIALIZER` before accessing `LOCALE_ID` provider', () => {
     let locale: string = '';
     @NgModule({

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -255,7 +255,10 @@ describe('TestBed', () => {
        // been imported as a `ModuleWithProviders` continues to have access to the declaration scope
        // of the NgModule.
        TestBed.resetTestingModule();
-       TestBed.configureTestingModule({imports: [{ngModule: HelloWorldModule}]});
+
+       const moduleWithProviders:
+           ModuleWithProviders<HelloWorldModule> = {ngModule: HelloWorldModule};
+       TestBed.configureTestingModule({imports: [moduleWithProviders]});
        TestBed.overrideComponent(
            HelloWorld, {set: {template: 'Overridden <greeting-cmp></greeting-cmp>'}});
 

--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -538,6 +538,8 @@ export class R3TestBedCompiler {
           this.queueTypeArray(maybeUnwrapFn(def.declarations), value);
           queueTypesFromModulesArrayRecur(maybeUnwrapFn(def.imports));
           queueTypesFromModulesArrayRecur(maybeUnwrapFn(def.exports));
+        } else if (isModuleWithProviders(value)) {
+          queueTypesFromModulesArrayRecur([value.ngModule]);
         }
       }
     };


### PR DESCRIPTION
When using `TestBed.overrideComponent`, the overridden component would
incorrectly loose access to its NgModule's declaration scope if the
NgModule had been imported into the testing NgModule as a
`ModuleWithProviders`, e.g. using a `forRoot` call.

The issue occurred as the `TestBed` compiler did not consider NgModules
that had been imported as a `ModuleWithProviders` when associating
NgModules with component overrides. This caused the overridden component
to be compiled standalone, meaning that it does not have access to
its NgModule's declarations. This commit extends the logic for
traversing the NgModule graph to also consider `ModuleWithProviders`
imports.

Fixes #42734