### PR TITLE
docs(bazel): fix outdated redirect URL for `/guide/bazel`

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -60,7 +60,7 @@
       {"type": 301, "source": "/docs/*/latest/quickstart.html", "destination": "/start"},
       {"type": 301, "source": "/docs/*/latest/guide/server-communication.html", "destination": "/guide/http"},
       {"type": 301, "source": "/docs/*/latest/guide/style-guide.html", "destination": "/guide/styleguide"},
-      {"type": 301, "source": "/guide/bazel", "destination": "https://github.com/angular/angular/blob/master/packages/bazel/src/schematics/README.md"},
+      {"type": 301, "source": "/guide/bazel", "destination": "https://github.com/angular/angular/blob/master/packages/bazel/docs/BAZEL_SCHEMATICS.md"},
       {"type": 301, "source": "/guide/cli-quickstart", "destination": "/start"},
       {"type": 301, "source": "/guide/service-worker-getstart", "destination": "/guide/service-worker-getting-started"},
       {"type": 301, "source": "/guide/service-worker-comm", "destination": "/guide/service-worker-communications"},

--- a/aio/tests/deployment/shared/URLS_TO_REDIRECT.txt
+++ b/aio/tests/deployment/shared/URLS_TO_REDIRECT.txt
@@ -198,7 +198,7 @@
 /getting-started/data --> /start/start-data
 /getting-started/forms --> /start/start-forms
 /getting-started/deployment --> /start/start-deployment
-/guide/bazel --> https://github.com/angular/angular/blob/master/packages/bazel/src/schematics/README.md
+/guide/bazel --> https://github.com/angular/angular/blob/master/packages/bazel/docs/BAZEL_SCHEMATICS.md
 /guide/change-log --> https://github.com/angular/angular/blob/master/CHANGELOG.md
 /guide/cli-quickstart --> /start
 /guide/displaying-data --> /start#template-syntax


### PR DESCRIPTION
The file we are redirecting `/guide/bazel` to was moved from `bazel/src/schematics/README.md` to `bazel/docs/BAZEL_SCHEMATICS.md` in commit 71b8c9ab29014f7e710e03ebda185c0a7c0c2620.

Update the Firebase configuration to use the new path in the redirect URL.
