### PR TITLE
improve @usageNotes message

### DIFF
--- a/aio/tools/transforms/templates/api/includes/description.html
+++ b/aio/tools/transforms/templates/api/includes/description.html
@@ -2,7 +2,7 @@
 <section class="description">
   <h2>Description</h2>
   {$ doc.description | trimBlankLines | marked $}
-  {% if doc.usageNotes %}<p>Further information available in the <a href="#usage-notes">Usage Notes...</a></p>{%
+  {% if doc.usageNotes %}<p>Further information is available in the <a href="#usage-notes">Usage Notes...</a></p>{%
   endif %}
 </section>
 {% endif %}


### PR DESCRIPTION
improve the @usageNotes message by adding the word "is"

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The generated message for usage notes in description sections is:
![Screenshot at 2021-07-18 10-38-49](https://user-images.githubusercontent.com/61631103/126062551-a84e7da0-f3fa-40fc-a3c5-016a5742031c.png)


Issue Number: N/A


## What is the new behavior?
The new generated message is:
![Screenshot at 2021-07-18 10-39-26](https://user-images.githubusercontent.com/61631103/126062558-b52627e2-4f1a-4792-a233-bf73e966c3c2.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This change was suggested by @TeriGlover in a previous PR ( https://github.com/angular/angular/pull/42704#discussion_r667152939 ) I didn't address it back there as it seemed a bit out of scope so I am now :slightly_smiling_face: 

I tried looking into how many docs this will effect but it's been difficult for me to point out, not all @usageNotes generate this (they need to be in a description), I guess it's not really necessary (nor too useful actually) to know precisely all the places this global change impacts

