### PR TITLE
feat(language-service): auto-apply optional chaining on nullable symbol

### DIFF
--- a/packages/language-service/ivy/test/completions_spec.ts
+++ b/packages/language-service/ivy/test/completions_spec.ts
@@ -806,7 +806,40 @@ describe('completions', () => {
       expectReplacementText(completions, templateFile.contents, '42');
     });
   });
+
+  describe('auto-apply optional chaining', () => {
+    it('should be able to complete on nullable symbol', () => {
+      const {templateFile} = setup('{{article.title}}', `article?: { title: string };`);
+      templateFile.moveCursorToText('{{article.title¦}}');
+      const completions = templateFile.getCompletionsAtPosition({
+        includeCompletionsWithInsertText: true,
+        includeAutomaticOptionalChainCompletions: true,
+      });
+      expectContainInsertText(completions, ts.ScriptElementKind.memberVariableElement, ['?.title']);
+      expectReplacementText(completions, templateFile.contents, '.title');
+    });
+
+    it('should be able to complete on NonNullable symbol', () => {
+      const {templateFile} = setup('{{article.title}}', `article: { title: string };`);
+      templateFile.moveCursorToText('{{article.title¦}}');
+      const completions = templateFile.getCompletionsAtPosition({
+        includeCompletionsWithInsertText: true,
+        includeAutomaticOptionalChainCompletions: true,
+      });
+      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
+      expectReplacementText(completions, templateFile.contents, 'title');
+    });
+  });
 });
+
+function expectContainInsertText(
+    completions: ts.CompletionInfo|undefined, kind: ts.ScriptElementKind|DisplayInfoKind,
+    insertTexts: string[]) {
+  expect(completions).toBeDefined();
+  for (const insertText of insertTexts) {
+    expect(completions!.entries).toContain(jasmine.objectContaining({insertText, kind} as any));
+  }
+}
 
 function expectContain(
     completions: ts.CompletionInfo|undefined, kind: ts.ScriptElementKind|DisplayInfoKind,


### PR DESCRIPTION
Support automatically inserts the optional chaining operator (`?.`)
when property access (`.`) is done on a nullable symbol.

Fixes https://github.com/angular/vscode-ng-language-service/issues/1094

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
