### PR TITLE
fix(language-service): provide dom event completions

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -154,6 +154,11 @@ export interface TemplateTypeChecker {
   getPotentialDomBindings(tagName: string): {attribute: string, property: string}[];
 
   /**
+   * Retrieve any potential DOM events.
+   */
+  getPotentialDomEvents(tagName: string): string[];
+
+  /**
    * Retrieve the type checking engine's metadata for the given directive class, if available.
    */
   getDirectiveMetadata(dir: ts.ClassDeclaration): TypeCheckableDirectiveMeta|null;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -582,6 +582,10 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
                           }));
   }
 
+  getPotentialDomEvents(tagName: string): string[] {
+    return REGISTRY.allKnownEventsOfElement(tagName);
+  }
+
   private getScopeData(component: ts.ClassDeclaration): ScopeData|null {
     if (this.scopeCache.has(component)) {
       return this.scopeCache.get(component)!;

--- a/packages/language-service/ivy/completions.ts
+++ b/packages/language-service/ivy/completions.ts
@@ -568,6 +568,11 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
       // the user is completing on a property binding `[foo|]`, don't offer output event
       // completions.
       switch (completion.kind) {
+        case AttributeCompletionKind.DomEvent:
+          if (this.node instanceof TmplAstBoundAttribute) {
+            continue;
+          }
+          break;
         case AttributeCompletionKind.DomAttribute:
         case AttributeCompletionKind.DomProperty:
           if (this.node instanceof TmplAstBoundEvent) {
@@ -644,6 +649,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
     let documentation: ts.SymbolDisplayPart[]|undefined = undefined;
     let info: DisplayInfo|null;
     switch (completion.kind) {
+      case AttributeCompletionKind.DomEvent:
       case AttributeCompletionKind.DomAttribute:
       case AttributeCompletionKind.DomProperty:
         // TODO(alxhub): ideally we would show the same documentation as quick info here. However,

--- a/packages/language-service/ivy/test/completions_spec.ts
+++ b/packages/language-service/ivy/test/completions_spec.ts
@@ -506,6 +506,21 @@ describe('completions', () => {
               ['[value]']);
         });
 
+        it('should return event completion', () => {
+          const {templateFile} = setup(`<button ></button>`, ``);
+          templateFile.moveCursorToText(`<button ¦>`);
+          const completions = templateFile.getCompletionsAtPosition();
+          expectContain(completions, DisplayInfoKind.EVENT, ['(click)']);
+        });
+
+        it('should return event completion with empty parens', () => {
+          const {templateFile} = setup(`<button ()></button>`, ``);
+          templateFile.moveCursorToText(`<button (¦)>`);
+          const completions = templateFile.getCompletionsAtPosition();
+          expectContain(completions, DisplayInfoKind.EVENT, ['(click)']);
+        });
+
+
         it('should return completions for a partial attribute', () => {
           const {appFile} = setupInlineTemplate(`<input val>`, '');
           appFile.moveCursorToText('<input val¦>');
@@ -535,6 +550,13 @@ describe('completions', () => {
               completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.PROPERTY),
               ['value']);
           expectReplacementText(completions, appFile.contents, 'val');
+        });
+
+        it('should return completions inside an event binding', () => {
+          const {templateFile} = setup(`<button (cl)=''></button>`, ``);
+          templateFile.moveCursorToText(`(cl¦)=''`);
+          const completions = templateFile.getCompletionsAtPosition();
+          expectContain(completions, DisplayInfoKind.EVENT, ['(click)']);
         });
       });
 


### PR DESCRIPTION
Native DOM events were previously not included in the completions in Ivy
because the dom schema registry would filter out events completely. This
change updates the registry to include events in the private
element->property map and excludes events from lookups outside of the
new `allKnownEventsOfElement` function.

fixes https://github.com/angular/vscode-ng-language-service/issues/1479


Reviewer notes: Autocompletion in the VE language service _did_ include native events so this addresses a regression from previous behavior.

https://github.com/angular/angular/blob/faf9f5a3bc444bb6cbf75916c8022f60e0742bca/packages/language-service/src/completions.ts#L253-L255
https://github.com/angular/angular/blob/faf9f5a3bc444bb6cbf75916c8022f60e0742bca/packages/language-service/src/html_info.ts#L449-L451
https://github.com/angular/angular/blob/faf9f5a3bc444bb6cbf75916c8022f60e0742bca/packages/language-service/src/html_info.ts#L424-L427