### PR TITLE
refactor(core): replace references to goog.LOCALE with goog.getLocale()

### DIFF
--- a/packages/core/src/application_module.ts
+++ b/packages/core/src/application_module.ts
@@ -44,16 +44,16 @@ export function _localeFactory(locale?: string): string {
 /**
  * Work out the locale from the potential global properties.
  *
- * * Closure Compiler: use `goog.LOCALE`.
+ * * Closure Compiler: use `goog.getLocale()`.
  * * Ivy enabled: use `$localize.locale`
  */
 export function getGlobalLocale(): string {
   if (typeof ngI18nClosureMode !== 'undefined' && ngI18nClosureMode &&
-      typeof goog !== 'undefined' && goog.LOCALE !== 'en') {
-    // * The default `goog.LOCALE` value is `en`, while Angular used `en-US`.
+      typeof goog !== 'undefined' && goog.getLocale() !== 'en') {
+    // * The default `goog.getLocale()` value is `en`, while Angular used `en-US`.
     // * In order to preserve backwards compatibility, we use Angular default value over
     //   Closure Compiler's one.
-    return goog.LOCALE;
+    return goog.getLocale();
   } else {
     // KEEP `typeof $localize !== 'undefined' && $localize.locale` IN SYNC WITH THE LOCALIZE
     // COMPILE-TIME INLINER.

--- a/packages/goog.d.ts
+++ b/packages/goog.d.ts
@@ -18,6 +18,7 @@ declare namespace goog {
   export const DEBUG: boolean;
   export const LOCALE: string;
   export const getMsg: (input: string, placeholders?: {[key: string]: string}) => string;
+  export const getLocale: () => string;
 }
 
 /**


### PR DESCRIPTION
It is necessary in order to distinguish 2 different reasons for referencing the compiled-in locale.

1. Some code just needs to pass the locale value on to logic that actually uses it.
2. Other code uses the locale value to select locale-specific user-visible data and behavior.

Code modified by this change is of the first kind and should use `goog.getLocale()` in the future.

Note: there are still references to the `goog.LOCALE` in Angular codebase, but they are of second type.


## PR Type
What kind of change does this PR introduce?

- [ ] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No