### PR TITLE
feat(dev-infra): update package version verification to allow for experimental version

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -6800,7 +6800,7 @@ class ReleaseAction {
     /** Verify the version of each generated package exact matches the specified version. */
     _verifyPackageVersions(version, packages) {
         return tslib.__awaiter(this, void 0, void 0, function* () {
-            /*** Experimental equivilent version for packages created with the provided version. */
+            /** Experimental equivalent version for packages created with the provided version. */
             const experimentalVersion = new semver.SemVer(`0.${version.major * 100 + version.minor}.${version.patch}`);
             for (const pkg of packages) {
                 const { version: packageJsonVersion } = JSON.parse(yield fs.promises.readFile(path.join(pkg.outputPath, 'package.json'), 'utf8'));

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -6800,11 +6800,15 @@ class ReleaseAction {
     /** Verify the version of each generated package exact matches the specified version. */
     _verifyPackageVersions(version, packages) {
         return tslib.__awaiter(this, void 0, void 0, function* () {
+            /*** Experimental equivilent version for packages created with the provided version. */
+            const experimentalVersion = new semver.SemVer(`0.${version.major * 100 + version.minor}.${version.patch}`);
             for (const pkg of packages) {
                 const { version: packageJsonVersion } = JSON.parse(yield fs.promises.readFile(path.join(pkg.outputPath, 'package.json'), 'utf8'));
-                if (version.compare(packageJsonVersion) !== 0) {
+                const mismatchesVersion = version.compare(packageJsonVersion) !== 0;
+                const mismatchesExperimental = experimentalVersion.compare(packageJsonVersion) !== 0;
+                if (mismatchesExperimental && mismatchesVersion) {
                     error(red('The built package version does not match the version being released.'));
-                    error(`  Release Version:   ${version.version}`);
+                    error(`  Release Version:   ${version.version} (${experimentalVersion.version})`);
                     error(`  Generated Version: ${packageJsonVersion}`);
                     throw new FatalReleaseActionError();
                 }

--- a/dev-infra/release/publish/actions.ts
+++ b/dev-infra/release/publish/actions.ts
@@ -508,13 +508,20 @@ export abstract class ReleaseAction {
 
   /** Verify the version of each generated package exact matches the specified version. */
   private async _verifyPackageVersions(version: semver.SemVer, packages: BuiltPackage[]) {
+    /*** Experimental equivilent version for packages created with the provided version. */
+    const experimentalVersion =
+        new semver.SemVer(`0.${version.major * 100 + version.minor}.${version.patch}`);
     for (const pkg of packages) {
       const {version: packageJsonVersion} =
           JSON.parse(await fs.readFile(join(pkg.outputPath, 'package.json'), 'utf8')) as
           {version: string, [key: string]: any};
-      if (version.compare(packageJsonVersion) !== 0) {
+
+      const mismatchesVersion = version.compare(packageJsonVersion) !== 0;
+      const mismatchesExperimental = experimentalVersion.compare(packageJsonVersion) !== 0;
+
+      if (mismatchesExperimental && mismatchesVersion) {
         error(red('The built package version does not match the version being released.'));
-        error(`  Release Version:   ${version.version}`);
+        error(`  Release Version:   ${version.version} (${experimentalVersion.version})`);
         error(`  Generated Version: ${packageJsonVersion}`);
         throw new FatalReleaseActionError();
       }

--- a/dev-infra/release/publish/actions.ts
+++ b/dev-infra/release/publish/actions.ts
@@ -508,7 +508,7 @@ export abstract class ReleaseAction {
 
   /** Verify the version of each generated package exact matches the specified version. */
   private async _verifyPackageVersions(version: semver.SemVer, packages: BuiltPackage[]) {
-    /*** Experimental equivilent version for packages created with the provided version. */
+    /** Experimental equivalent version for packages created with the provided version. */
     const experimentalVersion =
         new semver.SemVer(`0.${version.major * 100 + version.minor}.${version.patch}`);
     for (const pkg of packages) {


### PR DESCRIPTION
The angular-cli repo publishes experimental versioned packages in addition to standard
versioned packages.  Both experimental and standard versions, based on the expected new
version provided are treated as valid and correct.
