### PR TITLE
feat(forms): Give form statuses a more specific type

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -78,8 +78,8 @@ export abstract class AbstractControl {
     setParent(parent: FormGroup | FormArray): void;
     setValidators(validators: ValidatorFn | ValidatorFn[] | null): void;
     abstract setValue(value: any, options?: Object): void;
-    readonly status: string;
-    readonly statusChanges: Observable<any>;
+    readonly status: FormControlStatus;
+    readonly statusChanges: Observable<FormControlStatus>;
     readonly touched: boolean;
     get untouched(): boolean;
     get updateOn(): FormHooks;


### PR DESCRIPTION
Make Form Statuses use stricter types.

Specifically: narrow the type used for form statuses from string to a union of possible statuses. Change the API methods from `any` to use the new type.

This is a breaking change. However, as discussed below, breakage seems minimal, and google3 has been prepped to land this.

Background: we uncovered these `any` typings in the course of design work for typed forms. They could be fixed in a non-breaking manner by piggybacking them on top of the new typed forms generics, but it would be much cleaner to fix them separately if possible.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, form status is described with just a plain string, and the return type of `statusChanges` is `Observable<any>`.

Issue Number: N/A


## What is the new behavior?
Form status uses a more specific type, which can only be a valid status string (specifically, the union of all possible statuses). Accordingly, `statusChanges` and friends are strongly typed.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Yes, this is a breaking change: some consumers will expect the status to be an arbitrary string, and after this change, it must be a valid status string. I ran a TGP in google3, and there were 20k broken tests, but I was able to fix them all by addressing only seven root causes by hand. Most root causes were type confusion regarding the `any` types we currently use in `statusChanges` (Googlers, see b/194913527). The very small number of root causes suggests external breakage will be minimal, and what breakage does occur is likely due to incorrect use of `statusChanges`. After discussion with Alex and Andrew K, we think that breakage should be minimal enough that no schematic is required.

Here is the breaking change blurb from the commit message:

A new type called `FormControlStatus` has been introduced, which is a union of all possible status strings for form controls. `AbstractControl.status` has been narrowed from `string` to `FormControlStatus`, and `statusChanges` has been narrowed from `Observable<any>` to `Observable<FormControlStatus>`. Most applications should consume the new types seamlessly. Any breakage caused by this change is likely due to one of the following two problems: (1) the app is comparing `AbstractControl.status` against a string which is not a valid status; or, (2) the app is using `statusChanges` events as if they were something other than strings.

## Other information

TGP went green two days ago after making the fixes in google3.