### PR TITLE
fix(service-worker): NPE if onActionClick is undefined

### DIFF
--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -354,7 +354,7 @@ export class Driver implements Debuggable, UpdateSource {
 
     const notificationAction = action === '' || action === undefined ? 'default' : action;
 
-    const onActionClick = notification?.data?.onActionClick[notificationAction];
+    const onActionClick = notification?.data?.onActionClick?.[notificationAction];
 
     const urlToOpen = new URL(onActionClick?.url ?? '', this.scope.registration.scope).href;
 

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -1055,6 +1055,21 @@ describe('Driver', () => {
         });
       });
 
+      describe('no onActionClick field', () => {
+        it('has no client interaction', async () => {
+          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+          spyOn(scope.clients, 'openWindow');
+
+          await driver.initialized;
+          await scope.handleClick(
+              {title: 'This is a test without action', body: 'Test body without action', data: {}});
+          await scope.handleClick(
+              {title: 'This is a test with an action', body: 'Test body with an action', data: {}},
+              'someAction');
+          expect(scope.clients.openWindow).not.toHaveBeenCalled();
+        });
+      });
+
       describe('URL resolution', () => {
         it('should resolve relative to service worker scope', async () => {
           (scope.registration.scope as string) = 'http://localhost/foo/bar/';


### PR DESCRIPTION
Previously, it leads to fail if notification.data.onActionClick is undefined

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
