### PR TITLE
feat(router): emit activate/deactivate events when an outlet gets attached/detached

### DIFF
--- a/goldens/public-api/router/router.md
+++ b/goldens/public-api/router/router.md
@@ -615,6 +615,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     // (undocumented)
     activateWith(activatedRoute: ActivatedRoute, resolver: ComponentFactoryResolver | null): void;
     attach(ref: ComponentRef<any>, activatedRoute: ActivatedRoute): void;
+    attachEvents: EventEmitter<unknown>;
     // (undocumented)
     get component(): Object;
     // (undocumented)
@@ -622,6 +623,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     // (undocumented)
     deactivateEvents: EventEmitter<any>;
     detach(): ComponentRef<any>;
+    detachEvents: EventEmitter<unknown>;
     // (undocumented)
     get isActivated(): boolean;
     // (undocumented)
@@ -637,10 +639,12 @@ export interface RouterOutletContract {
     activateEvents?: EventEmitter<unknown>;
     activateWith(activatedRoute: ActivatedRoute, resolver: ComponentFactoryResolver | null): void;
     attach(ref: ComponentRef<unknown>, activatedRoute: ActivatedRoute): void;
+    attachEvents?: EventEmitter<unknown>;
     component: Object | null;
     deactivate(): void;
     deactivateEvents?: EventEmitter<unknown>;
     detach(): ComponentRef<unknown>;
+    detachEvents?: EventEmitter<unknown>;
     isActivated: boolean;
 }
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -5709,6 +5709,60 @@ describe('Integration', () => {
       expect(router.routeReuseStrategy).toBeInstanceOf(AttachDetachReuseStrategy);
     });
 
+    it('should emit an event when an outlet gets attached/detached', fakeAsync(() => {
+         @Component({
+           selector: 'container',
+           template:
+               `<router-outlet (attach)="recordAttached($event)" (detach)="recordDetached($event)"></router-outlet>`
+         })
+         class Container {
+           attachedComponents: any[] = [];
+           detachedComponents: any[] = [];
+
+           recordAttached(component: any): void {
+             this.attachedComponents.push(component);
+           }
+
+           recordDetached(component: any): void {
+             this.detachedComponents.push(component);
+           }
+         }
+
+         TestBed.configureTestingModule({
+           declarations: [Container],
+           imports: [RouterTestingModule],
+           providers: [{provide: RouteReuseStrategy, useClass: AttachDetachReuseStrategy}]
+         });
+
+         const router = TestBed.inject(Router);
+         const fixture = createRoot(router, Container);
+         const cmp = fixture.componentInstance;
+
+         router.resetConfig([{path: 'a', component: BlankCmp}, {path: 'b', component: SimpleCmp}]);
+
+         cmp.attachedComponents = [];
+         cmp.detachedComponents = [];
+
+         router.navigateByUrl('/a');
+         advance(fixture);
+         expect(cmp.attachedComponents.length).toEqual(0);
+         expect(cmp.detachedComponents.length).toEqual(0);
+
+         router.navigateByUrl('/b');
+         advance(fixture);
+         expect(cmp.attachedComponents.length).toEqual(0);
+         expect(cmp.detachedComponents.length).toEqual(1);
+         expect(cmp.detachedComponents[0] instanceof BlankCmp).toBe(true);
+
+         // the route will be reused by the `RouteReuseStrategy`
+         router.navigateByUrl('/a');
+         advance(fixture);
+         expect(cmp.attachedComponents.length).toEqual(1);
+         expect(cmp.attachedComponents[0] instanceof BlankCmp).toBe(true);
+         expect(cmp.detachedComponents.length).toEqual(1);
+         expect(cmp.detachedComponents[0] instanceof BlankCmp).toBe(true);
+       }));
+
     it('should support attaching & detaching fragments',
        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
          const fixture = createRoot(router, RootCmp);


### PR DESCRIPTION
Previously there was no way to subscribe for `attach`/`detach` events from the `RouterOutlet` when an outlet got attached/detached with `RouteReuseStrategy`. The changes add new outputs `attached`/`detached` for the `RouterOutlet` to emit events when an outlet gets attached/detached.