### PR TITLE
perf(docs-infra): reduce unnecessary whitespace in API docs

### DIFF
--- a/aio/tools/transforms/remark-package/services/renderMarkdown.js
+++ b/aio/tools/transforms/remark-package/services/renderMarkdown.js
@@ -22,7 +22,7 @@ module.exports = function renderMarkdown() {
       //   console.log(require('util').inspect(tree, { colors: true, depth: 4 }));
       // })
       .use(mapHeadings(headingMap))
-      .use(html, { handlers: { code } });
+      .use(html, { handlers: { code }, sanitize: false });
 
     return renderer.processSync(content).toString();
   };

--- a/aio/tools/transforms/templates/api/base.template.html
+++ b/aio/tools/transforms/templates/api/base.template.html
@@ -1,6 +1,6 @@
-{% import "../lib/githubLinks.html" as github -%}
-{% set comma = joiner(',') %}
-{% set breadcrumbDelimiter = joiner('&gt;') %}
+{%- import "../lib/githubLinks.html" as github -%}
+{%- set comma = joiner(',') -%}
+{%- set breadcrumbDelimiter = joiner('&gt;') -%}
 <article>
   <div class="breadcrumb-container">
     <div class="breadcrumb">
@@ -18,22 +18,27 @@
     </div>
     {$ github.githubLinks(doc, versionInfo) $}
   </div>
-  {% block header %}
+  {%- block header %}
   <header class="api-header">
     <h1>{$ doc.name | escape $}</h1>
-    {% if doc.global %}<label class="api-type-label global">global</label>{% endif %}
+    {%- if doc.global %}
+    <label class="api-type-label global">global</label>{% endif %}
     <label class="api-type-label {$ doc.docType $}">{$ doc.docType $}</label>
-    {% if doc.deprecated !== undefined %}<label class="api-status-label deprecated">deprecated</label>{% endif %}
-    {% if doc.security !== undefined %}<label class="api-status-label security">security</label>{% endif %}
-    {% if doc.pipeOptions.pure === 'false' %}<label class="api-status-label impure-pipe">impure</label>{% endif %}
-    {% if doc.docType === 'class' and doc.extensible !== true and not doc.isAbstract %}<label class="github-links api-status-label final" title="This class should not be extended.">
+    {%- if doc.deprecated !== undefined %}
+    <label class="api-status-label deprecated">deprecated</label>{% endif %}
+    {%- if doc.security !== undefined %}
+    <label class="api-status-label security">security</label>{% endif %}
+    {%- if doc.pipeOptions.pure === 'false' %}
+    <label class="api-status-label impure-pipe">impure</label>{% endif %}
+    {%- if doc.docType === 'class' and doc.extensible !== true and not doc.isAbstract %}
+    <label class="github-links api-status-label final" title="This class should not be extended.">
       <a href="{$ github.githubVersionedUrl(versionInfo) $}/docs/PUBLIC_API.md#final-classes">final</a>
     </label>{% endif %}
   </header>
-  {% endblock %}
+  {%- endblock %}
   <aio-toc class="embedded"></aio-toc>
 
   <div class="api-body">
-    {% block body %}{% endblock %}
+    {%- block body %}{% endblock -%}
   </div>
 </article>

--- a/aio/tools/transforms/templates/api/class.template.html
+++ b/aio/tools/transforms/templates/api/class.template.html
@@ -1,10 +1,10 @@
 {% import "lib/ngmodule.html" as ngModuleHelpers -%}
 {% extends 'export-base.template.html' -%}
-{% block overview %}
+{% block overview -%}
   {% include "includes/class-overview.html" %}
-{% endblock %}
-{% block details %}
+{%- endblock %}
+{% block details -%}
   {$ ngModuleHelpers.ngModuleList(doc.ngModules, 'Provided in') $}
   {% include "includes/description.html" %}
   {% include "includes/class-members.html" %}
-{% endblock %}
+{%- endblock %}

--- a/aio/tools/transforms/templates/api/directive.template.html
+++ b/aio/tools/transforms/templates/api/directive.template.html
@@ -9,21 +9,20 @@
   {% include "includes/selectors.html" %}
 
   {$ memberHelpers.renderDirectiveProperties(doc, 'Properties') $}
-
   {% include "includes/export-as.html" %}
 
-  {% if doc.description or doc.usageNotes %}
+  {%- if doc.description or doc.usageNotes %}
   <section class="description">
     <h2>Description</h2>
     {$ (doc.description or '') | trimBlankLines | marked $}
     {$ (doc.usageNotes or '') | trimBlankLines | marked $}
   </section>
-  {% endif %}
+  {%- endif %}
 
   {$ memberHelpers.renderProperties(doc.staticProperties, 'static-properties', 'static-property', 'Static properties') $}
   {$ memberHelpers.renderMethodDetails(versionInfo, doc.staticMethods, 'static-methods', 'static-method', 'Static methods') $}
   {$ memberHelpers.renderMethodDetails(versionInfo, doc.methods, 'instance-methods', 'instance-method', 'Methods') $}
   {$ memberHelpers.renderDirectiveAncestors(doc, 'methods') $}
-  {% endblock %}
+{%- endblock %}
 
 {% block endNotes %}{% endblock %}

--- a/aio/tools/transforms/templates/api/export-base.template.html
+++ b/aio/tools/transforms/templates/api/export-base.template.html
@@ -1,14 +1,15 @@
-{% extends 'base.template.html' -%}
+{%- extends 'base.template.html' -%}
 
-{% block body %}
+{%- block body %}
   <section class="short-description">{% block shortDescription %}
     {$ doc.shortDescription | marked $}
