### PR TITLE
fix(compiler-cli): correctly interpret token arrays in @Injectable `deps`

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/test/injectable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/injectable_spec.ts
@@ -5,6 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {WrappedNodeExpr} from '@angular/compiler';
+import * as ts from 'typescript';
 import {ErrorCode, FatalDiagnosticError, ngErrorCode} from '../../diagnostics';
 import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
@@ -42,6 +44,46 @@ runInEachFileSystem(() => {
            const res = handler.compileFull(TestClass, analysis);
            expect(res).not.toContain(jasmine.objectContaining({name: 'ɵprov'}));
          });
+    });
+
+    describe('fix', () => {
+      it('should compile dep without Array in @Injectable', () => {
+        const {handler, TestClass, reflectionHost} =
+            fixHandler(`export const Injectable: any; export const Self: any;`, `
+               import { Injectable,Self } from '@angular/core';
+               declare const someToken;
+               @Injectable({
+                 providedIn: 'any',
+                 useFactory: (token) => new TestClass(token),
+                 deps: [[Self, 'stringToken'], [new Self(), someToken], [1]]
+               })
+               export class TestClass {
+                 constructor(token){}
+               }`);
+        let detected =
+            handler.detect(TestClass, reflectionHost.getDecoratorsOfDeclaration(TestClass));
+        if (detected === undefined) {
+          throw new Error('Failed to recognize TestClass');
+        }
+        let {analysis} = handler.analyze(TestClass, detected.metadata);
+        if (analysis === undefined) {
+          throw new Error('Failed to analyze TestClass');
+        }
+        if (analysis.meta.deps === undefined) {
+          throw new Error('Failed to have deps');
+        }
+        analysis.meta.deps.forEach((item) => {
+          let nodeExpr =
+              item.token! as WrappedNodeExpr<ts.Identifier|ts.StringLiteral|ts.NumericLiteral>;
+          if (ts.isArrayLiteralExpression(nodeExpr.node)) {
+            throw new Error('dep can not be ArrayLiteralExpression!');
+          }
+          expect(
+              ts.isStringLiteral(nodeExpr.node) || ts.isIdentifier(nodeExpr.node) ||
+              ts.isNumericLiteral(nodeExpr.node))
+              .toBe(true);
+        });
+      });
     });
   });
 });
@@ -85,4 +127,24 @@ function setupHandler(errorOnDuplicateProv: boolean) {
     throw new Error('Failed to analyze TestClass');
   }
   return {handler, TestClass, ɵprov, analysis};
+}
+
+function fixHandler(angularCoreContent: string, entryFileContent: string) {
+  const ENTRY_FILE = absoluteFrom('/entry.ts');
+  const ANGULAR_CORE = absoluteFrom('/node_modules/@angular/core/index.d.ts');
+  const {program} = makeProgram([
+    {
+      name: ANGULAR_CORE,
+      contents: angularCoreContent,
+    },
+    {name: ENTRY_FILE, contents: entryFileContent},
+  ]);
+  const checker = program.getTypeChecker();
+  const reflectionHost = new TypeScriptReflectionHost(checker);
+  const injectableRegistry = new InjectableClassRegistry(reflectionHost);
+  const handler = new InjectableDecoratorHandler(
+      reflectionHost, false, false, injectableRegistry, NOOP_PERF_RECORDER, false);
+  const TestClass = getDeclaration(program, ENTRY_FILE, 'TestClass', isNamedClassDeclaration);
+
+  return {TestClass, reflectionHost, handler};
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/GOLDEN_PARTIAL.js
@@ -167,30 +167,18 @@ import * as i0 from "@angular/core";
 class SomeDep {
 }
 class MyAlternateService {
-    constructor(dep) { }
+    constructor(dep, optional) { }
 }
 export class MyService {
 }
 MyService.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyService, deps: [], target: i0.ɵɵFactoryTarget.Injectable });
-MyService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyService, providedIn: 'root', useFactory: (dep) => new MyAlternateService(dep), deps: [{ token: SomeDep }] });
+MyService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyService, providedIn: 'root', useFactory: (dep, optional) => new MyAlternateService(dep, optional), deps: [{ token: SomeDep }, { token: SomeDep, optional: true }] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyService, decorators: [{
             type: Injectable,
             args: [{
                     providedIn: 'root',
-                    useFactory: (dep) => new MyAlternateService(dep),
-                    deps: [SomeDep]
-                }]
-        }] });
-export class MyOptionalService {
-}
-MyOptionalService.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyOptionalService, deps: [], target: i0.ɵɵFactoryTarget.Injectable });
-MyOptionalService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyOptionalService, providedIn: 'root', useFactory: (dep) => new MyAlternateService(dep), deps: [{ token: SomeDep, optional: true }] });
-i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyOptionalService, decorators: [{
-            type: Injectable,
-            args: [{
-                    providedIn: 'root',
-                    useFactory: (dep) => new MyAlternateService(dep),
-                    deps: [[new Optional(), SomeDep]]
+                    useFactory: (dep, optional) => new MyAlternateService(dep, optional),
+                    deps: [SomeDep, [new Optional(), SomeDep]]
                 }]
         }] });
 
