### PR TITLE
refactor(common): removed TODO no longer considered necessary

### DIFF
--- a/packages/common/src/viewport_scroller.ts
+++ b/packages/common/src/viewport_scroller.ts
@@ -120,9 +120,7 @@ export class BrowserViewportScroller implements ViewportScroller {
     if (!this.supportsScrolling()) {
       return;
     }
-    // TODO(atscott): The correct behavior for `getElementsByName` would be to also verify that the
-    // element is an anchor. However, this could be considered a breaking change and should be
-    // done in a major version.
+
     const elSelected = findAnchorFromDocument(this.document, target);
 
     if (elSelected) {


### PR DESCRIPTION
The TODO comment suggesting to verify that the target element to
scroll to needs to be an anchor does not longer seems under consideration
so it can be removed (see: https://github.com/angular/angular/issues/43348)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #43348


## What is the new behavior?

Comment removed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

@atscott :slightly_smiling_face: :+1: 