### PR TITLE
fix(core): incorrectly inserting elements inside <template> element

### DIFF
--- a/packages/core/src/render3/interfaces/renderer_dom.ts
+++ b/packages/core/src/render3/interfaces/renderer_dom.ts
@@ -64,6 +64,7 @@ export interface RElement extends RNode {
   style: RCssStyleDeclaration;
   classList: RDomTokenList;
   className: string;
+  tagName: string;
   textContent: string|null;
   setAttribute(name: string, value: string|TrustedHTML|TrustedScript|TrustedScriptURL): void;
   removeAttribute(name: string): void;
@@ -92,6 +93,11 @@ export interface RText extends RNode {
 
 export interface RComment extends RNode {
   textContent: string|null;
+}
+
+export interface RTemplate extends RElement {
+  tagName: 'TEMPLATE';
+  content: RNode;
 }
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -23,7 +23,7 @@ import {unregisterLView} from './interfaces/lview_tracking';
 import {TElementNode, TIcuContainerNode, TNode, TNodeFlags, TNodeType, TProjectionNode, unusedValueExportToPlacateAjd as unused2} from './interfaces/node';
 import {unusedValueExportToPlacateAjd as unused3} from './interfaces/projection';
 import {isProceduralRenderer, ProceduralRenderer3, Renderer3, unusedValueExportToPlacateAjd as unused4} from './interfaces/renderer';
-import {RComment, RElement, RNode, RText} from './interfaces/renderer_dom';
+import {RComment, RElement, RNode, RTemplate, RText} from './interfaces/renderer_dom';
 import {isLContainer, isLView} from './interfaces/type_checks';
 import {CHILD_HEAD, CLEANUP, DECLARATION_COMPONENT_VIEW, DECLARATION_LCONTAINER, DestroyHookData, FLAGS, HookData, HookFn, HOST, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, T_HOST, TVIEW, TView, TViewType, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
 import {getNamespaceUri} from './namespaces';
@@ -620,7 +620,8 @@ export function nativeInsertBefore(
   if (isProceduralRenderer(renderer)) {
     renderer.insertBefore(parent, child, beforeNode, isMove);
   } else {
-    parent.insertBefore(child, beforeNode, isMove);
+    const targetParent = isTemplateNode(parent) ? parent.content : parent;
+    targetParent.insertBefore(child, beforeNode, isMove);
   }
 }
 
@@ -630,7 +631,8 @@ function nativeAppendChild(renderer: Renderer3, parent: RElement, child: RNode):
   if (isProceduralRenderer(renderer)) {
     renderer.appendChild(parent, child);
   } else {
-    parent.appendChild(child);
+    const targetParent = isTemplateNode(parent) ? parent.content : parent;
+    targetParent.appendChild(child);
   }
 }
 
@@ -651,6 +653,11 @@ function nativeRemoveChild(
   } else {
     parent.removeChild(child);
   }
+}
+
+/** Checks if an element is a `<template>` node. */
+function isTemplateNode(node: RElement): node is RTemplate {
+  return node.tagName === 'TEMPLATE' && (node as RTemplate).content !== undefined;
 }
 
 /**

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -2236,6 +2236,74 @@ describe('acceptance integration tests', () => {
     expect(lViewIds.map(getLViewById)).toEqual([null, null, null]);
   });
 
+  it('should handle content inside <template> elements', () => {
+    @Component({template: '<template><strong>Hello</strong><em>World</em></template>'})
+    class App {
+    }
+
+    TestBed.configureTestingModule({declarations: [App]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const template: HTMLTemplateElement = fixture.nativeElement.querySelector('template');
+    // `content` won't exist in browsers that don't support `template`.
+    const root = template.content || template;
+
+    expect(root.childNodes.length).toBe(2);
+    expect(root.childNodes[0].textContent).toBe('Hello');
+    expect((root.childNodes[0] as HTMLElement).tagName).toBe('STRONG');
+    expect(root.childNodes[1].textContent).toBe('World');
+    expect((root.childNodes[1] as HTMLElement).tagName).toBe('EM');
+  });
+
+  it('should be able to insert and remove elements inside <template>', () => {
+    @Component({template: '<template><strong *ngIf="render">Hello</strong></template>'})
+    class App {
+      render = true;
+    }
+
+    TestBed.configureTestingModule({declarations: [App], imports: [CommonModule]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const template: HTMLTemplateElement = fixture.nativeElement.querySelector('template');
+    // `content` won't exist in browsers that don't support `template`.
+    const root = template.content || template;
+
+    expect(root.querySelector('strong')).toBeTruthy();
+
+    fixture.componentInstance.render = false;
+    fixture.detectChanges();
+    expect(root.querySelector('strong')).toBeFalsy();
+
+    fixture.componentInstance.render = true;
+    fixture.detectChanges();
+    expect(root.querySelector('strong')).toBeTruthy();
+  });
+
+  it('should handle data binding inside <template> elements', () => {
+    @Component({template: '<template><strong>Hello {{name}}</strong></template>'})
+    class App {
+      name = 'Bilbo';
+    }
+
+    TestBed.configureTestingModule({declarations: [App]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const template: HTMLTemplateElement = fixture.nativeElement.querySelector('template');
+    // `content` won't exist in browsers that don't support `template`.
+    const root = template.content || template;
+    const strong = root.querySelector('strong')!;
+
+    expect(strong.textContent).toBe('Hello Bilbo');
+
+    fixture.componentInstance.name = 'Frodo';
+    fixture.detectChanges();
+
+    expect(strong.textContent).toBe('Hello Frodo');
+  });
+
   describe('tView.firstUpdatePass', () => {
     function isFirstUpdatePass() {
       const lView = getLView();

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1056,6 +1056,12 @@
     "name": "isPromise2"
   },
   {
+    "name": "isTemplateNode"
+  },
+  {
+    "name": "isTemplateNode2"
+  },
+  {
     "name": "isTypeProvider"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -267,6 +267,9 @@
     "name": "isProceduralRenderer"
   },
   {
+    "name": "isTemplateNode"
+  },
+  {
     "name": "leaveDI"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1182,6 +1182,12 @@
     "name": "isStylingValuePresent"
   },
   {
+    "name": "isTemplateNode"
+  },
+  {
+    "name": "isTemplateNode2"
+  },
+  {
     "name": "isTypeProvider"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1149,6 +1149,12 @@
     "name": "isStylingValuePresent"
   },
   {
+    "name": "isTemplateNode"
+  },
+  {
+    "name": "isTemplateNode2"
+  },
+  {
     "name": "isTypeProvider"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -186,6 +186,9 @@
     "name": "isProceduralRenderer"
   },
   {
+    "name": "isTemplateNode"
+  },
+  {
     "name": "leaveDI"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1488,6 +1488,12 @@
     "name": "isScheduler"
   },
   {
+    "name": "isTemplateNode"
+  },
+  {
+    "name": "isTemplateNode2"
+  },
+  {
     "name": "isTypeProvider"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -591,6 +591,9 @@
     "name": "isStylingValuePresent"
   },
   {
+    "name": "isTemplateNode"
+  },
+  {
     "name": "keyValueArrayGet"
   },
   {

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -169,12 +169,14 @@ class DefaultDomRenderer2 implements Renderer2 {
   }
 
   appendChild(parent: any, newChild: any): void {
-    parent.appendChild(newChild);
+    const targetParent = isTemplateNode(parent) ? parent.content : parent;
+    targetParent.appendChild(newChild);
   }
 
   insertBefore(parent: any, newChild: any, refChild: any): void {
     if (parent) {
-      parent.insertBefore(newChild, refChild);
+      const targetParent = isTemplateNode(parent) ? parent.content : parent;
+      targetParent.insertBefore(newChild, refChild);
     }
   }
 
@@ -286,6 +288,10 @@ function checkNoSyntheticProp(name: string, nameKind: string) {
   - There is corresponding configuration for the animation named \`${
         name}\` defined in the \`animations\` field of the \`@Component\` decorator (see https://angular.io/api/core/Component#animations).`);
   }
+}
+
+function isTemplateNode(node: any): node is HTMLTemplateElement {
+  return node.tagName === 'TEMPLATE' && node.content !== undefined;
 }
 
 class EmulatedEncapsulationDomRenderer2 extends DefaultDomRenderer2 {

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -114,6 +114,28 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
            expect(window.getComputedStyle(none).color).toEqual('rgb(0, 255, 0)');
          });
     }
+
+    if (browserDetection.supportsTemplateElement) {
+      it('should be able to append children to a <template> element', () => {
+        const template = document.createElement('template');
+        const child = document.createElement('div');
+
+        renderer.appendChild(template, child);
+
+        expect(child.parentNode).toBe(template.content);
+      });
+
+      it('should be able to insert children before others in a <template> element', () => {
+        const template = document.createElement('template');
+        const child = document.createElement('div');
+        const otherChild = document.createElement('div');
+        template.content.appendChild(child);
+
+        renderer.insertBefore(template, otherChild, child);
+
+        expect(otherChild.parentNode).toBe(template.content);
+      });
+    }
   });
 }
 

--- a/packages/platform-browser/testing/src/browser_util.ts
+++ b/packages/platform-browser/testing/src/browser_util.ts
@@ -88,6 +88,11 @@ export class BrowserDetection {
     const testEl = document.createElement('div') as any;
     return (typeof testEl.createShadowRoot !== 'undefined');
   }
+
+  get supportsTemplateElement() {
+    const testEl = document.createElement('template') as any;
+    return (typeof testEl.content !== 'undefined');
+  }
 }
 
 export const browserDetection: BrowserDetection = BrowserDetection.setup();

--- a/packages/platform-server/src/server_renderer.ts
+++ b/packages/platform-server/src/server_renderer.ts
@@ -88,12 +88,14 @@ class DefaultServerRenderer2 implements Renderer2 {
   }
 
   appendChild(parent: any, newChild: any): void {
-    parent.appendChild(newChild);
+    const targetParent = isTemplateNode(parent) ? parent.content : parent;
+    targetParent.appendChild(newChild);
   }
 
   insertBefore(parent: any, newChild: any, refChild: any): void {
     if (parent) {
-      parent.insertBefore(newChild, refChild);
+      const targetParent = isTemplateNode(parent) ? parent.content : parent;
+      targetParent.insertBefore(newChild, refChild);
     }
   }
 
@@ -240,6 +242,10 @@ function checkNoSyntheticProp(name: string, nameKind: string) {
   - There is corresponding configuration for the animation named \`${
         name}\` defined in the \`animations\` field of the \`@Component\` decorator (see https://angular.io/api/core/Component#animations).`);
   }
+}
+
+function isTemplateNode(node: any): node is HTMLTemplateElement {
+  return node.tagName === 'TEMPLATE' && node.content !== undefined;
 }
 
 class EmulatedEncapsulationServerRenderer2 extends DefaultServerRenderer2 {


### PR DESCRIPTION
Currently whenever we insert elements, we do it directly on the node using `appendChild` or `insertBefore`, however this doesn't work with `<template>` elements where the `template.content` has to be used.

These changes add a few checks to call `appendChild` and `insertBefore` on the `content` of the template.

Fixes #15557.