### PR TITLE
refactor(router): remove unnecessary getTransition function

### DIFF
--- a/packages/router/src/operators/recognize.ts
+++ b/packages/router/src/operators/recognize.ts
@@ -21,7 +21,7 @@ export function recognize(
     relativeLinkResolution: 'legacy'|'corrected'): MonoTypeOperatorFunction<NavigationTransition> {
   return mergeMap(
       t => recognizeFn(
-               rootComponentType, config, t.urlAfterRedirects, serializer(t.urlAfterRedirects),
+               rootComponentType, config, t.urlAfterRedirects!, serializer(t.urlAfterRedirects!),
                paramsInheritanceStrategy, relativeLinkResolution)
                .pipe(map(targetSnapshot => ({...t, targetSnapshot}))));
 }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -314,39 +314,6 @@ describe('Integration', () => {
        })));
   });
 
-
-  /**
-   * get/setTransition are private APIs. This test is needed though to guarantee the correct
-   * values are being used. Related to https://github.com/angular/angular/issues/30340 where
-   * stale transition data was being used when kicking off a new navigation.
-   */
-  describe('get/setTransition', () => {
-    it('should provide the most recent NavigationTransition',
-       fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
-         router.resetConfig([
-           {path: '', component: SimpleCmp}, {path: 'a', component: SimpleCmp},
-           {path: 'b', component: SimpleCmp}
-         ]);
-
-         const fixture = createRoot(router, RootCmp);
-
-         const initialTransition = (router as any).getTransition();
-
-         // Confirm initial value
-         expect(initialTransition.urlAfterRedirects.toString()).toBe('/');
-
-
-         router.navigateByUrl('/a', {replaceUrl: true});
-
-         tick();
-
-         // After a navigation, we should see the URL after redirect
-         const nextTransition = (router as any).getTransition();
-         // Confirm initial value
-         expect(nextTransition.urlAfterRedirects.toString()).toBe('/a');
-       })));
-  });
-
   describe('navigation warning', () => {
     const isInAngularZoneFn = NgZone.isInAngularZone;
     let warnings: string[] = [];


### PR DESCRIPTION
The getTransition helper function ensures that urlAfterRedirects is assigned for when
the router does not process the previous or current URL. In this case, we would set
the browserUrlTree to be the urlAfterRedirects, which was initialized to be the browserUrlTree.
This is a no-op, so there's no need for the getTransition function at all.

[TGP](https://fusion2.corp.google.com/presubmit/tap/395497359/OCL:395497359:BASE:396137091:1631391856202:d41fea79/targets)