### PR TITLE
fix(migrations): migration failed finding tsconfig file

### DIFF
--- a/packages/core/schematics/migrations/abstract-control-parent/index.ts
+++ b/packages/core/schematics/migrations/abstract-control-parent/index.ts
@@ -16,8 +16,8 @@ import {findParentAccesses} from './util';
 
 /** Migration that marks accesses of `AbstractControl.parent` as non-null. */
 export default function(): Rule {
-  return (tree: Tree) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const allPaths = [...buildPaths, ...testPaths];
 

--- a/packages/core/schematics/migrations/activated-route-snapshot-fragment/index.ts
+++ b/packages/core/schematics/migrations/activated-route-snapshot-fragment/index.ts
@@ -19,8 +19,8 @@ import {findFragmentAccesses, migrateActivatedRouteSnapshotFragment} from './uti
  * Migration that marks accesses of `ActivatedRouteSnapshot.fragment` as non-null.
  */
 export default function(): Rule {
-  return (tree: Tree) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const allPaths = [...buildPaths, ...testPaths];
 

--- a/packages/core/schematics/migrations/can-activate-with-redirect-to/index.ts
+++ b/packages/core/schematics/migrations/can-activate-with-redirect-to/index.ts
@@ -17,8 +17,8 @@ import {findLiteralsToMigrate, migrateLiteral} from './util';
 
 /** Migration that removes `canActivate` property from routes that also have `redirectTo`. */
 export default function(): Rule {
-  return (tree: Tree) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const allPaths = [...buildPaths, ...testPaths];
 

--- a/packages/core/schematics/migrations/dynamic-queries/index.ts
+++ b/packages/core/schematics/migrations/dynamic-queries/index.ts
@@ -20,8 +20,8 @@ import {identifyDynamicQueryNodes, removeOptionsParameter, removeStaticFlag} fro
  * Runs the dynamic queries migration for all TypeScript projects in the current CLI workspace.
  */
 export default function(): Rule {
-  return (tree: Tree) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const allPaths = [...buildPaths, ...testPaths];
 

--- a/packages/core/schematics/migrations/initial-navigation/index.ts
+++ b/packages/core/schematics/migrations/initial-navigation/index.ts
@@ -17,8 +17,8 @@ import {UpdateRecorder} from './update_recorder';
 
 /** Entry point for the v10 "initialNavigation RouterModule options" schematic. */
 export default function(): Rule {
-  return (tree: Tree) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
 
     if (!buildPaths.length && !testPaths.length) {

--- a/packages/core/schematics/migrations/missing-injectable/index.ts
+++ b/packages/core/schematics/migrations/missing-injectable/index.ts
@@ -17,8 +17,8 @@ import {UpdateRecorder} from './update_recorder';
 
 /** Entry point for the V9 "missing @Injectable" schematic. */
 export default function(): Rule {
-  return (tree: Tree, ctx: SchematicContext) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree, ctx: SchematicContext) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const failures: string[] = [];
 

--- a/packages/core/schematics/migrations/module-with-providers/index.ts
+++ b/packages/core/schematics/migrations/module-with-providers/index.ts
@@ -21,8 +21,8 @@ import {AnalysisFailure, ModuleWithProvidersTransform} from './transform';
  * Runs the ModuleWithProviders migration for all TypeScript projects in the current CLI workspace.
  */
 export default function(): Rule {
-  return (tree: Tree, ctx: SchematicContext) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree, ctx: SchematicContext) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const allPaths = [...buildPaths, ...testPaths];
     const failures: string[] = [];

--- a/packages/core/schematics/migrations/move-document/index.ts
+++ b/packages/core/schematics/migrations/move-document/index.ts
@@ -19,8 +19,8 @@ import {addToImport, createImport, removeFromImport} from './move-import';
 
 /** Entry point for the V8 move-document migration. */
 export default function(): Rule {
-  return (tree: Tree) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
 
     if (!buildPaths.length && !testPaths.length) {

--- a/packages/core/schematics/migrations/native-view-encapsulation/index.ts
+++ b/packages/core/schematics/migrations/native-view-encapsulation/index.ts
@@ -16,8 +16,8 @@ import {findNativeEncapsulationNodes} from './util';
 
 /** Migration that switches from `ViewEncapsulation.Native` to `ViewEncapsulation.ShadowDom`. */
 export default function(): Rule {
-  return (tree: Tree) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const allPaths = [...buildPaths, ...testPaths];
 

--- a/packages/core/schematics/migrations/navigation-extras-omissions/index.ts
+++ b/packages/core/schematics/migrations/navigation-extras-omissions/index.ts
@@ -17,8 +17,8 @@ import {findLiteralsToMigrate, migrateLiteral} from './util';
 
 /** Migration that switches `Router.navigateByUrl` and `Router.createUrlTree` to a new signature. */
 export default function(): Rule {
-  return (tree: Tree) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const allPaths = [...buildPaths, ...testPaths];
 

--- a/packages/core/schematics/migrations/relative-link-resolution/index.ts
+++ b/packages/core/schematics/migrations/relative-link-resolution/index.ts
@@ -17,8 +17,8 @@ import {UpdateRecorder} from './update_recorder';
 
 /** Entry point for the v11 "relativeLinkResolution RouterModule options" schematic. */
 export default function(): Rule {
-  return (tree: Tree) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
 
     if (!buildPaths.length && !testPaths.length) {

--- a/packages/core/schematics/migrations/renderer-to-renderer2/index.ts
+++ b/packages/core/schematics/migrations/renderer-to-renderer2/index.ts
@@ -26,8 +26,8 @@ const MODULE_AUGMENTATION_FILENAME = 'ɵɵRENDERER_MIGRATION_CORE_AUGMENTATION.d
  * https://hackmd.angular.io/UTzUZTnPRA-cSa_4mHyfYw
  */
 export default function(): Rule {
-  return (tree: Tree) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const allPaths = [...buildPaths, ...testPaths];
 

--- a/packages/core/schematics/migrations/router-link-empty-expression/index.ts
+++ b/packages/core/schematics/migrations/router-link-empty-expression/index.ts
@@ -30,8 +30,8 @@ interface FixedTemplate {
 
 /** Entry point for the RouterLink empty expression migration. */
 export default function(): Rule {
-  return (tree: Tree, context: SchematicContext) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree, context: SchematicContext) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
 
     if (!buildPaths.length && !testPaths.length) {

--- a/packages/core/schematics/migrations/router-preserve-query-params/index.ts
+++ b/packages/core/schematics/migrations/router-preserve-query-params/index.ts
@@ -20,8 +20,8 @@ import {findLiteralsToMigrate, migrateLiteral} from './util';
  * `NavigationExtras`'s `queryParamsHandling` attribute.
  */
 export default function(): Rule {
-  return (tree: Tree) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const allPaths = [...buildPaths, ...testPaths];
 

--- a/packages/core/schematics/migrations/static-queries/index.ts
+++ b/packages/core/schematics/migrations/static-queries/index.ts
@@ -45,7 +45,7 @@ export default function(): Rule {
 
 /** Runs the V8 migration static-query migration for all determined TypeScript projects. */
 async function runMigration(tree: Tree, context: SchematicContext) {
-  const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
   const basePath = process.cwd();
   const logger = context.logger;
 

--- a/packages/core/schematics/migrations/template-var-assignment/index.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/index.ts
@@ -23,8 +23,8 @@ const FAILURE_MESSAGE = `Found assignment to template variable.`;
 
 /** Entry point for the V8 template variable assignment schematic. */
 export default function(): Rule {
-  return (tree: Tree, context: SchematicContext) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree, context: SchematicContext) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
 
     if (!buildPaths.length && !testPaths.length) {

--- a/packages/core/schematics/migrations/undecorated-classes-with-decorated-fields/index.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-decorated-fields/index.ts
@@ -21,8 +21,8 @@ import {UpdateRecorder} from './update_recorder';
  * https://hackmd.io/vuQfavzfRG6KUCtU7oK_EA
  */
 export default function(): Rule {
-  return (tree: Tree, ctx: SchematicContext) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree, ctx: SchematicContext) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const allPaths = [...buildPaths, ...testPaths];
     const failures: string[] = [];

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/index.ts
@@ -32,8 +32,8 @@ const MIGRATION_AOT_FAILURE = 'This migration uses the Angular compiler internal
 
 /** Entry point for the V9 "undecorated-classes-with-di" migration. */
 export default function(): Rule {
-  return (tree: Tree, ctx: SchematicContext) => {
-    const {buildPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree, ctx: SchematicContext) => {
+    const {buildPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const failures: string[] = [];
     let programError = false;

--- a/packages/core/schematics/migrations/wait-for-async/index.ts
+++ b/packages/core/schematics/migrations/wait-for-async/index.ts
@@ -21,8 +21,8 @@ const MODULE_AUGMENTATION_FILENAME = 'ɵɵASYNC_MIGRATION_CORE_AUGMENTATION.d.ts
 
 /** Migration that switches from `async` to `waitForAsync`. */
 export default function(): Rule {
-  return (tree: Tree) => {
-    const {buildPaths, testPaths} = getProjectTsConfigPaths(tree);
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const allPaths = [...buildPaths, ...testPaths];
 

--- a/packages/core/schematics/test/abstract_control_parent_migration_spec.ts
+++ b/packages/core/schematics/test/abstract_control_parent_migration_spec.ts
@@ -28,6 +28,7 @@ describe('AbstractControl.parent migration', () => {
       compilerOptions: {lib: ['es2015'], strictNullChecks: true},
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
     // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.

--- a/packages/core/schematics/test/activated_route_snapshot_fragment_migration_spec.ts
+++ b/packages/core/schematics/test/activated_route_snapshot_fragment_migration_spec.ts
@@ -28,6 +28,7 @@ describe('ActivatedRouteSnapshot.fragment migration', () => {
       compilerOptions: {lib: ['es2015'], strictNullChecks: true},
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
     // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.

--- a/packages/core/schematics/test/all-migrations.spec.ts
+++ b/packages/core/schematics/test/all-migrations.spec.ts
@@ -29,6 +29,7 @@ describe('all migrations', () => {
 
     writeFile('/node_modules/@angular/core/index.d.ts', `export const MODULE: any;`);
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
     writeFile('/tsconfig.json', `{}`);

--- a/packages/core/schematics/test/can_activate_with_redirect_migration_spec.ts
+++ b/packages/core/schematics/test/can_activate_with_redirect_migration_spec.ts
@@ -31,6 +31,7 @@ describe('canActivate removal with redirectTo', () => {
       },
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
 

--- a/packages/core/schematics/test/dynamic_queries_migration_spec.ts
+++ b/packages/core/schematics/test/dynamic_queries_migration_spec.ts
@@ -30,6 +30,7 @@ describe('dynamic queries migration', () => {
       }
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
 

--- a/packages/core/schematics/test/initial_navigation_migration_spec.ts
+++ b/packages/core/schematics/test/initial_navigation_migration_spec.ts
@@ -30,6 +30,7 @@ describe('initial navigation migration', () => {
       }
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
 

--- a/packages/core/schematics/test/missing_injectable_migration_spec.ts
+++ b/packages/core/schematics/test/missing_injectable_migration_spec.ts
@@ -32,6 +32,7 @@ describe('Missing injectable migration', () => {
       },
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
 

--- a/packages/core/schematics/test/module_with_providers_migration_spec.ts
+++ b/packages/core/schematics/test/module_with_providers_migration_spec.ts
@@ -30,6 +30,7 @@ describe('ModuleWithProviders migration', () => {
       }
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
 

--- a/packages/core/schematics/test/move_document_migration_spec.ts
+++ b/packages/core/schematics/test/move_document_migration_spec.ts
@@ -30,6 +30,7 @@ describe('move-document migration', () => {
       },
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
 

--- a/packages/core/schematics/test/native_view_encapsulation_migration_spec.ts
+++ b/packages/core/schematics/test/native_view_encapsulation_migration_spec.ts
@@ -31,6 +31,7 @@ describe('ViewEncapsulation.Native migration', () => {
       },
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
 

--- a/packages/core/schematics/test/navigation_extras_omissions_migration_spec.ts
+++ b/packages/core/schematics/test/navigation_extras_omissions_migration_spec.ts
@@ -31,6 +31,7 @@ describe('NavigationExtras omissions migration', () => {
       },
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
     // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.

--- a/packages/core/schematics/test/preserve_query_params_migration_spec.ts
+++ b/packages/core/schematics/test/preserve_query_params_migration_spec.ts
@@ -31,6 +31,7 @@ describe('NavigationExtras preserveQueryParams migration', () => {
       },
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
     // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.

--- a/packages/core/schematics/test/project_tsconfig_paths_spec.ts
+++ b/packages/core/schematics/test/project_tsconfig_paths_spec.ts
@@ -17,18 +17,20 @@ describe('project tsconfig paths', () => {
     testTree = new UnitTestTree(new HostTree());
   });
 
-  it('should detect build tsconfig path inside of angular.json file', () => {
+  it('should detect build tsconfig path inside of angular.json file', async () => {
     testTree.create('/my-custom-config.json', '');
     testTree.create('/angular.json', JSON.stringify({
+      version: 1,
       projects: {my_name: {architect: {build: {options: {tsConfig: './my-custom-config.json'}}}}}
     }));
 
-    expect(getProjectTsConfigPaths(testTree).buildPaths).toEqual(['my-custom-config.json']);
+    expect((await getProjectTsConfigPaths(testTree)).buildPaths).toEqual(['my-custom-config.json']);
   });
 
-  it('should be able to read workspace configuration which is using JSON5 features', () => {
+  it('should be able to read workspace configuration which is using JSON5 features', async () => {
     testTree.create('/my-build-config.json', '');
     testTree.create('/angular.json', `{
+      version: 1,
       // Comments, unquoted properties or trailing commas are only supported in JSON5.
       projects: {
         with_tests: {
@@ -43,41 +45,36 @@ describe('project tsconfig paths', () => {
       },
     }`);
 
-    expect(getProjectTsConfigPaths(testTree).buildPaths).toEqual(['my-build-config.json']);
+    expect((await getProjectTsConfigPaths(testTree)).buildPaths).toEqual(['my-build-config.json']);
   });
 
-  it('should detect test tsconfig path inside of angular.json file', () => {
+  it('should detect test tsconfig path inside of angular.json file', async () => {
     testTree.create('/my-test-config.json', '');
     testTree.create('/angular.json', JSON.stringify({
+      version: 1,
       projects: {my_name: {architect: {test: {options: {tsConfig: './my-test-config.json'}}}}}
     }));
 
-    expect(getProjectTsConfigPaths(testTree).testPaths).toEqual(['my-test-config.json']);
+    expect((await getProjectTsConfigPaths(testTree)).testPaths).toEqual(['my-test-config.json']);
   });
 
-  it('should detect test tsconfig path inside of .angular.json file', () => {
+  it('should detect test tsconfig path inside of .angular.json file', async () => {
     testTree.create('/my-test-config.json', '');
     testTree.create('/.angular.json', JSON.stringify({
+      version: 1,
       projects: {with_tests: {architect: {test: {options: {tsConfig: './my-test-config.json'}}}}}
     }));
 
-    expect(getProjectTsConfigPaths(testTree).testPaths).toEqual(['my-test-config.json']);
+    expect((await getProjectTsConfigPaths(testTree)).testPaths).toEqual(['my-test-config.json']);
   });
 
-  it('should detect common tsconfigs if no workspace config could be found', () => {
-    testTree.create('/src/tsconfig.app.json', '');
-    testTree.create('/src/tsconfig.spec.json', '');
-
-    expect(getProjectTsConfigPaths(testTree).buildPaths).toEqual(['src/tsconfig.app.json']);
-    expect(getProjectTsConfigPaths(testTree).testPaths).toEqual(['src/tsconfig.spec.json']);
-  });
-
-  it('should not return duplicate tsconfig files', () => {
+  it('should not return duplicate tsconfig files', async () => {
     testTree.create('/tsconfig.json', '');
     testTree.create('/.angular.json', JSON.stringify({
+      version: 1,
       projects: {app: {architect: {build: {options: {tsConfig: 'tsconfig.json'}}}}}
     }));
 
-    expect(getProjectTsConfigPaths(testTree).buildPaths).toEqual(['tsconfig.json']);
+    expect((await getProjectTsConfigPaths(testTree)).buildPaths).toEqual(['tsconfig.json']);
   });
 });

--- a/packages/core/schematics/test/relative_link_resolution_spec.ts
+++ b/packages/core/schematics/test/relative_link_resolution_spec.ts
@@ -30,6 +30,7 @@ describe('initial navigation migration', () => {
       }
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
 

--- a/packages/core/schematics/test/renderer_to_renderer2_migration_spec.ts
+++ b/packages/core/schematics/test/renderer_to_renderer2_migration_spec.ts
@@ -31,6 +31,7 @@ describe('Renderer to Renderer2 migration', () => {
       },
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
     // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.

--- a/packages/core/schematics/test/routerlink_empty_expr_migration_spec.ts
+++ b/packages/core/schematics/test/routerlink_empty_expr_migration_spec.ts
@@ -31,6 +31,7 @@ describe('routerlink emptyExpr assignment migration', () => {
       },
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
 

--- a/packages/core/schematics/test/static_queries_migration_template_spec.ts
+++ b/packages/core/schematics/test/static_queries_migration_template_spec.ts
@@ -33,6 +33,7 @@ describe('static-queries migration with template strategy', () => {
       },
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
 

--- a/packages/core/schematics/test/static_queries_migration_usage_spec.ts
+++ b/packages/core/schematics/test/static_queries_migration_usage_spec.ts
@@ -37,6 +37,7 @@ describe('static-queries migration with usage strategy', () => {
       },
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
 
@@ -671,6 +672,7 @@ describe('static-queries migration with usage strategy', () => {
       // recorded for TypeScript projects not at the schematic tree root.
       host.sync.rename(normalize('/tsconfig.json'), normalize('/src/tsconfig.json'));
       writeFile('/angular.json', JSON.stringify({
+        version: 1,
         projects: {t: {architect: {build: {options: {tsConfig: './src/tsconfig.json'}}}}}
       }));
 

--- a/packages/core/schematics/test/template_var_assignment_migration_spec.ts
+++ b/packages/core/schematics/test/template_var_assignment_migration_spec.ts
@@ -31,6 +31,7 @@ describe('template variable assignment migration', () => {
       },
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
 

--- a/packages/core/schematics/test/undecorated_classes_with_decorated_fields_migration_spec.ts
+++ b/packages/core/schematics/test/undecorated_classes_with_decorated_fields_migration_spec.ts
@@ -28,6 +28,7 @@ describe('Undecorated classes with decorated fields migration', () => {
 
     writeFile('/tsconfig.json', JSON.stringify({compilerOptions: {lib: ['es2015']}}));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
 
@@ -294,6 +295,7 @@ describe('Undecorated classes with decorated fields migration', () => {
 
   it('should not add multiple TODOs for ambiguous classes', async () => {
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {
         test: {
           architect: {

--- a/packages/core/schematics/test/undecorated_classes_with_di_migration_spec.ts
+++ b/packages/core/schematics/test/undecorated_classes_with_di_migration_spec.ts
@@ -35,6 +35,7 @@ describe('Undecorated classes with DI migration', () => {
       },
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
 

--- a/packages/core/schematics/test/wait_for_async_migration_spec.ts
+++ b/packages/core/schematics/test/wait_for_async_migration_spec.ts
@@ -31,6 +31,7 @@ describe('waitForAsync migration', () => {
       },
     }));
     writeFile('/angular.json', JSON.stringify({
+      version: 1,
       projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
     }));
     // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.

--- a/packages/core/schematics/utils/BUILD.bazel
+++ b/packages/core/schematics/utils/BUILD.bazel
@@ -9,7 +9,6 @@ ts_library(
         "//packages/compiler",
         "@npm//@angular-devkit/core",
         "@npm//@angular-devkit/schematics",
-        "@npm//@schematics/angular",
         "@npm//@types/inquirer",
         "@npm//@types/node",
         "@npm//typescript",

--- a/packages/core/schematics/utils/project_tsconfig_paths.ts
+++ b/packages/core/schematics/utils/project_tsconfig_paths.ts
@@ -49,6 +49,7 @@ export async function getProjectTsConfigPaths(tree: Tree):
   };
 }
 
+/** Get options for all configurations for the passed builder target. */
 function*
     allTargetOptions(target: workspaces.TargetDefinition):
         Iterable<[string | undefined, Record<string, json.JsonValue|undefined>]> {
@@ -81,7 +82,10 @@ function createHost(tree: Tree): workspaces.WorkspaceHost {
       return tree.overwrite(path, data);
     },
     async isDirectory(path: string): Promise<boolean> {
-      // approximate a directory check
+      // Approximate a directory check.
+      // We don't need to consider empty directories and hence this is a good enough approach.
+      // This is also per documentation, see:
+      // https://angular.io/guide/schematics-for-libraries#get-the-project-configuration
       return !tree.exists(path) && tree.getDir(path).subfiles.length > 0;
     },
     async isFile(path: string): Promise<boolean> {

--- a/packages/core/schematics/utils/project_tsconfig_paths.ts
+++ b/packages/core/schematics/utils/project_tsconfig_paths.ts
@@ -6,82 +6,93 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {JsonParseMode, normalize, parseJson} from '@angular-devkit/core';
+import {json, normalize, virtualFs, workspaces} from '@angular-devkit/core';
 import {Tree} from '@angular-devkit/schematics';
-import {WorkspaceProject} from '@schematics/angular/utility/workspace-models';
-
-/** Name of the default Angular CLI workspace configuration files. */
-const defaultWorkspaceConfigPaths = ['/angular.json', '/.angular.json'];
 
 /**
  * Gets all tsconfig paths from a CLI project by reading the workspace configuration
  * and looking for common tsconfig locations.
  */
-export function getProjectTsConfigPaths(tree: Tree): {buildPaths: string[], testPaths: string[]} {
+export async function getProjectTsConfigPaths(tree: Tree):
+    Promise<{buildPaths: string[]; testPaths: string[];}> {
   // Start with some tsconfig paths that are generally used within CLI projects. Note
   // that we are not interested in IDE-specific tsconfig files (e.g. /tsconfig.json)
-  const buildPaths = new Set<string>(['src/tsconfig.app.json']);
-  const testPaths = new Set<string>(['src/tsconfig.spec.json']);
+  const buildPaths = new Set<string>();
+  const testPaths = new Set<string>();
 
-  // Add any tsconfig directly referenced in a build or test task of the angular.json workspace.
-  const workspace = getWorkspaceConfigGracefully(tree);
-
-  if (workspace) {
-    const projects = Object.keys(workspace.projects).map(name => workspace.projects[name]);
-    for (const project of projects) {
-      const buildPath = getTargetTsconfigPath(project, 'build');
-      const testPath = getTargetTsconfigPath(project, 'test');
-
-      if (buildPath) {
-        buildPaths.add(buildPath);
+  const workspace = await getWorkspace(tree);
+  for (const [, project] of workspace.projects) {
+    for (const [name, target] of project.targets) {
+      if (name !== 'build' && name !== 'test') {
+        continue;
       }
 
-      if (testPath) {
-        testPaths.add(testPath);
+      for (const [, options] of allTargetOptions(target)) {
+        const tsConfig = options.tsConfig;
+        // Filter out tsconfig files that don't exist in the CLI project.
+        if (typeof tsConfig !== 'string' || !tree.exists(tsConfig)) {
+          continue;
+        }
+
+        if (name === 'build') {
+          buildPaths.add(normalize(tsConfig));
+        } else {
+          testPaths.add(normalize(tsConfig));
+        }
       }
     }
   }
 
-  // Filter out tsconfig files that don't exist in the CLI project.
   return {
-    buildPaths: Array.from(buildPaths).filter(p => tree.exists(p)),
-    testPaths: Array.from(testPaths).filter(p => tree.exists(p)),
+    buildPaths: [...buildPaths],
+    testPaths: [...testPaths],
   };
 }
 
-/** Gets the tsconfig path from the given target within the specified project. */
-function getTargetTsconfigPath(project: WorkspaceProject, targetName: string): string|null {
-  if (project.targets && project.targets[targetName] && project.targets[targetName].options &&
-      project.targets[targetName].options.tsConfig) {
-    return normalize(project.targets[targetName].options.tsConfig);
+function*
+    allTargetOptions(target: workspaces.TargetDefinition):
+        Iterable<[string | undefined, Record<string, json.JsonValue|undefined>]> {
+  if (target.options) {
+    yield [undefined, target.options];
   }
 
-  if (project.architect && project.architect[targetName] && project.architect[targetName].options &&
-      project.architect[targetName].options.tsConfig) {
-    return normalize(project.architect[targetName].options.tsConfig);
+  if (!target.configurations) {
+    return;
   }
-  return null;
+
+  for (const [name, options] of Object.entries(target.configurations)) {
+    if (options) {
+      yield [name, options];
+    }
+  }
 }
 
-/**
- * Resolve the workspace configuration of the specified tree gracefully. We cannot use the utility
- * functions from the default Angular schematics because those might not be present in older
- * versions of the CLI. Also it's important to resolve the workspace gracefully because
- * the CLI project could be still using `.angular-cli.json` instead of thew new config.
- */
-function getWorkspaceConfigGracefully(tree: Tree): any {
-  const path = defaultWorkspaceConfigPaths.find(filePath => tree.exists(filePath));
-  const configBuffer = tree.read(path!);
+function createHost(tree: Tree): workspaces.WorkspaceHost {
+  return {
+    async readFile(path: string): Promise<string> {
+      const data = tree.read(path);
+      if (!data) {
+        throw new Error('File not found.');
+      }
 
-  if (!path || !configBuffer) {
-    return null;
-  }
+      return virtualFs.fileBufferToString(data);
+    },
+    async writeFile(path: string, data: string): Promise<void> {
+      return tree.overwrite(path, data);
+    },
+    async isDirectory(path: string): Promise<boolean> {
+      // approximate a directory check
+      return !tree.exists(path) && tree.getDir(path).subfiles.length > 0;
+    },
+    async isFile(path: string): Promise<boolean> {
+      return tree.exists(path);
+    },
+  };
+}
 
-  try {
-    // Parse the workspace file as JSON5 which is also supported for CLI
-    // workspace configurations.
-    return parseJson(configBuffer.toString(), JsonParseMode.Json5);
-  } catch (e) {
-    return null;
-  }
+async function getWorkspace(tree: Tree): Promise<workspaces.WorkspaceDefinition> {
+  const host = createHost(tree);
+  const {workspace} = await workspaces.readWorkspace('/', host);
+
+  return workspace;
 }


### PR DESCRIPTION
With this change we change the logic to locate the tsconfig files. The public API to locate, read and parse the workspace configuration should be use instead of the custom implemented logic.

The custom implemented logic depended on methods which have long been deprecated and are not removed in version 13 of the Angular CLI. This was not caught during development/UT because this repo is using outdated Angular Tooling packages.

This change also updates a number of spec files which previously creating an invalid Angular workspace configuration file.

Closes #43334

**NB: in a seperate PR we should update the tooling packages to version 13**
https://github.com/angular/angular/blob/5472c28fa1ddc002a93803a14ed5c6c865ca4dd8/package.json#L43-L47
https://github.com/angular/angular/blob/5472c28fa1ddc002a93803a14ed5c6c865ca4dd8/package.json#L66