### PR TITLE
feat(router): Add `Route.title` with a configurable `TitleStrategy`

### DIFF
--- a/aio/content/examples/router/src/app/app-routing.module.10.ts
+++ b/aio/content/examples/router/src/app/app-routing.module.10.ts
@@ -1,0 +1,44 @@
+// #docplaster
+import {NgModule} from '@angular/core';
+import {PageTitleStrategy, RouterModule, Routes} from '@angular/router';  // CLI imports router
+
+// #docregion page-title
+const routes: Routes = [
+  {
+    path: 'first-component',
+    component: FirstComponent,  // this is the component with the <router-outlet> in the template
+    data: {pageTitle: 'First component'},
+    children: [
+      {
+        path: 'child-a',             // child route path
+        component: ChildAComponent,  // child route component that the router renders
+        data: {pageTitle: 'child a'},
+      },
+      {
+        path: 'child-b',
+        component: ChildBComponent,  // another child route component that the router renders
+        data: {pageTitle: 'child b'},
+      },
+    ],
+  },
+];
+// #enddocregion page-title
+
+
+// #docregion custom-page-title
+export class TemplatePageTitleStrategy extends PageTitleStrategy {
+  override setTitle(title: string) {
+    this.title.setTitle(`My Application | ${title}`);
+  }
+}
+// #enddocregion custom-page-title
+
+// #docregion page-title
+@NgModule({
+  imports: [RouterModule.forRoot(routes)],
+  exports: [RouterModule],
+})
+export class AppRoutingModule {
+  constructor(title: PageTitleStrategy) {}
+}
+// #enddocregion page-title

--- a/aio/content/examples/router/src/app/app-routing.module.10.ts
+++ b/aio/content/examples/router/src/app/app-routing.module.10.ts
@@ -1,6 +1,7 @@
 // #docplaster
-import {Injectable, NgModule} from '@angular/core';
-import {PageTitleStrategy, RouterModule, Routes} from '@angular/router';  // CLI imports router
+import {Injectable, NgModule,} from '@angular/core';
+import {Title} from '@angular/platform-browser';
+import {RouterModule, RouterStateSnapshot, Routes, TitleStrategy} from '@angular/router';  // CLI imports router
 
 // #docregion page-title
 const routes: Routes = [
@@ -33,9 +34,16 @@ export class ResolvedChildATitle {
 
 
 // #docregion custom-page-title
-export class TemplatePageTitleStrategy extends PageTitleStrategy {
-  override setTitle(title: string) {
-    this.title.setTitle(`My Application | ${title}`);
+export class TemplatePageTitleStrategy extends TitleStrategy {
+  constructor(private readonly title: Title) {
+    super();
+  }
+
+  override updateTitle(routerState: RouterStateSnapshot) {
+    const title = this.buildTitle(routerState);
+    if (title !== undefined) {
+      this.title.setTitle(`My Application | ${title}`);
+    }
   }
 }
 
@@ -43,7 +51,7 @@ export class TemplatePageTitleStrategy extends PageTitleStrategy {
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule],
   providers: [
-    {provide: PageTitleStrategy, useClass: TemplatePageTitleStrategy},
+    {provide: TitleStrategy, useClass: TemplatePageTitleStrategy},
   ]
 })
 export class AppRoutingModule {

--- a/aio/content/examples/router/src/app/app-routing.module.10.ts
+++ b/aio/content/examples/router/src/app/app-routing.module.10.ts
@@ -1,27 +1,34 @@
 // #docplaster
-import {NgModule} from '@angular/core';
+import {Injectable, NgModule} from '@angular/core';
 import {PageTitleStrategy, RouterModule, Routes} from '@angular/router';  // CLI imports router
 
 // #docregion page-title
 const routes: Routes = [
   {
     path: 'first-component',
+    title: 'First component',
     component: FirstComponent,  // this is the component with the <router-outlet> in the template
-    data: {pageTitle: 'First component'},
     children: [
       {
-        path: 'child-a',             // child route path
+        path: 'child-a',  // child route path
+        title: ResolvedChildATitle,
         component: ChildAComponent,  // child route component that the router renders
-        data: {pageTitle: 'child a'},
       },
       {
         path: 'child-b',
+        title: 'child b',
         component: ChildBComponent,  // another child route component that the router renders
-        data: {pageTitle: 'child b'},
       },
     ],
   },
 ];
+
+@Injectable({providedIn: 'root'})
+export class ResolvedChildATitle {
+  resolve() {
+    return Promise.resolve('child a');
+  }
+}
 // #enddocregion page-title
 
 
@@ -31,14 +38,14 @@ export class TemplatePageTitleStrategy extends PageTitleStrategy {
     this.title.setTitle(`My Application | ${title}`);
   }
 }
-// #enddocregion custom-page-title
 
-// #docregion page-title
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule],
+  providers: [
+    {provide: PageTitleStrategy, useClass: TemplatePageTitleStrategy},
+  ]
 })
 export class AppRoutingModule {
-  constructor(title: PageTitleStrategy) {}
 }
-// #enddocregion page-title
+// #enddocregion custom-page-title

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -226,6 +226,22 @@ The one difference is that you place child routes in a `children` array within t
 
 </code-example>
 
+{@ setting-the-page-title}
+
+## Setting the page title
+
+Each page in your application should have a unique title so that they can be identified in the browser history.
+The `Router` sets the document's title using the `pageTitle` property in the route data when using the 
+`PageTitleStrategy`. All you need to do to enable this in your application is inject the `PageTitleStrategy`
+somewhere in your application. In this example, we inject `PageTitleStrategy` in the `AppRoutingModule` constructor:
+
+<code-example path="router/src/app/app-routing.module.10.ts" region="page-title" header="AppRoutingModule (excerpt)">
+</code-example>
+
+You can also provide a custom page title strategy by extending the `PageTitleStrategy`.
+<code-example path="router/src/app/app-routing.module.10.ts" region="custom-page-title" header="AppRoutingModule (excerpt)">
+</code-example>
+
 {@a using-relative-paths}
 
 ## Using relative paths

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -237,10 +237,8 @@ The `Router` sets the document's title using the `title` property from the `Rout
 </code-example>
 
 Note that the `title` property follows the same rules as static route `data` and dynamic values that implement `Resolve`.
-This is also true for `paramsInheritanceStrategy`. The `title` property will be copied inherited in the same 
-manner was as data and resolved data.
 
-You can also provide a custom page title strategy by extending the `PageTitleStrategy`.
+You can also provide a custom title strategy by extending the `TitleStrategy`.
 <code-example path="router/src/app/app-routing.module.10.ts" region="custom-page-title" header="AppRoutingModule (excerpt)">
 </code-example>
 

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -231,12 +231,14 @@ The one difference is that you place child routes in a `children` array within t
 ## Setting the page title
 
 Each page in your application should have a unique title so that they can be identified in the browser history.
