### PR TITLE
feat(language-service): Add method for retrieving the component templ…

### DIFF
--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -52,6 +52,7 @@ export type GetTcbResponse = {
 };
 
 export type GetComponentLocationsForTemplateResponse = ts.DocumentSpan[];
+export type GetTemplateLocationForComponentResponse = ts.DocumentSpan|undefined;
 
 /**
  * `NgLanguageService` describes an instance of an Angular language service,
@@ -60,6 +61,8 @@ export type GetComponentLocationsForTemplateResponse = ts.DocumentSpan[];
 export interface NgLanguageService extends ts.LanguageService {
   getTcb(fileName: string, position: number): GetTcbResponse|undefined;
   getComponentLocationsForTemplate(fileName: string): GetComponentLocationsForTemplateResponse;
+  getTemplateLocationForComponent(fileName: string, position: number):
+      GetTemplateLocationForComponentResponse;
 }
 
 export function isNgLanguageService(ls: ts.LanguageService|

--- a/packages/language-service/ivy/test/get_template_location_for_component_spec.ts
+++ b/packages/language-service/ivy/test/get_template_location_for_component_spec.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+
+import {assertFileNames, createModuleAndProjectWithDeclarations, humanizeDocumentSpanLike, LanguageServiceTestEnv} from '../testing';
+
+describe('get template location for component', () => {
+  beforeEach(() => {
+    initMockFileSystem('Native');
+  });
+
+  it('finds location of inline template', () => {
+    const files = {
+      'app.ts': `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: '<div>{{ myProp }}</div>',
+      })
+      export class AppCmp {
+        myProp!: string;
+      }`
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    appFile.moveCursorToText('my¦Prop!: string');
+    const result = appFile.getTemplateLocationForComponent()!;
+    assertFileNames([result], ['app.ts']);
+    expect(humanizeDocumentSpanLike(result, env).textSpan).toEqual(`'<div>{{ myProp }}</div>'`);
+  });
+
+  it('finds location of external template', () => {
+    const files = {
+      'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              templateUrl: './app.html',
+            })
+            export class AppCmp {
+              myProp!: string;
+            }`,
+      'app.html': '<div>{{ myProp }}</div>'
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    appFile.moveCursorToText('my¦Prop!: string');
+    const result = appFile.getTemplateLocationForComponent()!;
+    assertFileNames([result], ['app.html']);
+  });
+
+  it('finds correct location when there are multiple components in one file', () => {
+    const files = {
+      'app.ts': `
+      import {Component} from '@angular/core';
+
+      @Component({
+        templateUrl: './template1.html',
+      })
+      export class Template1 {
+      }
+      @Component({
+        templateUrl: './template2.html',
+      })
+      export class Template2 {
+      }
+      `,
+      'template1.html': '',
+      'template2.html': ''
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    appFile.moveCursorToText('export class Temp¦late1');
+    const result1 = appFile.getTemplateLocationForComponent()!;
+    assertFileNames([result1], ['template1.html']);
+
+    appFile.moveCursorToText('export class Temp¦late2');
+    const result2 = appFile.getTemplateLocationForComponent()!;
+    assertFileNames([result2], ['template2.html']);
+  });
+
+  it('returns nothing when cursor is not in a component', () => {
+    const files = {
+      'app.ts': `
+      import {Directive} from '@angular/core';
+
+      @Directive({selector: 'my-dir'})
+      export class MyDir {
+      }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    appFile.moveCursorToText('MyDir¦');
+    expect(appFile.getTemplateLocationForComponent()).toBeUndefined();
+  });
+
+  it('returns nothing when cursor is not in a component', () => {
+    const files = {
+      'app.ts': `
+      import {Component} from '@angular/core';
+
+      const x = 1;
+
+      @Component({template: 'abc'})
+      export class MyDir {
+      }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    appFile.moveCursorToText('const x¦');
+    expect(appFile.getTemplateLocationForComponent()).toBeUndefined();
+  });
+
+  it('returns template when cursor is on `class` keyword', () => {
+    const files = {
+      'app.ts': `
+      import {Component} from '@angular/core';
+
+      @Component({template: 'abc'})
+      export class MyDir {
+      }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    appFile.moveCursorToText('cla¦ss');
+    const result = appFile.getTemplateLocationForComponent()!;
+    assertFileNames([result], ['app.ts']);
+    expect(humanizeDocumentSpanLike(result, env).textSpan).toEqual(`'abc'`);
+  });
+});

--- a/packages/language-service/ivy/testing/src/buffer.ts
+++ b/packages/language-service/ivy/testing/src/buffer.ts
@@ -80,6 +80,10 @@ export class OpenBuffer {
     return this.ngLS.getTcb(this.scriptInfo.fileName, this._cursor);
   }
 
+  getTemplateLocationForComponent() {
+    return this.ngLS.getTemplateLocationForComponent(this.scriptInfo.fileName, this._cursor);
+  }
+
   getQuickInfoAtPosition() {
     return this.ngLS.getQuickInfoAtPosition(this.scriptInfo.fileName, this._cursor);
   }

--- a/packages/language-service/ivy/ts_plugin.ts
+++ b/packages/language-service/ivy/ts_plugin.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript/lib/tsserverlibrary';
 
-import {GetComponentLocationsForTemplateResponse, GetTcbResponse, NgLanguageService} from '../api';
+import {GetComponentLocationsForTemplateResponse, GetTcbResponse, GetTemplateLocationForComponentResponse, NgLanguageService} from '../api';
 
 import {LanguageService} from './language_service';
 
@@ -155,6 +155,15 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     return ngLS.getComponentLocationsForTemplate(fileName);
   }
 
+  /**
+   * Given a location inside a component, finds the location of the inline template or the file for
+   * the `templateUrl`.
+   */
+  function getTemplateLocationForComponent(
+      fileName: string, position: number): GetTemplateLocationForComponentResponse {
+    return ngLS.getTemplateLocationForComponent(fileName, position);
+  }
+
   return {
     ...tsLS,
     getSemanticDiagnostics,
@@ -171,6 +180,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     getCompilerOptionsDiagnostics,
     getComponentLocationsForTemplate,
     getSignatureHelpItems,
+    getTemplateLocationForComponent,
   };
 }
 

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -124,6 +124,11 @@ export function create(info: tss.server.PluginCreateInfo): NgLanguageService {
     return undefined;
   }
 
+  function getTemplateLocationForComponent(fileName: string, position: number) {
+    // Not implemented in VE Language Service
+    return undefined;
+  }
+
   function getComponentLocationsForTemplate(fileName: string) {
     // Not implemented in VE Language Service
     return [];
@@ -140,5 +145,6 @@ export function create(info: tss.server.PluginCreateInfo): NgLanguageService {
     getDefinitionAndBoundSpan,
     getTcb,
     getComponentLocationsForTemplate,
+    getTemplateLocationForComponent,
   };
 }


### PR DESCRIPTION
…ate at the cursor location

This method is the @angular/language-service side of the implementation
for https://github.com/angular/vscode-ng-language-service/issues/1485

Given a location in a file, if the location is inside a component,
`getTemplateLocationForComponent` will return the `DocumentSpan` of the
inline `template` or the `DocumentSpan` for the file that the
`templateUrl` points to.
