### PR TITLE
Couple of release notes generator fixes

### DIFF
--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -5653,7 +5653,10 @@ class RenderContext {
          * of the group title.
          */
         const commitGroups = Array.from(groups.entries())
-            .map(([title, commits]) => ({ title, commits }))
+            .map(([title, commits]) => ({
+            title,
+            commits: commits.sort((a, b) => a.type > b.type ? 1 : a.type < b.type ? -1 : 0)
+        }))
             .sort((a, b) => a.title > b.title ? 1 : a.title < b.title ? -1 : 0);
         // If the configuration provides a sorting order, updated the sorted list of group keys to
         // satisfy the order of the groups provided in the list with any groups not found in the list at

--- a/dev-infra/ng-dev.js
+++ b/dev-infra/ng-dev.js
@@ -5733,6 +5733,12 @@ class RenderContext {
     replaceCommitHeaderPullRequestNumber(header) {
         return header.replace(/\(#(\d+)\)$/, (_, g) => `(${this.pullRequestToLink(+g)})`);
     }
+    /**
+     * Bulletize a paragraph.
+     */
+    bulletizeText(text) {
+        return '- ' + text.replace(/\\n/g, '\\n  ');
+    }
 }
 /**
  * Builds a date stamp for stamping in release notes.
@@ -5784,14 +5790,8 @@ _%>
   for (const group of asCommitGroups(breakingChanges)) {
 _%>
 ### <%- group.title %>
-
+<%- group.commits.map(commit => bulletizeText(commit.breakingChanges[0].text)).join('\\n\\n') %>
 <%_
-    for (const commit of group.commits) {
-_%>
-<%- commit.breakingChanges[0].text %>
-
-<%_
-    }
   }
 }
 _%>
@@ -5805,13 +5805,8 @@ _%>
   for (const group of asCommitGroups(deprecations)) {
 _%>
 ### <%- group.title %>
-
+<%- group.commits.map(commit => bulletizeText(commit.deprecations[0].text)).join('\\n\\n') %>
 <%_
-    for (const commit of group.commits) {
-_%>
-<%- commit.deprecations[0].text %>
-<%_
-    }
   }
 }
 _%>
@@ -5876,14 +5871,8 @@ _%>
   for (const group of asCommitGroups(breakingChanges)) {
 _%>
 ### <%- group.title %>
-
+<%- group.commits.map(commit => bulletizeText(commit.breakingChanges[0].text)).join('\\n\\n') %>
 <%_
-    for (const commit of group.commits) {
-_%>
-<%- commit.breakingChanges[0].text %>
-
-<%_
-    }
   }
 }
 _%>
@@ -5897,19 +5886,19 @@ _%>
   for (const group of asCommitGroups(deprecations)) {
 _%>
 ### <%- group.title %>
-
+<%- group.commits.map(commit => bulletizeText(commit.deprecations[0].text)).join('\\n\\n') %>
 <%_
-    for (const commit of group.commits) {
-_%>
-<%- commit.deprecations[0].text %>
-<%_
-    }
   }
 }
 _%>
 
 <%_
-const authors = commits.filter(unique('author')).map(c => c.author).sort();
+const botsAuthorName = ['dependabot[bot]', 'Renovate Bot'];
+const authors = commits
+  .filter(unique('author'))
+  .map(c => c.author)
+  .filter(a => !botsAuthorName.includes(a))
+  .sort();
 if (authors.length === 1) {
 _%>
 ## Special Thanks:

--- a/dev-infra/release/notes/context.ts
+++ b/dev-infra/release/notes/context.ts
@@ -69,9 +69,13 @@ export class RenderContext {
      * Array of CommitGroups containing the discovered commit groups. Sorted in alphanumeric order
      * of the group title.
      */
-    const commitGroups = Array.from(groups.entries())
-                             .map(([title, commits]) => ({title, commits}))
-                             .sort((a, b) => a.title > b.title ? 1 : a.title < b.title ? -1 : 0);
+    const commitGroups =
+        Array.from(groups.entries())
+            .map(([title, commits]) => ({
+                   title,
+                   commits: commits.sort((a, b) => a.type > b.type ? 1 : a.type < b.type ? -1 : 0)
+                 }))
+            .sort((a, b) => a.title > b.title ? 1 : a.title < b.title ? -1 : 0);
 
     // If the configuration provides a sorting order, updated the sorted list of group keys to
     // satisfy the order of the groups provided in the list with any groups not found in the list at

--- a/dev-infra/release/notes/context.ts
+++ b/dev-infra/release/notes/context.ts
@@ -161,6 +161,13 @@ export class RenderContext {
   replaceCommitHeaderPullRequestNumber(header: string): string {
     return header.replace(/\(#(\d+)\)$/, (_, g) => `(${this.pullRequestToLink(+g)})`);
   }
+
+  /**
+   * Bulletize a paragraph.
+   */
+  bulletizeText(text: string): string {
+    return '- ' + text.replace(/\\n/g, '\\n  ');
+  }
 }
 
 

--- a/dev-infra/release/notes/templates/changelog.ts
+++ b/dev-infra/release/notes/templates/changelog.ts
@@ -37,14 +37,8 @@ _%>
   for (const group of asCommitGroups(breakingChanges)) {
 _%>
 ### <%- group.title %>
-
+<%- group.commits.map(commit => bulletizeText(commit.breakingChanges[0].text)).join('\\n\\n') %>
 <%_
-    for (const commit of group.commits) {
-_%>
-<%- commit.breakingChanges[0].text %>
-
-<%_
-    }
   }
 }
 _%>
@@ -58,13 +52,8 @@ _%>
   for (const group of asCommitGroups(deprecations)) {
 _%>
 ### <%- group.title %>
-
+<%- group.commits.map(commit => bulletizeText(commit.deprecations[0].text)).join('\\n\\n') %>
 <%_
-    for (const commit of group.commits) {
-_%>
-<%- commit.deprecations[0].text %>
-<%_
-    }
   }
 }
 _%>

--- a/dev-infra/release/notes/templates/github-release.ts
+++ b/dev-infra/release/notes/templates/github-release.ts
@@ -37,14 +37,8 @@ _%>
   for (const group of asCommitGroups(breakingChanges)) {
 _%>
 ### <%- group.title %>
-
+<%- group.commits.map(commit => bulletizeText(commit.breakingChanges[0].text)).join('\\n\\n') %>
 <%_
-    for (const commit of group.commits) {
-_%>
-<%- commit.breakingChanges[0].text %>
-
-<%_
-    }
   }
 }
 _%>
@@ -58,19 +52,19 @@ _%>
   for (const group of asCommitGroups(deprecations)) {
 _%>
 ### <%- group.title %>
-
+<%- group.commits.map(commit => bulletizeText(commit.deprecations[0].text)).join('\\n\\n') %>
 <%_
-    for (const commit of group.commits) {
-_%>
-<%- commit.deprecations[0].text %>
-<%_
-    }
   }
 }
 _%>
 
 <%_
-const authors = commits.filter(unique('author')).map(c => c.author).sort();
+const botsAuthorName = ['dependabot[bot]', 'Renovate Bot'];
+const authors = commits
+  .filter(unique('author'))
+  .map(c => c.author)
+  .filter(a => !botsAuthorName.includes(a))
+  .sort();
 if (authors.length === 1) {
 _%>
 ## Special Thanks:


### PR DESCRIPTION
**fix(dev-infra): add breaklines and bullets to deprecation and breaking changes messages**

Previously, various breaking changes and deprecation messages were being displayed as single entry due to the lack of new lines., because EJS is trimming them due to https://github.com/angular/angular/blob/9fb79d38aade67f6f3bcdac0ffa93b8806baa215/dev-infra/release/notes/release-notes.ts#L49

Even with the whitespace however, when having multiple breaking changes, it was hard to distinguish each one, hence we added bullets.

**Before**
```md
## Breaking Changes
### @angular/cli
We drop support for Node.js versions prior to `12.20`.
### @angular-devkit/build-angular
Support for `karma-coverage-instanbul-reporter` has been dropped in favor of the official karma coverage plugin `karma-coverage`.
With this change we removed several deprecated builder options
- `extractCss` has been removed from the browser builder. CSS is now always extracted.
- `servePathDefaultWarning` and `hmrWarning` have been removed from the dev-server builder. These options had no effect.
The automatic inclusion of Angular-required ES2015 polyfills to support ES5 browsers has been removed. Previously when targetting ES5 within the application's TypeScript configuration or listing an ES5 requiring browser in the browserslist file, Angular-required polyfills were included in the built application. However, with Angular no longer supporting IE11, there are now no browsers officially supported by Angular that would require these polyfills. As a result, the automatic inclusion of these ES2015 polyfills has been removed. Any polyfills manually added to an application's code are not affected by this change.
Differential loading support has been removed. With Angular no longer supporting IE11, there are now no browsers officially supported by Angular that require ES5 code. As a result, differential loading's functionality for creating and conditionally loading ES5 and ES2015+ variants of an application is no longer required.
Deprecated `@angular-devkit/build-angular:tslint` builder has been removed. Use https://github.com/angular-eslint/angular-eslint instead.
We remove inlining of Google fonts in WOFF format since IE 11 is no longer supported. Other supported browsers use WOFF2.
Support for `node-sass` has been removed. `sass` will be used by default to compile SASS and SCSS files.
### @angular-devkit/schematics
With this change we remove the following deprecated APIs
- `TslintFixTask`
- `TslintFixTaskOptions`

**Note:** this only effects schematics developers.
```

**After**
```md
## Breaking Changess
### @angular-devkit/build-angular
- Support for `karma-coverage-instanbul-reporter` has been dropped in favor of the official karma coverage plugin `karma-coverage`.

- With this change we removed several deprecated builder options
  - `extractCss` has been removed from the browser builder. CSS is now always extracted.
  - `servePathDefaultWarning` and `hmrWarning` have been removed from the dev-server builder. These options had no effect.

- The automatic inclusion of Angular-required ES2015 polyfills to support ES5 browsers has been removed. Previously when targetting ES5 within the application's TypeScript configuration or listing an ES5 requiring browser in the browserslist file, Angular-required polyfills were included in the built application. However, with Angular no longer supporting IE11, there are now no browsers officially supported by Angular that would require these polyfills. As a result, the automatic inclusion of these ES2015 polyfills has been removed. Any polyfills manually added to an application's code are not affected by this change.

- Differential loading support has been removed. With Angular no longer supporting IE11, there are now no browsers officially supported by Angular that require ES5 code. As a result, differential loading's functionality for creating and conditionally loading ES5 and ES2015+ variants of an application is no longer required.

- Deprecated `@angular-devkit/build-angular:tslint` builder has been removed. Use https://github.com/angular-eslint/angular-eslint instead.

- We remove inlining of Google fonts in WOFF format since IE 11 is no longer supported. Other supported browsers use WOFF2.

- Support for `node-sass` has been removed. `sass` will be used by default to compile SASS and SCSS files.
### @angular-devkit/schematics
- With this change we remove the following deprecated APIs
  - `TslintFixTask`
  - `TslintFixTaskOptions`
```

Live example of this change can be viewed https://github.com/angular/angular-cli/releases/tag/13.0.0-next.0

---

**fix(dev-infra): sort commits by type in release notes**

Currently, the commit messages are not sorted by type which makes it harder to looks for a specific commit type, such as fixes, perf improvements or features.

**Before**
```md

| [cdfaeee08](https://github.com/angular/angular-cli/commit/cdfaeee089f3458b1924eb516a2b4275e662b079) | fix(@angular-devkit/build-angular): support both pure annotation forms for static properties |
| [2aa6f579d](https://github.com/angular/angular-cli/commit/2aa6f579d7b5af13eeb5bbf35f78d5411738b98a) | fix(@angular-devkit/build-angular): do not consume inline sourcemaps when vendor sourcemaps is disabled. |
| [167eed465](https://github.com/angular/angular-cli/commit/167eed4654be4480c45d7fdfe7a0b9f160170289) | fix(@angular-devkit/build-angular): update Angular peer dependencies to v13.0 prerelease |
| [7dcfffaff](https://github.com/angular/angular-cli/commit/7dcfffafff6f3d29bbe679a90cdf77b1292fec0b) | feat(@angular-devkit/build-angular): drop support for `karma-coverage-instanbul-reporter` |
| [f5d019f9d](https://github.com/angular/angular-cli/commit/f5d019f9d6ad6d8fdea37836564d9ee190deb23c) | fix(@angular-devkit/build-angular): avoid attempting to optimize copied JavaScript assets |
| [8758e4415](https://github.com/angular/angular-cli/commit/8758e4415d7ef6301c4441db0014e24f1cc8d146) | fix(@angular-devkit/build-angular): handle null maps in JavaScript optimizer worker |
| [f53bf9dc2](https://github.com/angular/angular-cli/commit/f53bf9dc21ee9aa8a682b8a82ee8a9870fa859e1) | feat(@angular-devkit/build-angular): add `type=module` to all scripts tags |
| [20e48a33c](https://github.com/angular/angular-cli/commit/20e48a33c14a1b0b959ba0a45018df53a3e129c8) | feat(@angular-devkit/build-angular): remove deprecated options |
| [7576136b2](https://github.com/angular/angular-cli/commit/7576136b2fc8a9173b0a92e2ab14c9bc2559081e) | feat(@angular-devkit/build-angular): remove automatic inclusion of ES5 browser polyfills |
| [701214d17](https://github.com/angular/angular-cli/commit/701214d174586fe7373b6155024c9b6e97b26377) | feat(@angular-devkit/build-angular): remove differential loading support |
| [e78f6ab5d](https://github.com/angular/angular-cli/commit/e78f6ab5d8f00338d826c8407ce5c8fca40cf097) | feat(@angular-devkit/build-angular): remove deprecated tslint builder |
| [ac3fc2752](https://github.com/angular/angular-cli/commit/ac3fc2752f28761e1cd42157b59dcf2364ae5567) | feat(@angular-devkit/build-angular): drop support for `node-sass` |
| [c1efaa17f](https://github.com/angular/angular-cli/commit/c1efaa17feb1d2911dcdea12688d75086d410bf1) | fix(@angular-devkit/build-angular): calculate valid Angular versions from peerDependencies |
| [d750c686f](https://github.com/angular/angular-cli/commit/d750c686fd26f3ccfccb039027bd816a91279497) | fix(@angular-devkit/build-angular): add priority to copy-webpack-plugin patterns |
```

**After**
```md
| [7dcfffaff](https://github.com/angular/angular-cli/commit/7dcfffafff6f3d29bbe679a90cdf77b1292fec0b) | feat(@angular-devkit/build-angular): drop support for `karma-coverage-instanbul-reporter` |
| [f53bf9dc2](https://github.com/angular/angular-cli/commit/f53bf9dc21ee9aa8a682b8a82ee8a9870fa859e1) | feat(@angular-devkit/build-angular): add `type=module` to all scripts tags |
| [20e48a33c](https://github.com/angular/angular-cli/commit/20e48a33c14a1b0b959ba0a45018df53a3e129c8) | feat(@angular-devkit/build-angular): remove deprecated options |
| [7576136b2](https://github.com/angular/angular-cli/commit/7576136b2fc8a9173b0a92e2ab14c9bc2559081e) | feat(@angular-devkit/build-angular): remove automatic inclusion of ES5 browser polyfills |
| [701214d17](https://github.com/angular/angular-cli/commit/701214d174586fe7373b6155024c9b6e97b26377) | feat(@angular-devkit/build-angular): remove differential loading support |
| [e78f6ab5d](https://github.com/angular/angular-cli/commit/e78f6ab5d8f00338d826c8407ce5c8fca40cf097) | feat(@angular-devkit/build-angular): remove deprecated tslint builder |
| [ac3fc2752](https://github.com/angular/angular-cli/commit/ac3fc2752f28761e1cd42157b59dcf2364ae5567) | feat(@angular-devkit/build-angular): drop support for `node-sass` |
| [cdfaeee08](https://github.com/angular/angular-cli/commit/cdfaeee089f3458b1924eb516a2b4275e662b079) | fix(@angular-devkit/build-angular): support both pure annotation forms for static properties |
| [2aa6f579d](https://github.com/angular/angular-cli/commit/2aa6f579d7b5af13eeb5bbf35f78d5411738b98a) | fix(@angular-devkit/build-angular): do not consume inline sourcemaps when vendor sourcemaps is disabled. |
| [167eed465](https://github.com/angular/angular-cli/commit/167eed4654be4480c45d7fdfe7a0b9f160170289) | fix(@angular-devkit/build-angular): update Angular peer dependencies to v13.0 prerelease |
| [f5d019f9d](https://github.com/angular/angular-cli/commit/f5d019f9d6ad6d8fdea37836564d9ee190deb23c) | fix(@angular-devkit/build-angular): avoid attempting to optimize copied JavaScript assets |
| [8758e4415](https://github.com/angular/angular-cli/commit/8758e4415d7ef6301c4441db0014e24f1cc8d146) | fix(@angular-devkit/build-angular): handle null maps in JavaScript optimizer worker |
| [c1efaa17f](https://github.com/angular/angular-cli/commit/c1efaa17feb1d2911dcdea12688d75086d410bf1) | fix(@angular-devkit/build-angular): calculate valid Angular versions from peerDependencies |
| [d750c686f](https://github.com/angular/angular-cli/commit/d750c686fd26f3ccfccb039027bd816a91279497) | fix(@angular-devkit/build-angular): add priority to copy-webpack-plugin patterns |
```