### PR TITLE
feat(forms): allow min/max validator to be bound to null

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -415,7 +415,7 @@ export class MaxLengthValidator implements Validator, OnChanges {
 
 // @public
 export class MaxValidator extends AbstractValidatorDirective implements OnChanges {
-    max: string | number;
+    max: string | number | null;
     ngOnChanges(changes: SimpleChanges): void;
 }
 
@@ -432,7 +432,7 @@ export class MinLengthValidator implements Validator, OnChanges {
 
 // @public
 export class MinValidator extends AbstractValidatorDirective implements OnChanges {
-    min: string | number;
+    min: string | number | null;
     ngOnChanges(changes: SimpleChanges): void;
 }
 

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -13,16 +13,24 @@ import {AbstractControl} from '../model';
 import {emailValidator, maxLengthValidator, maxValidator, minLengthValidator, minValidator, NG_VALIDATORS, nullValidator, patternValidator, requiredTrueValidator, requiredValidator} from '../validators';
 
 /**
- * @description
  * Method that updates string to integer if not alread a number
  *
  * @param value The value to convert to integer
  * @returns value of parameter in number or integer.
  */
-function toNumber(value: string|number): number {
+function toInteger(value: string|number): number {
   return typeof value === 'number' ? value : parseInt(value, 10);
 }
 
+/**
+ * Method that ensures that provided value is a float (and converts it to float if needed).
+ *
+ * @param value The value to convert to float
+ * @returns value of parameter in number or float.
+ */
+function toFloat(value: string|number): number {
+  return typeof value === 'number' ? value : parseFloat(value);
+}
 /**
  * @description
  * Defines the map of errors returned from failed validation checks.
@@ -124,7 +132,7 @@ abstract class AbstractValidatorDirective implements Validator {
   handleChanges(changes: SimpleChanges): void {
     if (this.inputName in changes) {
       const input = this.normalizeInput(changes[this.inputName].currentValue);
-      this._validator = this.createValidator(input);
+      this._validator = this.enabled() ? this.createValidator(input) : nullValidator;
       if (this._onChange) {
         this._onChange();
       }
@@ -139,6 +147,18 @@ abstract class AbstractValidatorDirective implements Validator {
   /** @nodoc */
   registerOnValidatorChange(fn: () => void): void {
     this._onChange = fn;
+  }
+
+  /**
+   * @description
+   * Determines whether this validator is active or not. Base class implementation
+   * checks whether an input is defined (if the value is different from `null` and `undefined`).
+   * Validator classes that extend this base class can override this function with the logic
+   * specific to a particular validator directive.
+   */
+  enabled(): boolean {
+    const inputValue = (this as unknown as {[key: string]: unknown})[this.inputName];
+    return inputValue != null /* both `null` and `undefined` */;
   }
 }
 
@@ -177,18 +197,18 @@ export const MAX_VALIDATOR: StaticProvider = {
   selector:
       'input[type=number][max][formControlName],input[type=number][max][formControl],input[type=number][max][ngModel]',
   providers: [MAX_VALIDATOR],
-  host: {'[attr.max]': 'max ?? null'}
+  host: {'[attr.max]': 'enabled() ? max : null'}
 })
 export class MaxValidator extends AbstractValidatorDirective implements OnChanges {
   /**
    * @description
    * Tracks changes to the max bound to this directive.
    */
-  @Input() max!: string|number;
+  @Input() max!: string|number|null;
   /** @internal */
   override inputName = 'max';
   /** @internal */
-  override normalizeInput = (input: string): number => parseFloat(input);
+  override normalizeInput = (input: string|number): number => toFloat(input);
   /** @internal */
   override createValidator = (max: number): ValidatorFn => maxValidator(max);
   /**
@@ -237,18 +257,18 @@ export const MIN_VALIDATOR: StaticProvider = {
   selector:
       'input[type=number][min][formControlName],input[type=number][min][formControl],input[type=number][min][ngModel]',
   providers: [MIN_VALIDATOR],
-  host: {'[attr.min]': 'min ?? null'}
+  host: {'[attr.min]': 'enabled() ? min : null'}
 })
 export class MinValidator extends AbstractValidatorDirective implements OnChanges {
   /**
    * @description
    * Tracks changes to the min bound to this directive.
    */
-  @Input() min!: string|number;
+  @Input() min!: string|number|null;
   /** @internal */
   override inputName = 'min';
   /** @internal */
-  override normalizeInput = (input: string): number => parseFloat(input);
+  override normalizeInput = (input: string|number): number => toFloat(input);
   /** @internal */
   override createValidator = (min: number): ValidatorFn => minValidator(min);
   /**
@@ -590,7 +610,7 @@ export class MinLengthValidator implements Validator, OnChanges {
 
   private _createValidator(): void {
     this._validator =
-        this.enabled() ? minLengthValidator(toNumber(this.minlength!)) : nullValidator;
+        this.enabled() ? minLengthValidator(toInteger(this.minlength!)) : nullValidator;
   }
 
   /** @nodoc */
@@ -672,7 +692,7 @@ export class MaxLengthValidator implements Validator, OnChanges {
 
   private _createValidator(): void {
     this._validator =
-        this.enabled() ? maxLengthValidator(toNumber(this.maxlength!)) : nullValidator;
+        this.enabled() ? maxLengthValidator(toInteger(this.maxlength!)) : nullValidator;
   }
 
   /** @nodoc */

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -2005,6 +2005,92 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              verifyValidatorAttrValues({minlength: null, maxlength: null});
              verifyFormState({isValid: true});
            }));
