### PR TITLE
test(ngcc): use @angular npm packages in integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "@angular-devkit/build-optimizer": "0.1200.4",
     "@angular-devkit/core": "12.0.4",
     "@angular-devkit/schematics": "12.0.4",
+    "@angular/common-12": "npm:@angular/common@12.2.2",
+    "@angular/core-12": "npm:@angular/core@12.2.2",
     "@angular/cli": "12.0.4",
     "@babel/cli": "7.14.8",
     "@babel/core": "7.8.6",

--- a/packages/compiler-cli/ngcc/test/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/test/BUILD.bazel
@@ -78,12 +78,12 @@ babel(
     name = "fesm5_angular_core",
     outs = ["fesm5_angular_core.js"],
     args = [
-        "$(execpath //packages/core:npm_package)/fesm2015/core.js",
+        "$(execpath @npm//:node_modules/@angular/core-12/fesm2015/core.js)",
         "--presets @babel/preset-env",
         "--out-file $(execpath fesm5_angular_core.js)",
     ],
     data = [
-        "//packages/core:npm_package",
+        "@npm//:node_modules/@angular/core-12/fesm2015/core.js",
         "@npm//@babel/preset-env",
     ],
 )
@@ -94,15 +94,12 @@ jasmine_node_test(
     bootstrap = ["//tools/testing:node_no_angular_es5"],
     data = [
         ":fesm5_angular_core",
-        "//packages/common:npm_package",
-        "//packages/core:npm_package",
+        "@npm//@angular/common-12",
+        "@npm//@angular/core-12",
         "@npm//rxjs",
     ],
     shard_count = 4,
-    tags = [
-        # Disabled in AOT mode because we want ngcc to compile non-AOT Angular packages.
-        "no-ivy-aot",
-    ],
+    tags = ["ivy-only"],
     templated_args = [
         # TODO(josephperrott): update dependency usages to no longer need bazel patch module resolver
         # See: https://github.com/bazelbuild/rules_nodejs/wiki#--bazel_patch_module_resolver-now-defaults-to-false-2324

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -13,7 +13,7 @@ import * as os from 'os';
 import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem} from '../../../src/ngtsc/file_system';
 import {Folder, MockFileSystem, runInEachFileSystem, TestFile} from '../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../src/ngtsc/logging/testing';
-import {loadStandardTestFiles, loadTestFiles} from '../../../src/ngtsc/testing';
+import {loadTestFiles} from '../../../src/ngtsc/testing';
 import {getLockFilePath} from '../../src/locking/lock_file';
 import {mainNgcc} from '../../src/main';
 import {clearTsConfigCache} from '../../src/ngcc_options';
@@ -23,10 +23,10 @@ import {EntryPointManifestFile} from '../../src/packages/entry_point_manifest';
 import {Transformer} from '../../src/packages/transformer';
 import {DirectPackageJsonUpdater, PackageJsonUpdater} from '../../src/writing/package_json_updater';
 
-import {compileIntoApf, compileIntoFlatEs2015Package, compileIntoFlatEs5Package} from './util';
+import {compileIntoApf, compileIntoFlatEs2015Package, compileIntoFlatEs5Package, loadNgccIntegrationTestFiles} from './util';
 
 const ANGULAR_CORE_IMPORT_REGEX = /import \* as ɵngcc\d+ from '@angular\/core';/;
-const testFiles = loadStandardTestFiles({fakeCore: false, rxjs: true});
+const testFiles = loadNgccIntegrationTestFiles();
 
 runInEachFileSystem(() => {
   describe('ngcc main()', () => {

--- a/packages/compiler-cli/ngcc/test/integration/util.ts
+++ b/packages/compiler-cli/ngcc/test/integration/util.ts
@@ -8,10 +8,10 @@
 
 import * as ts from 'typescript';
 
-import {FileSystem, getFileSystem} from '../../../src/ngtsc/file_system';
-import {MockFileSystemPosix} from '../../../src/ngtsc/file_system/testing';
+import {AbsoluteFsPath, FileSystem, getFileSystem} from '../../../src/ngtsc/file_system';
+import {Folder, MockFileSystemPosix} from '../../../src/ngtsc/file_system/testing';
 
-import {loadStandardTestFiles} from '../../../src/ngtsc/testing';
+import {loadTestDirectory, loadTsLib, resolveNpmTreeArtifact} from '../../../src/ngtsc/testing';
 
 export type PackageSources = {
   [path: string]: string;
@@ -224,7 +224,24 @@ export function compileIntoApf(
       fs.resolve(`/node_modules/${pkgName}/package.json`), JSON.stringify(pkgJson, null, 2));
 }
 
-const stdFiles = loadStandardTestFiles({fakeCore: false});
+export function loadNgccIntegrationTestFiles(): Folder {
+  const tmpFs = new MockFileSystemPosix(true);
+  const basePath = '/' as AbsoluteFsPath;
+
+  loadTsLib(tmpFs, basePath);
+  loadTestDirectory(
+      tmpFs, resolveNpmTreeArtifact('@angular/core-12'),
+      tmpFs.resolve('/node_modules/@angular/core'));
+  loadTestDirectory(
+      tmpFs, resolveNpmTreeArtifact('@angular/common-12'),
+      tmpFs.resolve('/node_modules/@angular/common'));
+  loadTestDirectory(
+      tmpFs, resolveNpmTreeArtifact('typescript'), tmpFs.resolve('/node_modules/typescript'));
+  loadTestDirectory(tmpFs, resolveNpmTreeArtifact('rxjs'), tmpFs.resolve('/node_modules/rxjs'));
+  return tmpFs.dump();
+}
+
+const stdFiles = loadNgccIntegrationTestFiles();
 
 /**
  * Prepares a mock filesystem that contains all provided source files, which can be used to emit

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,6 +196,20 @@
     symbol-observable "4.0.0"
     uuid "8.3.2"
 
+"@angular/common-12@npm:@angular/common@12.2.2":
+  version "12.2.2"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-12.2.2.tgz#ae4736432387018ea29d81a3c73b09106e823276"
+  integrity sha512-cAfPHis8ynpR+qV9ViztCuNBjJ8YRDivvpUXtXecJYYBUPQt9uIiMLeqvBuWmFr+zKD+yAhWywbHEo/4m1JVtQ==
+  dependencies:
+    tslib "^2.2.0"
+
+"@angular/core-12@npm:@angular/core@12.2.2":
+  version "12.2.2"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-12.2.2.tgz#bf10931a059ee9e95ecbc3171303f2304958a601"
+  integrity sha512-zNgH1iFB1vCVNk9PZ+GCo0sZXD19Zt3BobgmHkWJ+PVXRPuKpuLBXWsq7d9IXdbFopQQWWfVHo0eDagIicrSFQ==
+  dependencies:
+    tslib "^2.2.0"
+
 "@angular/core@^10.0.0-0 || ^11.0.0":
   version "11.2.14"
   resolved "https://registry.yarnpkg.com/@angular/core/-/core-11.2.14.tgz#3ebe298c79d5413dc670d56b7f503bd4d788d4a8"


### PR DESCRIPTION
In anticipation of the removal of the View Engine npm package output,
the integration tests of ngcc are switched to use @angular packages for
from npm. The version 12 packages are guaranteed to always be View
Engine format which makes them suitable to be processed in the ngcc
integration tests.