### PR TITLE
fix(compiler-cli): use correct module import for types behind a `forwardRef`

### DIFF
--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -463,13 +463,14 @@ export class StaticInterpreter {
             node, DynamicValue.fromExternalReference(node.expression, lhs));
       }
 
-      // If the function is declared in a different file, resolve the foreign function expression
-      // using the absolute module name of that file (if any).
-      if (lhs.bestGuessOwningModule !== null) {
+      // If the foreign expression occurs in a different file, then assume that the owning module
+      // of the call expression should also be used for the resolved foreign expression.
+      if (expr.getSourceFile() !== node.expression.getSourceFile() &&
+          lhs.bestGuessOwningModule !== null) {
         context = {
           ...context,
           absoluteModuleName: lhs.bestGuessOwningModule.specifier,
-          resolutionContext: node.getSourceFile().fileName,
+          resolutionContext: lhs.bestGuessOwningModule.resolutionContext,
         };
       }
 

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/utils.ts
@@ -62,3 +62,14 @@ export function firstArgFfr(
     args: ReadonlyArray<ts.Expression>): ts.Expression {
   return args[0];
 }
+
+export const arrowReturnValueFfr: ForeignFunctionResolver = (_ref, args) => {
+  // Extracts the `Foo` from `() => Foo`.
+  return (args[0] as ts.ArrowFunction).body as ts.Expression;
+};
+
+export const returnTypeFfr: ForeignFunctionResolver = (ref) => {
+  // Extract the `Foo` from the return type of the `external` function declaration.
+  return ((ref.node as ts.FunctionDeclaration).type as ts.TypeReferenceNode).typeName as
+      ts.Identifier;
+};


### PR DESCRIPTION
The static interpreter assumed that a foreign function expression would
have to be imported from the absolute module specifier that was used for
the foreign function itself. This assumption does not hold for the
`forwardRef` foreign function resolver, as that extracts the resolved
expression from the function's argument, which is not behind the
absolute module import of the `forwardRef` function.

The prior behavior has worked for the typical usage of `forwardRef`,
when it is contained within the same source file as where the static
evaluation started. In that case, the resulting reference would
incorrectly have an absolute module guess of `@angular/core`, but the
local identifier emit strategy was capable of emitting the reference
without generating an import using the absolute module guess.

In the scenario where the static interpreter would first have to follow
a reference to a different source that contained the `forwardRef` would
the compilation fail. In that case, there is no local identifier
available such that the absolute module emitter would try to locate the
imported symbol from `@angular/core`. which fails as the symbol is not
exported from there.

This commit fixes the issue by checking whether a foreign expression
occurs in the same source file as the call expression. If it does, then
the absolute module specifier that was used to resolve the call
expression is ignored.

Fixes #42865