### PR TITLE
fix(core): add pure annotations to static property initializers

### DIFF
--- a/packages/animations/browser/src/render/animation_driver.ts
+++ b/packages/animations/browser/src/render/animation_driver.ts
@@ -47,7 +47,7 @@ export class NoopAnimationDriver implements AnimationDriver {
  * @publicApi
  */
 export abstract class AnimationDriver {
-  static NOOP: AnimationDriver = new NoopAnimationDriver();
+  static NOOP: AnimationDriver = /* @__PURE__ */ new NoopAnimationDriver();
 
   abstract validateStyleProperty(prop: string): boolean;
 

--- a/packages/animations/browser/src/render/special_cased_styles.ts
+++ b/packages/animations/browser/src/render/special_cased_styles.ts
@@ -44,7 +44,7 @@ export function packageNonAnimatableStyles(
  * `destroy()` is called then all styles will be removed.
  */
 export class SpecialCasedStyles {
-  static initialStylesByElement = new WeakMap<any, {[key: string]: any}>();
+  static initialStylesByElement = /* @__PURE__ */ new WeakMap<any, {[key: string]: any}>();
 
   private _state = SpecialCasedStylesState.Pending;
   private _initialStyles!: {[key: string]: any};

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -59,7 +59,7 @@ export const INJECTOR_IMPL = INJECTOR_IMPL__PRE_R3__;
  */
 export abstract class Injector {
   static THROW_IF_NOT_FOUND = THROW_IF_NOT_FOUND;
-  static NULL: Injector = new NullInjector();
+  static NULL: Injector = /* @__PURE__ */ new NullInjector();
 
   /**
    * Retrieves an instance from the injector based on the provided token.

--- a/packages/core/src/di/reflective_injector.ts
+++ b/packages/core/src/di/reflective_injector.ts
@@ -270,7 +270,7 @@ export abstract class ReflectiveInjector implements Injector {
 }
 
 export class ReflectiveInjector_ implements ReflectiveInjector {
-  private static INJECTOR_KEY = ReflectiveKey.get(Injector);
+  private static INJECTOR_KEY = /* @__PURE__ */ ReflectiveKey.get(Injector);
   /** @internal */
   _constructionCounter: number = 0;
   /** @internal */

--- a/packages/core/src/linker/component_factory_resolver.ts
+++ b/packages/core/src/linker/component_factory_resolver.ts
@@ -46,7 +46,7 @@ of the code in this cookbook
  * @publicApi
  */
 export abstract class ComponentFactoryResolver {
-  static NULL: ComponentFactoryResolver = new _NullComponentFactoryResolver();
+  static NULL: ComponentFactoryResolver = /* @__PURE__ */ new _NullComponentFactoryResolver();
   /**
    * Retrieves the factory object that creates a component of the given type.
    * @param component The component type.


### PR DESCRIPTION
Class static properties with initializers that cause code execution (for example, call expressions or new expressions) have the potential to cause side effects at module evaluation. This is similar in effect to module level code. As a result, optimizers can not safely remove a class with such a static property as the potential side effects may have meaningful effects on the state of the application execution. To allow classes with these type of static properties to be optimized and removed if unused, the initializer expressions for the static properties can be annotated as pure. This annotation provides a signal to an optimizer that the expression does not have any potential side effects and is useful in cases where static analysis can not currently prove that there are, in fact, no side effects caused by the initializer.

This supports addressing the size regressions in #42598

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
