### PR TITLE
fix(compiler-cli): Emit type annotations for synthesized decorator fi…

### DIFF
--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -715,7 +715,7 @@ describe('ngc transformer command-line', () => {
         const mymoduleSource = fs.readFileSync(mymodulejs, 'utf8');
         expect(mymoduleSource).toContain('@fileoverview added by tsickle');
         expect(mymoduleSource).toContain('@param {?} p');
-        expect(mymoduleSource).toMatch(/\/\*\* @nocollapse \*\/\s+MyComp\.ctorParameters = /);
+        expect(mymoduleSource).toContain('@nocollapse');
       });
     });
 

--- a/packages/compiler-cli/test/transformers/downlevel_decorators_transform_spec.ts
+++ b/packages/compiler-cli/test/transformers/downlevel_decorators_transform_spec.ts
@@ -424,11 +424,18 @@ describe('downlevel decorator transform', () => {
 
     expect(diagnostics.length).toBe(0);
     expect(output).toContain(dedent`
+      /** @type {!Array<{type: !Function, args: (undefined|!Array<?>)}>} */
       MyDir.decorators = [
         { type: core_1.Directive }
       ];
-      /** @nocollapse */
-      MyDir.ctorParameters = () => [
+      /**
+       * @type {function(): !Array<(null|{
+       *   type: ?,
+       *   decorators: (undefined|!Array<{type: !Function, args: (undefined|!Array<?>)}>),
+       * })>}
+       * @nocollapse
+       */
+       MyDir.ctorParameters = () => [
         { type: ClassInject }
       ];
     `);


### PR DESCRIPTION
…elds

Previously, the decorator transformer was annotating the synthesized properties with TS type annotations. However, because it ran after the JSDoc transformer, the TS types were just dropped from the emitted JS. Attempting to move the decorator transformer before the JSDoc transformer causes tsickle crashes because synthetic AST fragments are not attached to a SourceFile node.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
