### PR TITLE
fix(router): null/undefined routerLink should disable navigation

### DIFF
--- a/goldens/public-api/router/router.md
+++ b/goldens/public-api/router/router.md
@@ -524,7 +524,7 @@ export class RouterEvent {
 
 // @public
 export class RouterLink implements OnChanges {
-    constructor(router: Router, route: ActivatedRoute, tabIndex: string, renderer: Renderer2, el: ElementRef);
+    constructor(router: Router, route: ActivatedRoute, tabIndexAttribute: string | null | undefined, renderer: Renderer2, el: ElementRef);
     fragment?: string;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
@@ -541,7 +541,7 @@ export class RouterLink implements OnChanges {
         [k: string]: any;
     };
     // (undocumented)
-    get urlTree(): UrlTree;
+    get urlTree(): UrlTree | null;
 }
 
 // @public
@@ -571,7 +571,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
     constructor(router: Router, route: ActivatedRoute, locationStrategy: LocationStrategy);
     fragment?: string;
     // (undocumented)
-    href: string;
+    href: string | null;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): any;
     // (undocumented)
@@ -591,7 +591,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
     // (undocumented)
     target: string;
     // (undocumented)
-    get urlTree(): UrlTree;
+    get urlTree(): UrlTree | null;
 }
 
 // @public

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1428,9 +1428,6 @@
     "name": "getSelectedIndex"
   },
   {
-    "name": "getSelectedTNode"
-  },
-  {
     "name": "getSimpleChangesStore"
   },
   {
@@ -1516,9 +1513,6 @@
   },
   {
     "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isAnimationProp"
   },
   {
     "name": "isArray"
@@ -1905,9 +1899,6 @@
     "name": "setInjectImplementation"
   },
   {
-    "name": "setInputsForProperty"
-  },
-  {
     "name": "setInputsFromAttrs"
   },
   {
@@ -2092,9 +2083,6 @@
   },
   {
     "name": "ɵɵelementStart"
-  },
-  {
-    "name": "ɵɵhostProperty"
   },
   {
     "name": "ɵɵinject"

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -180,17 +180,32 @@ export class RouterLink implements OnChanges {
    */
   @Input() relativeTo?: ActivatedRoute|null;
 
-  private commands: any[] = [];
-  private preserve!: boolean;
+  private commands: any[]|null = null;
 
   /** @internal */
   onChanges = new Subject<RouterLink>();
 
   constructor(
       private router: Router, private route: ActivatedRoute,
-      @Attribute('tabindex') tabIndex: string, renderer: Renderer2, el: ElementRef) {
-    if (tabIndex == null) {
-      renderer.setAttribute(el.nativeElement, 'tabindex', '0');
+      @Attribute('tabindex') private readonly tabIndexAttribute: string|null|undefined,
+      private readonly renderer: Renderer2, private readonly el: ElementRef) {
+    this.setTabIndexIfNotOnNativeEl('0');
+  }
+
+  /**
+   * Modifies the tab index if there was not a tabindex attribute on the element during
+   * instantiation.
+   */
+  private setTabIndexIfNotOnNativeEl(newTabIndex: string|null) {
+    if (this.tabIndexAttribute != null /* both `null` and `undefined` */) {
+      return;
+    }
+    const renderer = this.renderer;
+    const nativeElement = this.el.nativeElement;
+    if (newTabIndex !== null) {
+      renderer.setAttribute(nativeElement, 'tabindex', newTabIndex);
+    } else {
+      renderer.removeAttribute(nativeElement, 'tabindex');
     }
   }
 
@@ -205,21 +220,27 @@ export class RouterLink implements OnChanges {
    * Commands to pass to {@link Router#createUrlTree Router#createUrlTree}.
    *   - **array**: commands to pass to {@link Router#createUrlTree Router#createUrlTree}.
    *   - **string**: shorthand for array of commands with just the string, i.e. `['/route']`
-   *   - **null|undefined**: shorthand for an empty array of commands, i.e. `[]`
+   *   - **null|undefined**: effectively disables the `routerLink`
    * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   @Input()
   set routerLink(commands: any[]|string|null|undefined) {
     if (commands != null) {
       this.commands = Array.isArray(commands) ? commands : [commands];
+      this.setTabIndexIfNotOnNativeEl('0');
     } else {
-      this.commands = [];
+      this.commands = null;
+      this.setTabIndexIfNotOnNativeEl(null);
     }
   }
 
   /** @nodoc */
   @HostListener('click')
   onClick(): boolean {
+    if (this.urlTree === null) {
+      return true;
+    }
+
     const extras = {
       skipLocationChange: attrBoolValue(this.skipLocationChange),
       replaceUrl: attrBoolValue(this.replaceUrl),
@@ -229,7 +250,10 @@ export class RouterLink implements OnChanges {
     return true;
   }
 
-  get urlTree(): UrlTree {
+  get urlTree(): UrlTree|null {
+    if (this.commands === null) {
+      return null;
+    }
     return this.router.createUrlTree(this.commands, {
       // If the `relativeTo` input is not defined, we want to use `this.route` by default.
       // Otherwise, we should use the value provided by the user in the input.
@@ -320,14 +344,13 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
    */
   @Input() relativeTo?: ActivatedRoute|null;
 
-  private commands: any[] = [];
+  private commands: any[]|null = null;
   private subscription: Subscription;
-  // TODO(issue/24571): remove '!'.
-  private preserve!: boolean;
 
   // the url displayed on the anchor element.
-  // TODO(issue/24571): remove '!'.
-  @HostBinding() href!: string;
+  // @HostBinding('attr.href') is used rather than @HostBinding() because it removes the
+  // href attribute when it becomes `null`.
+  @HostBinding('attr.href') href: string|null = null;
 
   /** @internal */
   onChanges = new Subject<RouterLinkWithHref>();
@@ -346,7 +369,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
    * Commands to pass to {@link Router#createUrlTree Router#createUrlTree}.
    *   - **array**: commands to pass to {@link Router#createUrlTree Router#createUrlTree}.
    *   - **string**: shorthand for array of commands with just the string, i.e. `['/route']`
-   *   - **null|undefined**: shorthand for an empty array of commands, i.e. `[]`
+   *   - **null|undefined**: Disables the link by removing the `href`
    * @see {@link Router#createUrlTree Router#createUrlTree}
    */
   @Input()
@@ -354,7 +377,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
     if (commands != null) {
       this.commands = Array.isArray(commands) ? commands : [commands];
     } else {
-      this.commands = [];
+      this.commands = null;
     }
   }
 
@@ -378,7 +401,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
       return true;
     }
 
-    if (typeof this.target === 'string' && this.target != '_self') {
+    if (typeof this.target === 'string' && this.target != '_self' || this.urlTree === null) {
       return true;
     }
 
@@ -392,10 +415,15 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   }
 
   private updateTargetUrlAndHref(): void {
-    this.href = this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(this.urlTree));
+    this.href = this.urlTree !== null ?
+        this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(this.urlTree)) :
+        null;
   }
 
-  get urlTree(): UrlTree {
+  get urlTree(): UrlTree|null {
+    if (this.commands === null) {
+      return null;
+    }
     return this.router.createUrlTree(this.commands, {
       // If the `relativeTo` input is not defined, we want to use `this.route` by default.
       // Otherwise, we should use the value provided by the user in the input.

--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -172,7 +172,8 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
         this.routerLinkActiveOptions :
         // While the types should disallow `undefined` here, it's possible without strict inputs
         (this.routerLinkActiveOptions.exact || false);
-    return (link: RouterLink|RouterLinkWithHref) => router.isActive(link.urlTree, options);
+    return (link: RouterLink|RouterLinkWithHref) =>
+               link.urlTree ? router.isActive(link.urlTree, options) : false;
   }
 
   private hasActiveLinks(): boolean {

--- a/packages/router/test/router_link_spec.ts
+++ b/packages/router/test/router_link_spec.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {Router} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
+
+describe('RouterLink', () => {
+  it('does not modify tabindex if already set on non-anchor element', () => {
+    @Component({template: `<div [routerLink]="link" tabindex="1"></div>`})
+    class LinkComponent {
+      link: string|null|undefined = '/';
+    }
+    TestBed.configureTestingModule({imports: [RouterTestingModule], declarations: [LinkComponent]});
+    const fixture = TestBed.createComponent(LinkComponent);
+    fixture.detectChanges();
+    const link = fixture.debugElement.query(By.css('div')).nativeElement;
+    expect(link.tabIndex).toEqual(1);
+
+    fixture.nativeElement.link = null;
+    fixture.detectChanges();
+    expect(link.tabIndex).toEqual(1);
+  });
+
+  describe('on a non-anchor', () => {
+    @Component({template: `<div [routerLink]="link"></div>`})
+    class LinkComponent {
+      link: string|null|undefined = '/';
+    }
+    let fixture: ComponentFixture<LinkComponent>;
+    let link: HTMLDivElement;
+    let router: Router;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule(
+          {imports: [RouterTestingModule], declarations: [LinkComponent]});
+      fixture = TestBed.createComponent(LinkComponent);
+      fixture.detectChanges();
+      link = fixture.debugElement.query(By.css('div')).nativeElement;
+      router = TestBed.inject(Router);
+
+      spyOn(router, 'navigateByUrl');
+      link.click();
+      expect(router.navigateByUrl).toHaveBeenCalled();
+      (router.navigateByUrl as jasmine.Spy).calls.reset();
+    });
+
+    it('null, removes tabIndex and does not navigate', () => {
+      fixture.componentInstance.link = null;
+      fixture.detectChanges();
+      expect(link.tabIndex).toEqual(-1);
+
+      link.click();
+      expect(router.navigateByUrl).not.toHaveBeenCalled();
+    });
+
+    it('undefined, removes tabIndex and does not navigate', () => {
+      fixture.componentInstance.link = undefined;
+      fixture.detectChanges();
+      expect(link.tabIndex).toEqual(-1);
+
+      link.click();
+      expect(router.navigateByUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('RouterLinkWithHref', () => {
+    @Component({template: `<a [routerLink]="link"></a>`})
+    class LinkComponent {
+      link: string|null|undefined = '/';
+    }
+    let fixture: ComponentFixture<LinkComponent>;
+    let link: HTMLAnchorElement;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule(
+          {imports: [RouterTestingModule], declarations: [LinkComponent]});
+      fixture = TestBed.createComponent(LinkComponent);
+      fixture.detectChanges();
+      link = fixture.debugElement.query(By.css('a')).nativeElement;
+    });
+
+    it('null, removes href', () => {
+      expect(link.outerHTML).toContain('href');
+      fixture.componentInstance.link = null;
+      fixture.detectChanges();
+      expect(link.outerHTML).not.toContain('href');
+    });
+
+    it('undefined, removes href', () => {
+      expect(link.outerHTML).toContain('href');
+      fixture.componentInstance.link = undefined;
+      fixture.detectChanges();
+      expect(link.outerHTML).not.toContain('href');
+    });
+  });
+});


### PR DESCRIPTION
The current behavior of `routerLink` for `null` and `undefined` inputs is to treat
the input the same as `[]`. This creates several unresolvable issues with
correctly disabling the links because `commands = []` does _not_ behave the same
as disabling a link. Instead, it navigates to the current page, but will also
clear any fragment and/or query params.

The new behavior of the `routerLink` input will be to completely disable navigation
for `null` and `undefined` inputs. For HTML Anchor elements, this will also mean
removing the `href` attribute.

Fixes #21457
Fixes #13980
Fixes #31154

BREAKING CHANGE:
Previously `null` and `undefined` inputs for `routerLink` were
equaivalent to empty string and there was no way to disable the link's
navigation.
In addition, the `href` is changed from a property `HostBinding()` to an
attribute binding (`HostBinding('attr.href')`). The effect of this
change is that `DebugElement.properties['href']` will now return the
`href` value returned by the native element which will be the full URL
rather than the internal value of the `RouterLink` `href` property.
