### PR TITLE
docs: fix interval type in the example

### DIFF
--- a/aio/content/examples/dynamic-component-loader/src/app/ad-banner.component.ts
+++ b/aio/content/examples/dynamic-component-loader/src/app/ad-banner.component.ts
@@ -21,7 +21,7 @@ export class AdBannerComponent implements OnInit, OnDestroy {
   @Input() ads: AdItem[] = [];
   currentAdIndex = -1;
   @ViewChild(AdDirective, {static: true}) adHost!: AdDirective;
-  interval: any;
+  interval: number | undefined;
 
   constructor(private componentFactoryResolver: ComponentFactoryResolver) { }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

`window.setInterval` returns a `number`, but the example is using `any`.


Issue Number: N/A


## What is the new behavior?

The new behavior is to use the correct type for `setInterval`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

~TypeScript can be confused between nodeJS and browser `setInterval`, using `window.setInterval` instead of the implicit `setInterval` remove this issue.~