### PR TITLE
Allow setting FormControl to undefined

### DIFF
--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -45,7 +45,7 @@ export {SelectMultipleControlValueAccessor} from './directives/select_multiple_c
 export {ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {FormBuilder} from './form_builder';
-export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormGroup} from './model';
+export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormGroup, FORM_CONTROL_UNDEFINED_VALUE} from './model';
 export {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from './validators';
 export {VERSION} from './version';
 

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -46,6 +46,11 @@ export const PENDING = 'PENDING';
 export const DISABLED = 'DISABLED';
 
 /**
+ * Symbol to signal the value should be set to undefined
+ */
+export const FORM_CONTROL_UNDEFINED_VALUE = Symbol();
+
+/**
  * A form can have several different statuses. Each
  * possible status is returned as a string literal.
  *
@@ -1434,7 +1439,7 @@ export class FormControl extends AbstractControl {
       formState.disabled ? this.disable({onlySelf: true, emitEvent: false}) :
                            this.enable({onlySelf: true, emitEvent: false});
     } else {
-      (this as {value: any}).value = this._pendingValue = formState;
+      (this as {value: any}).value = this._pendingValue = formState === FORM_CONTROL_UNDEFINED_VALUE ? undefined : formState;
     }
   }
 }


### PR DESCRIPTION
Allow setting forms to undefined using a special Symbol. Works around https://github.com/angular/angular/issues/40978

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe: Easy workaround for a bug that won't be fixed anytime soon.


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When initialising form controls, `undefined` is converted to `null`
Issue Number: #40978


## What is the new behavior?
Allows for passing the `FORM_CONTROL_UNDEFINED_VALUE` constant, which will initialise the value to `undefined`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
