### PR TITLE
fix: emit pure annotations to static property initializers

### DIFF
--- a/packages/animations/browser/src/render/animation_driver.ts
+++ b/packages/animations/browser/src/render/animation_driver.ts
@@ -47,7 +47,7 @@ export class NoopAnimationDriver implements AnimationDriver {
  * @publicApi
  */
 export abstract class AnimationDriver {
-  static NOOP: AnimationDriver = /* @__PURE__ */ new NoopAnimationDriver();
+  static NOOP: AnimationDriver = (/* @__PURE__ */ new NoopAnimationDriver());
 
   abstract validateStyleProperty(prop: string): boolean;
 

--- a/packages/animations/browser/src/render/special_cased_styles.ts
+++ b/packages/animations/browser/src/render/special_cased_styles.ts
@@ -44,7 +44,7 @@ export function packageNonAnimatableStyles(
  * `destroy()` is called then all styles will be removed.
  */
 export class SpecialCasedStyles {
-  static initialStylesByElement = /* @__PURE__ */ new WeakMap<any, {[key: string]: any}>();
+  static initialStylesByElement = (/* @__PURE__ */ new WeakMap<any, {[key: string]: any}>());
 
   private _state = SpecialCasedStylesState.Pending;
   private _initialStyles!: {[key: string]: any};

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -59,7 +59,7 @@ export const INJECTOR_IMPL = INJECTOR_IMPL__PRE_R3__;
  */
 export abstract class Injector {
   static THROW_IF_NOT_FOUND = THROW_IF_NOT_FOUND;
-  static NULL: Injector = /* @__PURE__ */ new NullInjector();
+  static NULL: Injector = (/* @__PURE__ */ new NullInjector());
 
   /**
    * Retrieves an instance from the injector based on the provided token.

--- a/packages/core/src/di/reflective_injector.ts
+++ b/packages/core/src/di/reflective_injector.ts
@@ -270,7 +270,7 @@ export abstract class ReflectiveInjector implements Injector {
 }
 
 export class ReflectiveInjector_ implements ReflectiveInjector {
-  private static INJECTOR_KEY = /* @__PURE__ */ ReflectiveKey.get(Injector);
+  private static INJECTOR_KEY = (/* @__PURE__ */ ReflectiveKey.get(Injector));
   /** @internal */
   _constructionCounter: number = 0;
   /** @internal */

--- a/packages/core/src/linker/component_factory_resolver.ts
+++ b/packages/core/src/linker/component_factory_resolver.ts
@@ -46,7 +46,7 @@ of the code in this cookbook
  * @publicApi
  */
 export abstract class ComponentFactoryResolver {
-  static NULL: ComponentFactoryResolver = /* @__PURE__ */ new _NullComponentFactoryResolver();
+  static NULL: ComponentFactoryResolver = (/* @__PURE__ */ new _NullComponentFactoryResolver());
   /**
    * Retrieves the factory object that creates a component of the given type.
    * @param component The component type.


### PR DESCRIPTION


Currently the pure annotations comments are not emitted because unless the entire expression is wrapped in braces.

See the below TypeScript playgrounds

https://www.typescriptlang.org/play?target=99&module=1&ts=4.4.2&ssl=8&ssc=1&pln=1&pc=1#code/MYGwhgzhAEByCuIQEkB2ArApsALgewCdoBvAXwFgAoKzADwAdCdowAjCHAsXaUSGNFlyESVaNA5gcAS2BwAqgBlF0ALzQA9ACpoAAQD6+gAryASgFFD0LRuipMAdziIUGbPgIAKAJQBuKhTUlMB4qBB4IJgAdCB4AOaegu6EUbBKin5UQA
```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
exports.Injector = void 0;
class NullInjector {
}
class Injector {
}
exports.Injector = Injector;
Injector.NULL = new NullInjector();
console.log(Injector.NULL);

```

https://www.typescriptlang.org/play?target=99&module=1&ts=4.4.2&ssl=4&ssc=18&pln=4&pc=33#code/MYGwhgzhAEByCuIQEkB2ArApsALgewCdoBvAXwFgAoKzADwAdCdowAjCHAsXaUSGNFlyESVaNA5gcAS2BwAqgBlF0ALzQAFAHoAVNAACAfUMAFeQCUAoseg6t0VJgDucRCgzZ8BDQEofAbioKakpgPFQIPBBMADoQPABzDUFPQhjYJUUAqiA

```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
exports.Injector = void 0;
class NullInjector {
}
class Injector {
}
exports.Injector = Injector;
Injector.NULL = ( /* @__PURE__ */new NullInjector());
console.log(Injector.NULL);
```