-    {% if doc.description %}<p><a href="#description">See more...</a></p>{% endif %}
+    {%- if doc.description %}
+    <p><a href="#description">See more...</a></p>{% endif %}
   {% endblock %}</section>
-  {% include "includes/security-notes.html" %}
-  {% include "includes/deprecation.html" %}
-  {% block overview %}{% endblock %}
-  {% include "includes/see-also.html" %}
-  {% block details %}{% endblock %}
-  {% block endNotes %}{% include "includes/usageNotes.html" %}{% endblock %}
-{% endblock %}
+  {%- include "includes/security-notes.html" -%}
+  {%- include "includes/deprecation.html" -%}
+  {%- block overview %}{% endblock -%}
+  {%- include "includes/see-also.html" -%}
+  {%- block details %}{% endblock -%}
+  {%- block endNotes %}{% include "includes/usageNotes.html" %}{% endblock -%}
+{%- endblock -%}

--- a/aio/tools/transforms/templates/api/includes/annotations.html
+++ b/aio/tools/transforms/templates/api/includes/annotations.html
@@ -1,9 +1,13 @@
 {%- if doc.decorators.length %}
 <section class="annotations">
   <h2>Annotations</h2>
+
   {%- for decorator in doc.decorators %}
-    <code-example language="ts" hideCopy="true" class="no-box api-heading{% if decorator.deprecated %} deprecated-api-item{% endif %}">@{$ decorator.name $}({$ decorator.arguments $})</code-example>
-    {% if not decorator.notYetDocumented %}{$ decorator.description | marked $}{% endif %}
-  {% endfor %}
+  <code-example language="ts" hideCopy="true" class="no-box api-heading{% if decorator.deprecated %} deprecated-api-item{% endif %}">@{$ decorator.name $}({$ decorator.arguments $})</code-example>
+
+  {%- if not decorator.notYetDocumented %}
+  {$ decorator.description | marked $}
+  {%- endif %}
+  {%- endfor %}
 </section>
-{% endif %}
+{%- endif -%}

--- a/aio/tools/transforms/templates/api/includes/class-members.html
+++ b/aio/tools/transforms/templates/api/includes/class-members.html
@@ -1,14 +1,14 @@
-{% import "lib/memberHelpers.html" as memberHelpers -%}
+{%- import "lib/memberHelpers.html" as memberHelpers -%}
 
-{$ memberHelpers.renderProperties(doc.staticProperties, 'static-properties', 'static-property', 'Static properties') $}
+{$- memberHelpers.renderProperties(doc.staticProperties, 'static-properties', 'static-property', 'Static properties') $}
 
-{$ memberHelpers.renderMethodDetails(versionInfo, doc.staticMethods, 'static-methods', 'static-method', 'Static methods') $}
+{$- memberHelpers.renderMethodDetails(versionInfo, doc.staticMethods, 'static-methods', 'static-method', 'Static methods') $}
 
-{% if doc.constructorDoc %}
+{%- if doc.constructorDoc %}
 <h2>Constructor</h2>
 {$ memberHelpers.renderMethodDetail(versionInfo, doc.constructorDoc, 'constructor') $}
-{% endif %}
+{%- endif %}
 
-{$ memberHelpers.renderProperties(doc.properties, 'instance-properties', 'instance-property', 'Properties') $}
+{$- memberHelpers.renderProperties(doc.properties, 'instance-properties', 'instance-property', 'Properties') $}
 
-{$ memberHelpers.renderMethodDetails(versionInfo, doc.methods, 'instance-methods', 'instance-method', 'Methods') $}
+{$- memberHelpers.renderMethodDetails(versionInfo, doc.methods, 'instance-methods', 'instance-method', 'Methods') $}

--- a/aio/tools/transforms/templates/api/includes/class-overview.html
+++ b/aio/tools/transforms/templates/api/includes/class-overview.html
@@ -1,5 +1,5 @@
-{% import "lib/memberHelpers.html" as memberHelper -%}
-{% import "lib/descendants.html" as descendants -%}
+{%- import "lib/memberHelpers.html" as memberHelper -%}
+{%- import "lib/descendants.html" as descendants -%}
 
 <section class="{$ doc.docType $}-overview">
 <code-example language="ts" hideCopy="true">

--- a/aio/tools/transforms/templates/api/includes/decorator-overview.html
+++ b/aio/tools/transforms/templates/api/includes/decorator-overview.html
@@ -1,12 +1,12 @@
-{% import "lib/descendants.html" as descendants -%}
+{%- import "lib/descendants.html" as descendants -%}
 
-{% macro renderOptionsTable(doc) %}
+{%- macro renderOptionsTable(doc) -%}
 <table class="is-full-width list-table option-overview">
   <thead>
     <tr><th>Option</th><th>Description</th></tr>
   </thead>
   <tbody>
-  {%- for option in doc.members %}
+    {%- for option in doc.members %}
     <tr class="option">
       <td>
         <a class="code-anchor" href="{$ doc.path $}#{$ option.anchor | urlencode $}">
@@ -15,19 +15,19 @@
       </td>
       <td>{$ option.shortDescription | marked $}</td>
     </tr>
-    {% endfor -%}
+    {%- endfor %}
   </tbody>
 </table>
 
-{% for ancestor in doc.extendsClauses %}{% if ancestor.doc %}
+{%- for ancestor in doc.extendsClauses %}{% if ancestor.doc %}
 <h3 class="no-toc">Inherited from <a class="code-anchor" href="{$ ancestor.doc.path $}">{$ ancestor.doc.name $}</a> decorator</h3>
 {$ renderOptionsTable(ancestor.doc) $}
