### PR TITLE
docs: fix app-hero-detaill typo

### DIFF
--- a/aio/content/examples/router/src/app/heroes/hero-detail/hero-detail.component.2.ts
+++ b/aio/content/examples/router/src/app/heroes/hero-detail/hero-detail.component.2.ts
@@ -8,7 +8,7 @@ import { HeroService } from '../hero.service';
 import { Hero } from '../hero';
 
 @Component({
-  selector: 'app-hero-detaill',
+  selector: 'app-hero-detail',
   templateUrl: './hero-detail.component.html',
   styleUrls: ['./hero-detail.component.css']
 })


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

This change is pretty useless since we never show the selector part anywhere, this is the only part of the example I believe we show:
![Screenshot at 2021-09-04 20-26-33](https://user-images.githubusercontent.com/61631103/132105893-cb44766f-fd2a-4979-a91e-9a6a882b4a8d.png)

I just noticed the typo and figured I could create a PR to fix it just to clean it up, but as I said it is a pretty useless change, if you don't think it is worth to merge this PR there's no problem :slightly_smiling_face: 