+
+        it('should not include the min and max validators for null', fakeAsync(() => {
+             @Component({
+               template:
+                   '<form><input type="number" name="minmaxinput" ngModel [min]="minlen" [max]="maxlen"></form>'
+             })
+             class MinLengthMaxLengthComponent {
+               minlen: number|null = null;
+               maxlen: number|null = null;
+               control!: FormControl;
+             }
+
+             const fixture = initTest(MinLengthMaxLengthComponent);
+             fixture.detectChanges();
+             tick();
+             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+
+             const form = fixture.debugElement.children[0].injector.get(NgForm);
+             const control =
+                 fixture.debugElement.children[0].injector.get(NgForm).control.get('minmaxinput')!;
+
+             interface minmax {
+               min: number|null;
+               max: number|null;
+             }
+
+             interface state {
+               isValid: boolean;
+               failedValidator?: string;
+             }
+
+             const setInputValue = (value: number) => {
+               input.value = value;
+               dispatchEvent(input, 'input');
+               fixture.detectChanges();
+             };
+             const verifyValidatorAttrValues = (values: {min: any, max: any}) => {
+               expect(input.getAttribute('min')).toBe(values.min);
+               expect(input.getAttribute('max')).toBe(values.max);
+             };
+             const setValidatorValues = (values: minmax) => {
+               fixture.componentInstance.minlen = values.min;
+               fixture.componentInstance.maxlen = values.max;
+               fixture.detectChanges();
+             };
+             const verifyFormState = (state: state) => {
+               expect(form.valid).toBe(state.isValid);
+               if (state.failedValidator) {
+                 expect(control!.hasError('min')).toEqual(state.failedValidator === 'min');
+                 expect(control!.hasError('max')).toEqual(state.failedValidator === 'max');
+               }
+             };
+
+             ////////// Actual test scenarios start below //////////
+             // 1. Verify that validators are disabled when input is `null`.
+             verifyValidatorAttrValues({min: null, max: null});
+             verifyValidatorAttrValues({min: null, max: null});
+
+             // 2. Verify that setting validator inputs (to a value different from `null`) activate
+             // validators.
+             setInputValue(12345);
+             setValidatorValues({min: 2, max: 4});
+             verifyValidatorAttrValues({min: '2', max: '4'});
+             verifyFormState({isValid: false, failedValidator: 'max'});
+
+             // 3. Changing value to the valid range should make the form valid.
+             setInputValue(3);
+             verifyFormState({isValid: true});
+
+             // 4. Changing value to trigger `minlength` validator.
+             setInputValue(1);
+             verifyFormState({isValid: false, failedValidator: 'min'});
+
+             // 5. Changing validator inputs to verify that attribute values are updated (and the
+             // form is now valid).
+             setInputValue(1);
+             setValidatorValues({min: 1, max: 5});
+             verifyValidatorAttrValues({min: '1', max: '5'});
+             verifyFormState({isValid: true});
+
+             // 6. Reset validator inputs back to `null` should deactivate validators.
+             setInputValue(123);
+             setValidatorValues({min: null, max: null});
+             verifyValidatorAttrValues({min: null, max: null});
+             verifyFormState({isValid: true});
+           }));
       });
 
       ['number', 'string'].forEach((inputType: string) => {


### PR DESCRIPTION
If the validator is bound o be
ull then no validation occurs and attribute is not added to DOM.

PR already raised for minLength and maxLength valdiator (https://github.com/angular/angular/pull/42565).
Changes were discussed in #42378

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Null data type is not supported

Issue Number: #42267.


## What is the new behavior?
Added support for null data type

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

This is one of many PR which is going to be raised for adding support of null validation. One can go through conversation here
#42378 (comment)
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
