### PR TITLE
feat(core): support TypeScript 4.4

### DIFF
--- a/aio/aio-builds-setup/dockerbuild/scripts-js/package.json
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/package.json
@@ -33,7 +33,7 @@
     "shelljs": "^0.8.4",
     "source-map-support": "^0.5.19",
     "tar-stream": "^2.1.3",
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.0",
@@ -49,6 +49,6 @@
     "supertest": "^4.0.2",
     "tslint": "^6.1.3",
     "tslint-jasmine-noSkipOrFocus": "^1.0.9",
-    "typescript": "~4.3.4"
+    "typescript": "~4.4.2"
   }
 }

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/tsconfig.json
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/tsconfig.json
@@ -33,6 +33,7 @@
     "noUnusedParameters": true,               /* Report errors on unused parameters. */
     "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,       /* Report errors for fallthrough cases in switch statement. */
+    "useUnknownInCatchVariables": false,         /* Avoid having to cast error objects inside `catch` clauses. */
 
     /* Module Resolution Options */
     // "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/yarn.lock
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/yarn.lock
@@ -2505,10 +2505,10 @@ tslib@^1.8.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
-tslib@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
-  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+tslib@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslint-jasmine-noSkipOrFocus@^1.0.9:
   version "1.0.9"
@@ -2563,10 +2563,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@~4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
-  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
+typescript@~4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 undefsafe@^2.0.2:
   version "2.0.2"

--- a/aio/package.json
+++ b/aio/package.json
@@ -102,7 +102,7 @@
     "@webcomponents/custom-elements": "1.5.0",
     "rxjs": "^6.6.7",
     "safevalues": "^0.1.8",