@@ -201,10 +189,6 @@ import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
     static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
-}
-export declare class MyOptionalService {
-    static ɵfac: i0.ɵɵFactoryDeclaration<MyOptionalService, never>;
-    static ɵprov: i0.ɵɵInjectableDeclaration<MyOptionalService>;
 }
 
 /****************************************************************************************************

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/GOLDEN_PARTIAL.js
@@ -167,24 +167,29 @@ import * as i0 from "@angular/core";
 class SomeDep {
 }
 class MyAlternateService {
+    constructor(dep) { }
 }
 export class MyService {
 }
 MyService.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyService, deps: [], target: i0.ɵɵFactoryTarget.Injectable });
-MyService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyService, providedIn: 'root', useFactory: () => new MyAlternateService(), deps: [{ token: SomeDep }] });
+MyService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyService, providedIn: 'root', useFactory: (dep) => new MyAlternateService(dep), deps: [{ token: SomeDep }] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyService, decorators: [{
             type: Injectable,
-            args: [{ providedIn: 'root', useFactory: () => new MyAlternateService(), deps: [SomeDep] }]
+            args: [{
+                    providedIn: 'root',
+                    useFactory: (dep) => new MyAlternateService(dep),
+                    deps: [SomeDep]
+                }]
         }] });
 export class MyOptionalService {
 }
 MyOptionalService.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyOptionalService, deps: [], target: i0.ɵɵFactoryTarget.Injectable });
-MyOptionalService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyOptionalService, providedIn: 'root', useFactory: () => new MyAlternateService(), deps: [{ token: SomeDep, optional: true }] });
+MyOptionalService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyOptionalService, providedIn: 'root', useFactory: (dep) => new MyAlternateService(dep), deps: [{ token: SomeDep, optional: true }] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyOptionalService, decorators: [{
             type: Injectable,
             args: [{
                     providedIn: 'root',
-                    useFactory: () => new MyAlternateService(),
+                    useFactory: (dep) => new MyAlternateService(dep),
                     deps: [[new Optional(), SomeDep]]
                 }]
         }] });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/GOLDEN_PARTIAL.js
@@ -162,7 +162,7 @@ export declare class MyService {
 /****************************************************************************************************
  * PARTIAL FILE: usefactory_with_deps.js
  ****************************************************************************************************/
-import { Injectable } from '@angular/core';
+import { Injectable, Optional } from '@angular/core';
 import * as i0 from "@angular/core";
 class SomeDep {
 }
@@ -176,6 +176,18 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
             type: Injectable,
             args: [{ providedIn: 'root', useFactory: () => new MyAlternateService(), deps: [SomeDep] }]
         }] });
+export class MyOptionalService {
+}
+MyOptionalService.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyOptionalService, deps: [], target: i0.ɵɵFactoryTarget.Injectable });
+MyOptionalService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyOptionalService, providedIn: 'root', useFactory: () => new MyAlternateService(), deps: [{ token: SomeDep, optional: true }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyOptionalService, decorators: [{
+            type: Injectable,
+            args: [{
+                    providedIn: 'root',
+                    useFactory: () => new MyAlternateService(),
+                    deps: [[new Optional(), SomeDep]]
+                }]
+        }] });
 
 /****************************************************************************************************
  * PARTIAL FILE: usefactory_with_deps.d.ts
@@ -184,6 +196,10 @@ import * as i0 from "@angular/core";
 export declare class MyService {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyService, never>;
     static ɵprov: i0.ɵɵInjectableDeclaration<MyService>;
+}
+export declare class MyOptionalService {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyOptionalService, never>;
+    static ɵprov: i0.ɵɵInjectableDeclaration<MyOptionalService>;
 }
 
 /****************************************************************************************************

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps.js
@@ -11,3 +11,17 @@ MyService.ɵprov = /*@__PURE__*/ $r3$.ɵɵdefineInjectable({
   },
   providedIn: 'root'
 });
