### PR TITLE
refactor(compiler-cli): deprecate the `fullTemplateTypeCheck` compile…

### DIFF
--- a/aio/content/examples/schematics-for-libraries/projects/my-lib/tsconfig.lib.json
+++ b/aio/content/examples/schematics-for-libraries/projects/my-lib/tsconfig.lib.json
@@ -17,12 +17,8 @@
     ]
   },
   "angularCompilerOptions": {
-    "annotateForClosureCompiler": true,
-    "skipTemplateCodegen": true,
-    "strictMetadataEmit": true,
-    "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true,
-    "enableResourceInlining": true
+    "strictTemplates": true,
+    "strictInjectionParameters": true
   },
   "exclude": [
     "src/test.ts",

--- a/aio/content/guide/angular-compiler-options.md
+++ b/aio/content/guide/angular-compiler-options.md
@@ -120,6 +120,12 @@ When `true` (recommended), enables the [binding expression validation](guide/aot
 
 Default is `false`, but when you use the CLI command `ng new --strict`, it is set to `true` in the generated project's configuration.
 
+<div class="alert is-important">
+
+The `fullTemplateTypeCheck` option has been deprecated in Angular 13 in favor of the `strictTemplates` family of compiler options.
+
+</div>
+
 ### `generateCodeForLibraries`
 
 When `true` (the default), generates factory files (`.ngfactory.js` and `.ngstyle.js`) for `.d.ts` files with a corresponding `.metadata.json` file.

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -50,6 +50,7 @@ v12 - v15
 | polyfills               | [reflect-metadata](#reflect-metadata)                                                         | <!--v8--> v11         |
 | npm package format      | [`esm5` and `fesm5` entry-points in @angular/* npm packages](guide/deprecations#esm5-fesm5)   | <!-- v9 --> v11       |
 | `@angular/compiler-cli` | [Input setter coercion](#input-setter-coercion)                                               | <!--v13--> v15        |
+| `@angular/compiler-cli` | [`fullTemplateTypeCheck`](#full-template-type-check)                                          | <!--v13--> v15        |
 | `@angular/core`         | [`defineInjectable`](#core)                                                                   | <!--v8--> v11         |
 | `@angular/core`         | [`entryComponents`](api/core/NgModule#entryComponents)                                        | <!--v9--> v11         |
 | `@angular/core`         | [`ANALYZE_FOR_ENTRY_COMPONENTS`](api/core/ANALYZE_FOR_ENTRY_COMPONENTS)                       | <!--v9--> v11         |
@@ -530,6 +531,36 @@ class SubmitButton {
   }
 }
 ```
+
+{@a full-template-type-check}
+### `fullTemplateTypeCheck`
+
+When compiling your application using the AOT compiler, your templates are type-checked according to a certain strictness level.
+Before Angular 9 there existed only two strictness levels of template type checking as determined by [the `fullTemplateTypeCheck` compiler option](guide/angular-compiler-options).
+In version 9 the `strictTemplates` family of compiler options has been introduced as a more fine-grained approach to configuring how strict your templates are being type-checked.
+
+The `fullTemplateTypeCheck` flag is being deprecated in favor of the new `strictTemplates` option and its related compiler options.
+Projects that currently have `fullTemplateTypeCheck: true` configured can migrate to the following set of compiler options to achieve the same level of type-checking:
+
+<code-example language="json" header="tsconfig.app.json">
+
+{
+  "angularCompilerOptions": {
+    ...
+    "strictTemplates": true,
+    "strictInputTypes": false,
+    "strictNullInputTypes": false,
+    "strictAttributeTypes": false,
+    "strictOutputEventTypes": false,
+    "strictDomEventTypes": false,
+    "strictDomLocalRefTypes": false,
+    "strictSafeNavigationTypes": false,
+    "strictContextGenerics": false,
+    ...
+  }
+}
+
+</code-example>
 
 {@a deprecated-cli-flags}
 

--- a/aio/content/guide/template-typecheck.md
+++ b/aio/content/guide/template-typecheck.md
@@ -24,8 +24,6 @@ The compiler also has some major limitations in this mode:
 
 In many cases, these things end up as type `any`, which can cause subsequent parts of the expression to go unchecked.
 
-
-
 ### Full mode
 
 If the `fullTemplateTypeCheck` flag is set to `true`, Angular is more aggressive in its type-checking within templates.
@@ -40,6 +38,12 @@ The following still have type `any`.
 * Local references to DOM elements.
 * The `$event` object.
 * Safe navigation expressions.
+
+<div class="alert is-important">
+
+The `fullTemplateTypeCheck` flag has been deprecated in Angular 13. The `strictTemplates` family of compiler options should be used instead.
+
+</div>
 
 
 {@a strict-mode}

--- a/goldens/public-api/compiler-cli/compiler_options.md
+++ b/goldens/public-api/compiler-cli/compiler_options.md
@@ -26,6 +26,7 @@ export interface LegacyNgcOptions {
     allowEmptyCodegenFiles?: boolean;
     flatModuleId?: string;
     flatModuleOutFile?: string;
+    // @deprecated
     fullTemplateTypeCheck?: boolean;
     preserveWhitespaces?: boolean;
     strictInjectionParameters?: boolean;
@@ -63,7 +64,6 @@ export interface StrictTemplateOptions {
 export interface TargetOptions {
     compilationMode?: 'full' | 'partial';
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -27,6 +27,10 @@ export interface LegacyNgcOptions {
    * For maximum type-checking, set this to `true`, and set `strictTemplates` to `true`.
    *
    * It is an error for this flag to be `false`, while `strictTemplates` is set to `true`.
+   *
+   * @deprecated The `fullTemplateTypeCheck` option has been superseded by the more granular
+   * `strictTemplates` family of compiler options. Usage of `fullTemplateTypeCheck` is therefore
+   * deprecated, `strictTemplates` and its related options should be used instead.
    */
   fullTemplateTypeCheck?: boolean;
 
@@ -127,7 +131,7 @@ export interface StrictTemplateOptions {
   /**
    * If `true`, implies all template strictness flags below (unless individually disabled).
    *
-   * This flag is a superset of `fullTemplateTypeCheck`.
+   * This flag is a superset of the deprecated `fullTemplateTypeCheck` option.
    *
    * Defaults to `false`, even if "fullTemplateTypeCheck" is `true`.
    */


### PR DESCRIPTION
…r option

When compiling your application using the AOT compiler, your templates
are type-checked according to a certain strictness level. Before Angular 9
there existed only two strictness levels of template type checking as
determined by [the `fullTemplateTypeCheck` compiler option](guide/angular-compiler-options).
In version 9 the `strictTemplates` family of compiler options has been
introduced as a more fine-grained approach to configuring how strict your
templates are being type-checked.

The `fullTemplateTypeCheck` flag is being deprecated in favor of the new
`strictTemplates` option and its related compiler options. Projects that
currently have `fullTemplateTypeCheck: true` configured can migrate to
the following set of compiler options to achieve the same level of
type-checking.

```json
{
  "angularCompilerOptions": {
    "strictTemplates": true,
    "strictInputTypes": false,
    "strictNullInputTypes": false,
    "strictAttributeTypes": false,
    "strictOutputEventTypes": false,
    "strictDomEventTypes": false,
    "strictDomLocalRefTypes": false,
    "strictSafeNavigationTypes": false,
    "strictContextGenerics": false,
  }
}
```