### PR TITLE
docs: remove unnecessary "https://angular.io/" from aio links

### DIFF
--- a/aio/content/guide/deployment.md
+++ b/aio/content/guide/deployment.md
@@ -480,6 +480,6 @@ The effects of defining a `deploy url` and `base href` can overlap.
 However, defining a `base href` has a few unique effects.
 * Defining a `base href` can be used for locating relative template (HTML) assets, and relative fetch/XMLHttpRequests.
 
-The `base href` can also be used to define the Angular router's default base (see [APP_BASE_HREF](https://angular.io/api/common/APP_BASE_HREF)). Users with more complicated setups may need to manually configure the `APP_BASE_HREF` token within the application. (e.g., application routing base is / but assets/scripts/etc. are at /assets/).
+The `base href` can also be used to define the Angular router's default base (see [APP_BASE_HREF](api/common/APP_BASE_HREF)). Users with more complicated setups may need to manually configure the `APP_BASE_HREF` token within the application. (e.g., application routing base is / but assets/scripts/etc. are at /assets/).
 
 Unlike the `base href` which can be defined in a single place, the `deploy url` needs to be hard-coded into an application at build time. This means specifying a `deploy url` will decrease build speed, but this is the unfortunate cost of using an option that embeds itself throughout an application. That is why a `base href` is generally the better option.

--- a/aio/content/guide/docs-style-guide.md
+++ b/aio/content/guide/docs-style-guide.md
@@ -1,6 +1,6 @@
 # Angular documentation style guide
 
