### PR TITLE
docs(service-worker): update SW guide to include changes about cache (#43163)

### DIFF
--- a/aio/content/guide/service-worker-devops.md
+++ b/aio/content/guide/service-worker-devops.md
@@ -326,8 +326,9 @@ essentially self-destructing.
 
 Also included in the `@angular/service-worker` NPM package is a small
 script `safety-worker.js`, which when loaded will unregister itself
-from the browser. This script can be used as a last resort to get rid
-of unwanted service workers already installed on client pages.
+from the browser and remove the service worker cache. This script can 
+be used as a last resort to get rid of unwanted service workers already 
+installed on client pages.
 
 It's important to note that you cannot register this worker directly,
 as old clients with cached state may not see a new `index.html` which
@@ -340,7 +341,7 @@ old Service Worker URL forever.
 
 This script can be used both to deactivate `@angular/service-worker`
 as well as any other Service Workers which might have been served in
-the past on your site.
+the past on your site along with the corresponding caches.
 
 ### Changing your app's location
 


### PR DESCRIPTION
Update `Safety Worker` section in `Service Worker` guide and mention that safety worker also removes the SW caches.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## What is the current behavior?
Safety worker now also removes the SW caches, this wasn't mentioned in docs

Issue Number: #43163

## What is the new behavior?

Update docs to mention that safety worker also removes the SW caches.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
