### PR TITLE
refactor(compiler): improve regular expression for stripping comments

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -629,7 +629,7 @@ const _polyfillHostRe = /-shadowcsshost/gim;
 const _colonHostRe = /:host/gim;
 const _colonHostContextRe = /:host-context/gim;
 
-const _commentRe = /\/\*\s*[\s\S]*?\*\//g;
+const _commentRe = /\/\*[\s\S]*?\*\//g;
 
 function stripComments(input: string): string {
   return input.replace(_commentRe, '');


### PR DESCRIPTION
Previously, the regular expression used by the compiler's ShadowDOM CSS shim to strip comments from CSS text was susceptible to [catastrophic backtracking][1], which could lead to exponential (O(2^n)) increase in complexity/execution time. More specifically, this would be triggered if the processed text contained an unterminated comment with lots of leading whitespace (i.e. `/*`, followed by lots of whitespace characters and no closing `*/`).

Although such input is unlikely in real-world scenarios, this commit improves the regular expression to not be susceptible to this issue.

[1]: https://www.regular-expressions.info/catastrophic.html
