### PR TITLE
fix(dev-infra): search since HEAD on the local branch for version tags when creating stamps

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -7765,7 +7765,7 @@ function getSCMVersions(mode) {
         const git = GitClient.get();
         if (mode === 'snapshot') {
             const localChanges = hasLocalChanges() ? '.with-local-changes' : '';
-            const { stdout: rawVersion } = git.run(['describe', '--match', '*[0-9]*.[0-9]*.[0-9]*', '--abbrev=7', '--tags', 'HEAD~100']);
+            const { stdout: rawVersion } = git.run(['describe', '--match', '*[0-9]*.[0-9]*.[0-9]*', '--abbrev=7', '--tags', 'HEAD']);
             const { version } = new semver.SemVer(rawVersion);
             const { version: experimentalVersion } = createExperimentalSemver(version);
             return {

--- a/dev-infra/release/stamping/env-stamp.ts
+++ b/dev-infra/release/stamping/env-stamp.ts
@@ -56,8 +56,8 @@ function getSCMVersions(mode: EnvStampMode): {version: string, experimentalVersi
     const git = GitClient.get();
     if (mode === 'snapshot') {
       const localChanges = hasLocalChanges() ? '.with-local-changes' : '';
-      const {stdout: rawVersion} = git.run(
-          ['describe', '--match', '*[0-9]*.[0-9]*.[0-9]*', '--abbrev=7', '--tags', 'HEAD~100']);
+      const {stdout: rawVersion} =
+          git.run(['describe', '--match', '*[0-9]*.[0-9]*.[0-9]*', '--abbrev=7', '--tags', 'HEAD']);
       const {version} = new SemVer(rawVersion);
       const {version: experimentalVersion} = createExperimentalSemver(version);
       return {


### PR DESCRIPTION
Using `HEAD~100` was errantly left in the snapshot stamping logic.
