### PR TITLE
docs: Add import line to router event example for clarification

### DIFF
--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -27,12 +27,14 @@ export type NavigationTrigger = 'imperative'|'popstate'|'hashchange';
  * The following code shows how a class subscribes to router events.
  *
  * ```ts
+ * import {Event, RouterEvent, Router} from '@angular/router';
+ *
  * class MyService {
- *   constructor(public router: Router, logger: Logger) {
+ *   constructor(public router: Router) {
  *     router.events.pipe(
  *        filter((e: Event): e is RouterEvent => e instanceof RouterEvent)
  *     ).subscribe((e: RouterEvent) => {
- *       logger.log(e.id, e.url);
+ *       // Do something
  *     });
  *   }
  * }


### PR DESCRIPTION
Without the `import {Event} from '@angular/router';`, the filter will
not work because the type is understood as the native `Event`.

Fixes #42920
