### PR TITLE
fix(language-service): exclude the `SafePropertyRead` when applying t…

### DIFF
--- a/packages/language-service/ivy/completions.ts
+++ b/packages/language-service/ivy/completions.ts
@@ -212,7 +212,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
       const replacementSpan = makeReplacementSpanFromAst(this.node);
 
       if (!(this.node.receiver instanceof ImplicitReceiver) &&
-          options?.includeCompletionsWithInsertText &&
+          !(this.node instanceof SafePropertyRead) && options?.includeCompletionsWithInsertText &&
           options.includeAutomaticOptionalChainCompletions !== false) {
         const symbol = this.templateTypeChecker.getSymbolOfNode(this.node.receiver, this.component);
         if (symbol?.kind === SymbolKind.Expression) {

--- a/packages/language-service/ivy/test/completions_spec.ts
+++ b/packages/language-service/ivy/test/completions_spec.ts
@@ -841,6 +841,17 @@ describe('completions', () => {
       expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
       expectReplacementText(completions, templateFile.contents, 'title');
     });
+
+    it('should not shift the start location when the user has input the optional chaining', () => {
+      const {templateFile} = setup('{{article?.title}}', `article?: { title: string };`);
+      templateFile.moveCursorToText('{{article?.title¦}}');
+      const completions = templateFile.getCompletionsAtPosition({
+        includeCompletionsWithInsertText: true,
+        includeAutomaticOptionalChainCompletions: true,
+      });
+      expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
+      expectReplacementText(completions, templateFile.contents, 'title');
+    });
   });
 });
 


### PR DESCRIPTION
…he optional chaining

When providing the completion for `SafePropertyRead`, the ts server
will not apply the optional chaining. So no need to shift the start
location of `replacementSpan` back.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