-The `Router` sets the document's title using the `pageTitle` property in the route data when using the 
-`PageTitleStrategy`. All you need to do to enable this in your application is inject the `PageTitleStrategy`
-somewhere in your application. In this example, we inject `PageTitleStrategy` in the `AppRoutingModule` constructor:
+The `Router` sets the document's title using the `title` property from the `Route` config.
 
 <code-example path="router/src/app/app-routing.module.10.ts" region="page-title" header="AppRoutingModule (excerpt)">
 </code-example>
+
+Note that the `title` property follows the same rules as static route `data` and dynamic values that implement `Resolve`.
+This is also true for `paramsInheritanceStrategy`. The `title` property will be copied inherited in the same 
+manner was as data and resolved data.
 
 You can also provide a custom page title strategy by extending the `PageTitleStrategy`.
 <code-example path="router/src/app/app-routing.module.10.ts" region="custom-page-title" header="AppRoutingModule (excerpt)">

--- a/goldens/public-api/router/router.md
+++ b/goldens/public-api/router/router.md
@@ -25,6 +25,7 @@ import { OnInit } from '@angular/core';
 import { QueryList } from '@angular/core';
 import { Renderer2 } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 import { Type } from '@angular/core';
 import { Version } from '@angular/core';
 import { ViewContainerRef } from '@angular/core';
@@ -346,6 +347,22 @@ export class OutletContext {
     resolver: ComponentFactoryResolver | null;
     // (undocumented)
     route: ActivatedRoute | null;
+}
+
+// @public
+export class PageTitleStrategy implements OnDestroy {
+    constructor(title: Title, router: Router);
+    // (undocumented)
+    getPageTitle(snapshot: RouterStateSnapshot): string | undefined;
+    // (undocumented)
+    ngOnDestroy(): void;
+    setTitle(title: string): void;
+    // (undocumented)
+    protected readonly title: Title;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<PageTitleStrategy, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<PageTitleStrategy>;
 }
 
 // @public

