### PR TITLE
docs: release notes for the v12.1.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="12.1.5"></a>
+# 12.1.5 (2021-08-04)
+This release contains various API docs improvements.
+
+
 <a name="12.2.0-rc.0"></a>
 # 12.2.0-rc.0 (2021-07-28)
 ### compiler-cli


### PR DESCRIPTION
Cherry-picks the changelog from the "12.1.x" branch to the next branch (master).