### PR TITLE
build(dev-infra):exlude-commit-message-filter-from-formatting

### DIFF
--- a/.ng-dev/format.ts
+++ b/.ng-dev/format.ts
@@ -24,6 +24,7 @@ export const format: FormatConfig = {
       // Do not format generated ng-dev script
       '!dev-infra/ng-dev.js',
       '!dev-infra/build-worker.js',
+      '!dev-infra/commit-message-filter.js',
       // Do not format compliance test-cases since they must match generated code
       '!packages/compiler-cli/test/compliance/test_cases/**/*.js',
       // Do not format the locale files which are checked-in for Google3, but generated using

--- a/dev-infra/commit-message-filter.js
+++ b/dev-infra/commit-message-filter.js
@@ -1,1 +1,2 @@
+//tslint:disable
 pr/merge/strategies/commit-message-filter.js


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [*] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [*] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Right now when running yarn lint, it fails due to commit-message-filter.js not exluded from ts-lint.

![image](https://user-images.githubusercontent.com/28726265/128764958-23ecb235-a4fc-4751-85fb-92181b1a4f0c.png)


## What is the new behavior?
No errors on `yarn lint `and prevent format by clang format.

## Does this PR introduce a breaking change?

- [ ] Yes
- [*] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
