### PR TITLE
fix(docs-infra): prevent main content from overlapping with ToC

### DIFF
--- a/aio/src/styles/1-layouts/sidenav/_sidenav.scss
+++ b/aio/src/styles/1-layouts/sidenav/_sidenav.scss
@@ -14,7 +14,7 @@ mat-sidenav-container.sidenav-container {
 
   &.has-floating-toc {
     .mat-sidenav-content {
-      padding-right: 18vw;
+      margin-right: 18vw;
     }
   }
 


### PR DESCRIPTION
Previously, if there was more content than what would horizontally fit in the main content area, it would overflow to the right and overlap with the Table of Contents (ToC).
This was accidentally introduced in #42787.

This PR fixes it by ensuring that the main content area will not overlap with ToC and the necessary space for the ToC will be reserved using `margin` (instead of `padding`, which contributes to the element's size).

Fixes #42867.
