### PR TITLE
refactor(forms): make error messages easier to tree shake

### DIFF
--- a/packages/forms/src/directives/error_examples.ts
+++ b/packages/forms/src/directives/error_examples.ts
@@ -6,58 +6,56 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export const FormErrorExamples = {
-  formControlName: `
-    <div [formGroup]="myGroup">
-      <input formControlName="firstName">
-    </div>
+export const formControlNameExample = `
+  <div [formGroup]="myGroup">
+    <input formControlName="firstName">
+  </div>
 
-    In your class:
+  In your class:
 
-    this.myGroup = new FormGroup({
-       firstName: new FormControl()
-    });`,
+  this.myGroup = new FormGroup({
+      firstName: new FormControl()
+  });`;
 
-  formGroupName: `
-    <div [formGroup]="myGroup">
-       <div formGroupName="person">
-          <input formControlName="firstName">
-       </div>
-    </div>
+export const formGroupNameExample = `
+  <div [formGroup]="myGroup">
+      <div formGroupName="person">
+        <input formControlName="firstName">
+      </div>
+  </div>
 
-    In your class:
+  In your class:
 
-    this.myGroup = new FormGroup({
-       person: new FormGroup({ firstName: new FormControl() })
-    });`,
+  this.myGroup = new FormGroup({
+      person: new FormGroup({ firstName: new FormControl() })
+  });`;
 
-  formArrayName: `
-    <div [formGroup]="myGroup">
-      <div formArrayName="cities">
-        <div *ngFor="let city of cityArray.controls; index as i">
-          <input [formControlName]="i">
-        </div>
+export const formArrayNameExample = `
+  <div [formGroup]="myGroup">
+    <div formArrayName="cities">
+      <div *ngFor="let city of cityArray.controls; index as i">
+        <input [formControlName]="i">
       </div>
     </div>
+  </div>
 
-    In your class:
+  In your class:
 
-    this.cityArray = new FormArray([new FormControl('SF')]);
-    this.myGroup = new FormGroup({
-      cities: this.cityArray
-    });`,
+  this.cityArray = new FormArray([new FormControl('SF')]);
+  this.myGroup = new FormGroup({
+    cities: this.cityArray
+  });`;
 
-  ngModelGroup: `
-    <form>
-       <div ngModelGroup="person">
-          <input [(ngModel)]="person.name" name="firstName">
-       </div>
-    </form>`,
+export const ngModelGroupExample = `
+  <form>
+      <div ngModelGroup="person">
+        <input [(ngModel)]="person.name" name="firstName">
+      </div>
+  </form>`;
 
-  ngModelWithFormGroup: `
-    <div [formGroup]="myGroup">
-       <input formControlName="firstName">
-       <input [(ngModel)]="showMoreControls" [ngModelOptions]="{standalone: true}">
-    </div>
-  `
-};
+export const ngModelWithFormGroupExample = `
+  <div [formGroup]="myGroup">
+      <input formControlName="firstName">
+      <input [(ngModel)]="showMoreControls" [ngModelOptions]="{standalone: true}">
+  </div>
+`;

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -18,7 +18,7 @@ import {NgControl} from './ng_control';
 import {NgForm} from './ng_form';
 import {NgModelGroup} from './ng_model_group';
 import {controlPath, isPropertyUpdated, selectValueAccessor, setUpControl} from './shared';
-import {TemplateDrivenErrors} from './template_driven_errors';
+import {formGroupNameException, missingNameException, modelParentException} from './template_driven_errors';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from './validators';
 
 export const formControlBinding: any = {
@@ -295,9 +295,9 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       if (!(this._parent instanceof NgModelGroup) &&
           this._parent instanceof AbstractFormGroupDirective) {
-        TemplateDrivenErrors.formGroupNameException();
+        throw formGroupNameException();
       } else if (!(this._parent instanceof NgModelGroup) && !(this._parent instanceof NgForm)) {
-        TemplateDrivenErrors.modelParentException();
+        throw modelParentException();
       }
     }
   }
