### PR TITLE
docs: add step to declare `ProductAlertsComponent` in tutorial

### DIFF
--- a/aio/content/examples/getting-started/src/app/app.module.ts
+++ b/aio/content/examples/getting-started/src/app/app.module.ts
@@ -10,14 +10,17 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { AppComponent } from './app.component';
 import { TopBarComponent } from './top-bar/top-bar.component';
 import { ProductListComponent } from './product-list/product-list.component';
+// #docregion declare-product-alerts
 import { ProductAlertsComponent } from './product-alerts/product-alerts.component';
+// #enddocregion declare-product-alerts
 import { ProductDetailsComponent } from './product-details/product-details.component';
 import { CartComponent } from './cart/cart.component';
 import { ShippingComponent } from './shipping/shipping.component';
 
-// #docregion product-details-route, http-client-module, shipping-route, cart-route
+// #docregion product-details-route, http-client-module, shipping-route, cart-route, declare-product-alerts
 
 @NgModule({
+  // #enddocregion declare-product-alerts
   imports: [
     BrowserModule,
     // #enddocregion product-details-route, cart-route
@@ -36,17 +39,20 @@ import { ShippingComponent } from './shipping/shipping.component';
     ])
   ],
   // #enddocregion product-details-route, cart-route
+  // #docregion declare-product-alerts
   declarations: [
     AppComponent,
     TopBarComponent,
     ProductListComponent,
     ProductAlertsComponent,
+    // #enddocregion declare-product-alerts
     ProductDetailsComponent,
     CartComponent,
 // #enddocregion http-client-module
     ShippingComponent
-// #docregion http-client-module
+  // #docregion declare-product-alerts, http-client-module
   ],
+  // #enddocregion declare-product-alerts
   bootstrap: [
     AppComponent
   ]

--- a/aio/content/start/index.md
+++ b/aio/content/start/index.md
@@ -199,7 +199,11 @@ This section walks you through creating a child component, `ProductAlertsCompone
 
   <code-example header="src/app/product-alerts/product-alerts.component.html" path="getting-started/src/app/product-alerts/product-alerts.component.1.html"></code-example>
 
-1. To display `ProductAlertsComponent` as a child of `ProductListComponent`, add the selector, `<app-product-alerts>` to `product-list.component.html`.
+1. To make `ProductAlertsComponent` available to other components in the application, add it to `AppModule`'s declarations in `app.module.ts`.
+
+  <code-example header="src/app/app.module.ts" path="getting-started/src/app/app.module.ts" region="declare-product-alerts"></code-example>
+
+1. Finally, to display `ProductAlertsComponent` as a child of `ProductListComponent`, add the selector, `<app-product-alerts>` to `product-list.component.html`.
   Pass the current product as input to the component using property binding.
 
   <code-example header="src/app/product-list/product-list.component.html" path="getting-started/src/app/product-list/product-list.component.5.html" region="app-product-alerts"></code-example>


### PR DESCRIPTION
The getting-started tutorial at angular.io/start instructs users to generate a `ProductAlertsComponent` using the "Angular generator" feature in [StackBlitz](https://stackblitz.com/). However, unlike the Angular CLI, generating a component in StackBlitz does not automatically declare it in `AppModule`, which is a requirement for the component to be used in the application. This resulted in a compile error when following the tutorial instructions.

This commit fixes this by adding a step to manually import and declare the newly generated component in `app.module.ts`.

Fixes #43020.
Closes #43212.