-    "tslib": "^2.2.0",
+    "tslib": "^2.3.0",
     "zone.js": "~0.11.4"
   },
   "devDependencies": {
@@ -181,7 +181,7 @@
     "ts-node": "^10.0.0",
     "tsec": "^0.1.5",
     "tslint": "~6.1.3",
-    "typescript": "~4.3.4",
+    "typescript": "~4.4.2",
     "uglify-js": "^3.13.3",
     "unist-util-filter": "^2.0.3",
     "unist-util-source": "^3.0.0",

--- a/aio/tsconfig.json
+++ b/aio/tsconfig.json
@@ -10,6 +10,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "useUnknownInCatchVariables": false,
     "sourceMap": true,
     "declaration": false,
     "downlevelIteration": true,

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -12778,7 +12778,7 @@ tslib@^1.10.0, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.2.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.2.0, tslib@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -12917,10 +12917,10 @@ typescript@~3.2.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
   integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
-typescript@~4.3.4:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@~4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 ua-parser-js@^0.7.28:
   version "0.7.28"

--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -107,6 +107,12 @@ INTEGRATION_TESTS = {
         # root @npm//typescript package.
         "pinned_npm_packages": ["typescript"],
     },
+    "typings_test_ts44": {
+        # Special case for `typings_test_ts44` test as we want to pin
+        # `typescript` at version 4.4.x for that test and not link to the
+        # root @npm//typescript package.
+        "pinned_npm_packages": ["typescript"],
+    },
 }
 
 [

--- a/integration/typings_test_ts44/include-all.ts
+++ b/integration/typings_test_ts44/include-all.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+
+
+import * as animations from '@angular/animations';
+import * as animationsBrowser from '@angular/animations/browser';
+import * as animationsBrowserTesting from '@angular/animations/browser/testing';
+import * as common from '@angular/common';
+import * as commonHttp from '@angular/common/http';
+import * as commonTesting from '@angular/common/testing';
+import * as commonHttpTesting from '@angular/common/testing';
+import * as compiler from '@angular/compiler';
+import * as compilerTesting from '@angular/compiler/testing';
+import * as core from '@angular/core';
+import * as coreTesting from '@angular/core/testing';
+import * as elements from '@angular/elements';
+import * as forms from '@angular/forms';
+import * as platformBrowser from '@angular/platform-browser';
+import * as platformBrowserDynamic from '@angular/platform-browser-dynamic';
+import * as platformBrowserDynamicTesting from '@angular/platform-browser-dynamic/testing';
+import * as platformBrowserAnimations from '@angular/platform-browser/animations';
+import * as platformBrowserTesting from '@angular/platform-browser/testing';
+import * as platformServer from '@angular/platform-server';
+import * as platformServerInit from '@angular/platform-server/init';
+import * as platformServerTesting from '@angular/platform-server/testing';
+import * as router from '@angular/router';
+import * as routerTesting from '@angular/router/testing';
+import * as routerUpgrade from '@angular/router/upgrade';
+import * as serviceWorker from '@angular/service-worker';
+import * as upgrade from '@angular/upgrade';
+import * as upgradeStatic from '@angular/upgrade/static';
+import * as upgradeTesting from '@angular/upgrade/static/testing';
+
+export default {
+  animations,
+  animationsBrowser,
+  animationsBrowserTesting,
+  common,
+  commonTesting,
+  commonHttp,
+  commonHttpTesting,
+  compiler,
+  compilerTesting,
+  core,
+  coreTesting,
+  elements,
+  forms,
+  platformBrowser,
+  platformBrowserTesting,
+  platformBrowserDynamic,
+  platformBrowserDynamicTesting,
+  platformBrowserAnimations,
+  platformServer,
+  platformServerInit,
+  platformServerTesting,
+  router,
+  routerTesting,
+  routerUpgrade,
+  serviceWorker,
+  upgrade,
+  upgradeStatic,
+  upgradeTesting,
+};

--- a/integration/typings_test_ts44/package.json
+++ b/integration/typings_test_ts44/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "angular-integration",
+  "description": "Assert that users with TypeScript 4.4 can type-check an Angular application",
+  "version": "0.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "@angular/animations": "file:../../dist/packages-dist/animations",
+    "@angular/common": "file:../../dist/packages-dist/common",
+    "@angular/compiler": "file:../../dist/packages-dist/compiler",
+    "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
+    "@angular/core": "file:../../dist/packages-dist/core",
+    "@angular/elements": "file:../../dist/packages-dist/elements",
+    "@angular/forms": "file:../../dist/packages-dist/forms",
+    "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
+    "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
+    "@angular/platform-server": "file:../../dist/packages-dist/platform-server",
+    "@angular/router": "file:../../dist/packages-dist/router",
+    "@angular/service-worker": "file:../../dist/packages-dist/service-worker",
+    "@angular/upgrade": "file:../../dist/packages-dist/upgrade",
+    "@types/jasmine": "file:../../node_modules/@types/jasmine",
+    "rxjs": "file:../../node_modules/rxjs",
+    "typescript": "4.4.2",
+    "zone.js": "file:../../dist/zone.js-dist/archive/zone.js.tgz"
+  },
+  "scripts": {
+    "test": "tsc"
+  }
+}

--- a/integration/typings_test_ts44/tsconfig.json
+++ b/integration/typings_test_ts44/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "experimentalDecorators": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "./dist/out-tsc",
+    "rootDir": ".",
+    "target": "es5",
+    "lib": [
+      "es5",
+      "dom",
+      "es2015.collection",
+      "es2015.iterable",
+      "es2015.promise"
+    ],
+    "types": [],
+  },
+  "files": [
+    "include-all.ts",
+    "node_modules/@types/jasmine/index.d.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -147,9 +147,9 @@
     "terser": "^4.4.0",
     "tmp": "0.2.1",
     "tsickle": "0.38.1",
-    "tslib": "^2.2.0",
+    "tslib": "^2.3.0",
     "tslint": "6.1.3",
-    "typescript": "~4.3.4",
+    "typescript": "~4.4.2",
     "xhr2": "0.2.1",
     "yargs": "^17.0.0"
   },
@@ -191,6 +191,7 @@
   "// 4": "Overwrite graceful-fs to a version that does not rely on the 'natives' package. This fixes gulp for >= 10.13, more information: #28213",
   "// 5": "Ensure a single version of webdriver-manager so it is hoisted as the integration tests depend on it being found at ../../node_modules/webdriver-manager",
   "// 6": "Ensure that `@babel/*` packages match the below versions to avoid conflicts with `types/babel__*`",
