### PR TITLE
fix(core): correctly handle `null` or `undefined` in `ErrorHandler#handleError()`

### DIFF
--- a/packages/core/src/error_handler.ts
+++ b/packages/core/src/error_handler.ts
@@ -7,6 +7,7 @@
  */
 
 import {getDebugContext, getErrorLogger, getOriginalError} from './errors';
+import {DebugContext} from './view/types';
 
 
 
@@ -58,17 +59,17 @@ export class ErrorHandler {
   }
 
   /** @internal */
-  _findContext(error: any): any {
+  _findContext(error: any): DebugContext|null {
     return error ? (getDebugContext(error) || this._findContext(getOriginalError(error))) : null;
   }
 
   /** @internal */
-  _findOriginalError(error: Error): any {
-    let e = getOriginalError(error);
+  _findOriginalError(error: any): Error|null {
+    let e = error && getOriginalError(error);
     while (e && getOriginalError(e)) {
       e = getOriginalError(e);
     }
 
-    return e;
+    return e || null;
   }
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -21,8 +21,8 @@ export function getOriginalError(error: Error): Error {
   return (error as any)[ERROR_ORIGINAL_ERROR];
 }
 
-export function getErrorLogger(error: Error): (console: Console, ...values: any[]) => void {
-  return (error as any)[ERROR_LOGGER] || defaultErrorLogger;
+export function getErrorLogger(error: unknown): (console: Console, ...values: any[]) => void {
+  return error && (error as any)[ERROR_LOGGER] || defaultErrorLogger;
 }
 
 

--- a/packages/core/test/error_handler_spec.ts
+++ b/packages/core/test/error_handler_spec.ts
@@ -23,13 +23,18 @@ function errorToString(error: any) {
   const errorHandler = new ErrorHandler();
   (errorHandler as any)._console = logger as any;
   errorHandler.handleError(error);
-  return logger.res.map(line => line.join('#')).join('\n');
+  return logger.res.map(line => line.map(x => `${x}`).join('#')).join('\n');
 }
 
 describe('ErrorHandler', () => {
   it('should output exception', () => {
     const e = errorToString(new Error('message!'));
     expect(e).toContain('message!');
+  });
+
+  it('should correctly handle `null` or `undefined`', () => {
+    expect(errorToString(null)).toBe('ERROR#null');
+    expect(errorToString(undefined)).toBe('ERROR#undefined');
   });
 
   describe('context', () => {

--- a/packages/core/test/error_handler_spec.ts
+++ b/packages/core/test/error_handler_spec.ts
@@ -32,7 +32,12 @@ describe('ErrorHandler', () => {
     expect(e).toContain('message!');
   });
 
-  it('should correctly handle `null` or `undefined`', () => {
+  it('should correctly handle primitive values', () => {
+    expect(errorToString('message')).toBe('ERROR#message');
+    expect(errorToString(404)).toBe('ERROR#404');
+    expect(errorToString(0)).toBe('ERROR#0');
+    expect(errorToString(true)).toBe('ERROR#true');
+    expect(errorToString(false)).toBe('ERROR#false');
     expect(errorToString(null)).toBe('ERROR#null');
     expect(errorToString(undefined)).toBe('ERROR#undefined');
   });


### PR DESCRIPTION
Since `ErrorHandler#handleError()` expects an argument of type `any` it should be able to handle values such as `null` and `undefined`. Previously, it failed to handle these values, because it was trying to access properties on them.

This PR fixes it by ensuring no properties are accessed on `null` or `undefined` values.

NOTE: This is part of fully addressing #28106.

Fixes #21252.