### PR TITLE
docs: drop IE 11 from browser compatibility docs

### DIFF
--- a/aio/content/guide/browser-support.md
+++ b/aio/content/guide/browser-support.md
@@ -20,13 +20,6 @@ Angular supports most recent browsers. This includes the following specific vers
     <td>2 most recent major versions</td>
   </tr>
   <tr>
-    <td>IE</td>
-    <td>
-      11<br>
-      <em>*deprecated, see the <a href="guide/deprecations#internet-explorer-11">deprecations guide</a></em>
-    </td>
-  </tr>
-  <tr>
     <td>Safari</td>
     <td>2 most recent major versions</td>
   </tr>
@@ -48,16 +41,6 @@ using [Sauce Labs](https://saucelabs.com/) and
 [BrowserStack](https://www.browserstack.com/).
 
 </div>
-
-
-{@a ie11}
-## Configuring Angular CLI for compatibility with IE11
-
-While Angular supports all browsers listed above, in order to improve the build times and output,  Angular CLI applications don't support IE11 by default.
-
-Angular CLI uses [`browserlist`](https://github.com/browserslist/browserslist) to configure browser support for applications.
-
-You can enable the IE11 support by following the instructions in the `.browserslistrc` file at the root of your project.
 
 ## Polyfills
 
@@ -138,20 +121,8 @@ Some features of Angular may require additional polyfills.
     </td>
     <td>
       <p>If AnimationBuilder is used, enables scrubbing
-      support for IE/Edge and Safari.
+      support for Edge and Safari.
       (Chrome and Firefox support this natively).</p>
-    </td>
-  </tr>
-
-  <tr style="vertical-align: top">
-    <td>
-      <a href="api/common/NgClass">NgClass</a> on SVG elements
-    </td>
-    <td>
-      <a href="guide/browser-support#classlist">classList</a>
-    </td>
-    <td>
-      IE 11
     </td>
   </tr>
 </table>
@@ -171,17 +142,6 @@ The following polyfills are used to test the framework itself. They are a good s
     <th>
       Size*
     </th>
-  </tr>
-  <tr>
-    <td>
-      <a id='classlist' href="https://github.com/eligrey/classList.js">classList</a>
-    </td>
-    <td>
-      Public domain
-    </td>
-    <td>
-      1KB
-    </td>
   </tr>
   <tr>
     <td>
@@ -222,8 +182,8 @@ For example:
     // __Zone_disable_on_property = true; // disable patch onProperty such as onclick
     // __zone_symbol__UNPATCHED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
     /*
-     * in IE/Edge developer tools, the addEventListener will also be wrapped by zone.js
-     * with the following flag, it will bypass `zone.js` patch for IE/Edge
+     * in Edge developer tools, the addEventListener will also be wrapped by zone.js
+     * with the following flag, it will bypass `zone.js` patch for Edge
      */
     // __Zone_enable_cross_context_check = true;
   &lt;/script>

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -443,14 +443,6 @@ If you rely on the behavior that the same object instance should cause change de
 - Clone the resulting value so that it has a new identity.
 - Explicitly call [`ChangeDetectorRef.detectChanges()`](api/core/ChangeDetectorRef#detectchanges) to force the update.
 
-### Internet Explorer 11
-Angular support for Microsoft's Internet Explorer 11 (IE11) is deprecated and will be removed in Angular v13.
-Ending IE11 support allows Angular to take advantage of web platform APIs present only in evergreen browsers, resulting in better APIs for developers and more capabilities for application users.
-An additional motivation behind this removal is the drop in global usage of IE11 to just ~1% (as of March 2021).
-For full rationale and discussion behind this deprecation see [RFC: Internet Explorer 11 support deprecation and removal](https://github.com/angular/angular/issues/41840).
-
-*Note: IE11 will be supported in Angular v12 LTS releases through November 2022.*
-
 {@a deprecated-cli-flags}
 ## Deprecated CLI APIs and Options
 


### PR DESCRIPTION
Support for IE 11 was deprecated in v12 and in v13 the support is fully dropped. This commit updates the browser compatibility docs and removes IE 11 as a supported browser.

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No