-{% endif %}{% endfor %}
-{% endmacro %}
+{%- endif %}{% endfor %}
+{%- endmacro -%}
 
-{% if doc.members.length %}
+{%- if doc.members.length %}
 <section class="decorator-overview">
   {$ renderOptionsTable(doc) $}
   {$ descendants.renderDescendants(doc, 'decorator', 'Subclasses') $}
 </section>
-{% endif %}
+{%- endif -%}

--- a/aio/tools/transforms/templates/api/includes/deprecation.html
+++ b/aio/tools/transforms/templates/api/includes/deprecation.html
@@ -1,5 +1,5 @@
-{% if doc.deprecated !== undefined %}
+{%- if doc.deprecated !== undefined %}
 <section class="deprecated">
   {$ ('**Deprecated:** ' + doc.deprecated) | marked $}
 </section>
-{% endif %}
+{%- endif -%}

--- a/aio/tools/transforms/templates/api/includes/description.html
+++ b/aio/tools/transforms/templates/api/includes/description.html
@@ -1,8 +1,10 @@
-{% if doc.description %}
+{%- if doc.description %}
 <section class="description">
   <h2>Description</h2>
-  {$ doc.description | trimBlankLines | marked $}
-  {% if doc.usageNotes %}<p>Further information is available in the <a href="#usage-notes">Usage Notes...</a></p>{%
-  endif %}
+  {$ doc.description | trimBlankLines | marked | trim $}
+
+  {%- if doc.usageNotes %}
+  <p>Further information is available in the <a href="#usage-notes">Usage Notes...</a></p>
+  {%- endif %}
 </section>
-{% endif %}
+{%- endif -%}

--- a/aio/tools/transforms/templates/api/includes/element-attributes.html
+++ b/aio/tools/transforms/templates/api/includes/element-attributes.html
@@ -14,8 +14,8 @@
         <td><code>{$ attribute.name $}</code></td>
         <td>{$ attribute.description | marked $}</td>
       </tr>
-      {% endfor %}
+      {%- endfor %}
     </tbody>
   </table>
 </section>
-{% endif %}
+{%- endif -%}

--- a/aio/tools/transforms/templates/api/includes/export-as.html
+++ b/aio/tools/transforms/templates/api/includes/export-as.html
@@ -14,8 +14,8 @@
         <td><code>{$ exportAs $}</code></td>
         <td><code>#myTemplateVar="{$ exportAs $}"</code></td>
       </tr>
-      {% endfor %}
+      {%- endfor %}
     </tbody>
   </table>
 </section>
-{% endif %}
+{%- endif -%}

--- a/aio/tools/transforms/templates/api/includes/interface-overview.html
+++ b/aio/tools/transforms/templates/api/includes/interface-overview.html
@@ -1,4 +1,4 @@
-{% import "lib/memberHelpers.html" as memberHelper -%}
+{%- import "lib/memberHelpers.html" as memberHelper -%}
 
 <section class="interface-overview">
 <code-example language="ts" hideCopy="true">

--- a/aio/tools/transforms/templates/api/includes/metadata.html
+++ b/aio/tools/transforms/templates/api/includes/metadata.html
@@ -1,13 +1,16 @@
-{% if doc.members.length %}
+{%- if doc.members.length %}
 <section class="meta-data">
   <h2>Metadata properties</h2>
-    {% for metadata in doc.members %}{% if not metadata.internal %}
+    {%- for metadata in doc.members %}{% if not metadata.internal %}
     <div class="metadata-member">
       <a name="{$ metadata.name $}" class="anchor-offset"></a>
       <code-example language="ts" hideCopy="true">{$ metadata.name $}{$ params.paramList(metadata.parameters) | trim $}{$ params.returnType(metadata.type) $}</code-example>
-      {%- if not metadata.notYetDocumented %}{$ metadata.description | marked $}{% endif -%}
+
+      {%- if not metadata.notYetDocumented %}
+      {$ metadata.description | marked $}
+      {%- endif %}
     </div>
     {% if not loop.last %}<hr class="hr-margin">{% endif %}
   {% endif %}{% endfor %}
 </section>
-{% endif %}
+{%- endif -%}

