### PR TITLE
Revert "build(dev-infra): exlude commit message filter from formatting (#43091)"

### DIFF
--- a/.ng-dev/format.ts
+++ b/.ng-dev/format.ts
@@ -24,7 +24,6 @@ export const format: FormatConfig = {
       // Do not format generated ng-dev script
       '!dev-infra/ng-dev.js',
       '!dev-infra/build-worker.js',
-      '!dev-infra/commit-message-filter.js',
       // Do not format compliance test-cases since they must match generated code
       '!packages/compiler-cli/test/compliance/test_cases/**/*.js',
       // Do not format the locale files which are checked-in for Google3, but generated using

--- a/dev-infra/commit-message-filter.js
+++ b/dev-infra/commit-message-filter.js
@@ -1,2 +1,1 @@
-//tslint:disable
 pr/merge/strategies/commit-message-filter.js


### PR DESCRIPTION
This reverts commit 7edb1282213854ffb1ae0a1a6a3bdc6abdcb3faf.

The reason for the revert is the breakage of the merge tooling (`dev-infra/commit-message-filter.js: No such file or directory`).