### PR TITLE
feat(forms): add addValidators and hasValidators methods to AbstractControl

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -21,6 +21,8 @@ import { Version } from '@angular/core';
 // @public
 export abstract class AbstractControl {
     constructor(validators: ValidatorFn | ValidatorFn[] | null, asyncValidators: AsyncValidatorFn | AsyncValidatorFn[] | null);
+    addAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void;
+    addValidators(validators: ValidatorFn | ValidatorFn[]): void;
     get asyncValidator(): AsyncValidatorFn | null;
     set asyncValidator(asyncValidatorFn: AsyncValidatorFn | null);
     clearAsyncValidators(): void;
@@ -39,7 +41,9 @@ export abstract class AbstractControl {
     readonly errors: ValidationErrors | null;
     get(path: Array<string | number> | string): AbstractControl | null;
     getError(errorCode: string, path?: Array<string | number> | string): any;
+    hasAsyncValidator(validator: AsyncValidatorFn): boolean;
     hasError(errorCode: string, path?: Array<string | number> | string): boolean;
+    hasValidator(validator: ValidatorFn): boolean;
     get invalid(): boolean;
     markAllAsTouched(): void;
     markAsDirty(opts?: {
@@ -62,15 +66,17 @@ export abstract class AbstractControl {
     abstract patchValue(value: any, options?: Object): void;
     get pending(): boolean;
     readonly pristine: boolean;
+    removeAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void;
+    removeValidators(validators: ValidatorFn | ValidatorFn[]): void;
     abstract reset(value?: any, options?: Object): void;
     get root(): AbstractControl;
-    setAsyncValidators(newValidator: AsyncValidatorFn | AsyncValidatorFn[] | null): void;
+    setAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[] | null): void;
     setErrors(errors: ValidationErrors | null, opts?: {
         emitEvent?: boolean;
     }): void;
     // (undocumented)
     setParent(parent: FormGroup | FormArray): void;
-    setValidators(newValidator: ValidatorFn | ValidatorFn[] | null): void;
+    setValidators(validators: ValidatorFn | ValidatorFn[] | null): void;
     abstract setValue(value: any, options?: Object): void;
     readonly status: string;
     readonly statusChanges: Observable<any>;
@@ -384,7 +390,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
     resetForm(value?: any): void;
     readonly submitted: boolean;
     updateModel(dir: FormControlName, value: any): void;
-    }
+}
 
 // @public
 export class FormGroupName extends AbstractFormGroupDirective implements OnInit, OnDestroy {
@@ -403,7 +409,7 @@ export class MaxLengthValidator implements Validator, OnChanges {
     ngOnChanges(changes: SimpleChanges): void;
     registerOnValidatorChange(fn: () => void): void;
     validate(control: AbstractControl): ValidationErrors | null;
-    }
+}
 
 // @public
 export class MaxValidator extends AbstractValidatorDirective implements OnChanges {
@@ -418,7 +424,7 @@ export class MinLengthValidator implements Validator, OnChanges {
     ngOnChanges(changes: SimpleChanges): void;
     registerOnValidatorChange(fn: () => void): void;
     validate(control: AbstractControl): ValidationErrors | null;
-    }
+}
 
 // @public
 export class MinValidator extends AbstractValidatorDirective implements OnChanges {
@@ -539,7 +545,7 @@ export class PatternValidator implements Validator, OnChanges {
     pattern: string | RegExp;
     registerOnValidatorChange(fn: () => void): void;
     validate(control: AbstractControl): ValidationErrors | null;
-    }
+}
 
 // @public
 export class RadioControlValueAccessor extends ɵangular_packages_forms_forms_g implements ControlValueAccessor, OnDestroy, OnInit {
@@ -631,7 +637,6 @@ export class Validators {
 
 // @public (undocumented)
 export const VERSION: Version;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -49,7 +49,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 1150,
-        "main-es2015": 162346,
+        "main-es2015": 163007,
         "polyfills-es2015": 36975
       }
     }

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -666,6 +666,9 @@
     "name": "addToViewTree"
   },
   {
+    "name": "addValidators"
+  },
+  {
     "name": "allocExpando"
   },
   {
@@ -1083,6 +1086,9 @@
     "name": "hasValidLength"
   },
   {
+    "name": "hasValidator"
+  },
+  {
     "name": "hostReportError"
   },
   {
@@ -1272,6 +1278,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "makeValidatorsArray"
+  },
+  {
     "name": "map"
   },
   {
@@ -1429,6 +1438,9 @@
   },
   {
     "name": "removeStyle"
+  },
+  {
+    "name": "removeValidators"
   },
   {
     "name": "renderComponent"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -654,6 +654,9 @@
     "name": "addToViewTree"
   },
   {
+    "name": "addValidators"
+  },
+  {
     "name": "allocExpando"
   },
   {
@@ -1047,6 +1050,9 @@
     "name": "hasTagAndTypeMatch"
   },
   {
+    "name": "hasValidator"
+  },
+  {
     "name": "hostReportError"
   },
   {
@@ -1233,6 +1239,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "makeValidatorsArray"
+  },
+  {
     "name": "map"
   },
   {
@@ -1393,6 +1402,9 @@
   },
   {
     "name": "removeStyle"
+  },
+  {
+    "name": "removeValidators"
   },
   {
     "name": "renderComponent"

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -663,3 +663,56 @@ export function getControlAsyncValidators(control: AbstractControl): AsyncValida
     AsyncValidatorFn[]|null {
   return (control as any)._rawAsyncValidators as AsyncValidatorFn | AsyncValidatorFn[] | null;
 }
+
+/**
+ * Accepts a singleton validator, an array, or null, and returns an array type with the provided
+ * validators.
+ *
+ * @param validators A validator, validators, or null.
+ * @returns A validators array.
+ */
+export function makeValidatorsArray<T extends ValidatorFn|AsyncValidatorFn>(validators: T|T[]|
+                                                                            null): T[] {
+  if (!validators) return [];
+  return Array.isArray(validators) ? validators : [validators];
+}
+
+/**
+ * Determines whether a validator or validators array has a given validator.
+ *
+ * @param validators The validator or validators to compare against.
+ * @param validator The validator to check.
+ * @returns Whether the validator is present.
+ */
+export function hasValidator<T extends ValidatorFn|AsyncValidatorFn>(
+    validators: T|T[]|null, validator: T): boolean {
+  return Array.isArray(validators) ? validators.includes(validator) : validators === validator;
+}
+
+/**
+ * Combines two arrays of validators into one. If duplicates are provided, only one will be added.
+ *
+ * @param validators The new validators.
+ * @param currentValidators The base array of currrent validators.
+ * @returns An array of validators.
+ */
+export function addValidators<T extends ValidatorFn|AsyncValidatorFn>(
+    validators: T|T[], currentValidators: T|T[]|null): T[] {
+  const current = makeValidatorsArray(currentValidators);
+  const validatorsToAdd = makeValidatorsArray(validators);
+  validatorsToAdd.forEach((v: T) => {
+    // Note: if there are duplicate entries in the new validators array,
+    // only the first one would be added to the current list of validarors.
+    // Duplicate ones would be ignored since `hasValidator` would detect
+    // the presence of a validator function and we update the current list in place.
+    if (!hasValidator(current, v)) {
+      current.push(v);
+    }
+  });
+  return current;
+}
+
+export function removeValidators<T extends ValidatorFn|AsyncValidatorFn>(
+    validators: T|T[], currentValidators: T|T[]|null): T[] {
+  return makeValidatorsArray(currentValidators).filter(v => !hasValidator(validators, v));
+}

--- a/packages/forms/test/form_builder_spec.ts
+++ b/packages/forms/test/form_builder_spec.ts
@@ -69,6 +69,17 @@ describe('Form Builder', () => {
     expect(g.controls['login'].asyncValidator).toBe(asyncValidator);
   });
 
+  it('should support controls with validators that are later modified', () => {
+    const g = b.group({'login': b.control(null, syncValidator, asyncValidator)});
+    expect(g.controls['login'].value).toBeNull();
+    expect(g.controls['login'].validator).toBe(syncValidator);
+    expect(g.controls['login'].asyncValidator).toBe(asyncValidator);
+    g.controls['login'].addValidators(Validators.required);
+    expect(g.controls['login'].hasValidator(Validators.required)).toBe(true);
+    g.controls['login'].removeValidators(Validators.required);
+    expect(g.controls['login'].hasValidator(Validators.required)).toBe(false);
+  });
+
   it('should support controls with no validators and whose form state is undefined', () => {
     const g = b.group({'login': b.control(undefined)});
     expect(g.controls['login'].value).toBeNull();

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -312,6 +312,57 @@ describe('FormControl', () => {
       c.setValidators([Validators.required]);
       expect(c.validator).not.toBe(null);
     });
+
+    it('should check presence of and remove a validator set in the control constructor', () => {
+      const c = new FormControl('', Validators.required);
+      expect(c.hasValidator(Validators.required)).toEqual(true);
+
+      c.removeValidators(Validators.required);
+      expect(c.hasValidator(Validators.required)).toEqual(false);
+
+      c.addValidators(Validators.required);
+      expect(c.hasValidator(Validators.required)).toEqual(true);
+    });
+
+    it('should check presence of and remove a validator set with addValidators', () => {
+      const c = new FormControl('');
+      expect(c.hasValidator(Validators.required)).toEqual(false);
+      c.addValidators(Validators.required);
+      expect(c.hasValidator(Validators.required)).toEqual(true);
+
+      c.removeValidators(Validators.required);
+      expect(c.hasValidator(Validators.required)).toEqual(false);
+    });
+
+    it('should check presence of and remove multiple validators set at the same time', () => {
+      const c = new FormControl('3');
+      const minValidator = Validators.min(4);
+      c.addValidators([Validators.required, minValidator]);
+      expect(c.hasValidator(Validators.required)).toEqual(true);
+      expect(c.hasValidator(minValidator)).toEqual(true);
+
+      c.removeValidators([Validators.required, minValidator]);
+      expect(c.hasValidator(Validators.required)).toEqual(false);
+      expect(c.hasValidator(minValidator)).toEqual(false);
+    });
+
+    it('should be able to remove a validator added multiple times', () => {
+      const c = new FormControl('', Validators.required);
+      c.addValidators(Validators.required);
+      c.addValidators(Validators.required);
+      expect(c.hasValidator(Validators.required)).toEqual(true);
+
+      c.removeValidators(Validators.required);
+      expect(c.hasValidator(Validators.required)).toEqual(false);
+    });
+
+    it('should return false when checking presence of a validator not identical by reference',
+       () => {
+         const minValidator = Validators.min(5);
+         const c = new FormControl('1', minValidator);
+         expect(c.hasValidator(minValidator)).toEqual(true);
+         expect(c.hasValidator(Validators.min(5))).toEqual(false);
+       });
   });
 
   describe('asyncValidator', () => {
@@ -508,6 +559,61 @@ describe('FormControl', () => {
          tick();
          expect(c.status).toEqual('DISABLED');
        }));
+
+    it('should check presence of and remove a validator set in the control constructor', () => {
+      const asyncVal = asyncValidator('expected');
+      const c = new FormControl('', null, asyncVal);
+      expect(c.hasAsyncValidator(asyncVal)).toEqual(true);
+
+      c.removeAsyncValidators(asyncVal);
+      expect(c.hasAsyncValidator(asyncVal)).toEqual(false);
+
+      c.addAsyncValidators(asyncVal);
+      expect(c.hasAsyncValidator(asyncVal)).toEqual(true);
+    });
+
+    it('should check presence of and remove a validator set with addValidators', () => {
+      const c = new FormControl('');
+      const asyncVal = asyncValidator('expected');
+      c.addAsyncValidators(asyncVal);
+      expect(c.hasAsyncValidator(asyncVal)).toEqual(true);
+
+      c.removeAsyncValidators(asyncVal);
+      expect(c.hasAsyncValidator(asyncVal)).toEqual(false);
+    });
+
+    it('should check presence of and remove multiple validators set at the same time', () => {
+      const c = new FormControl('3');
+      const asyncVal1 = asyncValidator('expected1');
+      const asyncVal2 = asyncValidator('expected2');
+      c.addAsyncValidators([asyncVal1, asyncVal2]);
+      expect(c.hasAsyncValidator(asyncVal1)).toEqual(true);
+      expect(c.hasAsyncValidator(asyncVal2)).toEqual(true);
+
+      c.removeAsyncValidators([asyncVal1, asyncVal2]);
+      expect(c.hasAsyncValidator(asyncVal1)).toEqual(false);
+      expect(c.hasAsyncValidator(asyncVal2)).toEqual(false);
+    });
+
+    it('should be able to remove a validator added multiple times', () => {
+      const asyncVal = asyncValidator('expected');
+      const c = new FormControl('', null, asyncVal);
+      c.addAsyncValidators(asyncVal);
+      c.addAsyncValidators(asyncVal);
+      expect(c.hasAsyncValidator(asyncVal)).toEqual(true);
+
+      c.removeAsyncValidators(asyncVal);
+      expect(c.hasAsyncValidator(asyncVal)).toEqual(false);
+    });
+
+    it('should return false when checking presence of a validator not identical by reference',
+       () => {
+         const asyncVal = asyncValidator('expected');
+         const asyncValDifferentFn = asyncValidator('expected');
+         const c = new FormControl('1', null, asyncVal);
+         expect(c.hasAsyncValidator(asyncVal)).toEqual(true);
+         expect(c.hasAsyncValidator(asyncValDifferentFn)).toEqual(false);
+       });
   });
 
   describe('dirty', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #13461

It is currently not possible to modify the validator set on a FormControl, or check for a particular validator's presence.


## What is the new behavior?

Add getValidators and hasValidators methods (for both sync and async) to the FormControl API, enabling vaioud use cases in a longstanding issue.

Several new functionalities are possible with this change: the most requested is that callers can now check whether a control has a required validator. Other uses include incrementally changing the validators set without doing an expensive operation to reset all validators.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Closes #13461.
