### PR TITLE
fix(compiler-cli): use correct module resolution context for absolute…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -30,7 +30,7 @@ export class DtsMetadataReader implements MetadataReader {
    */
   getNgModuleMetadata(ref: Reference<ClassDeclaration>): NgModuleMeta|null {
     const clazz = ref.node;
-    const resolutionContext = clazz.getSourceFile().fileName;
+
     // This operation is explicitly not memoized, as it depends on `ref.ownedByModuleGuess`.
     // TODO(alxhub): investigate caching of .d.ts module metadata.
     const ngModuleDef = this.reflector.getMembersOfClass(clazz).find(
@@ -49,12 +49,10 @@ export class DtsMetadataReader implements MetadataReader {
     const [_, declarationMetadata, importMetadata, exportMetadata] = ngModuleDef.type.typeArguments;
     return {
       ref,
-      declarations: extractReferencesFromType(
-          this.checker, declarationMetadata, ref.ownedByModuleGuess, resolutionContext),
-      exports: extractReferencesFromType(
-          this.checker, exportMetadata, ref.ownedByModuleGuess, resolutionContext),
-      imports: extractReferencesFromType(
-          this.checker, importMetadata, ref.ownedByModuleGuess, resolutionContext),
+      declarations:
+          extractReferencesFromType(this.checker, declarationMetadata, ref.bestGuessOwningModule),
+      exports: extractReferencesFromType(this.checker, exportMetadata, ref.bestGuessOwningModule),
+      imports: extractReferencesFromType(this.checker, importMetadata, ref.bestGuessOwningModule),
       schemas: [],
       rawDeclarations: null,
     };

--- a/packages/compiler-cli/src/ngtsc/metadata/test/dts_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/test/dts_spec.ts
@@ -142,19 +142,19 @@ runInEachFileSystem(() => {
       const dtsReader =
           new DtsMetadataReader(typeChecker, new TypeScriptReflectionHost(typeChecker));
 
-      const withoutModule = dtsReader.getNgModuleMetadata(new Reference(clazz))!;
-      expect(withoutModule.exports.length).toBe(2);
+      const withoutOwningModule = dtsReader.getNgModuleMetadata(new Reference(clazz))!;
+      expect(withoutOwningModule.exports.length).toBe(2);
 
       // `AbsoluteDir` was imported from an absolute module so the export Reference should have
       // a corresponding best guess owning module.
-      expect(withoutModule.exports[0].bestGuessOwningModule).toEqual({
+      expect(withoutOwningModule.exports[0].bestGuessOwningModule).toEqual({
         specifier: 'absolute',
         resolutionContext: externalSf.fileName,
       });
 
       // `RelativeDir` was imported from a relative module specifier so the original reference's
       // best guess owning module should have been retained, which was null.
-      expect(withoutModule.exports[1].bestGuessOwningModule).toBeNull();
+      expect(withoutOwningModule.exports[1].bestGuessOwningModule).toBeNull();
 
       const owningModule: OwningModule = {
         specifier: 'module',

--- a/packages/compiler-cli/src/ngtsc/metadata/test/dts_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/test/dts_spec.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 
 import {absoluteFrom, getFileSystem, getSourceFileOrError} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
-import {Reference} from '../../imports';
+import {OwningModule, Reference} from '../../imports';
 import {isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
 import {loadFakeCore, makeProgram} from '../../testing';
 
@@ -88,6 +88,94 @@ runInEachFileSystem(() => {
 
       const meta = dtsReader.getDirectiveMetadata(new Reference(clazz))!;
       expect(meta.isStructural).toBeTrue();
+    });
+
+    it('should retain an absolute owning module for relative imports', () => {
+      const externalPath = absoluteFrom('/external.d.ts');
+      const {program} = makeProgram(
+          [
+            {
+              name: externalPath,
+              contents: `
+          import * as i0 from '@angular/core';
+          import * as i1 from 'absolute';
+          import * as i2 from './relative';
+
+          export declare class ExternalModule {
+            static ɵmod: i0.ɵɵNgModuleDeclaration<RelativeModule, [typeof i2.RelativeDir], never, [typeof i1.AbsoluteDir, typeof i2.RelativeDir]>;
+          }
+        `
+            },
+            {
+              name: absoluteFrom('/relative.d.ts'),
+              contents: `
+          import * as i0 from '@angular/core';
+
+          export declare class RelativeDir {
+            static ɵdir: i0.ɵɵDirectiveDeclaration<RelativeDir, '[dir]', never, never, never, never>;
+          }
+        `
+            },
+            {
+              name: absoluteFrom('/node_modules/absolute.d.ts'),
+              contents: `
+          import * as i0 from '@angular/core';
+
+          export declare class AbsoluteDir {
+            static ɵdir: i0.ɵɵDirectiveDeclaration<ExternalDir, '[dir]', never, never, never, never>;
+          }
+        `
+            }
+          ],
+          {
+            skipLibCheck: true,
+            lib: ['es6', 'dom'],
+          });
+
+      const externalSf = getSourceFileOrError(program, externalPath);
+      const clazz = externalSf.statements[3];
+      if (!isNamedClassDeclaration(clazz)) {
+        return fail('Expected class declaration');
+      }
+
+      const typeChecker = program.getTypeChecker();
+      const dtsReader =
+          new DtsMetadataReader(typeChecker, new TypeScriptReflectionHost(typeChecker));
+
+      const withoutModule = dtsReader.getNgModuleMetadata(new Reference(clazz))!;
+      expect(withoutModule.exports.length).toBe(2);
+
+      // `AbsoluteDir` was imported from an absolute module so the export Reference should have
+      // a corresponding best guess owning module.
+      expect(withoutModule.exports[0].bestGuessOwningModule).toEqual({
+        specifier: 'absolute',
+        resolutionContext: externalSf.fileName,
+      });
+
+      // `RelativeDir` was imported from a relative module specifier so the original reference's
+      // best guess owning module should have been retained, which was null.
+      expect(withoutModule.exports[1].bestGuessOwningModule).toBeNull();
+
+      const owningModule: OwningModule = {
+        specifier: 'module',
+        resolutionContext: absoluteFrom('/context.ts'),
+      };
+      const withOwningModule = dtsReader.getNgModuleMetadata(new Reference(clazz, owningModule))!;
+      expect(withOwningModule.exports.length).toBe(2);
+
+      // Again, `AbsoluteDir` was imported from an absolute module so the export Reference should
+      // have a corresponding best guess owning module; the owning module of the incoming reference
+      // is irrelevant here.
+      expect(withOwningModule.exports[0].bestGuessOwningModule).toEqual({
+        specifier: 'absolute',
+        resolutionContext: externalSf.fileName,
+      });
+
+      // As `RelativeDir` was imported from a relative module specifier, the export Reference should
+      // continue to have the owning module of the incoming reference as the relatively imported
+      // symbol is assumed to also be exported from the absolute module specifier as captured in the
+      // best guess owning module.
+      expect(withOwningModule.exports[1].bestGuessOwningModule).toEqual(owningModule);
     });
   });
 });


### PR DESCRIPTION
… imports in .d.ts files

The compiler keeps track of how a declaration has been referenced
using absolute module imports and from which path the absolute module
should be resolved from. There was a bug in how the .d.ts metadata
extraction would incorrectly use the .d.ts file itself as resolution
context for symbols that had been imported using a relative module
specifier. This could result in module resolution failures.

For example, when extracting NgModule metadata from
`/node_modules/lib/index.d.ts` that looks like

```
import {LibDirective} from './dir';

@NgModule({
  declarations: [LibDirective],
  exports: [LibDirective],
})
export class LibModule {}
```

and `/app.module.ts` that contains

```
import {LibModule} from 'lib';

@NgModule({
  imports: [LibModule],
})
export class AppModule {}
```

then `AppModule` would have recorded a reference to `LibModule` using
the `'lib'` module specifier. When extracting the NgModule metadata from
the `/node_modules/lib/index.d.ts` file the relative import into `./dir`
would create a reference using `'lib'` as absolute module specifier but
`/node_modules/lib/index.d.ts` as resolution context path. The latter is
incorrect, as `'lib'` needs to be resolved from `/app.module.ts` and not
from within the library itself.

Fixes #42810