### PR TITLE
refactor(router): clean up unnecessary flag in `restoreHistory` function

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -898,19 +898,11 @@ export class Router {
                            // AngularJS sync code which looks for a value here in order to determine
                            // whether or not to handle a given popstate event or to leave it to the
                            // Angular router.
-                           this.restoreHistory(t);
-                           this.cancelNavigationTransition(t, cancelationReason);
-                         } else {
-                           // We cannot trigger a `location.historyGo` if the
-                           // cancellation was due to a new navigation before the previous could
-                           // complete. This is because `location.historyGo` triggers a `popstate`
-                           // which would also trigger another navigation. Instead, treat this as a
-                           // redirect and do not reset the state.
-                           this.cancelNavigationTransition(t, cancelationReason);
-                           // TODO(atscott): The same problem happens here with a fresh page load
-                           // and a new navigation before that completes where we won't set a page
-                           // id.
+                           this.resetUrlToCurrentUrlTree();
                          }
+                         // Note: Other `canceledNavigationResolution` strategies will not support
+                         // the AngularJS use-case that's mentioned above.
+                         this.cancelNavigationTransition(t, cancelationReason);
                        }
                        // currentNavigation should always be reset to null here. If navigation was
                        // successful, lastSuccessfulTransition will have already been set. Therefore
@@ -941,7 +933,7 @@ export class Router {
                            // This is only applicable with initial navigation, so setting
                            // `navigated` only when not redirecting resolves this scenario.
                            this.navigated = true;
-                           this.restoreHistory(t, true);
+                           this.restoreHistory(t);
                          }
                          const navCancel = new NavigationCancel(
                              t.id, this.serializeUrl(t.extractedUrl), e.message);
@@ -978,7 +970,7 @@ export class Router {
                          /* All other errors should reset to the router's internal URL reference to
                           * the pre-error state. */
                        } else {
-                         this.restoreHistory(t, true);
+                         this.restoreHistory(t);
                          const navError =
                              new NavigationError(t.id, this.serializeUrl(t.extractedUrl), e);
                          eventsSubject.next(navError);
@@ -1488,7 +1480,7 @@ export class Router {
    * Performs the necessary rollback action to restore the browser URL to the
    * state before the transition.
    */
-  private restoreHistory(t: NavigationTransition, restoringFromCaughtError = false) {
+  private restoreHistory(t: NavigationTransition) {
     if (this.canceledNavigationResolution === 'computed') {
       const targetPagePosition = this.currentPageId - t.targetPageId;
       // The navigator change the location before triggered the browser event,
@@ -1516,13 +1508,7 @@ export class Router {
         // there's no restoration needed.
       }
     } else if (this.canceledNavigationResolution === 'replace') {
-      // TODO(atscott): It seems like we should _always_ reset the state here. It would be a no-op
-      // for `deferred` navigations that haven't change the internal state yet because guards
-      // reject. For 'eager' navigations, it seems like we also really should reset the state
-      // because the navigation was cancelled. Investigate if this can be done by running TGP.
-      if (restoringFromCaughtError) {
-        this.resetState(t);
-      }
+      this.resetState(t);
       this.resetUrlToCurrentUrlTree();
     }
   }


### PR DESCRIPTION
This restores the `finalize` function to directly call
`resetUrlToCurrentUrlTree`, as it was before efb440eb2f507f9a2675f2663f1af0b3c574c902.
This allows us to simplify the `restoreHistory` function because it no
longer needs to handle the call from `finalize` where it should not
reset the internal router state.
