### PR TITLE
fix(upgrade): Do not trigger duplicate navigation events from Angular…

### DIFF
--- a/packages/router/src/private_export.ts
+++ b/packages/router/src/private_export.ts
@@ -8,5 +8,6 @@
 
 
 export {ɵEmptyOutletComponent} from './components/empty_outlet';
+export {RestoredState as ɵRestoredState} from './router';
 export {assignExtraOptionsToRouter as ɵassignExtraOptionsToRouter, ROUTER_PROVIDERS as ɵROUTER_PROVIDERS} from './router_module';
 export {flatten as ɵflatten} from './utils/collection';

--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -76,8 +76,9 @@ export function setUpLocationSync(ngUpgrade: UpgradeModule, urlType: 'path'|'has
   ngUpgrade.$injector.get('$rootScope')
       .$on(
           '$locationChangeStart',
-          (event: any, newUrl: string, oldUrl: string, newState?: RestoredState,
-           oldState?: RestoredState) => {
+          (event: any, newUrl: string, oldUrl: string,
+           newState?: {[k: string]: unknown}|RestoredState,
+           oldState?: {[k: string]: unknown}|RestoredState) => {
             // Navigations coming from Angular router have a navigationId state
             // property. Don't trigger Angular router navigation again if it is
             // caused by a URL change from the current Angular router

--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -84,8 +84,8 @@ export function setUpLocationSync(ngUpgrade: UpgradeModule, urlType: 'path'|'has
             // navigation.
             const currentNavigationId = router.getCurrentNavigation()?.id;
             const newStateNavigationId = newState?.navigationId;
-            if (newStateNavigationId !== undefined ||
-                Number(newStateNavigationId) === currentNavigationId) {
+            if (newStateNavigationId !== undefined &&
+                newStateNavigationId === currentNavigationId) {
               return;
             }
 

--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -8,7 +8,7 @@
 
 import {Location} from '@angular/common';
 import {APP_BOOTSTRAP_LISTENER, ComponentRef, InjectionToken} from '@angular/core';
-import {Router} from '@angular/router';
+import {Router, ɵRestoredState as RestoredState} from '@angular/router';
 import {UpgradeModule} from '@angular/upgrade/static';
 
 /**
@@ -74,20 +74,34 @@ export function setUpLocationSync(ngUpgrade: UpgradeModule, urlType: 'path'|'has
   const location: Location = ngUpgrade.injector.get(Location);
 
   ngUpgrade.$injector.get('$rootScope')
-      .$on('$locationChangeStart', (_: any, next: string, __: string) => {
-        let url;
-        if (urlType === 'path') {
-          url = resolveUrl(next);
-        } else if (urlType === 'hash') {
-          // Remove the first hash from the URL
-          const hashIdx = next.indexOf('#');
-          url = resolveUrl(next.substring(0, hashIdx) + next.substring(hashIdx + 1));
-        } else {
-          throw 'Invalid URLType passed to setUpLocationSync: ' + urlType;
-        }
-        const path = location.normalize(url.pathname);
-        router.navigateByUrl(path + url.search + url.hash);
-      });
+      .$on(
+          '$locationChangeStart',
+          (event: any, newUrl: string, oldUrl: string, newState?: RestoredState,
+           oldState?: RestoredState) => {
+            // Navigations coming from Angular router have a navigationId state
+            // property. Don't trigger Angular router navigation again if it is
+            // caused by a URL change from the current Angular router
+            // navigation.
+            const currentNavigationId = router.getCurrentNavigation()?.id;
+            const newStateNavigationId = newState?.navigationId;
+            if (newStateNavigationId !== undefined ||
+                Number(newStateNavigationId) === currentNavigationId) {
+              return;
+            }
+
+            let url;
+            if (urlType === 'path') {
+              url = resolveUrl(newUrl);
+            } else if (urlType === 'hash') {
+              // Remove the first hash from the URL
+              const hashIdx = newUrl.indexOf('#');
+              url = resolveUrl(newUrl.substring(0, hashIdx) + newUrl.substring(hashIdx + 1));
+            } else {
+              throw 'Invalid URLType passed to setUpLocationSync: ' + urlType;
+            }
+            const path = location.normalize(url.pathname);
+            router.navigateByUrl(path + url.search + url.hash);
+          });
 }
 
 /**

--- a/packages/router/upgrade/test/BUILD.bazel
+++ b/packages/router/upgrade/test/BUILD.bazel
@@ -13,9 +13,13 @@ ts_library(
     srcs = glob(["**/*.ts"]),
     deps = [
         "//packages/common",
+        "//packages/common/testing",
+        "//packages/common/upgrade",
+        "//packages/core",
         "//packages/core/testing",
         "//packages/private/testing",
         "//packages/router",
+        "//packages/router/testing",
         "//packages/router/upgrade",
         "//packages/upgrade/static",
     ],

--- a/packages/router/upgrade/test/upgrade.spec.ts
+++ b/packages/router/upgrade/test/upgrade.spec.ts
@@ -188,4 +188,38 @@ describe('setUpLocationSync', () => {
       Object.defineProperty(anchorProto, 'pathname', originalDescriptor!);
     }
   });
+
+  it('should not duplicate navigations triggered by Angular router', fakeAsync(() => {
+       spyOn(TestBed.inject(UrlCodec), 'parse').and.returnValue({
+         pathname: '',
+         href: '',
+         protocol: '',
+         host: '',
+         search: '',
+         hash: '',
+         hostname: '',
+         port: '',
+       });
+       const $rootScope = upgradeModule.$injector.get('$rootScope');
+       spyOn($rootScope, '$broadcast').and.callThrough();
+       setUpLocationSync(upgradeModule);
+       // Inject location shim so its urlChangeListener subscribes
+       TestBed.inject($locationShim);
+
+       router.navigateByUrl('/1');
+       location.normalize.and.returnValue('/1');
+       flush();
+       expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
+       expect($rootScope.$broadcast.calls.argsFor(0)[0]).toEqual('$locationChangeStart');
+       expect($rootScope.$broadcast.calls.argsFor(1)[0]).toEqual('$locationChangeSuccess');
+       $rootScope.$broadcast.calls.reset();
+       router.navigateByUrl.calls.reset();
+
+       location.go('/2');
+       location.normalize.and.returnValue('/2');
+       flush();
+       expect($rootScope.$broadcast.calls.argsFor(0)[0]).toEqual('$locationChangeStart');
+       expect($rootScope.$broadcast.calls.argsFor(1)[0]).toEqual('$locationChangeSuccess');
+       expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
+     }));
 });

--- a/packages/router/upgrade/test/upgrade.spec.ts
+++ b/packages/router/upgrade/test/upgrade.spec.ts
@@ -7,31 +7,100 @@
  */
 
 import {Location} from '@angular/common';
-import {TestBed} from '@angular/core/testing';
+import {$locationShim, UrlCodec} from '@angular/common/upgrade';
+import {fakeAsync, flush, TestBed} from '@angular/core/testing';
 import {Router} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
 import {setUpLocationSync} from '@angular/router/upgrade';
 import {UpgradeModule} from '@angular/upgrade/static';
 
+import {LocationUpgradeTestModule} from './upgrade_location_test_module';
+
+export class MockUpgradeModule {
+  $injector = {
+    get(key: string) {
+      if (key === '$rootScope') {
+        return new $rootScopeMock();
+      } else {
+        throw new Error(`Unsupported mock service requested: ${key}`);
+      }
+    }
+  };
+}
+
+export function injectorFactory() {
+  const rootScopeMock = new $rootScopeMock();
+  const rootElementMock = {on: () => undefined};
+  return function $injectorGet(provider: string) {
+    if (provider === '$rootScope') {
+      return rootScopeMock;
+    } else if (provider === '$rootElement') {
+      return rootElementMock;
+    } else {
+      throw new Error(`Unsupported injectable mock: ${provider}`);
+    }
+  };
+}
+
+export class $rootScopeMock {
+  private watchers: any[] = [];
+  private events: {[k: string]: any[]} = {};
+  runWatchers() {
+    this.watchers.forEach(fn => fn());
+  }
+
+  $watch(fn: any) {
+    this.watchers.push(fn);
+  }
+
+  $broadcast(evt: string, ...args: any[]) {
+    if (this.events[evt]) {
+      this.events[evt].forEach(fn => {
+        fn.apply(fn, [/** angular.IAngularEvent*/ {}, ...args]);
+      });
+    }
+    return {
+      defaultPrevented: false,
+      preventDefault() {
+        this.defaultPrevented = true;
+      }
+    };
+  }
+
+  $on(evt: string, fn: any) {
+    if (!this.events[evt]) {
+      this.events[evt] = [];
+    }
+    this.events[evt].push(fn);
+  }
+
+  $evalAsync(fn: any) {
+    fn();
+  }
+
+  $digest() {}
+}
+
 describe('setUpLocationSync', () => {
   let upgradeModule: UpgradeModule;
-  let RouterMock: any;
-  let LocationMock: any;
+  let router: any;
+  let location: any;
 
   beforeEach(() => {
-    RouterMock = jasmine.createSpyObj('Router', ['navigateByUrl']);
-    LocationMock = jasmine.createSpyObj('Location', ['normalize']);
-
     TestBed.configureTestingModule({
-      providers: [
-        UpgradeModule, {provide: Router, useValue: RouterMock},
-        {provide: Location, useValue: LocationMock}
+      imports: [
+        RouterTestingModule.withRoutes([{path: '1', children: []}, {path: '2', children: []}]),
+        UpgradeModule,
+        LocationUpgradeTestModule.config(),
       ],
     });
 
     upgradeModule = TestBed.inject(UpgradeModule);
-    upgradeModule.$injector = {
-      get: jasmine.createSpy('$injector.get').and.returnValue({'$on': () => undefined})
-    };
+    router = TestBed.inject(Router);
+    location = TestBed.inject(Location);
+    spyOn(router, 'navigateByUrl').and.callThrough();
+    spyOn(location, 'normalize').and.callThrough();
+    upgradeModule.$injector = {get: injectorFactory()};
   });
 
   it('should throw an error if the UpgradeModule.bootstrap has not been called', () => {
@@ -45,10 +114,8 @@ describe('setUpLocationSync', () => {
 
   it('should get the $rootScope from AngularJS and set an $on watch on $locationChangeStart',
      () => {
-       const $rootScope = jasmine.createSpyObj('$rootScope', ['$on']);
-
-       upgradeModule.$injector.get.and.callFake(
-           (name: string) => (name === '$rootScope') && $rootScope);
+       const $rootScope = upgradeModule.$injector.get('$rootScope');
+       spyOn($rootScope, '$on');
 
        setUpLocationSync(upgradeModule);
 
@@ -62,21 +129,21 @@ describe('setUpLocationSync', () => {
     const normalizedPathname = 'foo';
     const query = '?query=1&query2=3';
     const hash = '#new/hash';
-    const $rootScope = jasmine.createSpyObj('$rootScope', ['$on']);
+    const $rootScope = upgradeModule.$injector.get('$rootScope');
+    spyOn($rootScope, '$on');
 
-    upgradeModule.$injector.get.and.returnValue($rootScope);
-    LocationMock.normalize.and.returnValue(normalizedPathname);
+    location.normalize.and.returnValue(normalizedPathname);
 
     setUpLocationSync(upgradeModule);
 
     const callback = $rootScope.$on.calls.argsFor(0)[1];
     callback({}, url + pathname + query + hash, '');
 
-    expect(LocationMock.normalize).toHaveBeenCalledTimes(1);
-    expect(LocationMock.normalize).toHaveBeenCalledWith(pathname);
+    expect(location.normalize).toHaveBeenCalledTimes(1);
+    expect(location.normalize).toHaveBeenCalledWith(pathname);
 
-    expect(RouterMock.navigateByUrl).toHaveBeenCalledTimes(1);
-    expect(RouterMock.navigateByUrl).toHaveBeenCalledWith(normalizedPathname + query + hash);
+    expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
+    expect(router.navigateByUrl).toHaveBeenCalledWith(normalizedPathname + query + hash);
   });
 
   it('should allow configuration to work with hash-based routing', () => {
@@ -86,21 +153,20 @@ describe('setUpLocationSync', () => {
     const query = '?query=1&query2=3';
     const hash = '#new/hash';
     const combinedUrl = url + '#' + pathname + query + hash;
-    const $rootScope = jasmine.createSpyObj('$rootScope', ['$on']);
-
-    upgradeModule.$injector.get.and.returnValue($rootScope);
-    LocationMock.normalize.and.returnValue(normalizedPathname);
+    const $rootScope = upgradeModule.$injector.get('$rootScope');
+    spyOn($rootScope, '$on');
+    location.normalize.and.returnValue(normalizedPathname);
 
     setUpLocationSync(upgradeModule, 'hash');
 
     const callback = $rootScope.$on.calls.argsFor(0)[1];
     callback({}, combinedUrl, '');
 
-    expect(LocationMock.normalize).toHaveBeenCalledTimes(1);
-    expect(LocationMock.normalize).toHaveBeenCalledWith(pathname);
+    expect(location.normalize).toHaveBeenCalledTimes(1);
+    expect(location.normalize).toHaveBeenCalledWith(pathname);
 
-    expect(RouterMock.navigateByUrl).toHaveBeenCalledTimes(1);
-    expect(RouterMock.navigateByUrl).toHaveBeenCalledWith(normalizedPathname + query + hash);
+    expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
+    expect(router.navigateByUrl).toHaveBeenCalledWith(normalizedPathname + query + hash);
   });
 
   it('should work correctly on browsers that do not start pathname with `/`', () => {
@@ -109,15 +175,15 @@ describe('setUpLocationSync', () => {
     Object.defineProperty(anchorProto, 'pathname', {get: () => 'foo/bar'});
 
     try {
-      const $rootScope = jasmine.createSpyObj('$rootScope', ['$on']);
-      upgradeModule.$injector.get.and.returnValue($rootScope);
+      const $rootScope = upgradeModule.$injector.get('$rootScope');
+      spyOn($rootScope, '$on');
 
       setUpLocationSync(upgradeModule);
 
       const callback = $rootScope.$on.calls.argsFor(0)[1];
       callback({}, '', '');
 
-      expect(LocationMock.normalize).toHaveBeenCalledWith('/foo/bar');
+      expect(location.normalize).toHaveBeenCalledWith('/foo/bar');
     } finally {
       Object.defineProperty(anchorProto, 'pathname', originalDescriptor!);
     }

--- a/packages/router/upgrade/test/upgrade.spec.ts
+++ b/packages/router/upgrade/test/upgrade.spec.ts
@@ -16,18 +16,6 @@ import {UpgradeModule} from '@angular/upgrade/static';
 
 import {LocationUpgradeTestModule} from './upgrade_location_test_module';
 
-export class MockUpgradeModule {
-  $injector = {
-    get(key: string) {
-      if (key === '$rootScope') {
-        return new $rootScopeMock();
-      } else {
-        throw new Error(`Unsupported mock service requested: ${key}`);
-      }
-    }
-  };
-}
-
 export function injectorFactory() {
   const rootScopeMock = new $rootScopeMock();
   const rootElementMock = {on: () => undefined};
@@ -45,9 +33,6 @@ export function injectorFactory() {
 export class $rootScopeMock {
   private watchers: any[] = [];
   private events: {[k: string]: any[]} = {};
-  runWatchers() {
-    this.watchers.forEach(fn => fn());
-  }
 
   $watch(fn: any) {
     this.watchers.push(fn);
@@ -78,7 +63,9 @@ export class $rootScopeMock {
     fn();
   }
 
-  $digest() {}
+  $digest() {
+    this.watchers.forEach(fn => fn());
+  }
 }
 
 describe('setUpLocationSync', () => {

--- a/packages/router/upgrade/test/upgrade_location_test_module.ts
+++ b/packages/router/upgrade/test/upgrade_location_test_module.ts
@@ -24,8 +24,6 @@ export interface LocationUpgradeTestingConfig {
  * @description
  *
  * Is used in DI to configure the router.
- *
- * @publicApi
  */
 export const LOC_UPGRADE_TEST_CONFIG =
     new InjectionToken<LocationUpgradeTestingConfig>('LOC_UPGRADE_TEST_CONFIG');

--- a/packages/router/upgrade/test/upgrade_location_test_module.ts
+++ b/packages/router/upgrade/test/upgrade_location_test_module.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {APP_BASE_HREF, CommonModule, Location, LocationStrategy, PlatformLocation} from '@angular/common';
+import {MockPlatformLocation} from '@angular/common/testing';
+import {$locationShim, $locationShimProvider, LocationUpgradeModule, UrlCodec} from '@angular/common/upgrade';
+import {Inject, InjectionToken, ModuleWithProviders, NgModule, Optional} from '@angular/core';
+import {UpgradeModule} from '@angular/upgrade/static';
+
+export interface LocationUpgradeTestingConfig {
+  useHash?: boolean;
+  hashPrefix?: string;
+  urlCodec?: typeof UrlCodec;
+  startUrl?: string;
+  appBaseHref?: string;
+}
+
+/**
+ * @description
+ *
+ * Is used in DI to configure the router.
+ *
+ * @publicApi
+ */
+export const LOC_UPGRADE_TEST_CONFIG =
+    new InjectionToken<LocationUpgradeTestingConfig>('LOC_UPGRADE_TEST_CONFIG');
+
+
+export const APP_BASE_HREF_RESOLVED = new InjectionToken<string>('APP_BASE_HREF_RESOLVED');
+
+/**
+ * Module used for configuring Angular's LocationUpgradeService.
+ */
+@NgModule({imports: [CommonModule]})
+export class LocationUpgradeTestModule {
+  static config(config?: LocationUpgradeTestingConfig):
+      ModuleWithProviders<LocationUpgradeTestModule> {
+    return {
+      ngModule: LocationUpgradeTestModule,
+      providers: [
+        {provide: LOC_UPGRADE_TEST_CONFIG, useValue: config || {}}, {
+          provide: PlatformLocation,
+          useFactory: (appBaseHref?: string) => {
+            if (config && config.appBaseHref != null) {
+              appBaseHref = config.appBaseHref;
+            } else if (appBaseHref == null) {
+              appBaseHref = '';
+            }
+            return new MockPlatformLocation(
+                {startUrl: config && config.startUrl, appBaseHref: appBaseHref});
+          },
+          deps: [[new Inject(APP_BASE_HREF), new Optional()]]
+        },
+        {
+          provide: $locationShim,
+          useFactory: provide$location,
+          deps: [
+            UpgradeModule, Location, PlatformLocation, UrlCodec, LocationStrategy,
+            LOC_UPGRADE_TEST_CONFIG
+          ]
+        },
+        LocationUpgradeModule
+            .config({
+              appBaseHref: config && config.appBaseHref,
+              useHash: config && config.useHash || false
+            })
+            .providers!
+      ],
+    };
+  }
+}
+
+export function provide$location(
+    ngUpgrade: UpgradeModule, location: Location, platformLocation: PlatformLocation,
+    urlCodec: UrlCodec, locationStrategy: LocationStrategy, config?: LocationUpgradeTestingConfig) {
+  const $locationProvider =
+      new $locationShimProvider(ngUpgrade, location, platformLocation, urlCodec, locationStrategy);
+
+  $locationProvider.hashPrefix(config && config.hashPrefix);
+  $locationProvider.html5Mode(config && !config.useHash);
+
+  return $locationProvider.$get();
+}


### PR DESCRIPTION
… Router

This code mimics behavior that Google Analytics has been using to
prevent duplicate navigations. They set up their own `HybridRoutingService`
location sync to avoid duplicate navigations that came from the Angular
router. This would happen because the Angular router would trigger a
navigation, which would then get picked up by the `$locationShim`, which
would trigger a `$locationChangeStart`, which would then be picked up by
the `setUpLocationSync` watcher here, which would again trigger a
navigation in the Angular Router.

All of this can be prevented by checking if the `navigationId` exists on
the history state object. This property is added by the Angular router
during navigations.

fixes #21610
