### PR TITLE
build(docs-infra): upgrade cli command docs sources to 0ab046223

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -18,7 +18,7 @@
     "build-local": "yarn ~~build",
     "prebuild-local-ci": "yarn setup-local-ci",
     "build-local-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 18bbd044d",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 0ab046223",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#12.1.x](https://github.com/angular/angular/tree/12.1.x) from [cli-builds#12.1.x](https://github.com/angular/cli-builds/tree/12.1.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/18bbd044d...0ab046223):

**Modified**
- help/generate.json