### PR TITLE
fix(router): add more context to `Unhandled Navigation Error`

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1372,7 +1372,7 @@ export class Router {
           t.resolve(true);
         },
         e => {
-          this.console.warn(`Unhandled Navigation Error: `);
+          this.console.warn(`Unhandled Navigation Error: ${e}`);
         });
   }
 


### PR DESCRIPTION
Previously, the error message was not added to `Unhandled Navigation Error`

Before
```
main.js:1 Unhandled Navigation Error:
```

After
```
main.js:1 Unhandled Navigation Error: SecurityError: Failed to execute 'replaceState' on 'History': A history state object with URL 'http://localhost:4200/' cannot be created in a document with origin 'http://127.0.0.1:8080' and URL 'http://127.0.0.1:8080/'.
```