@@ -306,7 +306,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
     if (this.options && this.options.name) this.name = this.options.name;
 
     if (!this._isStandalone() && !this.name && (typeof ngDevMode === 'undefined' || ngDevMode)) {
-      TemplateDrivenErrors.missingNameException();
+      throw missingNameException();
     }
   }
 

--- a/packages/forms/src/directives/ng_model_group.ts
+++ b/packages/forms/src/directives/ng_model_group.ts
@@ -13,7 +13,7 @@ import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
 import {AbstractFormGroupDirective} from './abstract_form_group_directive';
 import {ControlContainer} from './control_container';
 import {NgForm} from './ng_form';
-import {TemplateDrivenErrors} from './template_driven_errors';
+import {modelGroupParentException} from './template_driven_errors';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from './validators';
 
 export const modelGroupProvider: any = {
@@ -72,7 +72,7 @@ export class NgModelGroup extends AbstractFormGroupDirective implements OnInit, 
   override _checkParentType(): void {
     if (!(this._parent instanceof NgModelGroup) && !(this._parent instanceof NgForm) &&
         (typeof ngDevMode === 'undefined' || ngDevMode)) {
-      TemplateDrivenErrors.modelGroupParentException();
+      throw modelGroupParentException();
     }
   }
 }

--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -12,7 +12,7 @@ import {FormControl} from '../../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '../control_value_accessor';
 import {NgControl} from '../ng_control';
-import {ReactiveErrors} from '../reactive_errors';
+import {disabledAttrWarning} from '../reactive_errors';
 import {_ngModelWarning, cleanUpControl, isPropertyUpdated, selectValueAccessor, setUpControl} from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
 
@@ -72,7 +72,7 @@ export class FormControlDirective extends NgControl implements OnChanges, OnDest
   @Input('disabled')
   set isDisabled(isDisabled: boolean) {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
-      ReactiveErrors.disabledAttrWarning();
+      console.warn(disabledAttrWarning);
     }
   }
 

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -14,7 +14,7 @@ import {AbstractFormGroupDirective} from '../abstract_form_group_directive';
 import {ControlContainer} from '../control_container';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '../control_value_accessor';
 import {NgControl} from '../ng_control';
-import {ReactiveErrors} from '../reactive_errors';
+import {controlParentException, disabledAttrWarning, ngModelGroupException} from '../reactive_errors';
 import {_ngModelWarning, controlPath, isPropertyUpdated, selectValueAccessor} from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
 
@@ -96,7 +96,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
   @Input('disabled')
   set isDisabled(isDisabled: boolean) {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
-      ReactiveErrors.disabledAttrWarning();
+      console.warn(disabledAttrWarning);
     }
   }
 
@@ -192,12 +192,12 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       if (!(this._parent instanceof FormGroupName) &&
           this._parent instanceof AbstractFormGroupDirective) {
-        ReactiveErrors.ngModelGroupException();
+        throw ngModelGroupException();
       } else if (
           !(this._parent instanceof FormGroupName) &&
           !(this._parent instanceof FormGroupDirective) &&
           !(this._parent instanceof FormArrayName)) {
-        ReactiveErrors.controlParentException();
+        throw controlParentException();
       }
     }
   }

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -12,7 +12,7 @@ import {FormArray, FormControl, FormGroup} from '../../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {ControlContainer} from '../control_container';
 import {Form} from '../form_interface';
-import {ReactiveErrors} from '../reactive_errors';
+import {missingFormException} from '../reactive_errors';
 import {cleanUpControl, cleanUpFormContainer, cleanUpValidators, removeListItem, setUpControl, setUpFormContainer, setUpValidators, syncPendingControls} from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
 