+  "// 7": "TypeScript has to be resolved to 4.4 temporarily until @microsoft/api-extractor is updated",
   "resolutions": {
     "**/graceful-fs": "4.2.8",
     "**/webdriver-manager": "12.1.8",
@@ -200,6 +201,7 @@
     "@babel/preset-env": "7.10.2",
     "@babel/template": "7.8.6",
     "@babel/traverse": "7.8.6",
-    "@babel/types": "7.8.6"
+    "@babel/types": "7.8.6",
+    "typescript": "4.4.2"
   }
 }

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -8,7 +8,7 @@
     "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER"

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -26,13 +26,13 @@
     "@microsoft/api-extractor": "7.18.7",
     "shelljs": "0.8.4",
     "tsickle": "^0.38.0",
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "@angular/compiler-cli": "0.0.0-PLACEHOLDER",
     "@bazel/typescript": ">=1.0.0",
     "terser": "^4.3.1",
-    "typescript": ">=4.2.3 <4.4",
+    "typescript": ">=4.2.3 <4.5",
     "rollup": ">=1.20.0",
     "rollup-plugin-commonjs": ">=9.0.0",
     "rollup-plugin-node-resolve": ">=4.2.0",

--- a/packages/benchpress/package.json
+++ b/packages/benchpress/package.json
@@ -4,7 +4,6 @@
   "description": "Benchpress - a framework for e2e performance tests",
   "main": "index.js",
   "typings": "./index.d.ts",
-  "strictNullChecks": true,
   "dependencies": {
     "@angular/core": "^12.0.0",
     "reflect-metadata": "^0.1.13"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,7 +9,7 @@
   },
   "locales": "locales",
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",

--- a/packages/compiler-cli/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/esm5_host.ts
@@ -573,6 +573,7 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
    *
    * 1. `__spread(arguments)`
    * 2. `__spreadArray([], __read(arguments))`
+   * 3. `__spreadArray([], __read(arguments), false)`
    *
    * The tslib helpers may have been emitted inline as in the above example, or they may be read
    * from a namespace import.
