### PR TITLE
feat(dev-infra): include experimental version stamp in env stamps

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -7682,7 +7682,7 @@ function buildEnvStamp(mode) {
     console.info(`BUILD_SCM_HASH ${getCurrentBranchOrRevision()}`);
     console.info(`BUILD_SCM_LOCAL_CHANGES ${hasLocalChanges()}`);
     console.info(`BUILD_SCM_USER ${getCurrentGitUser()}`);
-    const [version, experimentalVersion] = getSCMVersions(mode);
+    const { version, experimentalVersion } = getSCMVersions(mode);
     console.info(`BUILD_SCM_VERSION ${version}`);
     console.info(`BUILD_SCM_EXPERIMENTAL_VERSION ${experimentalVersion}`);
     process.exit();
@@ -7704,16 +7704,17 @@ function getSCMVersions(mode) {
         const packageJsonPath = path.join(git.baseDir, 'package.json');
         const { version } = new semver.SemVer(require(packageJsonPath).version);
         const { version: experimentalVersion } = createExperimentalSemver(new semver.SemVer(version));
-        return [version, experimentalVersion];
+        return { version, experimentalVersion };
     }
     if (mode === 'snapshot') {
         const localChanges = hasLocalChanges() ? '.with-local-changes' : '';
         const { stdout: rawVersion } = git.run(['describe', '--match', '*[0-9]*.[0-9]*.[0-9]*', '--abbrev=7', '--tags', 'HEAD~100']);
         const { version } = new semver.SemVer(rawVersion);
         const { version: experimentalVersion } = createExperimentalSemver(version);
-        return [version, experimentalVersion].map(v => {
-            return `${v.replace(/-([0-9]+)-g/, '+$1.sha-')}${localChanges}`;
-        });
+        return {
+            version: `${version.replace(/-([0-9]+)-g/, '+$1.sha-')}${localChanges}`,
+            experimentalVersion: `${experimentalVersion.replace(/-([0-9]+)-g/, '+$1.sha-')}${localChanges}`,
+        };
     }
     throw Error('No environment stamp mode was provided.');
 }

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -6201,6 +6201,7 @@ function semverInc(version, release, identifier) {
 }
 /** Creates the equivalent experimental version for a provided SemVer. */
 function createExperimentalSemver(version) {
+    version = new semver.SemVer(version);
     var experimentalVersion = new semver.SemVer(version.format());
     experimentalVersion.major = 0;
     experimentalVersion.minor = version.major * 100 + version.minor;
@@ -7681,7 +7682,9 @@ function buildEnvStamp(mode) {
     console.info(`BUILD_SCM_HASH ${getCurrentBranchOrRevision()}`);
     console.info(`BUILD_SCM_LOCAL_CHANGES ${hasLocalChanges()}`);
     console.info(`BUILD_SCM_USER ${getCurrentGitUser()}`);
-    console.info(`BUILD_SCM_VERSION ${getSCMVersion(mode)}`);
+    const [version, experimentalVersion] = getSCMVersions(mode);
+    console.info(`BUILD_SCM_VERSION ${version}`);
+    console.info(`BUILD_SCM_EXPERIMENTAL_VERSION ${experimentalVersion}`);
     process.exit();
 }
 /** Whether the repo has local changes. */
@@ -7690,24 +7693,29 @@ function hasLocalChanges() {
     return git.hasUncommittedChanges();
 }
 /**
- * Get the version for generated packages.
+ * Get the versions for generated packages.
  *
  * In snapshot mode, the version is based on the most recent semver tag.
  * In release mode, the version is based on the base package.json version.
  */
-function getSCMVersion(mode) {
+function getSCMVersions(mode) {
     const git = GitClient.get();
     if (mode === 'release') {
         const packageJsonPath = path.join(git.baseDir, 'package.json');
-        const { version } = require(packageJsonPath);
-        return version;
+        const { version } = new semver.SemVer(require(packageJsonPath).version);
+        const { version: experimentalVersion } = createExperimentalSemver(new semver.SemVer(version));
+        return [version, experimentalVersion];
     }
     if (mode === 'snapshot') {
-        const version = git.run(['describe', '--match', '[0-9]*.[0-9]*.[0-9]*', '--abbrev=7', '--tags', 'HEAD'])
-            .stdout.trim();
-        return `${version.replace(/-([0-9]+)-g/, '+$1.sha-')}${(hasLocalChanges() ? '.with-local-changes' : '')}`;
+        const localChanges = hasLocalChanges() ? '.with-local-changes' : '';
+        const { stdout: rawVersion } = git.run(['describe', '--match', '*[0-9]*.[0-9]*.[0-9]*', '--abbrev=7', '--tags', 'HEAD~100']);
+        const { version } = new semver.SemVer(rawVersion);
+        const { version: experimentalVersion } = createExperimentalSemver(version);
+        return [version, experimentalVersion].map(v => {
+            return `${v.replace(/-([0-9]+)-g/, '+$1.sha-')}${localChanges}`;
+        });
     }
-    return '0.0.0';
+    throw Error('No environment stamp mode was provided.');
 }
 /** Get the current branch or revision of HEAD. */
 function getCurrentBranchOrRevision() {

--- a/dev-infra/release/BUILD.bazel
+++ b/dev-infra/release/BUILD.bazel
@@ -14,7 +14,9 @@ ts_library(
         "//dev-infra/release/set-dist-tag",
         "//dev-infra/utils",
         "@npm//@types/node",
+        "@npm//@types/semver",
         "@npm//@types/yargs",
+        "@npm//semver",
         "@npm//yargs",
     ],
 )

--- a/dev-infra/release/stamping/env-stamp.ts
+++ b/dev-infra/release/stamping/env-stamp.ts
@@ -7,7 +7,9 @@
  */
 
 import {join} from 'path';
+import {SemVer} from 'semver';
 import {GitClient} from '../../utils/git/git-client';
+import {createExperimentalSemver} from '../../utils/semver';
 
 export type EnvStampMode = 'snapshot'|'release';
 
@@ -27,7 +29,9 @@ export function buildEnvStamp(mode: EnvStampMode) {
   console.info(`BUILD_SCM_HASH ${getCurrentBranchOrRevision()}`);
   console.info(`BUILD_SCM_LOCAL_CHANGES ${hasLocalChanges()}`);
   console.info(`BUILD_SCM_USER ${getCurrentGitUser()}`);
-  console.info(`BUILD_SCM_VERSION ${getSCMVersion(mode)}`);
+  const [version, experimentalVersion] = getSCMVersions(mode);
+  console.info(`BUILD_SCM_VERSION ${version}`);
+  console.info(`BUILD_SCM_EXPERIMENTAL_VERSION ${experimentalVersion}`);
   process.exit();
 }
 
@@ -38,26 +42,30 @@ function hasLocalChanges() {
 }
 
 /**
- * Get the version for generated packages.
+ * Get the versions for generated packages.
  *
  * In snapshot mode, the version is based on the most recent semver tag.
  * In release mode, the version is based on the base package.json version.
  */
-function getSCMVersion(mode: EnvStampMode) {
+function getSCMVersions(mode: EnvStampMode) {
   const git = GitClient.get();
   if (mode === 'release') {
     const packageJsonPath = join(git.baseDir, 'package.json');
-    const {version} = require(packageJsonPath);
-    return version;
+    const {version} = new SemVer(require(packageJsonPath).version);
+    const {version: experimentalVersion} = createExperimentalSemver(new SemVer(version));
+    return [version, experimentalVersion];
   }
   if (mode === 'snapshot') {
-    const version =
-        git.run(['describe', '--match', '[0-9]*.[0-9]*.[0-9]*', '--abbrev=7', '--tags', 'HEAD'])
-            .stdout.trim();
-    return `${version.replace(/-([0-9]+)-g/, '+$1.sha-')}${
-        (hasLocalChanges() ? '.with-local-changes' : '')}`;
+    const localChanges = hasLocalChanges() ? '.with-local-changes' : '';
+    const {stdout: rawVersion} = git.run(
+        ['describe', '--match', '*[0-9]*.[0-9]*.[0-9]*', '--abbrev=7', '--tags', 'HEAD~100']);
+    const {version} = new SemVer(rawVersion);
+    const {version: experimentalVersion} = createExperimentalSemver(version);
+    return [version, experimentalVersion].map(v => {
+      return `${v.replace(/-([0-9]+)-g/, '+$1.sha-')}${localChanges}`;
+    });
   }
-  return '0.0.0';
+  throw Error('No environment stamp mode was provided.');
 }
 
 /** Get the current branch or revision of HEAD. */

--- a/dev-infra/utils/semver.ts
+++ b/dev-infra/utils/semver.ts
@@ -19,7 +19,8 @@ export function semverInc(
 }
 
 /** Creates the equivalent experimental version for a provided SemVer. */
-export function createExperimentalSemver(version: semver.SemVer): semver.SemVer {
+export function createExperimentalSemver(version: string|semver.SemVer): semver.SemVer {
+  version = new semver.SemVer(version);
   const experimentalVersion = new semver.SemVer(version.format());
   experimentalVersion.major = 0;
   experimentalVersion.minor = version.major * 100 + version.minor;


### PR DESCRIPTION
Include the determined experimental version for stamping in the env stamps
created for release and snapshot builds.
