### PR TITLE
refactor(router): Remove TODO and slightly adjust eager browserUrlTree update

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -662,16 +662,13 @@ export class Router {
                            (this.onSameUrlNavigation === 'reload' ? true : urlTransition) &&
                            this.urlHandlingStrategy.shouldProcessUrl(t.rawUrl);
 
-                       // If the source of the navigation is from a browser event, the URL is
-                       // already updated. We already need to sync the internal state.
-                       if (isBrowserTriggeredNavigation(t.source)) {
-                         // TODO(atscott): this should be `t.extractedUrl`. The `browserUrlTree`
-                         // should only be the part of the URL that is handled by the router. In
-                         // addition, this should only be done if we process the current url.
-                         this.browserUrlTree = t.rawUrl;
-                       }
 
                        if (processCurrentUrl) {
+                         // If the source of the navigation is from a browser event, the URL is
+                         // already updated. We already need to sync the internal state.
+                         if (isBrowserTriggeredNavigation(t.source)) {
+                           this.browserUrlTree = t.extractedUrl;
+                         }
                          return of(t).pipe(
                              // Fire NavigationStart event
                              switchMap(t => {


### PR DESCRIPTION
No test was added for this case because I can't think of a test case to
write that would work.

This change updates the code for a consistent mental model of setting
the `browserUrlTree`. It's only meant to track the `UrlTree` that the
`UrlHandlingStrategy` is set to extract, not the full `rawUrl`. Notice
that everywhere else, the `browserUrlTree` is set to
`urlAfterRedirects`, which is computed based on the extracted URL, _not_
the `rawUrl`.

Additional reviewer note: I will run TGP to ensure this does not break anything. Additionally, this bit of code was only recently added, which is additional defense of this being unlikely to break anything.