### PR TITLE
docs(router): use the correct `live-example` name in `routing-overview.md`

### DIFF
--- a/aio/content/guide/routing-overview.md
+++ b/aio/content/guide/routing-overview.md
@@ -6,7 +6,7 @@ As users perform application tasks, they need to move between the different [vie
 To handle the navigation from one [view](guide/glossary#view) to the next, you use the Angular **`Router`**.
 The **`Router`** enables navigation by interpreting a browser URL as an instruction to change the view.
 
-To explore a sample app featuring the router's primary features, see the <live-example stackblitz="router"></live-example>.
+To explore a sample app featuring the router's primary features, see the <live-example name="router"></live-example>.
 
 ## Prerequisites
 


### PR DESCRIPTION
The previously used code (`<live-example stackblitz="router">`) would try to target the `router.stackblitz.json` file inside the (non-existent) `routing-overview` example (same as the guide's name).

This commit fixes the code to correctly express the original intention of targeting the default `stackblitz.json` file of the `router` example with `<live-example name="router">`.

Fixes #43167.
