### PR TITLE
docs: fix leftover text from previous version

### DIFF
--- a/aio/content/guide/event-binding.md
+++ b/aio/content/guide/event-binding.md
@@ -53,8 +53,8 @@ After those steps, if you add event listeners for the `scroll` event, the listen
 1. Parent directives listen for the event by binding to this property and accessing the data through the `$event` object.
 
 Consider an `ItemDetailComponent` that presents item information and responds to user actions.
-Although the `ItemDetailComponent` has a delete button, it doesn't contain the functionality to delete the hero.
-It can only raise an event reporting the user's delete request.
+Although the `ItemDetailComponent` has a delete button, it doesn't contain the functionality to display warning message.
+It can raise an event reporting the deleted item.
 
 
 <code-example path="event-binding/src/app/item-detail/item-detail.component.html" header="src/app/item-detail/item-detail.component.html (template)" region="line-through"></code-example>


### PR DESCRIPTION
**What?**
Explanation changed to reflect currently used code example.
**Why?**
In new code example used we are not deleting hero in parent component. 
We are displaying warning message.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
