### PR TITLE
refactor(compiler-cli): remove unused closureCompilerEnabled from NgtscProgram

### DIFF
--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -37,7 +37,6 @@ export class NgtscProgram implements api.Program {
    */
   private tsProgram: ts.Program;
 
-  private closureCompilerEnabled: boolean;
   private host: NgCompilerHost;
   private incrementalStrategy: TrackedIncrementalBuildStrategy;
 
@@ -52,8 +51,6 @@ export class NgtscProgram implements api.Program {
     if (!options.disableTypeScriptVersionCheck) {
       verifySupportedTypeScriptVersion();
     }
-
-    this.closureCompilerEnabled = !!options.annotateForClosureCompiler;
 
     const reuseProgram = oldProgram?.compiler.getCurrentProgram();
     this.host = NgCompilerHost.wrap(delegateHost, rootNames, options, reuseProgram ?? null);


### PR DESCRIPTION
remove the NgtscProgram's private field closureCompilerEnabled as that
is not being used in the class itself

![Screenshot at 2021-08-14 11-10-33](https://user-images.githubusercontent.com/61631103/129442843-98bfe755-8c6e-4760-8946-10712c9d79c3.png)


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


Issue Number: N/A


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