@@ -356,7 +356,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
 
   private _checkFormPresent() {
     if (!this.form && (typeof ngDevMode === 'undefined' || ngDevMode)) {
-      ReactiveErrors.missingFormException();
+      throw missingFormException();
     }
   }
 }

--- a/packages/forms/src/directives/reactive_directives/form_group_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_name.ts
@@ -12,7 +12,7 @@ import {FormArray} from '../../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {AbstractFormGroupDirective} from '../abstract_form_group_directive';
 import {ControlContainer} from '../control_container';
-import {ReactiveErrors} from '../reactive_errors';
+import {arrayParentException, groupParentException} from '../reactive_errors';
 import {controlPath} from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
 
@@ -98,7 +98,7 @@ export class FormGroupName extends AbstractFormGroupDirective implements OnInit,
   /** @internal */
   override _checkParentType(): void {
     if (_hasInvalidParent(this._parent) && (typeof ngDevMode === 'undefined' || ngDevMode)) {
-      ReactiveErrors.groupParentException();
+      throw groupParentException();
     }
   }
 }
@@ -207,7 +207,7 @@ export class FormArrayName extends ControlContainer implements OnInit, OnDestroy
 
   private _checkParentType(): void {
     if (_hasInvalidParent(this._parent) && (typeof ngDevMode === 'undefined' || ngDevMode)) {
-      ReactiveErrors.arrayParentException();
+      throw arrayParentException();
     }
   }
 }

--- a/packages/forms/src/directives/reactive_errors.ts
+++ b/packages/forms/src/directives/reactive_errors.ts
@@ -6,87 +6,82 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {formArrayNameExample, formControlNameExample, formGroupNameExample, ngModelGroupExample} from './error_examples';
 
-import {FormErrorExamples as Examples} from './error_examples';
 
