### PR TITLE
fix(core): use correct injector when resolving DI tokens from within …

### DIFF
--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -17,6 +17,7 @@ import {EMPTY_ARRAY} from '../util/empty';
 import {stringify} from '../util/stringify';
 
 import {resolveForwardRef} from './forward_ref';
+import {setInjectImplementation} from './inject_switch';
 import {InjectionToken} from './injection_token';
 import {Injector} from './injector';
 import {catchInjectorError, injectArgs, NG_TEMP_TOKEN_PATH, setCurrentInjector, THROW_IF_NOT_FOUND, USE_VALUE, ɵɵinject} from './injector_compatibility';
@@ -186,6 +187,7 @@ export class R3Injector {
     this.assertNotDestroyed();
     // Set the injection context.
     const previousInjector = setCurrentInjector(this);
+    const previousInjectImplementation = setInjectImplementation(undefined);
     try {
       // Check for the SkipSelf flag.
       if (!(flags & InjectFlags.SkipSelf)) {
@@ -234,7 +236,8 @@ export class R3Injector {
         throw e;
       }
     } finally {
-      // Lastly, clean up the state by restoring the previous injector.
+      // Lastly, restore the previous injection context.
+      setInjectImplementation(previousInjectImplementation);
       setCurrentInjector(previousInjector);
     }
   }

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -93,6 +93,9 @@
     "name": "injectArgs"
   },
   {
+    "name": "injectInjectorOnly"
+  },
+  {
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
@@ -109,6 +112,9 @@
   },
   {
     "name": "setCurrentInjector"
+  },
+  {
+    "name": "setInjectImplementation"
   },
   {
     "name": "stringify"


### PR DESCRIPTION
…a directive provider factory

When a directive provides a DI token using a factory function and
interacting with a standalone injector from within that factory, the
standalone injector should not have access to either the directive
injector nor the NgModule injector; only the standalone injector should
be used.

This commit ensures that a standalone injector never reaches into the
directive-level injection context while resolving DI tokens.

Fixes #42651