### PR TITLE
refactor(compiler-cli): remove extra 'diagnostic' from readResource comment

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/api/src/interfaces.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/interfaces.ts
@@ -45,7 +45,7 @@ export interface ResourceHost {
    * Load a referenced resource either statically or asynchronously. If the host returns a
    * `Promise<string>` it is assumed the user of the corresponding `Program` will call
    * `loadNgStructureAsync()`. Returning  `Promise<string>` outside `loadNgStructureAsync()` will
-   * cause a diagnostics diagnostic error or an exception to be thrown.
+   * cause a diagnostics error or an exception to be thrown.
    */
   readResource(fileName: string): Promise<string>|string;
 


### PR DESCRIPTION
Very minor change, just fixing a comment which I believe has an extra `diagnostic`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

Issue Number: N/A

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No