### PR TITLE
Missing informations to import ProductDetailsComponent

### DIFF
--- a/aio/content/start/start-routing.md
+++ b/aio/content/start/start-routing.md
@@ -21,7 +21,7 @@ This section shows you how to define a route to show individual product details.
     In the file list, right-click the `app` folder, choose `Angular Generator` and `Component`.
     Name the component `product-details`.
 
-1. In `app.module.ts`, add a route for product details, with a `path` of `products/:productId` and `ProductDetailsComponent` for the `component`.
+1. In `app.module.ts`, add a route for product details, with a `path` of `products/:productId` and `ProductDetailsComponent` for the `component`. Also `import { ProductDetailsComponent } from './product-details/product-details.component'; ` and add `ProductDetailsComponent` to the declaration.
 
     <code-example header="src/app/app.module.ts" path="getting-started/src/app/app.module.ts" region="product-details-route">
     </code-example>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes


## What is the current behavior?

The getting-started tutorial at angular.io/start instructs users to generate a ProductAlertsComponent using the "Angular generator" feature in StackBlitz. However, unlike the Angular CLI, generating a component in StackBlitz does not automatically declare it in AppModule, which is a requirement for the component to be used in the application. This resulted in a compile error when following the tutorial instructions.

This commit fixes this by adding a step to manually import and declare the newly generated component in app.module.ts.

Fixes #43020.
Closes #43212.



