### PR TITLE
refactor(common): change encoding function in httpparams for better p…

### DIFF
--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -89,18 +89,28 @@ function paramParser(rawParams: string, codec: HttpParameterCodec): Map<string, 
   }
   return map;
 }
+
+/**
+ * Encode input string with standard encodeURIComponent and then un-encode specific characters.
+ */
+const STANDARD_ENCODING_REGEX = /%(\d[a-f0-9])/gi;
+const STANDARD_ENCODING_REPLACEMENTS: {[x: string]: string} = {
+  '40': '@',
+  '3A': ':',
+  '24': '$',
+  '2C': ',',
+  '3B': ';',
+  '2B': '+',
+  '3D': '=',
+  '3F': '?',
+  '2F': '/',
+};
+
 function standardEncoding(v: string): string {
-  return encodeURIComponent(v)
-      .replace(/%40/gi, '@')
-      .replace(/%3A/gi, ':')
-      .replace(/%24/gi, '$')
-      .replace(/%2C/gi, ',')
-      .replace(/%3B/gi, ';')
-      .replace(/%2B/gi, '+')
-      .replace(/%3D/gi, '=')
-      .replace(/%3F/gi, '?')
-      .replace(/%2F/gi, '/');
+  return encodeURIComponent(v).replace(
+      STANDARD_ENCODING_REGEX, (s, t) => STANDARD_ENCODING_REPLACEMENTS[t] ?? s);
 }
+
 function valueToString(value: string|number|boolean): string {
   return `${value}`;
 }

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -174,6 +174,15 @@ import {HttpParams} from '@angular/common/http/src/params';
       });
     });
 
+    describe('encoding', () => {
+      it('should encode parameters', () => {
+        const body = new HttpParams({fromString: 'a=standard_chars'});
+        expect(body.toString()).toEqual('a=standard_chars');
+        const body2 = new HttpParams({fromString: 'a=1 2 3&b=mail@test&c=3_^[]$&d=eq=1'});
+        expect(body2.toString()).toEqual('a=1%202%203&b=mail@test&c=3_%5E%5B%5D$&d=eq=1');
+      });
+    });
+
     describe('toString', () => {
       it('should stringify string params', () => {
         const body = new HttpParams({fromObject: {a: '', b: '2', c: '3'}});


### PR DESCRIPTION
…erformances and coding standards

HttpParams uses custom encoding function "standardEncoding" to encode query string preserving specific charachters. This refactoring aims to improve performances and code quality of that function by using a RegExp and a Map object instead of a chain of replace functions.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Parameters string passes through encodeURIComponent and then into a chain of replace that un-encodes some characters.
Although it has been pointed out that this behaviour is non-standard and hard to understand for some developers (cfr. #19710) this commit doesn't change the function's output but only improves its internals.

## What is the new behavior?

The new function produces the same output but using an object for better readability and a single `replace` operation with better performances.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
