### PR TITLE
build(docs-infra): upgrade cli command docs sources to cf835b898

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -18,7 +18,7 @@
     "build-local": "yarn ~~build",
     "prebuild-local-ci": "yarn setup-local-ci",
     "build-local-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 129d45cfa",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js cf835b898",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#master](https://github.com/angular/angular/tree/master) from [cli-builds#master](https://github.com/angular/cli-builds/tree/master).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/129d45cfa...cf835b898):

**Modified**
- help/build.json
- help/e2e.json
- help/serve.json

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/edfd9b4ae...cf835b898) since PR #43024:

**Modified**
- help/build.json
- help/serve.json

##
Closes #43024