--- a/goldens/public-api/router/router.md
+++ b/goldens/public-api/router/router.md
@@ -352,8 +352,10 @@ export class OutletContext {
 // @public
 export class PageTitleStrategy implements OnDestroy {
     constructor(title: Title, router: Router);
+    activate(): void;
+    getResolvedTitleForRoute(snapshot: ActivatedRouteSnapshot): any;
     // (undocumented)
-    getPageTitle(snapshot: RouterStateSnapshot): string | undefined;
+    getTitleForPage(snapshot: RouterStateSnapshot): string | undefined;
     // (undocumented)
     ngOnDestroy(): void;
     setTitle(title: string): void;
@@ -457,6 +459,7 @@ export interface Route {
     redirectTo?: string;
     resolve?: ResolveData;
     runGuardsAndResolvers?: RunGuardsAndResolvers;
+    title?: string | unknown;
 }
 
 // @public

--- a/goldens/public-api/router/router.md
+++ b/goldens/public-api/router/router.md
@@ -170,6 +170,18 @@ export type Data = {
 };
 
 // @public
+export class DefaultTitleStrategy extends TitleStrategy {
+    constructor(title: Title);
+    // (undocumented)
+    readonly title: Title;
+    updateTitle(snapshot: RouterStateSnapshot): void;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<DefaultTitleStrategy, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<DefaultTitleStrategy>;
+}
+
+// @public
 export class DefaultUrlSerializer implements UrlSerializer {
     parse(url: string): UrlTree;
     serialize(tree: UrlTree): string;
@@ -350,24 +362,6 @@ export class OutletContext {
 }
 
 // @public
-export class PageTitleStrategy implements OnDestroy {
-    constructor(title: Title, router: Router);
-    activate(): void;
-    getResolvedTitleForRoute(snapshot: ActivatedRouteSnapshot): any;
-    // (undocumented)
-    getTitleForPage(snapshot: RouterStateSnapshot): string | undefined;
-    // (undocumented)
-    ngOnDestroy(): void;
-    setTitle(title: string): void;
-    // (undocumented)
-    protected readonly title: Title;
-    // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<PageTitleStrategy, never>;
-    // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<PageTitleStrategy>;
-}
-
-// @public
 export interface ParamMap {
     get(name: string): string | null;
     getAll(name: string): string[];
@@ -512,6 +506,7 @@ export class Router {
     readonly routerState: RouterState;
     serializeUrl(url: UrlTree): string;
     setUpLocationChangeListener(): void;
+    titleStrategy?: TitleStrategy;
     get url(): string;
     urlHandlingStrategy: UrlHandlingStrategy;
     urlUpdateStrategy: 'deferred' | 'eager';
@@ -759,6 +754,14 @@ export class Scroll {
     readonly routerEvent: NavigationEnd;
     // (undocumented)
     toString(): string;
+}
+
+// @public
+export abstract class TitleStrategy {
+    // (undocumented)
+    buildTitle(snapshot: RouterStateSnapshot): string | undefined;
+    getResolvedTitleForRoute(snapshot: ActivatedRouteSnapshot): any;
+    abstract updateTitle(snapshot: RouterStateSnapshot): void;
 }
 
 // @public

--- a/goldens/public-api/router/testing/testing.md
+++ b/goldens/public-api/router/testing/testing.md
@@ -12,6 +12,7 @@ import * as i1 from '@angular/router';
 import { Injector } from '@angular/core';
 import { Location as Location_2 } from '@angular/common';
 import { ModuleWithProviders } from '@angular/core';
+import { PageTitleStrategy } from '@angular/router';
 import { Route } from '@angular/router';
 import { Router } from '@angular/router';
 import { RouteReuseStrategy } from '@angular/router';
@@ -21,6 +22,7 @@ import { UrlSerializer } from '@angular/router';
 
 // @public
 export class RouterTestingModule {
+    constructor(pageTitle: PageTitleStrategy);
     // (undocumented)
     static withRoutes(routes: Routes, config?: ExtraOptions): ModuleWithProviders<RouterTestingModule>;
     // (undocumented)

--- a/goldens/public-api/router/testing/testing.md
+++ b/goldens/public-api/router/testing/testing.md
@@ -34,7 +34,10 @@ export class RouterTestingModule {
 }
 
 // @public
-export function setupTestingRouter(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location_2, compiler: Compiler, injector: Injector, routes: Route[][], opts?: ExtraOptions | UrlHandlingStrategy, urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy, defaultTitleStrategy?: DefaultTitleStrategy, titleStrategy?: TitleStrategy): Router;
+export function setupTestingRouter(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location_2, compiler: Compiler, injector: Injector, routes: Route[][], opts?: ExtraOptions | UrlHandlingStrategy, urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy, titleStrategy?: TitleStrategy): Router;
+
+// @public
+export function setupTestingRouterInternal(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location_2, compiler: Compiler, injector: Injector, routes: Route[][], opts?: ExtraOptions | UrlHandlingStrategy, urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy, defaultTitleStrategy?: DefaultTitleStrategy, titleStrategy?: TitleStrategy): Router;
 
 // (No @packageDocumentation comment for this package)
 

--- a/goldens/public-api/router/testing/testing.md
+++ b/goldens/public-api/router/testing/testing.md
@@ -6,23 +6,23 @@
 
 import { ChildrenOutletContexts } from '@angular/router';
 import { Compiler } from '@angular/core';
+import { DefaultTitleStrategy } from '@angular/router';
 import { ExtraOptions } from '@angular/router';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/router';
 import { Injector } from '@angular/core';
 import { Location as Location_2 } from '@angular/common';
 import { ModuleWithProviders } from '@angular/core';
-import { PageTitleStrategy } from '@angular/router';
 import { Route } from '@angular/router';
 import { Router } from '@angular/router';
 import { RouteReuseStrategy } from '@angular/router';
 import { Routes } from '@angular/router';
+import { TitleStrategy } from '@angular/router';
 import { UrlHandlingStrategy } from '@angular/router';
 import { UrlSerializer } from '@angular/router';
 
 // @public
 export class RouterTestingModule {
-    constructor(pageTitle: PageTitleStrategy);
     // (undocumented)
     static withRoutes(routes: Routes, config?: ExtraOptions): ModuleWithProviders<RouterTestingModule>;
     // (undocumented)
@@ -34,7 +34,7 @@ export class RouterTestingModule {
 }
 
 // @public
-export function setupTestingRouter(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location_2, compiler: Compiler, injector: Injector, routes: Route[][], opts?: ExtraOptions | UrlHandlingStrategy, urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy): Router;
+export function setupTestingRouter(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location_2, compiler: Compiler, injector: Injector, routes: Route[][], opts?: ExtraOptions | UrlHandlingStrategy, urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy, defaultTitleStrategy?: DefaultTitleStrategy, titleStrategy?: TitleStrategy): Router;
 
 // (No @packageDocumentation comment for this package)
 

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -42,7 +42,7 @@
     "master": {
       "uncompressed": {
         "runtime": 2835,
-        "main": 231989,
+        "main": 233348,
         "polyfills": 37244,
         "src_app_lazy_lazy_module_ts": 795
       }

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -555,6 +555,9 @@
     "name": "RouteExampleModule"
   },
   {
+    "name": "RouteTitle"
+  },
+  {
     "name": "Router"
   },
   {
@@ -709,6 +712,9 @@
   },
   {
     "name": "ThrowIfEmptySubscriber"
+  },
+  {
+    "name": "Title"
   },
   {
     "name": "Tree"
@@ -991,6 +997,9 @@
   },
   {
     "name": "createTemplateRef"
+  },
+  {
+    "name": "createTitle"
   },
   {
     "name": "deactivateRouteAndItsChildren"
@@ -1690,6 +1699,9 @@
   },
   {
     "name": "optionsReducer"
+  },
+  {
+    "name": "pageTitleInitializer"
   },
   {
     "name": "paramCompareMap"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -171,6 +171,9 @@
     "name": "DefaultKeyValueDifferFactory"
   },
   {
+    "name": "DefaultTitleStrategy"
+  },
+  {
     "name": "DefaultUrlSerializer"
   },
   {
@@ -717,6 +720,9 @@
     "name": "Title"
   },
   {
+    "name": "TitleStrategy"
+  },
+  {
     "name": "Tree"
   },
   {
@@ -997,9 +1003,6 @@
   },
   {
     "name": "createTemplateRef"
-  },
-  {
-    "name": "createTitle"
   },
   {
     "name": "deactivateRouteAndItsChildren"
@@ -1699,9 +1702,6 @@
   },
   {
     "name": "optionsReducer"
-  },
-  {
-    "name": "pageTitleInitializer"
   },
   {
     "name": "paramCompareMap"

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -369,7 +369,9 @@ export type RunGuardsAndResolvers =
  */
 export interface Route {
   /**
-   * Used to define a page title for the route.
+   * Used to define a page title for the route. This can be a static string or an `Injectable` that
+   * implements `Resolve`.
+   *
    * @see `PageTitleStrategy`
    */
   title?: string|unknown;

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -369,6 +369,12 @@ export type RunGuardsAndResolvers =
  */
 export interface Route {
   /**
+   * Used to define a page title for the route.
+   * @see `PageTitleStrategy`
+   */
+  title?: string|unknown;
+
+  /**
    * The path to match against. Cannot be used together with a custom `matcher` function.
    * A URL string that uses router matching notation.
    * Can be a wild card (`**`) that matches any URL (see Usage Notes below).

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -13,6 +13,7 @@ export {RouterLinkActive} from './directives/router_link_active';
 export {RouterOutlet, RouterOutletContract} from './directives/router_outlet';
 export {ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized, Scroll} from './events';
 export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, Resolve} from './interfaces';
+export {PageTitleStrategy} from './page_title_strategy';
 export {BaseRouteReuseStrategy, DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
 export {Navigation, NavigationBehaviorOptions, NavigationExtras, Router, UrlCreationOptions} from './router';
 export {ROUTES} from './router_config_loader';

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -13,7 +13,7 @@ export {RouterLinkActive} from './directives/router_link_active';
 export {RouterOutlet, RouterOutletContract} from './directives/router_outlet';
 export {ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized, Scroll} from './events';
 export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, Resolve} from './interfaces';
-export {PageTitleStrategy} from './page_title_strategy';
+export {DefaultTitleStrategy, TitleStrategy} from './page_title_strategy';
 export {BaseRouteReuseStrategy, DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
 export {Navigation, NavigationBehaviorOptions, NavigationExtras, Router, UrlCreationOptions} from './router';
 export {ROUTES} from './router_config_loader';

--- a/packages/router/src/page_title_strategy.ts
+++ b/packages/router/src/page_title_strategy.ts
@@ -6,52 +6,64 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, OnDestroy} from '@angular/core';
+import {APP_INITIALIZER, Injectable, OnDestroy} from '@angular/core';
 import {Title} from '@angular/platform-browser';
+import {Subscription} from 'rxjs';
 import {filter} from 'rxjs/operators';
 
 import {NavigationEnd} from './events';
 import {Router} from './router';
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
 import {PRIMARY_OUTLET} from './shared';
+import {RouteTitle as TitleKey} from './utils/config';
 
 /**
  * Provides a strategy for setting the page title after a router navigation.
  *
  * The built-in implementation traverses the router state snapshot and finds the deepest primary
- * outlet with `pageTitle` on the route data. Given the `Routes` below, navigating to
+ * outlet with `title` property. Given the `Routes` below, navigating to
  * `/base/child(popup:aux)` would result in the document title being set to "child".
  * ```
  * [
- *   {path: 'base', data: {pageTitle: 'base'}, children: [
- *     {path: 'child', data: {pageTitle: 'child'}},
+ *   {path: 'base', title: 'base', children: [
+ *     {path: 'child', title: 'child'},
  *   ],
- *   {path: 'aux', outlet: 'popup', data: {pageTitle: 'popupTitle'}}
+ *   {path: 'aux', outlet: 'popup', title: 'popupTitle'}
  * ]
  * ```
  *
  * This class be used as a base class for custom title strategies. That is, you can create your own
- * class that extends the `PageTitleStrategy`.
+ * class that extends the `PageTitleStrategy`. Note that in the above example, the `title` from the
+ * named outlet is never used. However, a custom strategy might be implemented to incorporate titles
+ * in named outlets.
  *
  * @publicApi
  * @see [Page title guide](guide/router#setting-the-page-title)
  */
 @Injectable({providedIn: 'root'})
 export class PageTitleStrategy implements OnDestroy {
-  private readonly eventsSubscription =
-      this.router.events
-          .pipe(
-              filter((e): e is NavigationEnd => e instanceof NavigationEnd),
-              )
-          .subscribe(() => {
-            this.onNavigationEnd();
-          });
+  private eventsSubscription?: Subscription;
 
   constructor(protected readonly title: Title, private readonly router: Router) {}
 
+  /**
+   * Activates the `PageTitleStrategy` by subscribing to the router `NavigationEnd` events.
+   */
+  activate(): void {
+    if (this.eventsSubscription) return;
+
+    this.eventsSubscription = this.router.events
+                                  .pipe(
+                                      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+                                      )
+                                  .subscribe(() => {
+                                    this.onNavigationEnd();
+                                  });
+  }
+
   private onNavigationEnd(): void {
     const routerState = this.router.routerState.snapshot;
-    const title = this.getPageTitle(routerState);
+    const title = this.getTitleForPage(routerState);
     if (title !== undefined) {
       this.setTitle(title);
     }
@@ -69,20 +81,41 @@ export class PageTitleStrategy implements OnDestroy {
   /**
    * @returns The `pageTitle` in the `data` of the deepest primary route.
    */
-  getPageTitle(snapshot: RouterStateSnapshot): string|undefined {
+  getTitleForPage(snapshot: RouterStateSnapshot): string|undefined {
     let pageTitle: string|undefined;
     let route: ActivatedRouteSnapshot|undefined = snapshot.root;
     while (route !== undefined) {
-      pageTitle = route.data.pageTitle ?? pageTitle;
+      pageTitle = this.getResolvedTitleForRoute(route) ?? pageTitle;
       route = route.children.find(child => child.outlet === PRIMARY_OUTLET);
     }
     return pageTitle;
   }
 
   /**
+   * Given an `ActivatedRouteSnapshot`, returns the final value of the
+   * `Route.title` property, which can either be a static string or a resolved value.
+   */
+  getResolvedTitleForRoute(snapshot: ActivatedRouteSnapshot) {
+    return snapshot.data[TitleKey];
+  }
+
+  /**
    * @nodoc
    */
   ngOnDestroy() {
-    this.eventsSubscription.unsubscribe();
+    this.eventsSubscription?.unsubscribe();
   }
 }
+
+/**
+ * Initializer for the `PageTitleStrategy` which activates the strategy as part of the
+ * `APP_INITIALIZER`.
+ */
+export const pageTitleInitializer = {
+  provide: APP_INITIALIZER,
+  multi: true,
+  useFactory: (pageTitle: PageTitleStrategy): () => void => {
+    return () => pageTitle.activate();
+  },
+  deps: [PageTitleStrategy],
+};

--- a/packages/router/src/page_title_strategy.ts
+++ b/packages/router/src/page_title_strategy.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injectable, OnDestroy} from '@angular/core';
+import {Title} from '@angular/platform-browser';
+import {filter} from 'rxjs/operators';
+
+import {NavigationEnd} from './events';
+import {Router} from './router';
+import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
+import {PRIMARY_OUTLET} from './shared';
+
+/**
+ * Provides a strategy for setting the page title after a router navigation.
+ *
+ * The built-in implementation traverses the router state snapshot and finds the deepest primary
+ * outlet with `pageTitle` on the route data. Given the `Routes` below, navigating to
+ * `/base/child(popup:aux)` would result in the document title being set to "child".
+ * ```
+ * [
+ *   {path: 'base', data: {pageTitle: 'base'}, children: [
+ *     {path: 'child', data: {pageTitle: 'child'}},
+ *   ],
+ *   {path: 'aux', outlet: 'popup', data: {pageTitle: 'popupTitle'}}
+ * ]
+ * ```
+ *
+ * This class be used as a base class for custom title strategies. That is, you can create your own
+ * class that extends the `PageTitleStrategy`.
+ *
+ * @publicApi
+ * @see [Page title guide](guide/router#setting-the-page-title)
+ */
+@Injectable({providedIn: 'root'})
+export class PageTitleStrategy implements OnDestroy {
+  private readonly eventsSubscription =
+      this.router.events
+          .pipe(
+              filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+              )
+          .subscribe(() => {
+            this.onNavigationEnd();
+          });
+
+  constructor(protected readonly title: Title, private readonly router: Router) {}
+
+  private onNavigationEnd(): void {
+    const routerState = this.router.routerState.snapshot;
+    const title = this.getPageTitle(routerState);
+    if (title !== undefined) {
+      this.setTitle(title);
+    }
+  }
+
+  /**
+   * Sets the title of the browser to the given value.
+   *
+   * @param title The `pageTitle` from the deepest primary route.
+   */
+  setTitle(title: string): void {
+    this.title.setTitle(title);
+  }
+
+  /**
+   * @returns The `pageTitle` in the `data` of the deepest primary route.
+   */
+  getPageTitle(snapshot: RouterStateSnapshot): string|undefined {
+    let pageTitle: string|undefined;
+    let route: ActivatedRouteSnapshot|undefined = snapshot.root;
+    while (route !== undefined) {
+      pageTitle = route.data.pageTitle ?? pageTitle;
+      route = route.children.find(child => child.outlet === PRIMARY_OUTLET);
+    }
+    return pageTitle;
+  }
+
+  /**
+   * @nodoc
+   */
+  ngOnDestroy() {
+    this.eventsSubscription.unsubscribe();
+  }
+}

--- a/packages/router/src/page_title_strategy.ts
+++ b/packages/router/src/page_title_strategy.ts
@@ -6,16 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_INITIALIZER, Injectable, OnDestroy} from '@angular/core';
+import {Injectable} from '@angular/core';
 import {Title} from '@angular/platform-browser';
-import {Subscription} from 'rxjs';
-import {filter} from 'rxjs/operators';
 
-import {NavigationEnd} from './events';
-import {Router} from './router';
+import {RouteTitle as TitleKey} from './operators/resolve_data';
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
 import {PRIMARY_OUTLET} from './shared';
-import {RouteTitle as TitleKey} from './utils/config';
 
 /**
  * Provides a strategy for setting the page title after a router navigation.
@@ -32,56 +28,22 @@ import {RouteTitle as TitleKey} from './utils/config';
  * ]
  * ```
  *
- * This class be used as a base class for custom title strategies. That is, you can create your own
- * class that extends the `PageTitleStrategy`. Note that in the above example, the `title` from the
- * named outlet is never used. However, a custom strategy might be implemented to incorporate titles
- * in named outlets.
+ * This class can be used as a base class for custom title strategies. That is, you can create your
+ * own class that extends the `TitleStrategy`. Note that in the above example, the `title`
+ * from the named outlet is never used. However, a custom strategy might be implemented to
+ * incorporate titles in named outlets.
  *
  * @publicApi
  * @see [Page title guide](guide/router#setting-the-page-title)
  */
-@Injectable({providedIn: 'root'})
-export class PageTitleStrategy implements OnDestroy {
-  private eventsSubscription?: Subscription;
-
-  constructor(protected readonly title: Title, private readonly router: Router) {}
+export abstract class TitleStrategy {
+  /** Performs the application title update. */
+  abstract updateTitle(snapshot: RouterStateSnapshot): void;
 
   /**
-   * Activates the `PageTitleStrategy` by subscribing to the router `NavigationEnd` events.
+   * @returns The `title` of the deepest primary route.
    */
-  activate(): void {
-    if (this.eventsSubscription) return;
-
-    this.eventsSubscription = this.router.events
-                                  .pipe(
-                                      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
-                                      )
-                                  .subscribe(() => {
-                                    this.onNavigationEnd();
-                                  });
-  }
-
-  private onNavigationEnd(): void {
-    const routerState = this.router.routerState.snapshot;
-    const title = this.getTitleForPage(routerState);
-    if (title !== undefined) {
-      this.setTitle(title);
-    }
-  }
-
-  /**
-   * Sets the title of the browser to the given value.
-   *
-   * @param title The `pageTitle` from the deepest primary route.
-   */
-  setTitle(title: string): void {
-    this.title.setTitle(title);
-  }
-
-  /**
-   * @returns The `pageTitle` in the `data` of the deepest primary route.
-   */
-  getTitleForPage(snapshot: RouterStateSnapshot): string|undefined {
+  buildTitle(snapshot: RouterStateSnapshot): string|undefined {
     let pageTitle: string|undefined;
     let route: ActivatedRouteSnapshot|undefined = snapshot.root;
     while (route !== undefined) {
@@ -98,24 +60,26 @@ export class PageTitleStrategy implements OnDestroy {
   getResolvedTitleForRoute(snapshot: ActivatedRouteSnapshot) {
     return snapshot.data[TitleKey];
   }
-
-  /**
-   * @nodoc
-   */
-  ngOnDestroy() {
-    this.eventsSubscription?.unsubscribe();
-  }
 }
 
 /**
- * Initializer for the `PageTitleStrategy` which activates the strategy as part of the
- * `APP_INITIALIZER`.
+ * The default `TitleStrategy` used by the router that updates the title using the `Title` service.
  */
-export const pageTitleInitializer = {
-  provide: APP_INITIALIZER,
-  multi: true,
-  useFactory: (pageTitle: PageTitleStrategy): () => void => {
-    return () => pageTitle.activate();
-  },
-  deps: [PageTitleStrategy],
-};
+@Injectable({providedIn: 'root'})
+export class DefaultTitleStrategy extends TitleStrategy {
+  constructor(readonly title: Title) {
+    super();
+  }
+
+  /**
+   * Sets the title of the browser to the given value.
+   *
+   * @param title The `pageTitle` from the deepest primary route.
+   */
+  override updateTitle(snapshot: RouterStateSnapshot): void {
+    const title = this.buildTitle(snapshot);
+    if (title !== undefined) {
+      this.title.setTitle(title);
+    }
+  }
+}

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -21,6 +21,7 @@ import {checkGuards} from './operators/check_guards';
 import {recognize} from './operators/recognize';
 import {resolveData} from './operators/resolve_data';
 import {switchTap} from './operators/switch_tap';
+import {TitleStrategy} from './page_title_strategy';
 import {DefaultRouteReuseStrategy, RouteReuseStrategy} from './route_reuse_strategy';
 import {RouterConfigLoader} from './router_config_loader';
 import {ChildrenOutletContexts} from './router_outlet_context';
@@ -508,6 +509,11 @@ export class Router {
    * A strategy for re-using routes.
    */
   routeReuseStrategy: RouteReuseStrategy = new DefaultRouteReuseStrategy();
+
+  /**
+   * A strategy for setting the title based on the `routerState`.
+   */
+  titleStrategy?: TitleStrategy;
 
   /**
    * How to handle a navigation request to the current URL. One of:
@@ -1339,6 +1345,7 @@ export class Router {
               .next(new NavigationEnd(
                   t.id, this.serializeUrl(t.extractedUrl), this.serializeUrl(this.currentUrlTree)));
           this.lastSuccessfulNavigation = this.currentNavigation;
+          this.titleStrategy?.updateTitle(this.routerState.snapshot);
           t.resolve(true);
         },
         e => {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -525,7 +525,7 @@ export class Router {
   onSameUrlNavigation: 'reload'|'ignore' = 'ignore';
 
   /**
-   * How to merge parameters, data, and resolved data from parent to child
+   * How to merge parameters, data, resolved data, and title from parent to child
    * routes. One of:
    *
    * - `'emptyOnly'` : Inherit parent parameters, data, and resolved data

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -16,6 +16,7 @@ import {RouterLink, RouterLinkWithHref} from './directives/router_link';
 import {RouterLinkActive} from './directives/router_link_active';
 import {RouterOutlet} from './directives/router_outlet';
 import {Event} from './events';
+import {pageTitleInitializer} from './page_title_strategy';
 import {RouteReuseStrategy} from './route_reuse_strategy';
 import {ErrorHandler, Router} from './router';
 import {ROUTES} from './router_config_loader';
@@ -146,6 +147,7 @@ export class RouterModule {
         },
         {provide: NgProbeToken, multi: true, useFactory: routerNgProbeToken},
         provideRouterInitializer(),
+        pageTitleInitializer,
       ],
     };
   }

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -8,6 +8,7 @@
 
 import {APP_BASE_HREF, HashLocationStrategy, Location, LOCATION_INITIALIZED, LocationStrategy, PathLocationStrategy, PlatformLocation, ViewportScroller} from '@angular/common';
 import {ANALYZE_FOR_ENTRY_COMPONENTS, APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, ApplicationRef, Compiler, ComponentRef, Inject, Injectable, InjectionToken, Injector, ModuleWithProviders, NgModule, NgProbeToken, OnDestroy, Optional, Provider, SkipSelf} from '@angular/core';
+import {Title} from '@angular/platform-browser';
 import {of, Subject} from 'rxjs';
 
 import {EmptyOutletComponent} from './components/empty_outlet';
@@ -16,7 +17,7 @@ import {RouterLink, RouterLinkWithHref} from './directives/router_link';
 import {RouterLinkActive} from './directives/router_link_active';
 import {RouterOutlet} from './directives/router_outlet';
 import {Event} from './events';
-import {pageTitleInitializer} from './page_title_strategy';
+import {DefaultTitleStrategy, TitleStrategy} from './page_title_strategy';
 import {RouteReuseStrategy} from './route_reuse_strategy';
 import {ErrorHandler, Router} from './router';
 import {ROUTES} from './router_config_loader';
@@ -54,8 +55,8 @@ export const ROUTER_PROVIDERS: Provider[] = [
     useFactory: setupRouter,
     deps: [
       UrlSerializer, ChildrenOutletContexts, Location, Injector, Compiler, ROUTES,
-      ROUTER_CONFIGURATION, [UrlHandlingStrategy, new Optional()],
-      [RouteReuseStrategy, new Optional()]
+      ROUTER_CONFIGURATION, DefaultTitleStrategy, [TitleStrategy, new Optional()],
+      [UrlHandlingStrategy, new Optional()], [RouteReuseStrategy, new Optional()]
     ]
   },
   ChildrenOutletContexts,
@@ -147,7 +148,6 @@ export class RouterModule {
         },
         {provide: NgProbeToken, multi: true, useFactory: routerNgProbeToken},
         provideRouterInitializer(),
-        pageTitleInitializer,
       ],
     };
   }
@@ -455,6 +455,7 @@ export interface ExtraOptions {
 export function setupRouter(
     urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location,
     injector: Injector, compiler: Compiler, config: Route[][], opts: ExtraOptions = {},
+    defaultTitleStrategy: DefaultTitleStrategy, titleStrategy?: TitleStrategy,
     urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy) {
   const router =
       new Router(null, urlSerializer, contexts, location, injector, compiler, flatten(config));
@@ -466,6 +467,8 @@ export function setupRouter(
   if (routeReuseStrategy) {
     router.routeReuseStrategy = routeReuseStrategy;
   }
+
+  router.titleStrategy = titleStrategy ?? defaultTitleStrategy;
 
   assignExtraOptionsToRouter(opts, router);
 

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -112,13 +112,6 @@ function getFullPath(parentPath: string, currentRoute: Route): string {
 }
 
 /**
- * A private symbol used to store the value of `Route.title` inside the `Route.data` if it is a
- * static string or `Route.resolve` if anything else. This allows us to reuse the existing route
- * data/resolvers to support the title feature without new instrumentation in the `Router` pipeline.
- */
-export const RouteTitle = Symbol('RouteTitle');
-
-/**
  * Makes a copy of the config and adds any default required properties.
  */
 export function standardizeConfig(r: Route): Route {
@@ -127,16 +120,6 @@ export function standardizeConfig(r: Route): Route {
   if (!c.component && (children || c.loadChildren) && (c.outlet && c.outlet !== PRIMARY_OUTLET)) {
     c.component = EmptyOutletComponent;
   }
-  if (c.title !== undefined) {
-    if (typeof c.title === 'string' || c.title === null) {
-      c.data = c.data ?? {};
-      c.data[RouteTitle] = c.title;
-    } else {
-      c.resolve = c.resolve ?? {};
-      c.resolve[RouteTitle] = c.title;
-    }
-  }
-
   return c;
 }
 

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -112,6 +112,13 @@ function getFullPath(parentPath: string, currentRoute: Route): string {
 }
 
 /**
+ * A private symbol used to store the value of `Route.title` inside the `Route.data` if it is a
+ * static string or `Route.resolve` if anything else. This allows us to reuse the existing route
+ * data/resolvers to support the title feature without new instrumentation in the `Router` pipeline.
+ */
+export const RouteTitle = Symbol('RouteTitle');
+
+/**
  * Makes a copy of the config and adds any default required properties.
  */
 export function standardizeConfig(r: Route): Route {
@@ -120,6 +127,16 @@ export function standardizeConfig(r: Route): Route {
   if (!c.component && (children || c.loadChildren) && (c.outlet && c.outlet !== PRIMARY_OUTLET)) {
     c.component = EmptyOutletComponent;
   }
+  if (c.title !== undefined) {
+    if (typeof c.title === 'string' || c.title === null) {
+      c.data = c.data ?? {};
+      c.data[RouteTitle] = c.title;
+    } else {
+      c.resolve = c.resolve ?? {};
+      c.resolve[RouteTitle] = c.title;
+    }
+  }
+
   return c;
 }
 

--- a/packages/router/test/page_title_strategy_spec.ts
+++ b/packages/router/test/page_title_strategy_spec.ts
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DOCUMENT} from '@angular/common';
+import {Component, Injectable, NgModule} from '@angular/core';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {Title} from '@angular/platform-browser';
+import {Router, RouterModule} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
+
+import {PageTitleStrategy} from '../src';
+
+describe('page title strategy', () => {
+  it('does not set page title by default (so that the feature is non-breaking)', fakeAsync(() => {
+       TestBed.configureTestingModule({
+         imports: [
+           RouterTestingModule.withRoutes(
+               [{path: 'home', data: {pageTitle: 'My Application'}, component: BlankCmp}]),
+           TestModule,
+         ],
+       });
+       const router = TestBed.inject(Router);
+       const document = TestBed.inject(DOCUMENT);
+       document.title = 'before';
+
+       router.navigateByUrl('home');
+       tick();
+
+       expect(document.title).toBe('before');
+     }));
+
+  describe('BrowserPageTitleStrategy', () => {
+    let router: Router;
+    let document: Document;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule,
+          TestModule,
+        ],
+      });
+      router = TestBed.inject(Router);
+      document = TestBed.inject(DOCUMENT);
+      TestBed.inject(PageTitleStrategy);
+    });
+
+    it('sets page title from data', fakeAsync(() => {
+         router.resetConfig(
+             [{path: 'home', data: {pageTitle: 'My Application'}, component: BlankCmp}]);
+         router.navigateByUrl('home');
+         tick();
+         expect(document.title).toBe('My Application');
+       }));
+
+    it('sets page title from resolved data', fakeAsync(() => {
+         router.resetConfig(
+             [{path: 'home', resolve: {pageTitle: TitleResolver}, component: BlankCmp}]);
+         router.navigateByUrl('home');
+         tick();
+         expect(document.title).toBe('resolved title');
+       }));
+
+    it('sets title with child routes', fakeAsync(() => {
+         router.resetConfig([{
+           path: 'home',
+           data: {pageTitle: 'My Application'},
+           children: [
+             {path: '', data: {pageTitle: 'child title'}, component: BlankCmp},
+           ]
+         }]);
+         router.navigateByUrl('home');
+         tick();
+         expect(document.title).toBe('child title');
+       }));
+
+    it('sets title with child routes and named outlets', fakeAsync(() => {
+         router.resetConfig([
+           {
+             path: 'home',
+             data: {pageTitle: 'My Application'},
+             children: [
+               {path: '', data: {pageTitle: 'child title'}, component: BlankCmp},
+               {
+                 path: '',
+                 outlet: 'childaux',
+                 data: {pageTitle: 'child aux title'},
+                 component: BlankCmp
+               },
+             ],
+           },
+           {path: 'compose', component: BlankCmp, outlet: 'aux', data: {pageTile: 'compose'}}
+         ]);
+         router.navigateByUrl('home(aux:compose)');
+         tick();
+         expect(document.title).toBe('child title');
+       }));
+
+    it('sets page title with paramsInheritanceStrategy=always', fakeAsync(() => {
+         router.paramsInheritanceStrategy = 'always';
+         router.resetConfig([
+           {
+             path: 'home',
+             data: {pageTitle: 'My Application'},
+             children: [
+               {
+                 path: '',
+                 // Must set pageTitle to `null` or it will inherit from parent if it doesn't have
+                 // its own value
+                 data: {pageTitle: null},
+                 children: [{
+                   path: '',
+                   resolve: {pageTitle: TitleResolver},
+                   component: BlankCmp,
+                 }]
+               },
+             ],
+           },
+         ]);
+         router.navigateByUrl('home');
+         tick();
+         expect(document.title).toBe('resolved title');
+       }));
+  });
+
+  describe('custom strategies', () => {
+    it('overriding the setTitle method', fakeAsync(() => {
+         @Injectable({providedIn: 'root'})
+         class TemplatePageTitleStrategy extends PageTitleStrategy {
+           // Example of how setTitle could implement a template for the title
+           override setTitle(title: string) {
+             this.title.setTitle(`My Application | ${title}`);
+           }
+         }
+
+         TestBed.configureTestingModule({
+           imports: [
+             RouterTestingModule,
+             TestModule,
+           ],
+         });
+         TestBed.inject(TemplatePageTitleStrategy);
+         const router = TestBed.inject(Router);
+         const document = TestBed.inject(DOCUMENT);
+         router.resetConfig([
+           {
+             path: 'home',
+             data: {pageTitle: 'Home'},
+             children: [
+               {path: '', data: {pageTitle: 'Child'}, component: BlankCmp},
+             ],
+           },
+         ]);
+
+         router.navigateByUrl('home');
+         tick();
+         expect(document.title).toEqual('My Application | Child');
+       }));
+  });
+});
+
+@Component({template: ''})
+export class BlankCmp {
+}
+
+@Component({
+  template: `
+<router-outlet></router-outlet>
+<router-outlet name="aux"></router-outlet>
+`
+})
+export class RootCmp {
+}
+
+@NgModule({
+  declarations: [BlankCmp],
+  imports: [RouterModule],
+})
+export class TestModule {
+}
+
+
+@Injectable({providedIn: 'root'})
+export class TitleResolver {
+  resolve() {
+    return 'resolved title';
+  }
+}

--- a/packages/router/test/page_title_strategy_spec.ts
+++ b/packages/router/test/page_title_strategy_spec.ts
@@ -7,15 +7,13 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {Component, Injectable, NgModule} from '@angular/core';
+import {Component, Inject, Injectable, NgModule} from '@angular/core';
 import {fakeAsync, TestBed, tick} from '@angular/core/testing';
-import {Router, RouterModule} from '@angular/router';
+import {Router, RouterModule, RouterStateSnapshot, TitleStrategy} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 
-import {PageTitleStrategy} from '../src';
-
-describe('page title strategy', () => {
-  describe('default PageTitleStrategy', () => {
+describe('title strategy', () => {
+  describe('DefaultTitleStrategy', () => {
     let router: Router;
     let document: Document;
 
@@ -28,7 +26,6 @@ describe('page title strategy', () => {
       });
       router = TestBed.inject(Router);
       document = TestBed.inject(DOCUMENT);
-      TestBed.inject(PageTitleStrategy);
     });
 
     it('sets page title from data', fakeAsync(() => {
@@ -122,10 +119,15 @@ describe('page title strategy', () => {
   describe('custom strategies', () => {
     it('overriding the setTitle method', fakeAsync(() => {
          @Injectable({providedIn: 'root'})
-         class TemplatePageTitleStrategy extends PageTitleStrategy {
+         class TemplatePageTitleStrategy extends TitleStrategy {
+           constructor(@Inject(DOCUMENT) private readonly document: Document) {
+             super();
+           }
+
            // Example of how setTitle could implement a template for the title
-           override setTitle(title: string) {
-             this.title.setTitle(`My Application | ${title}`);
+           override updateTitle(state: RouterStateSnapshot) {
+             const title = this.buildTitle(state);
+             this.document.title = `My Application | ${title}`;
            }
          }
 
@@ -134,7 +136,7 @@ describe('page title strategy', () => {
              RouterTestingModule,
              TestModule,
            ],
-           providers: [{provide: PageTitleStrategy, useClass: TemplatePageTitleStrategy}]
+           providers: [{provide: TitleStrategy, useClass: TemplatePageTitleStrategy}]
          });
          const router = TestBed.inject(Router);
          const document = TestBed.inject(DOCUMENT);

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -9,7 +9,8 @@
 import {Location, LocationStrategy} from '@angular/common';
 import {MockLocationStrategy, SpyLocation} from '@angular/common/testing';
 import {Compiler, Injector, ModuleWithProviders, NgModule, Optional} from '@angular/core';
-import {ChildrenOutletContexts, ExtraOptions, NoPreloading, PreloadingStrategy, provideRoutes, Route, Router, ROUTER_CONFIGURATION, RouteReuseStrategy, RouterModule, ROUTES, Routes, UrlHandlingStrategy, UrlSerializer, ɵassignExtraOptionsToRouter as assignExtraOptionsToRouter, ɵflatten as flatten, ɵROUTER_PROVIDERS as ROUTER_PROVIDERS} from '@angular/router';
+import {ChildrenOutletContexts, ExtraOptions, NoPreloading, PageTitleStrategy, PreloadingStrategy, provideRoutes, Route, Router, ROUTER_CONFIGURATION, RouteReuseStrategy, RouterModule, ROUTES, Routes, UrlHandlingStrategy, UrlSerializer, ɵassignExtraOptionsToRouter as assignExtraOptionsToRouter, ɵflatten as flatten, ɵROUTER_PROVIDERS as ROUTER_PROVIDERS} from '@angular/router';
+
 import {EXTRA_ROUTER_TESTING_PROVIDERS} from './extra_router_testing_providers';
 
 function isUrlHandlingStrategy(opts: ExtraOptions|
@@ -98,6 +99,10 @@ export function setupTestingRouter(
   ]
 })
 export class RouterTestingModule {
+  constructor(pageTitle: PageTitleStrategy) {
+    pageTitle.activate();
+  }
+
   static withRoutes(routes: Routes, config?: ExtraOptions):
       ModuleWithProviders<RouterTestingModule> {
     return {

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -9,7 +9,7 @@
 import {Location, LocationStrategy} from '@angular/common';
 import {MockLocationStrategy, SpyLocation} from '@angular/common/testing';
 import {Compiler, Injector, ModuleWithProviders, NgModule, Optional} from '@angular/core';
-import {ChildrenOutletContexts, ExtraOptions, NoPreloading, PageTitleStrategy, PreloadingStrategy, provideRoutes, Route, Router, ROUTER_CONFIGURATION, RouteReuseStrategy, RouterModule, ROUTES, Routes, UrlHandlingStrategy, UrlSerializer, ɵassignExtraOptionsToRouter as assignExtraOptionsToRouter, ɵflatten as flatten, ɵROUTER_PROVIDERS as ROUTER_PROVIDERS} from '@angular/router';
+import {ChildrenOutletContexts, DefaultTitleStrategy, ExtraOptions, NoPreloading, PreloadingStrategy, provideRoutes, Route, Router, ROUTER_CONFIGURATION, RouteReuseStrategy, RouterModule, ROUTES, Routes, TitleStrategy, UrlHandlingStrategy, UrlSerializer, ɵassignExtraOptionsToRouter as assignExtraOptionsToRouter, ɵflatten as flatten, ɵROUTER_PROVIDERS as ROUTER_PROVIDERS} from '@angular/router';
 
 import {EXTRA_ROUTER_TESTING_PROVIDERS} from './extra_router_testing_providers';
 
@@ -29,7 +29,8 @@ export function setupTestingRouter(
     urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location,
     compiler: Compiler, injector: Injector, routes: Route[][],
     opts?: ExtraOptions|UrlHandlingStrategy, urlHandlingStrategy?: UrlHandlingStrategy,
-    routeReuseStrategy?: RouteReuseStrategy) {
+    routeReuseStrategy?: RouteReuseStrategy, defaultTitleStrategy?: DefaultTitleStrategy,
+    titleStrategy?: TitleStrategy) {
   const router =
       new Router(null!, urlSerializer, contexts, location, injector, compiler, flatten(routes));
   if (opts) {
@@ -49,6 +50,8 @@ export function setupTestingRouter(
   if (routeReuseStrategy) {
     router.routeReuseStrategy = routeReuseStrategy;
   }
+
+  router.titleStrategy = titleStrategy ?? defaultTitleStrategy;
 
   return router;
 }
@@ -89,9 +92,17 @@ export function setupTestingRouter(
       provide: Router,
       useFactory: setupTestingRouter,
       deps: [
-        UrlSerializer, ChildrenOutletContexts, Location, Compiler, Injector, ROUTES,
-        ROUTER_CONFIGURATION, [UrlHandlingStrategy, new Optional()],
-        [RouteReuseStrategy, new Optional()]
+        UrlSerializer,
+        ChildrenOutletContexts,
+        Location,
+        Compiler,
+        Injector,
+        ROUTES,
+        ROUTER_CONFIGURATION,
+        [UrlHandlingStrategy, new Optional()],
+        [RouteReuseStrategy, new Optional()],
+        [DefaultTitleStrategy, new Optional()],
+        [TitleStrategy, new Optional()],
       ]
     },
     {provide: PreloadingStrategy, useExisting: NoPreloading},
@@ -99,10 +110,6 @@ export function setupTestingRouter(
   ]
 })
 export class RouterTestingModule {
-  constructor(pageTitle: PageTitleStrategy) {
-    pageTitle.activate();
-  }
-
   static withRoutes(routes: Routes, config?: ExtraOptions):
       ModuleWithProviders<RouterTestingModule> {
     return {

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -21,6 +21,21 @@ function isUrlHandlingStrategy(opts: ExtraOptions|
 }
 
 /**
+ * Router setup factory function used for testing. Only used internally to keep the factory that's
+ * marked as publicApi cleaner (i.e. not having _both_ `TitleStrategy` and `DefaultTitleStrategy`).
+ */
+export function setupTestingRouterInternal(
+    urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location,
+    compiler: Compiler, injector: Injector, routes: Route[][],
+    opts?: ExtraOptions|UrlHandlingStrategy, urlHandlingStrategy?: UrlHandlingStrategy,
+    routeReuseStrategy?: RouteReuseStrategy, defaultTitleStrategy?: DefaultTitleStrategy,
+    titleStrategy?: TitleStrategy) {
+  return setupTestingRouter(
+      urlSerializer, contexts, location, compiler, injector, routes, opts, urlHandlingStrategy,
+      routeReuseStrategy, titleStrategy ?? defaultTitleStrategy);
+}
+
+/**
  * Router setup factory function used for testing.
  *
  * @publicApi
@@ -29,8 +44,7 @@ export function setupTestingRouter(
     urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location,
     compiler: Compiler, injector: Injector, routes: Route[][],
     opts?: ExtraOptions|UrlHandlingStrategy, urlHandlingStrategy?: UrlHandlingStrategy,
-    routeReuseStrategy?: RouteReuseStrategy, defaultTitleStrategy?: DefaultTitleStrategy,
-    titleStrategy?: TitleStrategy) {
+    routeReuseStrategy?: RouteReuseStrategy, titleStrategy?: TitleStrategy) {
   const router =
       new Router(null!, urlSerializer, contexts, location, injector, compiler, flatten(routes));
   if (opts) {
@@ -51,7 +65,7 @@ export function setupTestingRouter(
     router.routeReuseStrategy = routeReuseStrategy;
   }
 
-  router.titleStrategy = titleStrategy ?? defaultTitleStrategy;
+  router.titleStrategy = titleStrategy;
 
   return router;
 }
@@ -90,7 +104,7 @@ export function setupTestingRouter(
     {provide: LocationStrategy, useClass: MockLocationStrategy},
     {
       provide: Router,
-      useFactory: setupTestingRouter,
+      useFactory: setupTestingRouterInternal,
       deps: [
         UrlSerializer,
         ChildrenOutletContexts,


### PR DESCRIPTION
This commit provides a service, `PageTitleStrategy` for setting
the document page title after a successful router navigation.

Users can provide custom strategies by extending `TitleStrategy` and
adding a provider which overrides it.

The strategy takes advantage of the pre-existing `data` and `resolve` concepts
in the Router implementation:

We can copy the `Route.title` into `data`/`resolve` in a
non-breaking way by using a `symbol` as the key. This ensures that we
do not have any collisions with pre-existing property names. By using
`data` and `resolve`, we do not have to add anything more to
the router navigation pipeline to support this feature.

resolves angular#7630

reviewer notes: [thoughts/design doc](https://docs.google.com/document/d/1ZqMp8sT46koXUF-uZd6PZ3CzNhpzcRyOAjcVdhyYarE/edit?usp=sharing)