-This style guide covers the standards for writing [Angular documentation on angular.io](https://angular.io/docs).
+This style guide covers the standards for writing [Angular documentation on angular.io](docs).
 These standards ensure consistency in writing style, Markdown conventions, and code snippets.
 
 ## Prerequisites
@@ -207,7 +207,7 @@ Do not create a node that is both a header and an item node by specifying the `u
 
 ## Code snippets
 
-[Angular.io](https://angular.io/docs) has a custom framework that enables authors to include code snippets directly from working example applications that are automatically tested as part of documentation builds.
+[Angular.io](docs) has a custom framework that enables authors to include code snippets directly from working example applications that are automatically tested as part of documentation builds.
 
 In addition to working code snippets, example code can include terminal commands, a fragment of TypeScript or HTML, or an entire code file.
 

--- a/aio/content/guide/entry-components.md
+++ b/aio/content/guide/entry-components.md
@@ -2,8 +2,8 @@
 
 <div class="alert is-helpful">
 
-Entry components have been deprecated with the [Ivy rendering engine](https://angular.io/guide/ivy). 
-For more information, see [entryComponents deprecation](https://angular.io/guide/deprecations#entrycomponents-and-analyze_for_entry_components-no-longer-required) in the [Deprecated APIs and features](https://angular.io/guide/deprecations).
+Entry components have been deprecated with the [Ivy rendering engine](guide/ivy).
+For more information, see [entryComponents deprecation](guide/deprecations#entrycomponents-and-analyze_for_entry_components-no-longer-required) in the [Deprecated APIs and features](guide/deprecations).
 
 </div>
 

--- a/aio/content/guide/form-validation.md
+++ b/aio/content/guide/form-validation.md
@@ -355,4 +355,4 @@ new FormControl('', {updateOn: 'blur'});
 
 ## Interaction with native HTML form validation
 
-By default, Angular disables [native HTML form validation](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Constraint_validation) by adding the `novalidate` attribute on the enclosing `<form>` and uses directives to match these attributes with validator functions in the framework. If you want to use native validation **in combination** with Angular-based validation, you can re-enable it with the `ngNativeValidate` directive. See the [API docs](https://angular.io/api/forms/NgForm#native-dom-validation-ui) for details.
+By default, Angular disables [native HTML form validation](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Constraint_validation) by adding the `novalidate` attribute on the enclosing `<form>` and uses directives to match these attributes with validator functions in the framework. If you want to use native validation **in combination** with Angular-based validation, you can re-enable it with the `ngNativeValidate` directive. See the [API docs](api/forms/NgForm#native-dom-validation-ui) for details.

--- a/aio/content/guide/lazy-loading-ngmodules.md
+++ b/aio/content/guide/lazy-loading-ngmodules.md
@@ -104,7 +104,7 @@ The import path is the relative path to the module.
 <div class="callout is-helpful">
 <header>String-based lazy loading</header>
 
-In Angular version 8, the string syntax for the `loadChildren` route specification [was deprecated](https://angular.io/guide/deprecations#loadchildren-string-syntax) in favor of the `import()` syntax. However, you can opt into using string-based lazy loading (`loadChildren: './path/to/module#Module'`) by including the lazy-loaded routes in your `tsconfig` file, which includes the lazy-loaded files in the compilation.
+In Angular version 8, the string syntax for the `loadChildren` route specification [was deprecated](guide/deprecations#loadchildren-string-syntax) in favor of the `import()` syntax. However, you can opt into using string-based lazy loading (`loadChildren: './path/to/module#Module'`) by including the lazy-loaded routes in your `tsconfig` file, which includes the lazy-loaded files in the compilation.
 
 By default the CLI will generate projects with stricter file inclusions intended to be used with the `import()` syntax.
 

--- a/aio/content/guide/npm-packages.md
+++ b/aio/content/guide/npm-packages.md
@@ -58,7 +58,7 @@ To add a new dependency, use the [`ng add`](cli/add) command.
 ### Angular packages
 
 The following Angular packages are included as dependencies in the default `package.json` file for a new Angular workspace.
-For a complete list of Angular packages, see the [API reference](https://angular.io/api?type=package).
+For a complete list of Angular packages, see the [API reference](api?type=package).
 
 Package name                               | Description
 ----------------------------------------   | --------------------------------------------------

--- a/aio/content/guide/roadmap.md
+++ b/aio/content/guide/roadmap.md
@@ -10,7 +10,7 @@ The projects below are not associated with a particular Angular version. We'll r
 
 ### Improve test times and debugging with automatic test environment tear down
 
-To improve test time and create better isolation across tests, we want to change <code>[TestBed](https://angular.io/api/core/testing/TestBed)</code> to automatically clean up and tear down the test environment after each test run.
+To improve test time and create better isolation across tests, we want to change <code>[TestBed](api/core/testing/TestBed)</code> to automatically clean up and tear down the test environment after each test run.
 
 ### Deprecate and remove IE11 support
 
@@ -32,7 +32,7 @@ MDC Web is a library created by Google's Material Design team that provides reus
 
 We're evaluating components in Angular Material against accessibility standards such as WCAG and working to fix any issues that arise from this process.
 
-### Remove legacy [View Engine](https://angular.io/guide/ivy)
+### Remove legacy [View Engine](guide/ivy)
 
 After the transition of all our internal tooling to Ivy is completed, we will remove the legacy View Engine for reduced Angular conceptual overhead, smaller package size, lower maintenance cost, and lower codebase complexity.
 
@@ -46,7 +46,7 @@ To ensure we provide a future-proof e2e testing strategy, we want to evaluate th
 
 ### Angular libraries use Ivy
 
-Earlier in 2020, we shared an [RFC](https://github.com/angular/angular/issues/38366) for Ivy library distribution. After invaluable feedback from the community, we developed a design of the project. We are now investing in the development of Ivy library distribution, including an update of the library package format to use Ivy compilation, unblock the deprecation of the View Engine library format, and [ngcc](https://angular.io/guide/glossary#ngcc).
+Earlier in 2020, we shared an [RFC](https://github.com/angular/angular/issues/38366) for Ivy library distribution. After invaluable feedback from the community, we developed a design of the project. We are now investing in the development of Ivy library distribution, including an update of the library package format to use Ivy compilation, unblock the deprecation of the View Engine library format, and [ngcc](guide/glossary#ngcc).
 
 ### Ensure smooth adoption for future RxJS changes (v7 and beyond)
 

--- a/aio/content/guide/updating.md
+++ b/aio/content/guide/updating.md
@@ -37,7 +37,7 @@ To check your application's version of Angular: From within your project directo
 {@a checking-version-angular}
 ## Finding the current version of Angular
 
-The most recent stable released version of Angular appears in the [Angular documentation](https://angular.io/docs "Angular documentation") at the bottom of the left side navigation. For example, `stable (v5.2.9)`.
+The most recent stable released version of Angular appears in the [Angular documentation](docs "Angular documentation") at the bottom of the left side navigation. For example, `stable (v5.2.9)`.
 
 You can also find the most current version of Angular by using the CLI command [`ng update`](cli/update). By default, [`ng update`](cli/update)(without additional arguments) lists the updates that are available to you.
 

--- a/aio/content/guide/what-is-angular.md
+++ b/aio/content/guide/what-is-angular.md
@@ -204,7 +204,7 @@ These libraries are only required if and when they can help you add functionalit
 
 This topic is intended to give you a brief overview of what Angular is, the advantages it provides, and what to expect as you start to build your applications.
 
-To see Angular in action, see our [Getting Started](https://angular.io/start) tutorial. This tutorial uses [stackblitz.com](https://stackblitz.com/), for you to explore a working example of Angular without any installation requirements.
+To see Angular in action, see our [Getting Started](start) tutorial. This tutorial uses [stackblitz.com](https://stackblitz.com/), for you to explore a working example of Angular without any installation requirements.
 
 To explore Angular's capabilities further, we recommend reading through the sections, Understanding Angular and Developer Guides.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

I just noticed that we have some unncessary "https://angular.io/" prefixes to our links so I am removing them as a simple clean up and for consistency sake

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