-export class ReactiveErrors {
-  static controlParentException(): void {
-    throw new Error(
-        `formControlName must be used with a parent formGroup directive.  You'll want to add a formGroup
-       directive and pass it an existing FormGroup instance (you can create one in your class).
+export function controlParentException(): Error {
+  return new Error(
+      `formControlName must be used with a parent formGroup directive.  You'll want to add a formGroup
+      directive and pass it an existing FormGroup instance (you can create one in your class).
+
+    Example:
+
+    ${formControlNameExample}`);
+}
+
+export function ngModelGroupException(): Error {
+  return new Error(
+      `formControlName cannot be used with an ngModelGroup parent. It is only compatible with parents
+      that also have a "form" prefix: formGroupName, formArrayName, or formGroup.
+
+      Option 1:  Update the parent to be formGroupName (reactive form strategy)
+
+      ${formGroupNameExample}
+
+      Option 2: Use ngModel instead of formControlName (template-driven strategy)
+
+      ${ngModelGroupExample}`);
+}
+
+export function missingFormException(): Error {
+  return new Error(`formGroup expects a FormGroup instance. Please pass one in.
 
       Example:
 
-      ${Examples.formControlName}`);
-  }
+      ${formControlNameExample}`);
+}
 
-  static ngModelGroupException(): void {
-    throw new Error(
-        `formControlName cannot be used with an ngModelGroup parent. It is only compatible with parents
-       that also have a "form" prefix: formGroupName, formArrayName, or formGroup.
+export function groupParentException(): Error {
+  return new Error(
+      `formGroupName must be used with a parent formGroup directive.  You'll want to add a formGroup
+    directive and pass it an existing FormGroup instance (you can create one in your class).
 
-       Option 1:  Update the parent to be formGroupName (reactive form strategy)
+    Example:
 
-        ${Examples.formGroupName}
+    ${formGroupNameExample}`);
+}
 
-        Option 2: Use ngModel instead of formControlName (template-driven strategy)
-
-        ${Examples.ngModelGroup}`);
-  }
-
-  static missingFormException(): void {
-    throw new Error(`formGroup expects a FormGroup instance. Please pass one in.
-
-       Example:
-
-       ${Examples.formControlName}`);
-  }
-
-  static groupParentException(): void {
-    throw new Error(
-        `formGroupName must be used with a parent formGroup directive.  You'll want to add a formGroup
+export function arrayParentException(): Error {
+  return new Error(
+      `formArrayName must be used with a parent formGroup directive.  You'll want to add a formGroup
       directive and pass it an existing FormGroup instance (you can create one in your class).
 
       Example:
 
-      ${Examples.formGroupName}`);
-  }
+      ${formArrayNameExample}`);
+}
 
-  static arrayParentException(): void {
-    throw new Error(
-        `formArrayName must be used with a parent formGroup directive.  You'll want to add a formGroup
-       directive and pass it an existing FormGroup instance (you can create one in your class).
+export const disabledAttrWarning = `
+  It looks like you're using the disabled attribute with a reactive form directive. If you set disabled to true
+  when you set up this control in your component class, the disabled attribute will actually be set in the DOM for
+  you. We recommend using this approach to avoid 'changed after checked' errors.
 
-        Example:
+  Example:
+  form = new FormGroup({
+    first: new FormControl({value: 'Nancy', disabled: true}, Validators.required),
+    last: new FormControl('Drew', Validators.required)
+  });
+`;
 
-        ${Examples.formArrayName}`);
-  }
+export function ngModelWarning(directiveName: string): string {
+  return `
+  It looks like you're using ngModel on the same form field as ${directiveName}.
+  Support for using the ngModel input property and ngModelChange event with
+  reactive form directives has been deprecated in Angular v6 and will be removed
+  in a future version of Angular.
 
-  static disabledAttrWarning(): void {
-    console.warn(`
-      It looks like you're using the disabled attribute with a reactive form directive. If you set disabled to true
-      when you set up this control in your component class, the disabled attribute will actually be set in the DOM for
-      you. We recommend using this approach to avoid 'changed after checked' errors.
-
-      Example:
-      form = new FormGroup({
-        first: new FormControl({value: 'Nancy', disabled: true}, Validators.required),
-        last: new FormControl('Drew', Validators.required)
-      });
-    `);
-  }
-
-  static ngModelWarning(directiveName: string): void {
-    console.warn(`
-    It looks like you're using ngModel on the same form field as ${directiveName}.
-    Support for using the ngModel input property and ngModelChange event with
-    reactive form directives has been deprecated in Angular v6 and will be removed
-    in a future version of Angular.
-
-    For more information on this, see our API docs here:
-    https://angular.io/api/forms/${
-        directiveName === 'formControl' ? 'FormControlDirective' :
-                                          'FormControlName'}#use-with-ngmodel
-    `);
-  }
+  For more information on this, see our API docs here:
+  https://angular.io/api/forms/${
+      directiveName === 'formControl' ? 'FormControlDirective' : 'FormControlName'}#use-with-ngmodel
+  `;
 }

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -16,7 +16,7 @@ import {BuiltInControlValueAccessor, ControlValueAccessor} from './control_value
 import {DefaultValueAccessor} from './default_value_accessor';
 import {NgControl} from './ng_control';
 import {FormArrayName} from './reactive_directives/form_group_name';
-import {ReactiveErrors} from './reactive_errors';
+import {ngModelWarning} from './reactive_errors';
 import {AsyncValidatorFn, Validator, ValidatorFn} from './validators';
 
 
