### PR TITLE
fix(common): keyvalue pipe resort output when compareFn changes

### DIFF
--- a/packages/common/src/pipes/keyvalue_pipe.ts
+++ b/packages/common/src/pipes/keyvalue_pipe.ts
@@ -49,6 +49,7 @@ export class KeyValuePipe implements PipeTransform {
 
   private differ!: KeyValueDiffer<any, any>;
   private keyValues: Array<KeyValue<any, any>> = [];
+  private compareFn: (a: KeyValue<any, any>, b: KeyValue<any, any>) => number = defaultComparator;
 
   /*
    * NOTE: when the `input` value is a simple Record<K, V> object, the keys are extracted with
@@ -91,13 +92,17 @@ export class KeyValuePipe implements PipeTransform {
     }
 
     const differChanges: KeyValueChanges<K, V>|null = this.differ.diff(input as any);
+    const compareFnChanged = compareFn !== this.compareFn;
 
     if (differChanges) {
       this.keyValues = [];
       differChanges.forEachItem((r: KeyValueChangeRecord<K, V>) => {
         this.keyValues.push(makeKeyValuePair(r.key, r.currentValue!));
       });
+    }
+    if (differChanges || compareFnChanged) {
       this.keyValues.sort(compareFn);
+      this.compareFn = compareFn;
     }
     return this.keyValues;
   }

--- a/packages/common/test/pipes/keyvalue_pipe_spec.ts
+++ b/packages/common/test/pipes/keyvalue_pipe_spec.ts
@@ -51,6 +51,15 @@ describe('KeyValuePipe', () => {
         {key: 'a', value: 1}, {key: 'b', value: 1}
       ]);
     });
+    it('should reorder when compareFn changes', () => {
+      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
+      const input = {'b': 1, 'a': 2};
+      pipe.transform<string, number>(input);
+      expect(pipe.transform<string, number>(input, (a, b) => a.value - b.value)).toEqual([
+        {key: 'b', value: 1},
+        {key: 'a', value: 2},
+      ]);
+    });
     it('should return the same ref if nothing changes', () => {
       const pipe = new KeyValuePipe(defaultKeyValueDiffers);
       const transform1 = pipe.transform({1: 2});
@@ -113,6 +122,15 @@ describe('KeyValuePipe', () => {
             {key: {id: 0}, value: 1},
             {key: {id: 1}, value: 1},
           ]);
+    });
+    it('should reorder when compareFn changes', () => {
+      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
+      const input = new Map([['b', 1], ['a', 2]]);
+      pipe.transform<string, number>(input);
+      expect(pipe.transform<string, number>(input, (a, b) => a.value - b.value)).toEqual([
+        {key: 'b', value: 1},
+        {key: 'a', value: 2},
+      ]);
     });
     it('should return the same ref if nothing changes', () => {
       const pipe = new KeyValuePipe(defaultKeyValueDiffers);


### PR DESCRIPTION
fix issue where keyvalue pipe did not sort output on compareFn change. issue #42819

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, when using the keyvalue pipe, when the map was not changed, the output is not resorted even
if the comparer function is changed (issue #42819).

Issue Number: #42819


## What is the new behavior?
The output is sorted when the function changes, even if map is unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