--- a/aio/tools/transforms/templates/api/includes/pipe-overview.html
+++ b/aio/tools/transforms/templates/api/includes/pipe-overview.html
@@ -1,6 +1,6 @@
-{%- import "lib/memberHelpers.html" as memberHelpers -%}
-{%- import "lib/ngmodule.html" as ngModuleHelpers -%}
-{%- import "lib/paramList.html" as params -%}
+{%- import "lib/memberHelpers.html" as memberHelpers %}
+{%- import "lib/ngmodule.html" as ngModuleHelpers %}
+{%- import "lib/paramList.html" as params %}
 
 <section class="{$ doc.docType $}-overview">
   <code-example hideCopy="true" class="no-box api-heading{% if doc.deprecated %} deprecated-api-item{% endif %}">{{ {$ doc.valueParam.name $}_expression | <span class="kwd nocode">{$ doc.pipeName $}</span>

--- a/aio/tools/transforms/templates/api/includes/pipe-overview.html
+++ b/aio/tools/transforms/templates/api/includes/pipe-overview.html
@@ -1,6 +1,6 @@
-{% import "lib/memberHelpers.html" as memberHelpers -%}
-{% import "lib/ngmodule.html" as ngModuleHelpers -%}
-{% import "lib/paramList.html" as params -%}
+{%- import "lib/memberHelpers.html" as memberHelpers -%}
+{%- import "lib/ngmodule.html" as ngModuleHelpers -%}
+{%- import "lib/paramList.html" as params -%}
 
 <section class="{$ doc.docType $}-overview">
   <code-example hideCopy="true" class="no-box api-heading{% if doc.deprecated %} deprecated-api-item{% endif %}">{{ {$ doc.valueParam.name $}_expression | <span class="kwd nocode">{$ doc.pipeName $}</span>
@@ -13,12 +13,12 @@
 
   {$ ngModuleHelpers.ngModuleList(doc.ngModules, 'Exported from') $}
 
-  {% if doc.valueParam.type %}
+  {%- if doc.valueParam.type %}
   <h2>Input value</h2>
   {$ params.renderParameters([doc.valueParam], 'pipe-parameters', 'pipe-parameter', true) $}
-  {% endif %}
-  {% if doc.pipeParams.length %}
+  {%- endif %}
+  {%- if doc.pipeParams.length %}
   <h2>Parameters</h2>
   {$ params.renderParameters(doc.pipeParams, 'pipe-parameters', 'pipe-parameter', true) $}
-  {% endif %}
+  {%- endif %}
 </section>

--- a/aio/tools/transforms/templates/api/includes/security-notes.html
+++ b/aio/tools/transforms/templates/api/includes/security-notes.html
@@ -1,6 +1,6 @@
-{% if doc.security %}
+{%- if doc.security %}
 <section "security">
   <h2>Security risk</h2>
   {$ doc.security | marked $}
 </section>
-{% endif %}
+{%- endif -%}

--- a/aio/tools/transforms/templates/api/includes/see-also.html
+++ b/aio/tools/transforms/templates/api/includes/see-also.html
@@ -2,8 +2,8 @@
 <section class="see-also">
   <h2>See also</h2>
   <ul>
-  {% for see in doc.see %}
-    <li>{$ see | marked $}</li>{% endfor %}
+    {%- for see in doc.see %}
+    <li>{$ see | marked | trim $}</li>{% endfor %}
   </ul>
 </section>
-{% endif %}
+{%- endif -%}

--- a/aio/tools/transforms/templates/api/includes/selectors.html
+++ b/aio/tools/transforms/templates/api/includes/selectors.html
@@ -1,14 +1,15 @@
 {%- if doc.selector %}
 <section class="selector-list">
   <h2>Selectors</h2>
-  {% if doc.selectors %}
-    {$ doc.selectors | marked $}
-  {% else %}
+
+  {%- if doc.selectors %}
+  {$ doc.selectors | marked $}
+  {%- else %}
   <ul>
     {%- for selector in doc.selectorArray %}
     <li><code>{$ selector | replace(r/(:not\([^()]+\))/g, '<i>$1</i>') $}</code></li>
-    {% endfor %}
+    {%- endfor %}
   </ul>
-  {% endif %}
+  {%- endif %}
 </section>
-{% endif %}
+{%- endif -%}

--- a/aio/tools/transforms/templates/api/includes/usageNotes.html
+++ b/aio/tools/transforms/templates/api/includes/usageNotes.html
@@ -1,6 +1,6 @@
-{% if doc.usageNotes %}
+{%- if doc.usageNotes %}
 <section class="usage-notes">
   <h2>Usage notes</h2>
   {$ doc.usageNotes | marked $}
 </section>
-{% endif %}
+{%- endif -%}

--- a/aio/tools/transforms/templates/api/lib/descendants.html
+++ b/aio/tools/transforms/templates/api/lib/descendants.html
@@ -1,22 +1,23 @@
-{% macro renderDescendantList(descendants, descendantType, recursed, docTypeMatcher) %}
-{% if descendants.length %}
+{%- macro renderDescendantList(descendants, descendantType, recursed, docTypeMatcher) -%}
+{%- if descendants.length %}
 <ul>
-  {% for descendant in descendants %}
-    <li>
-      <code>{$ descendant.name $}</code>
-      {$ renderDescendantList(descendant.descendants | filterByPropertyValue('docType', docTypeMatcher) | filterByPropertyValue('privateExport', undefined), docType, recursed, docTypeMatcher) $}
-    </li>
-  {% endfor %}
+  {%- for descendant in descendants %}
+  <li>
+    <code>{$ descendant.name $}</code>
+    {$ renderDescendantList(descendant.descendants | filterByPropertyValue('docType', docTypeMatcher) | filterByPropertyValue('privateExport', undefined), docType, recursed, docTypeMatcher) $}
+  </li>
+  {%- endfor %}
 </ul>
-{% endif %}
-{% endmacro -%}
+{%- endif -%}
+{%- endmacro %}
 
-{%- macro renderDescendants(doc, descendantType, title='', recursed=true, docTypeMatcher=descendantType) %}
-  {% set descendants = doc.descendants | filterByPropertyValue('docType', docTypeMatcher) | filterByPropertyValue('privateExport', undefined) %}
-  {% if descendants.length %}
+{%- macro renderDescendants(doc, descendantType, title='', recursed=true, docTypeMatcher=descendantType) -%}
+  {%- set descendants = doc.descendants | filterByPropertyValue('docType', docTypeMatcher) | filterByPropertyValue('privateExport', undefined) -%}
+  {%- if descendants.length %}
   <div class="descendants {$ descendantType $}">
-    {% if title %}<h2>{$ title $}</h2>{% endif %}
+    {%- if title %}
+    <h2>{$ title $}</h2>{% endif %}
     {$ renderDescendantList(descendants, descendantType, recursed, docTypeMatcher) $}
   </div>
-  {% endif %}
-{% endmacro %}
+  {%- endif -%}
+{%- endmacro %}

--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -41,14 +41,15 @@
 
 {%- macro renderOverloadInfo(overload, cssClass, method) -%}
 <div class="overload-info">
-  {% if overload.shortDescription and (overload.shortDescription != method.shortDescription) %}
+  {% if overload.shortDescription and (overload.shortDescription != method.shortDescription) -%}
   <div class="short-description">
     {$ overload.shortDescription | marked $}
-  </div>{% endif %}
+  </div>
+  {% endif -%}
 
   <code-example language="ts" hideCopy="true" class="no-box api-heading{% if overload.deprecated %} deprecated-api-item{% endif %}">{$ renderMemberSyntax(overload) $}</code-example>
 
-  {% if overload.deprecated !== undefined %}
+  {%- if overload.deprecated !== undefined %}
   <div class="deprecated">
     {$ ('**Deprecated** ' + overload.deprecated) | marked $}
   </div>{% endif %}
@@ -56,22 +57,21 @@
   <h6 class="no-anchor">Parameters</h6>
   {$ params.renderParameters(overload.parameterDocs, cssClass + '-parameters', cssClass + '-parameter', true) $}
 
-  {% if overload.type or overload.returns.type %}
+  {%- if overload.type or overload.returns.type %}
   <h6 class="no-anchor">Returns</h6>
   {% marked %}`{$ (overload.type or overload.returns.type) $}`{% if overload.returns %}: {$ overload.returns.description $}{% endif %}{% endmarked %}
-  {% endif %}
+  {%- endif %}
 
-
-  {% if overload.throws.length %}
+  {%- if overload.throws.length %}
   <h6 class="no-anchor">Throws</h6>
-  {% for error in overload.throws %}
+  {%- for error in overload.throws %}
   {% marked %}`{$ (error.typeList or 'Error') $}` {$ error.description $}{% endmarked %}
-  {% endfor %}
-  {% endif %}
+  {%- endfor %}
+  {%- endif %}
 
-  {% if overload.description and (overload.description != method.description) -%}
+  {%- if overload.description and (overload.description != method.description) %}
   <div class="description">
-    {$ overload.description | marked $}
+    {$ overload.description | marked | trim $}
   </div>
   {%- endif %}
 </div>
@@ -80,60 +80,64 @@
 {%- macro renderMethodDetail(versionInfo, method, cssClass) -%}
 <a id="{$ method.anchor $}"></a>
 <table class="is-full-width method-table {$ cssClass $}">
-  {% if method.name !== 'constructor' %}<thead><tr><th>
+  {%- if method.name !== 'constructor' %}
+  <thead><tr><th>
     <div class="with-github-links">
-    <h3>
-      {%- if method.isCallMember %}<i>call signature</i>
-      {%- elseif method.isNewMember %}<i>construct signature</i>
-      {%- else %}{$ method.name $}()
-      {%- endif -%}
-    </h3>
-    {$ github.githubLinks(method, versionInfo) $}
+      <h3>
+        {%- if method.isCallMember %}<i>call signature</i>
+        {%- elseif method.isNewMember %}<i>construct signature</i>
+        {%- else %}{$ method.name $}()
+        {%- endif -%}
+      </h3>
+      {$ github.githubLinks(method, versionInfo) $}
     </div>
-  </th></tr></thead>{% endif %}
+  </th></tr></thead>
+  {%- endif %}
   <tbody>
-    {% if method.shortDescription %}<tr>
+  {%- if method.shortDescription %}
+    <tr>
       <td class="short-description">
         {$ method.shortDescription | marked $}
 
-        {% if method.containerDoc.docType === 'class' and method.name === 'constructor' and not method.containerDoc.isAbstract and method.containerDoc.extensible !== true %}
+        {%- if method.containerDoc.docType === 'class' and method.name === 'constructor' and not method.containerDoc.isAbstract and method.containerDoc.extensible !== true %}
         <p class="final-message">
           This class is "final" and should not be extended.
           See the <a href="{$ github.githubVersionedUrl(versionInfo) $}/docs/PUBLIC_API.md#final-classes">public API notes</a>.
         </p>
-        {% endif %}
+        {% endif -%}
 
         {%- if method.see.length %}
         <p>See also:</p>
         <ul>
-        {% for see in method.see %}
-          <li>{$ see | marked $}</li>{% endfor %}
+          {%- for see in method.see %}
+          <li>{$ see | marked $}</li>
+          {%- endfor %}
         </ul>
-        {% endif %}
+        {% endif -%}
       </td>
-    </tr>{% endif %}
-  {% if method.overloads.length == 0 %}
+    </tr>{% endif -%}
+  {%- if method.overloads.length == 0 %}
     <tr>
       <td>
         {$ renderOverloadInfo(method, cssClass + '-overload', method) $}
       </td>
     </tr>
-  {% elseif method.overloads.length < 3 -%}
-    {% if method.isAbstract %}
-      <tr>
-        <td>
-          {$ renderOverloadInfo(method, cssClass + '-overload', method) $}
-        </td>
-      </tr>
-    {% endif %}
-    {% for overload in method.overloads -%}
+  {%- elseif method.overloads.length < 3 -%}
+    {%- if method.isAbstract %}
+    <tr>
+      <td>
+        {$ renderOverloadInfo(method, cssClass + '-overload', method) $}
+      </td>
+    </tr>
+    {%- endif %}
+    {%- for overload in method.overloads %}
     <tr>
       <td>
         {$ renderOverloadInfo(overload, cssClass + '-overload', method) $}
       </td>
     </tr>
-    {% endfor -%}
-  {% else -%}
+    {%- endfor -%}
+  {%- else %}
     <tr>
       <td>
         <details class="overloads">
@@ -146,22 +150,24 @@
             </span>
           </summary>
           <div class="details-content">
-            {% if method.isAbstract %}
-              {$ renderOverloadInfo(method, cssClass + '-overload', method) $}
-              <hr class="hr-margin fullwidth">
-            {% endif %}
-            {% for overload in method.overloads %}
-              <h5 class="no-anchor">Overload #{$ loop.index $}</h5>
-              {$ renderOverloadInfo(overload, cssClass + '-overload', method) $}
-              {% if not loop.last %}<hr class="hr-margin">{% endif %}
-            {% endfor %}
+            {%- if method.isAbstract %}
+            {$ renderOverloadInfo(method, cssClass + '-overload', method) $}
+            <hr class="hr-margin fullwidth">
+            {%- endif %}
+
+            {%- for overload in method.overloads %}
+            <h5 class="no-anchor">Overload #{$ loop.index $}</h5>
+            {$ renderOverloadInfo(overload, cssClass + '-overload', method) $}
+            {%- if not loop.last %}
+            <hr class="hr-margin">{% endif %}
+            {%- endfor %}
           </div>
         </details>
       </td>
     </tr>
-  {% endif %}
+  {%- endif %}
 
-  {% if method.description -%}
+  {%- if method.description %}
     <tr>
       <td class="description">
         {$ method.description | marked({ h3: 'h5' }) $}
@@ -169,7 +175,7 @@
     </tr>
   {%- endif %}
 
-  {% if method.usageNotes -%}
+  {%- if method.usageNotes %}
     <tr>
       <td class="usage-notes">
         <h4 id="{$ method.anchor $}-usage-notes">Usage Notes</h4>
@@ -177,26 +183,27 @@
       </td>
     </tr>
   {%- endif %}
-    </tbody>
+  </tbody>
 </table>
-{% endmacro -%}
+{%- endmacro -%}
 
 {%- macro renderMethodDetails(versionInfo, methods, containerClass, itemClass, headingText) -%}
-{% set nonInternalMethods = methods | filterByPropertyValue('internal', undefined) %}
-{% if nonInternalMethods.length %}
+{%- set nonInternalMethods = methods | filterByPropertyValue('internal', undefined) -%}
+{%- if nonInternalMethods.length %}
 <section class="{$ containerClass $}">
   <h2>{$ headingText $}</h2>
-  {% for member in nonInternalMethods %}
-    {$ renderMethodDetail(versionInfo, member, itemClass) $}
-  {% endfor %}
+
+  {%- for member in nonInternalMethods %}
+  {$ renderMethodDetail(versionInfo, member, itemClass) $}
+  {%- endfor %}
 </section>
-{% endif %}
+{%- endif %}
 {%- endmacro -%}
 
 
 {%- macro renderProperties(properties, containerClass, propertyClass, headingText, headings, headingLevel = 2) -%}
-{% set nonInternalProperties = properties | filterByPropertyValue('internal', undefined) %}
-{% if nonInternalProperties.length -%}
+{%- set nonInternalProperties = properties | filterByPropertyValue('internal', undefined) -%}
+{%- if nonInternalProperties.length %}
 <section class="{$ containerClass $}">
   <h{$ headingLevel $}>{$ headingText $}</h{$ headingLevel $}>
   <table class="is-full-width list-table property-table">
@@ -207,54 +214,62 @@
       </tr>
     </thead>
     <tbody>
-    {% for property in nonInternalProperties %}
+      {%- for property in nonInternalProperties %}
       <tr class="{$ propertyClass $}">
         <td>
           <a id="{$ property.anchor $}"></a>
           <code class="{% if property.deprecated %} deprecated-api-item{% endif %}">{$ renderMemberSyntax(property) $}</code>
         </td>
         <td>
-          {%- if (property.isGetAccessor or property.isReadonly) and not property.isSetAccessor %}<span class='read-only-property'>Read-Only</span>{% endif %}
-          {%- if property.isSetAccessor and not property.isGetAccessor %}<span class='write-only-property'>Write-Only</span>{% endif %}
-          {% if property.constructorParamDoc %} <span class='from-constructor'>Declared in Constructor</span>{% endif %}
-          {% if property.shortDescription %}{$ property.shortDescription | marked $}{% endif %}
+          {%- if (property.isGetAccessor or property.isReadonly) and not property.isSetAccessor %}
+          <span class='read-only-property'>Read-Only</span>{% endif %}
+
+          {%- if property.isSetAccessor and not property.isGetAccessor %}
+          <span class='write-only-property'>Write-Only</span>{% endif %}
+
+          {%- if property.constructorParamDoc %}
+          <span class='from-constructor'>Declared in Constructor</span>{% endif %}
+
+          {%- if property.shortDescription %}
+          {$ property.shortDescription | marked | trim $}{% endif %}
           {$ (property.description or property.constructorParamDoc.description) | marked $}
+
           {%- if property.see.length %}
           <p>See also:</p>
           <ul>
-          {% for see in property.see %}
+            {%- for see in property.see %}
             <li>{$ see | marked $}</li>{% endfor %}
           </ul>
-          {% endif %}
-          </td>
-    </tr>
-    {% endfor %}
+          {%- endif %}
+        </td>
+      </tr>
+      {%- endfor %}
     </tbody>
   </table>
 </section>
 {%- endif -%}
 {%- endmacro -%}
 
-{% macro renderDirectiveAncestors(doc, collectionName) %}
-{%- for ancestor in doc.extendsClauses %}{% if ancestor.doc %}
-{% set nonInternalMembers = ancestor.doc[collectionName] | filterByPropertyValue('internal', undefined) %}
-{% if nonInternalMembers.length -%}
+{%- macro renderDirectiveAncestors(doc, collectionName) -%}
+{%- for ancestor in doc.extendsClauses %}{% if ancestor.doc -%}
+{%- set nonInternalMembers = ancestor.doc[collectionName] | filterByPropertyValue('internal', undefined) -%}
+{%- if nonInternalMembers.length %}
 <section class="inherited-members-list">
   <h3>Inherited from <code><a class="code-anchor" href="{$ ancestor.doc.path $}">{$ ancestor.doc.name $}</a></code></h3>
   <ul>
-  {% for member in nonInternalMembers %}
+    {%- for member in nonInternalMembers %}
     <li>
-        <code><a class="code-anchor" href="{$ ancestor.doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member) $}</a></code>
+      <code><a class="code-anchor" href="{$ ancestor.doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member) $}</a></code>
     </li>
-  {% endfor %}
+    {%- endfor %}
   </ul>
 </section>
-{% endif %}
+{%- endif %}
 {$ renderDirectiveAncestors(ancestor.doc, collectionName) $}
-{% endif %}{% endfor -%}
-{% endmacro %}
+{%- endif %}{% endfor -%}
+{%- endmacro -%}
 
-{% macro renderDirectiveProperties(doc, heading) %}
+{%- macro renderDirectiveProperties(doc, heading) -%}
 {$ renderProperties(doc.properties, 'instance-properties', 'instance-property', heading) $}
 {$ renderDirectiveAncestors(doc, 'properties') $}
-{% endmacro %}
+{%- endmacro -%}

--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -83,10 +83,10 @@
   {% if method.name !== 'constructor' %}<thead><tr><th>
     <div class="with-github-links">
     <h3>
-      {% if method.isCallMember %}<i>call signature</i>
-      {% elseif method.isNewMember %}<i>construct signature</i>
-      {% else %}{$ method.name $}()
-      {% endif %}
+      {%- if method.isCallMember %}<i>call signature</i>
+      {%- elseif method.isNewMember %}<i>construct signature</i>
+      {%- else %}{$ method.name $}()
+      {%- endif -%}
     </h3>
     {$ github.githubLinks(method, versionInfo) $}
     </div>

--- a/aio/tools/transforms/templates/api/lib/ngmodule.html
+++ b/aio/tools/transforms/templates/api/lib/ngmodule.html
@@ -1,18 +1,18 @@
-{% macro ngModuleList(ngModules, heading) %}
-{% if ngModules and ngModules.length > 0 %}
+{%- macro ngModuleList(ngModules, heading) -%}
+{%- if ngModules and ngModules.length > 0 %}
 <h2>{$ heading $}</h2>
 <ul>
-{% for ngModule in ngModules %}
+  {%- for ngModule in ngModules %}
   <li>
-    {% if ngModule.path %}
+    {%- if ngModule.path %}
     <a href="{$ ngModule.path $}">
       <code-example language="ts" hideCopy="true" class="no-box">{$ ngModule.name | escape $}</code-example>
     </a>
-    {% else %}
-      <code-example language="ts" hideCopy="true" class="no-box">'{$ ngModule | escape $}'</code-example>
-    {% endif %}
+    {%- else %}
+    <code-example language="ts" hideCopy="true" class="no-box">'{$ ngModule | escape $}'</code-example>
+    {%- endif %}
   </li>
-{% endfor %}
+  {%- endfor %}
 </ul>
-{% endif %}
-{% endmacro %}
+{%- endif -%}
+{%- endmacro -%}

--- a/aio/tools/transforms/templates/api/lib/paramList.html
+++ b/aio/tools/transforms/templates/api/lib/paramList.html
@@ -1,4 +1,4 @@
-{% macro paramList(params, truncateLines) -%}
+{%- macro paramList(params, truncateLines) -%}
   {%- if params -%}
     ({%- for param in params -%}
       {$ param | escape | truncateCode(truncateLines) $}{% if not loop.last %}, {% endif %}
@@ -7,7 +7,7 @@
 {%- endmacro -%}
 
 
-{% macro returnType(returnType) -%}
+{%- macro returnType(returnType) -%}
   {%- if returnType %}: {$ returnType | escape $}{% endif -%}
 {%- endmacro -%}
 
@@ -15,22 +15,26 @@
 {%- if parameters.length -%}
 <table class="is-full-width list-table parameters-table {$ containerClass $}">
   <tbody>
-  {% for parameter in parameters %}
+    {%- for parameter in parameters %}
     <tr class="{$ parameterClass $}">
       <td class="param-name">
         <a id="{$ parameter.anchor $}"></a>
         <code>{$ parameter.name $}</code>
       </td>
-      {% if showType %}<td class="param-type"><code>{% if r/^\{/.test(parameter.type) and r/\}$/.test(parameter.type) and parameter.type.length > 20 %}object{% else %}{$ parameter.type $}{% endif %}</code></td>{% endif %}
+      {%- if showType %}
+      <td class="param-type"><code>{% if r/^\{/.test(parameter.type) and r/\}$/.test(parameter.type) and parameter.type.length > 20 %}object{% else %}{$ parameter.type $}{% endif %}</code></td>
+      {%- endif %}
       <td class="param-description">
-      {% marked %}
-      {% if (parameter.shortDescription | trim) or (parameter.description | trim) %}{$ parameter.shortDescription + '\n\n' + parameter.description $}
-      {% endif %}
+        {%- if (parameter.shortDescription | trim) or (parameter.description | trim) %}
+        {$ (parameter.shortDescription + '\n\n' + parameter.description) | trim | marked $}
+        {%- endif %}
 
-      {% if parameter.isOptional or parameter.defaultValue !== undefined %}Optional. Default is `{$ parameter.defaultValue === undefined and 'undefined' or parameter.defaultValue $}`.{% endif %}
-      {% endmarked %}
+        {%- if parameter.isOptional or parameter.defaultValue !== undefined %}
+        {% marked %}Optional. Default is `{$ parameter.defaultValue === undefined and 'undefined' or parameter.defaultValue $}`.{% endmarked %}
+        {%- endif %}
       </td>
-    </tr>{% endfor %}
+    </tr>
+    {%- endfor %}
   </tbody>
 </table>
 {%- else -%}

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -4768,11 +4768,6 @@ electron-to-chromium@^1.3.793:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz#21502100f11aead6c501d1cd7f2504f16c936642"
   integrity sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA==
 
-"emoji-regex@>=6.0.0 <=6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.1.tgz#c6cd0ec1b0642e2a3c67a1137efc5e796da4f88e"
-  integrity sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=
-
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -6007,11 +6002,9 @@ getpass@^0.1.1:
     assert-plus "^1.0.0"
 
 github-slugger@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.3.0.tgz#9bd0a95c5efdfc46005e82a906ef8e2a059124c9"
-  integrity sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==
-  dependencies:
-    emoji-regex ">=6.0.0 <=6.1.1"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.4.0.tgz#206eb96cdb22ee56fdc53a28d5a302338463444e"
+  integrity sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ==
 
 glob-parent@^3.1.0:
   version "3.1.0"
@@ -8770,7 +8763,7 @@ minimalistic-assert@^1.0.0:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2:
+minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -11038,9 +11038,9 @@ rehype@^8.0.0:
     unified "^7.0.0"
 
 remark-html@^13.0.0:
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/remark-html/-/remark-html-13.0.1.tgz#d5b2d8be01203e61fc37403167ca7584879ad675"
-  integrity sha512-K5KQCXWVz+harnyC+UVM/J9eJWCgjYRqFeZoZf2NgP0iFbuuw/RgMZv3MA34b/OEpGnstl3oiOUtZzD3tJ+CBw==
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/remark-html/-/remark-html-13.0.2.tgz#de5f052749ff61fc904c9708c155c88a2e2655dc"
+  integrity sha512-LhSRQ+3RKdBqB/RGesFWkNNfkGqprDUCwjq54SylfFeNyZby5kqOG8Dn/vYsRoM8htab6EWxFXCY6XIZvMoRiQ==
   dependencies:
     hast-util-sanitize "^3.0.0"
     hast-util-to-html "^7.0.0"


### PR DESCRIPTION
The HTML for the docs pages is generated by Dgeni based on some [Nunjucks][1] templates.

Previously, these templates were set up in a way that introduced a lot excess whitespace in the generated HTML, unnecessarily bloating the corresponding JSON files that need to be downloaded in order to view a certain docs page. This has been discussed in #28105 and was again observed while investigating #43285.

This commit refactors some of the templates related to API docs (which seem to be the most affected ones) to drastically reduce the amount of excess whitespace. More specifically, the total size of all files in `generated/docs/api/` was reduced from ~13MB to ~7MB.

Besides the reduced payload size for each API page, this change will also reduce the amount of memory needed by the ServiceWorker to cache the API pages that have been visited by a user.

NOTE:
The affected files are not eagerly downloaded when navigating to angular.io. Instead, each file is downloaded individually, as soon as a user visits the corresponding API docs page. Therefore, the impact of this change will be relatively small for most users.

##
This PR also updates `github-slugger` to 1.4.0 and `remark-html` to 13.0.2.

##
<details>
<summary>Script used to process API docs for comparison purposes</summary>

```js
// Imports
const fs = require('fs');
const path = require('path');

// Variables
const rootSrcDir = path.resolve(process.argv[2]);
const rootDstDir = `${rootSrcDir}-processed`;
const rootDstDirNows = `${rootSrcDir}-processed-nows`;

// Run
fs.mkdirSync(rootDstDir);
fs.mkdirSync(rootDstDirNows);
processDir(rootSrcDir, rootDstDir, rootDstDirNows);

// Helpers
function processDir(srcDir, dstDir, dstDirNows) {
  fs.readdirSync(srcDir).
    map(name => [path.join(srcDir, name), path.join(dstDir, name), path.join(dstDirNows, name)]).
    forEach(([srcPath, dstPath, dstPathNows]) => {
      try {
        if (fs.statSync(srcPath).isDirectory()) {
          fs.mkdirSync(dstPath);
          fs.mkdirSync(dstPathNows);
          return processDir(srcPath, dstPath, dstPathNows);
        }

        const json = JSON.parse(fs.readFileSync(srcPath, 'utf8'));

        if (typeof json.contents !== 'string') {
          fs.copyFileSync(srcPath, dstPath);
          fs.copyFileSync(srcPath, dstPathNows);
        } else {
          const html = json.contents.trim();
          fs.writeFileSync(dstPath.replace(/\.json$/, '.html'), html);
          fs.writeFileSync(
              dstPathNows.replace(/\.json$/, '.html'),
              html.
                replace(/(?<=^|\n) *\r?\n/g, '').
                replace(/^ +</gm, '<').
                replace(/(>)\s+(<)/g, '$1$2').
                replace(/(<p>)\s+(Optional)/g, '$1$2'));
        }
      } catch (err) {
        console.error(`Error processing '${srcPath}'.`);
        throw err;
      }
    });
}
```
</details>

[1]: https://mozilla.github.io/nunjucks/