### PR TITLE
docs: add redirect from angular.io/guide to angular.io/docs

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -61,7 +61,7 @@
       {"type": 301, "source": "/docs/*/latest/guide/server-communication.html", "destination": "/guide/http"},
       {"type": 301, "source": "/docs/*/latest/guide/style-guide.html", "destination": "/guide/styleguide"},
       {"type": 301, "source": "/guide/bazel", "destination": "https://github.com/angular/angular/blob/master/packages/bazel/docs/BAZEL_SCHEMATICS.md"},
-      {"type": 301, "source": "/guide/", "destination": "/docs"},
+      {"type": 301, "source": "/guide", "destination": "/docs"},
       {"type": 301, "source": "/guide/cli-quickstart", "destination": "/start"},
       {"type": 301, "source": "/guide/i18n", "destination": "/guide/i18n-overview"},
       {"type": 301, "source": "/guide/service-worker-getstart", "destination": "/guide/service-worker-getting-started"},

--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -61,6 +61,7 @@
       {"type": 301, "source": "/docs/*/latest/guide/server-communication.html", "destination": "/guide/http"},
       {"type": 301, "source": "/docs/*/latest/guide/style-guide.html", "destination": "/guide/styleguide"},
       {"type": 301, "source": "/guide/bazel", "destination": "https://github.com/angular/angular/blob/master/packages/bazel/docs/BAZEL_SCHEMATICS.md"},
+      {"type": 301, "source": "/guide/", "destination": "/docs"},
       {"type": 301, "source": "/guide/cli-quickstart", "destination": "/start"},
       {"type": 301, "source": "/guide/i18n", "destination": "/guide/i18n-overview"},
       {"type": 301, "source": "/guide/service-worker-getstart", "destination": "/guide/service-worker-getting-started"},

--- a/aio/tests/deployment/shared/URLS_TO_REDIRECT.txt
+++ b/aio/tests/deployment/shared/URLS_TO_REDIRECT.txt
@@ -203,6 +203,7 @@
 /guide/cli-quickstart --> /start
 /guide/displaying-data --> /start#template-syntax
 /guide/i18n --> /guide/i18n-overview
+/guide --> /docs
 /guide/learning-angular --> /start
 /guide/learning-angular.html --> /start
 /guide/metadata --> /guide/aot-compiler


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
https://angular.io/guide results in page not found.
Issue Number: N/A


## What is the new behavior?
https://angular.io/guide redirects to https://angular.io/docs

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