@@ -360,7 +360,7 @@ export function _ngModelWarning(
 
   if (((warningConfig === null || warningConfig === 'once') && !type._ngModelWarningSentOnce) ||
       (warningConfig === 'always' && !instance._ngModelWarningSent)) {
-    ReactiveErrors.ngModelWarning(name);
+    console.warn(ngModelWarning(name));
     type._ngModelWarningSentOnce = true;
     instance._ngModelWarningSent = true;
   }

--- a/packages/forms/src/directives/template_driven_errors.ts
+++ b/packages/forms/src/directives/template_driven_errors.ts
@@ -6,55 +6,54 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {FormErrorExamples as Examples} from './error_examples';
+import {formControlNameExample, formGroupNameExample, ngModelGroupExample, ngModelWithFormGroupExample} from './error_examples';
 
-export class TemplateDrivenErrors {
-  static modelParentException(): void {
-    throw new Error(`
-      ngModel cannot be used to register form controls with a parent formGroup directive.  Try using
-      formGroup's partner directive "formControlName" instead.  Example:
 
-      ${Examples.formControlName}
+export function modelParentException(): Error {
+  return new Error(`
+    ngModel cannot be used to register form controls with a parent formGroup directive.  Try using
+    formGroup's partner directive "formControlName" instead.  Example:
 
-      Or, if you'd like to avoid registering this form control, indicate that it's standalone in ngModelOptions:
+    ${formControlNameExample}
 
-      Example:
+    Or, if you'd like to avoid registering this form control, indicate that it's standalone in ngModelOptions:
 
-      ${Examples.ngModelWithFormGroup}`);
-  }
+    Example:
 
-  static formGroupNameException(): void {
-    throw new Error(`
-      ngModel cannot be used to register form controls with a parent formGroupName or formArrayName directive.
+    ${ngModelWithFormGroupExample}`);
+}
 
-      Option 1: Use formControlName instead of ngModel (reactive strategy):
+export function formGroupNameException(): Error {
+  return new Error(`
+    ngModel cannot be used to register form controls with a parent formGroupName or formArrayName directive.
 
-      ${Examples.formGroupName}
+    Option 1: Use formControlName instead of ngModel (reactive strategy):
 
-      Option 2:  Update ngModel's parent be ngModelGroup (template-driven strategy):
+    ${formGroupNameExample}
 
-      ${Examples.ngModelGroup}`);
-  }
+    Option 2:  Update ngModel's parent be ngModelGroup (template-driven strategy):
 
-  static missingNameException() {
-    throw new Error(
-        `If ngModel is used within a form tag, either the name attribute must be set or the form
-      control must be defined as 'standalone' in ngModelOptions.
+    ${ngModelGroupExample}`);
+}
 
-      Example 1: <input [(ngModel)]="person.firstName" name="first">
-      Example 2: <input [(ngModel)]="person.firstName" [ngModelOptions]="{standalone: true}">`);
-  }
+export function missingNameException(): Error {
+  return new Error(
+      `If ngModel is used within a form tag, either the name attribute must be set or the form
+    control must be defined as 'standalone' in ngModelOptions.
 
-  static modelGroupParentException() {
-    throw new Error(`
-      ngModelGroup cannot be used with a parent formGroup directive.
+    Example 1: <input [(ngModel)]="person.firstName" name="first">
+    Example 2: <input [(ngModel)]="person.firstName" [ngModelOptions]="{standalone: true}">`);
+}
 
-      Option 1: Use formGroupName instead of ngModelGroup (reactive strategy):
+export function modelGroupParentException(): Error {
+  return new Error(`
+    ngModelGroup cannot be used with a parent formGroup directive.
 
-      ${Examples.formGroupName}
+    Option 1: Use formGroupName instead of ngModelGroup (reactive strategy):
 
-      Option 2:  Use a regular form tag instead of the formGroup directive (template-driven strategy):
+    ${formGroupNameExample}
 
-      ${Examples.ngModelGroup}`);
-  }
+    Option 2:  Use a regular form tag instead of the formGroup directive (template-driven strategy):
+
+    ${ngModelGroupExample}`);
 }


### PR DESCRIPTION
Currently the error message functions are defined as static methods on a class which means that as soon as one of them is used somewhere, all of them have to be retained. This isn't a problem at the moment, because all of them are behind `ngDevMode` checks, but it's error prone and it's easy to fix.

These changes move them out into functions so that they can be imported individually. It also has the advantage of allowing Webpack to minify the function names.