### PR TITLE
docs: Fix wrongly provided/Injected AnimalService

### DIFF
--- a/aio/content/guide/hierarchical-dependency-injection.md
+++ b/aio/content/guide/hierarchical-dependency-injection.md
@@ -1021,8 +1021,8 @@ The logical tree representation shows why this is:
          @Inject(AnimalService, @Optional)=>"🦔">
     <!-- ^^@SkipSelf() starts here,  @Host() stops here^^ -->
     <app-child>
-      <#VIEW @Provide(AnimalService="🦔")
-             @Inject(AnimalService, @SkipSelf, @Host, @Optional)=>"🐶">
+      <#VIEW @Provide(AnimalService="🐶")
+             @Inject(AnimalService, @SkipSelf, @Host, @Optional)=>"🦔">
                <!-- Add @SkipSelf ^^-->
       </#VIEW>
       </app-child>


### PR DESCRIPTION
In the logical tree example which demonstrate the use of `@SkipSelf` and  `@Host`, the provided and injected `AnimalService` are reversed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the logical tree example which demonstrate the use of `@SkipSelf` and  `@Host`, the provided and injected `AnimalService` are reversed.
The `<app-child>` is providing hedgehog 🦔, instead of dog 🐶. And the injected value is a dog 🐶 instead of hedgehog 🦔

## What is the new behavior?
The `<app-child>` should provide a dog 🐶, instead of hedgehog 🦔. And the injected value should be a hedgehog 🦔 instead of dog 🐶.

The next section of the same documentation describe exactly what the new behavior should be:

"`@SkipSelf()`, causes the injector to start its search for the `AnimalService` at the `<app-root>`, not the `<app-child>`, where the request originates, and `@Host()` stops the search at the `<app-root>` `<#VIEW>`. Since `AnimalService` is provided by way of the `viewProviders` array, the injector finds 🦔 (hedgehog) in the `<#VIEW>`."

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