@@ -587,8 +588,8 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
       // `__spread(arguments)`
       return call.args.length === 1 && isArgumentsIdentifier(call.args[0]);
     } else if (call.helper === KnownDeclaration.TsHelperSpreadArray) {
-      // `__spreadArray([], __read(arguments))`
-      if (call.args.length !== 2) {
+      // `__spreadArray([], __read(arguments), false)`
+      if (call.args.length !== 2 && call.args.length !== 3) {
         return false;
       }
 

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -381,7 +381,7 @@ runInEachFileSystem(() => {
 
          const jsContents = fs.readFile(_(`/node_modules/test-package/esm5/src/index.js`));
          // Verify that the ES5 bundle does contain the expected downleveling syntax.
-         expect(jsContents).toContain('__spreadArray([], __read(arguments))');
+         expect(jsContents).toContain('__spreadArray([], __read(arguments), false)');
          expect(jsContents)
              .toContain(
                  'var ɵSubClass_BaseFactory; return function SubClass_Factory(t) { return (ɵSubClass_BaseFactory || (ɵSubClass_BaseFactory = ɵngcc0.ɵɵgetInheritedFactory(SubClass)))(t || SubClass); };');
@@ -420,7 +420,7 @@ runInEachFileSystem(() => {
 
          const jsContents = fs.readFile(_(`/node_modules/test-package/esm5/src/index.js`));
          // Verify that the ES5 bundle does contain the expected downleveling syntax.
-         expect(jsContents).toContain('__spreadArray([], __read(arguments))');
+         expect(jsContents).toContain('__spreadArray([], __read(arguments), false)');
          expect(jsContents)
              .toContain(
                  'var ɵSubClass_BaseFactory; return function SubClass_Factory(t) { return (ɵSubClass_BaseFactory || (ɵSubClass_BaseFactory = ɵngcc0.ɵɵgetInheritedFactory(SubClass)))(t || SubClass); };');

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -23,12 +23,12 @@
     "semver": "^7.0.0",
     "source-map": "^0.6.1",
     "sourcemap-codec": "^1.4.8",
-    "tslib": "^2.2.0",
+    "tslib": "^2.3.0",
     "yargs": "^17.0.0"
   },
   "peerDependencies": {
     "@angular/compiler": "0.0.0-PLACEHOLDER",
-    "typescript": ">=4.2.3 <4.4"
+    "typescript": ">=4.2.3 <4.5"
   },
   "repository": {
     "type": "git",

--- a/packages/compiler-cli/src/transformers/downlevel_decorators_transform.ts
+++ b/packages/compiler-cli/src/transformers/downlevel_decorators_transform.ts
@@ -67,8 +67,7 @@ function extractMetadataFromSingleDecorator(
         for (const arg of call.arguments) {
           args.push(arg);
         }
-        const argsArrayLiteral = ts.createArrayLiteral(args);
-        argsArrayLiteral.elements.hasTrailingComma = true;
+        const argsArrayLiteral = ts.createArrayLiteral(ts.createNodeArray(args, true));
         metadataProperties.push(ts.createPropertyAssignment('args', argsArrayLiteral));
       }
       break;

--- a/packages/compiler-cli/src/typescript_support.ts
+++ b/packages/compiler-cli/src/typescript_support.ts
@@ -25,7 +25,7 @@ const MIN_TS_VERSION = '4.2.3';
  * Note: this check is disabled in g3, search for
  * `angularCompilerOptions.disableTypeScriptVersionCheck` config param value in g3.
  */
-const MAX_TS_VERSION = '4.4.0';
+const MAX_TS_VERSION = '4.5.0';
 
 /**
  * The currently used version of TypeScript, which can be adjusted for testing purposes using

--- a/packages/compiler-cli/test/transformers/downlevel_decorators_transform_spec.ts
+++ b/packages/compiler-cli/test/transformers/downlevel_decorators_transform_spec.ts
@@ -182,7 +182,7 @@ describe('downlevel decorator transform', () => {
 
     expect(diagnostics.length).toBe(0);
     expect(output).toContain(dedent`
-      MyClass = tslib_1.__decorate([
+      MyClass = (0, tslib_1.__decorate)([
         SomeUnknownDecorator()
       ], MyClass);
     `);
@@ -197,7 +197,7 @@ describe('downlevel decorator transform', () => {
 
     expect(diagnostics.length).toBe(0);
     expect(output).toContain(dedent`
-      MyClass = tslib_1.__decorate([
+      MyClass = (0, tslib_1.__decorate)([
         DecoratorBuilder().customClassDecorator
       ], MyClass);
     `);
@@ -231,7 +231,7 @@ describe('downlevel decorator transform', () => {
 
     expect(diagnostics.length).toBe(0);
     expect(output).toContain(dedent`
-      tslib_1.__decorate([
+      (0, tslib_1.__decorate)([
         SomeDecorator()
       ], MyDir.prototype, "disabled", void 0);
     `);
@@ -428,6 +428,8 @@ describe('downlevel decorator transform', () => {
       MyDir.decorators = [
         { type: core_1.Directive }
       ];
+    `);
+    expect(output).toContain(dedent`
       /**
        * @type {function(): !Array<(null|{
        *   type: ?,
@@ -671,8 +673,8 @@ describe('downlevel decorator transform', () => {
       expect(diagnostics.length).toBe(0);
       expect(output).not.toContain('MyService.decorators');
       expect(output).toContain(dedent`
-        MyService = tslib_1.__decorate([
-          core_1.Injectable()
+        MyService = (0, tslib_1.__decorate)([
+          (0, core_1.Injectable)()
         ], MyService);
       `);
     });
@@ -697,8 +699,8 @@ describe('downlevel decorator transform', () => {
         MyService.ctorParameters = () => [
           { type: InjectClass }
         ];
-        MyService = tslib_1.__decorate([
-          core_1.Injectable()
+        MyService = (0, tslib_1.__decorate)([
+          (0, core_1.Injectable)()
         ], MyService);
       `);
     });
@@ -723,8 +725,8 @@ describe('downlevel decorator transform', () => {
         MyService.ctorParameters = () => [
           { type: InjectClass, decorators: [{ type: core_1.Inject, args: ['test',] }] }
         ];
-        MyService = tslib_1.__decorate([
-          core_1.Injectable()
+        MyService = (0, tslib_1.__decorate)([
+          (0, core_1.Injectable)()
         ], MyService);
       `);
     });

--- a/packages/compiler-cli/test/transformers/inline_resources_spec.ts
+++ b/packages/compiler-cli/test/transformers/inline_resources_spec.ts
@@ -47,7 +47,7 @@ describe('inline resources transformer', () => {
       expect(actual).not.toContain('templateUrl:');
       expect(actual.replace(/\s+/g, ' '))
           .toContain(
-              'Foo = __decorate([ core_1.Component({ template: "Some template", otherProp: 3 }) ], Foo)');
+              'Foo = __decorate([ (0, core_1.Component)({ template: "Some template", otherProp: 3 }) ], Foo)');
     });
     it('should allow different quotes', () => {
       const actual = convert(`import {Component} from '@angular/core';
@@ -172,8 +172,6 @@ function convert(source: string) {
   const context = new MockAotContext('/', {[baseFileName + '.ts']: source});
   const host = new MockCompilerHost(context);
 
-  const sourceFile =
-      ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, /* setParentNodes */ true);
   const program = ts.createProgram(
       [fileName], {
         module: ts.ModuleKind.CommonJS,
@@ -186,7 +184,7 @@ function convert(source: string) {
         program, {loadResource, resourceNameToFileName: (u: string) => u})]
   };
   let result = '';
-  const emitResult = program.emit(
+  program.emit(
       moduleSourceFile, (emittedFileName, data, writeByteOrderMark, onError, sourceFiles) => {
         if (fileName.startsWith(moduleName)) {
           result = data;

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -8,7 +8,7 @@
     "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "repository": {
     "type": "git",

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -260,9 +260,9 @@ export class Binary extends AST {
 export class Unary extends Binary {
   // Redeclare the properties that are inherited from `Binary` as `never`, as consumers should not
   // depend on these fields when operating on `Unary`.
-  override left: never;
-  override right: never;
-  override operation: never;
+  override left: never = null as never;
+  override right: never = null as never;
+  override operation: never = null as never;
 
   /**
    * Creates a unary minus expression "-x", represented as `Binary` using "0 - x".

--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -381,7 +381,7 @@ class _TreeBuilder {
     // `_peek.type` from TS. Otherwise TS will narrow the type of `_peek.type` preventing it from
     // being able to consider `ATTR_VALUE_INTERPOLATION` as an option. This is because TS is not
     // able to see that `_advance()` will actually mutate `_peek`.
-    const nextTokenType = this._peek.type;
+    const nextTokenType = this._peek.type as TokenType;
     if (nextTokenType === TokenType.ATTR_VALUE_TEXT) {
       valueStartSpan = this._peek.sourceSpan;
       valueEnd = this._peek.sourceSpan.end;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
     "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "rxjs": "^6.5.3 || ^7.0.0",

--- a/packages/core/schematics/tsconfig.json
+++ b/packages/core/schematics/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "noImplicitReturns": true,
     "noImplicitOverride": true,
+    "useUnknownInCatchVariables": false,
     "noFallthroughCasesInSwitch": true,
     "strict": true,
     "moduleResolution": "node",

--- a/packages/core/src/reflection/reflection_capabilities.ts
+++ b/packages/core/src/reflection/reflection_capabilities.ts
@@ -43,13 +43,13 @@ import {GetterFn, MethodFn, SetterFn} from './types';
  * or downleveled to ES5 with `downlevelIteration` for TypeScript >= 4.2:
  * ```
  *   function MyClass() {
- *     var _this = _super.apply(this, __spreadArray([], __read(arguments))) || this;
+ *     var _this = _super.apply(this, __spreadArray([], __read(arguments), false)) || this;
  * ```
  *
  * More details can be found in: https://github.com/angular/angular/issues/38453.
  */
 export const ES5_DELEGATE_CTOR =
-    /^function\s+\S+\(\)\s*{[\s\S]+\.apply\(this,\s*(arguments|(?:[^()]+\(\[\],)?[^()]+\(arguments\))\)/;
+    /^function\s+\S+\(\)\s*{[\s\S]+\.apply\(this,\s*(arguments|(?:[^()]+\(\[\],)?[^()]+\(arguments\).*)\)/;
 /** Regular expression that detects ES2015 classes which extend from other classes. */
 export const ES2015_INHERITED_CLASS = /^class\s+[A-Za-z\d$_]*\s*extends\s+[^{]+{/;
 /**

--- a/packages/core/testing/src/resolvers.ts
+++ b/packages/core/testing/src/resolvers.ts
@@ -57,7 +57,7 @@ abstract class OverrideResolver<T> implements Resolver<T> {
       const isKnownType = annotation instanceof Directive || annotation instanceof Component ||
           annotation instanceof Pipe || annotation instanceof NgModule;
       if (isKnownType) {
-        return annotation instanceof this.type ? annotation : null;
+        return annotation instanceof this.type ? annotation as T : null;
       }
     }
     return null;

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -8,7 +8,7 @@
     "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -8,7 +8,7 @@
     "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",

--- a/packages/language-service/ivy/test/legacy/mock_host.ts
+++ b/packages/language-service/ivy/test/legacy/mock_host.ts
@@ -154,6 +154,7 @@ export function setup() {
     useSingleInferredProject: true,
     useInferredProjectPerProjectRoot: true,
     typingsInstaller: ts.server.nullTypingsInstaller,
+    session: undefined
   });
   // Opening APP_COMPONENT forces a new ConfiguredProject to be created based
   // on the tsconfig.json in the test project.

--- a/packages/language-service/ivy/testing/src/env.ts
+++ b/packages/language-service/ivy/testing/src/env.ts
@@ -36,7 +36,7 @@ export class LanguageServiceTestEnv {
       cancellationToken: ts.server.nullCancellationToken,
       host,
       typingsInstaller: ts.server.nullTypingsInstaller,
-
+      session: undefined,
       useInferredProjectPerProjectRoot: true,
       useSingleInferredProject: true,
     });

--- a/packages/misc/angular-in-memory-web-api/package.json
+++ b/packages/misc/angular-in-memory-web-api/package.json
@@ -10,7 +10,7 @@
     "rxjs": "^6.5.3 || ^7.0.0"
   },
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "repository": {
     "type": "git",

--- a/packages/platform-browser-dynamic/package.json
+++ b/packages/platform-browser-dynamic/package.json
@@ -8,7 +8,7 @@
     "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -8,7 +8,7 @@
     "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "@angular/animations": "0.0.0-PLACEHOLDER",

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -140,7 +140,7 @@ class DefaultDomRenderer2 implements Renderer2 {
 
   destroy(): void {}
 
-  destroyNode: null;
+  destroyNode = null;
 
   createElement(name: string, namespace?: string): any {
     if (namespace) {

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "domino": "^2.1.2",
-    "tslib": "^2.2.0",
+    "tslib": "^2.3.0",
     "xhr2": "^0.2.0"
   },
   "repository": {

--- a/packages/platform-server/src/server_renderer.ts
+++ b/packages/platform-server/src/server_renderer.ts
@@ -67,7 +67,7 @@ class DefaultServerRenderer2 implements Renderer2 {
 
   destroy(): void {}
 
-  destroyNode: null;
+  destroyNode = null;
 
   createElement(name: string, namespace?: string, debugInfo?: any): any {
     if (namespace) {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/angular/angular/tree/master/packages/router",
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -47,7 +47,7 @@ export class SpyNgModuleFactoryLoader implements NgModuleFactoryLoader {
   /**
    * @docsNotRequired
    */
-  private _stubbedModules: {[path: string]: Promise<NgModuleFactory<any>>} = {};
+  private _stubbedModules: {[path: string]: Promise<NgModuleFactory<any>>|undefined} = {};
 
   /**
    * @docsNotRequired
@@ -71,7 +71,7 @@ export class SpyNgModuleFactoryLoader implements NgModuleFactoryLoader {
 
   load(path: string): Promise<NgModuleFactory<any>> {
     if (this._stubbedModules[path]) {
-      return this._stubbedModules[path];
+      return this._stubbedModules[path]!;
     } else {
       return <any>Promise.reject(new Error(`Cannot find module ${path}`));
     }

--- a/packages/service-worker/cli/tsconfig.json
+++ b/packages/service-worker/cli/tsconfig.json
@@ -10,6 +10,7 @@
     "outDir": "../../../dist/all/@angular/service-worker/cli-custom",
     "noImplicitAny": true,
     "noImplicitOverride": true,
+    "useUnknownInCatchVariables": false,
     "noFallthroughCasesInSwitch": true,
     "rootDir": ".",
     "paths": {

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -8,7 +8,7 @@
     "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -31,10 +31,10 @@ const MAX_IDLE_DELAY = 30000;
 
 const SUPPORTED_CONFIG_VERSION = 1;
 
-const NOTIFICATION_OPTION_NAMES: (keyof Notification)[] = [
+const NOTIFICATION_OPTION_NAMES = [
   'actions', 'badge', 'body', 'data', 'dir', 'icon', 'image', 'lang', 'renotify',
   'requireInteraction', 'silent', 'tag', 'timestamp', 'title', 'vibrate'
-];
+] as (keyof Notification)[];
 
 interface LatestEntry {
   latest: string;

--- a/packages/service-worker/worker/testing/events.ts
+++ b/packages/service-worker/worker/testing/events.ts
@@ -72,6 +72,7 @@ export class MockActivateEvent extends MockExtendableEvent {
 
 export class MockFetchEvent extends MockExtendableEvent implements FetchEvent {
   readonly preloadResponse = Promise.resolve();
+  handled = Promise.resolve(undefined);
   response: Promise<Response|undefined> = Promise.resolve(undefined);
 
   constructor(

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -10,6 +10,7 @@
     "noImplicitAny": true,
     "noImplicitOverride": true,
     "strictNullChecks": true,
+    "useUnknownInCatchVariables": false,
     "strict": true,
     "strictPropertyInitialization": true,
     "noFallthroughCasesInSwitch": true,

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -15,6 +15,7 @@
     "outDir": "../dist/all/@angular",
     "noImplicitAny": true,
     "noImplicitOverride": true,
+    "useUnknownInCatchVariables": false,
     "noFallthroughCasesInSwitch": true,
     "paths": {
       "selenium-webdriver": ["./node_modules/@types/selenium-webdriver/index.d.ts"],

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -8,7 +8,7 @@
     "node": "^12.14.1 || >=14.0.0"
   },
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -8,7 +8,7 @@
   "fesm2015": "./fesm2015/zone.js",
   "typings": "./zone.d.ts",
   "dependencies": {
-    "tslib": "^2.2.0"
+    "tslib": "^2.3.0"
   },
   "devDependencies": {
     "@externs/nodejs": "^1.5.0",
@@ -19,7 +19,7 @@
     "mocha": "^9.0.0",
     "mock-require": "3.0.3",
     "promises-aplus-tests": "^2.1.2",
-    "typescript": "~4.3.4"
+    "typescript": "~4.4.2"
   },
   "scripts": {
     "closuretest": "./scripts/closure/closure_compiler.sh",

--- a/packages/zone.js/test/browser/browser.spec.ts
+++ b/packages/zone.js/test/browser/browser.spec.ts
@@ -2969,25 +2969,30 @@ describe('Zone', function() {
                });
              }));
 
+      // Note: `navigator` is cast to `any` in this test, because the preferred way of accessing
+      // `getUserMedia` is through `navigator.mediaDevices`, however some older browsers still
+      // expose it directly on `navigator`.
       it('navigator.getUserMedia should in zone',
          ifEnvSupportsWithDone(
              () => {
-               return !isEdge() && navigator && typeof navigator.getUserMedia === 'function';
+               return !isEdge() && navigator &&
+                   typeof (navigator as any).getUserMedia === 'function';
              },
              (done: Function) => {
                const zone = Zone.current.fork({name: 'media'});
                zone.run(() => {
                  const constraints = {audio: true, video: {width: 1280, height: 720}};
-                 navigator.getUserMedia(
-                     constraints,
-                     () => {
-                       expect(Zone.current.name).toEqual(zone.name);
-                       done();
-                     },
-                     () => {
-                       expect(Zone.current.name).toEqual(zone.name);
-                       done();
-                     });
+                 (navigator as any)
+                     .getUserMedia(
+                         constraints,
+                         () => {
+                           expect(Zone.current.name).toEqual(zone.name);
+                           done();
+                         },
+                         () => {
+                           expect(Zone.current.name).toEqual(zone.name);
+                           done();
+                         });
                });
              }));
     });

--- a/packages/zone.js/test/typings/package.json
+++ b/packages/zone.js/test/typings/package.json
@@ -14,6 +14,6 @@
     "zone.js": "file:../../../../dist/bin/packages/zone.js/npm_package"
   },
   "devDependencies": {
-    "typescript": "~4.3.4"
+    "typescript": "~4.4.2"
   }
 }

--- a/packages/zone.js/tsconfig.json
+++ b/packages/zone.js/tsconfig.json
@@ -10,6 +10,7 @@
     "stripInternal": false,
     "strict": true,
     "noImplicitOverride": true,
+    "useUnknownInCatchVariables": false,
     "lib": [
       "es5",
       "dom",

--- a/packages/zone.js/yarn.lock
+++ b/packages/zone.js/yarn.lock
@@ -3940,7 +3940,7 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
-tslib@^2.2.0:
+tslib@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -3979,10 +3979,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@~4.3.4:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@~4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,7 +219,6 @@
 
 "@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#e79b0088150f63354090f9c12c2b97f1dd712566":
   version "0.0.0"
-  uid e79b0088150f63354090f9c12c2b97f1dd712566
   resolved "https://github.com/angular/dev-infra-private-builds.git#e79b0088150f63354090f9c12c2b97f1dd712566"
   dependencies:
     "@actions/core" "^1.4.0"
@@ -11921,7 +11920,6 @@ sauce-connect-launcher@^1.2.4:
 
 "sauce-connect@https://saucelabs.com/downloads/sc-4.6.2-linux.tar.gz":
   version "0.0.0"
-  uid "7b7f35433af9c3380758e048894d7b9aecf3754e"
   resolved "https://saucelabs.com/downloads/sc-4.6.2-linux.tar.gz#7b7f35433af9c3380758e048894d7b9aecf3754e"
 
 saucelabs@^1.5.0:
@@ -13428,30 +13426,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
-  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
-
-typescript@4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
-
-typescript@4.3.5, typescript@~4.3.4, typescript@~4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
-
-typescript@^3.9.5, typescript@^3.9.7:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
-
-typescript@~4.4.0:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
-  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+typescript@3.2.4, typescript@4.2.4, typescript@4.3.5, typescript@4.4.2, typescript@^3.9.5, typescript@^3.9.7, typescript@~4.3.5, typescript@~4.4.0, typescript@~4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 ua-parser-js@^0.7.28:
   version "0.7.28"


### PR DESCRIPTION
Adds support for TypeScript 4.4. High-level overview of the changes made in this PR:

* Bumps the various packages to `typescript@4.4.2` and `tslib@2.3.0`.
* The `useUnknownInCatchVariables` compiler option has been disabled so that we don't have to cast error objects explicitly everywhere.
* TS now passes in a third argument to the `__spreadArray` call inside child class constructors. I had to update a couple of places in the runtime and ngcc to be able to pick up the calls correctly.
* TS now generates code like `(0, foo)(arg1, arg2)` for imported function calls. I had to update a few of our tests to account for it. See https://github.com/microsoft/TypeScript/pull/44624.
* Our `ngtsc` test setup calls the private `matchFiles` function from TS. I had to update our usage, because a new parameter was added.
* There was one place where we were setting the readonly `hasTrailingComma` property. I updated the usage to pass in the value when constructing the object instead.
* Some browser types were updated which meant that I had to resolve some trivial type errors.
* The downlevel decorators tranform was running into an issue where the Closure synthetic comments were being emitted twice. I've worked around it by recreating the class declaration node instead of cloning it.