### PR TITLE
feat(dev-infra): allow preventing release notes from updating CHANGELOG.md file

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -6478,16 +6478,22 @@ class ReleaseAction {
      */
     waitForEditsAndCreateReleaseCommit(newVersion) {
         return tslib.__awaiter(this, void 0, void 0, function* () {
-            info(yellow('  ⚠   Please review the changelog and ensure that the log contains only changes ' +
-                'that apply to the public API surface. Manual changes can be made. When done, please ' +
-                'proceed with the prompt below.'));
-            if (!(yield promptConfirm('Do you want to proceed and commit the changes?'))) {
-                throw new UserAbortedReleaseActionError();
+            /** A list of files which have been modified and should be included in the commit. */
+            const modifiedFiles = [packageJsonPath];
+            if (!this.config.releaseNotes.noChangelogFile) {
+                // Include the modified CHANGELOG.md file.
+                modifiedFiles.push(changelogPath);
+                info(yellow('  ⚠   Please review the changelog and ensure that the log contains only changes ' +
+                    'that apply to the public API surface. Manual changes can be made. When done, please ' +
+                    'proceed with the prompt below.'));
+                if (!(yield promptConfirm('Do you want to proceed and commit the changes?'))) {
+                    throw new UserAbortedReleaseActionError();
+                }
             }
             // Commit message for the release point.
             const commitMessage = getCommitMessageForRelease(newVersion);
             // Create a release staging commit including changelog and version bump.
-            yield this.createCommit(commitMessage, [packageJsonPath, changelogPath]);
+            yield this.createCommit(commitMessage, modifiedFiles);
             info(green(`  ✓   Created release commit for: "${newVersion}".`));
         });
     }

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -6646,6 +6646,10 @@ class ReleaseAction {
      */
     prependReleaseNotesToChangelog(releaseNotes) {
         return tslib.__awaiter(this, void 0, void 0, function* () {
+            if (this.config.releaseNotes.noChangelogFile) {
+                debug('Skipping prepending release notes to changelog due to config.');
+                return;
+            }
             const localChangelogPath = path.join(this.projectDir, changelogPath);
             const localChangelog = yield fs.promises.readFile(localChangelogPath, 'utf8');
             const releaseNotesEntry = yield releaseNotes.getChangelogEntry();
@@ -6706,6 +6710,10 @@ class ReleaseAction {
      */
     cherryPickChangelogIntoNextBranch(releaseNotes, stagingBranch) {
         return tslib.__awaiter(this, void 0, void 0, function* () {
+            if (this.config.releaseNotes.noChangelogFile) {
+                debug('Skipping cherry pick of changelog into next branch due to config.');
+                return true;
+            }
             const nextBranch = this.active.next.branchName;
             const commitMessage = getReleaseNoteCherryPickCommitMessage(releaseNotes.version);
             // Checkout the next branch.

--- a/dev-infra/release/config/index.ts
+++ b/dev-infra/release/config/index.ts
@@ -43,6 +43,8 @@ export interface ReleaseNotesConfig {
    * groups will appear after these groups, sorted by `Array.sort`'s default sorting order.
    */
   groupOrder?: string[];
+  /** Whether to skip adding release notes to the CHANGELOG.md file. */
+  noChangelogFile?: boolean;
 }
 
 /** Configuration for releases in the dev-infra configuration. */

--- a/dev-infra/release/publish/actions.ts
+++ b/dev-infra/release/publish/actions.ts
@@ -320,6 +320,10 @@ export abstract class ReleaseAction {
    * @returns A boolean indicating whether the release notes have been prepended.
    */
   protected async prependReleaseNotesToChangelog(releaseNotes: ReleaseNotes): Promise<void> {
+    if (this.config.releaseNotes.noChangelogFile) {
+      debug('Skipping prepending release notes to changelog due to config.');
+      return;
+    }
     const localChangelogPath = join(this.projectDir, changelogPath);
     const localChangelog = await fs.readFile(localChangelogPath, 'utf8');
     const releaseNotesEntry = await releaseNotes.getChangelogEntry();
@@ -386,6 +390,10 @@ export abstract class ReleaseAction {
    */
   protected async cherryPickChangelogIntoNextBranch(
       releaseNotes: ReleaseNotes, stagingBranch: string): Promise<boolean> {
+    if (this.config.releaseNotes.noChangelogFile) {
+      debug('Skipping cherry pick of changelog into next branch due to config.');
+      return true;
+    }
     const nextBranch = this.active.next.branchName;
     const commitMessage = getReleaseNoteCherryPickCommitMessage(releaseNotes.version);
 


### PR DESCRIPTION
Create an option for release tooling to skip updating the CHANGELOG.md file
with the release notes.
