### PR TITLE
fix(docs-infra): improve aio contributors page responsiveness

### DIFF
--- a/aio/src/styles/2-modules/buttons/_buttons.scss
+++ b/aio/src/styles/2-modules/buttons/_buttons.scss
@@ -68,7 +68,8 @@ a.button.mat-button,
     @include mixins.line-height(48);
     margin: 8px;
     padding: 0px 16px;
-    width: 168px;
+    width: 16.8rem;
+    min-width: max-content;
 
     @media (max-width: 480px) {
       @include mixins.font-size(14);

--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -44,8 +44,8 @@ aio-contributor {
   }
 
   .contributor-info {
-    height: 168px;
-    width: 168px;
+    height: 100%;
+    width: 100%;
     display: flex;
     flex-direction: row;
     justify-content: center;
@@ -59,7 +59,7 @@ aio-contributor {
       display: flex;
       @include mixins.font-size(14);
       font-weight: 500;
-      margin: 8px;
+      margin: 0.8rem;
       padding: 0;
 
       &:hover {
@@ -67,16 +67,27 @@ aio-contributor {
       }
 
       &.icon {
-        min-width: 20px;
-        width: 20px;
+        $size: 2rem;
+        min-width: $size;
+        width: $size;
 
         mat-icon {
-          height: 20px;
-          width: 20px;
+          $size: 2rem;
+          height: $size;
+          width: $size;
+          font-size: 2rem;
+
+          &[svgicon] {
+            line-height: 0;
+
+            svg {
+              height: 100%;
+              width: 100%;
+            }
+          }
 
           &.link-icon {
-            margin-top: -7px;
-            transform: rotateZ(45deg);
+            transform: translateY(-10%) rotateZ(45deg);
           }
         }
       }
@@ -84,8 +95,10 @@ aio-contributor {
   }
 
   .contributor-card {
-    width: 250px;
-    height: 270px;
+    width: 25rem;
+    height: 27rem;
+    max-width: 310px;
+    max-height: 340px;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -147,8 +160,15 @@ aio-contributor {
     justify-content: center;
     border-radius: 50%;
     align-items: center;
-    height: 168px;
-    width: 168px;
+    $size: 16.8rem;
+    height: $size;
+    width: $size;
+    $min-size: 105px;
+    min-height: $min-size;
+    min-width: $min-size;
+    $max-size: 230px;
+    max-height: $max-size;
+    max-width: $max-size;
     background-size: cover;
     background-position: center;
     margin: 8px auto;

--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -111,17 +111,10 @@ aio-contributor {
       display: flex;
       flex-direction: column;
       box-sizing: border-box;
-    }
-
-    .card-front {
       justify-content: center;
     }
 
     .card-back {
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
       padding: 16px 24px;
       transform:rotateY(180deg);
 

--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -67,15 +67,14 @@ aio-contributor {
       }
 
       &.icon {
-        $size: 2rem;
+        $size: 20px;
         min-width: $size;
         width: $size;
 
         mat-icon {
-          $size: 2rem;
           height: $size;
           width: $size;
-          font-size: 2rem;
+          font-size: $size;
 
           &[svgicon] {
             line-height: 0;
@@ -110,7 +109,7 @@ aio-contributor {
     transition:transform ease 500ms;
 
     h3 {
-      margin: 8px 0;
+      margin: 0.8rem 0;
     }
 
     .card-front, .card-back {
@@ -139,7 +138,7 @@ aio-contributor {
       }
 
       p {
-        margin: 8px 0;
+        margin: 0.8rem 0;
         @include mixins.font-size(12);
         @include mixins.line-height(14);
         text-align: left;
@@ -171,7 +170,7 @@ aio-contributor {
     max-width: $max-size;
     background-size: cover;
     background-position: center;
-    margin: 8px auto;
+    margin: 0.8rem auto;
     transition: all .2s ease-in-out;
   }
 

--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -24,7 +24,6 @@ aio-contributor {
   border-radius: 4px;
   box-shadow: 0 2px 2px rgba(10, 16, 20, 0.24), 0 0 2px rgba(10, 16, 20, 0.12);
   transition: all .3s;
-  perspective: 800px;
 
   @media (hover) {
     &:hover {

--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -97,13 +97,6 @@ aio-contributor {
     height: 27rem;
     max-width: 310px;
     max-height: 340px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: space-between;
-    position: relative;
-    overflow: hidden;
-    border-radius: 4px;
     transform-style:preserve-3d;
     transition:transform ease 500ms;
 

--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -47,12 +47,9 @@ aio-contributor {
     height: 100%;
     width: 100%;
     display: flex;
-    flex-direction: row;
     flex-wrap: wrap;
     justify-content: center;
-    align-items: center;
     align-content: center;
-    text-align: center;
     /* There is no point in hiding this if we can't hover to show it. */
     @media (hover) { opacity: 0; }
     border-radius: 50%;
@@ -65,7 +62,6 @@ aio-contributor {
       margin: 0.8rem;
       width: 100%;
       justify-content: center;
-      padding: 0;
 
       &:hover {
         text-decoration: none;
@@ -82,8 +78,6 @@ aio-contributor {
           font-size: $size;
 
           &[svgicon] {
-            line-height: 0;
-
             svg {
               height: 100%;
               width: 100%;
@@ -91,7 +85,7 @@ aio-contributor {
           }
 
           &.link-icon {
-            transform: translateY(-10%) rotateZ(45deg);
+            transform: rotateZ(45deg);
           }
         }
       }

--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -154,10 +154,7 @@ aio-contributor {
   }
 
   .contributor-image {
-    display: flex;
-    justify-content: center;
     border-radius: 50%;
-    align-items: center;
     $size: 16.8rem;
     height: $size;
     width: $size;

--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -48,8 +48,10 @@ aio-contributor {
     width: 100%;
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     justify-content: center;
     align-items: center;
+    align-content: center;
     text-align: center;
     /* There is no point in hiding this if we can't hover to show it. */
     @media (hover) { opacity: 0; }
@@ -58,8 +60,11 @@ aio-contributor {
     .info-item {
       display: flex;
       @include mixins.font-size(14);
+      font-size: clamp(10px, 1.4rem, 30px);
       font-weight: 500;
       margin: 0.8rem;
+      width: 100%;
+      justify-content: center;
       padding: 0;
 
       &:hover {

--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -72,7 +72,7 @@ aio-contributor {
       }
 
       &.icon {
-        $size: 20px;
+        $size: 23px;
         min-width: $size;
         width: $size;
 

--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -3,7 +3,6 @@
 aio-contributor-list {
   .contributor-group {
     display: flex;
-    flex-direction: row;
     flex-wrap: wrap;
     justify-content: center;
   }
@@ -21,7 +20,6 @@ aio-contributor-list {
 
 aio-contributor {
   margin: 8px;
-  position: relative;
   cursor: pointer;
   border-radius: 4px;
   box-shadow: 0 2px 2px rgba(10, 16, 20, 0.24), 0 0 2px rgba(10, 16, 20, 0.12);


### PR DESCRIPTION
Improve the aio contributors page responsiveness regarding the browser's
font-size so that the page looks good regarding on font-size settings
(no cropped or cramped content)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The angular.io contributors page doesn't adapt well on different front-size settings

![before](https://user-images.githubusercontent.com/61631103/132127703-5bdc367f-0fbc-42c1-9406-537a16247d41.gif)


## What is the new behavior?

The angular.io contributors page adapt well on different front-size settings

![after](https://user-images.githubusercontent.com/61631103/132127714-f9aa9ac7-0147-4f4f-aaf9-7777eb3cf84a.gif)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
