### PR TITLE
fix(docs-infra): fix keyword color in CLI pages code blocks

### DIFF
--- a/aio/src/styles/2-modules/cli-pages/_cli-pages.scss
+++ b/aio/src/styles/2-modules/cli-pages/_cli-pages.scss
@@ -1,7 +1,7 @@
 .cli-name {
   font-weight: bold;
 
-  .kwd { color: initial }  /* override code format */
+  .kwd { color: inherit; }  /* override code format */
 }
 
 .cli-option-syntax {


### PR DESCRIPTION
Previously, names of CLI commands that also happened to be keywords were shown in black color in the code block demonstrating the command's usage. This worked fine when in light mode (where the code block background is white) but not in the recently introduced dark mode (where the code block background is dark gray).

This commit fixes this by ensuring the `.kwd` token color is reset inherited from its parent (which has an appropriate color for the current theme) instead of resetting it to its initial value (which is `black`).

**Before:**
![CLI pages keyword before][1]

**After:**
![cli-pages-keyword after][2]

##
You can see the fix in action at `/cli/add`:
- https://angular.io/cli/add
- https://pr42889-bd197fb.ngbuilds.io/cli/add


[1]: https://user-images.githubusercontent.com/8604205/126073803-af317f0c-d04f-4c3a-9a83-e92541d7dd5a.png
[2]: https://user-images.githubusercontent.com/8604205/126073806-1d57e3ed-90b1-4735-ae2a-d0a39862bb95.png
