### PR TITLE
fix(docs-infra): correctly detect chunk load errors

### DIFF
--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.ts
@@ -149,7 +149,7 @@ export class DocViewerComponent implements OnDestroy {
           this.setNoIndex(true);
 
           // TODO(gkalpak): Remove this once gathering debug info is no longer needed.
-          if (/loading chunk \d+ failed/i.test(errorMessage)) {
+          if (/loading chunk \S+ failed/i.test(errorMessage)) {
             // Print some info to help with debugging.
             // (There is no reason to wait for this async call to complete before continuing.)
             printSwDebugInfo();


### PR DESCRIPTION
It seems that at some point (potentially with the switch to Webpack 5) Webpack started using the full chunk name (instead of just a numeric identifier) in `ChunkLoadError` messages. So the error messages changed from:
```
ChunkLoadError: Loading chunk 2 failed.
```

...to:
```
ChunkLoadError: Loading chunk src_app_something_some_module_ts failed.
```

This commit updates the regex that is used to detect such errors (in order to print ServiceWorker-related debug info) to correctly recognize both error message formats.
