### PR TITLE
fix(dev-infra): do not include all types in api golden test

### DIFF
--- a/dev-infra/bazel/api-golden/index.bzl
+++ b/dev-infra/bazel/api-golden/index.bzl
@@ -46,7 +46,7 @@ def api_golden_test(
         include_default_files = False,
     )
 
-    test_data = ["//dev-infra/bazel/api-golden", "//:package.json", ":%s_data_typings" % name] + kwargs.get("data", [])
+    test_data = ["//dev-infra/bazel/api-golden", "//:package.json", ":%s_data_typings" % name] + data
 
     nodejs_test(
         name = name,

--- a/dev-infra/bazel/api-golden/index.bzl
+++ b/dev-infra/bazel/api-golden/index.bzl
@@ -1,3 +1,4 @@
+load("//dev-infra/bazel:extract_js_module_output.bzl", "extract_js_module_output")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary", "nodejs_test")
 
 nodejs_test_args = [
@@ -32,9 +33,24 @@ def api_golden_test(
 
     kwargs["tags"] = kwargs.get("tags", []) + ["api_guard"]
 
+    # For API golden tests not running against a NPM package, we extract all transitive
+    # declarations of the specified `data` targets. This is necessary because API extractor
+    # needs to resolve other targets that have been linked by the Bazel NodeJS rules. The
+    # linker by default only provides access to JavaScript sources, but the API extractor is
+    # specifically concerned with type definitions that we can extract manually here.
+    extract_js_module_output(
+        name = "%s_data_typings" % name,
+        deps = data,
+        provider = "JSModuleInfo",
+        include_declarations = True,
+        include_default_files = False,
+    )
+
+    test_data = ["//dev-infra/bazel/api-golden", "//:package.json", ":%s_data_typings" % name] + kwargs.get("data", [])
+
     nodejs_test(
         name = name,
-        data = ["//dev-infra/bazel/api-golden", "//:package.json"] + data,
+        data = test_data,
         entry_point = "//dev-infra/bazel/api-golden:index.ts",
         templated_args = nodejs_test_args + [golden, entry_point, "false", quoted_export_pattern],
         **kwargs
@@ -43,7 +59,7 @@ def api_golden_test(
     nodejs_binary(
         name = name + ".accept",
         testonly = True,
-        data = ["//dev-infra/bazel/api-golden", "//:package.json"] + data,
+        data = test_data,
         entry_point = "//dev-infra/bazel/api-golden:index.ts",
         templated_args = nodejs_test_args + [golden, entry_point, "true", quoted_export_pattern],
         **kwargs

--- a/dev-infra/bazel/api-golden/test_api_report.ts
+++ b/dev-infra/bazel/api-golden/test_api_report.ts
@@ -41,7 +41,12 @@ export async function testApiGolden(
   const tempDir = process.env.TEST_TMPDIR ?? process.cwd();
 
   const configObject: IConfigFile = {
-    compiler: {overrideTsconfig: {files: [indexFilePath]}},
+    compiler: {
+      overrideTsconfig:
+          // We disable inclusion of all `@types` installed as this throws-off API reports
+          // and causes different goldens when the API test is run outside sandbox.
+          {files: [indexFilePath], compilerOptions: {types: [], lib: ['esnext', 'dom']}}
+    },
     projectFolder: dirname(packageJsonPath),
     mainEntryPointFilePath: indexFilePath,
     dtsRollup: {enabled: false},


### PR DESCRIPTION
The API golden test tool should not include all types
from the `node_modules/`. This results in unnecessary
type resolution when the API golden tool is run outside
of sandbox (i.e. on windows or with `bazel run` for accept).