### PR TITLE
ci: exempt bazel scope from merge tool target label checks

### DIFF
--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -25,6 +25,9 @@ export const merge: DevInfraMergeConfig['merge'] = async api => {
       'master': '5aeb9a4124922d8ac08eb73b8f322905a32b0b3a',
       '10.0.x': '27b95ba64a5d99757f4042073fd1860e20e3ed24',
     },
-    targetLabelExemptScopes: ['dev-infra', 'docs-infra']
+    // `dev-infra` and `docs-infra` are not affecting the public NPM packages. Similarly,
+    // the `bazel` package is not considered part of the public API so that features
+    // can land in patch branches.
+    targetLabelExemptScopes: ['dev-infra', 'docs-infra', 'bazel']
   };
 };


### PR DESCRIPTION
Currently, changes with the `bazel` scope are guarded by the
merge tool target label checks. i.e. feature commits with
the `bazel` scope cannot land in the patch branch. This is
expected for all public packages, but given the `bazel`
package being used internal-only, it should be possible
to land these in a patch branch. Especially since we want
tooling to be in sync between version branches as much
as possible.