+// ...
+MyOptionalService.ɵprov = /*@__PURE__*/ $r3$.ɵɵdefineInjectable({
+  token: MyOptionalService,
+  factory: function MyOptionalService_Factory(t) {
+    let r = null;
+    if (t) {
+      r = new t();
+    } else {
+      r = (() => new MyAlternateService())($r3$.ɵɵinject(SomeDep, 8));
+    }
+    return r;
+  },
+  providedIn: 'root'
+});

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps.js
@@ -5,7 +5,7 @@ MyService.ɵprov = /*@__PURE__*/ $r3$.ɵɵdefineInjectable({
     if (t) {
       r = new t();
     } else {
-      r = (() => new MyAlternateService())($r3$.ɵɵinject(SomeDep));
+      r = ((dep) => new MyAlternateService(dep))($r3$.ɵɵinject(SomeDep));
     }
     return r;
   },
@@ -19,7 +19,7 @@ MyOptionalService.ɵprov = /*@__PURE__*/ $r3$.ɵɵdefineInjectable({
     if (t) {
       r = new t();
     } else {
-      r = (() => new MyAlternateService())($r3$.ɵɵinject(SomeDep, 8));
+      r = ((dep) => new MyAlternateService(dep))($r3$.ɵɵinject(SomeDep, 8));
     }
     return r;
   },

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps.js
@@ -5,21 +5,7 @@ MyService.ɵprov = /*@__PURE__*/ $r3$.ɵɵdefineInjectable({
     if (t) {
       r = new t();
     } else {
-      r = ((dep) => new MyAlternateService(dep))($r3$.ɵɵinject(SomeDep));
-    }
-    return r;
-  },
-  providedIn: 'root'
-});
-// ...
-MyOptionalService.ɵprov = /*@__PURE__*/ $r3$.ɵɵdefineInjectable({
-  token: MyOptionalService,
-  factory: function MyOptionalService_Factory(t) {
-    let r = null;
-    if (t) {
-      r = new t();
-    } else {
-      r = ((dep) => new MyAlternateService(dep))($r3$.ɵɵinject(SomeDep, 8));
+      r = ((dep, optional) => new MyAlternateService(dep, optional))($r3$.ɵɵinject(SomeDep), $r3$.ɵɵinject(SomeDep, 8));
     }
     return r;
   },

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps.ts
@@ -1,8 +1,16 @@
-import {Injectable} from '@angular/core';
+import {Injectable, Optional} from '@angular/core';
 
 class SomeDep {}
 class MyAlternateService {}
 
 @Injectable({providedIn: 'root', useFactory: () => new MyAlternateService(), deps: [SomeDep]})
 export class MyService {
+}
+
+@Injectable({
+  providedIn: 'root',
+  useFactory: () => new MyAlternateService(),
+  deps: [[new Optional(), SomeDep]]
+})
+export class MyOptionalService {
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps.ts
@@ -1,15 +1,21 @@
 import {Injectable, Optional} from '@angular/core';
 
 class SomeDep {}
-class MyAlternateService {}
+class MyAlternateService {
+  constructor(dep: SomeDep|null) {}
+}
 
-@Injectable({providedIn: 'root', useFactory: () => new MyAlternateService(), deps: [SomeDep]})
+@Injectable({
+  providedIn: 'root',
+  useFactory: (dep: SomeDep) => new MyAlternateService(dep),
+  deps: [SomeDep]
+})
 export class MyService {
 }
 
 @Injectable({
   providedIn: 'root',
-  useFactory: () => new MyAlternateService(),
+  useFactory: (dep: SomeDep|null) => new MyAlternateService(dep),
   deps: [[new Optional(), SomeDep]]
 })
 export class MyOptionalService {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps.ts
@@ -2,21 +2,13 @@ import {Injectable, Optional} from '@angular/core';
 
 class SomeDep {}
 class MyAlternateService {
-  constructor(dep: SomeDep|null) {}
+  constructor(dep: SomeDep, optional: SomeDep|null) {}
 }
 
 @Injectable({
   providedIn: 'root',
-  useFactory: (dep: SomeDep) => new MyAlternateService(dep),
-  deps: [SomeDep]
+  useFactory: (dep: SomeDep, optional: SomeDep|null) => new MyAlternateService(dep, optional),
+  deps: [SomeDep, [new Optional(), SomeDep]]
 })
 export class MyService {
-}
-
-@Injectable({
-  providedIn: 'root',
-  useFactory: (dep: SomeDep|null) => new MyAlternateService(dep),
-  deps: [[new Optional(), SomeDep]]
-})
-export class MyOptionalService {
 }


### PR DESCRIPTION
When specifying the `deps` array in the `@Injectable` decorator to
inject dependencies into the injectable's factory function, it should
be possible to use an array literal to configure how the dependency
should be resolved by the DI system.

For example, the following example is allowed:

```ts
@Injectable({
  providedIn: 'root',
  useFactory: a => new AppService(a),
  deps: [[new Optional(), 'a']],
})
export class AppService {
  constructor(a) {}
}
```

Here, the `'a'` string token should be injected as optional. However,
the AOT compiler incorrectly used the array literal itself as injection
token, resulting in a failure at runtime. Only if the token were to be
provided using `[new Optional(), new Inject('a')]` would it work
correctly.

This commit fixes the issue by using the last non-decorator in the
array literal as the token value, instead of the array literal itself.

Note that this is a loose interpretation of array literals: if a token
is omitted from the array literal then the array literal itself is used
as token, but any decorator such as `new Optional()` would still have
been applied. When there's multiple tokens in the list then only the
last one will be used as actual token, any prior tokens are silently
ignored. This behavior mirrors the JIT interpretation so is kept as is
for now, but may benefit from some stricter checking and better error
reporting in the future.

Fixes #42987

---

Thanks to @wszgrcy for their contribution.