### PR TITLE
docs: deprecate `aotSummaries` usage in TestBed

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -55,6 +55,8 @@ v12 - v15
 | `@angular/router`       | [`loadChildren` string syntax](#loadChildren)                                                 | <!--v9--> v11         |
 | `@angular/core/testing` | [`TestBed.get`](#testing)                                                                     | <!--v9--> v12         |
 | `@angular/core/testing` | [`async`](#testing)                                                                           | <!--v9--> v12         |
+| `@angular/core/testing` | [`aotSummaries` argument in `TestBed.initTestEnvironment`](#testing)                                                                           | <!--v13--> v14         |
+| `@angular/core/testing` | [`aotSummaries` field of the `TestModuleMetadata` type](#testing)                                                                           | <!--v13--> v14         |
 | `@angular/forms`        | [`FormBuilder.group` legacy options parameter](api/forms/FormBuilder#group)                   | <!--v11--> v14        |
 | `@angular/router`       | [`ActivatedRoute` params and `queryParams` properties](#activatedroute-props)                 | unspecified           |
 | template syntax         | [`/deep/`, `>>>`, and `::ng-deep`](#deep-component-style-selector)                            | <!--v7--> unspecified |
@@ -111,6 +113,8 @@ This section contains a complete list all of the currently-deprecated APIs, with
 |:---                                           |:---                                                 |:---                   |:---                                           |
 | [`TestBed.get`](api/core/testing/TestBed#get) | [`TestBed.inject`](api/core/testing/TestBed#inject) | v9                    | Same behavior, but type safe.                 |
 | [`async`](api/core/testing/async)             | [`waitForAsync`](api/core/testing/waitForAsync)     | v10                   | Same behavior, but rename to avoid confusion. |
+| [`aotSummaries` argument in `TestBed.initTestEnvironment`](api/core/testing/TestBed#inittestenvironment)             | No replacement needed     | v13                   | Summary files are unused in Ivy. |
+| [`aotSummaries` field of the `TestModuleMetadata` type](api/core/testing/TestModuleMetadata)             | No replacement needed     | v13                   | Summary files are unused in Ivy. |
 
 {@a forms}
 

--- a/goldens/public-api/core/testing/testing.md
+++ b/goldens/public-api/core/testing/testing.md
@@ -114,7 +114,7 @@ export interface TestBed {
     // @deprecated (undocumented)
     get(token: any, notFoundValue?: any): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, options?: TestEnvironmentOptions): void;
-    // (undocumented)
+    // @deprecated
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): void;
     // (undocumented)
     inject<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
@@ -172,9 +172,8 @@ export interface TestBedStatic {
     get<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
     // @deprecated (undocumented)
     get(token: any, notFoundValue?: any): any;
-    // (undocumented)
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, options?: TestEnvironmentOptions): TestBed;
-    // (undocumented)
+    // @deprecated
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
     // (undocumented)
     inject<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
@@ -220,9 +219,8 @@ export class TestComponentRenderer {
 
 // @public (undocumented)
 export interface TestEnvironmentOptions {
-    // (undocumented)
+    // @deprecated
     aotSummaries?: () => any[];
-    // (undocumented)
     teardown?: ModuleTeardownOptions;
 }
 

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -39,6 +39,20 @@ export interface TestBed {
   initTestEnvironment(
       ngModule: Type<any>|Type<any>[], platform: PlatformRef,
       options?: TestEnvironmentOptions): void;
+  /**
+   * Initialize the environment for testing with a compiler factory, a PlatformRef, and an
+   * angular module. These are common to every test in the suite.
+   *
+   * This may only be called once, to set up the common providers for the current test
+   * suite on the current platform. If you absolutely need to change the providers,
+   * first use `resetTestEnvironment`.
+   *
+   * Test modules and platforms for individual platforms are available from
+   * '@angular/<platform_name>/testing'.
+   *
+   * @deprecated This API that allows providing AOT summaries is deprecated, since summary files are
+   *     unused in Ivy.
+   */
   initTestEnvironment(
       ngModule: Type<any>|Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): void;
 

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -47,6 +47,9 @@ export type TestModuleMetadata = {
   declarations?: any[],
   imports?: any[],
   schemas?: Array<SchemaMetadata|any[]>,
+  /**
+   * @deprecated With Ivy, AOT summary files are unused.
+   */
   aotSummaries?: () => any[],
   teardown?: ModuleTeardownOptions;
 };
@@ -55,12 +58,21 @@ export type TestModuleMetadata = {
  * @publicApi
  */
 export interface TestEnvironmentOptions {
+  /**
+   * Provides a way to specify AOT summaries to use in TestBed.
+   * This parameter is unused and deprecated in Ivy.
+   *
+   * @deprecated With Ivy, AOT summary files are unused.
+   */
   aotSummaries?: () => any[];
+  /**
+   * Configures the test module teardown behavior in `TestBed`.
+   */
   teardown?: ModuleTeardownOptions;
 }
 
 /**
- * Object used to configure the test module teardown behavior in `TestBed`.
+ * Configures the test module teardown behavior in `TestBed`.
  * @publicApi
  */
 export interface ModuleTeardownOptions {
@@ -79,9 +91,34 @@ export interface ModuleTeardownOptions {
 export interface TestBedStatic {
   new(...args: any[]): TestBed;
 
+  /**
+   * Initialize the environment for testing with a compiler factory, a PlatformRef, and an
+   * angular module. These are common to every test in the suite.
+   *
+   * This may only be called once, to set up the common providers for the current test
+   * suite on the current platform. If you absolutely need to change the providers,
+   * first use `resetTestEnvironment`.
+   *
+   * Test modules and platforms for individual platforms are available from
+   * '@angular/<platform_name>/testing'.
+   */
   initTestEnvironment(
       ngModule: Type<any>|Type<any>[], platform: PlatformRef,
       options?: TestEnvironmentOptions): TestBed;
+  /**
+   * Initialize the environment for testing with a compiler factory, a PlatformRef, and an
+   * angular module. These are common to every test in the suite.
+   *
+   * This may only be called once, to set up the common providers for the current test
+   * suite on the current platform. If you absolutely need to change the providers,
+   * first use `resetTestEnvironment`.
+   *
+   * Test modules and platforms for individual platforms are available from
+   * '@angular/<platform_name>/testing'.
+   *
+   * @deprecated This API that allows providing AOT summaries is deprecated, since summary files are
+   *     unused in Ivy.
+   */
   initTestEnvironment(
       ngModule: Type<any>|Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
 


### PR DESCRIPTION
DEPRECATION:

In Ivy, AOT summary files are unused. Passing AOT summary files in TestBed has no effect, so the `aotSummaries` usage in TestBed is deprecated and will be removed in a future version of Angular.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Documentation content changes
 
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No