### PR TITLE
docs: add guidelines for localizing angular documentation

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1128,6 +1128,8 @@ groups:
           'aio/content/guide/docs-style-guide.md',
           'aio/content/examples/docs-style-guide/**',
           'aio/content/images/guide/docs-style-guide/**',
+          'aio/content/guide/localized-documentation.md',
+          'aio/content/guide/localizing-angular.md',
           'aio/content/guide/reviewing-content.md',
           'aio/content/guide/updating-content-github-ui.md',
           'aio/content/guide/updating-search-keywords.md',

--- a/aio/content/guide/contributors-guide-overview.md
+++ b/aio/content/guide/contributors-guide-overview.md
@@ -31,4 +31,9 @@ Before you get started with your contributions, we recommend that you review [Co
     <p>Review the syntax and styles used within the Angular documentation set.</p>
     <p class="card-footer">Get to know the writing style</p>
   </a>
+  <a href="guide/localizing-angular" class="docs-card" title="Angular localization guidelines">
+    <section>Angular localization guidelines</section>
+    <p>Learn about the guidelines for localizing Angular documentation.</p>
+    <p class="card-footer">Localize documentation</p>
+  </a>
 </div>

--- a/aio/content/guide/localized-documentation.md
+++ b/aio/content/guide/localized-documentation.md
@@ -1,0 +1,11 @@
+# Localized documentation
+
+This topic lists localized versions of the Angular documentation.
+
+* [Español](http://docs.angular.lat/)
+* [简体中文版](https://angular.cn/)
+* [正體中文版](https://angular.tw/)
+* [日本語版](https://angular.jp/)
+* [한국어](https://angular.kr/)
+
+For information on localizing Angular documentation, see [Angular localization guidelines](guide/localizing-angular).

--- a/aio/content/guide/localizing-angular.md
+++ b/aio/content/guide/localizing-angular.md
@@ -1,0 +1,68 @@
+# Angular localization guidelines
+
+One way to contribute to Angular's documentation is to localize it into another language. This topic describes what you need to know to localize Angular and have it listed on our [Localized documentation](guide/localized-documentation) page.
+
+## Before you begin
+
+Before you start localizing the Angular documentation, first check to see if a localized version already exists. See [Localized documentation](guide/localized-documentation) for a current list of localized versions of Angular documentation.
+
+## Getting started
+
+To have a localized version of Angular documentation listed on [angular.io](https://angular.io), you must either:
+
+* Be an Angular Google Developer Expert (GDE)
+* Have an Angular GDE nominate you for localizing the content
+
+Nomination, in this instance, means that the GDE knows who you are and can vouch for your capabilities. An Angular GDE can nominate someone by contacting the Angular team, providing your name, contact information, and the language to which you are localizing.
+
+## What to localize
+
+To localize Angular documentation, you must include, at a minimum, the following topics:
+
+* [Introduction to the Angular Docs](docs)
+* [What is Angular?](guide/what-is-angular)
+* [Getting started with Angular](start)
+  * [Adding navigation](start/start-routing)
+  * [Managing data](start/start-data)
+  * [User forms for user input](start/start-forms)
+  * [Deploying an application](start/start-deployment)
+  * [Setting up the local environment and workspace](guide/setup-local)
+* [Tour of Heroes app and tutorial](tutorial)
+  * [Create a new project](tutorial/toh-pt0)
+  * [The hero editor](tutorial/toh-pt1)
+  * [Display a selection list](tutorial/toh-pt2)   
+  * [Create a feature component](tutorial/toh-pt3)
+  * [Add services](tutorial/toh-pt4)
+  * [Add navigation with routing](tutorial/toh-pt5)
+  * [Get data from a server](tutorial/toh-pt6)
+
+Because these topics reflect the minimum documentation set for localization, the Angular documentation team takes special precautions when making any changes to these topics. Specifically:
+
+* The Angular team carefully assesses any incoming pull requests or issues to determine their impact on localized content.
+
+* Should the Angular team incorporate changes into these topics, the Angular team will communicate those changes to members of the localization community. See the section, [Communications](#communications), for more information.
+
+## Hosting
+
+Individuals and teams that localize Angular assume responsibility for hosting their localized site. The Angular team does not host localized content.
+
+## Awareness
+
+As part of the localization effort, the Angular documentation team adds localized documentation to [Localized documentation](guide/localized-documentation). This topic lists:
+
+* The language of the localized documentation
+* The URL for the localized documentation
+
+The Angular team can remove a link on this page for any reason, including but not limited to:
+
+* Unable to contact the individual or team
+* Issues or complaints about the documentation that go unaddressed
+
+## Communications
+
+The Angular documentation team uses a Slack channel to communicate with members of the community focused on localization efforts. After receiving a nomination to localize content, an individual or team can contact the Angular team to get access to this Slack channel.
+
+The Angular documentation team may also conduct meetings to discuss localization efforts. For example:
+
+* To discuss additional topics that should be part of the minimum documentation set
+* To discuss issues with content language that is difficult to translate/localize

--- a/aio/content/guide/localizing-angular.md
+++ b/aio/content/guide/localizing-angular.md
@@ -1,4 +1,4 @@
-# Angular localization guidelines
+# Angular documentation localization guidelines
 
 One way to contribute to Angular's documentation is to localize it into another language. This topic describes what you need to know to localize Angular and have it listed on our [Localized documentation](guide/localized-documentation) page.
 

--- a/aio/content/guide/localizing-angular.md
+++ b/aio/content/guide/localizing-angular.md
@@ -10,7 +10,7 @@ Before you start localizing the Angular documentation, first check to see if a l
 
 To have a localized version of Angular documentation listed on [angular.io](https://angular.io), you must either:
 
-* Be an Angular Google Developer Expert (GDE)
+* Be an Angular [Google Developer Expert (GDE)](https://developers.google.com/community/experts)
 * Have an Angular GDE nominate you for localizing the content
 
 Nomination, in this instance, means that the GDE knows who you are and can vouch for your capabilities. An Angular GDE can nominate someone by contacting the Angular team, providing your name, contact information, and the language to which you are localizing.
@@ -19,12 +19,12 @@ Nomination, in this instance, means that the GDE knows who you are and can vouch
 
 To localize Angular documentation, you must include, at a minimum, the following topics:
 
-* [Introduction to the Angular Docs](docs)
+* [Introduction to the Angular docs](docs)
 * [What is Angular?](guide/what-is-angular)
 * [Getting started with Angular](start)
   * [Adding navigation](start/start-routing)
   * [Managing data](start/start-data)
-  * [User forms for user input](start/start-forms)
+  * [Using forms for user input](start/start-forms)
   * [Deploying an application](start/start-deployment)
   * [Setting up the local environment and workspace](guide/setup-local)
 * [Tour of Heroes app and tutorial](tutorial)
@@ -39,23 +39,22 @@ To localize Angular documentation, you must include, at a minimum, the following
 Because these topics reflect the minimum documentation set for localization, the Angular documentation team takes special precautions when making any changes to these topics. Specifically:
 
 * The Angular team carefully assesses any incoming pull requests or issues to determine their impact on localized content.
-
-* Should the Angular team incorporate changes into these topics, the Angular team will communicate those changes to members of the localization community. See the section, [Communications](#communications), for more information.
+* If the Angular team incorporates changes into these topics, the Angular team will communicate those changes to members of the localization community. See the section, [Communications](#communications), for more information.
 
 ## Hosting
 
-Individuals and teams that localize Angular assume responsibility for hosting their localized site. The Angular team does not host localized content.
+Individuals and teams that localize Angular documentation assume responsibility for hosting their localized site. The Angular team does not host localized content. The Angular team is also not responsible for providing domain names.
 
 ## Awareness
 
-As part of the localization effort, the Angular documentation team adds localized documentation to [Localized documentation](guide/localized-documentation). This topic lists:
+As part of the localization effort, the Angular documentation team adds localized documentation to the [Localized documentation](guide/localized-documentation) page. This topic lists:
 
 * The language of the localized documentation
 * The URL for the localized documentation
 
 The Angular team can remove a link on this page for any reason, including but not limited to:
 
-* Unable to contact the individual or team
+* Inability to contact the individual or team
 * Issues or complaints about the documentation that go unaddressed
 
 ## Communications

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -1030,7 +1030,7 @@
             },
             {
               "url": "guide/localizing-angular",
-              "title": "Angular localization guidelines",
+              "title": "Angular doc localization guidelines",
               "tooltip": "Learn about the guidelines for localizing Angular documentation."
             },
             {

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -1027,6 +1027,17 @@
               "url": "guide/docs-style-guide",
               "title": "Documentation Style Guide",
               "tooltip": "Style guide for documentation authors."
+            },
+            {
+              "url": "guide/localizing-angular",
+              "title": "Angular localization guidelines",
+              "tooltip": "Learn about the guidelines for localizing Angular documentation."
+            },
+            {
+              "url": "guide/localized-documentation",
+              "title": "Localized documentation",
+              "tooltip": "A list of localized versions of the Angular documentation",
+              "hidden": true
             }
           ]
         }
@@ -1146,6 +1157,9 @@
         {
           "title": "한국어",
           "url": "https://angular.kr/"
+        },
+        { "title": "Complete language list",
+           "url": "guide/localized-documentation"
         }
       ]
     }

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -1158,8 +1158,9 @@
           "title": "한국어",
           "url": "https://angular.kr/"
         },
-        { "title": "Complete language list",
-           "url": "guide/localized-documentation"
+        { 
+          "title": "Complete language list",
+          "url": "guide/localized-documentation"
         }
       ]
     }


### PR DESCRIPTION
Adding first iteration of guidelines to support community members who want to localize Angular into different languages.