### PR TITLE
ci: avoid failures when yarn unlinks bazelisk in windows jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,10 @@ commands:
           keys:
             - *cache_key_win
             - *cache_key_win_fallback
+      # Install @bazel/bazelisk globally and use that for the first run.
+      # Workaround for https://github.com/bazelbuild/rules_nodejs/issues/894
+      # NB: the issue was for @bazel/bazel but the same problem applies to @bazel/bazelisk
+      - run: yarn global add @bazel/bazelisk@$env:BAZELISK_VERSION
       # On Windows `~/` is not resolved when using as a CLI value. `../` results in the same path.
       - run: yarn install --frozen-lockfile --non-interactive --cache-folder ../.cache/yarn
 
@@ -799,11 +803,11 @@ jobs:
       - setup_win
       - run:
           name: Build all windows CI targets
-          command: yarn bazel build --build_tag_filters=-ivy-only //packages/compiler-cli/...
+          command: bazel build --build_tag_filters=-ivy-only //packages/compiler-cli/...
           no_output_timeout: 15m
       - run:
           name: Test all windows CI targets
-          command: yarn bazel test --test_tag_filters="-ivy-only,-browser:chromium-local" //packages/compiler-cli/...
+          command: bazel test --test_tag_filters="-ivy-only,-browser:chromium-local" //packages/compiler-cli/...
           no_output_timeout: 15m
 
   test_ivy_aot_win:
@@ -812,11 +816,11 @@ jobs:
       - setup_win
       - run:
           name: Build all windows CI targets
-          command: yarn bazel build --config=ivy --build_tag_filters=-no-ivy-aot,-fixme-ivy-aot //packages/compiler-cli/...
+          command: bazel build --config=ivy --build_tag_filters=-no-ivy-aot,-fixme-ivy-aot //packages/compiler-cli/...
           no_output_timeout: 15m
       - run:
           name: Test all windows CI targets
-          command: yarn bazel test --config=ivy --test_tag_filters="-no-ivy-aot,-fixme-ivy-aot,-browser:chromium-local" //packages/compiler-cli/... //packages/localize/...
+          command: bazel test --config=ivy --test_tag_filters="-no-ivy-aot,-fixme-ivy-aot,-browser:chromium-local" //packages/compiler-cli/... //packages/localize/...
           no_output_timeout: 15m
       # Save dependencies to use on subsequent runs.
       - save_cache:


### PR DESCRIPTION
Windows disallows removal of files which are currently being used.
i.e. have active handles. This currently can result in permission denied
failures on the Windows CI jobs where `yarn bazel` resolves to the local
bazelisk installation that can be unlinked by `yarn_install` repository
fetching as part of the Bazel invocation, resulting in errors like:

```
ERROR: An error occurred during the fetch of repository 'npm':
   yarn_install failed: $ node tools/yarn/check-yarn.js
...
[4/5] Linking dependencies...
info If you think this is a bug, please open a bug report with the information provided in "C:\\users\\circleci\\ng\\yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
 (warning " > tsickle@0.34.3" has incorrect peer dependency "typescript@~3.3.1".
error An unexpected error occurred: "EPERM: operation not permitted, unlink 'C:\\users\\circleci\\ng\\node_modules\\@bazel\\bazel-win32_x64\\bazel-0.27.0-windows-x86_64.exe'".
Process stalled
Active handles:
  - Socket
  - Socket
  - Socket
)
```

We workaround this in order to improve CI stability in case the node modules are
being invalidated by Bazel, or through Yarns integrity checking. This happened
in one of the PRs constantly (even invalidating the cache did not work).

https://app.circleci.com/pipelines/github/angular/angular?branch=pull%2F43365

We had similar logic in the past, and this just restores it. It seems like this has been
removed by accident in https://github.com/devversion/angular/commit/0e5a945ed4c8017e754d519374d7e13bc1d5aee7

